### PR TITLE
Fix unhandled exception when removing a curve with bad labels

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36102.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36102.rst
@@ -1,0 +1,1 @@
+- Fix unhandled exception thrown when attempting to remove a curve from a plot that has a badly formatted label.

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -17,6 +17,7 @@ from mantidqt.widgets.plotconfigdialog import get_axes_names_dict, curve_in_ax
 from mantidqt.widgets.plotconfigdialog.curvestabwidget import CurveProperties, curve_has_errors, remove_curve_from_ax
 from mantidqt.widgets.plotconfigdialog.curvestabwidget.view import CurvesTabWidgetView
 from workbench.plotting.figureerrorsmanager import FigureErrorsManager
+from mantid.kernel import logger
 
 
 class CurvesTabWidgetPresenter:
@@ -204,7 +205,10 @@ class CurvesTabWidgetPresenter:
         ax = self.get_selected_ax()
         # Update the legend and redraw
         FigureErrorsManager.update_limits_and_legend(ax, self.legend_props)
-        ax.figure.canvas.draw()
+        try:
+            ax.figure.canvas.draw()
+        except ValueError as ex:
+            logger.error("Error redrawing figure canvas: \n" + str(ex))
 
         # Remove the curve from the curve selection list
         if self.remove_selected_curve_list_entry():


### PR DESCRIPTION
**Description of work**
If a curve has been given a badly formatted label in the figure settings, (e.g. $%$ for an axis label), then attempting to remove that curve from the plot will throw an exception, which is now handled.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes #36102.

**To test:**
See #36102 for how to reproduce, or open any spectrum plot, change an axis label to contain `$%$`, click `OK`. You should get a red error box at the top of the window. Now switch to the `Curves` tab and try to remove the curve, and you should get an error, but not an unhandled exception. Removing curves in other situations also worth checking.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- alternative
*There is no associated issue.*
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
