### PR TITLE
LoadMuonNexusV2 handle no grouping provided

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2NexusHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2NexusHelper.h
@@ -11,6 +11,7 @@
 #include "MantidGeometry/IDTypes.h"
 #include "MantidNexus/NexusClasses.h"
 
+#include <optional>
 #include <vector>
 
 namespace Mantid {
@@ -29,8 +30,8 @@ public:
   // Loads the good frame data from the nexus file
   NeXus::NXInt loadGoodFramesDataFromNexus(bool isFileMultiPeriod);
   // Loads the grouping data from the nexus file
-  std::vector<detid_t> loadDetectorGroupingFromNexus(const std::vector<detid_t> &loadedDetectors,
-                                                     bool isFileMultiPeriod, int periodNumber);
+  std::optional<std::vector<detid_t>> loadDetectorGroupingFromNexus(const std::vector<detid_t> &loadedDetectors,
+                                                                    bool isFileMultiPeriod, int periodNumber);
   // Load the orientation from the nexus entry
   std::string loadMainFieldDirectionFromNexus();
   // Load deadtime information

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonStrategy.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonStrategy.h
@@ -12,6 +12,8 @@
 #include "MantidGeometry/IDTypes.h"
 #include "MantidKernel/Logger.h"
 
+#include <optional>
+
 namespace Mantid {
 namespace DataHandling {
 class LoadMuonNexusV2NexusHelper;
@@ -40,8 +42,9 @@ public:
 
 protected:
   // Create grouping table
-  DataObjects::TableWorkspace_sptr createDetectorGroupingTable(const std::vector<detid_t> &specToLoad,
-                                                               const std::vector<detid_t> &grouping) const;
+  std::optional<DataObjects::TableWorkspace_sptr>
+  createDetectorGroupingTable(const std::vector<detid_t> &specToLoad,
+                              const std::optional<std::vector<detid_t>> &grouping) const;
   // Create deadtimes table
   DataObjects::TableWorkspace_sptr createDeadTimeTable(const std::vector<detid_t> &detectorsLoaded,
                                                        const std::vector<double> &deadTimes) const;

--- a/Framework/DataHandling/src/LoadMuonNexusV2NexusHelper.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2NexusHelper.cpp
@@ -88,26 +88,30 @@ NXInt LoadMuonNexusV2NexusHelper::loadGoodFramesDataFromNexus(bool isFileMultiPe
 // The method implemented here assumes that once implemented
 // each detector will map to a single group. If this is not the case,
 // the method will need to be altered.
-std::vector<detid_t>
+std::optional<std::vector<detid_t>>
 LoadMuonNexusV2NexusHelper::loadDetectorGroupingFromNexus(const std::vector<detid_t> &detectorsLoaded,
                                                           bool isFileMultiPeriod, int periodNumber) {
+  // Open nexus entry
+  NXClass detectorGroup = m_entry.openNXGroup(NeXusEntry::DETECTOR);
+  if (!detectorGroup.containsDataSet(NeXusEntry::GROUPING)) {
+    return std::nullopt;
+  }
+
   // We cast the numLoadedDetectors to an int, which is the index type used for
   // Nexus Data sets. As detectorsLoaded is derived from a nexus entry we
   // can be certain we won't overflow the integer type.
   int numLoadedDetectors = static_cast<int>(detectorsLoaded.size());
   std::vector<detid_t> grouping;
   grouping.reserve(numLoadedDetectors);
-  // Open nexus entry
-  NXClass detectorGroup = m_entry.openNXGroup(NeXusEntry::DETECTOR);
-  if (detectorGroup.containsDataSet(NeXusEntry::GROUPING)) {
-    NXInt groupingData = detectorGroup.openNXInt(NeXusEntry::GROUPING);
-    groupingData.load();
-    int groupingOffset = !isFileMultiPeriod ? 0 : (numLoadedDetectors) * (periodNumber - 1);
-    std::transform(detectorsLoaded.cbegin(), detectorsLoaded.cend(), std::back_inserter(grouping),
-                   [&groupingData, groupingOffset](const auto detectorNumber) {
-                     return groupingData[detectorNumber - 1 + groupingOffset];
-                   });
-  }
+
+  NXInt groupingData = detectorGroup.openNXInt(NeXusEntry::GROUPING);
+  groupingData.load();
+  int groupingOffset = !isFileMultiPeriod ? 0 : (numLoadedDetectors) * (periodNumber - 1);
+  std::transform(detectorsLoaded.cbegin(), detectorsLoaded.cend(), std::back_inserter(grouping),
+                 [&groupingData, groupingOffset](const auto detectorNumber) {
+                   return groupingData[detectorNumber - 1 + groupingOffset];
+                 });
+
   return grouping;
 }
 std::string LoadMuonNexusV2NexusHelper::loadMainFieldDirectionFromNexus() {

--- a/Framework/DataHandling/src/LoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/LoadMuonStrategy.cpp
@@ -48,6 +48,7 @@ LoadMuonStrategy::LoadMuonStrategy(Kernel::Logger &g_log, std::string filename, 
  */
 API::Workspace_sptr
 LoadMuonStrategy::loadDefaultDetectorGrouping(const DataObjects::Workspace2D &localWorkspace) const {
+  m_logger.information("Loading grouping information from IDF");
 
   auto instrument = localWorkspace.getInstrument();
   auto &run = localWorkspace.run();

--- a/Framework/DataHandling/src/LoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/LoadMuonStrategy.cpp
@@ -97,10 +97,13 @@ std::optional<DataObjects::TableWorkspace_sptr>
 LoadMuonStrategy::createDetectorGroupingTable(const std::vector<detid_t> &detectorsLoaded,
                                               const std::optional<std::vector<detid_t>> &grouping) const {
   if (!grouping) {
+    m_logger.information("No grouping information is provided in the Nexus file");
     return std::nullopt;
   }
   auto groupingIDs = *grouping;
   if (detectorsLoaded.size() != groupingIDs.size()) {
+    m_logger.information() << "The number of groupings in the provided Nexus file (" << groupingIDs.size()
+                           << ") does not match the number of loaded detectors (" << detectorsLoaded.size() << ").";
     return std::nullopt;
   }
 

--- a/Framework/DataHandling/src/MultiPeriodLoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/MultiPeriodLoadMuonStrategy.cpp
@@ -73,13 +73,13 @@ Workspace_sptr MultiPeriodLoadMuonStrategy::loadDetectorGrouping() const {
   for (int i = 0; i < m_workspaceGroup.getNumberOfEntries(); ++i) {
     int periodNumber = i + 1;
     auto grouping = m_nexusLoader.loadDetectorGroupingFromNexus(m_detectors, MULTIPERIODSLOADED, periodNumber);
-    TableWorkspace_sptr table = createDetectorGroupingTable(m_detectors, grouping);
+    auto table = createDetectorGroupingTable(m_detectors, grouping);
     // if any of the tables are empty we'll load grouping from the IDF
-    if (table->rowCount() == 0) {
-      m_logger.notice("Loading grouping information from IDF");
+    if (!table) {
+      m_logger.information("Loading grouping information from IDF");
       return loadDefaultDetectorGrouping(*std::dynamic_pointer_cast<Workspace2D>(m_workspaceGroup.getItem(i)));
     }
-    tableGroup->addWorkspace(table);
+    tableGroup->addWorkspace(*table);
   }
   return tableGroup;
 }

--- a/Framework/DataHandling/src/MultiPeriodLoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/MultiPeriodLoadMuonStrategy.cpp
@@ -76,7 +76,6 @@ Workspace_sptr MultiPeriodLoadMuonStrategy::loadDetectorGrouping() const {
     auto table = createDetectorGroupingTable(m_detectors, grouping);
     // if any of the tables are empty we'll load grouping from the IDF
     if (!table) {
-      m_logger.information("Loading grouping information from IDF");
       return loadDefaultDetectorGrouping(*std::dynamic_pointer_cast<Workspace2D>(m_workspaceGroup.getItem(i)));
     }
     tableGroup->addWorkspace(*table);

--- a/Framework/DataHandling/src/MultiPeriodLoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/MultiPeriodLoadMuonStrategy.cpp
@@ -72,10 +72,10 @@ Workspace_sptr MultiPeriodLoadMuonStrategy::loadDetectorGrouping() const {
   WorkspaceGroup_sptr tableGroup = std::make_shared<WorkspaceGroup>();
   for (int i = 0; i < m_workspaceGroup.getNumberOfEntries(); ++i) {
     int periodNumber = i + 1;
-    auto grouping = m_nexusLoader.loadDetectorGroupingFromNexus(m_detectors, MULTIPERIODSLOADED, periodNumber);
-    auto table = createDetectorGroupingTable(m_detectors, grouping);
+    auto const grouping = m_nexusLoader.loadDetectorGroupingFromNexus(m_detectors, MULTIPERIODSLOADED, periodNumber);
+    auto const table = createDetectorGroupingTable(m_detectors, grouping);
     // if any of the tables are empty we'll load grouping from the IDF
-    if (!table) {
+    if (!table || (*table)->rowCount() == 0) {
       return loadDefaultDetectorGrouping(*std::dynamic_pointer_cast<Workspace2D>(m_workspaceGroup.getItem(i)));
     }
     tableGroup->addWorkspace(*table);

--- a/Framework/DataHandling/src/SinglePeriodLoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/SinglePeriodLoadMuonStrategy.cpp
@@ -69,12 +69,12 @@ void SinglePeriodLoadMuonStrategy::loadGoodFrames() {
 Workspace_sptr SinglePeriodLoadMuonStrategy::loadDetectorGrouping() const {
 
   auto grouping = m_nexusLoader.loadDetectorGroupingFromNexus(m_detectors, m_isFileMultiPeriod, m_entryNumber);
-  TableWorkspace_sptr table = createDetectorGroupingTable(m_detectors, grouping);
+  auto table = createDetectorGroupingTable(m_detectors, grouping);
 
-  if (table->rowCount() != 0) {
-    return table;
+  if (table) {
+    return *table;
   } else {
-    m_logger.notice("Loading grouping information from IDF");
+    m_logger.information("Loading grouping information from IDF");
     return loadDefaultDetectorGrouping(m_workspace);
   }
 }

--- a/Framework/DataHandling/src/SinglePeriodLoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/SinglePeriodLoadMuonStrategy.cpp
@@ -74,7 +74,6 @@ Workspace_sptr SinglePeriodLoadMuonStrategy::loadDetectorGrouping() const {
   if (table) {
     return *table;
   } else {
-    m_logger.information("Loading grouping information from IDF");
     return loadDefaultDetectorGrouping(m_workspace);
   }
 }

--- a/Framework/DataHandling/src/SinglePeriodLoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/SinglePeriodLoadMuonStrategy.cpp
@@ -67,15 +67,12 @@ void SinglePeriodLoadMuonStrategy::loadGoodFrames() {
  * @returns :: Grouping table
  */
 Workspace_sptr SinglePeriodLoadMuonStrategy::loadDetectorGrouping() const {
-
-  auto grouping = m_nexusLoader.loadDetectorGroupingFromNexus(m_detectors, m_isFileMultiPeriod, m_entryNumber);
-  auto table = createDetectorGroupingTable(m_detectors, grouping);
-
-  if (table) {
+  auto const grouping = m_nexusLoader.loadDetectorGroupingFromNexus(m_detectors, m_isFileMultiPeriod, m_entryNumber);
+  auto const table = createDetectorGroupingTable(m_detectors, grouping);
+  if (table && (*table)->rowCount() != 0) {
     return *table;
-  } else {
-    return loadDefaultDetectorGrouping(m_workspace);
   }
+  return loadDefaultDetectorGrouping(m_workspace);
 }
 /**
  * Loads deadtime table from nexus file

--- a/Framework/DataHandling/test/LoadMuonNexusV2Test.h
+++ b/Framework/DataHandling/test/LoadMuonNexusV2Test.h
@@ -554,6 +554,22 @@ public:
 
     TS_ASSERT_EQUALS("5.033640;5.026534", run.getProperty("total_counts_period")->value());
   }
+
+  void test_loading_detector_grouping_table_when_grouping_info_is_empty_will_load_default_group_from_IDF() {
+    LoadMuonNexusV2 loader;
+    loader.initialize();
+    loader.setPropertyValue("Filename", "ARGUS00073601.nxs");
+    loader.setPropertyValue("DetectorGroupingTable", "detector_grouping");
+    loader.setPropertyValue("DeadTimeTable", "deadtime_table");
+    loader.setPropertyValue("OutputWorkspace", "outWS");
+
+    TS_ASSERT_THROWS_NOTHING(loader.execute());
+    TS_ASSERT(loader.isExecuted());
+
+    auto const detTable = AnalysisDataService::Instance().retrieveWS<TableWorkspace>("detector_grouping");
+    // When the grouping info is not provided, it should load the grouping from the IDF. The IDF has two groups.
+    TS_ASSERT_EQUALS(2, detTable->rowCount());
+  }
 };
 
 //------------------------------------------------------------------------------

--- a/Testing/Data/UnitTest/ARGUS00073601.nxs.md5
+++ b/Testing/Data/UnitTest/ARGUS00073601.nxs.md5
@@ -1,0 +1,1 @@
+b375fcf46ac793bec9d5e53d9c13a036

--- a/docs/source/release/v6.9.0/Muon/Algorithms/Bugfixes/35325.rst
+++ b/docs/source/release/v6.9.0/Muon/Algorithms/Bugfixes/35325.rst
@@ -1,0 +1,1 @@
+- Fixed the :ref:`LoadMuonNexusV2 <algm-LoadMuonNexusV2>` algorithm when loading a Nexus file with no grouping info so that it loads the grouping from the IDF.


### PR DESCRIPTION
### Description of work
This PR fixes a bug when loading a Nexus file which has no grouping information when using the `LoadMuonNexusV2` algorithm. When this is the case, the algorithm should load the default grouping from the IDF, and an 'information' message should be output to the logger.

Fixes #35325

### To test:
Run the following script in workbench. It should run successfully. The output table called "groups" should have two rows. This is the default detector grouping found in the ARGUS IDF.

```py
f="//isis/inst$/ndxargus/Instrument/data/cycle_22_5/ARGUS00073601.nxs"
ws=LoadMuonNexus(Filename=f, DeadTimeTable="dttab", DetectorGroupingTable="groups") 
```


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
