### PR TITLE
Fix versioning for untagged past release candidate

### DIFF
--- a/buildconfig/CMake/VersionNumber.cmake
+++ b/buildconfig/CMake/VersionNumber.cmake
@@ -36,13 +36,13 @@ execute_process(
 )
 
 # Expect format defined as in comments above. Major.Minor.Patch(.Patch)(.devN|rcN)(+abc)
-if(_version_str MATCHES "([0-9]+)\\.([0-9]+)\\.([0-9]+(\\.[0-9]+)*)(\\.dev[0-9]+|rc[0-9]+)?(\\+[A-Za-z0-9.]+)?")
+if(_version_str MATCHES "([0-9]+)\\.([0-9]+)\\.([0-9]+(\\.[0-9]+)*)(rc[0-9]+)?(\\.dev[0-9]+)?(\\+[A-Za-z0-9.]+)?")
   # Version components
   set(VERSION_MAJOR ${CMAKE_MATCH_1})
   set(VERSION_MINOR ${CMAKE_MATCH_2})
   set(VERSION_PATCH ${CMAKE_MATCH_3})
   # Ignore group 4 because it's contained within group 3.
-  set(VERSION_TWEAK ${CMAKE_MATCH_5}${CMAKE_MATCH_6})
+  set(VERSION_TWEAK ${CMAKE_MATCH_5}${CMAKE_MATCH_6}${CMAKE_MATCH_7})
 else()
   message(FATAL_ERROR "Error extracting version elements from: ${_version_str}\n${_error}")
 endif()

--- a/buildconfig/CMake/VersionNumber.cmake
+++ b/buildconfig/CMake/VersionNumber.cmake
@@ -28,7 +28,7 @@
 
 # Use versioningit to compute version number to match conda-build
 execute_process(
-  COMMAND "${Python_EXECUTABLE}" -c "import setup;print(setup.get_version())"
+  COMMAND "${Python_EXECUTABLE}" -m versioningit
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   OUTPUT_VARIABLE _version_str
   ERROR_VARIABLE _error


### PR DESCRIPTION
### Description of work

#### Summary of work
There was a bug in cmake parsing the version returned by versioningit when generated some of the version strings that are [pep440](https://peps.python.org/pep-0440/) compliant.

Fixes #36274.

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

1. `git fetch -p -t --al`
2. Go to your build directory and re-run cmake. This can be killed after the version information is printed.
3. Tag a new release candidate (do not push the tag) with something like v7.8.9rc42 and run cmake and see the version
4. Make a change, run cmake, and see the version
5. Commit the change, run cmake, and see the version
6. Make another change, run cmake, and see the version

*This does not require release notes* because it is an internal cmake change that users should not see.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
