### PR TITLE
35076 q e coverage input validation

### DIFF
--- a/docs/source/interfaces/utility/QE Coverage.rst
+++ b/docs/source/interfaces/utility/QE Coverage.rst
@@ -32,8 +32,8 @@ To overplot the calculated Q-E trajectories, set the "Plot Over" check box.
 
 The plot range is from Emin to Ei for direct, and from -Ef to Emax for indirect
 geometry spectrometers, and Emin and Emax may be inputted in the appropriate text
-box. If this box is left empty, Emin=-Ei/2 (Emax=Ef) is set automatically for
-direct (indirect) geometry.
+box. If the input for Emin is invalid or bigger than min(Ei), then Emin is
+automatically set to Emin = -max(Ei)/2 for direct (indirect) geometry.
 
 You can choose to create a 1D Mantid workspace for latter plotting using the
 "Create Workspace" check box.

--- a/docs/source/interfaces/utility/QE Coverage.rst
+++ b/docs/source/interfaces/utility/QE Coverage.rst
@@ -24,14 +24,15 @@ Options
 To use, select the geometry (direct or indirect) and instrument from the tabs
 and drop-down menu. For direct geometry spectrometers, an incident energy (Ei)
 in meV must be given; for indirect geometry machines, the final energies are
-fixed at a few values which must be selected from the drop-down menu. (Negative
-values of Ei are treated as positive - the program only uses the magnitude of Ei).
+fixed at a few values which must be selected from the drop-down menu. Only positive
+values of Ei are permitted. Several Q-E trajectories can be plotted simultaneously
+by providing several Ei values separated by commas.
 
 To overplot the calculated Q-E trajectories, set the "Plot Over" check box.
 
 The plot range is from Emin to Ei for direct, and from -Ef to Emax for indirect
 geometry spectrometers, and Emin and Emax may be inputted in the appropriate text
-box. If this box is left empty, Emin=-Ei (Emax=Ef) is set automatically for
+box. If this box is left empty, Emin=-Ei/2 (Emax=Ef) is set automatically for
 direct (indirect) geometry.
 
 You can choose to create a 1D Mantid workspace for latter plotting using the

--- a/docs/source/release/v6.9.0/Direct_Geometry/General/Bugfixes/35076.rst
+++ b/docs/source/release/v6.9.0/Direct_Geometry/General/Bugfixes/35076.rst
@@ -1,1 +1,1 @@
-- In the :ref:`QECoverage <QE Coverage>` tool, fixed crash and removed multiple pop-up windows when invalid input is passed to Ei and Emin (and S2 in the case of HYSPEC).
+- In the :ref:`QECoverage <QE Coverage>` tool, fixed crash and replaced multiple pop-up windows by warnings when invalid input is passed to Ei and Emin (and S2 in the case of HYSPEC).

--- a/docs/source/release/v6.9.0/Direct_Geometry/General/Bugfixes/35076.rst
+++ b/docs/source/release/v6.9.0/Direct_Geometry/General/Bugfixes/35076.rst
@@ -1,0 +1,1 @@
+- In the :ref:`QECoverage <QE Coverage>` tool, fixed crash and removed multiple pop-up windows when invalid input is passed to Ei and Emin (and S2 in the case of HYSPEC).

--- a/docs/source/release/v6.9.0/Indirect/Bugfixes/35076.rst
+++ b/docs/source/release/v6.9.0/Indirect/Bugfixes/35076.rst
@@ -1,1 +1,1 @@
-- In the :ref:`QECoverage <QE Coverage>` tool, fixed crash and removed multiple pop-up windows when invalid input is passed to Ei and Emin (and S2 in the case of HYSPEC).
+- In the :ref:`QECoverage <QE Coverage>` tool, fixed crash and replaced multiple pop-up windows by warnings when invalid input is passed to Ei and Emin (and S2 in the case of HYSPEC).

--- a/docs/source/release/v6.9.0/Indirect/Bugfixes/35076.rst
+++ b/docs/source/release/v6.9.0/Indirect/Bugfixes/35076.rst
@@ -1,0 +1,1 @@
+- In the :ref:`QECoverage <QE Coverage>` tool, fixed crash and removed multiple pop-up windows when invalid input is passed to Ei and Emin (and S2 in the case of HYSPEC).

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/QECoverage/QECoverageGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/QECoverage/QECoverageGUI.py
@@ -102,6 +102,9 @@ class QECoverageGUI(QtWidgets.QWidget):
         comma_sep_postv_floats_regex_str = r"^(\s*\+?[0-9]*\.?[0-9]*)(\s*,\s*\+?[0-9]*\.?[0-9]*)+\s*$"
         comma_sep_floats_validator = QRegExpValidator(QRegExp(comma_sep_postv_floats_regex_str))
         self.direct_ei_input.setValidator(comma_sep_floats_validator)
