### PR TITLE
LoadEventNexus code cleanup and small performance improvements

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
@@ -8,6 +8,7 @@
 
 #include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/Property.h"
+#include <mutex>
 
 namespace NeXus {
 class File;
@@ -28,6 +29,9 @@ public:
   /// Constructor with vector of DateAndTime
   BankPulseTimes(const std::vector<Mantid::Types::Core::DateAndTime> &times);
 
+  /// Threadsafe method to access cached information about sorting
+  bool arePulseTimesIncreasing() const;
+
   /// Equals
   bool equals(size_t otherNumPulse, const std::string &otherStartTime);
 
@@ -39,4 +43,8 @@ public:
 
   /// Vector of period numbers corresponding to each pulse
   std::vector<int> periodNumbers;
+
+private:
+  mutable int8_t m_sorting_info;
+  mutable std::mutex m_sortingMutex;
 };

--- a/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
@@ -45,6 +45,9 @@ public:
   std::vector<int> periodNumbers;
 
 private:
+  template <typename ValueType>
+  void readData(::NeXus::File &file, int64_t numValues, Mantid::Types::Core::DateAndTime &start);
+
   mutable int8_t m_sorting_info;
   mutable std::mutex m_sortingMutex;
 };

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadBankFromDiskTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadBankFromDiskTask.h
@@ -38,13 +38,13 @@ public:
 
 private:
   void loadPulseTimes(::NeXus::File &file);
-  std::vector<uint64_t> loadEventIndex(::NeXus::File &file);
+  std::unique_ptr<std::vector<uint64_t>> loadEventIndex(::NeXus::File &file);
   void prepareEventId(::NeXus::File &file, int64_t &start_event, int64_t &stop_event,
                       const std::vector<uint64_t> &event_index);
   std::unique_ptr<std::vector<uint32_t>> loadEventId(::NeXus::File &file);
   std::unique_ptr<std::vector<float>> loadTof(::NeXus::File &file);
   std::unique_ptr<std::vector<float>> loadEventWeights(::NeXus::File &file);
-  int64_t recalculateDataSize(const int64_t &size);
+  int64_t recalculateDataSize(const int64_t size);
 
   /// Algorithm being run
   DefaultEventLoader &m_loader;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadBankFromDiskTask.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadBankFromDiskTask.h
@@ -60,8 +60,9 @@ private:
   std::shared_ptr<BankPulseTimes> thisBankPulseTimes;
   /// Did we get an error in loading
   bool m_loadError;
-  /// Old names in the file?
-  bool m_oldNexusFileNames;
+  // Old names in the file are different
+  std::string m_detIdFieldName;
+  std::string m_timeOfFlightFieldName;
   /// Index to load start at in the file
   std::vector<int64_t> m_loadStart;
   /// How much to load in the file

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -147,6 +147,8 @@ public:
   double filter_tof_min;
   /// Filter by a maximum time-of-flight
   double filter_tof_max;
+  /// Tof range is being filtered
+  bool filter_tof_range;
 
   /// Minimum spectrum to load
   int32_t m_specMin;

--- a/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
@@ -68,21 +68,21 @@ private:
   /// Progress reporting
   API::Progress *prog;
   /// event pixel ID array
-  std::shared_ptr<std::vector<uint32_t>> event_id;
+  const std::shared_ptr<std::vector<uint32_t>> event_id;
   /// event TOF array
-  std::shared_ptr<std::vector<float>> event_time_of_flight;
+  const std::shared_ptr<std::vector<float>> event_time_of_flight;
   /// # of events in arrays
   size_t numEvents;
   /// index of the first event from event_index
   size_t startAt;
   /// vector of event index (length of # of pulses)
-  std::shared_ptr<std::vector<uint64_t>> event_index;
+  const std::shared_ptr<std::vector<uint64_t>> event_index;
   /// Pulse times for this bank
-  std::shared_ptr<BankPulseTimes> thisBankPulseTimes;
+  const std::shared_ptr<BankPulseTimes> thisBankPulseTimes;
   /// Flag for simulated data
   bool have_weight;
   /// event weights array
-  std::shared_ptr<std::vector<float>> event_weight;
+  const std::shared_ptr<std::vector<float>> event_weight;
   /// Minimum pixel id
   detid_t m_min_id;
   /// Maximum pixel id

--- a/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
@@ -55,6 +55,7 @@ private:
   size_t getWorkspaceIndexFromPixelID(const detid_t pixID);
   size_t getFirstEventIndex(const size_t pulseIndex) const;
   size_t getLastEventIndex(const size_t pulseIndex, const size_t numPulses) const;
