### PR TITLE
Prevent premature import of CrashReportPage

### DIFF
--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -186,6 +186,13 @@ def create_and_launch_workbench(app, command_line_options):
         FrameworkManagerImpl.Instance()
         main_window.post_mantid_init()
 
+        # This will check the current version. This is here in this form
+        # because previously this import would happen earlier in the startup process,
+        # which would then cause several side effects, one of which was the
+        # FrameworkManager being created prematurely. This was evident by the
+        # welcome message not appearing in the message window in Workbench.
+        from mantidqt.dialogs.errorreports.report import CrashReportPage  # noqa
+
         if main_window.splash:
             main_window.splash.hide()
 

--- a/qt/applications/workbench/workbench/plugins/exception_handler/__init__.py
+++ b/qt/applications/workbench/workbench/plugins/exception_handler/__init__.py
@@ -27,9 +27,7 @@ def exception_logger(main_window, exc_type, exc_value, exc_traceback):
     logger.error("".join(traceback.format_exception(exc_type, exc_value, exc_traceback)))
 
     if UsageService.isEnabled():
-        from mantidqt.dialogs.errorreports.report import CrashReportPage
-
-        page = CrashReportPage(show_continue_terminate=True)
+        page = create_crash_report_page(show_continue_terminate=True)
         presenter = ErrorReporterPresenter(page, "", "workbench", traceback.format_exception(exc_type, exc_value, exc_traceback))
         presenter.show_view_blocking()
         if not page.continue_working:
@@ -37,3 +35,9 @@ def exception_logger(main_window, exc_type, exc_value, exc_traceback):
     else:
         # show the exception message without the traceback
         WorkbenchErrorMessageBox(main_window, "".join(traceback.format_exception_only(exc_type, exc_value))).exec_()
+
+
+def create_crash_report_page(show_continue_terminate):
+    from mantidqt.dialogs.errorreports.report import CrashReportPage
+
+    return CrashReportPage(show_continue_terminate)

--- a/qt/applications/workbench/workbench/plugins/exception_handler/__init__.py
+++ b/qt/applications/workbench/workbench/plugins/exception_handler/__init__.py
@@ -9,7 +9,7 @@ import traceback
 
 from mantid.kernel import UsageService, logger
 from mantidqt.dialogs.errorreports.presenter import ErrorReporterPresenter
-from mantidqt.dialogs.errorreports.report import CrashReportPage
+
 from workbench.plugins.exception_handler.error_messagebox import WorkbenchErrorMessageBox
 
 
@@ -27,6 +27,8 @@ def exception_logger(main_window, exc_type, exc_value, exc_traceback):
     logger.error("".join(traceback.format_exception(exc_type, exc_value, exc_traceback)))
 
     if UsageService.isEnabled():
+        from mantidqt.dialogs.errorreports.report import CrashReportPage
+
         page = CrashReportPage(show_continue_terminate=True)
         presenter = ErrorReporterPresenter(page, "", "workbench", traceback.format_exception(exc_type, exc_value, exc_traceback))
         presenter.show_view_blocking()

--- a/qt/applications/workbench/workbench/plugins/test/test_exception_handler.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_exception_handler.py
@@ -32,9 +32,9 @@ class ExceptionHandlerTest(unittest.TestCase):
         self.assertEqual(1, mock_WorkbenchErrorMessageBox.call_count)
         mock_errorbox.exec_.assert_called_once_with()
 
-    @patch("workbench.plugins.exception_handler.CrashReportPage")
+    @patch("workbench.plugins.exception_handler.create_crash_report_page", autospec=True)
     @patch("workbench.plugins.exception_handler.logger")
-    def test_exception_logged(self, mock_logger, mock_CrashReportPage):
+    def test_exception_logged(self, mock_logger, mock_create_crash_report_page):
         UsageService.setEnabled(True)
 
         widget = MockQWidget()
@@ -42,6 +42,6 @@ class ExceptionHandlerTest(unittest.TestCase):
         exception_logger(widget, ValueError, None, None)
 
         self.assertEqual(1, mock_logger.error.call_count)
-        mock_CrashReportPage.assert_called_once_with(show_continue_terminate=True)
+        mock_create_crash_report_page.assert_called_once_with(show_continue_terminate=True)
         # 'user selects' continue working by default
         self.assertEqual(0, widget.close.call_count)

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/main.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/main.py
@@ -14,7 +14,6 @@ from qtpy import QT_VERSION
 from qtpy.QtCore import QCoreApplication, QSettings
 
 from mantidqt.dialogs.errorreports.presenter import ErrorReporterPresenter
-from mantidqt.dialogs.errorreports.report import CrashReportPage
 import mantidqt.utils.qt as qtutils
 
 
@@ -46,6 +45,8 @@ def main(argv: Sequence[str] = None) -> int:
     app.setOrganizationDomain(command_line_args.org_domain)
     app.setApplicationName(command_line_args.application)
     QSettings.setDefaultFormat(QSettings.IniFormat)
+    from mantidqt.dialogs.errorreports.report import CrashReportPage
+
     form = CrashReportPage(show_continue_terminate=False)
     presenter = ErrorReporterPresenter(form, exit_code_str, command_line_args.application)
     presenter.show_view()

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
@@ -10,7 +10,8 @@ from typing import Optional
 from qtpy.QtCore import QSettings
 
 from mantid.kernel import ConfigService, ErrorReporter, Logger, UsageService
-from mantidqt.dialogs.errorreports.report import MAX_STACK_TRACE_LENGTH
+
+MAX_STACK_TRACE_LENGTH = 10000
 
 
 class ErrorReporterPresenter(object):

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -25,7 +25,6 @@ For example:
 Thank you!"""
 
 PLAIN_TEXT_MAX_LENGTH = 3200
-MAX_STACK_TRACE_LENGTH = 10000
 MANTID_DOWNLOAD_LINK = "http://download.mantidproject.org"
 
 ErrorReportUIBase, ErrorReportUI = load_ui(__file__, "errorreport.ui")

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_presenter.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_presenter.py
@@ -7,8 +7,7 @@
 import unittest
 from unittest import mock
 
-from mantidqt.dialogs.errorreports.presenter import ErrorReporterPresenter
-from mantidqt.dialogs.errorreports.report import MAX_STACK_TRACE_LENGTH
+from mantidqt.dialogs.errorreports.presenter import ErrorReporterPresenter, MAX_STACK_TRACE_LENGTH
 
 
 class ErrorReportPresenterTest(unittest.TestCase):


### PR DESCRIPTION
Importing the CrashReportPage too early will cause a cascade of other imports. One consequence of this is that the FrameworkManager will be created too early, before logging has been setup correctly. This is visible by the welcome message not appearing in the Workbench message window. The changes I've made prevent this import, but then imports the CrashReportPage at a suitably late place, because this is required for the version checker to run. Maybe there's a better way of triggering the version checker.

**Description of work**
The aim was to stop the import of CrashReportPage too early in the startup process
- Added import of CrashReportPage at a "good" location where it doesn't cause problems (as far as I know). This line is to make the version checker run. Alternative solutions to making the version checker run are welcome, I didn't want to perform too much surgery right before release.
- Moved imports of CrashReportPage from the top of the file to where it's used, in a couple of places.
- Moved MAX_STACK_TRACE_LENGTH to the class where it's used to prevent an import.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes #36095 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Check the welcome message appears in the messages window in Workbench on startup. Could also try making Workbench crash (especially early on the startup process) and checking that the error reporter is still working. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **it fixes a regression**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.