### PR TITLE
Fix issue clicking on 2D view in Slice Viewer

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/36266.rst
+++ b/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/36266.rst
@@ -1,0 +1,1 @@
+- Fixed error in Slice Viewer when trying to click on the 2D plot after the `Add Peak` option is selected, but the peaks workspace has already been deleted.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -353,7 +353,9 @@ class PeaksViewerCollectionPresenter:
     #
     def add_delete_peak(self, pos):
         presenter_active = self.child_presenter(self._actions_view.active_peaksworkspace)
-        if self._actions_view.adding_mode_on:
+        if presenter_active is None:
+            logger.debug("PeaksViewer: No active peak presenter")
+        elif self._actions_view.adding_mode_on:
             logger.debug(f"PeaksViewer: Adding peak position {pos}")
             presenter_active.add_peak(pos)
         elif self._actions_view.erasing_mode_on:

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py
@@ -33,7 +33,6 @@ def create_mock_peaks_workspace(name="peaks"):
 
 @patch("mantidqt.widgets.sliceviewer.peaksviewer.presenter.create_peaksviewermodel", new_callable=FakePeaksModelFactory)
 class PeaksViewerCollectionPresenterTest(unittest.TestCase):
-
     # -------------------- success tests -----------------------------
 
     def test_append_constructs_PeaksViewerPresenter_for_call(self, mock_create_model):
@@ -224,6 +223,20 @@ class PeaksViewerCollectionPresenterTest(unittest.TestCase):
         view.deactivate_zoom_pan.assert_not_called()
         presenter.deactivate_zoom_pan(True)
         view.deactivate_zoom_pan.assert_called_once()
+
+    def test_deleting_peaks_workspace_disables_add_remove_peak(self, _):
+        presenter = PeaksViewerCollectionPresenter(MagicMock())
+        self.assertEqual(0, len(presenter._child_presenters))
+        name_peaks_ws = "peaks"
+        presenter.append_peaksworkspace(name_peaks_ws)
+        self.assertEqual(1, len(presenter._child_presenters))
+        presenter.remove_peaksworkspace(name_peaks_ws)
+        self.assertEqual(0, len(presenter._child_presenters))
+        # With no child presenters, any attempt to add or delete a peak
+        # will throw an exception since those operations act on the child
+        # presenter. Hence if nothing happens here it's working as expected.
+        presenter.add_delete_peak([1, 2, 3])
+        pass
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py
@@ -236,7 +236,6 @@ class PeaksViewerCollectionPresenterTest(unittest.TestCase):
         # will throw an exception since those operations act on the child
         # presenter. Hence if nothing happens here it's working as expected.
         presenter.add_delete_peak([1, 2, 3])
-        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of work
If a peaks workspace has been deleted then the corresponding presenter in Slice Viewer won't exist. If the `Add Peak` button has been selected then if you click on the plot it will try and call methods on the missing presenter.

Fixes #36266. See that same issue for steps to reproduce. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
Adding/removing peaks in Slice Viewer is the thing most likely to go wrong.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
