### PR TITLE
Fix crash when closing cpp interface while processing

### DIFF
--- a/docs/source/release/v6.9.0/Direct_Geometry/General/Bugfixes/36227.rst
+++ b/docs/source/release/v6.9.0/Direct_Geometry/General/Bugfixes/36227.rst
@@ -1,0 +1,1 @@
+- A crash when closing the ALFView interface while it is processing data has been fixed.

--- a/qt/widgets/common/src/BatchAlgorithmRunner.cpp
+++ b/qt/widgets/common/src/BatchAlgorithmRunner.cpp
@@ -54,7 +54,10 @@ BatchAlgorithmRunner::BatchAlgorithmRunner(QObject *parent)
       m_algorithmErrorObserver(*this, &BatchAlgorithmRunner::handleAlgorithmError),
       m_executeAsync(this, &BatchAlgorithmRunner::executeBatchAsyncImpl) {}
 
-BatchAlgorithmRunner::~BatchAlgorithmRunner() { removeAllObservers(); }
+BatchAlgorithmRunner::~BatchAlgorithmRunner() {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  removeAllObservers();
+}
 
 void BatchAlgorithmRunner::addAllObservers() {
   m_notificationCenter.addObserver(m_batchCompleteObserver);


### PR DESCRIPTION
**Description of work**
This PR fixes a crash seen on the ALFView interface caused by closing the interface while it is running an algorithm in a background thread. The problem was fixed by acquiring a lock on the mutex before destructing the `BatchAlgorithmRunner`.

**To test:**
Turn on the data archive
1. Open `Direct`->`ALFView`
2. Load run 86878
3. While it is loading, click the `x` in the top right
4. There should be no crash or freeze. You might see a warning message in the logger - this is fine

Fixes #36227

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
