### PR TITLE
Set default number density units as formula units/Ang^3 in single crystal reduction classes

### DIFF
--- a/Testing/SystemTests/tests/framework/SXDAnalysis.py
+++ b/Testing/SystemTests/tests/framework/SXDAnalysis.py
@@ -96,7 +96,8 @@ class SXDProcessSampleData(systemtesting.MantidSystemTest):
         sxd = SXD(vanadium_runno=23769, empty_runno=23768)
         sxd.van_ws = LoadNexus(Filename="SXD23779_processed_vanadium.nxs", OutputWorkspace="SXD23779_vanadium")
         sxd.set_sample(
-            Geometry={"Shape": "CSG", "Value": sxd.sphere_shape}, Material={"ChemicalFormula": "Na Cl", "SampleNumberDensity": 0.0223}
+            Geometry={"Shape": "CSG", "Value": sxd.sphere_shape},
+            Material={"ChemicalFormula": "Na Cl", "SampleNumberDensity": 0.0223, "NumberDensityUnit": "Atoms"},
         )
         sxd.set_goniometer_axes([0, 1, 0, 1])  # ccw rotation around vertical
         runno = 23767

--- a/docs/source/release/v6.9.0/Diffraction/Single_Crystal/Bugfixes/36193.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Single_Crystal/Bugfixes/36193.rst
@@ -1,0 +1,1 @@
+- Set default number density units as formula units per cubic Angstrom in the ISIS single crystal reduction classes (the units can be changed by passing the ``NumberDensityUnit`` argument in the material dictionary in ``set_sample`` - see :ref:`SetSampleMaterial<algm-SetSampleMaterial>` for details).

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -116,6 +116,10 @@ class BaseSX(ABC):
         self.runs[str(run)]["MD"] = BaseSX.retrieve(ws_md).name()
 
     def set_sample(self, **kwargs):
+        default_material = {"NumberDensityUnit": "Formula Units"}
+        if "Material" in kwargs:
+            # if no material in kwargs then setting this would produce an error in SetSample later
+            kwargs["Material"] = {**default_material, **kwargs["Material"]}
         self.sample_dict = kwargs
 
     def set_goniometer_axes(self, *args):

--- a/scripts/Diffraction/single_crystal/test/test_sxd.py
+++ b/scripts/Diffraction/single_crystal/test/test_sxd.py
@@ -204,6 +204,18 @@ class SXDTest(unittest.TestCase):
         for ws in [self.ws, self.peaks]:
             ClearUB(Workspace=ws)
 
+    def test_set_sample_with_material(self):
+        self.sxd.set_sample(
+            Geometry={"Shape": "CSG", "Value": self.sxd.sphere_shape}, Material={"ChemicalFormula": "C2 H4", "SampleNumberDensity": 0.02}
+        )
+
+        self.assertEqual(self.sxd.sample_dict["Material"]["NumberDensityUnit"], "Formula Units")
+
+    def test_set_sample_without_material(self):
+        self.sxd.set_sample(Geometry={"Shape": "CSG", "Value": self.sxd.sphere_shape})
+
+        self.assertFalse("Material" in self.sxd.sample_dict)
+
     #  --- methods specific to SXD class ---
 
     @patch("Diffraction.single_crystal.base_sx.mantid.SetGoniometer")


### PR DESCRIPTION
**Description of work**

Set default number density units as formula units/Ang^3 as opposed to the default in `SetMaterial` and `SetSample` which is atoms/Ang^3 (which is quite an unusual choice of unit for example when chemical formula has multiple atom species).

I found out the default unit was atoms/Ang^3 when writing the test documentation for the Sample Transmission Calculator #36188

**To test:**

(1) Run this script
```
from Diffraction.single_crystal.sxd import SXD

sxd = SXD(vanadium_runno=32857, empty_runno=32856)
                   
sxd.set_sample(Geometry={'Shape': 'CSG', 'Value': sxd.sphere_shape}, 
               Material={'ChemicalFormula': 'C2 H4', 'SampleNumberDensity': 0.02})
sxd.process_vanadium()
sxd.process_data([32863]) # 0 gonio rotation

print(mtd["SXD32863"].sample().getMaterial().numberDensity)
```

it should print out `0.12` (i.e. the original number density multiplied by the number of atoms in a unit cell i.e. 6)

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
