### PR TITLE
Updates to Indirect Inelastic manual testing doc

### DIFF
--- a/dev-docs/source/Testing/IndirectInelastic/IndirectInelasticAcceptanceTests.rst
+++ b/dev-docs/source/Testing/IndirectInelastic/IndirectInelasticAcceptanceTests.rst
@@ -6,6 +6,10 @@ Indirect Inelastic Testing
 .. contents::
    :local:
 
+*Prerequisites*
+
+- Download the `ISIS Sample Data <http://download.mantidproject.org>`_
+
 Data reduction
 --------------
 
@@ -21,7 +25,7 @@ Data reduction
 #. Open ``Interfaces`` > ``Indirect`` > ``Data reduction``
 #. Make sure ``Instrument`` is set to ``IRIS``
 #. Go to the ``ISIS calibration``
-#. Enter ``Run number`` 26173
+#. Enter ``Input Runs`` 26173
 #. Click ``Run``
 #. This should generate a workspace with ``_calib`` at the end, delete this workspace
 #. Change the ``Scale by factor`` value to 0.5
@@ -32,10 +36,10 @@ Data reduction
 #. This should generate a workspace with ``_res`` at the end
 #. In the ``Output`` options, select the ``_res`` workspace and click ``Plot Spectra``. This should produce a spectrum plot.
 #. Then select the ``_calib`` workspace and use the down arrow to click ``Plot Bins``. This should produce a bin plot.
-#. Enter ``Run number`` 55878-55879 and check ``Sum Files``
+#. Enter ``Input Runs`` 55878-55879 and check ``Sum Files``
 #. Click ``Run``, this should produce a ``_calib`` workspace
 #. Make sure that you keep the ``_calib`` workspace, it is needed for the next test
-#. Enter ``Run number`` 59057-59059 and check ``Sum Files``
+#. Enter ``Input Runs`` 59057-59059 and check ``Sum Files``
 #. Set ``Reflection`` to 004
 #. This should produce a new ``_calib`` workspace, with ``004`` in the name.
 #. Before moving on, set ``Reflection`` to 002
@@ -48,7 +52,7 @@ Data reduction
 #. Make sure ``Instrument`` is set to ``IRIS``
 #. Make sure the tab is set to ``ISIS Energy Transfer``
 #. Check the ``Sum Files`` box
-#. In the ``Run files`` box enter ``26184-26185``
+#. In the ``Input Runs`` box enter ``26184-26185``
 #. Click ``Run``
 #. Check the ``Use Calib File`` box
 #. Change ``File`` to ``Workspace`` and choose the ``_calib`` workspace previously created (55878 from the previous test)
@@ -62,7 +66,7 @@ Data reduction
 #. In the main GUI right-click on the ``iris26184_multi_graphite002_red`` workspace
 #. Choose ``Plot spectrum``, note the number of spectra, should be 6
 #. Choose ``Plot All``, this should result in a plot of all 6 spectra
-#. Go to the ``S(Q, W)`` tab
+#. Open ``Interfaces`` > ``Inelastic`` > ``Data Manipulation`` and go to the ``S(Q, W)`` tab
 #. Change ``File`` to ``Workspace`` and load the ``_red`` workspace just created
 #. ``Q-Low`` and ``Q-High`` should be automatically updated to the y axis range of the contour plot.
 #. ``E-Low`` and ``E-High`` should be automatically updated to the x axis range of the contour plot.
@@ -95,7 +99,7 @@ Data analysis Elwin
 #. Click ``Run``
 #. This should result in three new workspaces again, this time with file ranges as their name
 #. In the main GUI right-click on ``irs26174-26176_graphite002_red_elwin_eq2`` and choose ``Plot Spectrum``, choose ``Plot All``
-#. This should plot two lines of :math:`ln((meV))^{-1}` vs :math:`Q`
+#. This should plot two lines of :math:`ln((meV))^{-1}` vs :math:`Q2`
 #. Right-click on the ``irs26176_graphite002_elwin_eq`` workspace and ``Save Nexus``; save to a location of your choice; you will use this file in the next test
 
 Data analysis MSD


### PR DESCRIPTION
**Description of work**

Some small updates to the Indirect Inelastic manual testing doc as listed in the issue (#36071).

**To test:**

- Build the `dev-docs-html` target
- Run through the edited tests to make sure they work smoothly

Fixes #36071 

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
