### PR TITLE
Add test to ensure `algorithmFailed` signal is emmited upon failure of FitPropertyBrowser fitting

### DIFF
--- a/qt/widgets/common/test/FitPropertyBrowserTest.h
+++ b/qt/widgets/common/test/FitPropertyBrowserTest.h
@@ -8,11 +8,14 @@
 
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IFunction1D.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/ParamFunction.h"
+#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidQtWidgets/Common/FitPropertyBrowser.h"
 #include "MantidQtWidgets/Common/PropertyHandler.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h"
 #include <QApplication>
+#include <QSignalSpy>
 #include <QString>
 #include <QTimer>
 #include <cxxtest/TestSuite.h>
@@ -200,6 +203,17 @@ public:
     heightProperty = f0Handler->getParameterProperty(QString("Height"));
     height = heightProperty->valueText().toDouble();
     TS_ASSERT_EQUALS(height, 12);
+  }
+
+  void test_fit_error_handled_and_failed_signal_emmitted() {
+    QSignalSpy algFailedSpy(m_fitPropertyBrowser.get(), &MantidQt::MantidWidgets::FitPropertyBrowser::algorithmFailed);
+    auto ws = Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", 5, 5, 5);
+    Mantid::API::AnalysisDataService::Instance().addOrReplace("test_ws_name", ws);
+    m_fitPropertyBrowser->init();
+    m_fitPropertyBrowser->createCompositeFunction("name=UserFunction;");
+    m_fitPropertyBrowser->setWorkspaceName("test_ws_name");
+    m_fitPropertyBrowser->fit();
+    TS_ASSERT_EQUALS(algFailedSpy.count(), 1);
   }
 
 private:

--- a/qt/widgets/common/test/FitPropertyBrowserTest.h
+++ b/qt/widgets/common/test/FitPropertyBrowserTest.h
@@ -54,7 +54,10 @@ public:
     m_fitPropertyBrowser = std::make_unique<MantidQt::MantidWidgets::FitPropertyBrowser>();
   }
 
-  void tearDown() override { m_fitPropertyBrowser.reset(); }
+  void tearDown() override {
+    m_fitPropertyBrowser.reset();
+    Mantid::API::AnalysisDataService::Instance().clear();
+  }
 
   // This is a very specific test for a bug that is now fixed to prevent regression
   void test_FunctionFactory_notification_is_released() {

--- a/qt/widgets/common/test/FitPropertyBrowserTest.h
+++ b/qt/widgets/common/test/FitPropertyBrowserTest.h
@@ -205,15 +205,19 @@ public:
     TS_ASSERT_EQUALS(height, 12);
   }
 
-  void test_fit_error_handled_and_failed_signal_emmitted() {
-    QSignalSpy algFailedSpy(m_fitPropertyBrowser.get(), &MantidQt::MantidWidgets::FitPropertyBrowser::algorithmFailed);
+  void test_alg_failed_signal_emmitted_upon_exception() {
+    QSignalSpy algFailedSpy_failed(m_fitPropertyBrowser.get(),
+                                   &MantidQt::MantidWidgets::FitPropertyBrowser::algorithmFailed);
+    QSignalSpy algFailedSpy_finished(m_fitPropertyBrowser.get(),
+                                     &MantidQt::MantidWidgets::FitPropertyBrowser::algorithmFinished);
     auto ws = Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", 5, 5, 5);
     Mantid::API::AnalysisDataService::Instance().addOrReplace("test_ws_name", ws);
     m_fitPropertyBrowser->init();
     m_fitPropertyBrowser->createCompositeFunction("name=UserFunction;");
     m_fitPropertyBrowser->setWorkspaceName("test_ws_name");
     m_fitPropertyBrowser->fit();
-    TS_ASSERT_EQUALS(algFailedSpy.count(), 1);
+    TS_ASSERT_EQUALS(algFailedSpy_failed.count(), 1);
+    TS_ASSERT_EQUALS(algFailedSpy_finished.count(), 0);
   }
 
 private:

--- a/qt/widgets/common/test/FitPropertyBrowserTest.h
+++ b/qt/widgets/common/test/FitPropertyBrowserTest.h
@@ -56,7 +56,9 @@ public:
 
   void tearDown() override {
     m_fitPropertyBrowser.reset();
+    std::cout << "Tear down: fpb reset" << std::endl;
     Mantid::API::AnalysisDataService::Instance().clear();
+    std::cout << "Tear down: ads cleared" << std::endl;
   }
 
   // This is a very specific test for a bug that is now fixed to prevent regression
@@ -219,8 +221,11 @@ public:
     m_fitPropertyBrowser->createCompositeFunction("name=UserFunction;");
     m_fitPropertyBrowser->setWorkspaceName("test_ws_name");
     m_fitPropertyBrowser->fit();
+    std::cout << "Reached end of fitting" << std::endl;
     TS_ASSERT_EQUALS(algFailedSpy_failed.count(), 1);
+    std::cout << "Compared algorithmFailed count" << std::endl;
     TS_ASSERT_EQUALS(algFailedSpy_finished.count(), 0);
+    std::cout << "Compared algorithmFinished count" << std::endl;
   }
 
 private:


### PR DESCRIPTION
**Description of work**

https://github.com/mantidproject/mantid/pull/36269 reenables error handling in FitPropertyBrowser.

This PR adds a unit test to ensure the correct signal is emitted when an exception occurs during a fit algorithm launched by the `FitPropertyBrowser`.

**To test:**
New test passes.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
