### PR TITLE
Use SampleAngle rather than SANGLE

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MRGetTheta.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRGetTheta.py
@@ -47,7 +47,10 @@ class MRGetTheta(PythonAlgorithm):
         use_sangle = self.getProperty("UseSANGLE").value
 
         if use_sangle:
-            theta = self.read_log(_w, "SANGLE", target_units="rad", assumed_units="deg")
+            if "SampleAngle" in ws.getRun():
+                theta = self.read_log(_w, "SampleAngle", target_units="rad", assumed_units="deg")
+            else:
+                theta = self.read_log(_w, "SANGLE", target_units="rad", assumed_units="deg")
         else:
             dangle = self.read_log(_w, "DANGLE", target_units="rad", assumed_units="deg")
             if dangle0_overwrite == Property.EMPTY_DBL:

--- a/Framework/PythonInterface/plugins/algorithms/MRGetTheta.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRGetTheta.py
@@ -47,7 +47,7 @@ class MRGetTheta(PythonAlgorithm):
         use_sangle = self.getProperty("UseSANGLE").value
 
         if use_sangle:
-            if "SampleAngle" in ws.getRun():
+            if "SampleAngle" in _w.getRun():
                 theta = self.read_log(_w, "SampleAngle", target_units="rad", assumed_units="deg")
             else:
                 theta = self.read_log(_w, "SANGLE", target_units="rad", assumed_units="deg")


### PR DESCRIPTION
### Description of work
The BL-4A instrument now has a couple of options for how it defines the sample angle. Using the `SampleAngle` log abstracts out this choice.



#### Summary of work
The change here looks at the `SampleAngle` log first, if it exists. Otherwise it will use the `SANGLE` value as before.

#### Purpose of work
The BL-4A instrument now has a couple of options for how it defines the sample angle. Using the `SampleAngle` log abstracts out this choice.

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

To test, load any recent data file from July 2023 and see that the results don't change (because SampleAngle will be pointing to SANGLE).


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
