### PR TITLE
Clean up running algorithms on AlgorithmManager shutdown

### DIFF
--- a/Framework/API/src/AlgorithmManager.cpp
+++ b/Framework/API/src/AlgorithmManager.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/AlgorithmFactory.h"
 #include "MantidKernel/ConfigService.h"
+#include <thread>
 
 namespace Mantid::API {
 namespace {
@@ -185,5 +186,10 @@ size_t AlgorithmManagerImpl::removeFinishedAlgorithms() {
   return theCompletedInstances.size();
 }
 
-void AlgorithmManagerImpl::shutdown() { clear(); }
+void AlgorithmManagerImpl::shutdown() {
+  cancelAll();
+  while (runningInstances().size() > 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+}
 } // namespace Mantid::API

--- a/Framework/API/src/AlgorithmManager.cpp
+++ b/Framework/API/src/AlgorithmManager.cpp
@@ -191,5 +191,6 @@ void AlgorithmManagerImpl::shutdown() {
   while (runningInstances().size() > 0) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
+  clear();
 }
 } // namespace Mantid::API

--- a/Framework/DataHandling/src/DownloadInstrument.cpp
+++ b/Framework/DataHandling/src/DownloadInstrument.cpp
@@ -128,6 +128,7 @@ void DownloadInstrument::exec() {
       g_log.information() << "Downloading \"" << itMap.second << "\" from \"" << itMap.first << "\"\n";
     }
     doDownloadFile(itMap.first, itMap.second);
+    interruption_point();
   }
 
   setProperty("FileDownloadCount", static_cast<int>(fileMap.size()));

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -36,7 +36,7 @@ AlgorithmManagerImpl &instance() {
     PyRun_SimpleString("import atexit\n"
                        "def cleanupAlgorithmManager():\n"
                        "    from mantid.api import AlgorithmManager\n"
-                       "    AlgorithmManager.clear()\n"
+                       "    AlgorithmManager.shutdown()\n"
                        "atexit.register(cleanupAlgorithmManager)");
   });
   return mgr;
@@ -53,6 +53,11 @@ void clear(AlgorithmManagerImpl *self) {
   /// (see #33924). Fixing that is not trivial, so I am reverting this change until it can be resolved properly.
   // ReleaseGlobalInterpreterLock releaseGIL;
   return self->clear();
+}
+
+void shutdown(AlgorithmManagerImpl *self) {
+  ReleaseGlobalInterpreterLock releaseGIL;
+  return self->shutdown();
 }
 
 void cancelAll(AlgorithmManagerImpl *self) {
@@ -133,6 +138,7 @@ void export_AlgorithmManager() {
            "Returns a list of managed algorithm instances that are "
            "currently executing")
       .def("clear", &clear, arg("self"), "Clears the current list of managed algorithms")
+      .def("shutdown", &shutdown, arg("self"), "Cancels all running algorithms and waits for them to exit")
       .def("cancelAll", &cancelAll, arg("self"), "Requests that all currently running algorithms be cancelled")
       .def("Instance", instance, return_value_policy<reference_existing_object>(),
            "Return a reference to the singleton instance")

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -56,7 +56,8 @@ void clear(AlgorithmManagerImpl *self) {
 }
 
 void shutdown(AlgorithmManagerImpl *self) {
-  ReleaseGlobalInterpreterLock releaseGIL;
+  // See comment above for clear()
+  // ReleaseGlobalInterpreterLock releaseGIL;
   return self->shutdown();
 }
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -335,7 +335,7 @@ unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/E
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp:74
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/InstrumentFileFinder.cpp:36
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp:148
-unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp:115
+unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp:120
 constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:153
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp:251
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp:65

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -335,7 +335,7 @@ unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/E
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp:74
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/InstrumentFileFinder.cpp:36
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp:148
-unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp:120
+unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp:121
 constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:153
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp:251
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp:65

--- a/docs/source/release/v6.9.0/Framework/Algorithms/Bugfixes/35367.rst
+++ b/docs/source/release/v6.9.0/Framework/Algorithms/Bugfixes/35367.rst
@@ -1,0 +1,1 @@
+- Fixed potential error if algorithms are still running in the background when a python script finishes.


### PR DESCRIPTION
**Description of work**
If the `AlgorithmManager` goes out of scope while an algorithm is still running, then that algorithm will also go out of scope and be destroyed, but it will still be trying to execute, usually resulting in a segmentation fault. One example of this is in #35367. To fix this problem, when a python script finishes, any running algorithms will be cancelled by the `AlgorithmManager`. Both examples of this problem that I've seen result from `DownloadInstrument` executing at startup for a short script. The option to disable running `DownloadInstrument` at startup is available as a workaround in those particular cases.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes 35367 (will link later)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
- Changed the `atexit` method for `AlgorithmManager` to `shutdown` instead of `clear`, since `clear` will only free memory from completed algorithms.
- Changed `AlgorithmManager::shutdown` to cancel all running algorithms and wait for them to finish.
- Added a check inside the `DownloadInstrument` algorithm so that it can exit if cancelled.

**To test:**

See #35367 for how to reproduce. In summary, delete your `~/.mantid` folder (on Linux), (I also had to delete all the instrument definition files in the repository), then run `python -c from mantid.api import FrameworkManagerImpl as FMI;FMI.Instance()`. Probably also worth checking that exiting Workbench still works correctly.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
