### PR TITLE
Fix for waterfall plots not updating their axes limits when offsets were updated

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1137,10 +1137,10 @@ class MantidAxes(Axes):
 
         datafunctions.set_waterfall_toolbar_options_enabled(self)
 
+        self.relim()
         if not self.waterfall_has_fill():
             # The mpl ax.fill method already makes an autoscale request for us,
             # so we only need to do this if waterfall_update_fill hasn't been called
-            self.relim()
             self.autoscale()
 
         self.get_figure().canvas.draw()

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1136,6 +1136,13 @@ class MantidAxes(Axes):
             self.add_line(cap)
 
         datafunctions.set_waterfall_toolbar_options_enabled(self)
+
+        if not self.waterfall_has_fill():
+            # The mpl ax.fill method already makes an autoscale request for us,
+            # so we only need to do this if waterfall_update_fill hasn't been called
+            self.relim()
+            self.autoscale()
+
         self.get_figure().canvas.draw()
 
     def set_waterfall(self, state, x_offset=None, y_offset=None, fill=False):

--- a/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
@@ -672,6 +672,62 @@ class MantidAxesTest(unittest.TestCase):
         # There should still be only two filled areas (one for each line)
         self.assertEqual(len(datafunctions.get_waterfall_fills(ax)), 2)
 
+    def test_increasing_waterfall_x_offset_will_autoscale_x_axis(self):
+        fig, ax = plt.subplots(subplot_kw={"projection": "mantid"})
+        ax.plot([0, 1], [0, 1])
+        ax.plot([0, 1], [0, 1])
+
+        # Make a waterfall plot
+        ax.set_waterfall(True, x_offset=20)
+        x_high = ax.get_xlim()[1]
+
+        # Increase x offset
+        ax.update_waterfall(x_offset=40, y_offset=ax.waterfall_y_offset)
+
+        self.assertGreater(ax.get_xlim()[1], x_high)
+
+    def test_decreasing_waterfall_x_offset_will_autoscale_x_axis(self):
+        fig, ax = plt.subplots(subplot_kw={"projection": "mantid"})
+        ax.plot([0, 1], [0, 1])
+        ax.plot([0, 1], [0, 1])
+
+        # Make a waterfall plot
+        ax.set_waterfall(True, x_offset=40)
+        x_high = ax.get_xlim()[1]
+
+        # Decrease x offset
+        ax.update_waterfall(x_offset=20, y_offset=ax.waterfall_y_offset)
+
+        self.assertLess(ax.get_xlim()[1], x_high)
+
+    def test_increasing_waterfall_y_offset_will_autoscale_y_axis(self):
+        fig, ax = plt.subplots(subplot_kw={"projection": "mantid"})
+        ax.plot([0, 1], [0, 1])
+        ax.plot([0, 1], [0, 1])
+
+        # Make a waterfall plot
+        ax.set_waterfall(True, y_offset=20)
+        y_high = ax.get_ylim()[1]
+
+        # Increase y off set
+        ax.update_waterfall(x_offset=ax.waterfall_x_offset, y_offset=40)
+
+        self.assertGreater(ax.get_ylim()[1], y_high)
+
+    def test_decreasing_waterfall_y_offset_will_autoscale_y_axis(self):
+        fig, ax = plt.subplots(subplot_kw={"projection": "mantid"})
+        ax.plot([0, 1], [0, 1])
+        ax.plot([0, 1], [0, 1])
+
+        # Make a waterfall plot
+        ax.set_waterfall(True, y_offset=40)
+        y_high = ax.get_ylim()[1]
+
+        # Decrease y off set
+        ax.update_waterfall(x_offset=ax.waterfall_x_offset, y_offset=20)
+
+        self.assertLess(ax.get_ylim()[1], y_high)
+
     def test_imshow_with_origin_upper(self):
         image = self.ax.imshow(self.ws2d_histo, origin="upper")
 

--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36261.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36261.rst
@@ -1,0 +1,1 @@
+- Fix a bug where changing waterfall x and y off sets would not update the plot axes limits.


### PR DESCRIPTION
### Description of work

Previously, when fill was turned off, waterfall plots were not updating their axes limits when increasing or decreasing the x and y offset. This meant, with enough offset, plots could run out of the plot window.

It was working when fill was turned on because matplotlib's `ax.fill()` method makes an autoscale request. I've added in a request in the case the plot isn't filled, so the behaviour is the same.

Fixes #36261 

### To test:

- Load some data
- Plot a waterfall plot with several spectra
- Using the waterfall plot offset widget, increase x and y off sets
- The axes limits should increase to keep the plot in frame
- Decrease the off sets
- The axes limits should decrease
- Toggling fill on and off shouldn't affect things

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
