### PR TITLE
34368 Reverting invalid bg params on Engineering Diffraction's fitting tab

### DIFF
--- a/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/34368.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/34368.rst
@@ -1,1 +1,2 @@
-- Avoid writing invalid background estimation parameters in the Engineering Diffration's table of fitting tab
+- Avoid writing invalid background estimation parameters in the Engineering Diffration's table of fitting tab.
+- When invalid parameters are entered for the background estimation in the :ref:`Fitting tab <ui engineering fitting>` of the :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` they are overwritten with the last valid parameters used when the background is next calculated (immediately if `Subtract BG` is checked in the table).

--- a/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/34368.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/34368.rst
@@ -1,0 +1,1 @@
+- Avoid writing invalid background estimation parameters in the Engineering Diffration's table of fitting tab

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_model.py
@@ -180,7 +180,7 @@ class FittingDataModel(object):
                 bgsub_ws = Minus(LHSWorkspace=ws, RHSWorkspace=background, OutputWorkspace=bgsub_ws_name)
                 self._data_workspaces[ws_name].bgsub_ws = bgsub_ws
                 self._data_workspaces[ws_name].bgsub_ws_name = bgsub_ws_name
-                DeleteWorkspace(background)
+            DeleteWorkspace(background)
         else:
             logger.notice("Background workspace already calculated")
         return success_estimate_bg
@@ -198,8 +198,10 @@ class FittingDataModel(object):
         except (ValueError, RuntimeError) as e:
             # ValueError when Niter not positive integer, RuntimeError when Window too small
             logger.error("Error on arguments supplied to EnggEstimateFocusedBackground: " + str(e))
-            ws_bg = SetUncertainties(InputWorkspace=ws_name)  # copy data and zero errors
-            ws_bg = Minus(LHSWorkspace=ws_bg, RHSWorkspace=ws_bg)  # workspace of zeros with same num spectra
+            ws_bg = SetUncertainties(InputWorkspace=ws_name, OutputWorkspace=ws_name + "_bg")  # copy data and zero errors
+            ws_bg = Minus(
+                LHSWorkspace=ws_bg, RHSWorkspace=ws_bg, OutputWorkspace=ws_name + "_bg"
+            )  # workspace of zeros with same num spectra
             success = False
         return ws_bg, success
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_model.py
@@ -171,22 +171,26 @@ class FittingDataModel(object):
         ws = self._data_workspaces[ws_name].loaded_ws
         ws_bg = self._data_workspaces[ws_name].bgsub_ws
         ws_bg_params = self._data_workspaces[ws_name].bg_params
+        success_estimate_bg = True
         if not ws_bg or ws_bg_params == [] or bg_params[1:] != ws_bg_params[1:]:
-            background = self.estimate_background(ws_name, *bg_params[1:])
-            self._data_workspaces[ws_name].bg_params = bg_params
-            bgsub_ws_name = ws_name + "_bgsub"
-            bgsub_ws = Minus(LHSWorkspace=ws, RHSWorkspace=background, OutputWorkspace=bgsub_ws_name)
-            self._data_workspaces[ws_name].bgsub_ws = bgsub_ws
-            self._data_workspaces[ws_name].bgsub_ws_name = bgsub_ws_name
-            DeleteWorkspace(background)
+            background, success_estimate_bg = self.estimate_background(ws_name, *bg_params[1:])
+            if success_estimate_bg:
+                self._data_workspaces[ws_name].bg_params = bg_params
+                bgsub_ws_name = ws_name + "_bgsub"
+                bgsub_ws = Minus(LHSWorkspace=ws, RHSWorkspace=background, OutputWorkspace=bgsub_ws_name)
+                self._data_workspaces[ws_name].bgsub_ws = bgsub_ws
+                self._data_workspaces[ws_name].bgsub_ws_name = bgsub_ws_name
+                DeleteWorkspace(background)
         else:
             logger.notice("Background workspace already calculated")
+        return success_estimate_bg
 
     def update_bgsub_status(self, ws_name, status):
         if self._data_workspaces[ws_name].bg_params:
             self._data_workspaces[ws_name].bg_params[0] = status
 
     def estimate_background(self, ws_name, niter, xwindow, doSGfilter):
+        success = True
         try:
             ws_bg = EnggEstimateFocussedBackground(
                 InputWorkspace=ws_name, OutputWorkspace=ws_name + "_bg", NIterations=niter, XWindow=xwindow, ApplyFilterSG=doSGfilter
@@ -196,7 +200,8 @@ class FittingDataModel(object):
             logger.error("Error on arguments supplied to EnggEstimateFocusedBackground: " + str(e))
             ws_bg = SetUncertainties(InputWorkspace=ws_name)  # copy data and zero errors
             ws_bg = Minus(LHSWorkspace=ws_bg, RHSWorkspace=ws_bg)  # workspace of zeros with same num spectra
-        return ws_bg
+            success = False
+        return ws_bg, success
 
     def plot_background_figure(self, ws_name):
         def on_draw(event):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_presenter.py
@@ -193,14 +193,21 @@ class FittingDataPresenter(object):
                 self.model.update_bgsub_status(loaded_ws_name, is_sub)
                 if is_sub:
                     bg_params = self.view.read_bg_params_from_table(row)
-                    self.model.create_or_update_bgsub_ws(loaded_ws_name, bg_params)
+                    if not self.model.create_or_update_bgsub_ws(loaded_ws_name, bg_params):
+                        self._revert_bg_sub_table_values(loaded_ws_name, row)
                 if is_plotted:
                     self._update_plotted_ws_with_sub_state(loaded_ws_name, is_sub)
             elif col > 3:
                 if is_sub:
                     # bg params changed - revaluate background
                     bg_params = self.view.read_bg_params_from_table(row)
-                    self.model.create_or_update_bgsub_ws(loaded_ws_name, bg_params)
+                    if not self.model.create_or_update_bgsub_ws(loaded_ws_name, bg_params):
+                        self._revert_bg_sub_table_values(loaded_ws_name, row)
+
+    def _revert_bg_sub_table_values(self, loaded_ws_name, row):
+        original_bg_params = self.model.get_bg_params()[loaded_ws_name]
+        self.view.set_table_column(row, 4, original_bg_params[1])
+        self.view.set_table_column(row, 5, original_bg_params[2])
 
     def _update_plotted_ws_with_sub_state(self, ws_name, is_sub):
         ws = self.model.get_loaded_workspaces()[ws_name]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_view.py
@@ -187,6 +187,9 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
         else:
             self.get_table_item(row, col).setCheckState(QtCore.Qt.Unchecked)
 
+    def set_table_column(self, row, col, value):
+        self.get_table_item(row, col).setData(QtCore.Qt.EditRole, int(value))
+
     def update_file_filter(self, region, xunit):
         self.proxy_model.text_filter = "*"
         if region == "1 (North)":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/test/test_data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/test/test_data_model.py
@@ -218,7 +218,7 @@ class TestFittingDataModel(unittest.TestCase):
 
         self.assertFalse(success)
         mock_minus.assert_not_called()
-        mock_delete_ws.assert_not_called()
+        mock_delete_ws.assert_called()
 
     @patch(data_model_path + ".EnggEstimateFocussedBackground", side_effect=ValueError("mocked error"))
     @patch(data_model_path + ".SetUncertainties")

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/test/test_data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/test/test_data_presenter.py
@@ -381,14 +381,16 @@ class FittingDataPresenterTest(unittest.TestCase):
         self.model.get_loaded_workspaces.return_value = {"name1": self.ws1, "name2": self.ws2}
         self.model.estimate_background.return_value = self.ws2, True
 
-    def _setup_fitting_table_rows_for_invalid_bg_params(self, table_ws_names, changing_ws, original_bg_params, new_bg_params):
+    def _setup_fitting_table_rows_for_invalid_bg_params(
+        self, table_ws_names, changing_ws, original_bg_params, new_bg_params, get_item_checked_value, create_or_update_bgsub
+    ):
         self.presenter.row_numbers = data_presenter.TwoWayRowDict()
         for ws_index, ws in enumerate(table_ws_names):
             self.presenter.row_numbers[ws] = ws_index
         self.view.read_bg_params_from_table.return_value = new_bg_params
         self.model.get_bg_params.return_value = {changing_ws: original_bg_params}
-        self.view.get_item_checked.return_value = True
-        self.model.create_or_update_bgsub_ws.return_value = False
+        self.view.get_item_checked.return_value = get_item_checked_value
+        self.model.create_or_update_bgsub_ws.return_value = create_or_update_bgsub
 
     def test_handle_table_cell_changed_invalid_bg_params_on_niter(self):
         original_bg_params = [True, 50, 600, True]
@@ -397,6 +399,8 @@ class FittingDataPresenterTest(unittest.TestCase):
             changing_ws="WS_Name2",
             original_bg_params=original_bg_params,
             new_bg_params=[True, -100, 200, True],
+            get_item_checked_value=True,
+            create_or_update_bgsub=False,
         )
 
         self.presenter._handle_table_cell_changed(1, 4)
@@ -411,6 +415,8 @@ class FittingDataPresenterTest(unittest.TestCase):
             changing_ws="WS_Name2",
             original_bg_params=original_bg_params,
             new_bg_params=[True, 50, -200, True],
+            get_item_checked_value=True,
+            create_or_update_bgsub=False,
         )
         self.presenter._handle_table_cell_changed(1, 5)
         self.assertEqual(2, self.view.set_table_column.call_count)
@@ -424,6 +430,8 @@ class FittingDataPresenterTest(unittest.TestCase):
             changing_ws="WS_Name2",
             original_bg_params=original_bg_params,
             new_bg_params=[True, -50, -200, True],
+            get_item_checked_value=True,
+            create_or_update_bgsub=False,
         )
         self.presenter._update_plotted_ws_with_sub_state = mock.MagicMock()
         self.presenter._handle_table_cell_changed(1, 3)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/test/test_data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/test/test_data_presenter.py
@@ -381,51 +381,52 @@ class FittingDataPresenterTest(unittest.TestCase):
         self.model.get_loaded_workspaces.return_value = {"name1": self.ws1, "name2": self.ws2}
         self.model.estimate_background.return_value = self.ws2, True
 
-    def test_handle_table_cell_changed_invalid_bg_params_on_niter(self):
+    def _setup_fitting_table_rows_for_invalid_bg_params(self, table_ws_names, changing_ws, original_bg_params, new_bg_params):
         self.presenter.row_numbers = data_presenter.TwoWayRowDict()
-        self.presenter.row_numbers["WS_Name1"] = 0
-        self.presenter.row_numbers["WS_Name2"] = 1
-        self.view.read_bg_params_from_table.return_value = [True, -100, 200, True]
+        for ws_index, ws in enumerate(table_ws_names):
+            self.presenter.row_numbers[ws] = ws_index
+        self.view.read_bg_params_from_table.return_value = new_bg_params
+        self.model.get_bg_params.return_value = {changing_ws: original_bg_params}
         self.view.get_item_checked.return_value = True
         self.model.create_or_update_bgsub_ws.return_value = False
+
+    def test_handle_table_cell_changed_invalid_bg_params_on_niter(self):
         original_bg_params = [True, 50, 600, True]
-        self.model.get_bg_params.return_value = {"WS_Name2": original_bg_params}
+        self._setup_fitting_table_rows_for_invalid_bg_params(
+            table_ws_names=["WS_Name1", "WS_Name2"],
+            changing_ws="WS_Name2",
+            original_bg_params=original_bg_params,
+            new_bg_params=[True, -100, 200, True],
+        )
 
         self.presenter._handle_table_cell_changed(1, 4)
-
         self.assertEqual(2, self.view.set_table_column.call_count)
         calls = [mock.call(1, 4, original_bg_params[1]), mock.call(1, 5, original_bg_params[2])]
         self.view.set_table_column.assert_has_calls(calls, any_order=False)
 
     def test_handle_table_cell_changed_invalid_bg_params_on_xwindow(self):
-        self.presenter.row_numbers = data_presenter.TwoWayRowDict()
-        self.presenter.row_numbers["WS_Name1"] = 0
-        self.presenter.row_numbers["WS_Name2"] = 1
-        self.view.read_bg_params_from_table.return_value = [True, 50, -200, True]
-        self.view.get_item_checked.return_value = True
-        self.model.create_or_update_bgsub_ws.return_value = False
         original_bg_params = [True, 50, 600, True]
-        self.model.get_bg_params.return_value = {"WS_Name2": original_bg_params}
-
+        self._setup_fitting_table_rows_for_invalid_bg_params(
+            table_ws_names=["WS_Name1", "WS_Name2"],
+            changing_ws="WS_Name2",
+            original_bg_params=original_bg_params,
+            new_bg_params=[True, 50, -200, True],
+        )
         self.presenter._handle_table_cell_changed(1, 5)
-
         self.assertEqual(2, self.view.set_table_column.call_count)
         calls = [mock.call(1, 4, original_bg_params[1]), mock.call(1, 5, original_bg_params[2])]
         self.view.set_table_column.assert_has_calls(calls, any_order=False)
 
     def test_handle_table_cell_changed_invalid_bg_params_on_subtract_bg(self):
-        self.presenter.row_numbers = data_presenter.TwoWayRowDict()
-        self.presenter.row_numbers["WS_Name1"] = 0
-        self.presenter.row_numbers["WS_Name2"] = 1
-        self.view.read_bg_params_from_table.return_value = [True, -50, -200, True]
-        self.view.get_item_checked.return_value = True
-        self.model.create_or_update_bgsub_ws.return_value = False
         original_bg_params = [False, 50, 600, True]
-        self.model.get_bg_params.return_value = {"WS_Name2": original_bg_params}
+        self._setup_fitting_table_rows_for_invalid_bg_params(
+            table_ws_names=["WS_Name1", "WS_Name2"],
+            changing_ws="WS_Name2",
+            original_bg_params=original_bg_params,
+            new_bg_params=[True, -50, -200, True],
+        )
         self.presenter._update_plotted_ws_with_sub_state = mock.MagicMock()
-
         self.presenter._handle_table_cell_changed(1, 3)
-
         self.assertEqual(2, self.view.set_table_column.call_count)
         calls = [mock.call(1, 4, original_bg_params[1]), mock.call(1, 5, original_bg_params[2])]
         self.view.set_table_column.assert_has_calls(calls, any_order=False)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/test/test_data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/test/test_data_presenter.py
@@ -379,7 +379,57 @@ class FittingDataPresenterTest(unittest.TestCase):
         self.presenter.row_numbers["name1"] = 0
         self.presenter.row_numbers["name2"] = 1
         self.model.get_loaded_workspaces.return_value = {"name1": self.ws1, "name2": self.ws2}
-        self.model.estimate_background.return_value = self.ws2
+        self.model.estimate_background.return_value = self.ws2, True
+
+    def test_handle_table_cell_changed_invalid_bg_params_on_niter(self):
+        self.presenter.row_numbers = data_presenter.TwoWayRowDict()
+        self.presenter.row_numbers["WS_Name1"] = 0
+        self.presenter.row_numbers["WS_Name2"] = 1
+        self.view.read_bg_params_from_table.return_value = [True, -100, 200, True]
+        self.view.get_item_checked.return_value = True
+        self.model.create_or_update_bgsub_ws.return_value = False
+        original_bg_params = [True, 50, 600, True]
+        self.model.get_bg_params.return_value = {"WS_Name2": original_bg_params}
+
+        self.presenter._handle_table_cell_changed(1, 4)
+
+        self.assertEqual(2, self.view.set_table_column.call_count)
+        calls = [mock.call(1, 4, original_bg_params[1]), mock.call(1, 5, original_bg_params[2])]
+        self.view.set_table_column.assert_has_calls(calls, any_order=False)
+
+    def test_handle_table_cell_changed_invalid_bg_params_on_xwindow(self):
+        self.presenter.row_numbers = data_presenter.TwoWayRowDict()
+        self.presenter.row_numbers["WS_Name1"] = 0
+        self.presenter.row_numbers["WS_Name2"] = 1
+        self.view.read_bg_params_from_table.return_value = [True, 50, -200, True]
+        self.view.get_item_checked.return_value = True
+        self.model.create_or_update_bgsub_ws.return_value = False
+        original_bg_params = [True, 50, 600, True]
+        self.model.get_bg_params.return_value = {"WS_Name2": original_bg_params}
+
+        self.presenter._handle_table_cell_changed(1, 5)
+
+        self.assertEqual(2, self.view.set_table_column.call_count)
+        calls = [mock.call(1, 4, original_bg_params[1]), mock.call(1, 5, original_bg_params[2])]
+        self.view.set_table_column.assert_has_calls(calls, any_order=False)
+
+    def test_handle_table_cell_changed_invalid_bg_params_on_subtract_bg(self):
+        self.presenter.row_numbers = data_presenter.TwoWayRowDict()
+        self.presenter.row_numbers["WS_Name1"] = 0
+        self.presenter.row_numbers["WS_Name2"] = 1
+        self.view.read_bg_params_from_table.return_value = [True, -50, -200, True]
+        self.view.get_item_checked.return_value = True
+        self.model.create_or_update_bgsub_ws.return_value = False
+        original_bg_params = [False, 50, 600, True]
+        self.model.get_bg_params.return_value = {"WS_Name2": original_bg_params}
+        self.presenter._update_plotted_ws_with_sub_state = mock.MagicMock()
+
+        self.presenter._handle_table_cell_changed(1, 3)
+
+        self.assertEqual(2, self.view.set_table_column.call_count)
+        calls = [mock.call(1, 4, original_bg_params[1]), mock.call(1, 5, original_bg_params[2])]
+        self.view.set_table_column.assert_has_calls(calls, any_order=False)
+        self.presenter._update_plotted_ws_with_sub_state.assert_called_once_with("WS_Name2", True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of work**
Engineering Diffraction's fitting tab allows invalid background estimation parameters(Niter or XWindow) to be written to the table. Although the background is not re-calculated, the invalid values remains in the table overriding the original values. 

**Report to:** 
Saurabh (ENGIN-X)

**Summary of work**
When invalid background estimation parameters(Niter or XWindow) are written to the fitting tab, they would be reverted to the previous valid parameter it had been there

**Further detail of work**
The invalidation of the above parameters can occur due to various reasons such as negative values or incorrect values etc. These invalid condition would be captured and raised by EnggEstimateFocussedBackground algorithm and the values in the fitting table would be reverted to the valid values that were there before the invalidation. 

**To test:**

1. Follow instructions from Test 6 of manual testing instructions (latest version not merged)
https://github.com/mantidproject/mantid/blob/33e61abf3a7ed9a3e352ca91886efe03d9afc5b8/dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst

2. Enter invalid Niter or XWindow (e.g. negative values)

3. A warning would be thrown and value in the table would be overwrite the with the previous valid value.

Fixes #34368 

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
