### PR TITLE
Move verifyAndClear to teardown method in ExperimentPresenterTest

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -48,10 +48,16 @@ public:
 
   ExperimentPresenterTest() : m_view() { Mantid::API::FrameworkManager::Instance(); }
 
+  void tearDown() override {
+    // Verifying and clearing of expectations happens when mock variables are destroyed.
+    // Some of our mocks are created as member variables and will exist until all tests have run, so we need to
+    // explicitly verify and clear them after each test.
+    verifyAndClear();
+  }
+
   void testPresenterSubscribesToView() {
     EXPECT_CALL(m_view, subscribe(_)).Times(1);
     auto presenter = makePresenter();
-    verifyAndClear();
   }
 
   void testAllWidgetsAreEnabledWhenReductionPaused() {
@@ -60,8 +66,6 @@ public:
     EXPECT_CALL(m_view, enableAll()).Times(1);
     expectNotProcessingOrAutoreducing();
     presenter.notifyReductionPaused();
-
-    verifyAndClear();
   }
 
   void testAllWidgetsAreDisabledWhenReductionResumed() {
@@ -70,8 +74,6 @@ public:
     EXPECT_CALL(m_view, disableAll()).Times(1);
     expectProcessing();
     presenter.notifyReductionResumed();
-
-    verifyAndClear();
   }
 
   void testAllWidgetsAreEnabledWhenAutoreductionPaused() {
@@ -80,8 +82,6 @@ public:
     EXPECT_CALL(m_view, enableAll()).Times(1);
     expectNotProcessingOrAutoreducing();
     presenter.notifyAutoreductionPaused();
-
-    verifyAndClear();
   }
 
   void testAllWidgetsAreDisabledWhenAutoreductionResumed() {
@@ -90,8 +90,6 @@ public:
     EXPECT_CALL(m_view, disableAll()).Times(1);
     expectAutoreducing();
     presenter.notifyAutoreductionResumed();
-
-    verifyAndClear();
   }
 
   void testModelUpdatedWhenAnalysisModeChanged() {
@@ -101,7 +99,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.experiment().analysisMode(), AnalysisMode::MultiDetector);
-    verifyAndClear();
   }
 
   void testModelUpdatedWhenSummationTypeChanged() {
@@ -111,7 +108,6 @@ public:
     presenter.notifySummationTypeChanged();
 
     TS_ASSERT_EQUALS(presenter.experiment().summationType(), SummationType::SumInQ);
-    verifyAndClear();
   }
 
   void testSumInQWidgetsDisabledWhenChangeToSumInLambda() {
@@ -120,8 +116,6 @@ public:
     EXPECT_CALL(m_view, disableReductionType()).Times(1);
     EXPECT_CALL(m_view, disableIncludePartialBins()).Times(1);
     presenter.notifySummationTypeChanged();
-
-    verifyAndClear();
   }
 
   void testSumInQWidgetsEnabledWhenChangeToSumInQ() {
@@ -131,8 +125,6 @@ public:
     EXPECT_CALL(m_view, enableReductionType()).Times(1);
     EXPECT_CALL(m_view, enableIncludePartialBins()).Times(1);
     presenter.notifySummationTypeChanged();
-
-    verifyAndClear();
   }
 
   void testChangingIncludePartialBinsUpdatesModel() {
@@ -143,7 +135,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT(presenter.experiment().includePartialBins());
-    verifyAndClear();
   }
 
   void testChangingDebugOptionUpdatesModel() {
@@ -154,7 +145,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT(presenter.experiment().debug());
-    verifyAndClear();
   }
 
   void testSetBackgroundSubtractionUpdatesModel() {
@@ -162,7 +152,6 @@ public:
     expectSubtractBackground();
     presenter.notifySettingsChanged();
     assertBackgroundSubtractionOptionsSet(presenter);
-    verifyAndClear();
   }
 
   void testBackgroundSubtractionMethodIsEnabledWhenSubtractBackgroundIsChecked() {
@@ -170,7 +159,6 @@ public:
     expectSubtractBackground(true);
     EXPECT_CALL(m_view, enableBackgroundSubtractionMethod()).Times(1);
     presenter.notifySettingsChanged();
-    verifyAndClear();
   }
 
   void testPolynomialInputsEnabledWhenSubtractingPolynomialBackground() {
@@ -179,7 +167,6 @@ public:
     EXPECT_CALL(m_view, enablePolynomialDegree()).Times(1);
     EXPECT_CALL(m_view, enableCostFunction()).Times(1);
     presenter.notifySettingsChanged();
-    verifyAndClear();
   }
 
   void testPolynomialInputsDisabledWhenSubtractingPerDetectorAverage() {
@@ -188,7 +175,6 @@ public:
     EXPECT_CALL(m_view, disablePolynomialDegree()).Times(1);
     EXPECT_CALL(m_view, disableCostFunction()).Times(1);
     presenter.notifySettingsChanged();
-    verifyAndClear();
   }
 
   void testPolynomialInputsDisabledWhenSubtractingAveragePixelFit() {
@@ -197,7 +183,6 @@ public:
     EXPECT_CALL(m_view, disablePolynomialDegree()).Times(1);
     EXPECT_CALL(m_view, disableCostFunction()).Times(1);
     presenter.notifySettingsChanged();
-    verifyAndClear();
   }
 
   void testBackgroundSubtractionInputsDisabledWhenOptionTurnedOff() {
@@ -207,7 +192,6 @@ public:
     EXPECT_CALL(m_view, disablePolynomialDegree()).Times(1);
     EXPECT_CALL(m_view, disableCostFunction()).Times(1);
     presenter.notifySettingsChanged();
-    verifyAndClear();
   }
 
   void testTogglePolarizationCorrectionOptionUpdatesModel() {
@@ -215,7 +199,6 @@ public:
     expectPolarizationAnalysisOn();
     presenter.notifySettingsChanged();
     assertPolarizationAnalysisWorkspace(presenter);
-    verifyAndClear();
   }
 
   void testPolarizationCorrectionOptionDisablesWorkspaceInput() { runTestThatPolarizationCorrectionsDisabled(); }