+        self.invalid_ei_msg = (
+            "\nEi provided was invalid, Ei should be a positive float or a sequence of positive floats separated by commas"
+        )
         self.direct_ei_grid.addWidget(self.direct_ei_input)
         self.direct_grid.addWidget(self.direct_ei)
         self.emaxfield_msgbox = QtWidgets.QMessageBox()
@@ -121,6 +124,9 @@ class QECoverageGUI(QtWidgets.QWidget):
         self.direct_emin_input = QtWidgets.QLineEdit("-10", self.direct_emin)
         self.direct_emin_input.setValidator(QDoubleValidator())
         self.direct_emin_input.setToolTip("Minimum energy transfer to plot down to.")
+        self.invalid_emin_msg = (
+            "\nEmin provided was either invalid or bigger than minimum value of Ei , " "automatically changed value to Emin = -max(Ei) / 2"
+        )
         self.direct_emin_grid.addWidget(self.direct_emin_input)
         self.direct_grid.addWidget(self.direct_emin)
         self.direct_plotbtn = QtWidgets.QPushButton("Plot Q-E", self.tab_direct)
@@ -355,8 +361,7 @@ class QECoverageGUI(QtWidgets.QWidget):
         try:
             ei_vec = [float(val) for val in ei_str.split(",")]
         except ValueError:
-            msg = "\nEi provided was invalid, Ei should be a positive float or " "a sequence of positive floats separated by commas"
-            logger.warning(msg)
+            logger.warning(self.invalid_ei_msg)
             return
 
         try:
@@ -366,11 +371,7 @@ class QECoverageGUI(QtWidgets.QWidget):
         except ValueError:
             Emin = -max(ei_vec) / 2
             self.direct_emin_input.setText(str(Emin))
-            msg = (
-                "\nEmin provided was either invalid or bigger than minimum value of Ei , "
-                "automatically changed value to Emin = -max(Ei) / 2"
-            )
-            logger.warning(msg)
+            logger.warning(self.invalid_ei_msg)
 
         self.direct_s2_input.setText(str(self.s2))
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/QECoverage/QECoverageGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/QECoverage/QECoverageGUI.py
@@ -97,14 +97,10 @@ class QECoverageGUI(QtWidgets.QWidget):
         self.direct_ei_grid.addWidget(self.direct_ei_label)
         self.direct_ei_input = QtWidgets.QLineEdit("55", self.direct_ei)
         self.direct_ei_input.setToolTip("Incident Energy in meV")
-        comma_sep_floats_regex_str = r"^(\s*\+?[0-9]*\.?[0-9]*)(\s*,\s*\+?[0-9]*\.?[0-9]*)+\s*$"
-        comma_sep_floats_validator = QRegExpValidator(QRegExp(comma_sep_floats_regex_str))
+        comma_sep_postv_floats_regex_str = r"^(\s*\+?[0-9]*\.?[0-9]*)(\s*,\s*\+?[0-9]*\.?[0-9]*)+\s*$"
+        comma_sep_floats_validator = QRegExpValidator(QRegExp(comma_sep_postv_floats_regex_str))
         self.direct_ei_input.setValidator(comma_sep_floats_validator)
         self.direct_ei_grid.addWidget(self.direct_ei_input)
-        # self.emptyfield_msgbox = QtWidgets.QMessageBox()
-        # self.emptyfield_msgbox.setText("Invalid input has been provided for Ei or Emin! Please try again")
-        # self.ei_msgbox = QtWidgets.QMessageBox()
-        # self.ei_msgbox.setText("Ei cannot be negative! Please try again")
         self.ei_emin_msgbox = QtWidgets.QMessageBox()
         self.ei_emin_msgbox.setText("Emin must be less than the values provided for Ei! Please try again")
         self.direct_grid.addWidget(self.direct_ei)
