### PR TITLE
Fix bug in error propagation in FindSXPeaksConvolve

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/FindSXPeaksConvolve.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindSXPeaksConvolve.py
@@ -170,7 +170,7 @@ class FindSXPeaksConvolve(DataProcessorAlgorithm):
             # perform convolutions to integrate kernel/shoebox
             # pad with nearest so don't get peaks at edge when -ve values go outside data extent
             yconv = convolve(input=y, weights=kernel, mode="nearest")
-            econv = np.sqrt(convolve(input=e**2, weights=abs(kernel), mode="nearest"))
+            econv = np.sqrt(convolve(input=e**2, weights=kernel**2, mode="nearest"))
             with np.errstate(divide="ignore", invalid="ignore"):
                 intens_over_sig = yconv / econv  # ignore 0/0 which produces NaN (recall NaN > x = False)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/FindSXPeaksConvolveTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FindSXPeaksConvolveTest.py
@@ -67,11 +67,11 @@ class FindSXPeaksConvolveTest(unittest.TestCase):
         pk = peak_ws.getPeak(0)
         self.assertEqual(pk.getDetectorID(), 79)
         self.assertAlmostEqual(pk.getTOF(), 5.0, delta=1e-8)
-        self.assertAlmostEqual(pk.getIntensityOverSigma(), 6.0622, delta=1e-4)
+        self.assertAlmostEqual(pk.getIntensityOverSigma(), 6.7937, delta=1e-4)
         pk = peak_ws.getPeak(1)
         self.assertEqual(pk.getDetectorID(), 61)
         self.assertAlmostEqual(pk.getTOF(), 7.0, delta=1e-8)
-        self.assertAlmostEqual(pk.getIntensityOverSigma(), 5.3981, delta=1e-4)
+        self.assertAlmostEqual(pk.getIntensityOverSigma(), 6.1274, delta=1e-4)
 
     def test_exec_specify_nbins(self):
         out = FindSXPeaksConvolve(

--- a/docs/source/algorithms/FindSXPeaksConvolve-v1.rst
+++ b/docs/source/algorithms/FindSXPeaksConvolve-v1.rst
@@ -31,7 +31,7 @@ factor 1.25 along each dimension (such that there are approximately the same num
 background shell). The integral of the kernel and background shell together is zero.
 
 The integrated intensity is evaluated by convolution of the signal array with the kernel and the square of the error on
-the integrated intensity is determined by convolution of the squared error array with the absolute value of the kernel.
+the integrated intensity is determined by convolution of the squared error array with the squared value of the kernel.
 
 The threshold for peak detection is given by ``ThresholdIoverSigma`` which is the cutoff ratio of intensity/sigma (i.e.
 a valid peak would be expected to have intensity/sigma > 3). Stronger peaks will have a larger intensity/sigma.
@@ -54,7 +54,7 @@ Usage
 
 .. testoutput:: exampleFindSXPeaksConvolve
 
-    Found 313 peaks
+    Found 323 peaks
 
 
 .. categories::


### PR DESCRIPTION
**Description of work**
`FindSXPeaksConvolve` algorithm was added in release 6.8
The error convolution should use the `kernel**2` instead of `abs(kernel)` here 
https://github.com/mantidproject/mantid/blob/bab00599b2c85c7983aef18dc29f6873718a6e9e/Framework/PythonInterface/plugins/algorithms/FindSXPeaksConvolve.py#L173

Correcting this does offer a small improvement (both in number of peaks found and the error on the integrated intensity)
![image](https://github.com/mantidproject/mantid/assets/55979119/75627eee-4b66-47b9-8894-9d3f8e38ecdf)

**To test:**

Follow instructions in #35914

Fixes #36175


*This does not require release notes* because **algorithm was added this release**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.