### PR TITLE
33394 sliceviewer cut exports error fixes

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/33394.rst
+++ b/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/33394.rst
@@ -1,0 +1,1 @@
+- Enables slice viewer's 'y' cut exports for event workspaces without giving errors in line plot and ROI modes.

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -133,6 +133,7 @@ set(PYTHON_WIDGET_QT5_ONLY_TESTS
     mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
     mantidqt/widgets/sliceviewer/test/test_sliceviewer_zoom.py
     mantidqt/widgets/sliceviewer/test/test_workspace_info.py
+    mantidqt/widgets/sliceviewer/test/test_roi.py
     mantidqt/widgets/sliceviewer/cutviewer/test/test_cutviewer_model.py
     mantidqt/widgets/sliceviewer/cutviewer/test/test_cutviewer_presenter.py
     mantidqt/widgets/sliceviewer/cutviewer//representation/test/test_cut_representation.py

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_roi.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_roi.py
@@ -1,0 +1,46 @@
+import unittest
+from mantidqt.widgets.sliceviewer.models.roi import _adjust_xmin_xmax_for_event_workspace
+from mantid.simpleapi import *
+
+
+class TestROIDefs(unittest.TestCase):
+    def setUp(self) -> None:
+        np.random.seed(13)
+
+    def test_adjust_xmin_xmax_for_event_workspace(self):
+        event_ws = CreateSampleWorkspace(WorkspaceType="Event")
+        ws_index_min = np.random.randint(event_ws.getNumberHistograms())
+        xmin = xmax = np.random.uniform(event_ws.getTofMin(), event_ws.getTofMax())
+        new_xmin, new_xmax = _adjust_xmin_xmax_for_event_workspace(event_ws, xmin, xmax, ws_index_min)
+        self.assertEqual(new_xmin, event_ws.readX(ws_index_min)[event_ws.yIndexOfX(xmin)])
+        self.assertEqual(new_xmax, event_ws.readX(ws_index_min)[event_ws.yIndexOfX(xmin) + 1])
+
+    def test_adjust_xmin_xmax_for_event_workspace_for_unequal_xvalues(self):
+        event_ws = CreateSampleWorkspace(WorkspaceType="Event")
+        ws_index_min = np.random.randint(event_ws.getNumberHistograms())
+        xmin = np.random.uniform(event_ws.getTofMin(), event_ws.getTofMax() - 1)
+        xmax = np.random.uniform(xmin + 1, event_ws.getTofMax())
+        new_xmin, new_xmax = _adjust_xmin_xmax_for_event_workspace(event_ws, xmin, xmax, ws_index_min)
+        self.assertEqual(new_xmin, xmin)
+        self.assertEqual(new_xmax, xmax)
+
+    def test_no_adjust_to_xmin_xmax_for_non_event_workspace(self):
+        ws = CreateSampleWorkspace()
+        ws_index_min = np.random.randint(ws.getNumberHistograms())
+        xmin = np.random.uniform(ws.readX(ws_index_min)[0], ws.readX(ws_index_min)[-1] - 1)
+        xmax = np.random.uniform(xmin + 1, ws.readX(ws_index_min)[-1])
+        new_xmin, new_xmax = _adjust_xmin_xmax_for_event_workspace(ws, xmin, xmax, ws_index_min)
+        self.assertEqual(new_xmin, xmin)
+        self.assertEqual(new_xmax, xmax)
+
+    def test_no_adjust_to_xmin_xmax_for_non_event_workspace_equal_xvalues(self):
+        ws = CreateSampleWorkspace()
+        ws_index_min = np.random.randint(ws.getNumberHistograms())
+        xmin = xmax = np.random.uniform(ws.readX(ws_index_min)[0], ws.readX(ws_index_min)[-1])
+        new_xmin, new_xmax = _adjust_xmin_xmax_for_event_workspace(ws, xmin, xmax, ws_index_min)
+        self.assertEqual(new_xmin, xmin)
+        self.assertEqual(new_xmax, xmax)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Error when sliceviewer exports Y cuts as func of spectra for EventWorkspace it gave errors on lineplot mode and ROI modes.

#### Summary of work
Error raised in ROI mode was due to trying to apply Transpose algorithm on Event workspaces. As a fix to this Rebin algorithm was applied to PreserveEvents=False for event workspaces. The error raised in lineplot mode was due to having same xvalues in the pixel cuts for event workspaces. This was handled by re-adjusting the xmin and xmax values related to the Y cut which were initially equal to the edges of the corresponding bin.

Fixes #33394. 

### To test:

To Reproduce
(1) Load in CNCS_7860_event.nxs
(2) Open in sliceviewer
(3) Enable line plots
(4) Press 'y' and it should create the Y cut export without any errors
(5) Enable ROI
(6) Draw a rectangle
(7) Press 'y' and should create the Y cut export without any errors

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