@@ -135,10 +131,10 @@ class QECoverageGUI(QtWidgets.QWidget):
         self.direct_s2.setLayout(self.direct_s2_grid)
         self.direct_s2_label = QtWidgets.QLabel("s2", self.direct_s2)
         self.direct_s2_grid.addWidget(self.direct_s2_label)
-        self.direct_s2_input = QtWidgets.QLineEdit("30", self.direct_s2)
+        self.s2 = 30
+        self.direct_s2_input = QtWidgets.QLineEdit(str(self.s2), self.direct_s2)
         self.direct_s2_input.setValidator(QDoubleValidator())
         self.direct_s2_input.setToolTip("Scattering angle of middle of the HYSPEC detector bank.")
-        # self.direct_s2_input.textChanged[str].connect(self.onS2Changed)
         self.direct_s2_input.editingFinished.connect(self.onS2Changed)
         self.direct_s2_grid.addWidget(self.direct_s2_input)
         self.direct_grid.addWidget(self.direct_s2)
@@ -344,16 +340,12 @@ class QECoverageGUI(QtWidgets.QWidget):
             self.onIndirectInstActivated(self.indirect_inst_box.currentText())
 
     def onS2Changed(self):
-        # try:       # Double enforced be QDoubleValidator, blank space taken care of from editingFinished
-        s2 = float(self.direct_s2_input.text())
-        # except ValueError:
-        #     self.direct_s2_input.setText("0")
-        #     s2 = 0
+        self.s2 = float(self.direct_s2_input.text())
 
-        if abs(s2) <= 30:
-            self.tthlims = [0, abs(s2) + 30]
+        if abs(self.s2) <= 30:
+            self.tthlims = [0, abs(self.s2) + 30]
         else:
-            self.tthlims = [abs(s2) - 30, abs(s2) + 30]
+            self.tthlims = [abs(self.s2) - 30, abs(self.s2) + 30]
 
     def onClickDirectPlot(self):
         overplot = self.direct_plotover.isChecked()
@@ -369,39 +361,14 @@ class QECoverageGUI(QtWidgets.QWidget):
             Emin = float(self.direct_emin_input.text())
         except ValueError:
             Emin = -max(ei_vec) / 2
-            self.direct_emin_input.setText(str(Emin))  # Changed ei_vec[0] to max(ei_vec)
+            self.direct_emin_input.setText(str(Emin))
 
         if min(ei_vec) <= Emin:
             self.ei_emin_msgbox.show()
             Emin = min(ei_vec) - 1
             self.direct_emin_input.setText(str(Emin))
 
-        # eierr = "-----------------------------------------------------------------------------------\n"
-        # eierr += "Error: Invalid input Ei. This must be a number or a comma-separated list of numbers\n"
-        # eierr += "-----------------------------------------------------------------------------------\n"
-        # ei_vec = []
-        # if "," not in ei_str:
-        #     try:
-        #         ei_vec.append(float(ei_str))
-        #         ei_vec = self.direct_input_check(ei_vec)
-        #
-        #     except ValueError:
-        #         self.emptyfield_msgbox.show()
-        #         raise ValueError(eierr)
-        #
-        # else:
-        #     try:
-        #         ei_vec = [float(val) for val in ei_str.split(",")]
-        #         ei_vec = self.direct_input_check(ei_vec)
-        #
-        #     except ValueError:
-        #         self.emptyfield_msgbox.show()
-        #         raise ValueError(eierr)
-
-        # try:
-        #     Emin = float(self.direct_emin_input.text())
-        # except ValueError:
-        #     Emin = -max(ei_vec)
+        self.direct_s2_input.setText(str(self.s2))
 
         qe = calcQE(ei_vec, self.tthlims, emin=Emin)
 
@@ -452,52 +419,6 @@ class QECoverageGUI(QtWidgets.QWidget):
         self.axes.set_ylabel("Energy Transfer (meV)")
         self.axes.legend()
         self.canvas.draw()
