### PR TITLE
Add colorbar autoscaling limits tests

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
@@ -102,19 +102,6 @@ class ColorbarWidgetTest(TestCase):
         self.assertEqual(vmin, 0.0)
         self.assertEqual(vmax, 99.0)
 
-    def test_colorbar_limits_min_max_lognorm(self):
-        image = plt.imshow(self.data * np.nan, cmap="plasma", norm=Normalize(vmin=None, vmax=None))
-
-        self.widget.set_mappable(image)
-        self.widget.autoscale.setChecked(True)
-        self.widget.autotype.setCurrentIndex(0)
-        self.widget.norm.setCurrentIndex(1)
-
-        vmin, vmax = self.widget._calculate_auto_color_limits(self.data)
-
-        self.assertEqual(vmin, 0.0099)
-        self.assertEqual(vmax, 99.0)
-
     def test_colorbar_limits_3sigma(self):
         image = plt.imshow(self.data * np.nan, cmap="plasma", norm=Normalize(vmin=None, vmax=None))
 
@@ -150,6 +137,45 @@ class ColorbarWidgetTest(TestCase):
 
         self.assertEqual(vmin, 12.0)
         self.assertEqual(vmax, 87.0)
+
+    def test_colorbar_limits_min_max_lognorm(self):
+        image = plt.imshow(self.data * np.nan, cmap="plasma", norm=Normalize(vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
+        self.widget.autoscale.setChecked(True)
+        self.widget.autotype.setCurrentIndex(0)
+        self.widget.norm.setCurrentIndex(1)
+
+        vmin, vmax = self.widget._calculate_auto_color_limits(self.data)
+
+        self.assertEqual(vmin, 0.0099)
+        self.assertEqual(vmax, 99.0)
+
+    def test_colorbar_limits_min_max_symmetric_log10(self):
+        image = plt.imshow(self.data * np.nan, cmap="plasma", norm=Normalize(vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
+        self.widget.autoscale.setChecked(True)
+        self.widget.autotype.setCurrentIndex(0)
+        self.widget.norm.setCurrentIndex(2)
+
+        vmin, vmax = self.widget._calculate_auto_color_limits(self.data)
+
+        self.assertEqual(vmin, 0.0)
+        self.assertEqual(vmax, 99.0)
+
+    def test_colorbar_limits_min_max_power(self):
+        image = plt.imshow(self.data * np.nan, cmap="plasma", norm=Normalize(vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
+        self.widget.autoscale.setChecked(True)
+        self.widget.autotype.setCurrentIndex(0)
+        self.widget.norm.setCurrentIndex(3)
+
+        vmin, vmax = self.widget._calculate_auto_color_limits(self.data)
+
+        self.assertEqual(vmin, 0.0)
+        self.assertEqual(vmax, 99.0)
 
     def test_invalid_cmax_range_is_reset(self):
         image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=None, vmax=None))

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
@@ -91,6 +91,9 @@ class ColorbarWidgetTest(TestCase):
             self.assertEqual(c_max, 99)
 
     def test_colorbar_limits_min_max(self):
+        image = plt.imshow(self.data * np.nan, cmap="plasma", norm=Normalize(vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
         self.widget.autoscale.setChecked(True)
         self.widget.autotype.setCurrentIndex(0)
 
@@ -100,6 +103,9 @@ class ColorbarWidgetTest(TestCase):
         self.assertEqual(vmax, 99.0)
 
     def test_colorbar_limits_min_max_lognorm(self):
+        image = plt.imshow(self.data * np.nan, cmap="plasma", norm=Normalize(vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
         self.widget.autoscale.setChecked(True)
         self.widget.autotype.setCurrentIndex(0)
         self.widget.norm.setCurrentIndex(1)
@@ -110,6 +116,9 @@ class ColorbarWidgetTest(TestCase):
         self.assertEqual(vmax, 99.0)
 
     def test_colorbar_limits_3sigma(self):
+        image = plt.imshow(self.data * np.nan, cmap="plasma", norm=Normalize(vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
         self.widget.autoscale.setChecked(True)
         self.widget.autotype.setCurrentIndex(1)
 
@@ -119,6 +128,9 @@ class ColorbarWidgetTest(TestCase):
         self.assertEqual(vmax, 99.0)
 
     def test_colorbar_limits_15interquartile(self):
+        image = plt.imshow(self.data * np.nan, cmap="plasma", norm=Normalize(vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
         self.widget.autoscale.setChecked(True)
         self.widget.autotype.setCurrentIndex(2)
 
@@ -128,6 +140,9 @@ class ColorbarWidgetTest(TestCase):
         self.assertEqual(vmax, 99.0)
 
     def test_colorbar_limits_15median(self):
+        image = plt.imshow(self.data * np.nan, cmap="plasma", norm=Normalize(vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
         self.widget.autoscale.setChecked(True)
         self.widget.autotype.setCurrentIndex(3)
 

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
@@ -90,6 +90,52 @@ class ColorbarWidgetTest(TestCase):
             self.assertEqual(c_min, expected_c_min)
             self.assertEqual(c_max, 99)
 
+    def test_colorbar_limits_min_max(self):
+        self.widget.autoscale.setChecked(True)
+        self.widget.autotype.setCurrentIndex(0)
+
+        vmin, vmax = self.widget._calculate_auto_color_limits(self.data)
+
+        self.assertEqual(vmin, 0.0)
+        self.assertEqual(vmax, 99.0)
+
+    def test_colorbar_limits_min_max_lognorm(self):
+        self.widget.autoscale.setChecked(True)
+        self.widget.autotype.setCurrentIndex(0)
+        self.widget.norm.setCurrentIndex(1)
+
+        vmin, vmax = self.widget._calculate_auto_color_limits(self.data)
+
+        self.assertEqual(vmin, 0.0099)
+        self.assertEqual(vmax, 99.0)
+
+    def test_colorbar_limits_3sigma(self):
+        self.widget.autoscale.setChecked(True)
+        self.widget.autotype.setCurrentIndex(1)
+
+        vmin, vmax = self.widget._calculate_auto_color_limits(self.data)
+
+        self.assertEqual(vmin, 0.0)
+        self.assertEqual(vmax, 99.0)
+
+    def test_colorbar_limits_15interquartile(self):
+        self.widget.autoscale.setChecked(True)
+        self.widget.autotype.setCurrentIndex(2)
+
+        vmin, vmax = self.widget._calculate_auto_color_limits(self.data)
+
+        self.assertEqual(vmin, 0.0)
+        self.assertEqual(vmax, 99.0)
+
+    def test_colorbar_limits_15median(self):
+        self.widget.autoscale.setChecked(True)
+        self.widget.autotype.setCurrentIndex(3)
+
+        vmin, vmax = self.widget._calculate_auto_color_limits(self.data)
+
+        self.assertEqual(vmin, 12.0)
+        self.assertEqual(vmax, 87.0)
+
     def test_invalid_cmax_range_is_reset(self):
         image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=None, vmax=None))
 


### PR DESCRIPTION
**Description of work**
This pull request adds unit tests to the `_calculate_auto_color_limits` function in the color bar widget. It is a follow-up to PR #36119 and includes the previously missing unit tests.
**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->

<!-- If a user raised the original issue they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
A separate unit test has been added for each mode
**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**
Make sure the unit tests pass
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #36129. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