+  void preCountAndReserveMem();
 
   /// Algorithm being run
   DefaultEventLoader &m_loader;

--- a/Framework/DataHandling/src/BankPulseTimes.cpp
+++ b/Framework/DataHandling/src/BankPulseTimes.cpp
@@ -5,7 +5,6 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidDataHandling/BankPulseTimes.h"
-#include "MantidNexus/NexusIOHelper.h"
 
 #include <nexus/NeXusFile.hpp>
 #include <numeric>
@@ -43,7 +42,8 @@ BankPulseTimes::BankPulseTimes(::NeXus::File &file, const std::vector<int> &pNum
 
   // number of pulse times
   const auto dataInfo = file.getInfo();
-  const int64_t numValues = Mantid::NeXus::NeXusIOHelper::vectorVolume(dataInfo.dims);
+  const int64_t numValues =
+      std::accumulate(dataInfo.dims.cbegin(), dataInfo.dims.cend(), int64_t{1}, std::multiplies<>());
   if (numValues == 0)
     throw std::runtime_error("event_time_zero field has no data!");
 

--- a/Framework/DataHandling/src/BankPulseTimes.cpp
+++ b/Framework/DataHandling/src/BankPulseTimes.cpp
@@ -7,6 +7,7 @@
 #include "MantidDataHandling/BankPulseTimes.h"
 
 #include <nexus/NeXusFile.hpp>
+#include <numeric>
 
 using namespace Mantid::Kernel;
 //===============================================================================================
@@ -37,38 +38,55 @@ BankPulseTimes::BankPulseTimes(::NeXus::File &file, const std::vector<int> &pNum
   else
     file.getAttr("offset", startTime);
   Mantid::Types::Core::DateAndTime start(startTime);
-  // Load the seconds offsets
 
-  const auto heldTimeZeroType = file.getInfo().type;
+  // number of pulse times
+  const auto dataInfo = file.getInfo();
+  const int64_t numValues = std::accumulate(dataInfo.dims.cbegin(), dataInfo.dims.cend(), 0,
+                                            [](const int64_t accum, const int64_t value) { return accum + value; });
+  if (numValues == 0)
+    throw std::runtime_error("event_time_zero field has no data!");
+
+  const auto heldTimeZeroType = dataInfo.type;
+
   // Nexus only requires event_time_zero to be a NXNumber, we support two
   // possilites
   if (heldTimeZeroType == ::NeXus::FLOAT64) {
-    std::vector<double> seconds;
-    file.getData(seconds);
-    file.closeData();
-    // Now create the pulseTimes
-    if (seconds.size() == 0)
-      throw std::runtime_error("event_time_zero field has no data!");
-
-    std::transform(seconds.cbegin(), seconds.cend(), std::back_inserter(pulseTimes),
-                   [start](double seconds) { return start + seconds; });
+    this->readData<double>(file, numValues, start);
   } else if (heldTimeZeroType == ::NeXus::UINT64) {
-    std::vector<uint64_t> nanoseconds;
-    file.getData(nanoseconds);
-    file.closeData();
-    // Now create the pulseTimes
-    if (nanoseconds.size() == 0)
-      throw std::runtime_error("event_time_zero field has no data!");
-
-    std::transform(nanoseconds.cbegin(), nanoseconds.cend(), std::back_inserter(pulseTimes),
-                   [start](int64_t nanoseconds) { return start + nanoseconds; });
+    this->readData<uint64_t>(file, numValues, start);
   } else {
     throw std::invalid_argument("Unsupported type for event_time_zero");
   }
+  file.closeData();
+
   // Ensure that we always have a consistency between nPulses and
   // periodNumbers containers
   if (pulseTimes.size() != pNumbers.size()) {
     periodNumbers = std::vector<int>(pulseTimes.size(), FirstPeriod);
+  }
+}
+
+template <typename ValueType>
+void BankPulseTimes::readData(::NeXus::File &file, int64_t numValues, Mantid::Types::Core::DateAndTime &start) {
+  std::vector<int64_t> indexStart{0};
+  std::vector<int64_t> indexStep{std::min(numValues, static_cast<int64_t>(3600 * 60))}; // 1 hour at 60Hz
+
+  // getSlab needs the data allocated already
+  std::vector<ValueType> rawData(indexStep[0]);
+
+  // loop over chunks of data and transform each chunk
+  while ((indexStep[0] > 0) && (indexStart[0] < numValues)) {
+    file.getSlab(rawData.data(), indexStart, indexStep);
+
+    // Now create the pulseTimes
+    std::transform(rawData.cbegin(), rawData.cend(), std::back_inserter(pulseTimes),
+                   [start](ValueType incremental_time) { return start + incremental_time; });
+
+    // increment the slab to get
+    indexStart[0] += indexStep[0];
+    indexStep[0] = std::min(indexStep[0], numValues - indexStart[0]);
+    // resize the vector
+    rawData.resize(indexStep[0]);
   }
 }
 

--- a/Framework/DataHandling/src/BankPulseTimes.cpp
+++ b/Framework/DataHandling/src/BankPulseTimes.cpp
@@ -5,11 +5,13 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidDataHandling/BankPulseTimes.h"
+#include "MantidNexus/NexusIOHelper.h"
 
 #include <nexus/NeXusFile.hpp>
 #include <numeric>
 
 using namespace Mantid::Kernel;
+
 //===============================================================================================
 // BankPulseTimes
 //===============================================================================================
@@ -41,8 +43,7 @@ BankPulseTimes::BankPulseTimes(::NeXus::File &file, const std::vector<int> &pNum
 
   // number of pulse times
   const auto dataInfo = file.getInfo();
-  const int64_t numValues = std::accumulate(dataInfo.dims.cbegin(), dataInfo.dims.cend(), 0,
-                                            [](const int64_t accum, const int64_t value) { return accum + value; });
+  const int64_t numValues = Mantid::NeXus::NeXusIOHelper::vectorVolume(dataInfo.dims);
   if (numValues == 0)
     throw std::runtime_error("event_time_zero field has no data!");
 

--- a/Framework/DataHandling/src/BankPulseTimes.cpp
+++ b/Framework/DataHandling/src/BankPulseTimes.cpp
@@ -70,7 +70,7 @@ BankPulseTimes::BankPulseTimes(::NeXus::File &file, const std::vector<int> &pNum
 template <typename ValueType>
 void BankPulseTimes::readData(::NeXus::File &file, int64_t numValues, Mantid::Types::Core::DateAndTime &start) {
   std::vector<int64_t> indexStart{0};
-  std::vector<int64_t> indexStep{std::min(numValues, static_cast<int64_t>(3600 * 60))}; // 1 hour at 60Hz
+  std::vector<int64_t> indexStep{std::min(numValues, static_cast<int64_t>(12 * 3600 * 60))}; // 12 hour at 60Hz
 
   // getSlab needs the data allocated already
   std::vector<ValueType> rawData(indexStep[0]);

--- a/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
+++ b/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
@@ -443,10 +443,10 @@ void LoadBankFromDiskTask::run() {
   const auto startAt = static_cast<size_t>(m_loadStart[0]);
 
   // convert things to shared_arrays to share between tasks
-  std::shared_ptr<std::vector<uint32_t>> event_id_shrd(event_id.release());
-  std::shared_ptr<std::vector<float>> event_time_of_flight_shrd(event_time_of_flight.release());
-  std::shared_ptr<std::vector<float>> event_weight_shrd(event_weight.release());
-  std::shared_ptr<std::vector<uint64_t>> event_index_shrd(event_index.release());
+  std::shared_ptr<std::vector<uint32_t>> event_id_shrd(std::move(event_id));
+  std::shared_ptr<std::vector<float>> event_time_of_flight_shrd(std::move(event_time_of_flight));
+  std::shared_ptr<std::vector<float>> event_weight_shrd(std::move(event_weight));
+  std::shared_ptr<std::vector<uint64_t>> event_index_shrd(std::move(event_index));
 
   std::shared_ptr<Task> newTask1 = std::make_shared<ProcessBankData>(
       m_loader, entry_name, prog, event_id_shrd, event_time_of_flight_shrd, numEvents, startAt, event_index_shrd,

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1533,8 +1533,10 @@ void LoadEventNexus::setTimeFilters(const bool monitors) {
     // Nothing specified. Include everything
     filter_tof_min = -1e20;
     filter_tof_max = +1e20;
+    filter_tof_range = false;
   } else if ((filter_tof_min != EMPTY_DBL()) && (filter_tof_max != EMPTY_DBL())) {
     // Both specified. Keep these values
+    filter_tof_range = true;
   } else {
     std::string msg("You must specify both min & max or neither TOF filters");
     if (monitors)

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -153,7 +153,7 @@ void ProcessBankData::run() {
       // We cached a pointer to the vector<tofEvent> -> so retrieve it and add
       // the event
       const detid_t &detId = (*event_id)[eventIndex];
-      if ((detId - m_min_id) * (detId - m_max_id) <= 0) { // detId >= m_min_id && detId <= m_max_id) {
+      if (detId >= m_min_id && detId <= m_max_id) {
         // Create the tofevent
         const auto tof = static_cast<double>((*event_time_of_flight)[eventIndex]);
         // this is fancy for check if value is in range

--- a/Framework/Types/inc/MantidTypes/Core/DateAndTime.h
+++ b/Framework/Types/inc/MantidTypes/Core/DateAndTime.h
@@ -89,6 +89,8 @@ public:
   DateAndTime operator-(const int64_t nanosec) const;
   DateAndTime &operator-=(const int64_t nanosec);
 
+  DateAndTime operator+(const uint64_t nanosec) const;
+
   DateAndTime operator+(const time_duration &td) const;
   DateAndTime &operator+=(const time_duration &td);
   DateAndTime operator-(const time_duration &td) const;
@@ -151,6 +153,10 @@ inline DateAndTime::DateAndTime(const int64_t total_nanoseconds)
  * @return modified DateAndTime.
  */
 inline DateAndTime DateAndTime::operator+(const int64_t nanosec) const { return DateAndTime(_nanoseconds + nanosec); }
+
+inline DateAndTime DateAndTime::operator+(const uint64_t nanosec) const {
+  return DateAndTime(_nanoseconds + static_cast<int64_t>(nanosec));
+}
 
 /** + operator to add time.
  * @param sec :: duration to add

--- a/Framework/Types/inc/MantidTypes/Event/TofEvent.h
+++ b/Framework/Types/inc/MantidTypes/Event/TofEvent.h
@@ -62,7 +62,7 @@ public:
 
   /// Constructor, specifying the time of flight in microseconds and the frame
   /// id
-  TofEvent(double tof, const Core::DateAndTime pulsetime);
+  TofEvent(double tof, const Core::DateAndTime &pulsetime);
 
   /// Empty constructor
   TofEvent();
@@ -104,7 +104,7 @@ inline TofEvent::TofEvent(const double tof) : m_tof(tof), m_pulsetime(0) {}
  * @param tof :: time of flight, in microseconds
  * @param pulsetime :: absolute pulse time of the neutron.
  */
-inline TofEvent::TofEvent(const double tof, const Core::DateAndTime pulsetime) : m_tof(tof), m_pulsetime(pulsetime) {}
+inline TofEvent::TofEvent(const double tof, const Core::DateAndTime &pulsetime) : m_tof(tof), m_pulsetime(pulsetime) {}
 
 /// Empty constructor
 inline TofEvent::TofEvent() : m_tof(0), m_pulsetime(0) {}


### PR DESCRIPTION
### Description of work

It was hypothesized that an appreciable amount of time for `LoadEventNexus` was spent in the NeXus-api calling the hdf5-api. as seen in this picture from vtune (bigger file, local laptop)

![image (1)](https://github.com/mantidproject/mantid/assets/404003/80afc7bd-3b03-4b48-9877-761914794022)

This appears to not be the case. 

With that information, this PR aims to reduce copying objects in `LoadBankFromDiskTask`, refactors part of `ProcessBankData` to make the pre-counting events more visible in profiling, and reworks part of `BankPulseTime` to read parts of the file at a time and convert those parts. This last part is a large portion of the speed improvements seen.

#### Timings

The files being used are (both in `/SNS/SNAP/IPTS-28913/` subtree)
* `SNAP_57514.lite.nxs.h5` 7.7GB file, 10.6GB workspace
* `SNAP_57480.nxs.h5` 21GB file, 29.8GB workspace

The baseline for "fastest possible" is using `dd` to copy the file to `/dev/null`. 
This makes the time for reading and not writing.
`LoadEventNexus` is run with only a filename and output workspace name.

Timing on my laptop (run 5 times each):

| file                  | dd    | `main`   | this PR |
|--------------------|------|-------|----------|
| SNAP_57514 |  6.1s | 6.8s | 6.5s |
| SNAP_57480 | 17.0s | 28.2s  | 26.5s |

Timing on my analysis-node17 (run 5 times each for little file, run 2 times each for big file):

| file                 | dd    | `main`   | this PR |
|-------------------|-------|-------|----------|
| SNAP_57514 |    23s | 1m21s | 1m36s |
| SNAP_57480 | 1m4s | 4m20s | 4m55s |

analysis computer times for `LoadEventNexus` varied by ~30s

*There is no associated issue,* but it is related to [EWM2463](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2463)

### To test:

Since this is performance improvement, there isn't much to test. Try loading event nexus files and see that they still work.

*This does not require release notes* because it is a very minor performance improvement and is more of a code cleanup.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->



---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
