### PR TITLE
32689 Hide legend button added to fit toolbar

### DIFF
--- a/docs/source/release/v6.9.0/Diffraction/Engineering/New_features/32689.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Engineering/New_features/32689.rst
@@ -1,0 +1,1 @@
+- A new toolbar button named "Hide Legend" is introduced to toggle the visibility of the legend box of the :ref:`Engineering Diffraction interface <Engineering_Diffraction-ref>` :ref:`Fitting tab <ui engineering fitting>`. By Default the button is unchecked.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -46,7 +46,7 @@ class FittingPlotPresenter(object):
         self.view.set_slot_for_fit_toggled(self.fit_toggle)
         self.view.set_slot_for_serial_fit(self.do_serial_fit)
         self.view.set_slot_for_seq_fit(self.do_seq_fit)
-        self.view.set_slot_for_legend_toggled(self.toggle_legend)
+        self.view.set_slot_for_legend_toggled()
 
     def add_workspace_to_plot(self, ws):
         axes = self.view.get_axes()
@@ -102,9 +102,6 @@ class FittingPlotPresenter(object):
 
     def do_seq_fit(self):
         self.fit_all_started_notifier.notify_subscribers(True)
-
-    def toggle_legend(self):
-        self.view.update_figure()
 
     def do_fit_all_async(self, ws_names_list, do_sequential=True):
         previous_fit_browser = self.view.read_fitprop_from_browser()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -46,6 +46,7 @@ class FittingPlotPresenter(object):
         self.view.set_slot_for_fit_toggled(self.fit_toggle)
         self.view.set_slot_for_serial_fit(self.do_serial_fit)
         self.view.set_slot_for_seq_fit(self.do_seq_fit)
+        self.view.set_slot_for_legend_toggled(self.toggle_legend)
 
     def add_workspace_to_plot(self, ws):
         axes = self.view.get_axes()
@@ -101,6 +102,9 @@ class FittingPlotPresenter(object):
 
     def do_seq_fit(self):
         self.fit_all_started_notifier.notify_subscribers(True)
+
+    def toggle_legend(self):
+        self.view.update_figure()
 
     def do_fit_all_async(self, ws_names_list, do_sequential=True):
         previous_fit_browser = self.view.read_fitprop_from_browser()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_toolbar.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_toolbar.py
@@ -13,6 +13,7 @@ class FittingPlotToolbar(MantidNavigationToolbar):
     sig_toggle_fit_triggered = QtCore.Signal()
     sig_serial_fit_clicked = QtCore.Signal()
     sig_seq_fit_clicked = QtCore.Signal()
+    sig_toggle_legend = QtCore.Signal()
 
     toolitems = (
         MantidNavigationTool("Home", "Center display on contents", "mdi.home", "on_home_clicked", None),
@@ -24,6 +25,7 @@ class FittingPlotToolbar(MantidNavigationToolbar):
         MantidNavigationTool("Fit", "Open/close fitting tab", None, "toggle_fit", False),
         MantidNavigationTool("Serial Fit", "Fit each spec with the starting guess.", None, "serial_fit", None),
         MantidNavigationTool("Sequential Fit", "Fit each spec using the output of a previous run", None, "seq_fit", None),
+        MantidNavigationTool("Hide Legend", "Toggle the legend box on/off", None, "toggle_legend", False),
     )
 
     def __init__(self, canvas, parent, coordinates=True):
@@ -52,6 +54,12 @@ class FittingPlotToolbar(MantidNavigationToolbar):
 
     def seq_fit(self):
         self.sig_seq_fit_clicked.emit()
