### PR TITLE
Clip colorbar range in Sliceviewer

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -361,8 +361,10 @@ class ColorbarWidget(QWidget):
     def _calculate_auto_color_limits(self, signal):
         """Calculate auto scale limits"""
         scale_type = AUTO_SCALE_OPTS[self.autotype.currentIndex()]
+        signal_min, signal_max = np.nanmin(signal), np.nanmax(signal)
+
         if scale_type == "Min/Max":
-            vmin, vmax = np.nanmin(signal), np.nanmax(signal)
+            vmin, vmax = signal_min, signal_max
         elif scale_type == "3-Sigma":
             mean, sigma = np.nanmean(signal), np.nanstd(signal)
             vmin, vmax = mean - 3 * sigma, mean + 3 * sigma
@@ -373,6 +375,10 @@ class ColorbarWidget(QWidget):
             med = np.nanmedian(signal)
             mad = np.nanmedian(np.abs(signal - med))
             vmin, vmax = med - 1.5 * mad, med + 1.5 * mad
+
+        vmin = max(vmin, signal_min)
+        vmax = min(vmax, signal_max)
+
         # sanity checks
         if self._is_log_norm():
             if vmax <= 0:


### PR DESCRIPTION
**Description of work**
New autoscale options set colour limits outside the range of data in the Sliceviewer. This pull request limits bar values to the range of the data.
**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
The colour bar limits might get outside the range of the data
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
In '_calculate_auto_color_limits', 'vmin'/'vmax' are clipped by data max/min values after applying the selected option.
**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**
(1) Make a workspace
```
md_4D = CreateMDWorkspace(Dimensions=4, Extents=[0,2,-1,1,-1.5,1.5,-0.25,0.25], Names="H,K,L,E", Frames='HKL,HKL,HKL,General Frame',Units='r.l.u.,r.l.u.,r.l.u.,meV')
FakeMDEventData(InputWorkspace=md_4D, UniformParams='5e5') # 4D data
FakeMDEventData(InputWorkspace=md_4D, UniformParams='1e5,0.5,1.5,-0.5,0.5,-0.75,0.75,-0.1,0.1') # 4D data

# Add a non-orthogonal UB
expt_info = CreateSampleWorkspace()
md_4D.addExperimentInfo(expt_info)
SetUB(Workspace='md_4D', c=2, gamma=120)

md_3D_histo = BinMD(InputWorkspace='md_4D', AlignedDim0='H,-2,2,100', AlignedDim1='K,-1,1,100', AlignedDim2='L,-1.5,1.5,100')
```
(2)  Open `md_3D_histo` in sliceviewer
(3) Check autoscale under the colorbar
(4) Make a note of the min and max
(5) Select 3-sigma from dropdown-box under autoscale checkbox
(6) Note that the colorbar minimum must be 0, and its maximum should be +3 sigma (less than the data max value).

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #36087. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.