### PR TITLE
Perform unweighted average of log data in Eng Diff UI fitting tab if no proton_charge log

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/output_sample_logs.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/output_sample_logs.py
@@ -110,15 +110,14 @@ class SampleLogsGroupWorkspace(object):
         ]
         write_table_row(ADS.retrieve(self._run_info_name), row, irow)
         # add log data - loop over existing log workspaces not logs in settings as these might have changed
-        currentRunLogs = [l.name for l in run.getLogData()]
         nullLogValue = full(2, nan)  # default nan if can't read/average log data
         if run.getProtonCharge() > 0:
             for log in self._log_names:
                 avg, stdev = nullLogValue
                 if log in self._log_values[ws_name]:
                     avg, stdev = self._log_values[ws_name][log]  # already averaged
-                elif log in currentRunLogs:
-                    if "proton_charge" in currentRunLogs:
+                elif run.hasProperty(log):
+                    if run.hasProperty("proton_charge"):
                         avg, stdev = AverageLogData(ws_name, LogName=log, FixZero=False)
                     else:
                         # average filtered log values (excludes setup time)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/output_sample_logs.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/output_sample_logs.py
@@ -20,7 +20,7 @@ from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common impo
 from mantid.api import AnalysisDataService as ADS
 
 from os import path
-from numpy import full, nan, max
+from numpy import full, nan, max, mean, std
 
 
 def write_table_row(ws_table, row, irow):
@@ -112,18 +112,24 @@ class SampleLogsGroupWorkspace(object):
         # add log data - loop over existing log workspaces not logs in settings as these might have changed
         currentRunLogs = [l.name for l in run.getLogData()]
         nullLogValue = full(2, nan)  # default nan if can't read/average log data
-        if run.getProtonCharge() > 0 and "proton_charge" in currentRunLogs:
+        if run.getProtonCharge() > 0:
             for log in self._log_names:
+                avg, stdev = nullLogValue
                 if log in self._log_values[ws_name]:
                     avg, stdev = self._log_values[ws_name][log]  # already averaged
                 elif log in currentRunLogs:
-                    avg, stdev = AverageLogData(ws_name, LogName=log, FixZero=False)
-                else:
-                    avg, stdev = nullLogValue
+                    if "proton_charge" in currentRunLogs:
+                        avg, stdev = AverageLogData(ws_name, LogName=log, FixZero=False)
+                    else:
+                        # average filtered log values (excludes setup time)
+                        log_series = run.getProperty(log)
+                        avg = mean(log_series.filtered_value)
+                        stdev = std(log_series.filtered_value)
+                        logger.warning(f"{ws.name()} does not contain a proton charge log - an unweighted average has been performed.")
                 self._log_values[ws_name][log] = [avg, stdev]  # update model dict (even if nan)
         else:
             self._log_values[ws_name] = {log: nullLogValue for log in self._log_names}
-            logger.warning(f"{ws.name()} does not contain a proton charge log - log values cannot be averaged.")
+            logger.warning(f"{ws.name()} appears to be empty with zero integrated proton charge.")
 
         # write log values to table (nan if log could not be averaged)
         for log, avg_and_stdev in self._log_values[ws_name].items():

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_model.py
@@ -544,7 +544,7 @@ class TestGSAS2Model(unittest.TestCase):
         ][0]
         self.model._sample_logs_workspace_group._log_values = {"name1": {}}
         self.model._sample_logs_workspace_group._log_names = ["LogName"]
-        self.mock_run.getLogData.return_value = [self.mock_run.getLogData()[1]]  # only proton_charge
+        self.mock_run.hasProperty.return_value = False  # log not in ws
 
         self.model._sample_logs_workspace_group.add_log_to_table("name1", self.mock_ws, 3)
 


### PR DESCRIPTION
**Report to:** Tung-Lik (ENGIN-X)

**Summary of work**
For recent runs `AverageLogData` fails because the runs do not have a log called `proton_charge` (which used to be present in ENGINX runs) corresponding to the proton charge as a function of time (not just the integrated proton charge).

This PR performs an unweighted average of the log values (excluding setup time - hence the call to `log_series.filtered_value`) when the `proton_charge` log doesn't exist.

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**

(1) Follow instructions on original issue

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #36166

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
