### PR TITLE
Use std::future instead of a Poco::ActiveResult for async execution

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <atomic>
+#include <future>
 #include <memory>
 
 #include "MantidAPI/DllConfig.h"
@@ -232,6 +233,7 @@ public:
 
   /** @name Asynchronous Execution */
   Poco::ActiveResult<bool> executeAsync() override;
+  std::future<bool> executeAsyncFuture() override;
 
   /// Add an observer for a notification
   void addObserver(const Poco::AbstractObserver &observer) const override;

--- a/Framework/API/inc/MantidAPI/FrameworkManager.h
+++ b/Framework/API/inc/MantidAPI/FrameworkManager.h
@@ -11,6 +11,7 @@
 #include "MantidAPI/DllConfig.h"
 #include "MantidAPI/FileLoaderRegistry.h"
 #include "MantidKernel/SingletonHolder.h"
+#include <future>
 #include <memory>
 
 namespace Mantid {
@@ -65,6 +66,8 @@ public:
   bool deleteWorkspace(const std::string &wsName);
 
 private:
+  std::future<bool> m_downloadInstrumentAlg;
+  std::future<bool> m_checkVersionAlg;
   friend struct Mantid::Kernel::CreateUsingNew<FrameworkManagerImpl>;
 
   /// Private Constructor

--- a/Framework/API/inc/MantidAPI/IAlgorithm.h
+++ b/Framework/API/inc/MantidAPI/IAlgorithm.h
@@ -12,6 +12,7 @@
 #include "MantidAPI/DllConfig.h"
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidKernel/IPropertyManager.h"
+#include <future>
 
 namespace Poco {
 class AbstractObserver;
@@ -112,6 +113,10 @@ public:
 
   /// Asynchronous execution of the algorithm.
   virtual Poco::ActiveResult<bool> executeAsync() = 0;
+
+  /// Asynchronous execution - if the returned future object goes out of scope then
+  /// that is equivalent to calling .join() on a thread.
+  virtual std::future<bool> executeAsyncFuture() = 0;
 
   /// Execute as a Child Algorithm, with try/catch
   virtual void executeAsChildAlg() = 0;

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -35,6 +35,7 @@
 #include <json/json.h>
 
 #include <algorithm>
+#include <functional>
 #include <iterator>
 #include <map>
 #include <memory>
@@ -1589,6 +1590,11 @@ Poco::ActiveResult<bool> Algorithm::executeAsync() {
   m_executeAsync =
       std::make_unique<Poco::ActiveMethod<bool, Poco::Void, Algorithm>>(this, &Algorithm::executeAsyncImpl);
   return (*m_executeAsync)(Poco::Void());
+}
+
+std::future<bool> Algorithm::executeAsyncFuture() {
+  auto fun = std::bind(&Algorithm::executeAsyncImpl, this, Poco::Void());
+  return std::async(std::launch::async, fun);
 }
 
 /**Callback when an algorithm is executed asynchronously

--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -380,7 +380,7 @@ void FrameworkManagerImpl::updateInstrumentDefinitions() {
   try {
     auto algDownloadInstrument = Mantid::API::AlgorithmManager::Instance().create("DownloadInstrument");
     algDownloadInstrument->setAlgStartupLogging(false);
-    algDownloadInstrument->executeAsync();
+    m_downloadInstrumentAlg = algDownloadInstrument->executeAsyncFuture();
   } catch (Kernel::Exception::NotFoundError &) {
     g_log.debug() << "DowndloadInstrument algorithm is not available - cannot "
                      "update instrument definitions.\n";
@@ -392,7 +392,7 @@ void FrameworkManagerImpl::checkIfNewerVersionIsAvailable() {
   try {
     auto algCheckVersion = Mantid::API::AlgorithmManager::Instance().create("CheckMantidVersion");
     algCheckVersion->setAlgStartupLogging(false);
-    algCheckVersion->executeAsync();
+    m_checkVersionAlg = algCheckVersion->executeAsyncFuture();
   } catch (Kernel::Exception::NotFoundError &) {
     g_log.debug() << "CheckMantidVersion algorithm is not available - cannot "
                      "check if a newer version is available.\n";

--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/35367.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/35367.rst
@@ -1,0 +1,1 @@
+- Fix bug where Mantid would cause a segmentation fault on Linux if it exited while instrument files were still being downloaded.


### PR DESCRIPTION
Depending on a setting in the `Mantid.properties` file, the instrument files will be downloaded (if needed) on startup, but on a separate thread. If the main thread exits quickly enough then this leaves the download thread abandoned. It looked like the actual segfault comes from the Poco logging code, but it was difficult to pin down. By using an `std::future` to represent the outcome of the thread instead of a `Poco::ActiveResult` in the place where the algorithm is called, then this case of the main thread exiting is handled better.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes 35367 and a similar problem reported when running a python script that exits before the download of instrument files is complete. There is no longer a segmentation error when the main thread exits before the download instruments thread.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
- Added method `Algorithm::executeAsyncFuture()` that returns an `std::future` instead of a `Poco::ActiveResult`.
- Private member added to `FrameworkManager` to hang on to the `future` representing the instrument files download. If a `future` has no references then it will be destroyed, which will result in the equivalent of calling `.join()` on the thread and a loss of async.

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
- Error handling is slightly different on a `std::future` compared to a `Poco::ActiveResult`. On an `ActiveResult` any exception will be stored and then accessed by checking the `error()` method. On a `future` any exception will be thrown on an attempt to get the value of the `future` by calling `.get()`. 

**To test:**

See #35367 for one symptom of the problem fixed by these changes. I think the problem only happens on Linux. The method I was using to generate the segmentation fault was to delete all the instrument definition files (apart from the TOSCA ones) from `~/.mantid/instrument` and `mantid/instrument`, change `DownloadInstrument.cpp` to always force update, then run the script located [here](https://github.com/interactivereduction/autoreduction-scripts/blob/main/TOSCA/reduce.py). You'll need the archive mounted at `/archive` for the script to work.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
