### PR TITLE
Rewrite RebinRagged as a c++ algorithm

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -255,6 +255,7 @@ set(SRC_FILES
     src/RebinByPulseTimes.cpp
     src/RebinByTimeAtSample.cpp
     src/RebinByTimeBase.cpp
+    src/RebinRagged2.cpp
     src/RebinToWorkspace.cpp
     src/Rebunch.cpp
     src/RecordPythonScript.cpp
@@ -604,6 +605,7 @@ set(INC_FILES
     inc/MantidAlgorithms/RebinByPulseTimes.h
     inc/MantidAlgorithms/RebinByTimeAtSample.h
     inc/MantidAlgorithms/RebinByTimeBase.h
+    inc/MantidAlgorithms/RebinRagged2.h
     inc/MantidAlgorithms/RebinToWorkspace.h
     inc/MantidAlgorithms/Rebunch.h
     inc/MantidAlgorithms/RecordPythonScript.h
@@ -954,6 +956,7 @@ set(TEST_FILES
     Rebin2DTest.h
     RebinByPulseTimesTest.h
     RebinByTimeAtSampleTest.h
+    RebinRagged2Test.h
     RebinTest.h
     RebinToWorkspaceTest.h
     RebunchTest.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/Rebin.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Rebin.h
@@ -73,7 +73,7 @@ protected:
   void exec() override;
 
   void propagateMasks(const API::MatrixWorkspace_const_sptr &inputWS, const API::MatrixWorkspace_sptr &outputWS,
-                      int hist);
+                      const int hist, const bool IgnoreBinErrors = false);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/RebinRagged2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RebinRagged2.h
@@ -6,21 +6,22 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "MantidAPI/Algorithm.h"
-#include "MantidAlgorithms/DllConfig.h"
+#include "MantidAlgorithms/Rebin.h"
 
 namespace Mantid {
 namespace Algorithms {
 
 /** RebinRagged : TODO: DESCRIPTION
  */
-class MANTID_ALGORITHMS_DLL RebinRagged : public API::Algorithm {
+class MANTID_ALGORITHMS_DLL RebinRagged : public Rebin {
 public:
   const std::string name() const override;
   int version() const override;
   const std::string category() const override;
   const std::string summary() const override;
   const std::vector<std::string> seeAlso() const override { return {"Rebin", "ResampleX"}; }
+  /// Alias for the algorithm. Must override so it doesn't get parent class's
+  const std::string alias() const override { return ""; }
 
 private:
   void init() override;
@@ -28,6 +29,7 @@ private:
   std::map<std::string, std::string> validateInputs() override;
   static bool use_simple_rebin(std::vector<double> xmins, std::vector<double> xmaxs, std::vector<double> deltas);
   static void extend_value(size_t numSpec, std::vector<double> &array);
+  const std::string workspaceMethodName() const override { return ""; } // Override the one from Rebin to ignore us
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/RebinRagged2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RebinRagged2.h
@@ -1,0 +1,30 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAlgorithms/DllConfig.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+/** RebinRagged : TODO: DESCRIPTION
+ */
+class MANTID_ALGORITHMS_DLL RebinRagged : public API::Algorithm {
+public:
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
+
+private:
+  void init() override;
+  void exec() override;
+};
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/RebinRagged2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RebinRagged2.h
@@ -28,7 +28,7 @@ private:
   void exec() override;
   std::map<std::string, std::string> validateInputs() override;
   static bool use_simple_rebin(std::vector<double> xmins, std::vector<double> xmaxs, std::vector<double> deltas);
-  static void extend_value(size_t numSpec, std::vector<double> &array);
+  static void extend_value(int numSpec, std::vector<double> &array);
   const std::string workspaceMethodName() const override { return ""; } // Override the one from Rebin to ignore us
 };
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/RebinRagged2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RebinRagged2.h
@@ -20,10 +20,14 @@ public:
   int version() const override;
   const std::string category() const override;
   const std::string summary() const override;
+  const std::vector<std::string> seeAlso() const override { return {"Rebin", "ResampleX"}; }
 
 private:
   void init() override;
   void exec() override;
+  std::map<std::string, std::string> validateInputs() override;
+  static bool use_simple_rebin(std::vector<double> xmins, std::vector<double> xmaxs, std::vector<double> deltas);
+  static void extend_value(size_t numSpec, std::vector<double> &array);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -441,6 +441,7 @@ void Rebin::exec() {
  *  @param inputWS ::  The input workspace
  *  @param outputWS :: The output workspace
  *  @param hist ::    The index of the current histogram
+ *  @param ignoreErrors :: If to ignore bin errors
  */
 void Rebin::propagateMasks(const API::MatrixWorkspace_const_sptr &inputWS, const API::MatrixWorkspace_sptr &outputWS,
                            const int hist, const bool ignoreErrors) {

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -411,7 +411,7 @@ void Rebin::exec() {
     for (int i = 0; i < histnumber; ++i) {
       if (inputWS->hasMaskedBins(i)) // Does the current spectrum have any masked bins?
       {
-        this->propagateMasks(inputWS, outputWS, i);
+        this->propagateMasks(inputWS, outputWS, i, ignoreBinErrors);
       }
     }
     // Copy the units over too.
@@ -443,7 +443,7 @@ void Rebin::exec() {
  *  @param hist ::    The index of the current histogram
  */
 void Rebin::propagateMasks(const API::MatrixWorkspace_const_sptr &inputWS, const API::MatrixWorkspace_sptr &outputWS,
-                           int hist) {
+                           const int hist, const bool ignoreErrors) {
   // Not too happy with the efficiency of this way of doing it, but it's a lot
   // simpler to use the
   // existing rebin algorithm to distribute the weights than to re-implement it
@@ -476,7 +476,6 @@ void Rebin::propagateMasks(const API::MatrixWorkspace_const_sptr &inputWS, const
                     FrequencyStandardDeviations(errSize, 0));
   // Use rebin function to redistribute the weights. Note that distribution flag
   // is set
-  bool ignoreErrors = getProperty(PropertyNames::IGNR_BIN_ERR);
 
   try {
     auto newHist = HistogramData::rebin(oldHist, outputWS->binEdges(hist));

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -8,7 +8,6 @@
 #include "MantidHistogramData/Exception.h"
 #include "MantidHistogramData/Rebin.h"
 
-#include "MantidAPI/Axis.h"
 #include "MantidAPI/HistoWorkspace.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
@@ -345,18 +344,6 @@ void Rebin::exec() {
         PARALLEL_END_INTERRUPT_REGION
       }
       PARALLEL_CHECK_INTERRUPT_REGION
-
-      // Copy all the axes
-      for (int i = 1; i < inputWS->axes(); i++) {
-        outputWS->replaceAxis(i, std::unique_ptr<Axis>(inputWS->getAxis(i)->clone(outputWS.get())));
-        outputWS->getAxis(i)->unit() = inputWS->getAxis(i)->unit();
-      }
-
-      // Copy the units over too.
-      for (int i = 0; i < outputWS->axes(); ++i)
-        outputWS->getAxis(i)->unit() = inputWS->getAxis(i)->unit();
-      outputWS->setYUnit(eventInputWS->YUnit());
-      outputWS->setYUnitLabel(eventInputWS->YUnitLabel());
     }
 
     // Assign it to the output workspace property
@@ -381,9 +368,6 @@ void Rebin::exec() {
     // signal array
     outputWS = DataObjects::create<API::HistoWorkspace>(*inputWS, histnumber, XValues_new);
 
-    // Copy over the 'vertical' axis
-    if (inputWS->axes() > 1)
-      outputWS->replaceAxis(1, std::unique_ptr<Axis>(inputWS->getAxis(1)->clone(outputWS.get())));
     bool ignoreBinErrors = getProperty(PropertyNames::IGNR_BIN_ERR);
 
     Progress prog(this, 0.0, 1.0, histnumber);
@@ -413,10 +397,6 @@ void Rebin::exec() {
       {
         this->propagateMasks(inputWS, outputWS, i, ignoreBinErrors);
       }
-    }
-    // Copy the units over too.
-    for (int i = 0; i < outputWS->axes(); ++i) {
-      outputWS->getAxis(i)->unit() = inputWS->getAxis(i)->unit();
     }
 
     if (!isHist) {

--- a/Framework/Algorithms/src/RebinRagged2.cpp
+++ b/Framework/Algorithms/src/RebinRagged2.cpp
@@ -190,7 +190,7 @@ void RebinRagged::exec() {
 
         MantidVec y_data, e_data;
         // The EventList takes care of histogramming.
-        el.generateHistogram(XValues_new.rawData(), y_data, e_data);
+        el.generateHistogram(delta, XValues_new.rawData(), y_data, e_data);
 
         // Create and set the output histogram
         HistogramBuilder builder;

--- a/Framework/Algorithms/src/RebinRagged2.cpp
+++ b/Framework/Algorithms/src/RebinRagged2.cpp
@@ -1,0 +1,115 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidAlgorithms/RebinRagged2.h"
+#include "MantidAPI/HistoWorkspace.h"
+#include "MantidDataObjects/EventList.h"
+#include "MantidDataObjects/EventWorkspace.h"
+#include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/VectorHelper.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(RebinRagged)
+
+using namespace API;
+using namespace Kernel;
+using DataObjects::EventList;
+using DataObjects::EventWorkspace;
+using DataObjects::EventWorkspace_const_sptr;
+
+//----------------------------------------------------------------------------------------------
+
+/// Algorithms name for identification. @see Algorithm::name
+const std::string RebinRagged::name() const { return "RebinRagged"; }
+
+/// Algorithm's version for identification. @see Algorithm::version
+int RebinRagged::version() const { return 2; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string RebinRagged::category() const { return "TODO: FILL IN A CATEGORY"; }
+
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string RebinRagged::summary() const { return "TODO: FILL IN A SUMMARY"; }
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void RebinRagged::init() {
+  declareProperty(std::make_unique<WorkspaceProperty<>>("InputWorkspace", "", Direction::Input), "input workspace");
+  declareProperty(std::make_unique<WorkspaceProperty<>>("OutputWorkspace", "", Direction::Output), "output workspace");
+
+  declareProperty(std::make_unique<ArrayProperty<double>>("XMin"), "minimum x values with NaN meaning no minimum");
+  declareProperty(std::make_unique<ArrayProperty<double>>("XMax"), "maximum x values with NaN meaning no maximum");
+  declareProperty(std::make_unique<ArrayProperty<double>>("Delta"), "step parameter for rebin");
+  declareProperty("PreserveEvents", true, "False converts event workspaces to histograms");
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void RebinRagged::exec() {
+  MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
+  MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
+
+  bool PreserveEvents = getProperty("PreserveEvents");
+
+  // Rebinning in-place
+  bool inPlace = (inputWS == outputWS);
+
+  // workspace independent determination of length
+  const auto histnumber = static_cast<int>(inputWS->getNumberHistograms());
+
+  std::vector<double> xmins = getProperty("XMin");
+  std::vector<double> xmaxs = getProperty("XMax");
+  std::vector<double> deltas = getProperty("Delta");
+
+  xmins.resize(histnumber, xmins[0]);
+  xmaxs.resize(histnumber, xmaxs[0]);
+  deltas.resize(histnumber, deltas[0]);
+
+  // Now, determine if the input workspace is an EventWorkspace
+  EventWorkspace_const_sptr eventInputWS = std::dynamic_pointer_cast<const EventWorkspace>(inputWS);
+
+  if (eventInputWS) {
+
+    if (PreserveEvents) {
+      if (!inPlace) {
+        outputWS = inputWS->clone();
+      }
+      auto eventOutputWS = std::dynamic_pointer_cast<EventWorkspace>(outputWS);
+
+      for (int i = 0; i < histnumber; i++) {
+        auto xmin = xmins[i];
+        auto xmax = xmaxs[i];
+        const auto delta = deltas[i];
+
+        const auto inX = eventInputWS->x(i);
+        if (std::isnan(xmin))
+          xmin = inX.front();
+        if (std::isnan(xmax))
+          xmax = inX.back();
+
+        HistogramData::BinEdges XValues_new(0);
+        static_cast<void>(VectorHelper::createAxisFromRebinParams({xmin, delta, xmax}, XValues_new.mutableRawData()));
+        EventList &el = eventOutputWS->getSpectrum(i);
+        el.setHistogram(XValues_new);
+      }
+    } else {
+      throw Kernel::Exception::NotImplementedError("TODO: event to histogram");
+    }
+  } else {
+    throw Kernel::Exception::NotImplementedError("TODO: histgmra");
+  }
+
+  setProperty("OutputWorkspace", outputWS);
+}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/src/RebinRagged2.cpp
+++ b/Framework/Algorithms/src/RebinRagged2.cpp
@@ -120,7 +120,7 @@ void RebinRagged::exec() {
 
   if (use_simple_rebin(xmins, xmaxs, deltas)) {
     g_log.information("Using Rebin instead");
-    auto rebin = createChildAlgorithm("Rebin");
+    auto rebin = createChildAlgorithm("Rebin", 0.0, 1.0);
     rebin->setProperty("InputWorkspace", inputWS);
     rebin->setProperty("PreserveEvents", preserveEvents);
     const std::vector<double> params = {xmins[0], deltas[0], xmaxs[0]};

--- a/Framework/Algorithms/test/RebinRagged2Test.h
+++ b/Framework/Algorithms/test/RebinRagged2Test.h
@@ -200,4 +200,56 @@ public:
           TS_ASSERT_EQUALS(y, 14)
     }
   }
+
+  void test_event_workspace_preserverEvents_false() {
+    std::vector<double> xmins(200, 2600.);
+    xmins[11] = 3000.;
+    std::vector<double> xmaxs(200, 6200.);
+    xmaxs[12] = 5000.;
+    std::vector<double> deltas(200, 400.);
+    deltas[13] = 600.;
+
+    CreateSampleWorkspace createSampleWorkspaceAlgo;
+    createSampleWorkspaceAlgo.setChild(true);
+    createSampleWorkspaceAlgo.initialize();
+    createSampleWorkspaceAlgo.setPropertyValue("WorkspaceType", "Event");
+    createSampleWorkspaceAlgo.setPropertyValue("OutputWorkspace", "_unused_for_child");
+    createSampleWorkspaceAlgo.execute();
+    MatrixWorkspace_sptr ws = createSampleWorkspaceAlgo.getProperty("OutputWorkspace");
+
+    RebinRagged alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMin", xmins));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMax", xmaxs));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Delta", deltas));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("PreserveEvents", false));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    MatrixWorkspace_sptr result = alg.getProperty("OutputWorkspace");
+
+    TS_ASSERT_EQUALS(result->getNumberHistograms(), 200);
+
+    for (size_t i = 0; i < result->getNumberHistograms(); i++) {
+      const auto X = result->readX(i);
+      if (i == 11)
+        TS_ASSERT_EQUALS(X.size(), 9)
+      else if (i == 12 || i == 13)
+        TS_ASSERT_EQUALS(X.size(), 7)
+      else
+        TS_ASSERT_EQUALS(X.size(), 10)
+
+      const auto Y = result->readY(i);
+      if (i == 13)
+        for (const auto y : Y)
+          TS_ASSERT_EQUALS(y, 21)
+      else
+        for (const auto y : Y)
+          TS_ASSERT_EQUALS(y, 14)
+    }
+  }
 };

--- a/Framework/Algorithms/test/RebinRagged2Test.h
+++ b/Framework/Algorithms/test/RebinRagged2Test.h
@@ -10,6 +10,7 @@
 
 #include "MantidAlgorithms/CreateSampleWorkspace.h"
 #include "MantidAlgorithms/RebinRagged2.h"
+#include "MantidDataHandling/LoadNexusProcessed.h"
 
 using namespace Mantid;
 using namespace Mantid::DataObjects;
@@ -30,6 +31,123 @@ public:
     RebinRagged alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
+  }
+
+  void test_nomad_inplace() {
+    Mantid::DataHandling::LoadNexusProcessed loader;
+    loader.initialize();
+    loader.setProperty("Filename", "NOM_91796_banks.nxs");
+    loader.setProperty("OutputWorkspace", "NOM_91796_banks");
+    loader.execute();
+
+    RebinRagged alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", "NOM_91796_banks"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    const std::vector<double> xmins = {0.67, 1.20, 2.42, 3.70, 4.12, 0.39};
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMin", xmins));
+    const auto nan = std::numeric_limits<double>::quiet_NaN();
+    const std::vector<double> xmaxs = {10.20, 20.8, nan, nan, nan, 9.35};
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMax", xmaxs));
+    const std::vector<double> deltas = {0.02};
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Delta", deltas));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    MatrixWorkspace_sptr result = alg.getProperty("OutputWorkspace");
+
+    TS_ASSERT_EQUALS(result->getNumberHistograms(), 6);
+
+    const std::vector<double> expected_len = {478, 981, 1880, 1816, 1795, 449};
+
+    for (size_t i = 0; i < 6; i++) {
+      TS_ASSERT_EQUALS(result->readX(i).size(), expected_len[i]);
+    }
+  }
+
+  void test_nomad_no_mins() {
+    Mantid::DataHandling::LoadNexusProcessed loader;
+    loader.initialize();
+    loader.setProperty("Filename", "NOM_91796_banks.nxs");
+    loader.setProperty("OutputWorkspace", "NOM_91796_banks");
+    loader.execute();
+
+    RebinRagged alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", "NOM_91796_banks"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    const auto nan = std::numeric_limits<double>::quiet_NaN();
+    const std::vector<double> xmaxs = {10.20, 20.8, std::numeric_limits<double>::infinity(), nan, nan, 9.35};
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMax", xmaxs));
+    const std::vector<double> deltas = {0.04}; // double original data bin size
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Delta", deltas));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    MatrixWorkspace_sptr result = alg.getProperty("OutputWorkspace");
+
+    TS_ASSERT_EQUALS(result->getNumberHistograms(), 6);
+
+    const std::vector<double> expected_len = {256, 521, 1001, 1001, 1001, 235};
+
+    for (size_t i = 0; i < 6; i++) {
+      TS_ASSERT_EQUALS(result->readX(i).size(), expected_len[i]);
+    }
+  }
+
+  void test_hist_workspace() {
+    std::vector<double> xmins(200, 2600.);
+    xmins[11] = 3000.;
+    std::vector<double> xmaxs(200, 6200.);
+    xmaxs[12] = 5000.;
+    std::vector<double> deltas(200, 400.);
+    deltas[13] = 600.;
+
+    CreateSampleWorkspace createSampleWorkspaceAlgo;
+    createSampleWorkspaceAlgo.setChild(true);
+    createSampleWorkspaceAlgo.initialize();
+    createSampleWorkspaceAlgo.setPropertyValue("WorkspaceType", "Histogram");
+    createSampleWorkspaceAlgo.setPropertyValue("OutputWorkspace", "_unused_for_child");
+    createSampleWorkspaceAlgo.execute();
+    MatrixWorkspace_sptr ws = createSampleWorkspaceAlgo.getProperty("OutputWorkspace");
+
+    RebinRagged alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMin", xmins));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMax", xmaxs));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Delta", deltas));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    MatrixWorkspace_sptr result = alg.getProperty("OutputWorkspace");
+
+    TS_ASSERT_EQUALS(result->getNumberHistograms(), 200);
+
+    for (size_t i = 0; i < result->getNumberHistograms(); i++) {
+      const auto X = result->readX(i);
+      if (i == 11)
+        TS_ASSERT_EQUALS(X.size(), 9)
+      else if (i == 12 || i == 13)
+        TS_ASSERT_EQUALS(X.size(), 7)
+      else
+        TS_ASSERT_EQUALS(X.size(), 10)
+
+      const auto Y = result->readY(i);
+      if (i == 13)
+        for (const auto y : Y)
+          TS_ASSERT_DELTA(y, 0.9, 1e-9)
+      else
+        for (const auto y : Y)
+          TS_ASSERT_DELTA(y, 0.6, 1e-9)
+    }
   }
 
   void test_event_workspace() {

--- a/Framework/Algorithms/test/RebinRagged2Test.h
+++ b/Framework/Algorithms/test/RebinRagged2Test.h
@@ -1,0 +1,85 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAlgorithms/CreateSampleWorkspace.h"
+#include "MantidAlgorithms/RebinRagged2.h"
+
+using namespace Mantid;
+using namespace Mantid::DataObjects;
+using namespace Mantid::API;
+using namespace Mantid::DataHandling;
+
+using Mantid::Algorithms::CreateSampleWorkspace;
+using Mantid::Algorithms::RebinRagged;
+
+class RebinRagged2Test : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static RebinRagged2Test *createSuite() { return new RebinRagged2Test(); }
+  static void destroySuite(RebinRagged2Test *suite) { delete suite; }
+
+  void test_Init() {
+    RebinRagged alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
+
+  void test_event_workspace() {
+    std::vector<double> xmins(200, 2600.);
+    xmins[11] = 3000.;
+    std::vector<double> xmaxs(200, 6200.);
+    xmaxs[12] = 5000.;
+    std::vector<double> deltas(200, 400.);
+    deltas[13] = 600.;
+
+    CreateSampleWorkspace createSampleWorkspaceAlgo;
+    createSampleWorkspaceAlgo.setChild(true);
+    createSampleWorkspaceAlgo.initialize();
+    createSampleWorkspaceAlgo.setPropertyValue("WorkspaceType", "Event");
+    createSampleWorkspaceAlgo.setPropertyValue("OutputWorkspace", "_unused_for_child");
+    createSampleWorkspaceAlgo.execute();
+    MatrixWorkspace_sptr ws = createSampleWorkspaceAlgo.getProperty("OutputWorkspace");
+
+    RebinRagged alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMin", xmins));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XMax", xmaxs));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Delta", deltas));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    MatrixWorkspace_sptr result = alg.getProperty("OutputWorkspace");
+
+    TS_ASSERT_EQUALS(result->getNumberHistograms(), 200);
+
+    for (size_t i = 0; i < result->getNumberHistograms(); i++) {
+      const auto X = result->readX(i);
+      if (i == 11)
+        TS_ASSERT_EQUALS(X.size(), 9)
+      else if (i == 12 || i == 13)
+        TS_ASSERT_EQUALS(X.size(), 7)
+      else
+        TS_ASSERT_EQUALS(X.size(), 10)
+
+      const auto Y = result->readY(i);
+      if (i == 13)
+        for (const auto y : Y)
+          TS_ASSERT_EQUALS(y, 21)
+      else
+        for (const auto y : Y)
+          TS_ASSERT_EQUALS(y, 14)
+    }
+  }
+};

--- a/Framework/PythonInterface/test/python/plugins/algorithms/RebinRaggedTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/RebinRaggedTest.py
@@ -28,6 +28,7 @@ class RebinRaggedTest(unittest.TestCase):
             XMin=[0.67, 1.20, 2.42, 3.70, 4.12, 0.39],
             Delta=0.02,  # original data bin size
             XMax=[10.20, 20.8, np_nan, math_nan, np_nan, 9.35],
+            Version=1,
         )
 
         self.assertTrue(alg_test.isExecuted())
@@ -47,6 +48,7 @@ class RebinRaggedTest(unittest.TestCase):
             OutputWorkspace="NOM_91796_banks",
             Delta=0.04,  # double original data bin size
             XMax=[10.20, 20.8, np_inf, math_nan, np_nan, 9.35],
+            Version=1,
         )
 
         self.assertTrue(alg_test.isExecuted())
@@ -69,7 +71,7 @@ class RebinRaggedTest(unittest.TestCase):
 
         ws = api.CreateSampleWorkspace(OutputWorkspace="RebinRagged_hist", WorkspaceType="Histogram")
 
-        rebinned = api.RebinRagged(ws, XMin=xmins, XMax=xmaxs, Delta=deltas)
+        rebinned = api.RebinRagged(ws, XMin=xmins, XMax=xmaxs, Delta=deltas, Version=1)
 
         self.assertEqual(rebinned.getNumberHistograms(), 200)
         for i in range(rebinned.getNumberHistograms()):
@@ -103,7 +105,7 @@ class RebinRaggedTest(unittest.TestCase):
         ws = api.CreateSampleWorkspace(OutputWorkspace="RebinRagged_events", WorkspaceType="Event")
         orig_y = ws.readY(0)
 
-        rebinned = api.RebinRagged(ws, XMin=xmins, XMax=xmaxs, Delta=deltas)
+        rebinned = api.RebinRagged(ws, XMin=xmins, XMax=xmaxs, Delta=deltas, Version=1)
 
         self.assertEqual(rebinned.getNumberHistograms(), 200)
         for i in range(rebinned.getNumberHistograms()):

--- a/docs/source/algorithms/RebinRagged-v1.rst
+++ b/docs/source/algorithms/RebinRagged-v1.rst
@@ -36,7 +36,8 @@ This particular use-case, which uses the input workspace's binning, could be don
     RebinRagged(InputWorkspace=NOM_91796, OutputWorkspace='cropped',
                         Xmin=[0.67, 1.20, 2.42, 3.70, 4.12, 0.39],
                         Delta=0.02,
-                        Xmax=[10.20, 20.8, nan, nan, nan, 9.35])
+                        Xmax=[10.20, 20.8, nan, nan, nan, 9.35],
+                        Version=1)
 
 
 .. categories::

--- a/docs/source/algorithms/RebinRagged-v2.rst
+++ b/docs/source/algorithms/RebinRagged-v2.rst
@@ -1,0 +1,44 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+This is a workflow algorithm that rebins each spectrum of a workspace independently.
+This is intended for workspaces with a relatively small number of spectra (e.g. <10), but places no restrictions on the input workspace.
+
+The minimum and maximum values that are specified are interpreted as follows:
+
+* One value per spectrum. If there is only one value overall, it is used for all of the spectra.
+* ``numpy.nan``, ``math.nan``, and ``np.inf`` are interpreted to mean use the data's minimum or maximum x-value.
+
+The ``Delta`` parameter is required and can either be a single number which is common to all, or one number per spectra.
+Positive values are interpreted as constant step-size. Negative are logorithmic.
+
+Usage
+-----
+
+.. include:: ../usagedata-note.txt
+
+This is an example of how ``RebinRagged`` would be used near the end of a workflow to generate a real-space distribution of data after it had been reduced into a number of "banks" or "spectra."
+As mentioned above, ``numpy.nan`` or ``math.nan`` can both be used.
+This particular use-case, which uses the input workspace's binning, could be done with :ref:`CropWorkspaceRagged <algm-CropWorkspaceRagged>` with similar results.
+
+.. code-block:: python
+
+    from numpy import nan
+    NOM_91796 = LoadNexusProcessed(Filename='NOM_91796_banks.nxs')
+    RebinRagged(InputWorkspace=NOM_91796, OutputWorkspace='cropped',
+                        Xmin=[0.67, 1.20, 2.42, 3.70, 4.12, 0.39],
+                        Delta=0.02,
+                        Xmax=[10.20, 20.8, nan, nan, nan, 9.35])
+
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.9.0/Framework/Algorithms/New_features/36182.rst
+++ b/docs/source/release/v6.9.0/Framework/Algorithms/New_features/36182.rst
@@ -1,0 +1,1 @@
+- :ref:`RebinRagged <algm-RebinRagged>` has been converted from a python algorithm to a c++ algorithm. This should improve the performance of the algorithm. You can still use the Python version of :ref:`RebinRagged <algm-RebinRagged-v1>` by adding the option ``Version=1``.


### PR DESCRIPTION
**Description of work**

Rewrite `RebinRagged` as a c++ algorithm, this improve it's performance greatly. This is implemented as a Version 2 of RebinRagged.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**

You can try anything that worked with RebinRagged before and compare, you should get the same results, only faster,

_e.g._ this goes from ~4 seconds to ~0.01 seconds.

```python
CreateSampleWorkspace(OutputWorkspace='ws', WorkspaceType='Event', NumBanks=10)

# version 1
RebinRagged(InputWorkspace='ws',
            OutputWorkspace='expected_ragged',
            XMin=[x for x in range(1000)],
            XMax=[20000-x*10 for x in range(1000)],
            Delta=[10+x for x in range(1000)],
            Version=1)

# version 2
RebinRagged(InputWorkspace='ws',
            OutputWorkspace='ragged',
            XMin=[x for x in range(1000)],
            XMax=[20000-x*10 for x in range(1000)],
            Delta=[10+x for x in range(1000)])
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes [EWM2440](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2440)
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
