### PR TITLE
Include Imports Required to Run Scripts in Workspace Group Docs

### DIFF
--- a/docs/source/concepts/WorkspaceGroup.rst
+++ b/docs/source/concepts/WorkspaceGroup.rst
@@ -26,6 +26,8 @@ Workspace groups can be created in a more flexible way in the Python script wind
 
 .. testcode:: CreatingWorkspaceGroups
 
+    from mantid.simpleapi import *
+
     ws1 = CreateSampleWorkspace()
     ws2 = CreateSampleWorkspace()
     ws3 = CreateSampleWorkspace()
@@ -70,7 +72,10 @@ the group should then appear in the ADS with the given name. Using direct instan
 
 .. testcode:: CreatingWorkspaceGroupsInstantiated
 
+    from mantid.simpleapi import *
     from mantid.api import WorkspaceGroup
+
+    mtd.clear()
 
     ws1 = CreateSampleWorkspace()
     ws2 = CreateSampleWorkspace()
@@ -97,7 +102,10 @@ Alternatively, workspace group objects can be fed workspaces which are not in th
 
 .. testcode:: CreatingWorkspaceGroupsNoADS
 
+    from mantid.simpleapi import *
     from mantid.api import WorkspaceGroup
+
+    mtd.clear()
 
     ws1 = WorkspaceFactory.create("Workspace2D", 2, 2, 2)
     ws2 = WorkspaceFactory.create("Workspace2D", 2, 2, 2)
@@ -135,6 +143,7 @@ If you want to check if a variable points to something that is a Workspace Group
 
 .. testcode:: CheckGroupWorkspace
 
+    from mantid.simpleapi import *
     from mantid.api import WorkspaceGroup
 
     ws1 = CreateSampleWorkspace()
@@ -155,6 +164,8 @@ Looping over all of the members of a group
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. testcode:: GroupWorkspaceMembers
+
+    from mantid.simpleapi import *
 
     ws1 = CreateSampleWorkspace()
     ws2 = CreateSampleWorkspace()
@@ -186,6 +197,8 @@ You can pass workspace groups into any algorithm and Mantid will run that algori
 
 .. testcode:: CheckGroupWorkspace
 
+    from mantid.simpleapi import *
+
     ws1 = CreateSampleWorkspace()
     ws2 = CreateSampleWorkspace()
     wsGroup = GroupWorkspaces("ws1,ws2")
@@ -211,6 +224,8 @@ Final words of warning:
 
 .. testcode:: Iterative Deletion of Grouped Workspaces
 
+    from mantid.simpleapi import *
+
     ws1 = CreateSampleWorkspace()
     ws2 = CreateSampleWorkspace()
     wsGroup = GroupWorkspaces("ws1,ws2")
@@ -223,6 +238,8 @@ otherwise indexing will be confused by each deletion.
 - To Delete an entire group, just run:
 
 .. testcode:: Delete Entire Workspace
+
+    from mantid.simpleapi import *
 
     ws1 = CreateSampleWorkspace()
     ws2 = CreateSampleWorkspace()


### PR DESCRIPTION
**Description of work**

**Purpose of work**
Allows the scripts in the documentation to be copied into workbench/mantid python and run without needing changes or steps from the other scripts to be run, speeding up the manual testing process. 

**Summary of work**
Add imports for the `simpleapi` and ADS clears where required. 

**To test:**
1. Build the documentation `cmake --build . --target docs-html`
2. Open the `WorkspaceGroups.html` file in your browser.
3. Launch workbench
4. Copy each of the scripts into a fully blank scripting window and check they all run without errors. 

Fixes #36070 


*This does not require release notes* because **it concerns documentation only.**


---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.