-
-    def direct_input_check(self, ei_vec):
-        if len(ei_vec) > 0:
-            # ei_str = ""
-            # update_ei_str = False
-            # insert_comma = True
-            #
-            # for ei in ei_vec:
-            #     # if ei is equal to last value in ei_vec
-            #     if ei_vec[len(ei_vec) - 1] == ei:
-            #         insert_comma = False
-            #
-            #     if ei < 0:
-            #         update_ei_str = True
-            #         self.ei_msgbox.show()
-            #         ei = abs(ei)
-            #
-            #         ei_int = int(ei)
-            #         if insert_comma:
-            #             ei_str += str(ei_int) + ", "
-            #         else:
-            #             ei_str += str(ei_int)
-            #
-            #     else:
-            #         ei_int = int(ei)
-            #         if insert_comma:
-            #             ei_str += str(ei_int) + ", "
-            #         else:
-            #             ei_str += str(ei_int)
-
-            # if update_ei_str:
-            #     self.direct_ei_input.setText(ei_str)
-            #     ei_vec = [float(val) for val in ei_str.split(",")]
-
-            if self.direct_emin_input.text() == "":
-                self.direct_emin_input.setText(str((ei_vec[0] / 2) * -1))
-
-            # reset min_emin according to list provided
-            min_emin = float(self.direct_emin_input.text())
-            minimum = min(ei_vec)
-            if minimum <= min_emin:
-                self.ei_emin_msgbox.show()
-                renew_val = str(minimum - 1)
-                self.direct_emin_input.setText(renew_val)
-
-        return ei_vec
 
     def indirect_input_check(self, ana):
         Emax_min = 0

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/QECoverage/QECoverageGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/QECoverage/QECoverageGUI.py
@@ -9,6 +9,8 @@ from mantidqt.gui_helper import show_interface_help
 import numpy as np
 import mantid
 from qtpy import QtWidgets, QtCore
+from qtpy.QtGui import QDoubleValidator, QRegExpValidator
+from qtpy.QtCore import QRegExp
 from mantidqt.MPLwidgets import *
 from matplotlib.figure import Figure
 from scipy import constants
@@ -95,11 +97,14 @@ class QECoverageGUI(QtWidgets.QWidget):
         self.direct_ei_grid.addWidget(self.direct_ei_label)
         self.direct_ei_input = QtWidgets.QLineEdit("55", self.direct_ei)
         self.direct_ei_input.setToolTip("Incident Energy in meV")
+        comma_sep_floats_regex_str = r"^(\s*\+?[0-9]*\.?[0-9]*)(\s*,\s*\+?[0-9]*\.?[0-9]*)+\s*$"
+        comma_sep_floats_validator = QRegExpValidator(QRegExp(comma_sep_floats_regex_str))
+        self.direct_ei_input.setValidator(comma_sep_floats_validator)
         self.direct_ei_grid.addWidget(self.direct_ei_input)
-        self.emptyfield_msgbox = QtWidgets.QMessageBox()
-        self.emptyfield_msgbox.setText("Invalid input has been provided for Ei or Emin! Please try again")
-        self.ei_msgbox = QtWidgets.QMessageBox()
-        self.ei_msgbox.setText("Ei cannot be negative! Please try again")
+        # self.emptyfield_msgbox = QtWidgets.QMessageBox()
+        # self.emptyfield_msgbox.setText("Invalid input has been provided for Ei or Emin! Please try again")
+        # self.ei_msgbox = QtWidgets.QMessageBox()
+        # self.ei_msgbox.setText("Ei cannot be negative! Please try again")
         self.ei_emin_msgbox = QtWidgets.QMessageBox()
         self.ei_emin_msgbox.setText("Emin must be less than the values provided for Ei! Please try again")
         self.direct_grid.addWidget(self.direct_ei)
@@ -118,6 +123,7 @@ class QECoverageGUI(QtWidgets.QWidget):
         self.direct_emin_label = QtWidgets.QLabel("Emin", self.direct_emin)
         self.direct_emin_grid.addWidget(self.direct_emin_label)
         self.direct_emin_input = QtWidgets.QLineEdit("-10", self.direct_emin)
+        self.direct_emin_input.setValidator(QDoubleValidator())
         self.direct_emin_input.setToolTip("Minimum energy transfer to plot down to.")
         self.direct_emin_grid.addWidget(self.direct_emin_input)
         self.direct_grid.addWidget(self.direct_emin)
@@ -130,9 +136,11 @@ class QECoverageGUI(QtWidgets.QWidget):
         self.direct_s2_label = QtWidgets.QLabel("s2", self.direct_s2)
         self.direct_s2_grid.addWidget(self.direct_s2_label)
         self.direct_s2_input = QtWidgets.QLineEdit("30", self.direct_s2)
