### PR TITLE
Fix deadlock when using Python logging channels

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -52,6 +52,7 @@ dict getRegisteredAlgorithms(AlgorithmFactoryImpl const *const self, bool includ
   for (const auto &key : keys) {
     std::pair<std::string, int> algInfo;
     {
+      // We need to release the GIL here to prevent a deadlock when using Python log channels
       ReleaseGlobalInterpreterLock releaseGIL;
       algInfo = self->decodeName(key);
     }

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -10,6 +10,7 @@
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/core/GetPointer.h"
 #include "MantidPythonInterface/core/PythonObjectInstantiator.h"
+#include "MantidPythonInterface/core/ReleaseGlobalInterpreterLock.h"
 #include "MantidPythonInterface/core/UninstallTrace.h"
 
 #include <boost/python/class.hpp>
@@ -27,6 +28,7 @@
 using namespace Mantid::API;
 using namespace boost::python;
 using Mantid::PythonInterface::PythonObjectInstantiator;
+using Mantid::PythonInterface::ReleaseGlobalInterpreterLock;
 using Mantid::PythonInterface::UninstallTrace;
 
 GET_POINTER_SPECIALIZATION(AlgorithmFactoryImpl)
@@ -48,7 +50,11 @@ dict getRegisteredAlgorithms(AlgorithmFactoryImpl const *const self, bool includ
   const auto keys = self->getKeys(includeHidden);
   dict inventory;
   for (const auto &key : keys) {
-    auto algInfo = self->decodeName(key);
+    std::pair<std::string, int> algInfo;
+    {
+      ReleaseGlobalInterpreterLock releaseGIL;
+      algInfo = self->decodeName(key);
+    }
     object name(handle<>(to_python_value<const std::string &>()(algInfo.first)));
     object ver(handle<>(to_python_value<const int &>()(algInfo.second)));
     // There seems to be no way to "promote" the return of .get to a list

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -47,6 +47,12 @@ IAlgorithm_sptr create(AlgorithmManagerImpl *self, const std::string &algName, c
   return self->create(algName, version);
 }
 
+std::shared_ptr<Algorithm> createUnmanaged(AlgorithmManagerImpl *self, const std::string &algName,
+                                           const int &version = -1) {
+  ReleaseGlobalInterpreterLock releaseGIL;
+  return self->createUnmanaged(algName, version);
+}
+
 void clear(AlgorithmManagerImpl *self) {
   /// TODO We should release the GIL here otherwise we risk deadlock (see issue #33895). However, doing so causes
   /// test failures because it exposes an unreleated bug to do with the way we handle shared_ptrs to Python objects
@@ -113,7 +119,7 @@ GNU_DIAG_OFF("unused-local-typedef")
 GNU_DIAG_OFF("conversion")
 /// Define overload generators
 BOOST_PYTHON_FUNCTION_OVERLOADS(create_overloads, create, 2, 3)
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createUnmanaged_overloads, AlgorithmManagerImpl::createUnmanaged, 1, 2)
+BOOST_PYTHON_FUNCTION_OVERLOADS(createUnmanaged_overloads, createUnmanaged, 2, 3)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unused-local-typedef")
 ///@endcond
@@ -123,7 +129,7 @@ void export_AlgorithmManager() {
 
   class_<AlgorithmManagerImpl, boost::noncopyable>("AlgorithmManagerImpl", no_init)
       .def("create", &create, create_overloads((arg("name"), arg("version")), "Creates a managed algorithm."))
-      .def("createUnmanaged", &AlgorithmManagerImpl::createUnmanaged,
+      .def("createUnmanaged", &createUnmanaged,
            createUnmanaged_overloads((arg("name"), arg("version")), "Creates an unmanaged algorithm."))
       .def("size", &AlgorithmManagerImpl::size, arg("self"), "Returns the number of managed algorithms")
       .def("getAlgorithm", &getAlgorithm, (arg("self"), arg("id_holder")),

--- a/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
@@ -63,6 +63,7 @@ void updatePythonPaths() {
 FrameworkManagerImpl &instance() {
   // start the framework (if necessary)
   auto &frameworkMgr = []() -> auto & {
+    // We need to release the GIL here to prevent a deadlock when using Python log channels
     ReleaseGlobalInterpreterLock releaseGIL;
     return FrameworkManager::Instance();
   }

--- a/Testing/SystemTests/tests/framework/PythonChannels.py
+++ b/Testing/SystemTests/tests/framework/PythonChannels.py
@@ -1,0 +1,122 @@
+"""This test is to verify a fix for a deadlock that occurs when using
+the PythonStdoutChannel or PythonLoggingChannel Poco log channels and
+when the CheckMantidVersion or DownloadInstrument algorithms are run
+during Mantid Framework creation.
+
+The deadlock involves these logging channels first locking the mutex
+in Poco::SplitterChannel::log before trying to acquire the Python
+GIL. But the Python GIL is being currently locked by the main thread
+which is then trying to acquire the mutex in
+Poco::SplitterChannel::log.
+
+If any of these test raise a subprocess.TimeoutExpired error that
+means it has entered a deadlock.
+
+A python script is created and run in a separate process so that the
+`import mantid.simpleapi` can be tested correctly.
+
+This test stands up a http server to serve the request form these
+algorithms to avoid hitting the internet.
+
+"""
+
+import os
+import sys
+import time
+import unittest
+import subprocess
+import systemtesting
+from multiprocessing import Process
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+script_template = """
+import time
+from mantid.kernel import ConfigService
+from mantid.api import FrameworkManagerImpl
+
+# If the framework has already been created then this test is invalid.
+if FrameworkManagerImpl.hasInstance():
+    exit(1)
+
+ConfigService["logging.loggers.root.level"] = "debug"
+ConfigService["logging.channels.consoleChannel.class"] = "{LoggingClass}"
+
+ConfigService["CheckMantidVersion.GitHubReleaseURL"]="http://localhost:18888/version"
+ConfigService["UpdateInstrumentDefinitions.URL"]="http://localhost:18888/instruments"
+
+ConfigService["CheckMantidVersion.OnStartup"] = "{CheckMantidVersion}"
+ConfigService["UpdateInstrumentDefinitions.OnStartup"] = "{UpdateInstrumentDefinitions}"
+
+import mantid.simpleapi
+time.sleep(1)
+"""
+
+TEST_SCRIPT_NAME = "pythonloggingtestscript.py"
+
+
+def run_server():
+    class Handler(BaseHTTPRequestHandler):
+        def _set_headers(self):
+            self.send_response(200)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+
+        def do_GET(self):
+            time.sleep(0.1)
+            self._set_headers()
+            if self.path == "/instruments":
+                self.wfile.write("[]".encode())
+            else:
+                self.wfile.write('{"tag_name": "v6.8.0"}'.encode())
+
+    HTTPServer(("", 18888), Handler).serve_forever()
+
+
+class PythonLoggingTests(unittest.TestCase):
+    def test_PythonStdoutChannel_check_mantid_version(self):
+        self._create_script_and_execute(LoggingClass="PythonStdoutChannel", CheckMantidVersion=1)
+
+    def test_PythonLoggingChannel_check_mantid_version(self):
+        self._create_script_and_execute(LoggingClass="PythonLoggingChannel", CheckMantidVersion=1)
+
+    def test_PythonStdoutChannel_update_instruments(self):
+        self._create_script_and_execute(LoggingClass="PythonStdoutChannel", UpdateInstrumentDefinitions=1)
+
+    def test_PythonLoggingChannel_update_instruments(self):
+        self._create_script_and_execute(LoggingClass="PythonLoggingChannel", UpdateInstrumentDefinitions=1)
+
+    def _create_script_and_execute(self, LoggingClass="PythonStdoutChannel", CheckMantidVersion=0, UpdateInstrumentDefinitions=0):
+        with open(TEST_SCRIPT_NAME, "w") as f:
+            f.write(
+                script_template.format(
+                    LoggingClass=LoggingClass,
+                    CheckMantidVersion=CheckMantidVersion,
+                    UpdateInstrumentDefinitions=UpdateInstrumentDefinitions,
+                )
+            )
+
+        result = subprocess.run([sys.executable, TEST_SCRIPT_NAME], timeout=60)  # This will raise subprocess.TimeoutExpired if deadlocke
+        result.check_returncode()
+
+
+class PythonChannelTest(systemtesting.MantidSystemTest):
+    def __init__(self):
+        super().__init__()
+        self._success = False
+        self._server = Process(target=run_server)
+        self._server.start()
+
+    def cleanup(self):
+        self._server.terminate()
+        os.remove(TEST_SCRIPT_NAME)
+
+    def runTest(self):
+        suite = unittest.TestSuite()
+        suite.addTest(unittest.makeSuite(PythonLoggingTests, "test"))
+        runner = unittest.TextTestRunner()
+        try:
+            self.assertTrue(runner.run(suite).wasSuccessful())
+        except:
+            # Make sure cleanup does run
+            self.cleanup()
+            raise

--- a/Testing/SystemTests/tests/framework/PythonChannels.py
+++ b/Testing/SystemTests/tests/framework/PythonChannels.py
@@ -48,7 +48,7 @@ ConfigService["CheckMantidVersion.OnStartup"] = "{CheckMantidVersion}"
 ConfigService["UpdateInstrumentDefinitions.OnStartup"] = "{UpdateInstrumentDefinitions}"
 
 import mantid.simpleapi
-time.sleep(1)
+time.sleep(10)
 """
 
 TEST_SCRIPT_NAME = "pythonloggingtestscript.py"

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -238,7 +238,7 @@ unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/E
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp:30
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp:74
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/InstrumentFileFinder.cpp:36
-unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp:154
+unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp:155
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp:115
 constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:153
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp:251

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -238,7 +238,7 @@ unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/E
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp:30
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp:74
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/InstrumentFileFinder.cpp:36
-unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp:148
+unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp:154
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp:115
 constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:153
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp:251

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -239,7 +239,7 @@ unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/E
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp:74
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/InstrumentFileFinder.cpp:36
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp:155
-unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp:115
+unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp:121
 constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:153
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp:251
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp:65

--- a/docs/source/release/v6.9.0/Framework/Python/Bugfixes/36326.rst
+++ b/docs/source/release/v6.9.0/Framework/Python/Bugfixes/36326.rst
@@ -1,0 +1,1 @@
+- Fix a deadlock that occured when using debug level logging and PythonStdoutChannel or PythonLoggingChannel


### PR DESCRIPTION
### Description of work

Configuration required for this to occur

```
  logging.loggers.root.level=debug

  logging.channels.consoleChannel.class=PythonStdoutChannel
    or
  logging.channels.consoleChannel.class=PythonLoggingChannel

  CheckMantidVersion.OnStartup=1
    and/or
  UpdateInstrumentDefinitions.OnStartup=1
```

Then a deadlock happens when you do `import mantid.simpleapi`.

The deadlock involves the Python GIL and the mutex in `Poco:SplitterChannel::log`. During startup the `CheckMantidVersion` and/or `UpdateInstrumentDefinitions` are started asynchronously while the rest of the Framework continues to load. This causes a problem when one of the threads running those algorithms tries to send a log message, it first acquires the lock in poco before tring to acquire the GIL (required by the Python logging channels). But it can't because the main thread has the GIL, and then when the main thread tries to send a log message it can't acquire the lock in poco because the other thread currently has it, hence deadlock.

The two locks involved are the one in [PythonStdoutChannel](https://github.com/mantidproject/mantid/blob/5c5c19c346ef94ee943daa0e7fe8ed14c2723e29/Framework/PythonInterface/core/src/PythonStdoutChannel.cpp#L28) or [PythonLoggingChannel](https://github.com/mantidproject/mantid/blob/main/Framework/PythonInterface/core/src/PythonLoggingChannel.cpp#L72) and the one in [Poco::SplitterChannel::log](https://github.com/pocoproject/poco/blob/bd06526ee07e5b09165b141fc7ec0b5b705e7cee/Foundation/src/SplitterChannel.cpp#L81).

This fixes the deadlock by having the Framework release the GIL temporary in places that it tries to log messages, thereby allowing the threads running the startup algorithms to successfully finish logging, breaking the deadlock.

Here is a rough visual of what is happening.
![deadlock](https://github.com/mantidproject/mantid/assets/5595210/fa70e5a6-12ba-4bbf-afc5-2e5e74a6fd3e)


#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [2138](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2138)
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Set the configuration in `~/.mantid/Mantid.user.properties` and see that `import mantid.simpleapi` no longer deadlocks.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
