### PR TITLE
fix the issue with snspowderreduction when slicing

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -633,7 +633,8 @@ class SNSPowderReduction(DataProcessorAlgorithm):
 
                 # remove container run
                 api.RebinToWorkspace(WorkspaceToRebin=can_run_ws_name, WorkspaceToMatch=sam_ws_name, OutputWorkspace=can_run_ws_name)
-                api.Scale(InputWorkspace=can_run_ws_name, OutputWorkspace=can_run_ws_name, Factor=self._containerScaleFactor)
+                if samRunIndex == 0:
+                    api.Scale(InputWorkspace=can_run_ws_name, OutputWorkspace=can_run_ws_name, Factor=self._containerScaleFactor)
                 api.Minus(LHSWorkspace=sam_ws_name, RHSWorkspace=can_run_ws_name, OutputWorkspace=sam_ws_name)
                 # compress event if the sample run workspace is EventWorkspace
                 if is_event_workspace(sam_ws_name) and self.COMPRESS_TOL_TOF > 0.0:

--- a/docs/source/release/v6.9.0/Diffraction/Powder/Bugfixes/36221.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Powder/Bugfixes/36221.rst
@@ -1,0 +1,1 @@
+- Fix the issue with :ref:`SNSPowderReduction <algm-SNSPowderReduction>` where background scale factor was applied multiple times when processing sliced workspaces.


### PR DESCRIPTION
**Description of work**

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->

This PR is for fixing the background scaling issue with the `SNSPowderReduction` algorithm. When it with splitter workspace, the previous version was applying the background scale factor multiple times for the sliced workspaces reduction. To get a feel about this issue, open the attached jupyter notebook in the `jupyter.sns.gov` server and one should be able to see the effect of the background scale factor being applied multiple times, as shown below,

![Screenshot 2023-10-05 at 14 05 36](https://github.com/mantidproject/mantid/assets/2872152/c2ff3d3e-7ab2-48e7-9f2e-7cc435e80332)

Here is the jupyter notebook,

[TimeSlice.ipynb.zip](https://github.com/mantidproject/mantid/files/12821709/TimeSlice.ipynb.zip)


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Grab the jupyter notebook attached above and run it at `jupyter.sns.gov`.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
