### PR TITLE
Upgrade to matplotlib 3.7

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -958,7 +958,7 @@ class MantidAxes(Axes):
                 for col in artist_orig.collections:
                     col.remove()
             if hasattr(artist_orig, "colorbar_cid"):
-                artist_orig.callbacksSM.disconnect(artist_orig.colorbar_cid)
+                artist_orig.callbacks.disconnect(artist_orig.colorbar_cid)
         # If the colormap has been overridden then it needs to be passed in at
         # creation time
         if "colors" not in kwargs:
@@ -1270,7 +1270,7 @@ class MantidAxes(Axes):
         cb = colorbar
         cb.mappable = mappable
         mappable.colorbar = cb
-        mappable.colorbar_cid = mappable.callbacksSM.connect("changed", cb.update_normal)
+        mappable.colorbar_cid = mappable.callbacks.connect("changed", cb.update_normal)
         cb.update_normal(mappable)
 
     def _remove_matching_curve_from_creation_args(self, workspace_name, workspace_index, spec_num):

--- a/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
+++ b/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
@@ -138,7 +138,7 @@ class SamplingImage(MantidImage):
         this limits the range that the data will be sampled. Return True or False if extents have changed.
         """
         new_extent = self.axes.get_xlim() + self.axes.get_ylim()
-        if new_extent != self.get_extent():
+        if list(new_extent) != self.get_extent():
             self.set_extent(new_extent)
             return True
         else:

--- a/Framework/PythonInterface/mantid/plots/utility.py
+++ b/Framework/PythonInterface/mantid/plots/utility.py
@@ -151,7 +151,7 @@ def row_num(ax):
     Returns the row number of an input axes with relation to a gridspec
     """
     # An 'inset' axes does not have a subplotspec, so return None
-    return ax.get_subplotspec().rowspan.start if hasattr(ax, "get_subplotspec") else None
+    return ax.get_subplotspec().rowspan.start if ax.get_subplotspec() is not None else None
 
 
 def col_num(ax):
