### PR TITLE
Implement EventList generateHistogram without sorting, use within AlignAndFocusPowder

### DIFF
--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -328,7 +328,8 @@ void Rebin::exec() {
         const EventList &el = eventInputWS->getSpectrum(i);
         MantidVec y_data, e_data;
         // The EventList takes care of histogramming.
-        el.generateHistogram(XValues_new.rawData(), y_data, e_data);
+        el.generateHistogram(rbParams[0], rbParams[1], rbParams[2], XValues_new.rawData(), y_data,
+                             e_data); // Hack to test functionally, remove before flight
 
         // Copy the data over.
         outputWS->mutableY(i) = y_data;

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -328,8 +328,9 @@ void Rebin::exec() {
         const EventList &el = eventInputWS->getSpectrum(i);
         MantidVec y_data, e_data;
         // The EventList takes care of histogramming.
-        el.generateHistogram(rbParams[1], XValues_new.rawData(), y_data,
-                             e_data); // Hack to test functionally, remove before flight
+        el.generateHistogram(
+            rbParams[1], XValues_new.rawData(), y_data,
+            e_data); // Hack to test functionally, will only work for linear and log binning, remove before flight
 
         // Copy the data over.
         outputWS->mutableY(i) = y_data;

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -328,7 +328,7 @@ void Rebin::exec() {
         const EventList &el = eventInputWS->getSpectrum(i);
         MantidVec y_data, e_data;
         // The EventList takes care of histogramming.
-        el.generateHistogram(rbParams[0], rbParams[1], rbParams[2], XValues_new.rawData(), y_data,
+        el.generateHistogram(rbParams[1], XValues_new.rawData(), y_data,
                              e_data); // Hack to test functionally, remove before flight
 
         // Copy the data over.

--- a/Framework/Algorithms/test/RebinTest.h
+++ b/Framework/Algorithms/test/RebinTest.h
@@ -1393,6 +1393,35 @@ public:
     }
   }
 
+  void test_histogram_unsorted_linear() { do_test_unsorted(false, "0.0,4.0,100"); }
+
+  void test_histogram_unsorted_linear2() { do_test_unsorted(false, "4.0"); }
+
+  void test_histogram_unsorted_varying_step() { do_test_unsorted(true, "0.0,2.0,50,4.0,100"); }
+
+  void test_histogram_unsorted_log() { do_test_unsorted(false, "1.0,-1,100"); }
+
+  void test_histogram_unsorted_reverse_log() { do_test_unsorted(true, "1.0,-1,100", true); }
+
+  void test_histogram_unsorted_power() { do_test_unsorted(true, "1.0,0.5,100", false, 0.5); }
+
+  void do_test_unsorted(bool expectSorted, std::string params, bool useReverseLogarithmic = false, double power = 0) {
+    EventWorkspace_sptr test_in = WorkspaceCreationHelper::createEventWorkspace2(50, 100);
+
+    Rebin rebin;
+    rebin.initialize();
+    rebin.setProperty("InputWorkspace", test_in);
+    rebin.setPropertyValue("OutputWorkspace", "output");
+    rebin.setProperty("Params", params);
+    rebin.setProperty("Power", power);
+    rebin.setProperty("UseReverseLogarithmic", useReverseLogarithmic);
+    rebin.setProperty("PreserveEvents", false);
+    TS_ASSERT(rebin.execute());
+    TS_ASSERT(rebin.isExecuted());
+
+    TS_ASSERT_EQUALS(test_in->getSpectrum(0).isSortedByTof(), expectSorted);
+  }
+
 private:
   Workspace2D_sptr Create1DWorkspace(int size) {
     auto retVal = createWorkspace<Workspace2D>(1, size, size - 1);

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -205,8 +205,8 @@ public:
                          EventList *destination);
   // get EventType declaration
   void generateHistogram(const MantidVec &X, MantidVec &Y, MantidVec &E, bool skipError = false) const override;
-  void generateHistogram(const double xmin, const double step, const double xmax, const MantidVec &X, MantidVec &Y,
-                         MantidVec &E, bool skipError = false) const;
+  void generateHistogram(const double step, const MantidVec &X, MantidVec &Y, MantidVec &E,
+                         bool skipError = false) const;
   void generateHistogramPulseTime(const MantidVec &X, MantidVec &Y, MantidVec &E,
                                   bool skipError = false) const override;
 
@@ -354,8 +354,7 @@ private:
                                                                      const double &tofOffset) const;
 
   void generateCountsHistogram(const MantidVec &X, MantidVec &Y) const;
-  void generateCountsHistogram(const double xmin, const double step, const double xmax, const MantidVec &X,
-                               MantidVec &Y) const;
+  void generateCountsHistogram(const double step, const MantidVec &X, MantidVec &Y) const;
 
   static size_t findLinearBin(const MantidVec &X, const double xmin, const double step, const double tof);
   static size_t findLogBin(const MantidVec &X, const double tof, const double divisor, const double offset);
@@ -387,8 +386,8 @@ private:
   template <class T>
   static void histogramForWeightsHelper(const std::vector<T> &events, const MantidVec &X, MantidVec &Y, MantidVec &E);
   template <class T>
-  static void histogramForWeightsHelper(const std::vector<T> &events, const double xmin, const double step,
-                                        const double xmax, const MantidVec &X, MantidVec &Y, MantidVec &E);
+  static void histogramForWeightsHelper(const std::vector<T> &events, const double step, const MantidVec &X,
+                                        MantidVec &Y, MantidVec &E);
   template <class T>
   static void integrateHelper(std::vector<T> &events, const double minX, const double maxX, const bool entireRange,
                               double &sum, double &error);

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -356,8 +356,8 @@ private:
   void generateCountsHistogram(const MantidVec &X, MantidVec &Y) const;
   void generateCountsHistogram(const double step, const MantidVec &X, MantidVec &Y) const;
 
-  static boost::optional<size_t> findLinearBin(const MantidVec &X, const double xmin, const double step,
-                                               const double tof);
+  static boost::optional<size_t> findLinearBin(const MantidVec &X, const double tof, const double divisor,
+                                               const double offset);
   static boost::optional<size_t> findLogBin(const MantidVec &X, const double tof, const double divisor,
                                             const double offset);
   static boost::optional<size_t> findExactBin(const MantidVec &X, const double tof, size_t n_bin);

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -354,10 +354,12 @@ private:
                                                                      const double &tofOffset) const;
 
   void generateCountsHistogram(const MantidVec &X, MantidVec &Y) const;
