### PR TITLE
Prevent premature import of CrashReportPage

### DIFF
--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -11,7 +11,6 @@ from qtpy.QtWidgets import QMessageBox
 
 from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.utils.qt import load_ui
-from mantid.simpleapi import CheckMantidVersion
 
 from .details import MoreDetailsDialog
 
@@ -39,7 +38,6 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
     CONTACT_INFO = "ContactInfo"
     NAME = "Name"
     EMAIL = "Email"
-    _, _, newer_version_available = CheckMantidVersion()
 
     def __init__(self, parent=None, show_continue_terminate=False):
         super(self.__class__, self).__init__(parent)
@@ -63,7 +61,11 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         self.icon.setPixmap(QtGui.QPixmap(":/images/crying_mantid.png"))
 
         self.requestTextBrowser.anchorClicked.connect(self.interface_manager.showWebPage)
-        if self.newer_version_available:
+
+        from mantid.simpleapi import CheckMantidVersion
+
+        _, _, newer_version_available = CheckMantidVersion()
+        if newer_version_available:
             msg = (
                 "<span style=\" font-family:'.SF NS Text'; font-size:12pt; color:#000000;\">"
                 "Warning: your version of MantidWorkbench is out of date.<br>"


### PR DESCRIPTION
Importing the CrashReportPage too early will cause a cascade of other imports. One consequence of this is that the FrameworkManager will be created too early, before logging has been setup correctly. This is visible by the welcome message not appearing in the Workbench message window. 

**Description of work**
The aim was to stop the import of CrashReportPage too early in the startup process
- Moved import of CrashReportPage from the top of the file to where it's used, which is somewhere not called in the startup process.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes #36095 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Check the welcome message appears in the messages window in Workbench on startup. Could also try making Workbench crash (especially early on the startup process) and checking that the error reporter is still working. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **it fixes a regression**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.