### PR TITLE
mark DSFInterp and DSFInterp1DFit  for deprecation

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/DSFinterp.py
+++ b/Framework/PythonInterface/plugins/algorithms/DSFinterp.py
@@ -18,10 +18,11 @@ from mantid.kernel import (
     EnabledWhenProperty,
     PropertyCriterion,
 )
+from mantid.utils.deprecator import deprecated_algorithm
 
 
+@deprecated_algorithm(new_name=None, deprecation_date="2023-10-01")
 class DSFinterp(PythonAlgorithm):
-
     channelgroup = None
 
     def category(self):

--- a/Framework/PythonInterface/plugins/functions/DSFinterp1DFit.py
+++ b/Framework/PythonInterface/plugins/functions/DSFinterp1DFit.py
@@ -19,7 +19,6 @@ from mantid import logger
 
 
 class DSFinterp1DFit(IFunction1D):
-
     _RegressionTypes = None
     _minWindow = None
     _InputWorkspaces = None
@@ -184,6 +183,7 @@ try:
     import dsfinterp  # noqa
 
     FunctionFactory.subscribe(DSFinterp1DFit)
+    logger.warning("As of 2023-10-01, DSFinterp1DFit is officially deprecated and will be removed in Mantid 6.10")
 except ImportError:
     logger.debug(
         "Failed to subscribe fit function DSFinterp1DFit. "

--- a/docs/source/algorithms/DSFinterp-v1.rst
+++ b/docs/source/algorithms/DSFinterp-v1.rst
@@ -6,6 +6,8 @@
 
 .. properties::
 
+.. note:: As of 2023-10-01, this algorithm is officially deprecated and will be removed in Mantid 6.10
+
 Description
 -----------
 

--- a/docs/source/release/v6.9.0/Framework/Algorithms/Bugfixes/36294.rst
+++ b/docs/source/release/v6.9.0/Framework/Algorithms/Bugfixes/36294.rst
@@ -1,0 +1,1 @@
+- Algorithm :ref:`DSFinterp <algm-DSFinterp>` which is not registered because of a missing dependency has been marked for deprecation.

--- a/docs/source/release/v6.9.0/Framework/Algorithms/Bugfixes/36294.rst
+++ b/docs/source/release/v6.9.0/Framework/Algorithms/Bugfixes/36294.rst
@@ -1,1 +1,1 @@
-- Algorithm :ref:`DSFinterp <algm-DSFinterp>` which is not registered because of a missing dependency has been marked for deprecation.
+- Algorithm DSFinterp, which is not registered because of a missing dependency, has been marked for deprecation.

--- a/docs/source/release/v6.9.0/Framework/Fit_Functions/Bugfixes/36294.rst
+++ b/docs/source/release/v6.9.0/Framework/Fit_Functions/Bugfixes/36294.rst
@@ -1,0 +1,1 @@
+- Fit Function :ref:`DSFinterp1DFit <func-DSFinterp1DFit>` which is not registered because of a missing dependency has been marked for deprecation.

--- a/docs/source/release/v6.9.0/Framework/Fit_Functions/Bugfixes/36294.rst
+++ b/docs/source/release/v6.9.0/Framework/Fit_Functions/Bugfixes/36294.rst
@@ -1,1 +1,1 @@
-- Fit Function :ref:`DSFinterp1DFit <func-DSFinterp1DFit>` which is not registered because of a missing dependency has been marked for deprecation.
+- Fit Function DSFinterp1DFit, which is not registered because of a missing dependency has been marked for deprecation.


### PR DESCRIPTION
**Description of work**
Mark `DSFInterp` and `DSFInterp1DFit` as deprecated for next release (and to be removed in the subsequent release).

**Purpose of work**
`DSFInterp` and `DSFInterp1DFit` are not being used, they're not even registered since they try to import a python package not listed as a dependency. Furthermore, support for the dependency has been discontinued.

**To test:**
No need to test as this is only a deprecation warning and both `DSFInterp` and `DSFInterp1DFit` are never registered

Fixes #36292
<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
