### PR TITLE
Reenable error handling in FitPropertyBrowser

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -152,9 +152,6 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         This is called after Fit finishes to update the fit curves.
         :param name: The name of Fit's output workspace.
         """
-        if not name:
-            self.fit_notifier.notify_subscribers([])
-            return
         super(EngDiffFitPropertyBrowser, self).fitting_done_slot(name)
         self.save_current_setup(self.workspaceName())
         self.fit_notifier.notify_subscribers([self.get_fitprop()])
@@ -162,7 +159,7 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
     @Slot()
     def fitting_failed_slot(self):
         """
-        This is called after Fit fails due to an acception thrown.
+        This is called after Fit fails due to an exception thrown.
         """
         self.fit_notifier.notify_subscribers([])
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -35,6 +35,7 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         self.fit_enabled_notifier = GenericObservable()
         self.fit_started_notifier = GenericObservable()
         self.algorithmStarted.connect(self.fitting_started_slot)
+        self.algorithmFailed.connect(self.fitting_failed_slot)
 
     def set_output_window_names(self):
         """
@@ -157,6 +158,13 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         super(EngDiffFitPropertyBrowser, self).fitting_done_slot(name)
         self.save_current_setup(self.workspaceName())
         self.fit_notifier.notify_subscribers([self.get_fitprop()])
+
+    @Slot()
+    def fitting_failed_slot(self):
+        """
+        This is called after Fit fails due to an acception thrown.
+        """
+        self.fit_notifier.notify_subscribers([])
 
     @Slot()
     def function_changed_slot(self):

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -333,6 +333,7 @@ signals:
   void currentChanged() const;
   void functionRemoved();
   void algorithmFinished(const QString & /*_t1*/);
+  void algorithmFailed();
   void algorithmStarted(const QString & /*_t1*/);
   void workspaceIndexChanged(int index);
   void updatePlotSpectrum(int index);

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1641,7 +1641,7 @@ void FitPropertyBrowser::doFit(int maxIterations) {
       QCoreApplication::processEvents();
     }
     if (!result.error().empty()) {
-      emit algorithmFinished(QString());
+      emit algorithmFailed();
     }
   } catch (const std::exception &e) {
     QString msg = "Fit algorithm failed.\n\n" + QString(e.what()) + "\n";


### PR DESCRIPTION
**Description of work**

https://github.com/mantidproject/mantid/pull/36125 adds code to emit a `algorithmFinished` signal if an algorithm throws an error. In the `FitPropertyBrowser`, the `algorithmFinished` signal is inferred to mean that the algorithm has been successful. The `FitPropertyBrowser` therefore tries to access fit workspaces that do not exist.

This causes an unhandled exception to be thrown whenever an error is thrown in a fit algorithm.

To circumvent this, I have added a new signal `algorithmFailed`, that is now emitted instead. The code inside `EngDiff_fitpropertybrowser` added to stop the GUI hang seen in #36091 has been moved to a slot that responds to this signal.

**To test:**

Follow instructions to these issues:
- https://github.com/mantidproject/mantid/issues/36091
- https://github.com/mantidproject/mantid/issues/36265

Fixes #36265

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