-  void generateCountsHistogramUnsorted(const double xmin, const double step, const double xmax, const MantidVec &X,
-                                       MantidVec &Y) const;
-  void generateCountsHistogramUnsortedLog(const double xmin, const double step, const double xmax, const MantidVec &X,
-                                          MantidVec &Y) const;
+  void generateCountsHistogram(const double xmin, const double step, const double xmax, const MantidVec &X,
+                               MantidVec &Y) const;
+
+  size_t findLinearBin(const MantidVec &X, const double xmin, const double step, const double tof) const;
+  size_t findLogBin(const MantidVec &X, const double tof, const double divisor, const double offset) const;
+  size_t findExactBin(const MantidVec &X, const double tof, size_t n_bin) const;
 
   void generateCountsHistogramPulseTime(const MantidVec &X, MantidVec &Y) const;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -205,6 +205,8 @@ public:
                          EventList *destination);
   // get EventType declaration
   void generateHistogram(const MantidVec &X, MantidVec &Y, MantidVec &E, bool skipError = false) const override;
+  void generateHistogram(const double xmin, const double step, const double xmax, const MantidVec &X, MantidVec &Y,
+                         MantidVec &E, bool skipError = false) const;
   void generateHistogramPulseTime(const MantidVec &X, MantidVec &Y, MantidVec &E,
                                   bool skipError = false) const override;
 
@@ -352,6 +354,10 @@ private:
                                                                      const double &tofOffset) const;
 
   void generateCountsHistogram(const MantidVec &X, MantidVec &Y) const;
+  void generateCountsHistogramUnsorted(const double xmin, const double step, const double xmax, const MantidVec &X,
+                                       MantidVec &Y) const;
+  void generateCountsHistogramUnsortedLog(const double xmin, const double step, const double xmax, const MantidVec &X,
+                                          MantidVec &Y) const;
 
   void generateCountsHistogramPulseTime(const MantidVec &X, MantidVec &Y) const;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -357,9 +357,9 @@ private:
   void generateCountsHistogram(const double xmin, const double step, const double xmax, const MantidVec &X,
                                MantidVec &Y) const;
 