+        self.direct_s2_input.setValidator(QDoubleValidator())
         self.direct_s2_input.setToolTip("Scattering angle of middle of the HYSPEC detector bank.")
+        # self.direct_s2_input.textChanged[str].connect(self.onS2Changed)
+        self.direct_s2_input.editingFinished.connect(self.onS2Changed)
         self.direct_s2_grid.addWidget(self.direct_s2_input)
-        self.direct_s2_input.textChanged[str].connect(self.onS2Changed)
         self.direct_grid.addWidget(self.direct_s2)
         self.direct_s2.hide()
         self.direct_grid.addStretch(10)
@@ -335,11 +343,13 @@ class QECoverageGUI(QtWidgets.QWidget):
         else:
             self.onIndirectInstActivated(self.indirect_inst_box.currentText())
 
-    def onS2Changed(self, text):
-        try:
-            s2 = float(text)
-        except ValueError:
-            s2 = 0
+    def onS2Changed(self):
+        # try:       # Double enforced be QDoubleValidator, blank space taken care of from editingFinished
+        s2 = float(self.direct_s2_input.text())
+        # except ValueError:
+        #     self.direct_s2_input.setText("0")
+        #     s2 = 0
+
         if abs(s2) <= 30:
             self.tthlims = [0, abs(s2) + 30]
         else:
@@ -349,32 +359,50 @@ class QECoverageGUI(QtWidgets.QWidget):
         overplot = self.direct_plotover.isChecked()
         createws = self.direct_createws.isChecked()
         ei_str = self.direct_ei_input.text()
-        eierr = "-----------------------------------------------------------------------------------\n"
-        eierr += "Error: Invalid input Ei. This must be a number or a comma-separated list of numbers\n"
-        eierr += "-----------------------------------------------------------------------------------\n"
-        ei_vec = []
-        if "," not in ei_str:
-            try:
-                ei_vec.append(float(ei_str))
-                ei_vec = self.direct_input_check(ei_vec)
 
-            except ValueError:
-                self.emptyfield_msgbox.show()
-                raise ValueError(eierr)
-
-        else:
-            try:
-                ei_vec = [float(val) for val in ei_str.split(",")]
-                ei_vec = self.direct_input_check(ei_vec)
-
-            except ValueError:
-                self.emptyfield_msgbox.show()
-                raise ValueError(eierr)
+        try:
+            ei_vec = [float(val) for val in ei_str.split(",")]
+        except ValueError:  # Fails on empty string and '+'
+            return
 
         try:
             Emin = float(self.direct_emin_input.text())
         except ValueError:
-            Emin = -max(ei_vec)
+            Emin = -max(ei_vec) / 2
+            self.direct_emin_input.setText(str(Emin))  # Changed ei_vec[0] to max(ei_vec)
+
+        if min(ei_vec) <= Emin:
+            self.ei_emin_msgbox.show()
+            Emin = min(ei_vec) - 1
+            self.direct_emin_input.setText(str(Emin))
+
+        # eierr = "-----------------------------------------------------------------------------------\n"
+        # eierr += "Error: Invalid input Ei. This must be a number or a comma-separated list of numbers\n"
+        # eierr += "-----------------------------------------------------------------------------------\n"
+        # ei_vec = []
+        # if "," not in ei_str:
+        #     try:
+        #         ei_vec.append(float(ei_str))
+        #         ei_vec = self.direct_input_check(ei_vec)
+        #
+        #     except ValueError:
+        #         self.emptyfield_msgbox.show()
+        #         raise ValueError(eierr)
+        #
+        # else:
+        #     try:
+        #         ei_vec = [float(val) for val in ei_str.split(",")]
+        #         ei_vec = self.direct_input_check(ei_vec)
+        #
+        #     except ValueError:
+        #         self.emptyfield_msgbox.show()
+        #         raise ValueError(eierr)
+
+        # try:
+        #     Emin = float(self.direct_emin_input.text())
+        # except ValueError:
+        #     Emin = -max(ei_vec)
+
         qe = calcQE(ei_vec, self.tthlims, emin=Emin)
 
         if not overplot:
@@ -427,36 +455,36 @@ class QECoverageGUI(QtWidgets.QWidget):
 
     def direct_input_check(self, ei_vec):
         if len(ei_vec) > 0:
