### PR TITLE
Change returns to const reference for better performance

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/DateAndTime.h
+++ b/Framework/Kernel/inc/MantidKernel/DateAndTime.h
@@ -31,9 +31,9 @@ public:
   TimeInterval(const std::string &from, const std::string &to);
 
   /// Beginning of the interval
-  Types::Core::DateAndTime start() const { return m_start; }
+  const Types::Core::DateAndTime &start() const { return m_start; }
   /// End of the interval
-  Types::Core::DateAndTime stop() const { return m_stop; }
+  const Types::Core::DateAndTime &stop() const { return m_stop; }
   /// True if the interval is not empty
   bool isValid() const { return m_stop > m_start; }
 

--- a/Framework/Kernel/src/DateAndTime.cpp
+++ b/Framework/Kernel/src/DateAndTime.cpp
@@ -40,10 +40,10 @@ TimeInterval::TimeInterval(const std::string &from, const std::string &to) {
 }
 
 bool TimeInterval::overlaps(const TimeInterval *other) const {
-  const auto thisBegin = this->start();
-  const auto thisEnd = this->stop();
-  const auto otherBegin = other->start();
-  const auto otherEnd = other->stop();
+  const auto &thisBegin = this->start();
+  const auto &thisEnd = this->stop();
+  const auto &otherBegin = other->start();
+  const auto &otherEnd = other->stop();
 
   return ((otherBegin < thisEnd) && (otherBegin >= thisBegin)) || ((otherEnd < thisEnd) && (otherEnd >= thisBegin)) ||
          ((thisBegin < otherEnd) && (thisBegin >= otherBegin)) || ((thisEnd < otherEnd) && (thisEnd >= otherBegin));

--- a/Framework/Kernel/src/SplittingInterval.cpp
+++ b/Framework/Kernel/src/SplittingInterval.cpp
@@ -27,8 +27,8 @@ int SplittingInterval::index() const { return m_index; }
 /// And operator. Return the smallest time interval where both intervals are
 /// TRUE.
 SplittingInterval SplittingInterval::operator&(const SplittingInterval &b) const {
-  const auto begin = std::max(this->start(), b.start());
-  const auto end = std::min(this->stop(), b.stop());
+  const auto &begin = std::max(this->start(), b.start());
+  const auto &end = std::min(this->stop(), b.stop());
 
   return SplittingInterval(begin, end, this->index());
 }
@@ -41,8 +41,8 @@ SplittingInterval SplittingInterval::operator|(const SplittingInterval &b) const
                                 "operator to non-overlapping "
                                 "SplittingInterval's.");
 
-  const auto begin = std::min(this->start(), b.start());
-  const auto end = std::max(this->stop(), b.stop());
+  const auto &begin = std::min(this->start(), b.start());
+  const auto &end = std::max(this->stop(), b.stop());
 
   return SplittingInterval(begin, end, this->index());
 }
@@ -156,7 +156,7 @@ SplittingIntervalVec removeFilterOverlap(const SplittingIntervalVec &a) {
   auto it = a.cbegin();
   while (it != a.cend()) {
     // All following intervals will start at or after this one
-    DateAndTime start = it->start();
+    const DateAndTime &start = it->start();
     DateAndTime stop = it->stop();
 
     // Keep looking for the next interval where there is a gap (start > old


### PR DESCRIPTION
This modifies `TimeInterval` and `SplittingInterval` to use const references. This change allows for fewer data copies which speed up the various things in event filtering.

**To test:**

This is a performance improvement and should not change any test results.

*There is no associated issue,* but it is related to [EWM1943](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1943)

*This does not require release notes* because it is part of an overall performance improvement and will be covered in the release notes of #36069.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