@@ -238,7 +221,6 @@ public:
     EXPECT_CALL(m_fileHandler, fileExists(fullTestPath)).WillOnce(Return(true));
     EXPECT_CALL(m_view, showPolCorrFilePathValid()).Times(1);
     presenter.notifySettingsChanged();
-    verifyAndClear();
   }
 
   void testInvalidPolarizationPathShowsAsInvalid() {
@@ -251,7 +233,6 @@ public:
     EXPECT_CALL(m_fileHandler, fileExists(fullTestPath)).WillOnce(Return(false));
     EXPECT_CALL(m_view, showPolCorrFilePathInvalid()).Times(1);
     presenter.notifySettingsChanged();
-    verifyAndClear();
   }
 
   void testSetFloodCorrectionsUpdatesModel() {
@@ -263,7 +244,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.experiment().floodCorrections(), floodCorr);
-    verifyAndClear();
   }
 
   void testSetFloodCorrectionsUpdatesModelForFilePath() {
@@ -279,7 +259,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.experiment().floodCorrections(), floodCorr);
-    verifyAndClear();
   }
 
   void testSetFloodCorrectionsUpdatesModelForNoCorrections() {
@@ -291,7 +270,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.experiment().floodCorrections(), floodCorr);
-    verifyAndClear();
   }
 
   void testSetFloodCorrectionsToWorkspaceEnablesInputs() {
@@ -321,7 +299,6 @@ public:
     EXPECT_CALL(m_fileHandler, fileExists(fullTestPath)).WillOnce(Return(true));
     EXPECT_CALL(m_view, showFloodCorrFilePathValid()).Times(1);
     presenter.notifySettingsChanged();
-    verifyAndClear();
   }
 
   void testInvalidFloodPathShowsAsInvalid() {
@@ -334,7 +311,6 @@ public:
     EXPECT_CALL(m_fileHandler, fileExists(fullTestPath)).WillOnce(Return(false));
     EXPECT_CALL(m_view, showFloodCorrFilePathInvalid()).Times(1);
     presenter.notifySettingsChanged();
-    verifyAndClear();
   }
 
   void testSetValidTransmissionRunRange() {
@@ -391,7 +367,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.experiment().transmissionStitchOptions().scaleRHS(), scaleRHS);
-    verifyAndClear();
   }
 
   void testSetTransmissionParamsAreInvalidIfContainNonNumericValue() {
@@ -403,7 +378,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.experiment().transmissionStitchOptions().rebinParameters(), "");
-    verifyAndClear();
   }
 
   void testSetStitchOptions() {
@@ -416,7 +390,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.experiment().stitchParameters(), optionsMap);
-    verifyAndClear();
   }
 
   void testSetStitchOptionsInvalid() {
@@ -429,7 +402,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.experiment().stitchParameters(), emptyOptionsMap);
-    verifyAndClear();
   }
 
   void testSetStitchOptionsTrueTextReplacedWithValue() {
@@ -442,7 +414,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.experiment().stitchParameters(), optionsMap);
-    verifyAndClear();
   }
 
   void testSetStitchOptionsFalseTextReplacedWithValue() {
@@ -455,7 +426,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.experiment().stitchParameters(), optionsMap);
-    verifyAndClear();
   }
 
   void testNewLookupRowRequested() {
@@ -466,8 +436,6 @@ public:
     // new value should be requested from view to update model
     EXPECT_CALL(m_view, getLookupTable()).Times(1);
     presenter.notifyNewLookupRowRequested();
-
-    verifyAndClear();
   }
 
   void testRemoveLookupRowRequested() {
@@ -479,8 +447,6 @@ public:
     // new value should be requested from view to update model
     EXPECT_CALL(m_view, getLookupTable()).Times(1);
     presenter.notifyRemoveLookupRowRequested(indexToRemove);
-
-    verifyAndClear();
   }
 
   void testChangingLookupRowUpdatesModel() {
@@ -499,7 +465,6 @@ public:
       TS_ASSERT_EQUALS(lookupRows[0].thetaOrWildcard(), defaultsWithFirstAngle().thetaOrWildcard());
       TS_ASSERT_EQUALS(lookupRows[1].thetaOrWildcard(), defaultsWithSecondAngle().thetaOrWildcard());
     }
