### PR TITLE
Redraw rescaled y axis in superplot on normalisation

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36103.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36103.rst
@@ -1,0 +1,1 @@
+- Fixed bug where the y axis in the superplot window did not scale immediately when selecting the "Normalise by max" option.

--- a/qt/python/mantidqt/mantidqt/widgets/superplot/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/superplot/presenter.py
@@ -233,6 +233,7 @@ class SuperplotPresenter:
         axes = figure.gca()
         axes.relim()
         axes.autoscale()
+        self._update_plot()
 
     def on_drop(self, name):
         """


### PR DESCRIPTION
**Description of work**
Without this change the y axis is not drawn rescaled in the superplot window when you check the normalise box until you trigger a redraw via some other means.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes #36103.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
See #36103, and it's also worth playing around a bit with the "Normalise by max" option.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