-            ei_str = ""
-            update_ei_str = False
-            insert_comma = True
+            # ei_str = ""
+            # update_ei_str = False
+            # insert_comma = True
+            #
+            # for ei in ei_vec:
+            #     # if ei is equal to last value in ei_vec
+            #     if ei_vec[len(ei_vec) - 1] == ei:
+            #         insert_comma = False
+            #
+            #     if ei < 0:
+            #         update_ei_str = True
+            #         self.ei_msgbox.show()
+            #         ei = abs(ei)
+            #
+            #         ei_int = int(ei)
+            #         if insert_comma:
+            #             ei_str += str(ei_int) + ", "
+            #         else:
+            #             ei_str += str(ei_int)
+            #
+            #     else:
+            #         ei_int = int(ei)
+            #         if insert_comma:
+            #             ei_str += str(ei_int) + ", "
+            #         else:
+            #             ei_str += str(ei_int)
 
-            for ei in ei_vec:
-                # if ei is equal to last value in ei_vec
-                if ei_vec[len(ei_vec) - 1] == ei:
-                    insert_comma = False
-
-                if ei < 0:
-                    update_ei_str = True
-                    self.ei_msgbox.show()
-                    ei = abs(ei)
-
-                    ei_int = int(ei)
-                    if insert_comma:
-                        ei_str += str(ei_int) + ", "
-                    else:
-                        ei_str += str(ei_int)
-
-                else:
-                    ei_int = int(ei)
-                    if insert_comma:
-                        ei_str += str(ei_int) + ", "
-                    else:
-                        ei_str += str(ei_int)
-
-            if update_ei_str:
-                self.direct_ei_input.setText(ei_str)
-                ei_vec = [float(val) for val in ei_str.split(",")]
+            # if update_ei_str:
+            #     self.direct_ei_input.setText(ei_str)
+            #     ei_vec = [float(val) for val in ei_str.split(",")]
 
             if self.direct_emin_input.text() == "":
                 self.direct_emin_input.setText(str((ei_vec[0] / 2) * -1))


### PR DESCRIPTION
**Description of work**
- Implemented input validation on QECoverage GUI and handled exceptions in a sane way.
- Fixes #35076 

**Purpose of work**
- Avoid Mantid crashing and displaying multiple error windows  due to nonsensical input fields.
- Easily taken care of by setting a Validator to QLineEdit fields.

**Summary of work**
- There are three input fields:
  - Ei, Emin and s2:
  -  ![image](https://github.com/mantidproject/mantid/assets/80104863/fb1a4ad7-8966-4e5a-8e6a-f182963e07c5)
  - Set a QDoubleValidator for Emin and s2 (to only accept floats)
  - Set a QRegExpValidator to Ei, to personalise input to accept only positive floats separated by commas

**Further detail of work**
- Went over the functions `onClickDirectPlot` and `direct_input_check` and realised the rules for the allowed inputs:
    - Ei must be one or more floats separated by commas
    - All floats in Ei must be positive
    - Emin must be a float (positive or negative)
    - s2 must be a float (positive or negative)
    - If any value of Ei is less than Emin, show warning window and update Emin to `min(Ei)-1`
    - If a value for Emin is not provided, set `Emin = -max(Ei) / 2`
        - Actually, the original version had `Emin = -Ei[0] / 2`, but my version is more universal
        - Emin sets the minimum limit for the QE curves, so the choice is arbitrary anyway
- Added general handling of exceptions
   - If the input of Ei or s2 is invalid (empty space or `+`), nothing happens when clicking to plot. 
   - In the case of invalid s2, when plotting the value will update to the last valid input used.
   - If Emin is invalid, the value will update to `Emin = -max(Ei) / 2`

**To test:**
- Try the default settings first
- Leave the Ei field empty or with just `+` and click to plot. Check that nothing happens
- Add a list of floats to Ei and empty the field Emin. Click to plot and check that Emin gets updated.
- Edit Emin to be bigger than one of the values in Ei. Check that you get a message and the value gets updated.
- Change s2 to an empty field. Click to plot and check that it reverts back to the previous value.
- Change s2 to a different value and check plot changes.
- Try to write letters or other characters in any of the fields. Check this is not possible.
- There are no unit tests for this fix.
- There are not release notes for this fix.

edit:
**Release Notes**
- Added two release notes under Direct and Indirect Geometry
- Built the target `docs-html` and confirmed that links are working and structure looks good

Fixes #35076.
---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
