### PR TITLE
Take into account the projection matrix when adding and showing peaks

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/36232.rst
+++ b/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/36232.rst
@@ -1,0 +1,1 @@
+- Fix issue when adding peaks was not taking into account the projection matrix when calculating HKL.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/model.py
@@ -118,8 +118,7 @@ class PeaksViewerModel(TableWorkspaceDisplayModel):
         frame_to_slice_fn = self._frame_to_slice_fn(frame)
         peak = self.ws.getPeak(selected_index)
         slicepoint = slice_info.slicepoint
-        iz_peak = slice_info.adjust_index_for_preceding_nonq_dims(slice_info.z_index)
-        slicepoint[slice_info.z_index] = getattr(peak, frame_to_slice_fn)()[iz_peak]
+        slicepoint[slice_info.z_index] = slice_info.transform(getattr(peak, frame_to_slice_fn)())[2]
 
         return slicepoint
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
@@ -78,6 +78,7 @@ class PeaksViewerModelTest(unittest.TestCase):
         slice_info.slicepoint = [0.5, None, None]
         slice_info.z_index = 0
         slice_info.adjust_index_for_preceding_nonq_dims.side_effect = lambda index: index
+        slice_info.transform.side_effect = lambda pos: [pos[1], pos[2], pos[0]]
 
         slicepoint = model.slicepoint(0, slice_info, SpecialCoordinateSystem.QSample)
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -187,6 +187,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
             range=dimensions.get_slicerange(),
             qflags=dimensions.qflags,
             axes_angles=axes_angles,
+            proj_matrix=self.get_proj_matrix(),
         )
 
     def get_proj_matrix(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
@@ -9,7 +9,7 @@
 import unittest
 
 # 3rd party
-from numpy import full, radians, sin
+from numpy import full, radians, sin, eye
 
 # local imports
 from mantidqt.widgets.sliceviewer.models.sliceinfo import SliceInfo
@@ -158,6 +158,37 @@ class SliceInfoTest(unittest.TestCase):
             qflags=(True, True, True, True),
         )
 
+    def test_slicepoint_proj_matrix(self):
+        info = make_sliceinfo(proj_matrix=[[1.0, 0.0, 1.0], [1.0, 0.0, -1.0], [0.0, 1.0, 0.0]])
+
+        ## point to HKL
+
+        # HKL=[0,0,1]
+        HKL = info.inverse_transform([0, 1, 0])
+        self.assertEqual(HKL[0], 0)
+        self.assertEqual(HKL[1], 0)
+        self.assertEqual(HKL[2], 1)
+
+        # HKL=[1,1,0]
+        HKL = info.inverse_transform([1, 0, 0])
+        self.assertEqual(HKL[0], 1)
+        self.assertEqual(HKL[1], 1)
+        self.assertEqual(HKL[2], 0)
+
+        ## HKL to point
+
+        # HKL=[0,0,1]
+        point = info.transform([0, 0, 1])
+        self.assertEqual(point[0], 0)
+        self.assertEqual(point[1], 1)
+        self.assertEqual(point[2], 0)
+
+        # HKL=[1,1,0]
+        point = info.transform([1, 1, 0])
+        self.assertEqual(point[0], 1)
+        self.assertEqual(point[1], 0)
+        self.assertEqual(point[2], 0)
+
 
 def make_sliceinfo(
     point=(None, None, 0.5),
@@ -165,8 +196,9 @@ def make_sliceinfo(
     dimrange=(None, None, (-15, 15)),
     qflags=[True, True, True],
     axes_angles=full((3, 3), radians(90)),
+    proj_matrix=eye(3),
 ):
-    return SliceInfo(point=point, transpose=transpose, range=dimrange, qflags=qflags, axes_angles=axes_angles)
+    return SliceInfo(point=point, transpose=transpose, range=dimrange, qflags=qflags, axes_angles=axes_angles, proj_matrix=proj_matrix)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of work**

Fixes sliceviewer not taking into account the projection matrix

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->

Before if your projection matrix was anything other than identity, the display of peaks and adding of peaks gave the wrong point/HKL.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**

Create a workspace with a non-standard projection, _e.g._

```python
md = CreateMDWorkspace(Dimensions=3, Extents="-5,5,-5,5,-5,5", Names="[H,H,0],[0,0,L],[H,-H,0]", Units="r.l.u.,r.l.u.,r.l.u.", Frames="HKL,HKL,HKL")
AddSampleLog(md, LogName="sample")
md.getExperimentInfo(0).run().addProperty("W_MATRIX", [1.0, 0.0, 1.0, 1.0, 0.0, -1.0, 0.0, 1.0, 0.0], True)
peaks = CreatePeaksWorkspace(OutputType="LeanElasticPeak", NUmberOfPeaks=0)
SetUB(peaks)
```

Then open sliceviewer, show the peaks workspace, adding new peaks should now have the correct HKL

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes [EWM2640](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2640)

Fixes #32472
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
