### PR TITLE
Changes in Redfield documentation.

### DIFF
--- a/docs/source/fitting/fitfunctions/Redfield.rst
+++ b/docs/source/fitting/fitfunctions/Redfield.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 The Redfield formula for the Longitudinal Field (LF) dependence of the muon spin relaxation rate, :math:`\Lambda`, given in units of
-:math:`\s^{-1}`, with the applied longitudinal magnetic field, for given local magnetic field (:math:`H_\text{loc}`) and correlation time of
+:math:`\mu s^{-1}`, with the applied longitudinal magnetic field, for given local magnetic field (:math:`H_\text{loc}`) and correlation time of
 fluctuations at muon spin sites (:math:`\tau`) is:
 
 .. math:: \Lambda(t)= \frac{2\gamma^2_\mu H^2_\text{loc}\tau}{1+\gamma^2_\mu H^2_\text{LF} \tau^2}
@@ -19,7 +19,7 @@ where,
 
 :math:`H_\text{loc}` is the local magnetic field, in Gauss,
 
-:math:`H_\text{LF}` is the longitudinal magnetic field applied, in Gauss,
+:math:`H_\text{LF}` is the applied longitudinal magnetic field, in Gauss,
 
 :math:`\tau' is the muon spin correlation time, in microseconds, with expression given as :math:`\tau = \frac{1}{f}`
 where :math:`f` is the frequency of fluctuation at muon sites.

--- a/docs/source/fitting/fitfunctions/Redfield.rst
+++ b/docs/source/fitting/fitfunctions/Redfield.rst
@@ -9,30 +9,41 @@ Redfield
 Description
 -----------
 
-The Redfield formula for the LF dependence on the muon spin relaxation rate.
+The Redfield formula for the Longitudinal Field (LF) dependence of the muon spin relaxation rate, :math:`\Lambda`, given in units of
+:math:`\s^{-1}`, with the applied longitudinal magnetic field, for given local magnetic field (:math:`H_\text{loc}`) and correlation time of
+fluctuations at muon spin sites (:math:`\tau`) is:
 
 .. math:: \Lambda(t)= \frac{2\gamma^2_\mu H^2_\text{loc}\tau}{1+\gamma^2_\mu H^2_\text{LF} \tau^2}
 
 where,
 
-:math:`H_\text{loc}` is the local magnetic field,
+:math:`H_\text{loc}` is the local magnetic field, in Gauss,
 
-:math:`H_\text{LF}` is the longitudinal magnetic field applied,
+:math:`H_\text{LF}` is the longitudinal magnetic field applied, in Gauss,
 
-and its expression is given as :math:`\tau = \frac{1}{f}`
+:math:`\tau' is the muon spin correlation time, in microseconds, with expression given as :math:`\tau = \frac{1}{f}`
 where :math:`f` is the frequency of fluctuation at muon sites.
 
+And :math:'\gamma_\mu' is the gyromagnetic ratio of the muon spin, given in units of :math:'[rad]x\frac{MHz}{Gauss}'
 .. plot::
 
-   from mantid.simpleapi import FunctionWrapper
-   import matplotlib.pyplot as plt
-   import numpy as np
-   x = np.logspace(-2, 4, num = 1000)
-   y = FunctionWrapper("Redfield")
-   fig, ax=plt.subplots()
-   ax.plot(x, y(x))
-   ax.set_xlabel('t($\mu$s)')
-   ax.set_ylabel('A(t)')
+    from mantid.simpleapi import FunctionWrapper
+    import matplotlib.pyplot as plt
+    import numpy as np
+    x = np.logspace(-1, 3.4, num = 200)
+    h = np.linspace(0.05, 0.2, 5)
+    y = []
+    Redfield = FunctionWrapper("Redfield")
+    for hloc in h:
+        y.append(Redfield(x, hloc))
+
+    fig, ax = plt.subplots()
+
+    ax.plot(x, np.array(y).T, label=['{:.2f}'.format(item) for item in h])
+    ax.legend(title='$H_{loc}$ (G)')
+    ax.set_xscale("log")
+    ax.set_xlabel('$H_{LF}$ (Gauss)')
+    ax.set_ylabel('$\Lambda(\mu s^{-1})$')
 
 .. attributes::
 

