### PR TITLE
Matplotlib backend is imported before Gcf is initialised

### DIFF
--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -30,7 +30,6 @@ from qtpy.QtCore import QCoreApplication, Qt
 # QApplication is created or paths to Qt's resources will not be set up correctly
 from workbench.app.resources import qCleanupResources
 from workbench.config import APPNAME, ORG_DOMAIN, ORGANIZATION
-from workbench.plugins.exception_handler import exception_logger
 from workbench.widgets.about.presenter import AboutPresenter
 
 # Constants
@@ -172,6 +171,8 @@ def create_and_launch_workbench(app, command_line_options):
 
         # decorates the excepthook callback with the reference to the main window
         # this is used in case the user wants to terminate the workbench from the error window shown
+        from workbench.plugins.exception_handler import exception_logger
+
         sys.excepthook = partial(exception_logger, main_window)
 
         # Load matplotlib as early as possible and set our defaults

--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -114,11 +114,11 @@ def initialize():
 
 
 def initialise_qapp_and_launch_workbench(command_line_options):
-    # It is very important the global figure manager in matplotlib is initialised before the first import of matplotlib.
     from workbench.plotting.config import init_mpl_gcf
 
-    # if "matplotlib" in sys.modules:
-    #    raise RuntimeError("matplotlib has been imported before the global figure manager was initialised")
+    # It is very important this assertion is met. If matplotlib is imported before we set the 'Gcf' object to our
+    # custom global figure manager, then the plotting in mantid will be broken.
+    assert "matplotlib.backend_bases" not in sys.modules
 
     init_mpl_gcf()
 

--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -116,8 +116,11 @@ def initialize():
 
 
 def initialise_qapp_and_launch_workbench(command_line_options):
-    # Set the global figure manager in matplotlib. Very important this happens first.
+    # It is very important the global figure manager in matplotlib is initialised before the first import of matplotlib.
     from workbench.plotting.config import init_mpl_gcf
+
+    if "matplotlib" in sys.modules:
+        raise RuntimeError("matplotlib has been imported before the global figure manager was initialised")
 
     init_mpl_gcf()
 

--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -17,7 +17,6 @@ import multiprocessing
 from mantid.api import FrameworkManagerImpl
 from mantid.kernel import ConfigService, UsageService, version_str as mantid_version_str
 from mantidqt.utils.qt import plugins
-from mantidqt.dialogs.errorreports import main as errorreports_main
 import mantidqt.utils.qt as qtutils
 
 # Find Qt plugins for development builds on some platforms
@@ -119,8 +118,8 @@ def initialise_qapp_and_launch_workbench(command_line_options):
     # It is very important the global figure manager in matplotlib is initialised before the first import of matplotlib.
     from workbench.plotting.config import init_mpl_gcf
 
-    if "matplotlib" in sys.modules:
-        raise RuntimeError("matplotlib has been imported before the global figure manager was initialised")
+    # if "matplotlib" in sys.modules:
+    #    raise RuntimeError("matplotlib has been imported before the global figure manager was initialised")
 
     init_mpl_gcf()
 
@@ -147,6 +146,7 @@ def start_error_reporter():
     """
     Used to start the error reporter if the program has segfaulted.
     """
+    from mantidqt.dialogs.errorreports import main as errorreports_main
 
     errorreports_main.main(["--application", APPNAME, "--orgname", ORGANIZATION, "--orgdomain", ORG_DOMAIN])
 

--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -114,11 +114,8 @@ def initialize():
 
 
 def initialise_qapp_and_launch_workbench(command_line_options):
+    # Set the global figure manager in matplotlib. Very important this happens first.
     from workbench.plotting.config import init_mpl_gcf
-
-    # It is very important this assertion is met. If matplotlib is imported before we set the 'Gcf' object to our
-    # custom global figure manager, then the plotting in mantid will be broken.
-    assert "matplotlib.backend_bases" not in sys.modules
 
     init_mpl_gcf()
 

--- a/qt/applications/workbench/workbench/plotting/config.py
+++ b/qt/applications/workbench/workbench/plotting/config.py
@@ -45,8 +45,9 @@ def init_mpl_gcf():
     """
     Replace vanilla Gcf with our custom manager
     """
-    # It is very important this assertion is met. If matplotlib is imported before we set the 'Gcf' object to our
-    # custom global figure manager, then the plotting in mantid will be broken.
+    # It is very important this assertion is met. If the matplotlib backend is imported
+    # before we set the 'Gcf' object to our custom global figure manager, then the plotting
+    # in Mantid will be broken.
     assert "matplotlib.backend_bases" not in sys.modules
 
     setattr(_pylab_helpers, "Gcf", GlobalFigureManager)

--- a/qt/applications/workbench/workbench/plotting/config.py
+++ b/qt/applications/workbench/workbench/plotting/config.py
@@ -10,6 +10,7 @@
 # system imports
 
 # 3rd-party imports
+import sys
 import warnings
 
 import matplotlib as mpl
@@ -44,6 +45,10 @@ def init_mpl_gcf():
     """
     Replace vanilla Gcf with our custom manager
     """
+    # It is very important this assertion is met. If matplotlib is imported before we set the 'Gcf' object to our
+    # custom global figure manager, then the plotting in mantid will be broken.
+    assert "matplotlib.backend_bases" not in sys.modules
+
     setattr(_pylab_helpers, "Gcf", GlobalFigureManager)
 
 


### PR DESCRIPTION
**Description of work**
Prior to this PR, calling the following in a python script in Mantid was not showing the plot
```python
import matplotlib.pyplot as plt
# Do a plot here ...
plt.show()
```

The reason why this was is because the `get_all_fig_managers` call in the `show` function was returning an empty list
https://github.com/matplotlib/matplotlib/blob/f71555a005ae918b882b07195ab79a71d9b691c8/lib/matplotlib/backend_bases.py#L3406
It should have been calling the `GlobalFigureManager::get_all_fig_managers` function provided in Mantid, but instead it was calling the in-build Gcf `get_all_fig_managers` function, thereby returning an empty list.

The reason why this was happening is because matplotlib backend was being imported earlier than when we set the 'Gcf' to be the GlobalFigureManager on this line
https://github.com/mantidproject/mantid/blob/de4ef237c4eca38bb60ddfd5b8090c39513c776c/qt/applications/workbench/workbench/plotting/config.py#L47

Therefore, the point at which the Gcf class gets imported into the matplotlib `backend_bases` file, it is still the build-in Gcf and not the GlobalFigureManager
https://github.com/matplotlib/matplotlib/blob/f71555a005ae918b882b07195ab79a71d9b691c8/lib/matplotlib/backend_bases.py#L49

This meant that calling `show()` would therefore not be using our GlobalFigureManager defined [here](https://github.com/mantidproject/mantid/blob/de4ef237c4eca38bb60ddfd5b8090c39513c776c/qt/applications/workbench/workbench/plotting/globalfiguremanager.py#L64), but instead it would use the built-in Gcf defined in the matplotlib backend.


We now have an important assert statement which checks to see if the matplotlib backend has been imported before the `init_mpl_gcf` function has run. If the backend **has** been imported, then an AssertionError is raised alerting the developer that plotting in Mantid is broken because the import order has changed.

No release note required as this is a regression since last release.

**To test:**
Run the script in the attached issue, and ensure the plot window is opened.

Fixes #36105

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.