### PR TITLE
Fix usage stats for IndirectSettings

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -356,5 +356,4 @@ shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlo
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp:106
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp:111
 unusedScopedObject:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp:188
-constVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectSettings.cpp:34
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FqFitAddWorkspaceDialog.cpp:71

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -68,7 +68,6 @@ set(MOC_FILES
     IndirectPlotOptionsView.h
     IndirectSassena.h
     IndirectSettings.h
-    IndirectSettingsPresenter.h
     IndirectSettingsView.h
     IndirectSimulation.h
     IndirectSimulationTab.h
@@ -91,6 +90,7 @@ set(INC_FILES
     IndirectDataValidationHelper.h
     IndirectPlotOptionsModel.h
     IndirectSettingsHelper.h
+    IndirectSettingsPresenter.h
     Notifier.h
     Reduction/ISISEnergyTransferData.h
     Reduction/ISISEnergyTransferValidator.h

--- a/qt/scientific_interfaces/Indirect/IIndirectSettingsView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectSettingsView.h
@@ -8,18 +8,17 @@
 
 #include "DllConfig.h"
 
-#include <QObject>
 #include <QWidget>
 
 namespace MantidQt {
 namespace CustomInterfaces {
+class IndirectSettingsPresenter;
 
-class MANTIDQT_INDIRECT_DLL IIndirectSettingsView : public QWidget {
-  Q_OBJECT
+class MANTIDQT_INDIRECT_DLL IIndirectSettingsView {
 
 public:
-  IIndirectSettingsView(QWidget *parent = nullptr) : QWidget(parent){};
-  virtual ~IIndirectSettingsView(){};
+  virtual QWidget *getView() = 0;
+  virtual void subscribePresenter(IndirectSettingsPresenter *presenter) = 0;
 
   virtual void setSelectedFacility(QString const &text) = 0;
   virtual QString getSelectedFacility() const = 0;
@@ -34,11 +33,6 @@ public:
   virtual void setApplyEnabled(bool enable) = 0;
   virtual void setOkEnabled(bool enable) = 0;
   virtual void setCancelEnabled(bool enable) = 0;
-
-signals:
-  void okClicked();
-  void applyClicked();
-  void cancelClicked();
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectBayes.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectBayes.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectBayes.h"
+#include "IndirectSettings.h"
 #include "Quasi.h"
 #include "ResNorm.h"
 #include "Stretch.h"
@@ -41,8 +42,7 @@ void IndirectBayes::initLayout() {
   connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
   connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this, SLOT(manageUserDirectories()));
 
-  // Needed to initially apply the settings loaded on the settings GUI
-  applySettings(getInterfaceSettings());
+  IndirectInterface::initLayout();
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectCorrections.cpp
@@ -9,6 +9,7 @@
 #include "ApplyAbsorptionCorrections.h"
 #include "CalculatePaalmanPings.h"
 #include "ContainerSubtraction.h"
+#include "IndirectSettings.h"
 
 namespace MantidQt::CustomInterfaces {
 DECLARE_SUBWINDOW(IndirectCorrections)
@@ -66,8 +67,7 @@ void IndirectCorrections::initLayout() {
   connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
   connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this, SLOT(manageUserDirectories()));
 
-  // Needed to initially apply the settings loaded on the settings GUI
-  applySettings(getInterfaceSettings());
+  IndirectInterface::initLayout();
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectDataReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReduction.cpp
@@ -8,6 +8,7 @@
 // Includes
 //----------------------
 #include "IndirectDataReduction.h"
+#include "IndirectSettings.h"
 
 #include "ILLEnergyTransfer.h"
 #include "ISISCalibration.h"
@@ -102,8 +103,7 @@ void IndirectDataReduction::initLayout() {
   m_uiForm.iicInstrumentConfiguration->updateInstrumentConfigurations(
       m_uiForm.iicInstrumentConfiguration->getInstrumentName());
 
-  // Needed to initially apply the settings loaded on the settings GUI
-  applySettings(getInterfaceSettings());
+  IndirectInterface::initLayout();
 }
 
 void IndirectDataReduction::applySettings(std::map<std::string, QVariant> const &settings) {

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectDiffractionReduction.h"
+#include "IndirectSettings.h"
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AlgorithmRuntimeProps.h"

--- a/qt/scientific_interfaces/Indirect/IndirectInterface.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectInterface.cpp
@@ -19,7 +19,7 @@ IndirectInterface::IndirectInterface(QWidget *parent) : UserSubWindow(parent) {}
 void IndirectInterface::initLayout() {
   // Needed to initially apply the settings loaded on the settings GUI
   applySettings();
-};
+}
 
 void IndirectInterface::help() {
   HelpWindow::showCustomInterface(QString::fromStdString(documentationPage()), QString("indirect"));

--- a/qt/scientific_interfaces/Indirect/IndirectInterface.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectInterface.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectInterface.h"
+#include "IndirectSettings.h"
 
 #include "MantidQtWidgets/Common/HelpWindow.h"
 #include "MantidQtWidgets/Common/InterfaceManager.h"
@@ -13,7 +14,12 @@ using namespace MantidQt::API;
 
 namespace MantidQt::CustomInterfaces {
 
-IndirectInterface::IndirectInterface(QWidget *parent) : UserSubWindow(parent), m_settings() {}
+IndirectInterface::IndirectInterface(QWidget *parent) : UserSubWindow(parent) {}
+
+void IndirectInterface::initLayout() {
+  // Needed to initially apply the settings loaded on the settings GUI
+  applySettings();
+};
 
 void IndirectInterface::help() {
   HelpWindow::showCustomInterface(QString::fromStdString(documentationPage()), QString("indirect"));
@@ -21,30 +27,17 @@ void IndirectInterface::help() {
 
 void IndirectInterface::settings() {
   auto subWindow = InterfaceManager().createSubWindow("Settings", this);
-  m_settings = dynamic_cast<IndirectSettings *>(subWindow);
-  connect(m_settings, SIGNAL(applySettings()), this, SLOT(applySettings()));
-  connect(m_settings, SIGNAL(closeSettings()), this, SLOT(closeSettings()));
+  auto settingsWindow = dynamic_cast<IndirectSettings *>(subWindow);
+  settingsWindow->connectInterface(this);
 
-  m_settings->loadSettings();
-  m_settings->setWindowModality(Qt::WindowModal);
-  m_settings->show();
+  settingsWindow->loadSettings();
+  settingsWindow->setWindowModality(Qt::WindowModal);
+  settingsWindow->show();
 }
 
-void IndirectInterface::applySettings() { applySettings(getInterfaceSettings()); }
+void IndirectInterface::applySettings() { applySettings(IndirectSettings::getSettings()); }
 
 void IndirectInterface::applySettings(std::map<std::string, QVariant> const &settings) { UNUSED_ARG(settings); }
-
-void IndirectInterface::closeSettings() {
-  disconnect(m_settings, SIGNAL(applySettings()), this, SLOT(applySettings()));
-  disconnect(m_settings, SIGNAL(closeSettings()), this, SLOT(closeSettings()));
-
-  if (auto settingsWindow = m_settings->window())
-    settingsWindow->close();
-
-  m_settings = nullptr;
-}
-
-std::map<std::string, QVariant> IndirectInterface::getInterfaceSettings() const { return m_settings->getSettings(); }
 
 void IndirectInterface::manageUserDirectories() { ManageUserDirectories::openManageUserDirectories(); }
 

--- a/qt/scientific_interfaces/Indirect/IndirectInterface.h
+++ b/qt/scientific_interfaces/Indirect/IndirectInterface.h
@@ -6,8 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "IndirectSettings.h"
-
 #include "MantidQtWidgets/Common/ManageUserDirectories.h"
 #include "MantidQtWidgets/Common/UserSubWindow.h"
 
@@ -20,6 +18,9 @@ class MANTIDQT_INDIRECT_DLL IndirectInterface : public MantidQt::API::UserSubWin
 public:
   explicit IndirectInterface(QWidget *parent = nullptr);
 
+public slots:
+  void applySettings();
+
 protected slots:
   void help();
   void settings();
@@ -27,19 +28,12 @@ protected slots:
   void showMessageBox(QString const &message);
 
 protected:
-  std::map<std::string, QVariant> getInterfaceSettings() const;
-
-private slots:
-  void applySettings();
-  void closeSettings();
+  virtual void initLayout() override;
 
 private:
-  virtual void initLayout() override{};
   virtual std::string documentationPage() const { return ""; };
 
   virtual void applySettings(std::map<std::string, QVariant> const &settings);
-
-  IndirectSettings *m_settings;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectInterface.h
+++ b/qt/scientific_interfaces/Indirect/IndirectInterface.h
@@ -6,6 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "DllConfig.h"
+
 #include "MantidQtWidgets/Common/ManageUserDirectories.h"
 #include "MantidQtWidgets/Common/UserSubWindow.h"
 

--- a/qt/scientific_interfaces/Indirect/IndirectInterface.h
+++ b/qt/scientific_interfaces/Indirect/IndirectInterface.h
@@ -31,6 +31,7 @@ protected:
 
 private slots:
   void applySettings();
+  void closeSettings();
 
 private:
   virtual void initLayout() override{};
@@ -38,7 +39,7 @@ private:
 
   virtual void applySettings(std::map<std::string, QVariant> const &settings);
 
-  std::unique_ptr<IndirectSettings> m_settings;
+  IndirectSettings *m_settings;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
@@ -19,7 +19,8 @@ IndirectSettings::IndirectSettings(QWidget *parent) : MantidQt::API::UserSubWind
 QIcon IndirectSettings::icon() { return Icons::getIcon(SETTINGS_ICON); }
 
 void IndirectSettings::initLayout() {
-  m_presenter = std::make_unique<IndirectSettingsPresenter>(this);
+  auto model = std::make_unique<IndirectSettingsModel>();
+  m_presenter = std::make_unique<IndirectSettingsPresenter>(std::move(model), new IndirectSettingsView(this));
 
   auto centralWidget = m_uiForm.centralWidget->layout();
   centralWidget->addWidget(m_presenter->getView());

--- a/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
@@ -16,36 +16,45 @@ DECLARE_SUBWINDOW(IndirectSettings)
 
 IndirectSettings::IndirectSettings(QWidget *parent) : MantidQt::API::UserSubWindow(parent) { m_uiForm.setupUi(this); }
 
+void IndirectSettings::connectInterface(IndirectInterface *indirectInterface) {
+  connect(this, SIGNAL(applySettings()), indirectInterface, SLOT(applySettings()));
+}
+
 QIcon IndirectSettings::icon() { return Icons::getIcon(SETTINGS_ICON); }
+
+std::map<std::string, QVariant> IndirectSettings::getSettings() {
+  std::map<std::string, QVariant> interfaceSettings;
+  interfaceSettings["RestrictInput"] = IndirectSettingsHelper::restrictInputDataByName();
+  interfaceSettings["ErrorBars"] = IndirectSettingsHelper::externalPlotErrorBars();
+  return interfaceSettings;
+}
 
 void IndirectSettings::initLayout() {
   auto model = std::make_unique<IndirectSettingsModel>();
   m_presenter = std::make_unique<IndirectSettingsPresenter>(std::move(model), new IndirectSettingsView(this));
+  m_presenter->subscribeParent(this);
 
   auto centralWidget = m_uiForm.centralWidget->layout();
   centralWidget->addWidget(m_presenter->getView());
+}
 
-  connect(m_presenter.get(), SIGNAL(applySettings()), this, SIGNAL(applySettings()));
-  connect(m_presenter.get(), SIGNAL(closeSettings()), this, SIGNAL(closeSettings()));
+void IndirectSettings::notifyApplySettings() { emit applySettings(); }
+
+void IndirectSettings::notifyCloseSettings() {
+  if (auto settingsWindow = window())
+    settingsWindow->close();
 }
 
 void IndirectSettings::otherUserSubWindowCreated(QPointer<UserSubWindow> window) { connectIndirectInterface(window); }
 
 void IndirectSettings::otherUserSubWindowCreated(QList<QPointer<UserSubWindow>> &windows) {
-  for (auto &window : windows)
+  for (auto const &window : windows)
     connectIndirectInterface(window);
 }
 
 void IndirectSettings::connectIndirectInterface(const QPointer<UserSubWindow> &window) {
   if (auto indirectInterface = dynamic_cast<IndirectInterface *>(window.data()))
-    connect(m_presenter.get(), SIGNAL(applySettings()), indirectInterface, SLOT(applySettings()));
-}
-
-std::map<std::string, QVariant> IndirectSettings::getSettings() const {
-  std::map<std::string, QVariant> settings;
-  settings["RestrictInput"] = IndirectSettingsHelper::restrictInputDataByName();
-  settings["ErrorBars"] = IndirectSettingsHelper::externalPlotErrorBars();
-  return settings;
+    connectInterface(indirectInterface);
 }
 
 void IndirectSettings::loadSettings() { m_presenter->loadSettings(); }

--- a/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
@@ -25,7 +25,7 @@ void IndirectSettings::initLayout() {
   centralWidget->addWidget(m_presenter->getView());
 
   connect(m_presenter.get(), SIGNAL(applySettings()), this, SIGNAL(applySettings()));
-  connect(m_presenter.get(), SIGNAL(closeSettings()), this, SLOT(closeSettings()));
+  connect(m_presenter.get(), SIGNAL(closeSettings()), this, SIGNAL(closeSettings()));
 }
 
 void IndirectSettings::otherUserSubWindowCreated(QPointer<UserSubWindow> window) { connectIndirectInterface(window); }
@@ -48,10 +48,5 @@ std::map<std::string, QVariant> IndirectSettings::getSettings() const {
 }
 
 void IndirectSettings::loadSettings() { m_presenter->loadSettings(); }
-
-void IndirectSettings::closeSettings() {
-  if (auto settingsWindow = window())
-    settingsWindow->close();
-}
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSettings.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettings.h
@@ -22,26 +22,37 @@ class QIcon;
 
 namespace MantidQt {
 namespace CustomInterfaces {
+class IndirectInterface;
 
-class MANTIDQT_INDIRECT_DLL IndirectSettings : public MantidQt::API::UserSubWindow {
+class MANTIDQT_INDIRECT_DLL IIndirectSettings {
+
+public:
+  virtual void notifyApplySettings() = 0;
+  virtual void notifyCloseSettings() = 0;
+};
+
+class MANTIDQT_INDIRECT_DLL IndirectSettings : public MantidQt::API::UserSubWindow, public IIndirectSettings {
   Q_OBJECT
 
 public:
   IndirectSettings(QWidget *parent = nullptr);
   ~IndirectSettings() = default;
 
+  void connectInterface(IndirectInterface *interface);
+
   static std::string name() { return "Settings"; }
   static QString categoryInfo() { return "Indirect"; }
   static QIcon icon();
+  static std::map<std::string, QVariant> getSettings();
 
   void initLayout() override;
   void loadSettings();
 
-  std::map<std::string, QVariant> getSettings() const;
+  void notifyApplySettings() override;
+  void notifyCloseSettings() override;
 
 signals:
   void applySettings();
-  void closeSettings();
 
 private:
   void otherUserSubWindowCreated(QPointer<UserSubWindow> window) override;

--- a/qt/scientific_interfaces/Indirect/IndirectSettings.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettings.h
@@ -41,8 +41,6 @@ public:
 
 signals:
   void applySettings();
-
-private slots:
   void closeSettings();
 
 private:

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.cpp
@@ -27,15 +27,6 @@ void IndirectSettingsPresenter::setUpPresenter() {
   connect(m_view.get(), SIGNAL(cancelClicked()), this, SLOT(closeDialog()));
 
   loadSettings();
-
-  // Temporary until better validation is used when loading data into interfaces
-  setDefaultRestrictData();
-}
-
-void IndirectSettingsPresenter::setDefaultRestrictData() const {
-  auto const isisFacility = m_model->getFacility() == "ISIS";
-  if (isisFacility)
-    setRestrictInputDataByName(isisFacility);
 }
 
 IIndirectSettingsView *IndirectSettingsPresenter::getView() { return m_view.get(); }

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectSettingsPresenter.h"
+#include "IndirectSettings.h"
 #include "IndirectSettingsHelper.h"
 
 namespace MantidQt::CustomInterfaces {
@@ -12,16 +13,18 @@ using namespace IndirectSettingsHelper;
 
 IndirectSettingsPresenter::IndirectSettingsPresenter(std::unique_ptr<IndirectSettingsModel> model,
                                                      IIndirectSettingsView *view)
-    : QObject(nullptr), m_model(std::move(model)), m_view(view) {
+    : m_model(std::move(model)), m_view(view) {
   m_view->subscribePresenter(this);
   loadSettings();
 }
 
 QWidget *IndirectSettingsPresenter::getView() { return m_view->getView(); }
 
+void IndirectSettingsPresenter::subscribeParent(IIndirectSettings *parent) { m_parent = parent; }
+
 void IndirectSettingsPresenter::notifyOkClicked() {
   saveSettings();
-  emit closeSettings();
+  m_parent->notifyCloseSettings();
 }
 
 void IndirectSettingsPresenter::notifyApplyClicked() {
@@ -30,7 +33,7 @@ void IndirectSettingsPresenter::notifyApplyClicked() {
   setApplyingChanges(false);
 }
 
-void IndirectSettingsPresenter::notifyCancelClicked() { emit closeSettings(); }
+void IndirectSettingsPresenter::notifyCancelClicked() { m_parent->notifyCloseSettings(); }
 
 void IndirectSettingsPresenter::loadSettings() {
   m_view->setSelectedFacility(QString::fromStdString(m_model->getFacility()));
@@ -45,7 +48,7 @@ void IndirectSettingsPresenter::saveSettings() {
   setRestrictInputDataByName(m_view->isRestrictInputByNameChecked());
   setExternalPlotErrorBars(m_view->isPlotErrorBarsChecked());
 
-  emit applySettings();
+  m_parent->notifyApplySettings();
 }
 
 void IndirectSettingsPresenter::setApplyingChanges(bool applyingChanges) {

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.h
@@ -22,30 +22,27 @@ class MANTIDQT_INDIRECT_DLL IndirectSettingsPresenter : public QObject {
   Q_OBJECT
 
 public:
-  explicit IndirectSettingsPresenter(QWidget *parent = nullptr);
-  explicit IndirectSettingsPresenter(IndirectSettingsModel *model, IIndirectSettingsView *view);
+  explicit IndirectSettingsPresenter(std::unique_ptr<IndirectSettingsModel> model, IIndirectSettingsView *view);
 
-  IIndirectSettingsView *getView();
+  QWidget *getView();
 
   void loadSettings();
+
+  void notifyOkClicked();
+  void notifyApplyClicked();
+  void notifyCancelClicked();
 
 signals:
   void closeSettings();
   void applySettings();
 
-private slots:
-  void applyAndCloseSettings();
-  void applyChanges();
-  void closeDialog();
-
 private:
-  void setUpPresenter();
   void saveSettings();
 
   void setApplyingChanges(bool applyingChanges);
 
   std::unique_ptr<IndirectSettingsModel> m_model;
-  std::unique_ptr<IIndirectSettingsView> m_view;
+  IIndirectSettingsView *m_view;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.h
@@ -40,7 +40,6 @@ private slots:
 
 private:
   void setUpPresenter();
-  void setDefaultRestrictData() const;
   void saveSettings();
 
   void setApplyingChanges(bool applyingChanges);

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.h
@@ -12,29 +12,23 @@
 
 #include <memory>
 
-#include <QObject>
-#include <QVariant>
-
 namespace MantidQt {
 namespace CustomInterfaces {
+class IIndirectSettings;
 
-class MANTIDQT_INDIRECT_DLL IndirectSettingsPresenter : public QObject {
-  Q_OBJECT
+class MANTIDQT_INDIRECT_DLL IndirectSettingsPresenter {
 
 public:
   explicit IndirectSettingsPresenter(std::unique_ptr<IndirectSettingsModel> model, IIndirectSettingsView *view);
 
   QWidget *getView();
+  void subscribeParent(IIndirectSettings *parent);
 
   void loadSettings();
 
   void notifyOkClicked();
   void notifyApplyClicked();
   void notifyCancelClicked();
-
-signals:
-  void closeSettings();
-  void applySettings();
 
 private:
   void saveSettings();
@@ -43,6 +37,7 @@ private:
 
   std::unique_ptr<IndirectSettingsModel> m_model;
   IIndirectSettingsView *m_view;
+  IIndirectSettings *m_parent;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsView.cpp
@@ -5,27 +5,32 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectSettingsView.h"
+#include "IndirectSettingsPresenter.h"
 
 #include "MantidQtWidgets/Common/HelpWindow.h"
 
 namespace MantidQt::CustomInterfaces {
 
 IndirectSettingsView::IndirectSettingsView(QWidget *parent)
-    : IIndirectSettingsView(parent), m_uiForm(std::make_unique<Ui::IndirectInterfaceSettings>()) {
+    : QWidget(parent), m_presenter(), m_uiForm(std::make_unique<Ui::IndirectInterfaceSettings>()) {
   m_uiForm->setupUi(this);
 
-  connect(m_uiForm->pbOk, SIGNAL(clicked()), this, SLOT(emitOkClicked()));
-  connect(m_uiForm->pbApply, SIGNAL(clicked()), this, SLOT(emitApplyClicked()));
-  connect(m_uiForm->pbCancel, SIGNAL(clicked()), this, SLOT(emitCancelClicked()));
+  connect(m_uiForm->pbOk, SIGNAL(clicked()), this, SLOT(notifyOkClicked()));
+  connect(m_uiForm->pbApply, SIGNAL(clicked()), this, SLOT(notifyApplyClicked()));
+  connect(m_uiForm->pbCancel, SIGNAL(clicked()), this, SLOT(notifyCancelClicked()));
 
   connect(m_uiForm->pbHelp, SIGNAL(clicked()), this, SLOT(openHelp()));
 }
 
-void IndirectSettingsView::emitOkClicked() { emit okClicked(); }
+QWidget *IndirectSettingsView::getView() { return this; }
 
-void IndirectSettingsView::emitApplyClicked() { emit applyClicked(); }
+void IndirectSettingsView::subscribePresenter(IndirectSettingsPresenter *presenter) { m_presenter = presenter; }
 
-void IndirectSettingsView::emitCancelClicked() { emit cancelClicked(); }
+void IndirectSettingsView::notifyOkClicked() { m_presenter->notifyOkClicked(); }
+
+void IndirectSettingsView::notifyApplyClicked() { m_presenter->notifyApplyClicked(); }
+
+void IndirectSettingsView::notifyCancelClicked() { m_presenter->notifyCancelClicked(); }
 
 void IndirectSettingsView::openHelp() {
   MantidQt::API::HelpWindow::showCustomInterface(QString("Indirect Settings"), QString("indirect"));

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsView.h
@@ -15,16 +15,20 @@
 #include <memory>
 
 #include <QObject>
+#include <QWidget>
 
 namespace MantidQt {
 namespace CustomInterfaces {
+class IndirectSettingsPresenter;
 
-class MANTIDQT_INDIRECT_DLL IndirectSettingsView : public IIndirectSettingsView {
+class MANTIDQT_INDIRECT_DLL IndirectSettingsView final : public QWidget, public IIndirectSettingsView {
   Q_OBJECT
 
 public:
   explicit IndirectSettingsView(QWidget *parent = nullptr);
-  virtual ~IndirectSettingsView() override = default;
+
+  QWidget *getView() override;
+  void subscribePresenter(IndirectSettingsPresenter *presenter) override;
 
   void setSelectedFacility(QString const &text) override;
   QString getSelectedFacility() const override;
@@ -41,12 +45,13 @@ public:
   void setCancelEnabled(bool enable) override;
 
 private slots:
-  void emitOkClicked();
-  void emitApplyClicked();
-  void emitCancelClicked();
+  void notifyOkClicked();
+  void notifyApplyClicked();
+  void notifyCancelClicked();
   void openHelp();
 
 private:
+  IndirectSettingsPresenter *m_presenter;
   std::unique_ptr<Ui::IndirectInterfaceSettings> m_uiForm;
 };
 

--- a/qt/scientific_interfaces/Indirect/IndirectSimulation.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSimulation.cpp
@@ -8,6 +8,7 @@
 #include "DensityOfStates.h"
 #include "IndirectMolDyn.h"
 #include "IndirectSassena.h"
+#include "IndirectSettings.h"
 #include "MantidKernel/ConfigService.h"
 
 namespace MantidQt::CustomInterfaces {

--- a/qt/scientific_interfaces/Indirect/IndirectTools.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTools.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectTools.h"
+#include "IndirectSettings.h"
 #include "IndirectTransmissionCalc.h"
 
 #include "MantidKernel/ConfigService.h"

--- a/qt/scientific_interfaces/Indirect/test/IndirectSettingsPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectSettingsPresenterTest.h
@@ -17,7 +17,6 @@
 using namespace MantidQt::CustomInterfaces;
 using namespace testing;
 
-namespace {
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 /// Mock object to mock the view
@@ -61,15 +60,13 @@ public:
   MOCK_CONST_METHOD0(getFacility, std::string());
 };
 
-GNU_DIAG_ON_SUGGEST_OVERRIDE
-
 class MockIndirectSettings : public IIndirectSettings {
 public:
   MOCK_METHOD0(notifyApplySettings, void());
   MOCK_METHOD0(notifyCloseSettings, void());
 };
 
-} // namespace
+GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 class IndirectSettingsPresenterTest : public CxxTest::TestSuite {
 public:

--- a/qt/scientific_interfaces/Indirect/test/IndirectSettingsPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectSettingsPresenterTest.h
@@ -9,6 +9,7 @@
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 
+#include "IndirectSettings.h"
 #include "IndirectSettingsPresenter.h"
 
 #include "MantidKernel/WarningSuppressions.h"
@@ -16,6 +17,7 @@
 using namespace MantidQt::CustomInterfaces;
 using namespace testing;
 
+namespace {
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 /// Mock object to mock the view
@@ -61,6 +63,14 @@ public:
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
 
+class MockIndirectSettings : public IIndirectSettings {
+public:
+  MOCK_METHOD0(notifyApplySettings, void());
+  MOCK_METHOD0(notifyCloseSettings, void());
+};
+
+} // namespace
+
 class IndirectSettingsPresenterTest : public CxxTest::TestSuite {
 public:
   static IndirectSettingsPresenterTest *createSuite() { return new IndirectSettingsPresenterTest(); }
@@ -72,6 +82,9 @@ public:
     auto model = std::make_unique<NiceMock<MockIndirectSettingsModel>>();
     m_model = model.get();
     m_presenter = std::make_unique<IndirectSettingsPresenter>(std::move(model), m_view.get());
+
+    m_parent = std::make_unique<NiceMock<MockIndirectSettings>>();
+    m_presenter->subscribeParent(m_parent.get());
   }
 
   void tearDown() override {
@@ -80,6 +93,7 @@ public:
 
     m_presenter.reset(); /// The model is destructed here
     m_view.reset();
+    m_parent.reset();
   }
 
   ///----------------------------------------------------------------------
@@ -142,4 +156,6 @@ private:
   std::unique_ptr<NiceMock<MockIndirectSettingsView>> m_view;
   NiceMock<MockIndirectSettingsModel> *m_model;
   std::unique_ptr<IndirectSettingsPresenter> m_presenter;
+
+  std::unique_ptr<NiceMock<MockIndirectSettings>> m_parent;
 };

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysis.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysis.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectDataAnalysis.h"
+#include "IndirectSettings.h"
 
 #include "IndirectDataAnalysisConvFitTab.h"
 #include "IndirectDataAnalysisFqFitTab.h"
@@ -51,8 +52,7 @@ void IndirectDataAnalysis::initLayout() {
   connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
   connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this, SLOT(manageUserDirectories()));
 
-  // Needed to initially apply the settings loaded on the settings GUI
-  applySettings(getInterfaceSettings());
+  IndirectInterface::initLayout();
 }
 
 std::string IndirectDataAnalysis::documentationPage() const { return "Inelastic Data Analysis"; }

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.cpp
@@ -9,6 +9,7 @@
 //----------------------
 #include "InelasticDataManipulation.h"
 
+#include "IndirectSettings.h"
 #include "InelasticDataManipulationElwinTab.h"
 #include "InelasticDataManipulationIqtTab.h"
 #include "InelasticDataManipulationMomentsTab.h"
@@ -75,8 +76,7 @@ void InelasticDataManipulation::initLayout() {
   auto const facility = Mantid::Kernel::ConfigService::Instance().getFacility();
   filterUiForFacility(QString::fromStdString(facility.name()));
 
-  // Needed to initially apply the settings loaded on the settings GUI
-  applySettings(getInterfaceSettings());
+  IndirectInterface::initLayout();
 }
 
 void InelasticDataManipulation::applySettings(std::map<std::string, QVariant> const &settings) {


### PR DESCRIPTION
**Description of work**
This PR does two things:
- It fixes the issue described in #36230 by only creating a settings interface when the settings button is clicked
- It does a small bit of refactoring of the IndirectSettings interface

The refactoring means that:
- The `IndirectSettingsPresenter` class is no longer tied to the Qt framework. (by using a subscriber pattern rather than connecting slots)
- The `IndirectSettingsPresenter` now has a non-owning raw-pointer to the view. The view is a top level widget owned by the QApplication
- The `IndirectInterface` no longer owns the `IndirectSettings` object. Again, this object is a top level widget and so the owner is the QApplication

**To test:**
Open any indirect interface
Click on the Settings icon (bottom left)
Adjust a setting and apply
Close and open the settings GUI to check the change was saved.
Open a second Indirect Interface and check that changing a setting will update the setting on all opened Indirect interfaces. The help menu should give a good explanation for what each option does.

Fixes #36230

*This does not require release notes* because **there are no user-facing changes in this PR**

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
