### PR TITLE
Fix bug in sliceviewer to exclude non-Q components from basis vectors in proj matrix

### DIFF
--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -648,6 +648,42 @@ class SliceViewerTestCreateMDEvent(systemtesting.MantidSystemTest, HelperTesting
         pres.view.close()
 
 
+class SliceViewerTestCreateMDHisto(systemtesting.MantidSystemTest, HelperTestingClass):
+    def runTest(self):
+        HelperTestingClass.__init__(self)
+
+        ws_4D_histo = CreateMDWorkspace(
+            Dimensions="4",
+            Extents="-3,3,-3,3,-3,3,-1,1",
+            Names="H,K,L,E",
+            Units="r.l.u.,r.l.u.,r.l.u.,meV",
+            Frames="HKL,HKL,HKL,General Frame",
+            SplitInto="2",
+            SplitThreshold="10",
+        )
+        expt_info = CreateSampleWorkspace()
+        ws_4D_histo.addExperimentInfo(expt_info)
+        SetUB(ws_4D_histo, 1, 1, 2, 90, 90, 120)
+        binned_ws = BinMD(
+            InputWorkspace=ws_4D_histo,
+            AxisAligned=False,
+            BasisVector0="L,r.l.u.,0,0,1,0",
+            BasisVector1="E,meV,0,0,0,1",
+            BasisVector2="H,r.l.u.,1,0,0,0",
+            BasisVector3="K,r.l.u.,0,1,0,0",
+            OutputExtents="-3,3,-1,1,-3,3,-3,3",
+            OutputBins="11,11,11,11",
+            OutputWorkspace="ws_4D_slice_axis_aligned",
+            NormalizeBasisVectors=False,
+        )
+
+        binned_ws.clearOriginalWorkspaces()
+
+        pres = SliceViewer(binned_ws)
+        self.assertListEqual(pres.get_proj_matrix().tolist(), [[0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]])
+        pres.view.close()
+
+
 # private helper functions
 def toolbar_actions(presenter, text_labels):
     """

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -529,10 +529,10 @@ class SliceViewerModel(SliceViewerBaseModel):
         return proj_matrix
 
     def projection_matrix_from_basis(self, ws):
-        proj_matrix = np.eye(3)
         ndims = ws.getNumDims()
         basis_matrix = np.zeros((ndims, ndims))
         if len(list(ws.getBasisVector(0))) == ndims:  # basis vectors valid
+            proj_matrix = np.eye(3)
             for idim in range(ndims):
                 basis_matrix[:, idim] = list(ws.getBasisVector(idim))
             # find columns of basis_matrix to keep (corresponding axes that are momentum transfer)
@@ -544,7 +544,9 @@ class SliceViewerModel(SliceViewerBaseModel):
             # extract proj matrix from basis vectors of q dimension
             # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
             proj_matrix[: q_comps.sum(), : q_comps.sum()] = basis_matrix[q_comps, :][:, q_axes]
-        return proj_matrix
+            return proj_matrix
+        else:
+            return np.zeros((3, 3))  # singular matrix should be ignored
 
     def get_proj_matrix(self):
         ws = self._get_ws()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -529,19 +529,21 @@ class SliceViewerModel(SliceViewerBaseModel):
         return proj_matrix
 
     def projection_matrix_from_basis(self, ws):
-        proj_matrix = np.zeros((3, 3))
+        proj_matrix = np.eye(3)
         ndims = ws.getNumDims()
         basis_matrix = np.zeros((ndims, ndims))
         if len(list(ws.getBasisVector(0))) == ndims:  # basis vectors valid
             for idim in range(ndims):
                 basis_matrix[:, idim] = list(ws.getBasisVector(idim))
-            # exclude non-Q dim elements from basis vectors
-            qflags = np.array([ws.getDimension(idim).getMDFrame().isQ() for idim in range(ndims)])
-            i_nonq = np.flatnonzero(np.invert(qflags))
-            qmask = np.invert(basis_matrix[:, i_nonq] == 1).ravel()
+            # find columns of basis_matrix to keep (corresponding axes that are momentum transfer)
+            q_axes = np.array([ws.getDimension(idim).getMDFrame().isQ() for idim in range(ndims)])
+            # find rows of basis matrix to exclude (corresponding to non-momentum components of basis vectors)
+            # note this depends on the order of the axes in the original workspace
+            i_nonq_axes = np.flatnonzero(np.invert(q_axes))
+            q_comps = np.invert(basis_matrix[:, i_nonq_axes].any(axis=1))
             # extract proj matrix from basis vectors of q dimension
             # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
-            proj_matrix[: qmask.sum(), : qflags.sum()] = basis_matrix[qmask, :][:, qflags]
+            proj_matrix[: q_comps.sum(), : q_comps.sum()] = basis_matrix[q_comps, :][:, q_axes]
         return proj_matrix
 
     def get_proj_matrix(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -507,9 +507,10 @@ class SliceViewerModelTest(unittest.TestCase):
         ws.getExperimentInfo().run().get().value = [0, 1, 1, 0, 0, 1, 1, 0, 0]
         model = SliceViewerModel(ws)
 
-        # should revert to orthogonal
+        # should revert to orthogonal (as given by basis vectors on workspace)
+        # i.e. not angles returned by proj_matrix in ws.getExperimentInfo().run().get().value
         axes_angles = model.get_axes_angles()
-        self.assertAlmostEqual(axes_angles[1, 2], np.pi / 4, delta=1e-10)
+        self.assertAlmostEqual(axes_angles[1, 2], np.pi / 2, delta=1e-10)
         for iy in range(1, 3):
             self.assertAlmostEqual(axes_angles[0, iy], np.pi / 2, delta=1e-10)
 
@@ -538,7 +539,7 @@ class SliceViewerModelTest(unittest.TestCase):
     def test_calculate_axes_angles_uses_W_if_basis_vectors_unavailable_and_W_available_MDHisto(self):
         # test MD histo
         ws = _create_mock_workspace(IMDHistoWorkspace, SpecialCoordinateSystem.HKL, has_oriented_lattice=True, ndims=3)
-        ws.getBasisVector.side_effect = lambda x: [0.0]
+        ws.getBasisVector.side_effect = lambda x: [0.0]  # will cause proj_matrix to be all zeros
         ws.getExperimentInfo().run().get().value = [0, 1, 1, 0, 0, 1, 1, 0, 0]
         model = SliceViewerModel(ws)
 


### PR DESCRIPTION
**Summary of work**
This was introduced in #35812 - there was a bug here but I think this didn't fix it!

Instead the `proj_matrix` would end up singular and it would default to the identity matrix because of this check
https://github.com/mantidproject/mantid/blob/291276d1b3f92d519f399310a3ef5f5d4a7c3d7f/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py#L555
which allowed the workspace to be opened, but it wasn't necessarily getting the right basis vectors

The root of the issue was here 
https://github.com/mantidproject/mantid/blob/291276d1b3f92d519f399310a3ef5f5d4a7c3d7f/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py#L541
It should have been 
`qmask = np.invert(basis_matrix[:, i_nonq].astype(bool).sum(axis=1).astype(bool))`
i.e. looking for the `i_nonq` columns of `basis_matrix` with rows which are non-zero (as opposed to the `i_nonq` rows in `basis_matrix` with non-zero columns which is what was happening prior to #35812).

The above is a bit messy so I have simplified it using `any` and have added some comments and renamed some variables to hopefully make this clearer.

**To test:**

(1) Run this script
```
ws_4D = CreateMDWorkspace(Dimensions='4', Extents='-3,3,-3,3,-3,3,-1,1',
                        Names='H,K,L,E', Units='r.l.u.,r.l.u.,r.l.u.,meV',
                        Frames='HKL,HKL,HKL,General Frame',
                        SplitInto='2', SplitThreshold='10')
expt_info = CreateSampleWorkspace()
ws_4D.addExperimentInfo(expt_info)
SetUB(ws_4D, 1,1,2,90,90,120)
ws_4D_slice = BinMD(InputWorkspace=ws_4D, AxisAligned=False,
                     BasisVector0='[00L],r.l.u.,0,0,1,0',
                     BasisVector1='E,meV,0,0,0,1',
                     BasisVector2='[HH0],r.l.u.,1,1,0,0',
                     BasisVector3='[-HH0],r.l.u.,-1,1,0,0',
                     OutputExtents='-3,3,-1,1,-3,3,-3,3',
                     OutputBins='11,11,11,11', OutputWorkspace="ws_4D_slice", NormalizeBasisVectors=False)
    

ws_4D_slice_axis_aligned = BinMD(InputWorkspace=ws_4D, AxisAligned=False,
                                 BasisVector0='L,r.l.u.,0,0,1,0',
                                 BasisVector1='E,meV,0,0,0,1',
                                 BasisVector2='H,r.l.u.,1,0,0,0',
                                 BasisVector3='K,r.l.u.,0,1,0,0',
                                 OutputExtents='-3,3,-1,1,-3,3,-3,3',
                                 OutputBins='11,11,11,11', OutputWorkspace="ws_4D_slice_axis_aligned", NormalizeBasisVectors=False)
```
(2) Open `ws_4D_slice` in sliceviewer and check non-orthogonal view is only enabled when non-Q axes are viewed (i.e. not E)
(3) When non-orthogonal view is enabled the gridlines should be orthogonal 
(4) Open `ws_4D_slice_axis_aligned`  and check non-orthogonal view is only enabled when non-Q axes are viewed (i.e. not E)
(5) When non-orthogonal view is enabled and L is one of the viewing axes the girdlines are orthogonal, if H and K are viewed the gridlines are nonorthogonal

Fixes #36080 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.