### PR TITLE
Fix UserFunction not updating in Muon Analysis

### DIFF
--- a/Framework/CurveFitting/src/Functions/UserFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/UserFunction.cpp
@@ -59,9 +59,11 @@ double *UserFunction::AddVariable(const char *varName, void *pufun) {
  * expression string
  */
 void UserFunction::setAttribute(const std::string &attName, const Attribute &value) {
+  auto const reevaluateFormula = attName == "Formula" && m_formula != value.value();
+
   IFunction::setAttribute(attName, value);
 
-  if (attName != "Formula") {
+  if (!reevaluateFormula) {
     return;
   }
 

--- a/Framework/CurveFitting/test/Functions/UserFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/UserFunctionTest.h
@@ -76,4 +76,26 @@ public:
     TS_ASSERT(categories.size() == 1);
     TS_ASSERT(categories[0] == "General");
   }
+
+  void test_setAttribute_will_reevaluate_function_if_it_has_changed() {
+    UserFunction fun;
+    fun.setAttribute("Formula", UserFunction::Attribute("a*x"));
+    fun.setParameter("a", 1.1);
+
+    fun.setAttribute("Formula", UserFunction::Attribute("a*x+b"));
+
+    // Check that the 'a' parameter has been reset
+    TS_ASSERT_EQUALS(0.0, fun.getParameter("a"));
+  }
+
+  void test_setAttribute_will_not_reevaluate_function_if_the_function_has_not_changed() {
+    UserFunction fun;
+    fun.setAttribute("Formula", UserFunction::Attribute("a*x"));
+    fun.setParameter("a", 1.1);
+
+    fun.setAttribute("Formula", UserFunction::Attribute("a*x"));
+
+    // Check that the 'a' parameter has not been reset
+    TS_ASSERT_EQUALS(1.1, fun.getParameter("a"));
+  }
 };

--- a/docs/source/release/v6.9.0/Muon/Muon_Analysis/Bugfixes/35621.rst
+++ b/docs/source/release/v6.9.0/Muon/Muon_Analysis/Bugfixes/35621.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where the parameters for a UserFunction after a simultaneous fit were not being updated.


### PR DESCRIPTION
### Description of work
This PR fixes a bug where the UserFunction selected in the Muon Analysis GUI was being re-evaluated each time the view was being updated. Each time the view is updated, the attributes in the function are synced with the function that has just been fitted. Even if the "Formula" attribute has not been changed, it was being updated and then re-evaluated after each fit. This effectively cleared the parameter values achieved from the previous fit, leaving them with a value of zero.

The solution was to ensure we only re-evaluate the UserFunction if the formula attribute has changed. 

Fixes #35621

### To test:
Open muon analysis
Set the instrument to MUSR
In the run box enter 62260
Go to the fitting tab
Tick the Simultaneous over box
Add a FlatBackground
Add a UserFunction - this used to cause a crash
In the UserFunction's formula box, press the ... to get a pop-up
In the big white box at the bottom enter a*x as the function and press use
Tick the global box next to the a parameter
Press fit
You should see that the `a` parameter has a non-zero value.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