-  size_t findLinearBin(const MantidVec &X, const double xmin, const double step, const double tof) const;
-  size_t findLogBin(const MantidVec &X, const double tof, const double divisor, const double offset) const;
-  size_t findExactBin(const MantidVec &X, const double tof, size_t n_bin) const;
+  static size_t findLinearBin(const MantidVec &X, const double xmin, const double step, const double tof);
+  static size_t findLogBin(const MantidVec &X, const double tof, const double divisor, const double offset);
+  static size_t findExactBin(const MantidVec &X, const double tof, size_t n_bin);
 
   void generateCountsHistogramPulseTime(const MantidVec &X, MantidVec &Y) const;
 
@@ -386,6 +386,9 @@ private:
 
   template <class T>
   static void histogramForWeightsHelper(const std::vector<T> &events, const MantidVec &X, MantidVec &Y, MantidVec &E);
+  template <class T>
+  static void histogramForWeightsHelper(const std::vector<T> &events, const double xmin, const double step,
+                                        const double xmax, const MantidVec &X, MantidVec &Y, MantidVec &E);
   template <class T>
   static void integrateHelper(std::vector<T> &events, const double minX, const double maxX, const bool entireRange,
                               double &sum, double &error);

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -356,9 +356,11 @@ private:
   void generateCountsHistogram(const MantidVec &X, MantidVec &Y) const;
   void generateCountsHistogram(const double step, const MantidVec &X, MantidVec &Y) const;
 
-  static size_t findLinearBin(const MantidVec &X, const double xmin, const double step, const double tof);
-  static size_t findLogBin(const MantidVec &X, const double tof, const double divisor, const double offset);
-  static size_t findExactBin(const MantidVec &X, const double tof, size_t n_bin);
+  static boost::optional<size_t> findLinearBin(const MantidVec &X, const double xmin, const double step,
+                                               const double tof);
+  static boost::optional<size_t> findLogBin(const MantidVec &X, const double tof, const double divisor,
+                                            const double offset);
+  static boost::optional<size_t> findExactBin(const MantidVec &X, const double tof, size_t n_bin);
 
   void generateCountsHistogramPulseTime(const MantidVec &X, MantidVec &Y) const;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
@@ -142,7 +142,6 @@ public:
 
   // Sort all event lists. Uses a parallelized algorithm
   void sortAll(EventSortType sortType, Mantid::API::Progress *prog) const;
-  void sortAllOld(EventSortType sortType, Mantid::API::Progress *prog) const;
 
   void getIntegratedSpectra(std::vector<double> &out, const double minX, const double maxX,
                             const bool entireRange) const override;

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -2207,8 +2207,28 @@ void EventList::generateCountsHistogramUnsorted(const double xmin, const double 
     if (tof < xmin || tof >= xmax)
       continue;
 
+    // approximate bin
     auto n_bin = static_cast<size_t>((tof - xmin) / step);
-    Y[n_bin]++;
+
+    // find exact bin
+    bool outOfBounds = false;
+
+    while (!outOfBounds && tof < X[n_bin]) {
+      if (n_bin == 0)
+        outOfBounds = true;
+      else
+        n_bin--;
+    }
+
+    while (!outOfBounds && tof >= X[n_bin + 1]) {
+      if (n_bin == x_size - 1)
+        outOfBounds = true;
+      else
+        n_bin++;
+    }
+
+    if (!outOfBounds)
+      Y[n_bin]++;
   }
 }
 
@@ -2247,8 +2267,28 @@ void EventList::generateCountsHistogramUnsortedLog(const double xmin, const doub
     if (tof < xmin || tof >= xmax)
       continue;
 
+    // approximate bin
     auto n_bin = static_cast<size_t>(log(tof) / divisor - offset);
-    Y[n_bin]++;
+
+    // find exact bin
+    bool outOfBounds = false;
+
+    while (!outOfBounds && tof < X[n_bin]) {
+      if (n_bin == 0)
+        outOfBounds = true;
+      else
+        n_bin--;
+    }
+
+    while (!outOfBounds && tof >= X[n_bin + 1]) {
+      if (n_bin == x_size - 1)
+        outOfBounds = true;
+      else
+        n_bin++;
+    }
+
+    if (!outOfBounds)
+      Y[n_bin]++;
   }
 }
 

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1778,7 +1778,6 @@ void EventList::histogramForWeightsHelper(const std::vector<T> &events, const Ma
     return;
   }
 
