### PR TITLE
Stop plot legends interfering with tight layout

### DIFF
--- a/Framework/PythonInterface/mantid/plots/legend.py
+++ b/Framework/PythonInterface/mantid/plots/legend.py
@@ -123,11 +123,15 @@ class LegendProperties(dict):
     def create_legend(cls, props, ax):
         # Imported here to prevent circular import.
         from mantid.plots.datafunctions import get_legend_handles
+        from matplotlib.layout_engine import TightLayoutEngine
 
         loc = ConfigService.getString("plots.legend.Location")
         font_size = float(ConfigService.getString("plots.legend.FontSize"))
         if not props:
-            legend_set_draggable(ax.legend(handles=get_legend_handles(ax), loc=loc, prop={"size": font_size}), True)
+            legend = ax.legend(handles=get_legend_handles(ax), loc=loc, prop={"size": font_size})
+            if type(ax.figure.get_layout_engine()) == TightLayoutEngine:
+                legend.set_in_layout(False)
+            legend_set_draggable(legend, True)
             return
 
         if "loc" in props.keys():
@@ -187,4 +191,9 @@ class LegendProperties(dict):
             text.set_color(props["entries_color"])
 
         legend.set_visible(props["visible"])
+
+        # Dragging the legend around in a tight layout plot causes some strange behaviour
+        if type(ax.figure.get_layout_engine()) == TightLayoutEngine:
+            legend.set_in_layout(False)
+
         legend_set_draggable(legend, True)

--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -228,8 +228,6 @@ def plot(
         legend = ax.get_legend()
         if legend is not None:
             legend.set_visible(show_legend)
-            # Stop legend interfering with the tight layout
-            legend.set_in_layout(False)
 
     # Can't have a waterfall plot with only one line.
     if len(nums) * len(workspaces) == 1 and waterfall:

--- a/Framework/PythonInterface/test/python/mantid/plots/legendTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/legendTest.py
@@ -32,6 +32,7 @@ class LegendTest(unittest.TestCase):
     def test_calling_create_legend_with_no_props_adds_legend_to_plot(self):
         ax = mock.Mock(spec=MantidAxes)
         ax.lines = [mock.Mock()]
+        ax.figure = mock.Mock()
 
         LegendProperties.create_legend(props=None, ax=ax)
 
@@ -41,6 +42,7 @@ class LegendTest(unittest.TestCase):
     def test_calling_create_legend_with_no_props_uses_config_values_in_legend(self, mock_ConfigService):
         ax = mock.Mock(spec=MantidAxes)
         ax.lines = [mock.Mock()]
+        ax.figure = mock.Mock()
 
         LegendProperties.create_legend(props=None, ax=ax)
 

--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36267.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36267.rst
@@ -1,0 +1,1 @@
+- Fixed bug where, in certain cases, dragging a plot's legend could cause the plot to resize.


### PR DESCRIPTION
### Description of work

In the [PR](https://github.com/mantidproject/mantid/pull/35195) where plots were set to have a tight layout by default, I had to detach the legend from the layout so that when you dragged it around it wouldn't resize the plot in strange ways.

This pr reimplements what fix in a more robust way, as the bug still exists if you cause the legend to update.

#### Summary of work 

Added a check to the `LegendProperties.create_legend()` method which sets `in_layout` to false if the plot has a tight layout. This ensures all legends go through this check

Fixes #36267

### To test:

- Load some data and plot 2 spectra
- Test dragging the legend, it should not resize the plot.
- Open the plot settings, go to the curves tab and remove ne of the lines
- Click okay and make sure the update legend also can be dragged without the plot resizing
- Finally, click 'Fit' to open the fitting interface
- Add a peak and run the fit
- Check the new legend also behaves as it should

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