--- a/docs/source/fitting/fitfunctions/Redfield.rst
+++ b/docs/source/fitting/fitfunctions/Redfield.rst
@@ -21,29 +21,29 @@ where,
 
 :math:`H_\text{LF}` is the applied longitudinal magnetic field, in Gauss,
 
-:math:`\tau' is the muon spin correlation time, in microseconds, with expression given as :math:`\tau = \frac{1}{f}`
+:math:`\tau` is the muon spin correlation time, in microseconds, with expression given as :math:`\tau = \frac{1}{f}`
 where :math:`f` is the frequency of fluctuation at muon sites.
 
 And :math:`\gamma_\mu` is the gyromagnetic ratio of the muon spin, given in units of :math:`[rad]x\frac{MHz}{Gauss}`
+
 .. plot::
 
-    from mantid.simpleapi import FunctionWrapper
-    import matplotlib.pyplot as plt
-    import numpy as np
-    x = np.logspace(-1, 3.4, num = 200)
-    h = np.linspace(0.05, 0.2, 5)
-    y = []
-    Redfield = FunctionWrapper("Redfield")
-    for hloc in h:
-        y.append(Redfield(x, hloc))
+	from mantid.simpleapi import FunctionWrapper
+	import matplotlib.pyplot as plt
+	import numpy as np
+	x = np.logspace(-1, 3.4, num = 200)
+	h = np.linspace(0.05, 0.2, 5)
+	y = []
+	Redfield = FunctionWrapper("Redfield")
+	for hloc in h:
+		y.append(Redfield(x, hloc))
 
-    fig, ax = plt.subplots()
-
-    ax.plot(x, np.array(y).T, label=['{:.2f}'.format(item) for item in h])
-    ax.legend(title='$H_{loc}$ (G)')
-    ax.set_xscale("log")
-    ax.set_xlabel('$H_{LF}$ (Gauss)')
-    ax.set_ylabel('$\Lambda(\mu s^{-1})$')
+	fig, ax = plt.subplots()
+	ax.plot(x, np.array(y).T, label=['{:.2f}'.format(item) for item in h])
+	ax.legend(title='$H_{loc}$ (G)')
+	ax.set_xscale("log")
+	ax.set_xlabel('$H_{LF}$ (Gauss)')
+	ax.set_ylabel('$\Lambda(\mu s^{-1})$')
 
 .. attributes::
 

--- a/docs/source/fitting/fitfunctions/Redfield.rst
+++ b/docs/source/fitting/fitfunctions/Redfield.rst
@@ -24,7 +24,7 @@ where,
 :math:`\tau' is the muon spin correlation time, in microseconds, with expression given as :math:`\tau = \frac{1}{f}`
 where :math:`f` is the frequency of fluctuation at muon sites.
 
-And :math:'\gamma_\mu' is the gyromagnetic ratio of the muon spin, given in units of :math:'[rad]x\frac{MHz}{Gauss}'
+And :math:`\gamma_\mu` is the gyromagnetic ratio of the muon spin, given in units of :math:`[rad]x\frac{MHz}{Gauss}`
 .. plot::
 
     from mantid.simpleapi import FunctionWrapper


### PR DESCRIPTION
### Description of work
This PR improves the description of the Redfield equation fitting function in the documentation page, to improve its readability. Units are expressed for all the parameters in the equation. Additionally, the xlabel in the original documentation file was incorrect, as it is not plotting the relaxation time but the applied longitudinal field. The plot has been corrected and parameter comparison with different local fields has been added. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #35502. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
