### PR TITLE
Fix crash from setting both waterfall offsets to 0

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1122,7 +1122,7 @@ class MantidAxes(Axes):
         for i in range(len(self.get_lines())):
             datafunctions.convert_single_line_to_waterfall(self, i, x_offset, y_offset)
 
-        if x_offset == 0 and y_offset == 0:
+        if x_offset == 0 and y_offset == 0 and self.is_waterfall():
             self.set_waterfall_fill(False)
             logger.information("x and y offset have been set to zero so the plot is no longer a waterfall plot.")
 

--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/35257.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/35257.rst
@@ -1,0 +1,1 @@
+- Fix for crash from setting both waterfall plot offsets to 0.


### PR DESCRIPTION
**Description of work**

When interacting with the waterfall plot offset dialogue, if you set both off sets to 0 then the plot is updated and made a regular plot. If you keep the dialogue open and then press return to close, it sends a third update. This caused an exception [(here)](https://github.com/mantidproject/mantid/blob/main/Framework/PythonInterface/mantid/plots/mantidaxes.py#L1206) since the plot was already not a waterfall. I've added a check into the update waterfall code to check that if the offsets are being set to 0, they are currently not both zero.

Possibly the waterfall plot offset dialogue emit signals a little too readily, but I like that you can watch the plot update as you change them.

**To test:**

Follow the issue description #35257 

Fixes #35257 
<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
