### PR TITLE
Discard the Figure resize event if it has a negative size

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -443,11 +443,11 @@ cstyleCast:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/Python/CodeExecution.cpp:87
 cstyleCast:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/Python/CodeExecution.cpp:90
 unusedStructMember:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/Python/CodeExecution.cpp:20
 unusedStructMember:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/Python/CodeExecution.cpp:21
-shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/mplcpp/src/ColorbarWidget.cpp:78
-shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/mplcpp/src/ColorbarWidget.cpp:82
-shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/mplcpp/src/ColorbarWidget.cpp:188
-shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/mplcpp/src/ColorbarWidget.cpp:208
-shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/mplcpp/src/ColorbarWidget.cpp:232
+shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/mplcpp/src/ColorbarWidget.cpp:80
+shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/mplcpp/src/ColorbarWidget.cpp:84
+shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/mplcpp/src/ColorbarWidget.cpp:190
+shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/mplcpp/src/ColorbarWidget.cpp:210
+shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/mplcpp/src/ColorbarWidget.cpp:234
 unknownMacro:${CMAKE_SOURCE_DIR}/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h:45
 constVariable:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/BankTextureBuilder.cpp:326
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/MiniPlotMpl.cpp:154

--- a/docs/source/release/v6.8.0/Workbench/InstrumentViewer/Bugfixes/36181.rst
+++ b/docs/source/release/v6.8.0/Workbench/InstrumentViewer/Bugfixes/36181.rst
@@ -1,0 +1,1 @@
+- An exception caused when the colorbar on the "Render" tab is resized to a negative value has been fixed.

--- a/qt/widgets/mplcpp/CMakeLists.txt
+++ b/qt/widgets/mplcpp/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIB_SRCS
     src/ErrorbarContainer.cpp
     src/Figure.cpp
     src/FigureCanvasQt.cpp
+    src/FigureEventFilter.cpp
     src/Line2D.cpp
     src/MantidAxes.cpp
     src/MantidColorMap.cpp
@@ -22,7 +23,9 @@ set(LIB_SRCS
     src/SingleMarker.cpp
 )
 
-set(MOC_HEADERS inc/MantidQtWidgets/MplCpp/ColorbarWidget.h inc/MantidQtWidgets/MplCpp/FigureCanvasQt.h)
+set(MOC_HEADERS inc/MantidQtWidgets/MplCpp/ColorbarWidget.h inc/MantidQtWidgets/MplCpp/FigureCanvasQt.h
+                inc/MantidQtWidgets/MplCpp/FigureEventFilter.h
+)
 
 set(NOMOC_HEADERS
     inc/MantidQtWidgets/MplCpp/Artist.h

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/FigureEventFilter.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/FigureEventFilter.h
@@ -1,0 +1,33 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidQtWidgets/MplCpp/DllConfig.h"
+
+#include <QEvent>
+#include <QObject>
+
+namespace MantidQt {
+namespace Widgets {
+namespace MplCpp {
+
+/**
+ * @brief Provides a QObject that can be installed to filter out unwanted
+ * QEvent's for a C++ Matplotlib Figure. For example, we do not want to
+ * process event's which attempt to do a negative resizing of a Matplotlib
+ * Figure because this causes an exception.
+ */
+class MANTID_MPLCPP_DLL FigureEventFilter : public QObject {
+  Q_OBJECT
+
+protected:
+  bool eventFilter(QObject *obj, QEvent *ev) override;
+};
+
+} // namespace MplCpp
+} // namespace Widgets
+} // namespace MantidQt

--- a/qt/widgets/mplcpp/src/ColorbarWidget.cpp
+++ b/qt/widgets/mplcpp/src/ColorbarWidget.cpp
@@ -9,6 +9,7 @@
 #include "MantidQtWidgets/MplCpp/Colors.h"
 #include "MantidQtWidgets/MplCpp/Figure.h"
 #include "MantidQtWidgets/MplCpp/FigureCanvasQt.h"
+#include "MantidQtWidgets/MplCpp/FigureEventFilter.h"
 #include "MantidQtWidgets/MplCpp/MantidColorMap.h"
 
 #include <QComboBox>
@@ -50,6 +51,7 @@ ColorbarWidget::ColorbarWidget(QWidget *parent)
     : QWidget(parent), m_ui(), m_mappable(Normalize(0, 1), getCMap(defaultCMapName())) {
   initLayout();
   connectSignals();
+  m_canvas->installEventFilterToMplCanvas(new FigureEventFilter());
 }
 
 /**

--- a/qt/widgets/mplcpp/src/FigureEventFilter.cpp
+++ b/qt/widgets/mplcpp/src/FigureEventFilter.cpp
@@ -1,0 +1,24 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidQtWidgets/MplCpp/FigureEventFilter.h"
+
+#include <QResizeEvent>
+
+namespace MantidQt::Widgets::MplCpp {
+
+bool FigureEventFilter::eventFilter(QObject *obj, QEvent *ev) {
+  if (ev->type() == QEvent::Resize) {
+    auto const size = static_cast<QResizeEvent *>(ev)->size();
+    if (size.width() < 1 || size.height() < 1) {
+      // The resize is negative and will cause an exception, so stop processing the event
+      return true;
+    }
+  }
+  return QObject::eventFilter(obj, ev);
+}
+
+} // namespace MantidQt::Widgets::MplCpp


### PR DESCRIPTION
**Description of work**
This PR ensures that a QResizeEvent for a C++ ColorbarWidget is discarded if the size is negative or zero. If either of these is true, matplotlib shows an exception which threatens to terminate Mantid.

The bug is present in InstrumentView as well and should be fixed now.

**To test:**
Follow the instructions in the attached issue

Fixes #36179

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