+
+    def toggle_legend(self):
+        self.sig_toggle_legend.emit()
+
+    def get_show_legend_value(self):
+        return not self._actions["toggle_legend"].isChecked()
 
     def handle_fit_browser_close(self):
         """

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -139,8 +139,12 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
     def set_slot_for_seq_fit(self, presenter_func):
         self.toolbar.sig_seq_fit_clicked.connect(presenter_func)
 
-    def set_slot_for_legend_toggled(self, presenter_func):
-        self.toolbar.sig_toggle_legend.connect(presenter_func)
+    def set_slot_for_legend_toggled(self):
+        self.toolbar.sig_toggle_legend.connect(self.toggle_legend)
+
+    def toggle_legend(self):
+        self.update_legend(self.get_axes()[0])
+        self.figure.canvas.draw()
 
     def show_cancel_button(self, show: bool):
         self.cancel_button.setVisible(show)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -139,6 +139,9 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
     def set_slot_for_seq_fit(self, presenter_func):
         self.toolbar.sig_seq_fit_clicked.connect(presenter_func)
 
+    def set_slot_for_legend_toggled(self, presenter_func):
+        self.toolbar.sig_toggle_legend.connect(presenter_func)
+
     def show_cancel_button(self, show: bool):
         self.cancel_button.setVisible(show)
         self.cancel_button.setEnabled(show)
@@ -169,7 +172,7 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
 
     def update_figure(self):
         self.toolbar.update()
-        self.update_legend(self.get_axes()[0])
+        self.update_legend(self.get_axes()[0], self.toolbar.get_show_legend_value())
         self.update_axes_position()
         self.figure.canvas.draw()
         self.update_fitbrowser()
@@ -209,10 +212,11 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         except:
             pass  # name may not be available if ws has just been deleted
 
-    def update_legend(self, ax):
+    def update_legend(self, ax, show_legend):
         if ax.get_lines():
             ax.make_legend()
             ax.get_legend().set_title("")
+            ax.get_legend().set_visible(show_legend)
         else:
             if ax.get_legend():
                 ax.get_legend().remove()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -172,7 +172,7 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
 
     def update_figure(self):
         self.toolbar.update()
-        self.update_legend(self.get_axes()[0], self.toolbar.get_show_legend_value())
+        self.update_legend(self.get_axes()[0])
         self.update_axes_position()
         self.figure.canvas.draw()
         self.update_fitbrowser()
@@ -212,11 +212,11 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         except:
             pass  # name may not be available if ws has just been deleted
 
-    def update_legend(self, ax, show_legend):
+    def update_legend(self, ax):
         if ax.get_lines():
             ax.make_legend()
             ax.get_legend().set_title("")
-            ax.get_legend().set_visible(show_legend)
+            ax.get_legend().set_visible(self.toolbar.get_show_legend_value())
         else:
             if ax.get_legend():
                 ax.get_legend().remove()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
@@ -241,6 +241,10 @@ class FittingPlotPresenterTest(unittest.TestCase):
         self.presenter._on_worker_error(error_message)
         mock_logger.assert_not_called()
 
+    def test_toggle_legend(self):
+        self.presenter.toggle_legend()
+        self.view.update_figure.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
@@ -241,10 +241,6 @@ class FittingPlotPresenterTest(unittest.TestCase):
         self.presenter._on_worker_error(error_message)
         mock_logger.assert_not_called()
 
-    def test_toggle_legend(self):
-        self.presenter.toggle_legend()
-        self.view.update_figure.assert_called_once()
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Description of work**

**Purpose of work**
Workspaces in the EngDiff UI have long names and therefore the legend in the fitting tab obscures the data.

**Summary of work**
A button was added to the fitting tab of the Engineering Diffraction interface so that the user can toggle the legend of the plots in the fitting tab to On/Off.

**To test:**

1) Follow the testing instructions of the Test 4 to plot some data https://github.com/mantidproject/mantid/blob/33e61abf3a7ed9a3e352ca91886efe03d9afc5b8/dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst#test-4
2) Click on Hide Legend button in the fitting tab.
3) Only the legend should disappear from the plot.
4) The Button should be ticked
5) When the button is unticked, the legend should reappear with correct labels of the plotted data.

Fixes #32689  

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
