### PR TITLE
Home button on 3D plots now resets the view

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36107.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36107.rst
@@ -1,0 +1,1 @@
+- Home button on a 3D plot will now reset the view to the default view.

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -145,6 +145,7 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
 
     def on_home_clicked(self):
         self.sig_home_clicked.emit()
+        self.home()
         self.push_current()
 
     def waterfall_conversion(self, is_waterfall):


### PR DESCRIPTION
**Description of work**
Fix the home button in 3D plots so the view is reset to the default view. `matplotlib.backend_bases.NavigationToolbar2` has a method called `home()` that's usually called when you click the home button, it resets the view. We've overridden the method for the home button but don't reset the view for 3D plots, so we can call this base method to fix it.

See https://matplotlib.org/stable/api/backend_bases_api.html#matplotlib.backend_bases.NavigationToolbar2.home

**Purpose of work**
Fixes #36107.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
See #36107 for original issue. Worth testing the home button on some different 2D and 3D plots.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
