### PR TITLE
Create peaks widget on Slice Viewer construction

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/35260.rst
+++ b/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/35260.rst
@@ -1,0 +1,1 @@
+- Fixed layout bug when toggling the peaks overlays interface on/off.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -351,6 +351,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
             return
         if names_to_overlay or names_overlayed:
             self._create_peaks_presenter_if_necessary().overlay_peaksworkspaces(names_to_overlay)
+            self.view.data_view.on_resize()
         else:
             self.view.peaks_view.hide()
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -618,5 +618,5 @@ class SliceViewerDataView(QWidget):
             self.conf.set(POWERSCALE, exponent)
 
     def on_resize(self):
-        if not self.line_plots_active:
+        if not self.line_plots_active and self.ax:
             self.ax.figure.tight_layout()  # tight_layout doesn't work with LinePlots enabled atm

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/view.py
@@ -46,8 +46,6 @@ class SliceViewerView(QWidget, ObservingView):
         self._splitter.addWidget(self._data_view)
         self._splitter.setCollapsible(0, False)
         self._splitter.splitterMoved.connect(self._data_view.on_resize)
-        #  peaks viewer off by default
-        self._peaks_view = None
         # config the splitter appearance
         splitterStyleStr = """QSplitter::handle{
             border: 1px solid gray;
@@ -62,6 +60,11 @@ class SliceViewerView(QWidget, ObservingView):
         layout.addWidget(self._splitter)
         self.setLayout(layout)
         self.refresh_queued = False
+
+        self._peaks_view = PeaksViewerCollectionView(MplPainter(self.data_view), self.presenter)
+        self.add_widget_to_splitter(self._peaks_view)
+        #  peaks viewer off by default
+        self._peaks_view.hide()
 
         # connect up additional peaks signals
         self.data_view.mpl_toolbar.peaksOverlayClicked.connect(self.peaks_overlay_clicked)
@@ -79,10 +82,6 @@ class SliceViewerView(QWidget, ObservingView):
 
     @property
     def peaks_view(self) -> PeaksViewerCollectionView:
-        """Lazily instantiates PeaksViewer and returns it"""
-        if self._peaks_view is None:
-            self._peaks_view = PeaksViewerCollectionView(MplPainter(self.data_view), self.presenter)
-            self.add_widget_to_splitter(self._peaks_view)
         return self._peaks_view
 
     def add_widget_to_splitter(self, widget):


### PR DESCRIPTION
Create the peaks widget on construction and then hide it, instead of waiting until it's first used. Creating it later seems to cause some layout issues. This fixes #35260.

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
- Moved peaks widget construction so it isn't lazily constructed.
- Added in a call to a resize method to ensure the axes being shown has a tight layout.

**To test:**
See #35260 for how to reproduce the original problem. Probably worth testing Slice Viewer in other random ways a bit, especially around the peaks mode. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