-    verifyAndClear();
   }
 
   void testMultipleUniqueAnglesAreValid() {
@@ -626,21 +591,18 @@ public:
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(AtLeast(1));
     presenter.notifySettingsChanged();
-    verifyAndClear();
   }
 
   void testChangingLookupRowNotifiesMainPresenter() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(AtLeast(1));
     presenter.notifyLookupRowChanged(0, 0);
-    verifyAndClear();
   }
 
   void testRestoreDefaultsUpdatesInstrument() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifyUpdateInstrumentRequested()).Times(1);
     presenter.notifyRestoreDefaultsRequested();
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesAnalysisModeInView() {
@@ -649,7 +611,6 @@ public:
     auto presenter = makePresenter(std::move(defaultOptions));
     EXPECT_CALL(m_view, setAnalysisMode("MultiDetectorAnalysis")).Times(1);
     presenter.notifyInstrumentChanged("POLREF");
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesAnalysisModeInModel() {
@@ -658,7 +619,6 @@ public:
     auto presenter = makePresenter(std::move(defaultOptions));
     presenter.notifyInstrumentChanged("POLREF");
     TS_ASSERT_EQUALS(presenter.experiment().analysisMode(), AnalysisMode::MultiDetector);
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesReductionOptionsInView() {
@@ -669,7 +629,6 @@ public:
     EXPECT_CALL(m_view, setReductionType("NonFlatSample")).Times(1);
     EXPECT_CALL(m_view, setIncludePartialBins(true)).Times(1);
     presenter.notifyInstrumentChanged("POLREF");
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesReductionOptionsInModel() {
@@ -680,7 +639,6 @@ public:
     TS_ASSERT_EQUALS(presenter.experiment().summationType(), SummationType::SumInQ);
     TS_ASSERT_EQUALS(presenter.experiment().reductionType(), ReductionType::NonFlatSample);
     TS_ASSERT_EQUALS(presenter.experiment().includePartialBins(), true);
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesDebugOptionsInView() {
@@ -689,7 +647,6 @@ public:
     auto presenter = makePresenter(std::move(defaultOptions));
     EXPECT_CALL(m_view, setDebugOption(true)).Times(1);
     presenter.notifyInstrumentChanged("POLREF");
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesDebugOptionsInModel() {
@@ -698,7 +655,6 @@ public:
     auto presenter = makePresenter(std::move(defaultOptions));
     presenter.notifyInstrumentChanged("POLREF");
     TS_ASSERT_EQUALS(presenter.experiment().debug(), true);
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesLookupRowInView() {
@@ -711,7 +667,6 @@ public:
         {"", "", "", "", "", "0.010000", "0.200000", "0.030000", "0.700000", "390-415", "370-389,416-430", ""}};
     EXPECT_CALL(m_view, setLookupTable(expected)).Times(1);
     presenter.notifyInstrumentChanged("POLREF");
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesLookupRowInModel() {
@@ -728,7 +683,6 @@ public:
     if (lookupRows.size() == 1) {
       TS_ASSERT_EQUALS(lookupRows.front(), expected);
     }
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesTransmissionRunRangeInView() {
@@ -739,7 +693,6 @@ public:
     EXPECT_CALL(m_view, setTransmissionEndOverlap(12.0)).Times(1);
     EXPECT_CALL(m_view, showTransmissionRangeValid()).Times(1);
     presenter.notifyInstrumentChanged("POLREF");
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesTransmissionRunRangeInModel() {
@@ -749,7 +702,6 @@ public:
     presenter.notifyInstrumentChanged("POLREF");
     auto const expected = RangeInLambda{10.0, 12.0};
     TS_ASSERT_EQUALS(presenter.experiment().transmissionStitchOptions().overlapRange(), expected);
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesCorrectionInView() {
@@ -765,7 +717,6 @@ public:
     EXPECT_CALL(m_view, setPolynomialDegree(3));
     EXPECT_CALL(m_view, setCostFunction("Unweighted least squares"));
     presenter.notifyInstrumentChanged("POLREF");
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesCorrectionInModel() {
@@ -778,7 +729,6 @@ public:
     assertBackgroundSubtractionOptionsSet(presenter);
     assertPolarizationAnalysisParameterFile(presenter);
     assertFloodCorrectionUsesParameterFile(presenter);
-    verifyAndClear();
   }
 
   void testInstrumentChangedDisconnectsNotificationsBackFromView() {
@@ -787,7 +737,6 @@ public:
     EXPECT_CALL(m_view, connectExperimentSettingsWidgets()).Times(1);
     auto presenter = makePresenter(std::move(defaultOptions));
     presenter.notifyInstrumentChanged("POLREF");
-    verifyAndClear();
   }
 
   void testPolarizationCorrectionsDisabledForINTER() {
@@ -829,8 +778,6 @@ public:
     TS_ASSERT_EQUALS(row.processingInstructions().get(), "10");
     TS_ASSERT_EQUALS(row.backgroundProcessingInstructions().get(), "11");
     TS_ASSERT_EQUALS(row.transmissionProcessingInstructions().get(), "12");
-
-    verifyAndClear();
   }
 
   void testNotifyPreviewApplyRequestedClearsProcessingInstructionsWhenMissing() {
@@ -848,8 +795,6 @@ public:
     TS_ASSERT(!row.processingInstructions());
     TS_ASSERT(!row.backgroundProcessingInstructions());
     TS_ASSERT(!row.transmissionProcessingInstructions());
-
-    verifyAndClear();
   }
 
   void testNotifyPreviewApplyRequestedDoesNotResetRowStateIfNoSettingsChanged() {
@@ -871,8 +816,6 @@ public:
     TS_ASSERT_EQUALS(row.processingInstructions().get(), "4-6");
     TS_ASSERT_EQUALS(row.backgroundProcessingInstructions().get(), "2-3,7-8");
     TS_ASSERT_EQUALS(row.transmissionProcessingInstructions().get(), "4");
-
-    verifyAndClear();
   }
 
   void testNotifyPreviewApplyRequestedResetsRowStateIfOnlyDetROIChanged() {
@@ -888,8 +831,6 @@ public:
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(1);
 
     presenter.notifyPreviewApplyRequested(previewRow);
-
-    verifyAndClear();
   }
 
   void testNotifyPreviewApplyRequestedResetsRowStateIfOnlySignalROIChanged() {
@@ -905,8 +846,6 @@ public:
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(1);
 
     presenter.notifyPreviewApplyRequested(previewRow);
-
-    verifyAndClear();
   }
 
   void testNotifyPreviewApplyRequestedResetsRowStateIfOnlyBackgroundROIChanged() {
@@ -922,8 +861,6 @@ public:
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(1);
 
     presenter.notifyPreviewApplyRequested(previewRow);
-
-    verifyAndClear();
   }
 
   void testNotifyPreviewApplyRequestedResetsRowStateIfOnlyTransmissionROIChanged() {
@@ -939,8 +876,6 @@ public:
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(1);
 
     presenter.notifyPreviewApplyRequested(previewRow);
-
-    verifyAndClear();
   }
 
   void testNotifyPreviewApplyRequestedMatchingRowNotFound() {
@@ -953,8 +888,6 @@ public:
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(0);
 
     TS_ASSERT_THROWS(presenter.notifyPreviewApplyRequested(previewRow), RowNotFoundException const &);
-
-    verifyAndClear();
   }
 
   void testNotifyPreviewApplyRequestedInvalidTable() {
@@ -970,8 +903,6 @@ public:
     // THEN an InvalidTableException is thrown.
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(0);
     TS_ASSERT_THROWS(presenter.notifyPreviewApplyRequested(previewRow), InvalidTableException const &);
-
-    verifyAndClear();
   }
 
 private:
@@ -1108,8 +1039,6 @@ private:
     EXPECT_CALL(m_mainPresenter, instrumentName()).Times(1).WillOnce(Return(instrument));
     EXPECT_CALL(m_view, enablePolarizationCorrections()).Times(1);
     presenter.notifySettingsChanged();
-
-    verifyAndClear();
   }
 
   void runTestThatPolarizationCorrectionsAreDisabledForInstrument(std::string const &instrument) {
@@ -1119,8 +1048,6 @@ private:
     EXPECT_CALL(m_view, setPolarizationCorrectionOption("None")).Times(1);
     EXPECT_CALL(m_view, disablePolarizationCorrections()).Times(1);
     presenter.notifySettingsChanged();
-
-    verifyAndClear();
   }
 
   void runTestThatPolarizationCorrectionsDisabled() {
@@ -1134,7 +1061,6 @@ private:
     presenter.notifySettingsChanged();
 
     assertPolarizationAnalysisNone(presenter);
-    verifyAndClear();
   }
 
   void runTestThatPolarizationCorrectionsUsesParameterFile() {
@@ -1147,7 +1073,6 @@ private:
     presenter.notifySettingsChanged();
 
     assertPolarizationAnalysisParameterFile(presenter);
-    verifyAndClear();
   }
 
   void runTestThatPolarizationCorrectionsUsesWorkspace() {
@@ -1161,7 +1086,6 @@ private:
     presenter.notifySettingsChanged();
 
     assertPolarizationAnalysisWorkspace(presenter);
-    verifyAndClear();
   }
 
   void runTestThatPolarizationCorrectionsUsesFilePath() {
@@ -1175,7 +1099,6 @@ private:
     presenter.notifySettingsChanged();
 
     assertPolarizationAnalysisWorkspace(presenter);
-    verifyAndClear();
   }
 
   void runWithFloodCorrectionInputsDisabled(std::string const &type) {
@@ -1185,8 +1108,6 @@ private:
     EXPECT_CALL(m_view, disableFloodCorrectionInputs()).Times(1);
     EXPECT_CALL(m_view, getFloodWorkspace()).Times(0);
     presenter.notifySettingsChanged();
-
-    verifyAndClear();
   }
 
   void runWithFloodCorrectionInputsEnabled(std::string const &type) {
@@ -1195,8 +1116,6 @@ private:
     EXPECT_CALL(m_view, getFloodCorrectionType()).Times(2).WillRepeatedly(Return(type));
     EXPECT_CALL(m_view, enableFloodCorrectionInputs()).Times(1);
     presenter.notifySettingsChanged();
-
-    verifyAndClear();
   }
 
   void runTestForValidTransmissionRunRange(RangeInLambda const &range, boost::optional<RangeInLambda> const &result) {
@@ -1206,7 +1125,6 @@ private:
     EXPECT_CALL(m_view, showTransmissionRangeValid()).Times(1);
     presenter.notifySettingsChanged();
     TS_ASSERT_EQUALS(presenter.experiment().transmissionStitchOptions().overlapRange(), result);
-    verifyAndClear();
   }
 
   void runTestForInvalidTransmissionRunRange(RangeInLambda const &range) {
@@ -1216,7 +1134,6 @@ private:
     EXPECT_CALL(m_view, showTransmissionRangeInvalid()).Times(1);
     presenter.notifySettingsChanged();
     TS_ASSERT_EQUALS(presenter.experiment().transmissionStitchOptions().overlapRange(), boost::none);
-    verifyAndClear();
   }
 
   // These functions create various rows in the per-theta defaults tables,
@@ -1260,7 +1177,6 @@ private:
     EXPECT_CALL(m_view, getLookupTable()).WillOnce(Return(optionsTable));
     EXPECT_CALL(m_view, showAllLookupRowsAsValid()).Times(1);
     presenter.notifyLookupRowChanged(1, 1);
-    verifyAndClear();
   }
 
   void runTestForInvalidOptionsTable(OptionsTable const &optionsTable, const std::vector<int> &rows,
@@ -1274,7 +1190,6 @@ private:
     }
     presenter.notifyLookupRowChanged(1, 1);
     TS_ASSERT(!presenter.hasValidSettings());
-    verifyAndClear();
   }
 
   void runTestForInvalidOptionsTable(OptionsTable const &optionsTable, int row, std::vector<int> columns) {
@@ -1295,7 +1210,6 @@ private:
       }
     }
     presenter.notifyLookupRowChanged(0, 0);
-    verifyAndClear();
   }
 
   void runTestForValidTransmissionParams(std::string const &params) {
@@ -1304,7 +1218,6 @@ private:
     EXPECT_CALL(m_view, showTransmissionStitchParamsValid());
     presenter.notifySettingsChanged();
     TS_ASSERT_EQUALS(presenter.experiment().transmissionStitchOptions().rebinParameters(), params);
-    verifyAndClear();
   }
 
   void runTestForInvalidTransmissionParams(std::string const &params) {
@@ -1313,7 +1226,6 @@ private:
     EXPECT_CALL(m_view, showTransmissionStitchParamsInvalid());
     presenter.notifySettingsChanged();
     TS_ASSERT_EQUALS(presenter.experiment().transmissionStitchOptions().rebinParameters(), "");
-    verifyAndClear();
   }
 };
 


### PR DESCRIPTION
**Description of work**

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
To improve the maintainability of this unit test class, as agreed in a recent PR review.

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
When using mock variables in our C++ unit tests, `Mock::VerifyAndClearExpectations` is called automatically when the variable is destroyed. However, many of our Reflectometry unit tests create member variables that are only destroyed once all tests have run, so we need to call `Mock::VerifyAndClearExpectations` ourselves after each test. This PR refactors the `ExperimentPresenterTest` so that this is done from the `tearDown()` method rather than needing to call it in each individual test, and I've also added a comment to explain why this is needed. This should make it easier for new tests to be added and for developers that are new to the test class to understand how things are working.

I was initially hoping to do a more involved refactor of the test to switch to using local mock variables, which is how some of our newer unit tests are set up and is considered the better way to handle this. However once I realised how involved this was going to be and how many of the Reflectometry test classes have been set up this way, it felt like this was a more proportionate fix for improving maintainability. Again, because of the number of test classes affected, I have only refactored the class that was flagged in a recent PR review. I have edited the linked issue to be more general so that we can gradually work through the remaining classes during maintenance periods.


**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Tests should pass.

Refs #35956. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **it is a unit test refactor.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.