### PR TITLE
`PDCalibration` should sort peak windows with centers

### DIFF
--- a/docs/source/release/v6.8.0/Diffraction/Powder/Bugfixes/36122.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Powder/Bugfixes/36122.rst
@@ -1,0 +1,1 @@
+* Fixed bug in `PDCalibration` which was not using the user-input peak windows unless they were pre-sorted.  No longer necessary to pre-sort peak centers and windows.


### PR DESCRIPTION
**Description of work**

This makes a change to `PDCalibration` to sort the peak windows along with the peak centers, so that the peak windows continue matching to their peak center.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

When the `"PeakWindows"` property was implemented in PR #32823 , it was not sorted along with the peak centers.  This means that, even though the peak windows are supposed to be in an order corresponding to reach peak center, if both lists were not pre-sorted then the centers and windows ended up mis-matched and the code would simply use the old behavior of the half-point to the next peak.

This was noticed by me (@rboston628 ) in Issue #36122 .

**Summary of work**

If the "PeakWindows" property is set, it is sorted along with the "PeakCenters".

**Further detail of work**

Uses a `std::map` to associate each peak center to a peak window (indicated by a pair) *and* to order the data by peak center inside the map, then extracts them back into vectors ordered by peak center.

``` cpp
  m_peaksInDspacing = getProperty("PeakPositions");
  std::vector<double> peakWindow = getProperty("PeakWindow");
  const std::size_t NUMPEAKS = m_peaksInDspacing.size();
  // if peak windows given for each peak center, sort all by peak center
  if (peakWindow.size() > 1) {
    // load windows into ordered map keyed by peak center
    // this preserves association of centers and window edges
    std::map<double, std::pair<double, double>> peakEdgeAndCenter;
    for (std::size_t i = 0; i < m_peaksInDspacing.size(); i++) {
      peakEdgeAndCenter[m_peaksInDspacing[i]] = {peakWindow[2 * i], peakWindow[2 * i + 1]};
    }
    m_peaksInDspacing.clear();
    m_peaksInDspacing.reserve(NUMPEAKS);
    peakWindow.clear();
    peakWindow.reserve(2 * NUMPEAKS);
    // retrieve ordered center, windows
    for (auto it = peakEdgeAndCenter.begin(); it != peakEdgeAndCenter.end(); it++) {
      m_peaksInDspacing.push_back(it->first);
      peakWindow.push_back(it->second.first);
      peakWindow.push_back(it->second.second);
    }
  } else {
    // Sort peak positions, required for correct peak window calculations
    std::sort(m_peaksInDspacing.begin(), m_peaksInDspacing.end());
  }
```

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #36122 .

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.