### PR TITLE
Use std::future instead of a Poco::ActiveResult for async execution

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -231,7 +231,7 @@ public:
   void setRethrows(const bool rethrow) override;
 
   /** @name Asynchronous Execution */
-  Poco::ActiveResult<bool> executeAsync() override;
+  std::future<bool> executeAsync() override;
 
   /// Add an observer for a notification
   void addObserver(const Poco::AbstractObserver &observer) const override;
@@ -461,7 +461,7 @@ private:
 
   bool executeInternal();
 
-  bool executeAsyncImpl(const Poco::Void &i);
+  bool executeAsyncImpl();
 
   bool doCallProcessGroups(Mantid::Types::Core::DateAndTime &start_time);
 

--- a/Framework/API/inc/MantidAPI/FrameworkManager.h
+++ b/Framework/API/inc/MantidAPI/FrameworkManager.h
@@ -66,6 +66,7 @@ public:
 
 private:
   friend struct Mantid::Kernel::CreateUsingNew<FrameworkManagerImpl>;
+  std::future<bool> _downloadInstrumentFiles;
 
   /// Private Constructor
   FrameworkManagerImpl();

--- a/Framework/API/inc/MantidAPI/IAlgorithm.h
+++ b/Framework/API/inc/MantidAPI/IAlgorithm.h
@@ -12,10 +12,10 @@
 #include "MantidAPI/DllConfig.h"
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidKernel/IPropertyManager.h"
+#include <future>
 
 namespace Poco {
 class AbstractObserver;
-template <class T> class ActiveResult;
 } // namespace Poco
 
 namespace Mantid {
@@ -111,7 +111,7 @@ public:
   virtual bool execute() = 0;
 
   /// Asynchronous execution of the algorithm.
-  virtual Poco::ActiveResult<bool> executeAsync() = 0;
+  virtual std::future<bool> executeAsync() = 0;
 
   /// Execute as a Child Algorithm, with try/catch
   virtual void executeAsChildAlg() = 0;

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -35,6 +35,7 @@
 #include <json/json.h>
 
 #include <algorithm>
+#include <functional>
 #include <iterator>
 #include <map>
 #include <memory>
@@ -1585,17 +1586,16 @@ private:
 /**
  * Asynchronous execution
  */
-Poco::ActiveResult<bool> Algorithm::executeAsync() {
-  m_executeAsync =
-      std::make_unique<Poco::ActiveMethod<bool, Poco::Void, Algorithm>>(this, &Algorithm::executeAsyncImpl);
-  return (*m_executeAsync)(Poco::Void());
+std::future<bool> Algorithm::executeAsync() {
+  auto fut = std::async(std::launch::async, std::bind(&Algorithm::executeAsyncImpl, this));
+  return fut;
 }
 
 /**Callback when an algorithm is executed asynchronously
  * @param i :: Unused argument
  * @return true if executed successfully.
  */
-bool Algorithm::executeAsyncImpl(const Poco::Void & /*unused*/) {
+bool Algorithm::executeAsyncImpl() {
   AsyncFlagHolder running(m_runningAsync);
   return this->execute();
 }

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -1592,7 +1592,6 @@ std::future<bool> Algorithm::executeAsync() {
 }
 
 /**Callback when an algorithm is executed asynchronously
- * @param i :: Unused argument
  * @return true if executed successfully.
  */
 bool Algorithm::executeAsyncImpl() {

--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -380,7 +380,7 @@ void FrameworkManagerImpl::updateInstrumentDefinitions() {
   try {
     auto algDownloadInstrument = Mantid::API::AlgorithmManager::Instance().create("DownloadInstrument");
     algDownloadInstrument->setAlgStartupLogging(false);
-    algDownloadInstrument->executeAsync();
+    _downloadInstrumentFiles = algDownloadInstrument->executeAsync();
   } catch (Kernel::Exception::NotFoundError &) {
     g_log.debug() << "DowndloadInstrument algorithm is not available - cannot "
                      "update instrument definitions.\n";

--- a/Framework/API/test/AlgorithmManagerTest.h
+++ b/Framework/API/test/AlgorithmManagerTest.h
@@ -166,7 +166,7 @@ public:
     Aptr = AlgorithmManager::Instance().create("AlgTest", -1);
 
     m_notificationValue = 0;
-    Poco::ActiveResult<bool> resA = Aptr->executeAsync();
+    std::future<bool> resA = Aptr->executeAsync();
     resA.wait();
     TSM_ASSERT_EQUALS("Notification was received.", m_notificationValue, 12345);
 

--- a/Framework/API/test/AsynchronousTest.h
+++ b/Framework/API/test/AsynchronousTest.h
@@ -98,10 +98,10 @@ public:
     AsyncAlgorithm alg;
     setupTest(alg);
     auto result = alg.executeAsync();
-    TS_ASSERT(!result.available())
+    TS_ASSERT(result.wait_for(std::chrono::seconds(0)) != std::future_status::ready)
     result.wait();
     generalChecks(alg, true, true, true, false);
-    TS_ASSERT(result.available())
+    TS_ASSERT(result.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
     TS_ASSERT_EQUALS(count, NO_OF_LOOPS)
     TS_ASSERT_EQUALS(alg.result, NO_OF_LOOPS - 1)
   }
@@ -133,10 +133,10 @@ public:
     setupTest(alg);
     alg.setPropertyValue("InputWorkspace", "groupWS");
     auto result = alg.executeAsync();
-    TS_ASSERT(!result.available())
+    TS_ASSERT(result.wait_for(std::chrono::seconds(0)) != std::future_status::ready)
     result.wait();
     generalChecks(alg, true, true, true, false);
-    TS_ASSERT(result.available())
+    TS_ASSERT(result.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
     // There are 2 * NO_OF_LOOPS because there are two child workspaces
     TS_ASSERT_EQUALS(count, NO_OF_LOOPS * 2)
     // The parent algorithm is not executed directly, so the result remains 0

--- a/Framework/LiveData/inc/MantidLiveData/FileEventDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/FileEventDataListener.h
@@ -57,7 +57,7 @@ private:
   /// that can
 
   /// Future that holds the result of the latest call to LoadEventPreNexus
-  std::unique_ptr<Poco::ActiveResult<bool>> m_chunkload;
+  std::unique_ptr<std::future<bool>> m_chunkload;
   void loadChunk();
   /// Shared pointer to the correct file loader instance - it needs to be kept
   /// alive.

--- a/Framework/LiveData/src/FileEventDataListener.cpp
+++ b/Framework/LiveData/src/FileEventDataListener.cpp
@@ -132,7 +132,7 @@ std::shared_ptr<Workspace> FileEventDataListener::extractData() {
 
   // If the loading of the chunk isn't finished, then we need to wait
   m_chunkload->wait();
-  if (!m_chunkload->data()) {
+  if (!m_chunkload->get()) {
     throw std::runtime_error(m_loaderName + " failed for some reason with file '" + m_filename + "'.");
   }
   // The loading succeeded: get the workspace from the ADS.
@@ -181,7 +181,7 @@ void FileEventDataListener::loadChunk() {
   }
   m_loader->setPropertyValue("OutputWorkspace",
                              m_tempWSname); // Goes into 'hidden' workspace
-  m_chunkload = std::make_unique<Poco::ActiveResult<bool>>(m_loader->executeAsync());
+  m_chunkload = std::make_unique<std::future<bool>>(m_loader->executeAsync());
 }
 
 } // namespace Mantid::LiveData

--- a/Framework/LiveData/test/MonitorLiveDataTest.h
+++ b/Framework/LiveData/test/MonitorLiveDataTest.h
@@ -74,7 +74,7 @@ public:
   /** Disallow if you detect another MonitorLiveData thread with the same */
   void test_DontAllowTwoAlgorithmsWithSameOutput() {
     IAlgorithm_sptr alg1 = makeAlgo("fake1");
-    Poco::ActiveResult<bool> res1 = alg1->executeAsync();
+    std::future<bool> res1 = alg1->executeAsync();
     while (!alg1->isRunning()) {
       Poco::Thread::sleep(10); // give it some time to start
     }
@@ -85,14 +85,14 @@ public:
 
     // Abort the thread.
     alg1->cancel();
-    res1.wait(10000);
+    res1.wait_for(std::chrono::seconds(10));
   }
 
   /** Disallow if you detect another MonitorLiveData thread with the
    * AccumulationWorkspace name */
   void test_DontAllowTwoAlgorithmsWithSameAccumulationWorkspace() {
     IAlgorithm_sptr alg1 = makeAlgo("fake1", "accum1");
-    Poco::ActiveResult<bool> res1 = alg1->executeAsync();
+    std::future<bool> res1 = alg1->executeAsync();
     while (!alg1->isRunning()) {
       Poco::Thread::sleep(10); // give it some time to start
     }
@@ -103,19 +103,19 @@ public:
 
     // Abort the thread.
     alg1->cancel();
-    res1.wait(10000);
+    res1.wait_for(std::chrono::seconds(10));
   }
 
   /** Disallow if you detect another MonitorLiveData thread with the same */
   void test_Allow_AnotherAlgo_IfTheOtherIsFinished() {
     // Start and stop one algorithm
     IAlgorithm_sptr alg1 = makeAlgo("fake1");
-    Poco::ActiveResult<bool> res1 = alg1->executeAsync();
+    std::future<bool> res1 = alg1->executeAsync();
     while (!alg1->isRunning()) {
       Poco::Thread::sleep(10); // give it some time to start
     }
     alg1->cancel();
-    res1.wait(10000);
+    res1.wait_for(std::chrono::seconds(10));
 
     // This algorithm if OK because the other is not still running
     IAlgorithm_sptr alg2 = makeAlgo("fake1");
@@ -131,8 +131,8 @@ public:
 
     // Run this algorithm
     IAlgorithm_sptr alg1 = makeAlgo("fake1", "", "Add", "Stop", "0.1");
-    Poco::ActiveResult<bool> res1 = alg1->executeAsync();
-    TS_ASSERT_THROWS_NOTHING(res1.wait(6000));
+    std::future<bool> res1 = alg1->executeAsync();
+    TS_ASSERT_THROWS_NOTHING(res1.wait_for(std::chrono::seconds(6)));
 
     TSM_ASSERT("The algorithm should have exited by itself.", !alg1->isRunning());
     TSM_ASSERT("The algorithm should have exited by itself.", alg1->isExecuted());
@@ -140,7 +140,7 @@ public:
     // Manually stop it so the test finishes, in case of failure
     if (alg1->isRunning()) {
       alg1->cancel();
-      res1.wait(1000);
+      res1.wait_for(std::chrono::seconds(1));
       return;
     }
 
@@ -154,7 +154,7 @@ public:
    * chunk number.
    * @return false if test failed*/
   bool runAlgoUntilChunk(const std::shared_ptr<MonitorLiveData> &alg1, size_t stopAtChunk) {
-    Poco::ActiveResult<bool> res1 = alg1->executeAsync();
+    std::future<bool> res1 = alg1->executeAsync();
     Poco::Thread::sleep(50);
     while (alg1->m_chunkNumber < stopAtChunk)
       Poco::Thread::sleep(5);

--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/35367.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/35367.rst
@@ -1,0 +1,1 @@
+- Fix bug where mantid would cause a segmentation fault on Linux if it exited while instrument files were still being downloaded.

--- a/qt/scientific_interfaces/General/StepScan.cpp
+++ b/qt/scientific_interfaces/General/StepScan.cpp
@@ -290,7 +290,7 @@ bool StepScan::mergeRuns() {
     addScanIndex->setProperty("LogType", "Number Series");
     addScanIndex->setProperty("LogText", Strings::toString(i + 1));
     auto result = addScanIndex->executeAsync();
-    while (!result.available()) {
+    while (result.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
       QApplication::processEvents();
     }
     if (!addScanIndex->isExecuted())
@@ -310,7 +310,7 @@ bool StepScan::mergeRuns() {
   const std::string summedWSName = "__summed_multifiles";
   merge->setPropertyValue("OutputWorkspace", summedWSName);
   auto result = merge->executeAsync();
-  while (!result.available()) {
+  while (result.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
     QApplication::processEvents();
   }
   if (!merge->isExecuted())
@@ -497,7 +497,7 @@ void StepScan::runStepScanAlg() {
     stepScan->setPropertyValue("InputWorkspace", m_inputWSName);
     ScopedStatusText _merging(this->m_uiForm.statusText, "Analyzing scan...");
     auto result = stepScan->executeAsync();
-    while (!result.available()) {
+    while (result.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
       QApplication::processEvents();
     }
     algSuccessful = stepScan->isExecuted();
@@ -548,7 +548,7 @@ bool StepScan::runStepScanAlgLive(const std::string &stepScanProperties) {
     Poco::Thread::sleep(100);
   }
   auto result = startLiveData->executeAsync();
-  while (!result.available()) {
+  while (result.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
     QApplication::processEvents();
   }
   if (!startLiveData->isExecuted())

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.cpp
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.cpp
@@ -72,13 +72,11 @@ void ALCBaselineModellingModel::fit(IFunction_const_sptr function, const std::ve
   fit->setProperty("CreateOutput", true);
 
   // Run async so that progress can be shown
-  Poco::ActiveResult<bool> result(fit->executeAsync());
-  while (!result.available()) {
+  std::future<bool> result(fit->executeAsync());
+  while (result.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
     QCoreApplication::processEvents();
   }
-  if (!result.error().empty()) {
-    throw std::runtime_error(result.error());
-  }
+  result.get();
 
   MatrixWorkspace_sptr fitOutput = fit->getProperty("OutputWorkspace");
   m_parameterTable = fit->getProperty("OutputParameters");

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -229,13 +229,11 @@ void ALCDataLoadingPresenter::load(const std::vector<std::string> &files) {
     // Set loading alg equal to alg
     this->m_LoadingAlg = alg;
     // Execute async so we can show progress bar
-    Poco::ActiveResult<bool> result(alg->executeAsync());
-    while (!result.available()) {
+    std::future<bool> result(alg->executeAsync());
+    while (result.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
       QCoreApplication::processEvents();
     }
-    if (!result.error().empty()) {
-      throw std::runtime_error(result.error());
-    }
+    result.get();
 
     MatrixWorkspace_sptr tmp = alg->getProperty("OutputWorkspace");
     IAlgorithm_sptr sortAlg = AlgorithmManager::Instance().create("SortXAxis");

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
@@ -97,7 +97,7 @@ void ALCPeakFittingModel::fitPeaks(IFunction_const_sptr peaks) {
   }
   try {
     // Calling .get() on a future will throw any exceptions from the future thread.
-    auto tmp = result.get();
+    result.get();
   } catch (const std::exception &e) {
     QString msg = "Fit algorithm failed.\n\n" + QString(e.what()) + "\n";
     emit errorInModel(msg);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmRunner.h
@@ -62,7 +62,7 @@ protected:
 
   /// For the asynchronous call in dynamic rebinning. Holds the result of
   /// asyncExecute() algorithm call
-  Poco::ActiveResult<bool> *m_asyncResult;
+  std::future<bool> *m_asyncResult;
 
   /// Reference to the algorithm executing asynchronously.
   Mantid::API::IAlgorithm_sptr m_asyncAlg;

--- a/qt/widgets/common/src/AlgorithmRunner.cpp
+++ b/qt/widgets/common/src/AlgorithmRunner.cpp
@@ -45,7 +45,7 @@ void AlgorithmRunner::cancelRunningAlgorithm() {
       m_asyncAlg->cancel();
     }
     if (m_asyncResult) {
-      m_asyncResult->tryWait(1000);
+      m_asyncResult->wait_for(std::chrono::seconds(1));
       delete m_asyncResult;
       m_asyncResult = nullptr;
     }
@@ -76,7 +76,7 @@ void AlgorithmRunner::startAlgorithm(Mantid::API::IAlgorithm_sptr alg) {
   alg->addObserver(m_progressObserver);
   // Start asynchronous execution
   m_asyncAlg = alg;
-  m_asyncResult = new Poco::ActiveResult<bool>(m_asyncAlg->executeAsync());
+  m_asyncResult = new std::future<bool>(m_asyncAlg->executeAsync());
 }
 
 /// Get back a pointer to the running algorithm

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1641,7 +1641,7 @@ void FitPropertyBrowser::doFit(int maxIterations) {
       QCoreApplication::processEvents();
     }
     // Calling .get() on a future will throw any exceptions that threw on the future thread
-    auto tmp = result.get();
+    result.get();
     emit algorithmFinished(QString());
 
   } catch (const std::exception &e) {


### PR DESCRIPTION
Depending on a setting in the `Mantid.properties` file, the instrument files will be downloaded (if needed) on startup, but on a separate thread. If the main thread exits quickly enough then this leaves the download thread abandoned. By using an `std::future` to represent the outcome of the thread instead of a `Poco::ActiveResult` then this case of the main thread exiting is handled better.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes 35367 and a similar problem reported when running a python script that exits before the download of instrument files is complete. There is no longer a segmentation error when the main thread exits before the download instruments thread.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
- Changed return value of `Algorithm::executeAsync()` from a `Poco::ActiveResult` to an `std::future`.
- Private member added to `FrameworkManager` to hang on to the `future` representing the instrument files download. If a `future` has no references then it will be destroyed, which will result in the equivalent of calling `.join()` on the thread and a loss of async.

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
- There isn't a method on `std::future` to check if the thread has completed. The suggested solution [here](https://stackoverflow.com/questions/10890242/get-the-status-of-a-stdfuture) is to call `wait_for` with a zero duration, which is what I've implemented.
- Error handling is slightly different on a `std::future` compared to a `Poco::ActiveResult`. On an `ActiveResult` any exception will be stored and then accessed by checking the `error()` method. On a `future` any exception will be thrown on an attempt to get the value of the `future` by calling `.get()`. 

**To test:**

See #35367 for one symptom of the problem fixed by these changes. I think the problem only happens on Linux. The method I was using to generate the segmentation fault was to delete all the instrument definition files, change `DownloadInstrument.cpp` to always force update, then run the script [here](https://github.com/interactivereduction/autoreduction-scripts/blob/main/TOSCA/reduce.py). Other testing around running algorithms asynchronously would be good.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
