### PR TITLE
Return DateAndTime by const reference

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/Events.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Events.h
@@ -144,13 +144,18 @@ public:
 
   double operator()() const;
   double tof() const;
-  Mantid::Types::Core::DateAndTime pulseTime() const;
+  const Mantid::Types::Core::DateAndTime &pulseTime() const;
+  Mantid::Types::Core::DateAndTime pulseTOFTime() const;
+  Mantid::Types::Core::DateAndTime pulseTOFTimeAtSample(const double &factor, const double &shift) const;
   double weight() const;
   double error() const;
   double errorSquared() const;
 
   /// Output a string representation of the event to a stream
   friend std::ostream &operator<<(std::ostream &os, const WeightedEvent &event);
+
+private:
+  inline static const Mantid::Types::Core::DateAndTime UNSET_DATEANDTIME = Mantid::Types::Core::DateAndTime(0);
 };
 #pragma pack(pop)
 
@@ -182,10 +187,17 @@ inline double WeightedEventNoTime::operator()() const { return m_tof; }
 /// Return the time-of-flight of the neutron, as a double.
 inline double WeightedEventNoTime::tof() const { return m_tof; }
 
-/** Return the pulse time; this returns 0 since this
- *  type of Event has no time associated.
- */
-inline Types::Core::DateAndTime WeightedEventNoTime::pulseTime() const { return 0; }
+/// Return the pulse time; this returns 0 since this type of Event has no time associated.
+inline const Types::Core::DateAndTime &WeightedEventNoTime::pulseTime() const { return UNSET_DATEANDTIME; }
+/// Return the pulse time; this returns 0 since this type of Event has no time associated.
+inline Types::Core::DateAndTime WeightedEventNoTime::pulseTOFTime() const { return UNSET_DATEANDTIME; }
+/// Return the pulse time; this returns 0 since this type of Event has no time associated.
+inline Types::Core::DateAndTime WeightedEventNoTime::pulseTOFTimeAtSample(const double &factor,
+                                                                          const double &shift) const {
+  UNUSED_ARG(factor);
+  UNUSED_ARG(shift);
+  return 0;
+}
 
 /// Return the weight of the neutron, as a double (it is saved as a float).
 inline double WeightedEventNoTime::weight() const { return m_weight; }

--- a/Framework/Types/inc/MantidTypes/Event/TofEvent.h
+++ b/Framework/Types/inc/MantidTypes/Event/TofEvent.h
@@ -83,7 +83,9 @@ public:
 
   double operator()() const;
   double tof() const;
-  Mantid::Types::Core::DateAndTime pulseTime() const;
+  const Mantid::Types::Core::DateAndTime &pulseTime() const;
+  Mantid::Types::Core::DateAndTime pulseTOFTime() const;
+  Mantid::Types::Core::DateAndTime pulseTOFTimeAtSample(const double &factor, const double &shift) const;
   double weight() const;
   double error() const;
   double errorSquared() const;
@@ -120,7 +122,7 @@ inline double TofEvent::operator()() const { return m_tof; }
 inline double TofEvent::tof() const { return m_tof; }
 
 /// Return the pulse time
-inline Core::DateAndTime TofEvent::pulseTime() const { return m_pulsetime; }
+inline const Core::DateAndTime &TofEvent::pulseTime() const { return m_pulsetime; }
 
 /// Return the weight of the event - exactly 1.0 always
 inline double TofEvent::weight() const { return 1.0; }

--- a/Framework/Types/src/Event/TofEvent.cpp
+++ b/Framework/Types/src/Event/TofEvent.cpp
@@ -8,6 +8,10 @@
 
 using std::ostream;
 
+namespace {
+constexpr double MICRO_SEC_TO_NANO{1000.0};
+}
+
 namespace Mantid::Types::Event {
 /** Comparison operator.
  * @param rhs: the other TofEvent to compare.
@@ -37,6 +41,16 @@ bool TofEvent::equals(const TofEvent &rhs, const double tolTof, const int64_t to
     return false;
   // then it is just if the pulse-times are equal
   return (this->m_pulsetime.equals(rhs.m_pulsetime, tolPulse));
+}
+
+/// Get the Pulse-time + TOF for each event in this EventList
+Mantid::Types::Core::DateAndTime TofEvent::pulseTOFTime() const {
+  return this->pulseTime() + static_cast<int64_t>(this->tof() * MICRO_SEC_TO_NANO);
+}
+
+/// Get the Pulse-time + time-of-flight of the neutron up to the sample, for each event in this EventList
+Mantid::Types::Core::DateAndTime TofEvent::pulseTOFTimeAtSample(const double &factor, const double &shift) const {
+  return this->pulseTime() + static_cast<int64_t>((factor * this->tof() + shift) * MICRO_SEC_TO_NANO);
 }
 
 /** Output a string representation of the event to a stream

--- a/Framework/Types/test/TofEventTest.h
+++ b/Framework/Types/test/TofEventTest.h
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cxxtest/TestSuite.h>
 
+using Mantid::Types::Core::DateAndTime;
 using Mantid::Types::Event::TofEvent;
 
 using std::size_t;
@@ -44,9 +45,11 @@ public:
     TofEvent e2 = TofEvent(e);
     TS_ASSERT_EQUALS(e2.tof(), 123);
     TS_ASSERT_EQUALS(e2.pulseTime(), 456);
+    TS_ASSERT_EQUALS(e2.pulseTOFTime(), DateAndTime(0., 123456.));
 
     TofEvent e3 = TofEvent(890.234, 321);
     TS_ASSERT_EQUALS(e3.tof(), 890.234);
     TS_ASSERT_EQUALS(e3.pulseTime(), 321);
+    TS_ASSERT_EQUALS(e3.pulseTOFTime(), DateAndTime(0., 890234. + 321.));
   }
 };


### PR DESCRIPTION
Since in many places there is no need to make a copy of the DateAndTime, return the object by const reference to reduce that.

This was discovered as part of #36069 and is being split out into a separate PR to make it a more obvious change.

**To test:**

All existing tests should continue to pass.

*There is no associated issue.*

*This does not require release notes* because it will never be directly observed by a user.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