@@ -159,7 +159,7 @@ def col_num(ax):
     Returns the column number of an input axes with relation to a gridspec
     """
     # An 'inset' axes does not have a subplotspec, so return None
-    return ax.get_subplotspec().colspan.start if hasattr(ax, "get_subplotspec") else None
+    return ax.get_subplotspec().colspan.start if ax.get_subplotspec() is not None else None
 
 
 def zoom_axis(ax, coord, x_or_y, factor):

--- a/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
@@ -679,7 +679,7 @@ class MantidAxesTest(unittest.TestCase):
         xy_pixels = self.ax.transAxes.transform((0, 0)) + (0.5, 0.5)
         bottom_left_corner = MouseEvent("motion_notify_event", self.fig.canvas, x=xy_pixels[0], y=xy_pixels[1])
 
-        self.assertEqual(image.get_extent(), (10.0, 30.0, 9.0, 3.0))
+        self.assertEqual(image.get_extent(), [10.0, 30.0, 9.0, 3.0])
         self.assertEqual(image.get_cursor_data(bottom_left_corner), 3.0)
 
     def test_imshow_with_origin_lower(self):
@@ -689,7 +689,7 @@ class MantidAxesTest(unittest.TestCase):
         xy_pixels = self.ax.transAxes.transform((0, 0)) + (0.5, 0.5)
         bottom_left_corner = MouseEvent("motion_notify_event", self.fig.canvas, x=xy_pixels[0], y=xy_pixels[1])
 
-        self.assertEqual(image.get_extent(), (10.0, 30.0, 3.0, 9.0))
+        self.assertEqual(image.get_extent(), [10.0, 30.0, 3.0, 9.0])
         self.assertEqual(image.get_cursor_data(bottom_left_corner), 2.0)
 
     def test_rename_workspace_relabels_curve_if_default_label(self):

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -26,7 +26,7 @@ numpy:
   - 1.22.*
 
 matplotlib:
-  - 3.6.*
+  - 3.7.*
 
 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch so should be fine after 1.12.4
 poco:

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -19,7 +19,7 @@ dependencies:
   - jsoncpp>=1.9.4,<2
   - libopenblas!=0.3.23,!=0.3.24 # pinned the same as macOS for consistency
   - librdkafka>=1.6.0
-  - matplotlib=3.6.*
+  - matplotlib=3.7.*
   - muparser>=2.3.2
   - nexus=4.4.*
   - ninja>=1.10.2

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -19,7 +19,7 @@ dependencies:
   - libopenblas!=0.3.23,!=0.3.24 # v0.3.23 causes a hang for the system tests on OSX, v0.3.24 causing unit test failure - investigation needed.
   - librdkafka>=1.6.0
   - muparser>=2.3.2
-  - matplotlib=3.6.*
+  - matplotlib=3.7.*
   - nexus=4.4.*
   - ninja>=1.10.2
   - numpy>=1.22,<1.25

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -19,7 +19,7 @@ dependencies:
   - librdkafka>=1.6.0
   - lib3mf # windows only
   - muparser>=2.3.2
-  - matplotlib=3.6.*
+  - matplotlib=3.7.*
   - nexus=4.4.*
   - ninja>=1.10.2
   - numpy>=1.22,<1.25

--- a/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
@@ -18,7 +18,6 @@ from mantidqt.widgets.plotconfigdialog.curvestabwidget import curve_has_errors, 
 
 
 class FigureErrorsManager(object):
-
     AXES_NOT_MANTIDAXES_ERR_MESSAGE = "Plot axes are not MantidAxes. There is no way to automatically load error data."
 
     def __init__(self, canvas):
@@ -55,7 +54,13 @@ class FigureErrorsManager(object):
         else:
             errorbar_cap_lines = []
 
-        ax.lines.insert(curve_index, ax.lines.pop())
+        # Since mpl 3.7 made ax.lines immutable, we have to do this workaround.
+        lines_to_remove = ax.get_lines()[curve_index:]
+        for line in lines_to_remove:
+            line.remove()
+        ax.add_line(lines_to_remove.pop())
+        for line in lines_to_remove:
+            ax.add_line(line)
 
         if isinstance(ax, MantidAxes) and ax.is_waterfall():
             datafunctions.convert_single_line_to_waterfall(ax, curve_index)

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -525,12 +525,10 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         for cap in errorbar_cap_lines:
             ax.add_line(cap)
 
-        """ArtistList will become an immutable tuple in matplotlib 3.7 which will prevent iterating through line_fill"""
-        for line_fill in fills:
+        for line_fill in reversed(fills):
             if line_fill not in ax.collections:
                 ax.add_collection(line_fill)
 
-        ax.collections.reverse()
         ax.update_waterfall(x, y)
 
         if ax.get_legend():

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -214,7 +214,7 @@ def get_axes_object_variable(ax):
     # plotted otherwise it returns a list
     ax_object_var = AXES_VARIABLE
 
-    if hasattr(ax, "get_gridspec") and hasattr(ax.get_gridspec(), "nrows") and hasattr(ax.get_gridspec(), "ncols"):
+    if ax.get_gridspec() and hasattr(ax.get_gridspec(), "nrows") and hasattr(ax.get_gridspec(), "ncols"):
         num_rows = ax.get_gridspec().nrows
         num_cols = ax.get_gridspec().ncols
     else:

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -277,7 +277,7 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
     @classmethod
     def _is_colorbar(cls, ax):
         """Determine whether an axes object is a colorbar"""
-        return ax.get_subplotspec() or hasattr(ax, "_colorbar")
+        return hasattr(ax, "_colorbar")
 
     def set_up_color_selector_toolbar_button(self, fig):
         # check if the action is already in the toolbar

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -277,7 +277,7 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
     @classmethod
     def _is_colorbar(cls, ax):
         """Determine whether an axes object is a colorbar"""
-        return not hasattr(ax, "get_subplotspec") or hasattr(ax, "_colorbar")
+        return ax.get_subplotspec() or hasattr(ax, "_colorbar")
 
     def set_up_color_selector_toolbar_button(self, fig):
         # check if the action is already in the toolbar

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -30,6 +30,7 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
         cls.x_label = "X"
         ax.set_xlabel(cls.x_label)
         cls.x_scale = "linear"
+        ax.set_xscale(cls.x_scale)
         cls.y_label = "Y"
         ax.set_ylabel(cls.y_label)
         cls.y_scale = "log"
@@ -223,7 +224,7 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
         new_view_mock = mock.Mock(get_selected_ax_name=lambda: "My Axes: (0, 0)", get_axis=lambda: "x", get_properties=lambda: {})
         ax = self.fig.get_axes()[0]
         setters = ["set_title", "set_lower_limit", "set_upper_limit", "set_label", "set_scale"]
-        expected_vals = [self.title, ax.get_xlim()[0], ax.get_xlim()[1], self.x_label, self.x_scale]
+        expected_vals = [self.title, ax.get_xlim()[0], ax.get_xlim()[1], self.x_label, self.x_scale.capitalize()]
         with mock.patch.object(presenter, "view", new_view_mock):
             presenter.update_view()
             for setter, value in zip(setters, expected_vals):

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -29,10 +29,10 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
         ax.set_title(cls.title)
         cls.x_label = "X"
         ax.set_xlabel(cls.x_label)
-        cls.x_scale = "Linear"
+        cls.x_scale = "linear"
         cls.y_label = "Y"
         ax.set_ylabel(cls.y_label)
-        cls.y_scale = "Log"
+        cls.y_scale = "log"
         ax.set_yscale(cls.y_scale)
         cls.canvas_color = (1.0, 1.0, 0.0, 1.0)
         ax.set_facecolor(cls.canvas_color)

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 
-import warnings
 
 from matplotlib.lines import Line2D
 
@@ -143,17 +142,16 @@ class CurvesTabWidgetPresenter:
         else:
             errorbar_cap_lines = []
 
-        # TODO: Accessing the ax.lines property is deprecated in mpl 3.5. It must be removed by mpl 3.7.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            # When a curve is redrawn it is moved to the back of the list of curves so here it is moved back to its previous
-            # position. This is so that the correct offset is applied to the curve if the plot is a waterfall plot, but it
-            # also just makes sense for the curve order to remain unchanged.
-            # ax.lines.insert(curve_index, ax.lines.pop())
-            lines_to_remove = ax.get_lines()[curve_index:]
-            map(lambda l: l.remove(), lines_to_remove)
-            ax.add_line(lines_to_remove.pop())
-            map(lambda l: ax.add_line(l), lines_to_remove)
+        # When a curve is redrawn it is moved to the back of the list of curves so here it is moved back to its previous
+        # position. This is so that the correct offset is applied to the curve if the plot is a waterfall plot, but it
+        # also just makes sense for the curve order to remain unchanged.
+        # Since mpl 3.7 made ax.lines immutable, we have to do this workaround.
+        lines_to_remove = ax.get_lines()[curve_index:]
+        for line in lines_to_remove:
+            line.remove()
+        ax.add_line(lines_to_remove.pop())
+        for line in lines_to_remove:
+            ax.add_line(line)
 
         if waterfall:
             # Set the waterfall offsets to what they were previously.

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -149,7 +149,11 @@ class CurvesTabWidgetPresenter:
             # When a curve is redrawn it is moved to the back of the list of curves so here it is moved back to its previous
             # position. This is so that the correct offset is applied to the curve if the plot is a waterfall plot, but it
             # also just makes sense for the curve order to remain unchanged.
-            ax.lines.insert(curve_index, ax.lines.pop())
+            # ax.lines.insert(curve_index, ax.lines.pop())
+            lines_to_remove = ax.get_lines()[curve_index:]
+            map(lambda l: l.remove(), lines_to_remove)
+            ax.add_line(lines_to_remove.pop())
+            map(lambda l: ax.add_line(l), lines_to_remove)
 
         if waterfall:
             # Set the waterfall offsets to what they were previously.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/representation/cut_representation.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/representation/cut_representation.py
@@ -110,7 +110,7 @@ class CutRepresentation:
             lines_to_clear.extend([self.start, self.end])  # normally don't delete these as artist data kept updated
         for line in lines_to_clear:
             if line in self.ax.lines:
-                self.ax.lines.remove(line)
+                line.remove()
 
     def on_press(self, event):
         if self.is_valid_event(event):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_painter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/representation/test/test_peaksviewer_representation_painter.py
@@ -18,7 +18,6 @@ from mantidqt.widgets.sliceviewer.peaksviewer.representation.painter import MplP
 
 
 class MplPainterTest(unittest.TestCase):
-
     # --------------- success tests -----------------
     def test_remove_calls_remove_on_artist(self):
         painter = MplPainter(MagicMock())
@@ -79,7 +78,7 @@ class MplPainterTest(unittest.TestCase):
         painter.shell(x, y, outer_radius, thick)
 
         painter.axes.add_patch.assert_called_once()
-        self._verify_patch(patch=painter.axes.add_patch.call_args[0][0], nvertices=100, alpha=None)
+        self._verify_patch(patch=painter.axes.add_patch.call_args[0][0], nvertices=99, alpha=None)
 
     def test_bbox_returns_ll_and_ur_of_containing_box(self):
         artist, view, axes, bbox, inv_trans = (MagicMock(),) * 5

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/HFIR_4Circle_Reduction/mplgraphicsview.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/HFIR_4Circle_Reduction/mplgraphicsview.py
@@ -1195,7 +1195,7 @@ class Qt4MplCanvas(FigureCanvas):
 
             for i_r in range(1, len(r)):
                 # remove the un-defined extra lines
-                self.axes.lines.remove(r[i_r])
+                r[i_r].remove()
         # END-IF-ELSE
 
         if annotation_list is not None and len(annotation_list) == len(vec_y):
@@ -1378,7 +1378,7 @@ class Qt4MplCanvas(FigureCanvas):
                 continue
             if isinstance(plot, tuple) is False:
                 try:
-                    self.axes.lines.remove(plot)
+                    plot.remove()
                 except ValueError as e:
                     print(
                         "[Error] Plot %s is not in axes.lines which has %d lines. Error message: %s"
@@ -1569,7 +1569,7 @@ class Qt4MplCanvas(FigureCanvas):
 
         if plot_key in self._lineDict:
             try:
-                self.axes.lines.remove(self._lineDict[plot_key])
+                self._lineDict[plot_key].remove()
             except ValueError as r_error:
                 error_message = "Unable to remove to 1D line %s (ID=%d) due to %s." % (
                     str(self._lineDict[plot_key]),

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/HFIR_4Circle_Reduction/mplgraphicsview3d.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/HFIR_4Circle_Reduction/mplgraphicsview3d.py
@@ -62,7 +62,7 @@ class MplPlot3dCanvas(FigureCanvas):
         """
         for plt in self._currPlotList:
             # del plt
