### PR TITLE
Fix error in generated MDHisto plot script

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -111,6 +111,11 @@ def _get_data_for_plot(axes, workspace, kwargs, with_dy=False, with_dx=False):
         (normalization, kwargs) = get_normalization(workspace, **kwargs)
         indices, kwargs = get_indices(workspace, **kwargs)
         (x, y, dy) = get_md_data1d(workspace, normalization, indices)
+        # Protect against unused arguments for MDHisto workspaces
+        if "wkspIndex" in kwargs:
+            kwargs.pop("wkspIndex")
+        if "specNum" in kwargs:
+            kwargs.pop("specNum")
         dx = None
         axis = None
     else:

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -236,6 +236,10 @@ class MantidAxes(Axes):
                     if artist == ws_artist:
                         return ws_artists.is_normalized
 
+    def get_is_mdhisto_workspace_for_artist(self, artist) -> bool:
+        workspace, _ = self.get_artists_workspace_and_workspace_index(artist)
+        return (workspace is not None) and workspace.isMDHistoWorkspace()
+
     def track_workspace_artist(
         self,
         workspace,

--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/35749.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/35749.rst
@@ -1,0 +1,1 @@
+- Fixed error in plot script generated for 1D MDHisto workspace plots.

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/lines.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/lines.py
@@ -149,10 +149,10 @@ def _get_mantid_specific_plot_kwargs(artist):
         return dict()
     sample_log_plot_details = ax.get_artists_sample_log_plot_details(artist)
     if sample_log_plot_details is None:
-        plot_kwargs = {
-            "wkspIndex": ax.get_artists_workspace_and_workspace_index(artist)[1],
-            "distribution": not ax.get_artist_normalization_state(artist),
-        }
+        plot_kwargs = dict()
+        if not ax.get_is_mdhisto_workspace_for_artist(artist):
+            plot_kwargs["wkspIndex"] = ax.get_artists_workspace_and_workspace_index(artist)[1]
+        plot_kwargs["distribution"] = not ax.get_artist_normalization_state(artist)
         ax_type = ax.creation_args[0].get("axis", None)
         if ax_type:
             plot_kwargs["axis"] = ax_type

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlines.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratorlines.py
@@ -17,7 +17,7 @@ from matplotlib.container import ErrorbarContainer
 from mantid.plots.utility import MantidAxType
 
 from unittest.mock import Mock, patch
-from mantid.simpleapi import CreateWorkspace, AddTimeSeriesLog
+from mantid.simpleapi import CreateWorkspace, AddTimeSeriesLog, CreateMDHistoWorkspace
 from workbench.plotting.plotscriptgenerator.lines import (
     _get_plot_command_kwargs_from_line2d,
     _get_errorbar_specific_plot_kwargs,
@@ -63,6 +63,16 @@ class PlotScriptGeneratorLinesTest(unittest.TestCase):
         cls.test_ws = CreateWorkspace(
             DataX=[10, 20, 30, 10, 20, 30], DataY=[2, 3, 4, 5], DataE=[1, 2, 3, 4], NSpec=2, OutputWorkspace="test_ws"
         )
+        cls.test_mdhisto_ws = CreateMDHistoWorkspace(
+            SignalInput="1,1,1",
+            ErrorInput="1,1,1",
+            Dimensionality=1,
+            Extents="0,2",
+            NumberOfBins="3",
+            Names="X",
+            Units="arb",
+            OutputWorkspace="test_mdhisto_ws",
+        )
 
     def setUp(self):
         fig = plt.figure()
@@ -83,6 +93,13 @@ class PlotScriptGeneratorLinesTest(unittest.TestCase):
         line = self.ax.plot(self.test_ws, **kwargs)[0]
         output = generate_plot_command(line)
         expected_command = "plot({}, {})".format(self.test_ws.name(), convert_args_to_string(None, kwargs))
+        self.assertEqual(expected_command, output)
+
+    def test_generate_plot_command_correct_arguments_for_mdhisto(self):
+        kwargs = copy(LINE2D_KWARGS)
+        line = self.ax.plot(self.test_mdhisto_ws, **kwargs)[0]
+        output = generate_plot_command(line)
+        expected_command = "plot({}, {})".format(self.test_mdhisto_ws.name(), convert_args_to_string(None, kwargs))
         self.assertEqual(expected_command, output)
 
     def test_generate_plot_command_returns_correct_string_for_sample_log(self):


### PR DESCRIPTION
### Description of work
Only add the `wkspIndex` argument to the plot script if the workspace is not an `MDHisto` workspace. Also add extra protection against the `wkspIndex` and/or the `specNum` being passed to `MDHisto` plot methods.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
- Check that the artist doesn't correspond to an `MDHisto` workspace before adding `wkspIndex` to the plot arguments in the generated script.
- Filter out `wkspIndex` and/or the `specNum` arguments when we know we're dealing with an `MDHisto` workspace. This should provide some extra protection, i.e. those arguments will now just be ignored instead of causing an error.

Fixes #35749. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
See #35749 for details on how to reproduce. Generated plot scripts are potentially affected so worth testing those for other plot types.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
