### PR TITLE
Propagate C++ exception to python for `createDialogFromName`

### DIFF
--- a/qt/python/mantidqt/mantidqt/_common.sip
+++ b/qt/python/mantidqt/mantidqt/_common.sip
@@ -347,6 +347,19 @@ public:
       const QString &optionalMsg = QString(),
       const QStringList &enabled = QStringList(),
       const QStringList &disabled = QStringList());
+  %MethodCode
+  try {
+    return sipCpp->createDialogFromName(*a0, a1, a2, a3, *a4, *a5, *a6, *a7);
+  } catch(const std::exception & exc) {
+    SIP_BLOCK_THREADS
+    PyErr_SetString(PyExc_RuntimeError, exc.what());
+    SIP_UNBLOCK_THREADS
+    return NULL;
+  } catch(...) {
+    sipRaiseUnknownException();
+    return NULL;
+  }
+ %End
 
   UserSubWindow *createSubWindow(
       const QString &interface_name,

--- a/qt/python/mantidqt/mantidqt/_common.sip
+++ b/qt/python/mantidqt/mantidqt/_common.sip
@@ -339,25 +339,14 @@ class InterfaceManager {
 using namespace MantidQt::API;
 %End
 public:
-  InterfaceManager();
+  InterfaceManager() throw(std::exception);
   AlgorithmDialog *createDialogFromName(
       const QString &algorithmName, const int version = -1,
       QWidget *parent = nullptr, bool forScript = false,
       const QHash<QString, QString> &presetValues = QHash<QString, QString>(),
       const QString &optionalMsg = QString(),
       const QStringList &enabled = QStringList(),
-      const QStringList &disabled = QStringList());
-  %MethodCode
-  try {
-    sipRes = sipCpp->createDialogFromName(*a0, a1, a2, a3, *a4, *a5, *a6, *a7);
-  } catch(const std::exception & exc) {
-    SIP_BLOCK_THREADS
-    PyErr_SetString(PyExc_RuntimeError, exc.what());
-    SIP_UNBLOCK_THREADS
-  } catch(...) {
-    sipRaiseUnknownException();
-  }
- %End
+      const QStringList &disabled = QStringList()) throw(std::exception);
 
   UserSubWindow *createSubWindow(
       const QString &interface_name,

--- a/qt/python/mantidqt/mantidqt/_common.sip
+++ b/qt/python/mantidqt/mantidqt/_common.sip
@@ -349,15 +349,13 @@ public:
       const QStringList &disabled = QStringList());
   %MethodCode
   try {
-    return sipCpp->createDialogFromName(*a0, a1, a2, a3, *a4, *a5, *a6, *a7);
+    sipRes = sipCpp->createDialogFromName(*a0, a1, a2, a3, *a4, *a5, *a6, *a7);
   } catch(const std::exception & exc) {
     SIP_BLOCK_THREADS
     PyErr_SetString(PyExc_RuntimeError, exc.what());
     SIP_UNBLOCK_THREADS
-    return NULL;
   } catch(...) {
     sipRaiseUnknownException();
-    return NULL;
   }
  %End
 

--- a/qt/python/mantidqt/sip/exceptions.sip
+++ b/qt/python/mantidqt/sip/exceptions.sip
@@ -2,6 +2,20 @@
 // Exceptions
 // ----------------------------------------------------------------------------
 
+%Exception std::exception(SIP_Exception) /PyName=BaseCppError/
+{
+%TypeHeaderCode
+#include <exception>
+%End
+%RaiseCode
+    const char *detail = sipExceptionRef.what();
+
+    SIP_BLOCK_THREADS
+    PyErr_SetString(PyExc_Exception, detail);
+    SIP_UNBLOCK_THREADS
+%End
+};
+
 %Exception std::runtime_error(SIP_Exception) /PyName=RuntimeError/
 {
 %TypeHeaderCode


### PR DESCRIPTION
**Description of work**
This PR ensures that the 'unknown' exceptions we are seeing in our #error-reports channel get propagated from C++ through to the python layer.
https://mantid.slack.com/archives/CPXMTE49L/p1695116309091469

I would like this to be considered for the `release-next` branch as I believe it would be useful to get this in for the next release so that we can get better error reports for the "createDialogFromName" failures.

**To test:**
1. Add a line to this file which throws a std::runtime_error or another exception on this line
https://github.com/mantidproject/mantid/blob/0793eaa482cfd3e64986bb53c90f2ebff83b77c5/qt/widgets/common/src/InterfaceManager.cpp#L140
2. build Mantid
3. On git bash, run the `python` shell
```sh
PYTHONPATH=<path_to_build_bin_folder> python
```
5. From this python shell, import the InterfaceManager and call the `createDialogFromName` function
```py
import mantid  # Needed to start the FrameworkManager
from mantidqt.interfacemanager import InterfaceManager
dialog = InterfaceManager().createDialogFromName("Rebin")
```
6. You should get the full exception message in your output, rather than just "Exception: unknown"

*There is no associated issue.* Its related to #36127 

This does not require release notes as it is more useful for developers rather than users.

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.