### PR TITLE
Fix GUI hang when eng diff peak type invalid

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -151,6 +151,9 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         This is called after Fit finishes to update the fit curves.
         :param name: The name of Fit's output workspace.
         """
+        if not name:
+            self.fit_notifier.notify_subscribers([self.get_fitprop()])
+            return
         super(EngDiffFitPropertyBrowser, self).fitting_done_slot(name)
         self.save_current_setup(self.workspaceName())
         self.fit_notifier.notify_subscribers([self.get_fitprop()])

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -152,7 +152,7 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         :param name: The name of Fit's output workspace.
         """
         if not name:
-            self.fit_notifier.notify_subscribers([self.get_fitprop()])
+            self.fit_notifier.notify_subscribers([])
             return
         super(EngDiffFitPropertyBrowser, self).fitting_done_slot(name)
         self.save_current_setup(self.workspaceName())

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
@@ -66,13 +66,16 @@ class FittingPresenter(object):
     def fit_done(self, fit_props):
         # triggered in the fit property browser
         self.enable_view()
-        self.plot_widget.set_final_state_progress_bar(fit_props)
-        self.plot_widget.fit_completed(
-            fit_props,
-            self.data_widget.presenter.get_loaded_ws_list(),
-            self.data_widget.presenter.get_active_ws_list(),
-            self.data_widget.presenter.get_log_ws_group_name(),
-        )
+        if fit_props:
+            self.plot_widget.set_final_state_progress_bar(fit_props)
+            self.plot_widget.fit_completed(
+                fit_props,
+                self.data_widget.presenter.get_loaded_ws_list(),
+                self.data_widget.presenter.get_active_ws_list(),
+                self.data_widget.presenter.get_log_ws_group_name(),
+            )
+        else:
+            self.plot_widget.set_final_state_progress_bar(None, status="Failed, invalid fit.")
 
     def disable_view(self, _=None, fit_all=False):
         self.data_widget.view.setEnabled(False)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/test/test_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/test/test_presenter.py
@@ -206,6 +206,21 @@ class FittingPresenterTest(unittest.TestCase):
             [mock.call.enable(), mock.call.progress_bar(fitprop_list), mock.call.fit_completed(fitprop_list, [], [], "")]
         )
 
+    def test_fit_done_call_order_failed_fit(self):
+        self.presenter.data_widget.presenter.model.get_all_log_workspaces_names = mock.MagicMock(return_value=[])
+        mock_manager = mock.Mock()
+        self.presenter.enable_view = mock.MagicMock()
+        self.presenter.plot_widget.set_final_state_progress_bar = mock.MagicMock()
+        self.presenter.plot_widget.fit_completed = mock.MagicMock()
+        mock_manager.enable, mock_manager.progress_bar = (
+            self.presenter.enable_view,
+            self.presenter.plot_widget.set_final_state_progress_bar,
+        )
+
+        self.presenter.fit_done([])
+        mock_manager.assert_has_calls([mock.call.enable(), mock.call.progress_bar(None, status="Failed, invalid fit.")])
+        self.presenter.plot_widget.fit_completed.assert_not_called()
+
     def test_enable_view_not_fit_all(self):
         self.presenter.data_widget.view.setEnabled = mock.MagicMock()
         self.presenter.plot_widget.enable_view_components = mock.MagicMock()

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1635,8 +1635,14 @@ void FitPropertyBrowser::doFit(int maxIterations) {
       }
     }
     observeFinish(alg);
-    alg->executeAsync();
+    Poco::ActiveResult<bool> result(alg->executeAsync());
     m_fitAlgParameters = alg->toString();
+    while (!result.available()) {
+      QCoreApplication::processEvents();
+    }
+    if (!result.error().empty()) {
+      emit algorithmFinished(QString());
+    }
   } catch (const std::exception &e) {
     QString msg = "Fit algorithm failed.\n\n" + QString(e.what()) + "\n";
     QMessageBox::critical(this, "Mantid - Error", msg);


### PR DESCRIPTION
**Description of work**

**Purpose of work**
Fix bug in Eng Diff when mistakenly selecting elastic peaks. These aren't valid, so it throws an error which cannot be caught by the interface to reactivate the GUI. 

**Summary of work**
Add a signal emit to the property browser to send a AlgorithmFinished signal even if the fitting results in an error. Then catch it in the engineering GUI so that the interface can be re-enabled. 

**To test:**

1. Download this file [ENGINX_305761_307521_bank_1_TOF.nxs.zip](https://github.com/mantidproject/mantid/files/12674607/ENGINX_305761_307521_bank_1_TOF.nxs.zip)
2. Load it into the Engineering Diffraction GUI's fitting tab (browse -> select file -> Add to plot -> load)
3. On the plot, click the fit button to open the fit property browser
4. Add an elastic peak to the plot
5. Fit > Fit
6. Should run without errors


Fixes #36091 


*This does not require release notes* because **regression**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.