### PR TITLE
Stop plotting data with different data units to plot on Engineering diffraction fitting tab

### DIFF
--- a/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/36164.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/36164.rst
@@ -1,0 +1,1 @@
+- Stop plotting data with different data units to plot on Engineering diffraction fitting tab

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
@@ -84,8 +84,10 @@ class EngineeringDiffractionDecoder(EngineeringDiffractionUIAttributes):
             fit_data_widget = presenter.fitting_presenter.data_widget
             fit_data_widget.model.restore_files(ws_names)
             fit_data_widget.presenter.plotted = set(obj_dic["plotted_workspaces"])
-            fit_data_widget.presenter.restore_table()
-
+            fit_data_widget.presenter.restore_table(clear_plotted=False)  # Note: clear_plotted=False would avoid
+            # presenter.plotted being cleared. Since the slot for presenter._handle_table_cell_changed was defined to
+            # use QtCore.Qt.QueuedConnection, during unit tests _handle_table_cell_changed callback is not getting
+            # triggered to restore presenter.plotted variable
             fit_plot_widget = presenter.fitting_presenter.plot_widget
             fit_results = obj_dic.get("fit_results", None)
             if fit_results is not None:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_presenter.py
@@ -95,8 +95,8 @@ class FittingDataPresenter(object):
             self.model.replace_workspace(name, workspace)
             self._repopulate_table()
 
-    def restore_table(self):  # used when the interface is being restored from a save or crash
-        self._repopulate_table()
+    def restore_table(self, clear_plotted=True):  # used when the interface is being restored from a save or crash
+        self._repopulate_table(clear_plotted)
 
     def _start_load_worker(self, filenames):
         """
@@ -126,13 +126,15 @@ class FittingDataPresenter(object):
         # subtract background - has to be done post repopulation, can't change default in _add_row_to_table
         [self.view.set_item_checkstate(self.row_numbers[wsname], 3, True) for wsname in wsnames]
 
-    def _repopulate_table(self):
+    def _repopulate_table(self, clear_plotted=True):
         """
         Populate the table with the information from the loaded workspaces.
         Will also handle any workspaces that need to be plotted.
         """
         workspaces_to_be_plotted = self.plotted.copy()
-        self.plotted.clear()
+
+        if clear_plotted:
+            self.plotted.clear()
 
         self._remove_all_table_rows()
         self.row_numbers.clear()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_presenter.py
@@ -8,6 +8,7 @@ from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common impo
 from mantid.simpleapi import logger
 from mantidqt.utils.asynchronous import AsyncTask
 from mantidqt.utils.observer_pattern import GenericObservable, GenericObserverWithArgPassing
+from mantid.api import AnalysisDataService as ADS
 
 
 class FittingDataPresenter(object):
@@ -119,6 +120,7 @@ class FittingDataPresenter(object):
         wsnames = self.model.get_last_added()
         if self.view.get_add_to_plot():
             self.plotted.update(wsnames)
+
         self._repopulate_table()
 
         # subtract background - has to be done post repopulation, can't change default in _add_row_to_table
@@ -129,6 +131,9 @@ class FittingDataPresenter(object):
         Populate the table with the information from the loaded workspaces.
         Will also handle any workspaces that need to be plotted.
         """
+        workspaces_to_be_plotted = self.plotted.copy()
+        self.plotted.clear()
+
         self._remove_all_table_rows()
         self.row_numbers.clear()
         self.all_plots_removed_notifier.notify_subscribers()
@@ -140,7 +145,7 @@ class FittingDataPresenter(object):
                 if bank == 0:
                     bank = "cropped"
                 active_ws_name = self.model.get_active_ws_name(name)
-                plotted = active_ws_name in self.plotted
+                plotted = active_ws_name in workspaces_to_be_plotted
                 self._add_row_to_table(name, i, run_no, bank, plotted, *self.model.get_bg_params()[name])
             except RuntimeError:
                 self._add_row_to_table(name, i)
@@ -183,8 +188,15 @@ class FittingDataPresenter(object):
                 ws = self.model.get_active_ws(loaded_ws_name)
                 ws_name = self.model.get_active_ws_name(loaded_ws_name)
                 if is_plotted:
-                    self.plot_added_notifier.notify_subscribers(ws)
-                    self.plotted.add(ws_name)
+                    if len(self.plotted) > 0:
+                        if ADS.retrieve(next(iter(self.plotted))).getXDimension().name == ws.getXDimension().name:
+                            self.plot_added_notifier.notify_subscribers(ws)
+                            self.plotted.add(ws_name)
+                        else:
+                            self.view.set_item_checkstate(row, col, False)
+                    else:
+                        self.plot_added_notifier.notify_subscribers(ws)
+                        self.plotted.add(ws_name)
                 else:
                     self.plot_removed_notifier.notify_subscribers(ws)
                     self.plotted.discard(ws_name)


### PR DESCRIPTION
**Description of work**
EngDiff UI fitting tab allows dSpacing and TOF data to be plotted on the same axis - as they have very different magnitudes this result sin the dSpacing data looking like a vertical line near 0.

**Report to:** 
Saurabh (ENGIN-X)

**Summary of work**
When the Units of already plotted data are different to the data intended to be plotted, the workbench will not allow the new data to be plotted on the same X-axis as long as the units of the X axis are inconsistent.

**Further detail of work**
When the Units of already plotted data are different to the data intended to be plotted, the workbench will not allow the new data to be plotted on the same X-axis. The user has either to untick the already plotted data as non plotted or remove them from the workspaces table in the fitting tab. Then only the data with a different Unit (ex: dSpacing/TOF) can be plotted on the EngDiff UI fitting tab. Even if the user tries to tick data with a different unit to be plotted, that tick will be reverted by the workbench as long as the already plotted data are inconsistent in the X axis. This was achieved by comparing the XDimension of the already plotted data and the data to be plotted in the FittingDataPresenter class. 

**To test:**
<!-- Instructions for testing.
See instructions for Test 4 in manual testing instructions
https://github.com/mantidproject/mantid/blob/33e61abf3a7ed9a3e352ca91886efe03d9afc5b8/dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst#test-4

(1) Load in .nxs for dSpaicng and TOF data
(2) Check the Plot box in the fit table
(3) The plot should not contain both TOF and dSpacing data and plot column should resemble with the plot having the correct workspaces with consistent x axis being marked as plotted and the rest as non plotted.
-->

Fixes #34370

<!-- delete this if you added release notes
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.