### PR TITLE
Fix crash in surface plot after changing properties

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36264.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36264.rst
@@ -1,0 +1,1 @@
+- Fixed bug that caused surface plots to hang and/or crash after changing properties such as axis labels or colour bar limits.

--- a/qt/python/mantidqt/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/functions.py
@@ -14,7 +14,6 @@ our custom window.
 # std imports
 
 import matplotlib
-from mpl_toolkits.axes_grid1.axes_divider import make_axes_area_auto_adjustable
 import numpy as np
 
 # local imports
@@ -357,10 +356,7 @@ def plot_surface(workspaces, fig=None):
 
         surface = ax.plot_surface(ws, cmap=ConfigService.getString("plots.images.Colormap"))
         ax.set_title(ws.name())
-        # Stops colour bar colliding with the plot. Also prevents the plot being pushed off the windows when resizing.
-        # "Top" direction is excluded since the title provides a buffer
-        make_axes_area_auto_adjustable(ax, pad=0, adjust_dirs=["left", "right", "bottom"])
-        fig.colorbar(surface, ax=[ax])
+        fig.colorbar(surface, pad=0.15)
         fig.show()
 
     return fig


### PR DESCRIPTION
### Description of work
Sometimes surface plots were throwing exceptions after changing properties such as axis labels or colour bar limits. These changes stop that from happening and also fix another bug where the surface plot would keep shrinking every time you changed the limit on the colour bar.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
- Removed call to `make_axes_area_auto_adjustable`. For unknown reasons this method (not one of ours) would cause an exception to be thrown (see issues referenced below) the next time `canvas.draw()` was called.
- Removed argument `ax=[ax]` from the call to `colorbar` because it seemed unnecessary and it caused a bug whereby every time you changed the colour bar limits it would shrink the available space in the figure window (so you'd have an ever-increasing amount of white space).
- Added some padding to the call to `colorbar` to prevent a collision with the surface plot z-axis label.

Fixes #36264
Fixes #36108 
Fixes #35750 

### To test:
See #36264 for the easiest way to reproduce the original problem.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
