### PR TITLE
Fix `ConvertDiffcal` logic and error throwing for signed mode

### DIFF
--- a/Framework/Algorithms/src/ConvertDiffCal.cpp
+++ b/Framework/Algorithms/src/ConvertDiffCal.cpp
@@ -133,25 +133,10 @@ detid_t getDetID(const OffsetsWorkspace_const_sptr &offsetsWS, const size_t inde
   return (*(detIDs.begin()));
 }
 
-/**
- * @throws std::logic_error if the offset found is non-physical.
- * @param offsetsWS
- * @param detid
- * @return The offset value or zero if not specified.
- */
-double getOffset(const OffsetsWorkspace_const_sptr &offsetsWS, const detid_t detid) {
-  const double offset = offsetsWS->getValue(detid, 0.0);
-  if (offset <= -1.) { // non-physical
-    std::stringstream msg;
-    msg << "Encountered offset of " << offset << " which converts data to negative d-spacing for detectorID " << detid
-        << "\n";
-    throw std::logic_error(msg.str());
-  }
-  return offset;
-}
+namespace { // anonymous namespace to enscope the below functions
 
 /** Calculate the DIFC for values not found from previous calibration
- *
+ * @throws in relative or absolute, throws logic error if offset <= -1
  * @param offsetsWS :: Offset Workspace used in calculations
  * @param index :: Index being calculated
  * @param spectrumInfo :: Spectrum info used
@@ -162,7 +147,7 @@ double getOffset(const OffsetsWorkspace_const_sptr &offsetsWS, const detid_t det
 double calculateDIFC(const OffsetsWorkspace_const_sptr &offsetsWS, const size_t index,
                      const Mantid::API::SpectrumInfo &spectrumInfo, const double binWidth, OFFSETMODE offsetMode) {
   const detid_t detid = getDetID(offsetsWS, index);
-  const double offset = getOffset(offsetsWS, detid);
+  const double offset = offsetsWS->getValue(detid, 0.0);
   double twotheta;
   try {
     twotheta = spectrumInfo.twoTheta(index);
@@ -184,13 +169,35 @@ double calculateDIFC(const OffsetsWorkspace_const_sptr &offsetsWS, const size_t 
   return newDIFC;
 }
 
-double updateSignedDIFC(const OffsetsWorkspace_const_sptr &offsetsWS, const size_t index, const double oldDIFC,
-                        const double binWidth) {
-  const detid_t detid = getDetID(offsetsWS, index);
-  const double offset = getOffset(offsetsWS, detid);
-  const double newDIFC = oldDIFC * pow(1.0 + fabs(binWidth), -1.0 * offset);
-  return newDIFC;
+/**
+ * @throws std::logic_error if the offset would lead to non-physical d-spacing.
+ * @param offset the offset, which is checked for physicality
+ * @param oldDIFC the prior value of DIFC, to be updated
+ * @param unused not used, for function template conformity
+ * @return The updated value of DIFC, if physical
+ */
+double updateAbsoluteDIFC(const double offset, const double oldDIFC, const double unused) {
+  UNUSED_ARG(unused);
+  if (offset <= -1.) { // non-physical
+    std::stringstream msg;
+    msg << "Encountered offset of " << offset << " which converts data to negative d-spacing from old DIFC " << oldDIFC
+        << "\n";
+    throw std::logic_error(msg.str());
+  }
+  return oldDIFC / (1.0 + offset);
 }
+
+/**
+ * @param offset the offset
+ * @param oldDIFC the prior value of DIFC, to be updated
+ * @param binWidth the binwidth that was used
+ * @return The updated value of DIFC when using signed offsets and logarithmic binning
+ */
+double updateSignedDIFC(const double offset, const double oldDIFC, const double binWidth) {
+  return oldDIFC * pow(1.0 + fabs(binWidth), -1.0 * offset);
+}
+
+} // end anonymous namespace
 
 //----------------------------------------------------------------------------------------------
 /** Execute the algorithm.
@@ -234,6 +241,16 @@ void ConvertDiffCal::exec() {
 
   const Mantid::API::SpectrumInfo &spectrumInfo = offsetsWS->spectrumInfo();
   Mantid::Geometry::DetectorInfo const &d_info = offsetsWS->detectorInfo();
+
+  // set the function to use for updating the DIFC value
+  // setting here avoids branching inside the for loop
+  std::function<double(const double, const double, const double)> newDIFC;
+  if (offsetMode == OffsetMode::SIGNED_OFFSET) {
+    newDIFC = updateSignedDIFC;
+  } else {
+    newDIFC = updateAbsoluteDIFC;
+  }
+
   for (size_t i = 0; i < numberOfSpectra; ++i) {
 
     /* obtain detector id for this spectra */
