### PR TITLE
AlignAndFocusPowderFromFiles: get value from StringArrayProperty to add the values to a list

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -291,8 +291,8 @@ class AlignAndFocusPowderFromFiles(DataProcessorAlgorithm):
                 try:
                     # put together list of logs that matter, all the others will be skipped
                     allowedLogs = []
-                    allowedLogs.extend(self.getProperty("FrequencyLogNames"))
-                    allowedLogs.extend(self.getProperty("WaveLengthLogNames"))
+                    allowedLogs.extend(self.getProperty("FrequencyLogNames").value)
+                    allowedLogs.extend(self.getProperty("WaveLengthLogNames").value)
                     # MetaDataOnly=True is only supported by LoadEventNexus
                     loader = self.__createLoader(filename, tempname, MetaDataOnly=True, AllowList=allowedLogs)
                     loader.execute()


### PR DESCRIPTION
**Description of work**
Resolves #36118 
Fix bug where an exception is raised when we try to extend a `list` with a `StringArrayProperty`. Get the values as a `list` first.

**To test:**
Run the following command on ORNL's analysis cluster:

```
from mantid.simpleapi import *

SNSPowderReduction(Filename='/SNS/PG3/IPTS-30920/nexus/PG3_55878.nxs.h5',
                   CalibrationFile='/SNS/PG3/shared/CALIBRATION/2023-1_11A_CAL/PG3_HT_JANIS_d52420_2022_02_22.h5',
                   CharacterizationRunsFile='/SNS/PG3/shared/CALIBRATION/2023-1_11A_CAL/PG3_char_2023_18_Jul-HighRes_JANIS_HT_1.4MW.txt,/SNS/PG3/shared/CALIBRATION/2023-1_11A_CAL/PG3_char_2023_18_Jul_JANIS_HT_limit.txt',
                   RemovePromptPulseWidth=50,
                   Binning='-0.0008',
                   BackgroundSmoothParams='5, 2',
                   FilterBadPulses=90,
                   ScaleData=100,
                   SaveAs='gsas topas and fullprof',
                   OutputDirectory='/SNS/PG3/IPTS-30920/shared/autoreduce//',
                   CacheDir='/SNS/PG3/IPTS-30920/shared/autoreduce//caching')
```


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #36118 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->


*This does not require release notes* because it is a bug fix

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.