### PR TITLE
Enable colour selection tool in contour plots

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36317.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36317.rst
@@ -1,0 +1,1 @@
+- Line Colour selection button is reenabled in the toolbar of contour plots.

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -17,7 +17,7 @@ from functools import wraps
 import matplotlib
 from matplotlib.axes import Axes
 from matplotlib.backend_bases import FigureManagerBase
-from matplotlib.collections import LineCollection
+from matplotlib.collections import LineCollection, PathCollection
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 from qtpy.QtCore import QObject, Qt
 from qtpy.QtGui import QImage
@@ -553,6 +553,8 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         for col in self.canvas.figure.get_axes()[0].collections:
             if isinstance(col, LineCollection):
                 col.set_color(colour.name())
+            elif isinstance(col, PathCollection):
+                col.set_edgecolor(colour.name())
 
         self.canvas.draw()
 

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -52,6 +52,21 @@ class ToolBarTest(unittest.TestCase):
         self.assertTrue(self._is_button_enabled(fig, "waterfall_fill_area"))
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_line_color_selection_buttons_correctly_enabled_for_contour_wireframe_plots(self, mock_qappthread):
+        """Checks that line_colour selection button is correctly enabled for wireframe and contour plots"""
+        mock_qappthread.return_value = mock_qappthread
+
+        plot_types = ["wireframe", "contour"]
+        for plot_type in plot_types:
+            ws = CreateSampleWorkspace()
+            plot_function = getattr(functions, f"plot_{plot_type}", None)
+            self.assertIsNotNone(plot_function)
+            fig = plot_function([ws])
+
+            # line_colour button should be enabled for contour and wireframe plots
+            self.assertTrue(self._is_button_enabled(fig, "line_colour"))
+
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
     def test_button_unchecked_for_plot_with_no_grid(self, mock_qappthread):
         mock_qappthread.return_value = mock_qappthread
 

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -7,7 +7,7 @@
 #    This file is part of the mantid workbench.
 #
 #
-from matplotlib.collections import LineCollection
+from matplotlib.collections import LineCollection, PathCollection
 from qtpy import QtCore, QtGui, QtPrintSupport, QtWidgets
 
 from mantid.plots import MantidAxes
@@ -242,8 +242,7 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
 
         # For contour and wireframe plots, add a toolbar option to change the colour of the lines.
         if figure_type(fig) in [FigureType.Wireframe, FigureType.Contour]:
-            if any(isinstance(col, LineCollection) for col in fig.get_axes()[0].collections):
-                self.set_up_color_selector_toolbar_button(fig)
+            self.set_up_color_selector_toolbar_button(fig)
 
         if figure_type(fig) in [FigureType.Surface, FigureType.Wireframe, FigureType.Mesh]:
             self.adjust_for_3d_plots()
@@ -293,10 +292,16 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         else:
             a.setToolTip("Set the colour of the contour lines.")
 
-        line_collection = next(col for col in fig.get_axes()[0].collections if isinstance(col, LineCollection))
-        initial_colour = convert_color_to_hex(line_collection.get_color()[0])
+        for col in fig.get_axes()[0].collections:
+            if isinstance(col, LineCollection):
+                current_ax_colour = col.get_color()
+                break
+            elif isinstance(col, PathCollection):
+                current_ax_colour = col.get_edgecolor()
+                break
 
-        colour_dialog = QtWidgets.QColorDialog(QtGui.QColor(initial_colour))
+        # initial QColorDialog colour
+        colour_dialog = QtWidgets.QColorDialog(QtGui.QColor(convert_color_to_hex(current_ax_colour)))
         colour_dialog.setOption(QtWidgets.QColorDialog.NoButtons)
         colour_dialog.setOption(QtWidgets.QColorDialog.DontUseNativeDialog)
         colour_dialog.currentColorChanged.connect(self.change_line_collection_colour)


### PR DESCRIPTION
### Description of work

 This issue reenables the colour selection tool for contour plots. 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->
Following issue (#34097 ), where it was not possible to change line of contour plots as call to contour function does not return as a set of LineCollections, but PathCollections. This was fixed by disabling the line colour selection feature for contour plots.

Fixes #34098 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

    1. Open Mantid
    2. Load MAR11060
    3. Right click on the Workspace in the ADS and click Plot -> 3D -> Contour
    4. The plot should load with no error messages and the line colour button should be available in the toolbar.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
