### PR TITLE
Improve DiffractionFocussing performance for PreserveEvents=False

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/DiffractionFocussing2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DiffractionFocussing2.h
@@ -115,6 +115,7 @@ private:
   std::vector<int> groupAtWorkspaceIndex;
   /// Map from the group number to the group's X vector
   std::map<int, HistogramData::BinEdges> group2xvector;
+  std::map<int, double> group2xstep;
   /// Map from the group number to the group's summed weight vector
   group2vectormap group2wgtvector;
   /// The number of (used) groups

--- a/Framework/WorkflowAlgorithms/test/AlignAndFocusPowderTest.h
+++ b/Framework/WorkflowAlgorithms/test/AlignAndFocusPowderTest.h
@@ -173,10 +173,10 @@ public:
     // Test the output
     // [465] 1942.1284, 2415.9
     TS_ASSERT_DELTA(m_outWS->x(0)[465], 1942.1284, 0.0001);
-    TS_ASSERT_DELTA(m_outWS->y(0)[465], 2415.9, 0.1);
+    TS_ASSERT_DELTA(m_outWS->y(0)[465], 2498, 0.1);
     // [974] 15076.563463: 60043.5
     TS_ASSERT_DELTA(m_outWS->x(0)[974], 15076.563463, 0.0001);
-    TS_ASSERT_DELTA(m_outWS->y(0)[974], 60043.5, 0.1);
+    TS_ASSERT_DELTA(m_outWS->y(0)[974], 59802, 0.1);
     AnalysisDataService::Instance().remove(m_outputWS);
   }
 

--- a/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36216.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36216.rst
@@ -1,0 +1,1 @@
+- By utilizing new methods in EventList :ref:`DiffractionFocussing <algm-DiffractionFocussing>` has improved performance when using EventWorkspaces and `PreverseEvents=False`.

--- a/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36216.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36216.rst
@@ -1,1 +1,1 @@
-- By utilizing new methods in EventList :ref:`DiffractionFocussing <algm-DiffractionFocussing>` has improved performance when using EventWorkspaces and `PreverseEvents=False`.
+- By utilizing new methods in EventList :ref:`DiffractionFocussing <algm-DiffractionFocussing>` has improved performance when using EventWorkspaces and ``PreverseEvents=False``.


### PR DESCRIPTION
**Description of work**

When using Event data with PreserveEvents=False, change DiffractionFocussing2 to histogram event data directly to the output X. This uses the new generateHistogram from #36136

Before the event data was converted to histogram using the input bins then rebinned to the output bins. Now it bin directly to the expected output bins. This can give a slightly different result in the end but it should be better/sharper peaks. This also improves the performance by using the new faster generateHistogram method

DiffractionFocussing should run faster than before and also AlignAndFocusPeaks should also run faster.

**To test:**

A good example of the performance gain is the system test `SNAPRedux.SNAPReduxSimple` which I see the duration of the `DiffractionFocussing` algorithm go from ~5 seconds down to ~3 seconds. I used https://github.com/mantidproject/mantid-profiler to profile this systemtest.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes [EWM2466](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2466)
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