@@ -242,7 +259,7 @@ void ConvertDiffCal::exec() {
     /* obtain the mask */
     if (!d_info.isMasked(internal_index)) {
       /* find the detector id's offset value in the offset workspace */
-      double new_offset_value = offsetsWS->getValue(detector_id);
+      double new_offset_value = offsetsWS->getValue(detector_id, 0.0);
 
       /* search for it in the table */
       auto iter = id_to_row.find(detector_id);
@@ -253,11 +270,7 @@ void ConvertDiffCal::exec() {
         int row_to_update = iter->second;
 
         double &difc_value_to_update = configWksp->cell<double>(row_to_update, 1);
-        if (offsetMode == OffsetMode::SIGNED_OFFSET) {
-          difc_value_to_update = updateSignedDIFC(offsetsWS, i, difc_value_to_update, binWidth);
-        } else {
-          difc_value_to_update = difc_value_to_update / (1.0 + new_offset_value);
-        }
+        difc_value_to_update = newDIFC(new_offset_value, difc_value_to_update, binWidth);
       }
 
       /* value was not found in PreviousCalibration - calculate from experiment's geometry */

--- a/Framework/Algorithms/src/ConvertDiffCal.cpp
+++ b/Framework/Algorithms/src/ConvertDiffCal.cpp
@@ -116,6 +116,8 @@ std::map<std::string, std::string> ConvertDiffCal::validateInputs() {
   return result;
 }
 
+namespace { // anonymous namespace to enscope the below functions
+
 /**
  * @throws std::logic_error if there is more than one detector id
  * for the spectrum.
@@ -132,8 +134,6 @@ detid_t getDetID(const OffsetsWorkspace_const_sptr &offsetsWS, const size_t inde
   }
   return (*(detIDs.begin()));
 }
-
-namespace { // anonymous namespace to enscope the below functions
 
 /** Calculate the DIFC for values not found from previous calibration
  * @throws in relative or absolute, throws logic error if offset <= -1


### PR DESCRIPTION
**Description of work**

Fixes error-handling logic and branching logic in the `ConvertDiffCal` algorithm to handle "Signed" mode.

The "Signed" offsets mode was implemented in PR #35862 , but is failing due to an error-handling case that is not relevant to "Signed" mode.

**Purpose of work**

The "Signed" mode was implemented to handle the case of calibration with full-spectrum, log-binned data.

The offsets are calculated using the "signed" mode, and then combined according to the formula

 $DIFC_{new} = DIFC_{old} \times (1 + |\Delta x|)^{-offset}$

In this formula, there is no possibility of a negative $DIFC_{new}$.  However, for the case of "Relative" or "Absolute" the formula is

$DIFC_{new} = DIFC_{old}  / (1 + offset)$

which _could_ result in negative $DIFC_{new}$ for $offset \leq -1$.  Therefore, errors are thrown for large negative offsets.  

In "Signed" mode, this error-checking behavior lead to unexpected failures when attempting calibration with data from SNAP.

This work is to remove the error checks in "Signed" mode, and retain them in other modes.

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

1. the `getOffsets` method is unnecessary, as it really only calls `getValue()`
2. the error-throwing on the offsets prior to compute is unnecessary, as the method which performs the computation, `Units::tofToDSpacingFactor()`, already does the same check and throws the same error.
3. put the non-member-functions defined in ConvertDiffcal.cpp inside an anonymous namespace so they don't pollute the rest of mantid.
4. use a std::function to prevent branching logic inside a for loop
5. add two tests to ensure (a) that errors are thrown in non-signed mode for very negative offsets, and (b) that no errors are thrown in signed mode for very negative offsets

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

The `getOffets()` method existed mostly to wrap `getValue()`  with a exception throwin.  This has been removed, as it is not necessary to throw the error here.

The `updateSignedDIFC()` method has been greatly simplified by directly passing it the offset that is already found in L262.

A sister method `updateAbsoluteDIFC()` handles the update for non-signed offsets.  The variables defined on this are so it has the same signature as the signed version.  There is error-handling here, parallel to that inside `Units::tofToDSpacingFactor()`.

Instead of a branch inside the for loop at L237, a `std::function` will pick between the signed or unsigned updates, and that function is called inside the for loop.

Two new tests.  
1. a negative test, ensuring failures in the non-signed cases with very negative offsets.  Errors should be thrown **both** if the DIFC are from a calibration table **and** if they are calculated from scratch.  Both are tested.  
2. makes sure there are no errors in the signed offsets mode case with very negative offsets.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Run the unit tests.

In workbench, **run the script posted in the comments below**

Fixes Issue #36121 .

*This does not require release notes* because it is fixing a bug in a feature that already has release notes associated,

*Additional context*
This work is captured in ORNL [EWM 2464](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2464)

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.