### PR TITLE
Fix inconsistency in StretchedExpFT documentation

### DIFF
--- a/docs/source/fitting/fitfunctions/StretchedExpFT.rst
+++ b/docs/source/fitting/fitfunctions/StretchedExpFT.rst
@@ -15,10 +15,9 @@ Description
 
 Provides the Fourier Transform of the Symmetrized Stretched Exponential Function
 
-.. math:: S(Q,E) = Height \int_{-\infty}^{\infty} dt/h \cdot e^{-i2\pi (E-Centre)t/h} \cdot e^{-|\frac{t}{Tau}|^{Beta}} )
+.. math:: S(Q,E) = Height \int_{-\infty}^{\infty} dt/h \cdot e^{-i2\pi (E-Centre)t/h} \cdot e^{-|\frac{t}{Tau}|^{Beta}}
 
-with :math:`h` Planck's constant. If the energy units of energy are micro-eV, then tau is expressed in pico-seconds. If E-units are micro-eV then
-tau is expressed in nano-seconds.
+with :math:`h` Planck's constant. If the energy units of energy are milli-eV, then tau is expressed in pico-seconds. If E-units are micro-eV then tau is expressed in nano-seconds.
 
 Properties:
 

--- a/docs/source/release/v6.8.0/Framework/Fit_Functions/Bugfixes/36223.rst
+++ b/docs/source/release/v6.8.0/Framework/Fit_Functions/Bugfixes/36223.rst
@@ -1,0 +1,1 @@
+- An inconsistency in the E units when compared to Tau has been fixed in the documentation for the :ref:`StretchedExpFT <func-StretchedExpFT>` function.


### PR DESCRIPTION
**Description of work**
This PR fixes an inconsistency in the StretchedExpFT fitting function documentation. It also removes an unmatched bracket from the end of one of the equations.

**To test:**
Code review. Make sure the changes make sense and you can build the `docs-html` target.

*There is no associated issue.*

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
