### PR TITLE
Speed up log value filtering in TimeSeriesProperty.

### DIFF
--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -282,7 +282,7 @@ void LogManager::filterByTime(const Types::Core::DateAndTime start, const Types:
 /**
  * Create a partial copy of this object such that every time series property is cloned according to the input TimeROI.
  * A partially cloned time series property should include all time values enclosed by the ROI regions,
- * each defined as [roi_start,roi_end], plus the values immediately before and after an ROI region, if available.
+ * each defined as [roi_begin,roi_end], plus the values immediately before and after an ROI region, if available.
  * Properties that are not time series will be cloned with no changes.
  * @param timeROI :: a series of time regions used to determine which time series values should be included in the copy.
  */
@@ -313,7 +313,7 @@ void LogManager::copyAndFilterProperties(const LogManager &other, const Kernel::
 
 /**
  * For time series properties, remove time values outside of this object's TimeROI.
- * Each TimeROI region is defined as [roi_start,roi_stop]. However, keep the values
+ * Each TimeROI region is defined as [roi_begin,roi_end]. However, keep the values
  * immediately before and after each timeROI region, if available.
  */
 void LogManager::removeDataOutsideTimeROI() {

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -282,7 +282,7 @@ void LogManager::filterByTime(const Types::Core::DateAndTime start, const Types:
 /**
  * Create a partial copy of this object such that every time series property is cloned according to the input TimeROI.
  * A partially cloned time series property should include all time values enclosed by the ROI regions,
- * each defined as [roi_start,roi_end), plus the values immediately before and after an ROI region, if available.
+ * each defined as [roi_start,roi_end], plus the values immediately before and after an ROI region, if available.
  * Properties that are not time series will be cloned with no changes.
  * @param timeROI :: a series of time regions used to determine which time series values should be included in the copy.
  */
@@ -313,7 +313,7 @@ void LogManager::copyAndFilterProperties(const LogManager &other, const Kernel::
 
 /**
  * For time series properties, remove time values outside of this object's TimeROI.
- * Each TimeROI region is defined as [roi_start,roi_stop). However, keep the values
+ * Each TimeROI region is defined as [roi_start,roi_stop]. However, keep the values
  * immediately before and after each timeROI region, if available.
  */
 void LogManager::removeDataOutsideTimeROI() {

--- a/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
@@ -46,7 +46,7 @@ public:
   virtual Property *cloneWithTimeShift(const double timeShift) const = 0;
 
   // Create a partial copy of this ITimeSeriesProperty-derived object according to a TimeROI. The partially cloned
-  // object will include all time values enclosed by the ROI regions defined as [roi_start,roi_end], plus the values
+  // object will include all time values enclosed by the ROI regions defined as [roi_begin,roi_end], plus the values
   // immediately before and after an ROI region, if available.
   virtual Property *cloneInTimeROI(const TimeROI &timeROI) const = 0;
 
@@ -75,7 +75,7 @@ public:
   // Returns whether the time series has been filtered
   virtual bool isFiltered() const = 0;
 
-  // Remove time values outside the TimeROI regions defined as [roi_start,roi_stop].
+  // Remove time values outside the TimeROI regions defined as [roi_begin,roi_end].
   // However, keep the values immediately before and after each ROI region, if available.
   virtual void removeDataOutsideTimeROI(const TimeROI &timeRoi) = 0;
 

--- a/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
@@ -46,7 +46,7 @@ public:
   virtual Property *cloneWithTimeShift(const double timeShift) const = 0;
 
   // Create a partial copy of this ITimeSeriesProperty-derived object according to a TimeROI. The partially cloned
-  // object will include all time values enclosed by the ROI regions defined as [roi_start,roi_end), plus the values
+  // object will include all time values enclosed by the ROI regions defined as [roi_start,roi_end], plus the values
   // immediately before and after an ROI region, if available.
   virtual Property *cloneInTimeROI(const TimeROI &timeROI) const = 0;
 
@@ -75,7 +75,7 @@ public:
   // Returns whether the time series has been filtered
   virtual bool isFiltered() const = 0;
 
-  // Remove time values outside the TimeROI regions defined as [roi_start,roi_stop).
+  // Remove time values outside the TimeROI regions defined as [roi_start,roi_stop].
   // However, keep the values immediately before and after each ROI region, if available.
   virtual void removeDataOutsideTimeROI(const TimeROI &timeRoi) = 0;
 

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -177,7 +177,7 @@ void PropertyManager::filterByProperty(const Kernel::TimeSeriesProperty<bool> &f
 /**
  * Create a partial copy of this object such that every time series property is cloned according to the input TimeROI.
  * A partially cloned time series property should include all time values enclosed by the ROI regions,
- * each defined as [roi_start,roi_end), plus the values immediately before and after an ROI region, if available.
+ * each defined as [roi_start,roi_end], plus the values immediately before and after an ROI region, if available.
  * Properties that are not time series will be cloned with no changes.
  * @param timeROI :: time region of interest, i.e. time boundaries used to determine which time series values should be
  * included in the copy.
@@ -199,7 +199,7 @@ PropertyManager *PropertyManager::cloneInTimeROI(const Kernel::TimeROI &timeROI)
 }
 
 /**
- * For time series properties, remove time values outside of TimeROI regions, each defined as [roi_start,roi_stop).
+ * For time series properties, remove time values outside of TimeROI regions, each defined as [roi_start,roi_stop].
  * However, keep the values immediately before and after each ROI region, if available.
  * @param timeROI :: a series of time regions used to determine which values to remove or to keep
  */

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -177,7 +177,7 @@ void PropertyManager::filterByProperty(const Kernel::TimeSeriesProperty<bool> &f
 /**
  * Create a partial copy of this object such that every time series property is cloned according to the input TimeROI.
  * A partially cloned time series property should include all time values enclosed by the ROI regions,
- * each defined as [roi_start,roi_end], plus the values immediately before and after an ROI region, if available.
+ * each defined as [roi_begin,roi_end], plus the values immediately before and after an ROI region, if available.
  * Properties that are not time series will be cloned with no changes.
  * @param timeROI :: time region of interest, i.e. time boundaries used to determine which time series values should be
  * included in the copy.
@@ -199,7 +199,7 @@ PropertyManager *PropertyManager::cloneInTimeROI(const Kernel::TimeROI &timeROI)
 }
 
 /**
- * For time series properties, remove time values outside of TimeROI regions, each defined as [roi_start,roi_stop].
+ * For time series properties, remove time values outside of TimeROI regions, each defined as [roi_begin,roi_end].
  * However, keep the values immediately before and after each ROI region, if available.
  * @param timeROI :: a series of time regions used to determine which values to remove or to keep
  */

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -179,7 +179,8 @@ void PropertyManager::filterByProperty(const Kernel::TimeSeriesProperty<bool> &f
  * A partially cloned time series property should include all time values enclosed by the ROI regions,
  * each defined as [roi_start,roi_end), plus the values immediately before and after an ROI region, if available.
  * Properties that are not time series will be cloned with no changes.
- * @param timeROI :: a series of time regions used to determine which time series values should be included in the copy.
+ * @param timeROI :: time region of interest, i.e. time boundaries used to determine which time series values should be
+ * included in the copy.
  */
 PropertyManager *PropertyManager::cloneInTimeROI(const Kernel::TimeROI &timeROI) {
   PropertyManager *newMgr = new PropertyManager();

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -405,23 +405,6 @@ void TimeROI::replaceROI(const std::vector<Types::Core::DateAndTime> &roi) {
 }
 
 /**
- * Updates the TimeROI values with the union with another TimeROI.
- * See https://en.wikipedia.org/wiki/Union_(set_theory) for more details
- *
- * Union with an empty TimeROI will do nothing.
- */
-void TimeROI::update_union(const TimeROI &other) {
-  // exit early if the two TimeROI are identical
-  if (*this == other)
-    return;
-
-  // add all the intervals from the other
-  for (const auto &interval : other.toTimeIntervals()) {
-    this->addROI(interval.start(), interval.stop());
-  }
-}
-
-/**
  * Updates the TimeROI values with the intersection with another TimeROI.
  * See https://en.wikipedia.org/wiki/Intersection for the intersection theory.
  * The algorithm is adapted from https://www.geeksforgeeks.org/find-intersection-of-intervals-given-by-two-lists/
@@ -465,11 +448,27 @@ void TimeROI::update_intersection(const TimeROI &other) {
       std::advance(it2, 2);
   }
 
-  // if the TimeROI became empty it is because there is no overlap reset the value to INVALID_ROI
   if (output.empty())
     output.replaceROI(USE_NONE);
 
   m_roi = std::move(output.m_roi);
+}
+
+/**
+ * Updates the TimeROI values with the union with another TimeROI.
+ * See https://en.wikipedia.org/wiki/Union_(set_theory) for more details
+ *
+ * Union with an empty TimeROI will do nothing.
+ */
+void TimeROI::update_union(const TimeROI &other) {
+  // exit early if the two TimeROI are identical
+  if (*this == other)
+    return;
+
+  // add all the intervals from the other
+  for (const auto &interval : other.toTimeIntervals()) {
+    this->addROI(interval.start(), interval.stop());
+  }
 }
 
 /**

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -24,25 +24,21 @@ namespace {
 /// static Logger definition
 Logger g_log("TimeSeriesProperty");
 
-/*
- * Returns true if all values in the TimeSeriesProperty are the same.
- * This assumes there is at least two values.
- * This is written to return early in case there are any non-matches.
+/**
+ * Check if all values in the input time vector are the same.
+ * This assumes there are at least two values.
+ * @param values :: a vector of time values.
+ * @return :: false if there is at least one non-match, true otherwise.
  */
-template <typename TYPE>
-bool allValuesAreSame(const std::vector<TimeValueUnit<TYPE>> &values, const std::string &name) {
-  const auto &first_value = values.front().value();
+template <typename TYPE> bool allValuesAreSame(const std::vector<TimeValueUnit<TYPE>> &values) {
   const std::size_t num_values = values.size();
+  assert(num_values > 1);
+  const auto &first_value = values.front().value();
   for (std::size_t i = 1; i < num_values; ++i) {
     if (first_value != values[i].value())
       return false;
   }
-
-  // getting this far means they are all equal
-  // but p-charge should never report back that the values are all the same
-  // because that would remove values inappropriately.
-  // This will almost never be the case for a real measurement.
-  return name != "proton_charge";
+  return true;
 }
 } // namespace
 
@@ -88,7 +84,7 @@ TimeSeriesProperty<TYPE>::TimeSeriesProperty(const Property *const p)
 
 /**
  * Create a partial copy of this object according to a TimeROI. The partially cloned object
- * should include all time values enclosed by the ROI regions, each defined as [roi_start,roi_end),
+ * should include all time values enclosed by the ROI regions, each defined as [roi_start,roi_end],
  * plus the values immediately before and after an ROI region, if available.
  * @param timeROI :: time region of interest, i.e. time boundaries used to determine which values should be included in
  * the copy.
@@ -293,24 +289,41 @@ void TimeSeriesProperty<TYPE>::createFilteredData(const TimeROI &timeROI,
                                                   std::vector<TimeValueUnit<TYPE>> &filteredData) const {
   filteredData.clear();
 
-  // these special cases can skip the complicated logic
+  // Expediently treat a few special cases
+
+  // Nothing to copy
   if (m_values.empty()) {
-    // nothing to copy
     return;
-  } else if (m_values.size() == 1 || allValuesAreSame(m_values, this->name())) {
-    // copy the first value
-    // if they are all the same, none of the others matter
-    filteredData.push_back(m_values.front());
-    return;
-  } else if (timeROI.useAll()) {
-    // copy everything
-    std::copy(m_values.cbegin(), m_values.cend(), std::back_inserter(filteredData));
-    return;
-  } else if (timeROI.useNone()) {
-    // copy the first value only
+  }
+
+  // Copy the only value
+  if (m_values.size() == 1) {
     filteredData.push_back(m_values.front());
     return;
   }
+
+  // Copy the first value only, if all values are the same
+  // Exclude "proton_charge" logs from consideration, because in a real measurement those values can't be the same,
+  // Removing some of them just because they are equal will cause wrong total proton charge results.
+  if (allValuesAreSame(m_values) && this->name() != "proton_charge") {
+    filteredData.push_back(m_values.front());
+    return;
+  }
+
+  // Copy everything
+  if (timeROI.useAll()) {
+    std::copy(m_values.cbegin(), m_values.cend(), std::back_inserter(filteredData));
+    return;
+  }
+
+  // Copy the first value only
+  if (timeROI.useNone()) {
+    filteredData.push_back(m_values.front());
+    return;
+  }
+
+  // Now treat the general case
+
   // Get all ROI time boundaries. Every other value is start/stop of an ROI "use" region.
   const std::vector<Types::Core::DateAndTime> &roiTimes = timeROI.getAllTimes();
   auto itROI = roiTimes.cbegin();
@@ -372,7 +385,7 @@ void TimeSeriesProperty<TYPE>::createFilteredData(const TimeROI &timeROI,
 }
 
 /**
- * Remove time values outside of TimeROI regions each defined as [roi_start,roi_stop).
+ * Remove time values outside of TimeROI regions each defined as [roi_start,roi_stop].
  * However, keep the values immediately before and after each ROI region, if available.
  * @param timeROI :: a series of time regions used to determine which values to remove or to keep
  */

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -84,7 +84,7 @@ TimeSeriesProperty<TYPE>::TimeSeriesProperty(const Property *const p)
 
 /**
  * Create a partial copy of this object according to a TimeROI. The partially cloned object
- * should include all time values enclosed by the ROI regions, each defined as [roi_start,roi_end],
+ * should include all time values enclosed by the ROI regions, each defined as [roi_begin,roi_end],
  * plus the values immediately before and after an ROI region, if available.
  * @param timeROI :: time region of interest, i.e. time boundaries used to determine which values should be included in
  * the copy.
@@ -278,7 +278,7 @@ template <typename TYPE> void TimeSeriesProperty<TYPE>::setName(const std::strin
 
 /**
  * Fill in the supplied vector of time series data according to the input TimeROI. Include all time values
- * within ROI regions, defined as [roi_start,roi_end], plus the values immediately before and after each ROI region,
+ * within ROI regions, defined as [roi_begin,roi_end], plus the values immediately before and after each ROI region,
  * if available.
  * @param timeROI :: time region of interest, i.e. time boundaries used to determine which values should be included in
  * the filtered data vector
@@ -385,7 +385,7 @@ void TimeSeriesProperty<TYPE>::createFilteredData(const TimeROI &timeROI,
 }
 
 /**
- * Remove time values outside of TimeROI regions each defined as [roi_start,roi_stop].
+ * Remove time values outside of TimeROI regions each defined as [roi_begin,roi_end].
  * However, keep the values immediately before and after each ROI region, if available.
  * @param timeROI :: a series of time regions used to determine which values to remove or to keep
  */

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -23,7 +23,13 @@
 #include <vector>
 
 using namespace Mantid::Kernel;
+using Mantid::Kernel::Logger;
 using Mantid::Types::Core::DateAndTime;
+
+namespace {
+/// static Logger definition
+Logger g_tspt_log("TimeSeriesPropertyTest");
+} // namespace
 
 class TimeSeriesPropertyStatisticsTest : public CxxTest::TestSuite {
 
@@ -460,6 +466,7 @@ public:
     std::vector<double> values_expected;
 
     // 1. TimeSeriesProperty with a single value should have no changes after filtering
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_1...");
     times = {DateAndTime("2007-11-30T16:19:00")};
     times_expected = times;
     values = {1.};
@@ -473,6 +480,7 @@ public:
     values = {1., 2.};
     values_expected = values;
     // a. TimeROI entirely between those values - no changes
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_2a...");
     times = {DateAndTime("2007-11-30T16:00:00"), DateAndTime("2007-11-30T20:00:00")};
     times_expected = times;
     tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_a", times, values);
@@ -483,6 +491,7 @@ public:
     // b. TimeROI entirely includes the values - no changes
 
     // b1. First roi entirely includes the values
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_2b1...");
     times = {DateAndTime("2007-11-30T16:17:15"), DateAndTime("2007-11-30T16:17:35")};
     times_expected = times;
     tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_b1", times, values);
@@ -491,6 +500,7 @@ public:
     TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // b2. First roi includes first value, second roi includes second value
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_2b2...");
     times = {DateAndTime("2007-11-30T16:17:15"), DateAndTime("2007-11-30T18:15:00")};
     times_expected = times;
     tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_b2", times, values);
@@ -499,6 +509,7 @@ public:
     TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // c. TimeROI includes first value and not second - no changes
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_2c...");
     times = {DateAndTime("2007-11-30T16:17:15"), DateAndTime("2007-11-30T16:18:25")};
     times_expected = times;
     tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_c", times, values);
@@ -507,6 +518,7 @@ public:
     TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // d. TimeROI includes second value and not first - no changes
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_2d...");
     times = {DateAndTime("2007-11-30T16:17:00"), DateAndTime("2007-11-30T16:18:10")};
     times_expected = times;
     tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_d", times, values);
@@ -515,6 +527,7 @@ public:
     TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // e. TimeROI is before both values - keep first
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_2e...");
     times = {DateAndTime("2007-11-30T16:18:35"), DateAndTime("2007-11-30T16:18:45")};
     tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_e", times, values);
     times_expected = {times[0]};
@@ -523,7 +536,19 @@ public:
     tsp_input->removeDataOutsideTimeROI(roi);
     TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
+    // e1. TimeROI right boundary is equal to the first value - keep both, b/c for log value copying purposes we treat
+    // TimeROI region as [inclusive,inclusive]
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_2e...");
+    times = {DateAndTime("2007-11-30T16:17:40"), DateAndTime("2007-11-30T16:18:45")};
+    tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_e1", times, values);
+    times_expected = {times[0], times[1]};
+    values_expected = {values[0], values[1]};
+    tsp_expected = std::make_unique<TimeSeriesProperty<double>>("two_values_e1", times_expected, values_expected);
+    tsp_input->removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
+
     // f. TimeROI is after both values - keep second
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_2f...");
     times = {DateAndTime("2007-11-30T16:16:10"), DateAndTime("2007-11-30T16:16:45")};
     tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_f", times, values);
     times_expected = {times[1]};   // second time
@@ -535,7 +560,8 @@ public:
     // 3. TimeSeriesProperty with three values
     values = {1., 2., 3.};
 
-    // a0 TimeROI entirely between the values - no changes
+    // a. TimeROI entirely between the values - no changes
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_3a...");
     times = {DateAndTime("2007-11-30T16:17:05"), DateAndTime("2007-11-30T16:18:00"),
              DateAndTime("2007-11-30T16:18:45")};
     tsp_input = std::make_unique<TimeSeriesProperty<double>>("three_values_a0", times, values);
@@ -545,7 +571,8 @@ public:
     tsp_input->removeDataOutsideTimeROI(roi);
     TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
-    // a. TimeROI includes first value only - keep the first two
+    // b. TimeROI includes first value only - keep the first two
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_3b...");
     times = {DateAndTime("2007-11-30T16:17:15"), DateAndTime("2007-11-30T16:18:30"),
              DateAndTime("2007-11-30T16:18:45")};
     tsp_input = std::make_unique<TimeSeriesProperty<double>>("three_values_a", times, values);
@@ -555,7 +582,8 @@ public:
     tsp_input->removeDataOutsideTimeROI(roi);
     TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
-    // b. TimeROI includes second value only - no changes
+    // c. TimeROI includes second value only - no changes
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_3c...");
     times = {DateAndTime("2007-11-30T16:17:00"), DateAndTime("2007-11-30T16:17:15"),
              DateAndTime("2007-11-30T16:18:30")};
     tsp_input = std::make_unique<TimeSeriesProperty<double>>("three_values_b", times, values);
@@ -565,7 +593,8 @@ public:
     tsp_input->removeDataOutsideTimeROI(roi);
     TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
-    // c. TimeROI includes third value only - keep the last two
+    // d. TimeROI includes third value only - keep the last two
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_3d...");
     times = {DateAndTime("2007-11-30T16:17:00"), DateAndTime("2007-11-30T16:17:05"),
              DateAndTime("2007-11-30T16:18:20")};
     tsp_input = std::make_unique<TimeSeriesProperty<double>>("three_values_c", times, values);

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -538,7 +538,7 @@ public:
 
     // e1. TimeROI right boundary is equal to the first value - keep both, b/c for log value copying purposes we treat
     // TimeROI region as [inclusive,inclusive]
-    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_2e...");
+    g_tspt_log.notice("\ntest_removeDataOutsideTimeROI_case_2e1...");
     times = {DateAndTime("2007-11-30T16:17:40"), DateAndTime("2007-11-30T16:18:45")};
     tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_e1", times, values);
     times_expected = {times[0], times[1]};

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -71,7 +71,6 @@ variableScope:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Statistics.cpp:58
 constParameter:${CMAKE_SOURCE_DIR}/build/_deps/span-src/include/tcb/span.hpp:323
 shadowFunction:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Matrix.cpp:128
 shadowFunction:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Matrix.cpp:943
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/TimeSeriesProperty.cpp:1831
 accessForwarded:${CMAKE_SOURCE_DIR}/Framework/HistogramData/inc/MantidHistogramData/Histogram.h:279
 accessForwarded:${CMAKE_SOURCE_DIR}/Framework/HistogramData/inc/MantidHistogramData/Histogram.h:291
 shadowFunction:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/SampleCorrections/RectangularBeamProfile.cpp:86


### PR DESCRIPTION
#### Description of work

While doing profiling for #36069, it was discovered that time filtering of log values was one of the performance bottlenecks. This PR refactors `TimeSeriesProperty<TYPE>::createFilteredData()` as follows:

- If all time values in the `TimeSeriesProperty` object are the same, copy only the first value.
- Iterate straight over the `TimeROI` implementation, i.e. a vector of time boundaries, instead of iterating over the `TimeROI` time intervals. Generating time intervals every time is very inefficient.
- Concurrently advance the `TimeROI` vector (length N) iterator and the time values vector (length M) iterator. This provides a time efficiency of O(N+M).
- Use const and references whenever possible to facilitate compiler optimization and avoid unnecessary copying of variables.

While the above work was being done, it was noted that unlike event filtering, the `TimeROI` regions in this case should be treated as `[inclusive,inclusive]`. If they were treated as [inclusive, exclusive), the existing `HYSPECReductionTest` system test would fail. However, no unit tests in `TimeSeriesPropertyTest` were testing that "inclusive right-boundary" condition. Correspondingly, a new unit test was added to check that functionality.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### To test:

`ctest -R KernelTest_TimeSeriesPropertyTest`

_There is no associated issue._

_This does not require release notes_ because it will never be directly observed by a user.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
