### PR TITLE
Fix unreliable python interface startup test

### DIFF
--- a/Testing/SystemTests/tests/qt/PythonInterfacesStartupTest.py
+++ b/Testing/SystemTests/tests/qt/PythonInterfacesStartupTest.py
@@ -43,6 +43,7 @@ class PythonInterfacesStartupTest(systemtesting.MantidSystemTest):
         import mantidqtinterfaces
 
         self._interface_directory = os.path.dirname(mantidqtinterfaces.__file__)
+        # The order of the scripts in this iterable is random
         self._interface_scripts = set(chain.from_iterable(gather_python_interface_names().values()))
 
     def runTest(self):

--- a/Testing/SystemTests/tests/qt/PythonInterfacesStartupTest.py
+++ b/Testing/SystemTests/tests/qt/PythonInterfacesStartupTest.py
@@ -13,6 +13,8 @@ from workbench.utils.gather_interfaces import gather_python_interface_names
 
 from qtpy.QtCore import QCoreApplication, QSettings
 
+ORGANIZATION_NAME = " "
+
 INSTRUMENT_SWITCHER = {"DGS_Reduction.py": "ARCS", "ORNL_SANS.py": "EQSANS", "Powder_Diffraction_Reduction.py": "NOM"}
 
 APP_NAME_SWITCHER = {"DGS_Reduction.py": "python", "ORNL_SANS.py": "python", "Powder_Diffraction_Reduction.py": "python"}
@@ -21,12 +23,13 @@ APP_NAME_SWITCHER = {"DGS_Reduction.py": "python", "ORNL_SANS.py": "python", "Po
 def set_instrument(interface_script_name):
     instrument = INSTRUMENT_SWITCHER.get(interface_script_name, None)
     if instrument is not None:
-        QSettings().setValue("instrument_name", instrument)
+        app_name = APP_NAME_SWITCHER.get(interface_script_name, "mantid")
+        QSettings(ORGANIZATION_NAME, app_name).setValue("instrument_name", instrument)
 
 
 def set_application_name(interface_script_name):
     app_name = APP_NAME_SWITCHER.get(interface_script_name, "mantid")
-    QCoreApplication.setOrganizationName(" ")
+    QCoreApplication.setOrganizationName(ORGANIZATION_NAME)
     QCoreApplication.setApplicationName(app_name)
 
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
@@ -13,7 +13,7 @@ import os
 import traceback
 from mantidqt.gui_helper import get_qapplication
 from qtpy.QtWidgets import QAction, QDialog, QFileDialog, QMainWindow, QMessageBox
-from qtpy.QtCore import QFile, QFileInfo, QSettings
+from qtpy.QtCore import QCoreApplication, QFile, QFileInfo, QSettings
 from mantid.kernel import Logger
 
 # Check whether Mantid is available
@@ -65,7 +65,7 @@ class ReductionGUI(QMainWindow):
             QMessageBox.warning(self, "WARNING", message)
 
         # Application settings
-        settings = QSettings()
+        settings = QSettings(QCoreApplication.organizationName(), QCoreApplication.applicationName())
 
         # Name handle for the instrument
         if instrument is None:


### PR DESCRIPTION
### Description of work

This PR fixes an unreliable failure in the `PythonInterfaceStartupTest`. A recent change to how we gather the interfaces names means that the list of python scripts has a random order each time the `gather_python_interfaces` function is called. In hindsight, it is much preferred to test opening the python interfaces in a random order (a bit like how we randomize the order of the system tests themselves).

The unreliable failure was caused by the `instrument_name` setting not propagating through to the interface script. This was because we were opening a new `QSettings` object with no parameters provided to its constructor, but it is actually recommended to provide an organization and application name to address the following potential problem:

- Namespace Conflicts: If your application doesn't have a unique organization and application name, you might encounter namespace conflicts with other applications that use the same default names. This can result in your application's settings interfering with or being interfered by settings from other applications, leading to unexpected behavior or data corruption.

*There is no associated issue.*

### To test:
Only a code review is required

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