-  // If the sizes are the same, then the "resize" command will NOT clear the
   // original values.
   bool mustFill = (Y.size() == x_size - 1);
   // Clear the Y data, assign all to 0.
@@ -1866,7 +1865,6 @@ void EventList::histogramForWeightsHelper(const std::vector<T> &events, const Ma
 template <class T>
 void EventList::histogramForWeightsHelper(const std::vector<T> &events, const double step, const MantidVec &X,
                                           MantidVec &Y, MantidVec &E) {
-  // For slight speed=up.
   size_t x_size = X.size();
 
   if (x_size <= 1) {
@@ -1875,25 +1873,9 @@ void EventList::histogramForWeightsHelper(const std::vector<T> &events, const do
     return;
   }
 
-  // If the sizes are the same, then the "resize" command will NOT clear the
-  // original values.
-  bool mustFill = (Y.size() == x_size - 1);
-  // Clear the Y data, assign all to 0.
   Y.resize(x_size - 1, 0.0);
-  // Clear the Error data, assign all to 0.
-  // Note: Errors will be squared until the last step.
   E.resize(x_size - 1, 0.0);
 
-  if (mustFill) {
-    // We must make sure the starting point is 0.0
-    std::fill(Y.begin(), Y.end(), 0.0);
-    std::fill(E.begin(), E.end(), 0.0);
-  }
-
-  //---------------------- Histogram without weights
-  //---------------------------------
-
-  // Do we even have any events to do?
   if (events.empty())
     return;
 

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1905,7 +1905,7 @@ void EventList::histogramForWeightsHelper(const std::vector<T> &events, const do
 
   if (step < 0) {
     findBin = findLogBin;
-    divisor = log(abs(step) + 1); // use this to do change of base
+    divisor = log1p(abs(step)); // use this to do change of base
     offset = log(xmin) / divisor;
   } else {
     findBin = findLinearBin;
@@ -2372,7 +2372,7 @@ void EventList::generateCountsHistogram(const double step, const MantidVec &X, M
 
   if (step < 0) {
     findBin = findLogBin;
-    divisor = log(abs(step) + 1); // use this to do change of base
+    divisor = log1p(abs(step)); // use this to do change of base
     offset = log(xmin) / divisor;
   } else {
     findBin = findLinearBin;

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1850,8 +1850,8 @@ void EventList::histogramForWeightsHelper(const std::vector<T> &events, const Ma
 }
 
 template <class T>
-void EventList::histogramForWeightsHelper(const std::vector<T> &events, const double xmin, const double step,
-                                          const double xmax, const MantidVec &X, MantidVec &Y, MantidVec &E) {
+void EventList::histogramForWeightsHelper(const std::vector<T> &events, const double step, const MantidVec &X,
+                                          MantidVec &Y, MantidVec &E) {
   // For slight speed=up.
   size_t x_size = X.size();
 
@@ -1882,6 +1882,9 @@ void EventList::histogramForWeightsHelper(const std::vector<T> &events, const do
   // Do we even have any events to do?
   if (events.empty())
     return;
+
+  const auto xmin = X.front();
+  const auto xmax = X.back();
 
   const auto divisor = log(abs(step) + 1); // use this to do change of base
   const auto offset = log(xmin) / divisor;
@@ -2002,21 +2005,21 @@ void EventList::generateHistogram(const MantidVec &X, MantidVec &Y, MantidVec &E
   }
 }
 
-void EventList::generateHistogram(const double xmin, const double step, const double xmax, const MantidVec &X,
-                                  MantidVec &Y, MantidVec &E, bool skipError) const {
+void EventList::generateHistogram(const double step, const MantidVec &X, MantidVec &Y, MantidVec &E,
+                                  bool skipError) const {
   switch (eventType) {
   case TOF:
-    this->generateCountsHistogram(xmin, step, xmax, X, Y);
+    this->generateCountsHistogram(step, X, Y);
     if (!skipError)
       this->generateErrorsHistogram(Y, E);
     break;
 
   case WEIGHTED:
-    histogramForWeightsHelper(this->weightedEvents, xmin, step, xmax, X, Y, E);
+    histogramForWeightsHelper(this->weightedEvents, step, X, Y, E);
     break;
 
   case WEIGHTED_NOTIME:
-    histogramForWeightsHelper(this->weightedEventsNoTime, xmin, step, xmax, X, Y, E);
+    histogramForWeightsHelper(this->weightedEventsNoTime, step, X, Y, E);
     break;
   }
 }
@@ -2262,6 +2265,7 @@ size_t EventList::findLogBin(const MantidVec &X, const double tof, const double 
 }
 
 size_t EventList::findExactBin(const MantidVec &X, const double tof, size_t n_bin) {
+
   while (tof < X[n_bin])
     n_bin--;
 
@@ -2280,8 +2284,7 @@ size_t EventList::findExactBin(const MantidVec &X, const double tof, size_t n_bi
  * @param X :: The x bins
  * @param Y :: The generated counts histogram
  */
-void EventList::generateCountsHistogram(const double xmin, const double step, const double xmax, const MantidVec &X,
-                                        MantidVec &Y) const {
+void EventList::generateCountsHistogram(const double step, const MantidVec &X, MantidVec &Y) const {
   // For slight speed=up.
   size_t x_size = X.size();
 
@@ -2297,6 +2300,9 @@ void EventList::generateCountsHistogram(const double xmin, const double step, co
   // Do we even have any events to do?
   if (this->events.empty())
     return;
+
+  const auto xmin = X.front();
+  const auto xmax = X.back();
 
   const auto divisor = log(abs(step) + 1); // use this to do change of base
   const auto offset = log(xmin) / divisor;

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1778,6 +1778,7 @@ void EventList::histogramForWeightsHelper(const std::vector<T> &events, const Ma
     return;
   }
 
+  // If the sizes are the same, then the "resize" command will NOT clear the
   // original values.
   bool mustFill = (Y.size() == x_size - 1);
   // Clear the Y data, assign all to 0.
@@ -1883,7 +1884,7 @@ void EventList::histogramForWeightsHelper(const std::vector<T> &events, const do
   const auto xmax = X.back();
 
   double divisor, offset;
-  boost::optional<size_t> (*findBin)(const MantidVec &, const double, const double, const double);
+  boost::optional<size_t> (*findBin)(const MantidVec &, const double, const double, const double); // function pointer
 
   if (step < 0) {
     findBin = findLogBin;
@@ -1896,7 +1897,7 @@ void EventList::histogramForWeightsHelper(const std::vector<T> &events, const do
   }
 
   for (const T &ev : events) {
-    double tof = ev.tof();
+    const double tof = ev.tof();
     if (tof < xmin || tof >= xmax)
       continue;
 
@@ -2027,7 +2028,7 @@ void EventList::generateHistogram(const MantidVec &X, MantidVec &Y, MantidVec &E
 void EventList::generateHistogram(const double step, const MantidVec &X, MantidVec &Y, MantidVec &E,
                                   bool skipError) const {
   // if events are already sorted, use faster sorted histogram method
-  if (isSortedByTof())
+  if (isSortedByTof() || empty())
     return generateHistogram(X, Y, E, skipError);
 
   switch (eventType) {
@@ -2299,7 +2300,8 @@ boost::optional<size_t> EventList::findLogBin(const MantidVec &X, const double t
   return findExactBin(X, tof, static_cast<size_t>(log(tof) / divisor - offset));
 }
 
-/** Find the exact bin which a TOF falls in starting from the provided estimated one.
+/** Find the exact bin which a TOF falls in starting from the provided estimated one. Estimated bin is expected to be
+ * within 1 of the correct bin
  *
  * @param X :: The x bins
  * @param tof :: TOF of the event we are trying to bin
@@ -2309,10 +2311,9 @@ boost::optional<size_t> EventList::findExactBin(const MantidVec &X, const double
   if (n_bin >= X.size())
     return boost::none;
 
-  while (tof < X[n_bin])
+  if (tof < X[n_bin])
     n_bin--;
-
-  while (tof >= X[n_bin + 1])
+  else if (tof >= X[n_bin + 1])
     n_bin++;
 
   return n_bin;
@@ -2350,7 +2351,7 @@ void EventList::generateCountsHistogram(const double step, const MantidVec &X, M
   const auto xmax = X.back();
 
   double divisor, offset;
-  boost::optional<size_t> (*findBin)(const MantidVec &, const double, const double, const double);
+  boost::optional<size_t> (*findBin)(const MantidVec &, const double, const double, const double); // function pointer
 
   if (step < 0) {
     findBin = findLogBin;
@@ -2363,7 +2364,7 @@ void EventList::generateCountsHistogram(const double step, const MantidVec &X, M
   }
 
   for (const TofEvent &ev : this->events) {
-    double tof = ev.tof();
+    const double tof = ev.tof();
     if (tof < xmin || tof >= xmax)
       continue;
 

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -2491,31 +2491,37 @@ public:
   void test_generateHistogramUnsortedLinear_TOF() {
     const auto e = createLinearTestData();
     run_generateHistogramUnsortedTest(e, {0., 0.1, 100.}, 999.);
+    run_generateHistogramUnsortedTest(e, {50., 1.0, 100.}, 490.);
   }
 
   void test_generateHistogramUnsortedLinear_WEIGHTED() {
     const auto e = createLinearTestData(WEIGHTED);
     run_generateHistogramUnsortedTest(e, {0., 0.1, 100.}, 999.);
+    run_generateHistogramUnsortedTest(e, {50., 1.0, 100.}, 490.);
   }
 
   void test_generateHistogramUnsortedLinear_WEIGHTED_NOTIME() {
     const auto e = createLinearTestData(WEIGHTED_NOTIME);
     run_generateHistogramUnsortedTest(e, {0., 0.1, 100.}, 999.);
+    run_generateHistogramUnsortedTest(e, {50., 1.0, 100.}, 490.);
   }
 
   void test_generateHistogramUnsortedLog_TOF() {
     const auto e = createLogTestData();
     run_generateHistogramUnsortedTest(e, {1., -0.001, 1.1}, 95.);
+    run_generateHistogramUnsortedTest(e, {1.05, -0.002, 1.1}, 45.);
   }
 
   void test_generateHistogramUnsortedLog_WEIGHTED() {
     const auto e = createLogTestData(WEIGHTED);
     run_generateHistogramUnsortedTest(e, {1., -0.001, 1.1}, 95.);
+    run_generateHistogramUnsortedTest(e, {1.05, -0.002, 1.1}, 45.);
   }
 
   void test_generateHistogramUnsortedLog_WEIGHTED_NOTIME() {
     const auto e = createLogTestData(WEIGHTED_NOTIME);
     run_generateHistogramUnsortedTest(e, {1., -0.001, 1.1}, 95.);
+    run_generateHistogramUnsortedTest(e, {1.05, -0.002, 1.1}, 45.);
   }
 
   void test_generateHistogramUnsortedLinear_TOF_bad_params() {

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
@@ -101,7 +101,6 @@ private:
   double tmin{0.0};
   double tmax{0.0};
   bool m_preserveEvents{false};
-  void doSortEvents(const Mantid::API::Workspace_sptr &ws);
   void compressEventsOutputWS(const double compressEventsTolerance, const double wallClockTolerance);
   bool shouldCompressUnfocused(const double compressTolerance, const double tofmin, const double tofmax,
                                const bool hasWallClockTolerance);

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -754,14 +754,6 @@ void AlignAndFocusPowder::exec() {
       if (m_processLowResTOF)
         m_lowResW = rebin(m_lowResW);
     } else if (!m_delta_ragged.empty()) {
-      // to speed up RebinRagged later, sort events once here
-      // making RebinRagged faster when preserveEvents=False would be better
-      if (!m_preserveEvents) {
-        doSortEvents(m_outputW);
-        if (m_processLowResTOF)
-          doSortEvents(m_lowResW);
-      }
-
       m_outputW = rebinRagged(m_outputW, true);
       if (m_processLowResTOF)
         m_lowResW = rebinRagged(m_lowResW, true);
@@ -1189,21 +1181,6 @@ void AlignAndFocusPowder::loadCalFile(const std::string &calFilename, const std:
       AnalysisDataService::Instance().addOrReplace(name, m_maskWS);
       this->setPropertyValue(PropertyNames::MASK_WKSP, name);
     }
-  }
-}
-
-//----------------------------------------------------------------------------------------------
-/** Perform SortEvents on the output workspaces
- * but only if they are EventWorkspaces.
- *
- * @param ws :: any Workspace. Does nothing if not EventWorkspace.
- */
-void AlignAndFocusPowder::doSortEvents(const Mantid::API::Workspace_sptr &ws) {
-  if (auto eventWS = std::dynamic_pointer_cast<EventWorkspace>(ws)) {
-    Algorithm_sptr alg = this->createChildAlgorithm("SortEvents");
-    alg->setProperty("InputWorkspace", eventWS);
-    alg->setPropertyValue("SortBy", "X Value");
-    alg->executeAsChildAlg();
   }
 }
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -197,8 +197,8 @@ constParameter:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/Utils.h:195
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDataObjects/EventList.h:144
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:959
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1055
-shadowFunction:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4070
-shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4071
+shadowFunction:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4052
+shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4053
 derefInvalidIterator:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1520
 shadowVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/OrientedLattice.cpp:234
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/NiggliCell.cpp:233

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -197,8 +197,8 @@ constParameter:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/Utils.h:195
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDataObjects/EventList.h:144
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:959
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1055
-shadowFunction:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4052
-shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4053
+shadowFunction:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4053
+shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4054
 derefInvalidIterator:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1520
 shadowVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/OrientedLattice.cpp:234
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/NiggliCell.cpp:233

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -197,8 +197,8 @@ constParameter:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/Utils.h:195
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDataObjects/EventList.h:144
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:959
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1055
-shadowFunction:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:3840
-shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:3841
+shadowFunction:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4070
+shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4071
 derefInvalidIterator:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1520
 shadowVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/OrientedLattice.cpp:234
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/NiggliCell.cpp:233

--- a/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36136.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36136.rst
@@ -1,0 +1,1 @@
+- :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>` will no longer sort events prior to doing :ref:`RebinRagged <algm-RebinRagged>` when ``PreserveEvents=False`` enabling it to ultilize performace improvement to :ref:`Rebin <algm-Rebin>`.

--- a/docs/source/release/v6.9.0/Framework/Algorithms/New_features/36136.rst
+++ b/docs/source/release/v6.9.0/Framework/Algorithms/New_features/36136.rst
@@ -1,0 +1,1 @@
+- A new method was added the histogram Event data without sorting the events first, which the :ref:`Rebin <algm-Rebin>` algorithm now uses when ``PreserveEvents=False``, giving a performance improvement.


### PR DESCRIPTION
**Description of work**

A new `generateHistogram` method has been added the `EventList` that will create the histogram without sorting the events first. Sorting events is slow, so this approach is faster. If the events are already sorted then the old method is called because it will be faster.

This should have a performance improvement when doing `Rebin` with `PreserveEvents=False` on any `EventWorkspace` that is unsorted. It does this by performing the histogram in a different way, it calculates which bin the event should go in instead of sorting the events first.

The `SortEvents` call in `AlignAndFocusPowder` for Ragged binning was removed to benefit from this speed improvement.

**To test:**

You can test this by running Rebin with `PreserveEvents=False` with any unsorted EventWorkspace.

To see an example of the performance improvements on my laptop, using `PG3_2538_event.nxs` from the SystemTest data and with different binning and number of histograms (by grouping them). The print at the end also shows that the input doesn't get sorted unlike what currently happens.

```python
for groupBy in (None, "bank", "All"):
    for step in ("100", "-0.01"):
        ws=LoadEventNexus("PG3_2538_event.nxs")
        if groupBy:
            groups = CreateGroupingWorkspace(ws, GroupDetectorsBy=groupBy)
            ws = GroupDetectors(ws, CopyGroupingFromWorkspace="groups")
        binned = Rebin(ws, f"9000,{step},25000", PreserveEvents=False)
        print(ws.getSpectrum(0).isSortedByTof())
```

|branch|linear|log|linear, group(bank)|log, group(bank)|linear, group(All)|log, group(All)|
|-|-|-|-|-|-|-|
|main|1.14s|1.03s|1.27s|1.27s|2.22s|2.24s|
|this|0.13s|0.34s|0.14s|0.37s|0.49s|1.24s|



<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes [EWM1866](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1866)

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.