-            self._myAxes.collections.remove(plt)
+            plt.remove()
         self._currPlotList = []
 
         return

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Colormap.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Colormap.h
@@ -18,7 +18,7 @@ namespace Widgets {
 namespace MplCpp {
 
 /**
- * @brief Defines a C++ wrapper for the matplotlib.cm.Colormap
+ * @brief Defines a C++ wrapper for the matplotlib.colors.Colormap
  * class
  */
 class MANTID_MPLCPP_DLL Colormap : public Common::Python::InstanceHolder {
@@ -28,6 +28,9 @@ public:
 
 /// Return the matplotlib.cm module
 MANTID_MPLCPP_DLL Common::Python::Object cmModule();
+
+/// Return the matplotlib.colormaps dict
+MANTID_MPLCPP_DLL Common::Python::Dict colormaps();
 
 /// Check if the named colormap if it exists
 MANTID_MPLCPP_DLL bool cmapExists(const QString &name);

--- a/qt/widgets/mplcpp/src/MantidColorMap.cpp
+++ b/qt/widgets/mplcpp/src/MantidColorMap.cpp
@@ -71,7 +71,7 @@ QString MantidColorMap::defaultColorMap() { return defaultCMapName(); }
  * match the existing interface in Plotting.
  * @param name The name of a colormap
  * @return The same name passed to the function if it exists
- * @throws std::runtime_error if the colomap does not exist
+ * @throws std::invalid_argument if the colomap does not exist
  */
 QString MantidColorMap::exists(const QString &name) {
   getCMap(name); // throws if it does not exist

--- a/qt/widgets/mplcpp/test/ColormapTest.h
+++ b/qt/widgets/mplcpp/test/ColormapTest.h
@@ -36,7 +36,7 @@ public:
 
   // ----------------------- Failure tests ------------------------
   void testgetCMapWithUnknownCMapThrowsException() {
-    TS_ASSERT_THROWS(getCMap("AnUnknownName"), const PythonException &);
+    TS_ASSERT_THROWS(getCMap("AnUnknownName"), const std::invalid_argument &);
   }
 
   void testConstructionWithNonColorMapObjectThrows() {

--- a/qt/widgets/mplcpp/test/MantidColormapTest.h
+++ b/qt/widgets/mplcpp/test/MantidColormapTest.h
@@ -24,7 +24,6 @@ public:
   // ----------------- failure tests ---------------------
 
   void testExistsThrowsIfMapDoesNotExist() {
-    using Mantid::PythonInterface::PythonException;
-    TS_ASSERT_THROWS(MantidColorMap::exists("NotAColormap"), const PythonException &);
+    TS_ASSERT_THROWS(MantidColorMap::exists("NotAColormap"), const std::invalid_argument &);
   }
 };


### PR DESCRIPTION
### Description of work

Upgrade from matplotlib `3.6.*` to `3.7.*`.

Change notes can be found [here](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.7.0.html)

#### Summary of work

This pr is mainly replacing removed methods / attributes with the recommended replacements. A particular challenge was the change which made [Axes children lists immutable](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.7.0.html#modification-of-axes-children-sublists). We rely on being able to recorder the `axes.lines` list for our waterfall plots, so a workaround had to be reached there.

Related to that change, some changes have been made to the HFIR 4Circle Reduction interface. There doesn't seem to be tests covering this code, so I've just spotted some things by eye and @zjmorgan is going to test.

Going to wait for #36334, so I can use the new release notes structure.

Fixes #36337
Fixes #36268
Fixes #36098
Fixes #35318

### To test:

Full package build can be found [here](https://builds.mantidproject.org/job/build_packages_from_branch/649/artifact/) (these built before I did the cpp colormap fix so there will be a deprecation warning about using `cm.get_cmap()` in some cases)

- Try to recreate the issues listed as fixed above.
- Run through the plotting section of the training course (or just try a wide array of plotting)
- Test some interfaces which use plots

There will probably be some introduced deprecation warnings so we should try and solve those now

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
