### PR TITLE
Add FindPeaksConvolve algorithm

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -150,6 +150,7 @@ set(SRC_FILES
     src/FindEPP.cpp
     src/FindPeakBackground.cpp
     src/FindPeaks.cpp
+    src/FindPeaksConvolve.cpp
     src/FitPeak.cpp
     src/FitPeaks.cpp
     src/FixGSASInstrumentFile.cpp
@@ -496,6 +497,7 @@ set(INC_FILES
     inc/MantidAlgorithms/FindEPP.h
     inc/MantidAlgorithms/FindPeakBackground.h
     inc/MantidAlgorithms/FindPeaks.h
+    inc/MantidAlgorithms/FindPeaksConvolve.h
     inc/MantidAlgorithms/FitPeak.h
     inc/MantidAlgorithms/FitPeaks.h
     inc/MantidAlgorithms/FixGSASInstrumentFile.h
@@ -854,6 +856,7 @@ set(TEST_FILES
     FindDetectorsOutsideLimitsTest.h
     FindEPPTest.h
     FindPeakBackgroundTest.h
+    FindPeaksConvolveTest.h
     FindPeaksTest.h
     FitPeakTest.h
     FitPeaksTest.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -28,7 +28,7 @@ typedef Eigen::TensorMap<const Eigen::Tensor<double, 1>> TensorMap_const;
 typedef Eigen::TensorMap<Eigen::Tensor<double, 1>> TensorMap;
 typedef Eigen::Map<const Eigen::VectorXd> EigenMap_const;
 
-const Mantid::HistogramData::HistogramX;
+class Mantid::HistogramData::HistogramX;
 
 namespace Mantid::Algorithms {
 
@@ -63,6 +63,8 @@ private:
   bool m_mergeNearbyPeaks;
   bool m_centreBins;
   Eigen::VectorXd m_pdf;
+  std::vector<std::string> m_intermediateWsNames;
+  std::mutex mtx;
 
   void init() override;
   void exec() override;
@@ -84,9 +86,10 @@ private:
   size_t findPeakInRawData(const int xIndex, const TensorMap_const &yData, size_t peakExtentBinNumber);
   void storePeakResults(const size_t dataIndex, std::vector<FindPeaksConvolve::PeakResult> &peakCentres);
   void generateNormalPDF(const int peakExtentBinNumber);
-  void createIntermediateWorkspaces(const size_t dataIndex, const Tensor1D &kernel, const Tensor1D &iOverSigma,
-                                    const HistogramData::HistogramX *xData);
-  void outputIntermediateWorkspace(const size_t dataIndex, const std::string &wsName, const std::vector<double> &xData,
+  std::vector<std::string> createIntermediateWorkspaces(const size_t dataIndex, const Tensor1D &kernel,
+                                                        const Tensor1D &iOverSigma,
+                                                        const HistogramData::HistogramX *xData);
+  void outputIntermediateWorkspace(const std::string &wsName, const std::vector<double> &xData,
                                    const std::vector<double> &yData);
   void outputResults();
   void outputResultsTable(const std::string &resultHeader);
@@ -94,7 +97,8 @@ private:
   createOutputTables(const std::vector<std::string> &outputTblNames);
   std::string populateOutputWorkspaces(const std::vector<std::string> &outputTblNames,
                                        const std::unordered_map<std::string, API::ITableWorkspace_sptr> &outputTbls);
-  API::WorkspaceGroup_sptr groupOutputWorkspaces(const std::vector<std::string> &outputTblNames);
+  API::WorkspaceGroup_sptr groupOutputWorkspaces(const std::string &outputName,
+                                                 const std::vector<std::string> &outputTblNames);
 };
 
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -28,7 +28,9 @@ typedef Eigen::TensorMap<const Eigen::Tensor<double, 1>> TensorMap_const;
 typedef Eigen::TensorMap<Eigen::Tensor<double, 1>> TensorMap;
 typedef Eigen::Map<const Eigen::VectorXd> EigenMap_const;
 
-class Mantid::HistogramData::HistogramX;
+namespace Mantid::HistogramData {
+class HistogramX;
+}
 
 namespace Mantid::Algorithms {
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -72,7 +72,6 @@ private:
   Eigen::VectorXd centreBinsXData(const HistogramData::HistogramX *xData);
   void extractPeaks(const size_t dataIndex, const Tensor1D &iOverSigma, const EigenMap_const &xData,
                     const TensorMap_const &yData, const size_t peakExtentBinNumber);
-  std::vector<std::pair<const int, const double>> filterDataForSignificantPoints(const Tensor1D &iOverSigma);
   size_t findPeakInRawData(const int xIndex, const TensorMap_const &yData, size_t peakExtentBinNumber);
   void storePeakResults(const size_t dataIndex, std::vector<FindPeaksConvolve::PeakResult> &peakCentres);
   Eigen::VectorXd generateNormalPDF(const int peakExtentBinNumber);

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -70,7 +70,7 @@ private:
   void performConvolution(const size_t dataIndex);
   Tensor1D createKernel(const int binCount) const;
   Tensor1D createSmoothKernel(const size_t kernelSize) const;
-  size_t getKernelBinCount(const HistogramData::HistogramX *xData) const;
+  size_t getKernelBinCount(const HistogramData::HistogramX *xData, const size_t dataIndex) const;
   double getXDataValue(const HistogramData::HistogramX *xData, const size_t xIndex) const;
   Eigen::VectorXd centreBinsXData(const HistogramData::HistogramX *xData) const;
   void extractPeaks(const size_t dataIndex, const Tensor1D &iOverSigma, const HistogramData::HistogramX *xData,

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -55,7 +55,7 @@ private:
   bool m_createIntermediateWorkspaces;
   bool m_findHighestDatapointInPeak;
   double m_iOverSigmaThreshold;
-  bool m_performBinaryClosing;
+  bool m_mergeNearbyPeaks;
 
   void init() override;
   void exec() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAlgorithms/DllConfig.h"
+#include "MantidHistogramData/Histogram.h"
 
 #include "Eigen/../unsupported/Eigen/CXX11/Tensor"
 #include "Eigen/Core"
@@ -56,20 +57,18 @@ private:
   void storeClassProperties();
 
   void performConvolution(const size_t dataIndex);
-  Tensor1D createKernel(const size_t binCount, const size_t dataIndex);
+  Tensor1D createKernel(const int binCount);
   Tensor1D createSmoothKernel(const size_t kernelSize);
   size_t getKernelBinCount(const HistogramData::HistogramX *xData) const;
-  Eigen::VectorXd centreBinsXData(const size_t dataIndex, const size_t kernelSize,
-                                  const HistogramData::HistogramX *xData);
+  Eigen::VectorXd centreBinsXData(const HistogramData::HistogramX *xData);
   void extractPeaks(const size_t dataIndex, const Tensor1D &iOverSigma, const EigenMap_const &xData,
                     const TensorMap_const &yData, const size_t peakExtentBinNumber);
   std::vector<std::pair<const int, const double>> filterDataForSignificantPoints(const Tensor1D &iOverSigma);
   size_t findPeakInRawData(const int xIndex, const TensorMap_const &yData, size_t peakExtentBinNumber);
-  void FindPeaksConvolve::storePeakResults(const size_t dataIndex,
-                                           std::vector<FindPeaksConvolve::PeakResult> &peakCentres);
-  Eigen::VectorXd generateNormalPDF(const size_t peakExtentBinNumber);
+  void storePeakResults(const size_t dataIndex, std::vector<FindPeaksConvolve::PeakResult> &peakCentres);
+  Eigen::VectorXd generateNormalPDF(const int peakExtentBinNumber);
   void createIntermediateWorkspaces(const size_t dataIndex, const Tensor1D &kernel, const Tensor1D &iOverSigma,
-                                    const EigenMap_const *xData);
+                                    const EigenMap_const &xData);
   void outputResults();
 };
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAlgorithms/DllConfig.h"
 #include "MantidHistogramData/Histogram.h"
 
@@ -81,8 +82,15 @@ private:
   Eigen::VectorXd generateNormalPDF(const int peakExtentBinNumber) const;
   void createIntermediateWorkspaces(const size_t dataIndex, const Tensor1D &kernel, const Tensor1D &iOverSigma,
                                     const HistogramData::HistogramX *xData);
+  void outputIntermediateWorkspace(const size_t dataIndex, const std::string &wsName, const std::vector<double> &xData,
+                                   const std::vector<double> &yData);
   void outputResults();
   void outputResultsTable(const std::string &resultHeader);
+  std::unordered_map<std::string, API::ITableWorkspace_sptr>
+  createOutputTables(const std::vector<std::string> &outputTblNames);
+  std::string populateOutputWorkspaces(const std::vector<std::string> &outputTblNames,
+                                       const std::unordered_map<std::string, API::ITableWorkspace_sptr> &outputTbls);
+  API::WorkspaceGroup_sptr groupOutputWorkspaces(const std::vector<std::string> &outputTblNames);
 };
 
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -61,6 +61,7 @@ private:
   double m_iOverSigmaThreshold;
   bool m_mergeNearbyPeaks;
   bool m_centreBins;
+  Eigen::VectorXd m_pdf;
 
   void init() override;
   void exec() override;
@@ -79,9 +80,9 @@ private:
   Eigen::VectorXd centreBinsXData(const HistogramData::HistogramX *xData) const;
   void extractPeaks(const size_t dataIndex, const Tensor1D &iOverSigma, const HistogramData::HistogramX *xData,
                     const TensorMap_const &yData, const size_t peakExtentBinNumber);
-  size_t findPeakInRawData(const int xIndex, const TensorMap_const &yData, size_t peakExtentBinNumber) const;
+  size_t findPeakInRawData(const int xIndex, const TensorMap_const &yData, size_t peakExtentBinNumber);
   void storePeakResults(const size_t dataIndex, std::vector<FindPeaksConvolve::PeakResult> &peakCentres);
-  Eigen::VectorXd generateNormalPDF(const int peakExtentBinNumber) const;
+  void generateNormalPDF(const int peakExtentBinNumber);
   void createIntermediateWorkspaces(const size_t dataIndex, const Tensor1D &kernel, const Tensor1D &iOverSigma,
                                     const HistogramData::HistogramX *xData);
   void outputIntermediateWorkspace(const size_t dataIndex, const std::string &wsName, const std::vector<double> &xData,

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAlgorithms/DllConfig.h"
 #include "MantidHistogramData/Histogram.h"
@@ -30,7 +31,8 @@ typedef Eigen::Map<const Eigen::VectorXd> EigenMap_const;
 
 namespace Mantid::Algorithms {
 
-/** FindPeaksConvolve : TODO: DESCRIPTION
+/** FindPeaksConvolve : Finds peak centres using convolution with a shoebox kernel to approximate the second derivative,
+ * taking maxima above an I/Sigma threshold. Algorithm designed by Richard Waite and implemented by Mial Lewis.
  */
 class MANTID_ALGORITHMS_DLL FindPeaksConvolve : public API::Algorithm {
 public:
@@ -44,7 +46,7 @@ private:
     const double centre;
     const double height;
     const double iOverSigma;
-    const double getAttribute(const std::string &attrString) const;
+    double getAttribute(const std::string &attrString) const;
   };
 
   std::unordered_map<std::string, Kernel::IValidator_sptr> m_validators;

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -7,10 +7,9 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
-#include "MantidAPI/ITableWorkspace.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/ITableWorkspace_fwd.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidAlgorithms/DllConfig.h"
-#include "MantidHistogramData/Histogram.h"
 
 // Disable warning 4554 on windows which is inherent in the Eigen::Tensor library.
 #ifdef _MSC_VER
@@ -28,6 +27,8 @@ typedef Eigen::Tensor<double, 1> Tensor1D;
 typedef Eigen::TensorMap<const Eigen::Tensor<double, 1>> TensorMap_const;
 typedef Eigen::TensorMap<Eigen::Tensor<double, 1>> TensorMap;
 typedef Eigen::Map<const Eigen::VectorXd> EigenMap_const;
+
+const Mantid::HistogramData::HistogramX;
 
 namespace Mantid::Algorithms {
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -1,0 +1,73 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAlgorithms/DllConfig.h"
+
+#include "Eigen/../unsupported/Eigen/CXX11/Tensor"
+#include "Eigen/Core"
+
+typedef Eigen::Tensor<double, 1> Tensor1D;
+typedef Eigen::TensorMap<const Eigen::Tensor<double, 1>> TensorMap_const;
+typedef Eigen::TensorMap<Eigen::Tensor<double, 1>> TensorMap;
+typedef Eigen::Map<const Eigen::VectorXd> EigenMap_const;
+
+namespace Mantid::Algorithms {
+
+/** FindPeaksConvolve : TODO: DESCRIPTION
+ */
+class MANTID_ALGORITHMS_DLL FindPeaksConvolve : public API::Algorithm {
+public:
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
+
+private:
+  struct PeakResult {
+    const double centre;
+    const double height;
+    const double iOverSigma;
+  };
+
+  std::unordered_map<std::string, Kernel::IValidator_sptr> m_validators;
+  API::MatrixWorkspace_sptr m_inputDataWS;
+  size_t m_specCount = -1;
+  std::vector<int> m_specNums;
+  std::vector<std::vector<FindPeaksConvolve::PeakResult>> m_peakResults;
+  size_t m_maxPeakCount;
+
+  bool m_createIntermediateWorkspaces;
+  bool m_findHighestDatapointInPeak;
+
+  void init() override;
+  void exec() override;
+
+  void initiateValidators();
+  std::pair<std::string, int> secondaryValidation() const;
+  const std::string validatePeakPositionInput() const;
+  const std::string validatePeakExtentInput() const;
+  void storeClassProperties();
+
+  void performConvolution(const size_t dataIndex);
+  Tensor1D createKernel(const size_t binCount, const size_t dataIndex);
+  Tensor1D createSmoothKernel(const size_t kernelSize);
+  size_t getKernelBinCount(const HistogramData::HistogramX *xData) const;
+  Eigen::VectorXd centreBinsXData(const size_t dataIndex, const size_t kernelSize,
+                                  const HistogramData::HistogramX *xData);
+  void FindPeaksConvolve::extractPeaks(const size_t dataIndex, const Tensor1D &iOverSigma, const EigenMap_const &xData,
+                                       const TensorMap_const &yData, const size_t peakExtentBinNumber);
+  size_t FindPeaksConvolve::findPeakInRawData(const int xIndex, const TensorMap_const &yData,
+                                              size_t peakExtentBinNumber);
+  Eigen::VectorXd generateNormalPDF(const size_t peakExtentBinNumber);
+  void createIntermediateWorkspaces(const size_t dataIndex, const Tensor1D &kernel, const Tensor1D &iOverSigma,
+                                    const EigenMap_const *xData);
+  void outputResults();
+};
+
+} // namespace Mantid::Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -40,10 +40,12 @@ private:
   size_t m_specCount = -1;
   std::vector<int> m_specNums;
   std::vector<std::vector<FindPeaksConvolve::PeakResult>> m_peakResults;
-  size_t m_maxPeakCount;
+  std::atomic<size_t> m_maxPeakCount;
 
   bool m_createIntermediateWorkspaces;
   bool m_findHighestDatapointInPeak;
+  double m_iOverSigmaThreshold;
+  bool m_performBinaryClosing;
 
   void init() override;
   void exec() override;
@@ -59,10 +61,12 @@ private:
   size_t getKernelBinCount(const HistogramData::HistogramX *xData) const;
   Eigen::VectorXd centreBinsXData(const size_t dataIndex, const size_t kernelSize,
                                   const HistogramData::HistogramX *xData);
-  void FindPeaksConvolve::extractPeaks(const size_t dataIndex, const Tensor1D &iOverSigma, const EigenMap_const &xData,
-                                       const TensorMap_const &yData, const size_t peakExtentBinNumber);
-  size_t FindPeaksConvolve::findPeakInRawData(const int xIndex, const TensorMap_const &yData,
-                                              size_t peakExtentBinNumber);
+  void extractPeaks(const size_t dataIndex, const Tensor1D &iOverSigma, const EigenMap_const &xData,
+                    const TensorMap_const &yData, const size_t peakExtentBinNumber);
+  std::vector<std::pair<const int, const double>> filterDataForSignificantPoints(const Tensor1D &iOverSigma);
+  size_t findPeakInRawData(const int xIndex, const TensorMap_const &yData, size_t peakExtentBinNumber);
+  void FindPeaksConvolve::storePeakResults(const size_t dataIndex,
+                                           std::vector<FindPeaksConvolve::PeakResult> &peakCentres);
   Eigen::VectorXd generateNormalPDF(const size_t peakExtentBinNumber);
   void createIntermediateWorkspaces(const size_t dataIndex, const Tensor1D &kernel, const Tensor1D &iOverSigma,
                                     const EigenMap_const *xData);

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -50,7 +50,6 @@ private:
 
   void initiateValidators();
   std::pair<std::string, int> secondaryValidation() const;
-  const std::string validatePeakPositionInput() const;
   const std::string validatePeakExtentInput() const;
   void storeClassProperties();
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -70,7 +70,7 @@ private:
   void performConvolution(const size_t dataIndex);
   Tensor1D createKernel(const int binCount) const;
   Tensor1D createSmoothKernel(const size_t kernelSize) const;
-  size_t getKernelBinCount(const HistogramData::HistogramX *xData, const size_t dataIndex) const;
+  std::pair<size_t, bool> getKernelBinCount(const HistogramData::HistogramX *xData) const;
   double getXDataValue(const HistogramData::HistogramX *xData, const size_t xIndex) const;
   Eigen::VectorXd centreBinsXData(const HistogramData::HistogramX *xData) const;
   void extractPeaks(const size_t dataIndex, const Tensor1D &iOverSigma, const HistogramData::HistogramX *xData,

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -10,11 +10,15 @@
 #include "MantidAlgorithms/DllConfig.h"
 #include "MantidHistogramData/Histogram.h"
 
-// Disable warning 4554 which is inherent in the Eigen::Tensor library.
+// Disable warning 4554 on windows which is inherent in the Eigen::Tensor library.
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4554)
 #include "Eigen/../unsupported/Eigen/CXX11/Tensor"
 #pragma warning(pop)
+#else
+#include "Eigen/../unsupported/Eigen/CXX11/Tensor"
+#endif
 
 #include "Eigen/Core"
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -10,7 +10,12 @@
 #include "MantidAlgorithms/DllConfig.h"
 #include "MantidHistogramData/Histogram.h"
 
+// Disable warning 4554 which is inherent in the Eigen::Tensor library.
+#pragma warning(push)
+#pragma warning(disable : 4554)
 #include "Eigen/../unsupported/Eigen/CXX11/Tensor"
+#pragma warning(pop)
+
 #include "Eigen/Core"
 
 typedef Eigen::Tensor<double, 1> Tensor1D;

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -56,6 +56,7 @@ private:
   bool m_findHighestDatapointInPeak;
   double m_iOverSigmaThreshold;
   bool m_mergeNearbyPeaks;
+  bool m_centreBins;
 
   void init() override;
   void exec() override;
@@ -69,14 +70,15 @@ private:
   Tensor1D createKernel(const int binCount);
   Tensor1D createSmoothKernel(const size_t kernelSize);
   size_t getKernelBinCount(const HistogramData::HistogramX *xData) const;
+  double getXDataValue(const HistogramData::HistogramX *xData, const size_t xIndex);
   Eigen::VectorXd centreBinsXData(const HistogramData::HistogramX *xData);
-  void extractPeaks(const size_t dataIndex, const Tensor1D &iOverSigma, const EigenMap_const &xData,
+  void extractPeaks(const size_t dataIndex, const Tensor1D &iOverSigma, const HistogramData::HistogramX *xData,
                     const TensorMap_const &yData, const size_t peakExtentBinNumber);
   size_t findPeakInRawData(const int xIndex, const TensorMap_const &yData, size_t peakExtentBinNumber);
   void storePeakResults(const size_t dataIndex, std::vector<FindPeaksConvolve::PeakResult> &peakCentres);
   Eigen::VectorXd generateNormalPDF(const int peakExtentBinNumber);
   void createIntermediateWorkspaces(const size_t dataIndex, const Tensor1D &kernel, const Tensor1D &iOverSigma,
-                                    const EigenMap_const &xData);
+                                    const HistogramData::HistogramX *xData);
   void outputResults();
 };
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -64,19 +64,20 @@ private:
   void initiateValidators();
   std::pair<std::string, int> secondaryValidation() const;
   const std::string validatePeakExtentInput() const;
+  const std::string validateWorkspaceIndexInput() const;
   void storeClassProperties();
 
   void performConvolution(const size_t dataIndex);
-  Tensor1D createKernel(const int binCount);
-  Tensor1D createSmoothKernel(const size_t kernelSize);
+  Tensor1D createKernel(const int binCount) const;
+  Tensor1D createSmoothKernel(const size_t kernelSize) const;
   size_t getKernelBinCount(const HistogramData::HistogramX *xData) const;
-  double getXDataValue(const HistogramData::HistogramX *xData, const size_t xIndex);
-  Eigen::VectorXd centreBinsXData(const HistogramData::HistogramX *xData);
+  double getXDataValue(const HistogramData::HistogramX *xData, const size_t xIndex) const;
+  Eigen::VectorXd centreBinsXData(const HistogramData::HistogramX *xData) const;
   void extractPeaks(const size_t dataIndex, const Tensor1D &iOverSigma, const HistogramData::HistogramX *xData,
                     const TensorMap_const &yData, const size_t peakExtentBinNumber);
-  size_t findPeakInRawData(const int xIndex, const TensorMap_const &yData, size_t peakExtentBinNumber);
+  size_t findPeakInRawData(const int xIndex, const TensorMap_const &yData, size_t peakExtentBinNumber) const;
   void storePeakResults(const size_t dataIndex, std::vector<FindPeaksConvolve::PeakResult> &peakCentres);
-  Eigen::VectorXd generateNormalPDF(const int peakExtentBinNumber);
+  Eigen::VectorXd generateNormalPDF(const int peakExtentBinNumber) const;
   void createIntermediateWorkspaces(const size_t dataIndex, const Tensor1D &kernel, const Tensor1D &iOverSigma,
                                     const HistogramData::HistogramX *xData);
   void outputResults();

--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -43,6 +43,7 @@ private:
     const double centre;
     const double height;
     const double iOverSigma;
+    const double getAttribute(const std::string &attrString) const;
   };
 
   std::unordered_map<std::string, Kernel::IValidator_sptr> m_validators;
@@ -81,6 +82,7 @@ private:
   void createIntermediateWorkspaces(const size_t dataIndex, const Tensor1D &kernel, const Tensor1D &iOverSigma,
                                     const HistogramData::HistogramX *xData);
   void outputResults();
+  void outputResultsTable(const std::string &resultHeader);
 };
 
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/FindPeaksConvolve.cpp
+++ b/Framework/Algorithms/src/FindPeaksConvolve.cpp
@@ -435,8 +435,13 @@ std::string FindPeaksConvolve::populateOutputWorkspaces(
         auto tbl = outputTbls.find(name);
         API::TableRow row{tbl->second->appendRow()};
         row << m_specNums[i];
-        for (const auto &peak : spec) {
-          row << peak.getAttribute(name);
+        for (size_t peak_i{0}; peak_i < m_maxPeakCount; peak_i++) {
+          if (peak_i < spec.size()) {
+            auto peak = spec[peak_i];
+            row << peak.getAttribute(name);
+          } else {
+            row << std::nan("");
+          }
         }
       }
     } else {

--- a/Framework/Algorithms/src/FindPeaksConvolve.cpp
+++ b/Framework/Algorithms/src/FindPeaksConvolve.cpp
@@ -1,0 +1,398 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+// NScD Oak Ridge National Laboratory, European Spallation Source,
+// Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidAlgorithms/FindPeaksConvolve.h"
+
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/TableRow.h"
+#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/BoundedValidator.h"
+#include "MantidKernel/IValidator.h"
+#include "MantidKernel/Logger.h"
+
+#include <boost/math/distributions/normal.hpp>
+#include <cmath>
+#include <ppl.h>
+
+namespace {
+Mantid::Kernel::Logger g_log("FindPeaksConvolve");
+}
+
+namespace Mantid::Algorithms {
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(FindPeaksConvolve)
+
+//----------------------------------------------------------------------------------------------
+
+/// Algorithms name for identification. @see Algorithm::name
+const std::string FindPeaksConvolve::name() const { return "FindPeaksConvolve"; }
+
+/// Algorithm's version for identification. @see Algorithm::version
+int FindPeaksConvolve::version() const { return 1; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string FindPeaksConvolve::category() const { return "Optimization\\PeakFinding"; }
+
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string FindPeaksConvolve::summary() const {
+  return "Finds peaks in a dataset through the use of a convolution vector";
+}
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void FindPeaksConvolve::init() {
+  initiateValidators();
+
+  declareProperty(std::make_unique<API::WorkspaceProperty<>>("InputWorkspace", "", Kernel::Direction::Input),
+                  "An input workspace.");
+  declareProperty(
+      std::make_unique<API::WorkspaceProperty<API::Workspace>>("OutputWorkspace", "", Kernel::Direction::Output),
+      "An output workspace.");
+  declareProperty("CreateIntermediateWorkspaces", false, "Output workspaces showing intermediate working steps");
+  declareProperty("WorkspaceIndex", EMPTY_INT(), m_validators["mustBeNonNegative"],
+                  "If set, only this spectrum will be searched for peaks "
+                  "(otherwise all are)");
+  declareProperty("NumberOfPeaks", EMPTY_INT(), m_validators["mustBeNonNegative"],
+                  "If set, the algorithm will attempt to find the input number of peaks");
+  declareProperty(std::make_unique<Kernel::ArrayProperty<double>>("PeakPositions"),
+                  "Optional: enter a comma-separated list of the expected "
+                  "X-position of the centre of the peaks. Only peaks within a tolerance "
+                  "of these positions will be fitted.");
+  declareProperty("PeakPositionTolerance", EMPTY_DBL(), m_validators["mustBeGreaterThanZero"],
+                  "Tolerance on the found peaks' positions against the input "
+                  "peak positions.");
+  declareProperty("EstimatedPeakExtent", EMPTY_DBL(), m_validators["mustBeGreaterThanZero"],
+                  "Estimated PeakExtent of the peaks to be found");
+  // EstimatedPeakExtentNBins needs a minimum of
+  declareProperty("EstimatedPeakExtentNBins", EMPTY_INT(), m_validators["mustBeGreaterThanOne"],
+                  "Optional: Estimated PeakExtent of the peaks to be found in number of bins");
+  declareProperty(std::make_unique<Kernel::ArrayProperty<double>>("PeakExtentRange"),
+                  "Optional: comma-separated min and max values of the range of Peak Extents "
+                  "to evaluate <min, max>");
+  declareProperty("IOversigmaThreshold", 2.0, m_validators["mustBeGreaterThanZero"],
+                  "Minimum Signal/Noise ratio for a peak to be considered significant");
+  declareProperty("PerformBinaryClosing", true,
+                  "Attempt to remove inflections in the data, where a local"
+                  " minima/maxima occurs which is not signficiant enough to be considered a peak");
+  declareProperty("FindHighestDataPointInPeak", false,
+                  "When searching for peaks in the raw data around the iOverSigma maxima, take the highest value,"
+                  " rather than favouring datapoints closer to the maxima");
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void FindPeaksConvolve::exec() {
+  storeClassProperties();
+  auto validation_res = secondaryValidation();
+  if (validation_res.second != 0) {
+    throw std::invalid_argument("Validation error: " + validation_res.first);
+  }
+
+  concurrency::parallel_for(size_t(0), m_specCount, [&](size_t i) { performConvolution(i); });
+  outputResults();
+}
+
+void FindPeaksConvolve::initiateValidators() {
+  m_validators.reserve(2); // Update depending upon number of validators.
+
+  auto mustBeNonNegative{std::make_shared<Kernel::BoundedValidator<int>>()};
+  mustBeNonNegative->setLower(0);
+  m_validators.emplace(std::make_pair("mustBeNonNegative", std::move(mustBeNonNegative)));
+
+  auto mustBeGreaterThanZero{std::make_shared<Kernel::BoundedValidator<double>>()};
+  mustBeGreaterThanZero->setLowerExclusive(0.0);
+  m_validators.emplace("mustBeGreaterThanZero", std::move(mustBeGreaterThanZero));
+
+  auto mustBeGreaterThanOne{std::make_shared<Kernel::BoundedValidator<int>>()};
+  mustBeGreaterThanOne->setLowerExclusive(1);
+  m_validators.emplace("mustBeGreaterThanOne", std::move(mustBeGreaterThanOne));
+}
+
+std::pair<std::string, int> FindPeaksConvolve::secondaryValidation() const {
+  std::string err_str{};
+  int err_code{0};
+
+  err_str += validatePeakPositionInput();
+  err_str += validatePeakExtentInput();
+
+  if (err_str != "") {
+    err_code = 1;
+  }
+  return std::make_pair(err_str, err_code);
+}
+
+const std::string FindPeaksConvolve::validatePeakPositionInput() const {
+  std::string err_str{};
+  const int numberOfPeaks = getProperty("NumberOfPeaks");
+  const std::vector<double> peakPositions = getProperty("PeakPositions");
+  const size_t peakPositionsSize{peakPositions.size()};
+
+  if ((numberOfPeaks != EMPTY_INT() && peakPositionsSize != 0) &&
+      (static_cast<size_t>(numberOfPeaks) != peakPositionsSize)) {
+    err_str += "Specified number of peaks and peak positions differ: " + std::to_string(numberOfPeaks) +
+               "!=" + std::to_string(peakPositionsSize);
+  }
+  return err_str;
+}
+
+const std::string FindPeaksConvolve::validatePeakExtentInput() const {
+  std::string err_str{};
+  const double peakExtent = getProperty("EstimatedPeakExtent");
+  const int peakExtentNBins = getProperty("EstimatedPeakExtentNBins");
+  if (peakExtent != EMPTY_DBL() && peakExtentNBins != EMPTY_INT()) {
+    err_str += "Peak Extent has been given in x units and in number of bins. Please specify one or the other. ";
+  }
+
+  const std::vector<double> peakExtentRange = getProperty("PeakExtentRange");
+  const size_t peakExtentRangeSize{peakExtentRange.size()};
+  if ((peakExtent != EMPTY_DBL() || peakExtentNBins != EMPTY_INT()) && peakExtentRangeSize) {
+    err_str += "Specific and Peak Extent range specified. Please specify one or the other. ";
+  }
+
+  // if (peakExtent >= ) {
+  //  err_str += "Peak extent range cannot be greater than xdata range. ";
+  //}
+  return err_str;
+}
+
+void FindPeaksConvolve::storeClassProperties() {
+  m_inputDataWS = getProperty("InputWorkspace");
+  m_createIntermediateWorkspaces = getProperty("CreateIntermediateWorkspaces");
+  m_findHighestDatapointInPeak = getProperty("FindHighestDataPointInPeak");
+  int wsIndex = getProperty("WorkspaceIndex");
+  if (wsIndex == EMPTY_INT()) {
+    m_specCount = static_cast<int>(m_inputDataWS->getNumberHistograms());
+    m_specNums.resize(m_specCount);
+    std::iota(std::begin(m_specNums), std::end(m_specNums), 0);
+  } else {
+    m_specCount = 1;
+    m_specNums.push_back(wsIndex);
+  }
+  m_peakResults.resize(m_specCount);
+}
+
+void FindPeaksConvolve::performConvolution(const size_t dataIndex) {
+  const HistogramData::HistogramX *xData{&m_inputDataWS->x(dataIndex)};
+  const auto kernelBinCount{getKernelBinCount(xData)};
+  const Tensor1D kernel{createKernel(kernelBinCount, dataIndex)};
+
+  const auto specNum{m_specNums[dataIndex]};
+  const auto binCount{m_inputDataWS->getNumberBins(specNum)};
+  const double paddingSize = (kernelBinCount * 1.5 - 2) / 2;
+  const TensorMap_const yData{&m_inputDataWS->y(specNum).front(), binCount};
+  Eigen::array<std::pair<double, double>, 1> paddings{std::make_pair(std::ceil(paddingSize), std::floor(paddingSize))};
+  const auto yData_padded{yData.pad(paddings)};
+  const Eigen::array<ptrdiff_t, 1> dims({0});
+  const Tensor1D yConvOutput{yData_padded.convolve(kernel, dims)};
+
+  const auto eData{TensorMap_const{&m_inputDataWS->e(specNum).front(), binCount}.pad(paddings)};
+  const Tensor1D eConvOutput{eData.square().convolve(kernel.square(), dims).sqrt()};
+
+  const Tensor1D smoothKernel{createSmoothKernel(kernelBinCount / 2)};
+  const Tensor1D iOverSigConvOutput{(yConvOutput / eConvOutput).convolve(smoothKernel, dims)};
+
+  EigenMap_const *xDataPostConv;
+  Eigen::VectorXd xDataCentredBins;
+  if (xData->size() != yData.size()) {
+    xDataCentredBins = centreBinsXData(dataIndex, kernelBinCount, xData);
+    xDataPostConv = &EigenMap_const{xDataCentredBins.data(), xDataCentredBins.size()};
+  } else {
+    xDataPostConv = &EigenMap_const(&xData->front(), xData->size());
+  }
+  extractPeaks(dataIndex, iOverSigConvOutput, *xDataPostConv, yData, kernelBinCount / 2);
+
+  if (m_createIntermediateWorkspaces) {
+    createIntermediateWorkspaces(dataIndex, kernel, iOverSigConvOutput, xDataPostConv);
+  }
+}
+
+Tensor1D FindPeaksConvolve::createKernel(const size_t binCount, const size_t dataIndex) {
+  Tensor1D kernel(binCount);
+  for (auto i{0}; i < binCount; i++) {
+    // consider if these 0.25/0.75 values should be inputs
+    if (i < std::ceil(binCount * 0.25) || i >= binCount * 0.75) {
+      kernel.data()[i] = -1;
+    } else {
+      kernel.data()[i] = 1;
+    }
+  }
+  return kernel;
+}
+
+Tensor1D FindPeaksConvolve::createSmoothKernel(const size_t kernelSize) {
+  Tensor1D kernel(kernelSize);
+  for (auto i{0}; i < kernelSize; i++) {
+    kernel.data()[i] = 1.0 / kernelSize;
+  }
+  return kernel;
+}
+
+size_t FindPeaksConvolve::getKernelBinCount(const HistogramData::HistogramX *xData) const {
+  // What is the minimum number of data points this works for - add validation
+  const double peakExtent = getProperty("EstimatedPeakExtent");
+  const int peakExtentNBins = getProperty("EstimatedPeakExtentNBins");
+
+  if (peakExtent != EMPTY_DBL()) {
+    const double x1{xData->rawData()[static_cast<size_t>(std::floor((xData->size() - 1) / 2))]};
+    const double x2{xData->rawData()[static_cast<size_t>(std::floor((xData->size() - 1) / 2)) + 1]};
+    return static_cast<size_t>(std::floor(peakExtent * 2 / (x2 - x1)));
+  } else {
+    return static_cast<size_t>(peakExtentNBins);
+  }
+}
+
+Eigen::VectorXd FindPeaksConvolve::centreBinsXData(const size_t dataIndex, const size_t kernelSize,
+                                                   const HistogramData::HistogramX *xData) {
+  Eigen::VectorXd xDataVec{0.5 * (EigenMap_const(&xData->front(), xData->size() - 1) +
+                                  EigenMap_const(&xData->front() + 1, xData->size() - 1))};
+  return xDataVec;
+}
+
+void FindPeaksConvolve::extractPeaks(const size_t dataIndex, const Tensor1D &iOverSigma, const EigenMap_const &xData,
+                                     const TensorMap_const &yData, const size_t peakExtentBinNumber) {
+  double iOverSigmaThreshold = getProperty("IOversigmaThreshold");
+  bool performBinaryClosing = getProperty("PerformBinaryClosing");
+  std::vector<std::pair<const int, const double>> closedData;
+  for (auto i{0}; i < iOverSigma.size(); i++) {
+    if (iOverSigma(i) > iOverSigmaThreshold) {
+      closedData.emplace_back(i, iOverSigma(i));
+    } else if (iOverSigma(i) <= 0 || !performBinaryClosing) {
+      closedData.emplace_back(i, 0);
+    }
+  }
+  closedData.emplace_back(closedData.size(), 0); // Guarentee data region close
+
+  int dataPointCount{0};
+  std::pair<int, double> dataRegionMax{0, 0.0};
+  std::vector<FindPeaksConvolve::PeakResult> peakCentres;
+  for (const auto &dataPoint : closedData) {
+    if (dataPoint.second != 0) {
+      if (dataPointCount == 0) {
+        dataRegionMax = dataPoint;
+      } else {
+        if (dataPoint.second > dataRegionMax.second) {
+          dataRegionMax = dataPoint;
+        }
+      }
+      dataPointCount++;
+    } else {
+      if (dataPointCount >= 2) {
+        size_t rawPeakIndex{findPeakInRawData(dataRegionMax.first, yData, peakExtentBinNumber)};
+        peakCentres.push_back(
+            FindPeaksConvolve::PeakResult{xData[rawPeakIndex], yData.data()[rawPeakIndex], dataRegionMax.second});
+      }
+      if (dataPointCount > 0) {
+        dataPointCount = 0;
+        dataRegionMax = std::make_pair(0, 0.0);
+      }
+    }
+  }
+
+  const size_t peakCount = peakCentres.size();
+  if (peakCount) {
+    if (peakCount > m_maxPeakCount) {
+      m_maxPeakCount = peakCount;
+    }
+    m_peakResults[dataIndex] = std::move(peakCentres);
+  }
+}
+
+size_t FindPeaksConvolve::findPeakInRawData(const int xIndex, const TensorMap_const &yData,
+                                            size_t peakExtentBinNumber) {
+  peakExtentBinNumber = (peakExtentBinNumber % 2 == 0) ? peakExtentBinNumber + 1 : peakExtentBinNumber;
+  int sliceStart{xIndex - static_cast<int>(std::floor(peakExtentBinNumber / 2.0))};
+  size_t adjPeakExtentBinNumber{peakExtentBinNumber};
+  int startAdj{0};
+
+  if (sliceStart < 0) {
+    startAdj = -sliceStart;
+    adjPeakExtentBinNumber = peakExtentBinNumber - startAdj;
+    sliceStart = 0;
+  } else if (sliceStart + adjPeakExtentBinNumber > yData.size() - 1) {
+    adjPeakExtentBinNumber = static_cast<size_t>(yData.size()) - sliceStart;
+  }
+
+  Eigen::VectorXd::Index maxIndex;
+  if (m_findHighestDatapointInPeak) {
+    const auto unweightedYData = EigenMap_const(yData.data() + sliceStart, adjPeakExtentBinNumber);
+    const double max_val = unweightedYData.maxCoeff(&maxIndex);
+  } else {
+    Eigen::VectorXd pdf{generateNormalPDF(peakExtentBinNumber)};
+    const auto weightedYData = EigenMap_const(yData.data() + sliceStart, adjPeakExtentBinNumber)
+                                   .cwiseProduct(EigenMap_const(pdf.data() + startAdj, adjPeakExtentBinNumber));
+    const double max_val = weightedYData.maxCoeff(&maxIndex);
+  }
+  return static_cast<size_t>(maxIndex) + sliceStart;
+}
+
+Eigen::VectorXd FindPeaksConvolve::generateNormalPDF(const size_t peakExtentBinNumber) {
+  // assert vector has odd size.
+  Eigen::VectorXd pdf{peakExtentBinNumber};
+  boost::math::normal_distribution<> dist(0.0, peakExtentBinNumber / 2.0); // assures 2 stddevs in the resultant vector
+  const size_t meanIdx{peakExtentBinNumber / 2};
+  for (auto i{0}; i < peakExtentBinNumber; ++i) {
+    int x{i - static_cast<int>(meanIdx)};
+    pdf(i) = boost::math::pdf(dist, x);
+  }
+  return pdf;
+}
+
+void FindPeaksConvolve::createIntermediateWorkspaces(const size_t dataIndex, const Tensor1D &kernel,
+                                                     const Tensor1D &iOverSigma, const EigenMap_const *xData) {
+  API::Algorithm_sptr alg{createChildAlgorithm("CreateWorkspace")};
+
+  alg->setProperty("OutputWorkspace", "iOverSigma");
+  alg->setProperty("DataX", std::vector<double>(xData->data(), xData->data() + xData->rows()));
+  alg->setProperty("DataY", std::vector<double>(iOverSigma.data(), iOverSigma.data() + iOverSigma.size()));
+  alg->execute();
+  API::MatrixWorkspace_sptr algOutput = alg->getProperty("OutputWorkspace");
+  API::AnalysisDataService::Instance().add("iOverSigma" + std::to_string(dataIndex), algOutput);
+
+  std::vector<double> xKernelData(kernel.size());
+  std::iota(std::begin(xKernelData), std::end(xKernelData), 0.0);
+  alg->resetProperties();
+  alg->setProperty("OutputWorkspace", "kernelWorkspace");
+  alg->setProperty("DataX", std::move(xKernelData));
+  alg->setProperty("DataY", std::vector<double>(kernel.data(), kernel.data() + kernel.size()));
+  alg->execute();
+  API::MatrixWorkspace_sptr algKernelOutput = alg->getProperty("OutputWorkspace");
+  API::AnalysisDataService::Instance().add("kernelWorkspace" + std::to_string(dataIndex), algKernelOutput);
+}
+
+void FindPeaksConvolve::outputResults() {
+  API::ITableWorkspace_sptr table{API::WorkspaceFactory::Instance().createTable("TableWorkspace")};
+  table->addColumn("int", "SpecIndex");
+  for (auto i{0}; i < m_maxPeakCount; i++) {
+    table->addColumn("double", "PeakCentre_" + std::to_string(i));
+    table->addColumn("double", "PeakHeight_" + std::to_string(i));
+    table->addColumn("double", "PeakIOverSigma_" + std::to_string(i));
+  }
+
+  std::string noPeaksStr{""};
+  for (auto i{0}; i < m_peakResults.size(); i++) {
+    const auto spec = std::move(m_peakResults[i]);
+    if (!spec.empty()) {
+      API::TableRow row{table->appendRow()};
+      row << i;
+      for (const auto &peak : spec) {
+        row << peak.centre << peak.height << peak.iOverSigma;
+      }
+    } else {
+      noPeaksStr += std::to_string(i) + ", ";
+    }
+  }
+  if (noPeaksStr != "") {
+    g_log.notice("No peaks found for spectrum index: " + noPeaksStr);
+  }
+  setProperty("OutputWorkspace", table);
+}
+} // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/FindPeaksConvolve.cpp
+++ b/Framework/Algorithms/src/FindPeaksConvolve.cpp
@@ -201,7 +201,8 @@ void FindPeaksConvolve::performConvolution(const size_t dataIndex) {
 
     const Tensor1D smoothKernel{
         createSmoothKernel(static_cast<size_t>(std::ceil(static_cast<double>(kernelBinCount.first) / 2.0)))};
-    const Tensor1D iOverSigConvOutput{(yConvOutput / eConvOutput).convolve(smoothKernel, dims)};
+    Tensor1D iOverSig{(yConvOutput / eConvOutput).unaryExpr([](double val) { return std::isfinite(val) ? val : 0.0; })};
+    const Tensor1D iOverSigConvOutput{iOverSig.convolve(smoothKernel, dims)};
 
     extractPeaks(dataIndex, iOverSigConvOutput, xData, yData, kernelBinCount.first / 2);
 

--- a/Framework/Algorithms/src/FindPeaksConvolve.cpp
+++ b/Framework/Algorithms/src/FindPeaksConvolve.cpp
@@ -191,9 +191,9 @@ Tensor1D FindPeaksConvolve::createKernel(const int binCount) {
   for (int i{0}; i < binCount; i++) {
     // consider if these 0.25/0.75 values should be inputs
     if (i < std::ceil(binCount) * 0.25 || i >= binCount * 0.75) {
-      kernel.data()[i] = -1;
+      kernel.data()[i] = -1.0;
     } else {
-      kernel.data()[i] = 1;
+      kernel.data()[i] = 1.0;
     }
   }
   return kernel;
@@ -279,7 +279,7 @@ FindPeaksConvolve::filterDataForSignificantPoints(const Tensor1D &iOverSigma) {
       closedData.emplace_back(i, 0);
     }
   }
-  closedData.emplace_back(closedData.size(), 0); // Guarentee data region close
+  closedData.emplace_back(static_cast<int>(closedData.size()), 0); // Guarentee data region close
   return closedData;
 }
 

--- a/Framework/Algorithms/src/FindPeaksConvolve.cpp
+++ b/Framework/Algorithms/src/FindPeaksConvolve.cpp
@@ -8,9 +8,12 @@
 #include "MantidAlgorithms/FindPeaksConvolve.h"
 
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidHistogramData/Histogram.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/IValidator.h"

--- a/Framework/Algorithms/src/FindPeaksConvolve.cpp
+++ b/Framework/Algorithms/src/FindPeaksConvolve.cpp
@@ -349,6 +349,7 @@ void FindPeaksConvolve::createIntermediateWorkspaces(const size_t dataIndex, con
   alg->setProperty("OutputWorkspace", "kernel");
   alg->setProperty("DataX", std::move(xKernelData));
   alg->setProperty("DataY", std::vector<double>(kernel.data(), kernel.data() + kernel.size()));
+  alg->execute();
   API::MatrixWorkspace_sptr algKernelOutput = alg->getProperty("OutputWorkspace");
   API::AnalysisDataService::Instance().addOrReplace(
       m_inputDataWS->getName() + "_kernel_" + std::to_string(m_specNums[dataIndex]), algKernelOutput);

--- a/Framework/Algorithms/src/FindPeaksConvolve.cpp
+++ b/Framework/Algorithms/src/FindPeaksConvolve.cpp
@@ -60,23 +60,10 @@ void FindPeaksConvolve::init() {
   declareProperty("WorkspaceIndex", EMPTY_INT(), m_validators["mustBeNonNegative"],
                   "If set, only this spectrum will be searched for peaks "
                   "(otherwise all are)");
-  declareProperty("NumberOfPeaks", EMPTY_INT(), m_validators["mustBeNonNegative"],
-                  "If set, the algorithm will attempt to find the input number of peaks");
-  declareProperty(std::make_unique<Kernel::ArrayProperty<double>>("PeakPositions"),
-                  "Optional: enter a comma-separated list of the expected "
-                  "X-position of the centre of the peaks. Only peaks within a tolerance "
-                  "of these positions will be fitted.");
-  declareProperty("PeakPositionTolerance", EMPTY_DBL(), m_validators["mustBeGreaterThanZero"],
-                  "Tolerance on the found peaks' positions against the input "
-                  "peak positions.");
   declareProperty("EstimatedPeakExtent", EMPTY_DBL(), m_validators["mustBeGreaterThanZero"],
                   "Estimated PeakExtent of the peaks to be found");
-  // EstimatedPeakExtentNBins needs a minimum of
   declareProperty("EstimatedPeakExtentNBins", EMPTY_INT(), m_validators["mustBeGreaterThanOne"],
                   "Optional: Estimated PeakExtent of the peaks to be found in number of bins");
-  declareProperty(std::make_unique<Kernel::ArrayProperty<double>>("PeakExtentRange"),
-                  "Optional: comma-separated min and max values of the range of Peak Extents "
-                  "to evaluate <min, max>");
   declareProperty("IOversigmaThreshold", 2.0, m_validators["mustBeGreaterThanZero"],
                   "Minimum Signal/Noise ratio for a peak to be considered significant");
   declareProperty("PerformBinaryClosing", true,
@@ -121,27 +108,12 @@ std::pair<std::string, int> FindPeaksConvolve::secondaryValidation() const {
   std::string err_str{};
   int err_code{0};
 
-  err_str += validatePeakPositionInput();
   err_str += validatePeakExtentInput();
 
   if (err_str != "") {
     err_code = 1;
   }
   return std::make_pair(err_str, err_code);
-}
-
-const std::string FindPeaksConvolve::validatePeakPositionInput() const {
-  std::string err_str{};
-  const int numberOfPeaks = getProperty("NumberOfPeaks");
-  const std::vector<double> peakPositions = getProperty("PeakPositions");
-  const size_t peakPositionsSize{peakPositions.size()};
-
-  if ((numberOfPeaks != EMPTY_INT() && peakPositionsSize != 0) &&
-      (static_cast<size_t>(numberOfPeaks) != peakPositionsSize)) {
-    err_str += "Specified number of peaks and peak positions differ: " + std::to_string(numberOfPeaks) +
-               "!=" + std::to_string(peakPositionsSize);
-  }
-  return err_str;
 }
 
 const std::string FindPeaksConvolve::validatePeakExtentInput() const {
@@ -152,15 +124,6 @@ const std::string FindPeaksConvolve::validatePeakExtentInput() const {
     err_str += "Peak Extent has been given in x units and in number of bins. Please specify one or the other. ";
   }
 
-  const std::vector<double> peakExtentRange = getProperty("PeakExtentRange");
-  const size_t peakExtentRangeSize{peakExtentRange.size()};
-  if ((peakExtent != EMPTY_DBL() || peakExtentNBins != EMPTY_INT()) && peakExtentRangeSize) {
-    err_str += "Specific and Peak Extent range specified. Please specify one or the other. ";
-  }
-
-  // if (peakExtent >= ) {
-  //  err_str += "Peak extent range cannot be greater than xdata range. ";
-  //}
   return err_str;
 }
 

--- a/Framework/Algorithms/src/FindPeaksConvolve.cpp
+++ b/Framework/Algorithms/src/FindPeaksConvolve.cpp
@@ -333,17 +333,18 @@ void FindPeaksConvolve::createIntermediateWorkspaces(const size_t dataIndex, con
   alg->setProperty("DataY", std::vector<double>(iOverSigma.data(), iOverSigma.data() + iOverSigma.size()));
   alg->execute();
   API::MatrixWorkspace_sptr algOutput = alg->getProperty("OutputWorkspace");
-  API::AnalysisDataService::Instance().add("iOverSigma" + std::to_string(dataIndex), algOutput);
+  API::AnalysisDataService::Instance().addOrReplace(
+      m_inputDataWS->getName() + "_iOverSigma_" + std::to_string(m_specNums[dataIndex]), algOutput);
 
   std::vector<double> xKernelData(kernel.size());
   std::iota(std::begin(xKernelData), std::end(xKernelData), 0.0);
   alg->resetProperties();
-  alg->setProperty("OutputWorkspace", "kernelWorkspace");
+  alg->setProperty("OutputWorkspace", "kernel");
   alg->setProperty("DataX", std::move(xKernelData));
   alg->setProperty("DataY", std::vector<double>(kernel.data(), kernel.data() + kernel.size()));
-  alg->execute();
   API::MatrixWorkspace_sptr algKernelOutput = alg->getProperty("OutputWorkspace");
-  API::AnalysisDataService::Instance().add("kernelWorkspace" + std::to_string(dataIndex), algKernelOutput);
+  API::AnalysisDataService::Instance().addOrReplace(
+      m_inputDataWS->getName() + "_kernel_" + std::to_string(m_specNums[dataIndex]), algKernelOutput);
 }
 
 void FindPeaksConvolve::outputResults() {

--- a/Framework/Algorithms/src/FindPeaksConvolve.cpp
+++ b/Framework/Algorithms/src/FindPeaksConvolve.cpp
@@ -8,7 +8,6 @@
 #include "MantidAlgorithms/FindPeaksConvolve.h"
 
 #include "MantidAPI/AnalysisDataService.h"
-#include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidAPI/WorkspaceFactory.h"
@@ -445,7 +444,7 @@ std::string FindPeaksConvolve::populateOutputWorkspaces(
   return noPeaksStr;
 }
 
-const double FindPeaksConvolve::PeakResult::getAttribute(const std::string &attrString) const {
+double FindPeaksConvolve::PeakResult::getAttribute(const std::string &attrString) const {
   if (attrString == "PeakCentre") {
     return centre;
   } else if (attrString == "PeakYPosition") {

--- a/Framework/Algorithms/test/FindPeaksConvolveTest.h
+++ b/Framework/Algorithms/test/FindPeaksConvolveTest.h
@@ -14,7 +14,6 @@
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAlgorithms/FindPeaksConvolve.h"
 #include "MantidDataHandling/LoadNexusProcessed.h"
-#include "MantidHistogramData/Histogram.h"
 
 using Mantid::Algorithms::FindPeaksConvolve;
 

--- a/Framework/Algorithms/test/FindPeaksConvolveTest.h
+++ b/Framework/Algorithms/test/FindPeaksConvolveTest.h
@@ -14,6 +14,7 @@
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAlgorithms/FindPeaksConvolve.h"
 #include "MantidDataHandling/LoadNexusProcessed.h"
+#include "MantidHistogramData/Histogram.h"
 
 using Mantid::Algorithms::FindPeaksConvolve;
 

--- a/Framework/Algorithms/test/FindPeaksConvolveTest.h
+++ b/Framework/Algorithms/test/FindPeaksConvolveTest.h
@@ -10,8 +10,6 @@
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
-#include "MantidAPI/ITableWorkspace.h"
-#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAlgorithms/FindPeaksConvolve.h"
 #include "MantidDataHandling/LoadNexusProcessed.h"
 

--- a/Framework/Algorithms/test/FindPeaksConvolveTest.h
+++ b/Framework/Algorithms/test/FindPeaksConvolveTest.h
@@ -75,7 +75,7 @@ public:
   void test_exec() {
     auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
     alg->setProperty("EstimatedPeakExtent", "100");
-    alg->setProperty("IOversigmaThreshold", "3");
+    alg->setProperty("IOverSigmaThreshold", "3");
     TS_ASSERT_THROWS_NOTHING(alg->execute(););
     TS_ASSERT(alg->isExecuted());
 
@@ -89,7 +89,7 @@ public:
   void test_execPeakExtentNBins() {
     auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
     alg->setProperty("EstimatedPeakExtentNBins", "25");
-    alg->setProperty("IOversigmaThreshold", "3");
+    alg->setProperty("IOverSigmaThreshold", "3");
     TS_ASSERT_THROWS_NOTHING(alg->execute(););
     TS_ASSERT(alg->isExecuted());
 
@@ -103,7 +103,7 @@ public:
   void test_execHighestDataPoint() {
     auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
     alg->setProperty("EstimatedPeakExtent", "100");
-    alg->setProperty("IOversigmaThreshold", "3");
+    alg->setProperty("IOverSigmaThreshold", "3");
     alg->setProperty("FindHighestDataPointInPeak", true);
     TS_ASSERT_THROWS_NOTHING(alg->execute(););
     TS_ASSERT(alg->isExecuted());
@@ -126,10 +126,10 @@ public:
     assert_peak_centres_equal(resultWs, expectedPeakCentres);
   }
 
-  void test_execNoisyDataLargeKernelWithBinaryClosing() {
+  void test_execNoisyDataLargeKernelWithMergePeaks() {
     auto alg = set_up_alg(INPUT_TEST_WS_NAME + "_noisy", OUTPUT_TEST_WS_NAME);
     alg->setProperty("EstimatedPeakExtent", "500");
-    alg->setProperty("IOversigmaThreshold", "5");
+    alg->setProperty("IOverSigmaThreshold", "5");
     TS_ASSERT_THROWS_NOTHING(alg->execute(););
     TS_ASSERT(alg->isExecuted());
 
@@ -138,11 +138,11 @@ public:
     assert_peak_centres_equal(resultWs, expectedPeakCentres);
   }
 
-  void test_execNoisyDataLargeKernelNoBinaryClosing() {
+  void test_execNoisyDataLargeKernelNoMergePeaks() {
     auto alg = set_up_alg(INPUT_TEST_WS_NAME + "_noisy", OUTPUT_TEST_WS_NAME);
     alg->setProperty("EstimatedPeakExtent", "500");
-    alg->setProperty("IOversigmaThreshold", "5");
-    alg->setProperty("PerformBinaryClosing", false);
+    alg->setProperty("IOverSigmaThreshold", "5");
+    alg->setProperty("MergeNearbyPeaks", false);
     TS_ASSERT_THROWS_NOTHING(alg->execute(););
     TS_ASSERT(alg->isExecuted());
 
@@ -155,6 +155,11 @@ public:
     auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
     alg->setProperty("EstimatedPeakExtent", "100");
     alg->setProperty("EstimatedPeakExtentNBins", "100");
+    TS_ASSERT_THROWS(alg->execute(), std::invalid_argument &);
+  }
+
+  void test_execSpecifyNoPeakExtentAndBins() {
+    auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
     TS_ASSERT_THROWS(alg->execute(), std::invalid_argument &);
   }
 };

--- a/Framework/Algorithms/test/FindPeaksConvolveTest.h
+++ b/Framework/Algorithms/test/FindPeaksConvolveTest.h
@@ -1,0 +1,103 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidAlgorithms/FindPeaksConvolve.h"
+#include "MantidDataHandling/LoadNexusProcessed.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+
+using Mantid::Algorithms::FindPeaksConvolve;
+
+namespace {
+/// Load focussed data file - from FindPeaksTest
+void loadNexusProcessed(const std::string &filename, const std::string &wsname) {
+  Mantid::DataHandling::LoadNexusProcessed loader;
+  loader.initialize();
+  loader.setProperty("Filename", filename);
+  loader.setProperty("OutputWorkspace", wsname);
+  loader.execute();
+  TS_ASSERT(loader.isExecuted());
+  TS_ASSERT(Mantid::API::AnalysisDataService::Instance().doesExist(wsname));
+}
+
+Mantid::API::Algorithm_sptr set_up_alg(const std::string &input_ws_name, const std::string &output_ws_name) {
+  auto alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged("FindPeaksConvolve");
+  // auto alg = Mantid::API::Algorithm::createAlgorithm("FindPeaksConvolve");
+  // Don't put output in ADS by default
+  alg->setChild(true);
+  TS_ASSERT_THROWS_NOTHING(alg->initialize());
+  TS_ASSERT(alg->isInitialized())
+  TS_ASSERT_THROWS_NOTHING(alg->setProperty("InputWorkspace", input_ws_name));
+  TS_ASSERT_THROWS_NOTHING(alg->setPropertyValue("OutputWorkspace", output_ws_name));
+  return alg;
+}
+
+const std::string INPUT_TEST_WS_NAME = "FindPeaksTest_peaksWS"; // Data reused from FindPeaksTest
+const std::string OUTPUT_TEST_WS_NAME = "FindPeaksConvolve_final_output";
+} // anonymous namespace
+
+class FindPeaksConvolveTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static FindPeaksConvolveTest *createSuite() { return new FindPeaksConvolveTest(); }
+  static void destroySuite(FindPeaksConvolveTest *suite) { delete suite; }
+
+  void setUp() override {
+    // Load data file into ADS once
+    if (!Mantid::API::AnalysisDataService::Instance().doesExist(INPUT_TEST_WS_NAME)) {
+      loadNexusProcessed("focussed.nxs", INPUT_TEST_WS_NAME);
+    }
+  }
+
+  void test_peak_number_and_position_mismatch() {
+    auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
+    alg->setProperty("NumberOfPeaks", "3");
+    alg->setProperty("PeakPositions", "1, 2, 3, 4");
+    TS_ASSERT_THROWS(alg->execute(), std::invalid_argument)
+  }
+
+  void test_FWHM_specific_and_range_both_specified() {
+    auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
+    alg->setProperty("EstimatedPeakExtent", "15");
+    alg->setProperty("PeakExtentRange", "10,20");
+    TS_ASSERT_THROWS(alg->execute(), std::invalid_argument)
+  }
+
+  void test_exec() {
+    // auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
+    int64_t nhist = 1;
+    int64_t nbins = 17;
+    bool ishist = false;
+    double xval(0), yval(0), eval(0), dxval(1);
+    std::string wsName = "test_ws";
+
+    Mantid::API::MatrixWorkspace_sptr ws = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
+        WorkspaceCreationHelper::create2DWorkspaceWithValuesAndXerror(nhist, nbins, ishist, xval, yval, eval, dxval));
+    std::vector<double> yValues{1, 1, 1, 1, 1.5, 2, 3, 5, 8, 5, 3, 2, 1.5, 1, 1, 1, 1};
+
+    for (std::size_t j = 0; j < yValues.size(); ++j) {
+      ws->dataY(0)[j] = yValues[j];
+      ws->dataX(0)[j] = j;
+      ws->dataE(0)[j] = 1;
+    }
+
+    Mantid::API::AnalysisDataService::Instance().add(wsName, ws);
+
+    auto alg = set_up_alg(wsName, OUTPUT_TEST_WS_NAME);
+    alg->setProperty("EstimatedPeakExtent", "5");
+    TS_ASSERT_THROWS_NOTHING(alg->execute(););
+    TS_ASSERT(alg->isExecuted());
+  }
+
+  void test_Something() { TS_FAIL("You forgot to write a test!"); }
+};

--- a/Framework/Algorithms/test/FindPeaksConvolveTest.h
+++ b/Framework/Algorithms/test/FindPeaksConvolveTest.h
@@ -9,6 +9,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAlgorithms/FindPeaksConvolve.h"
 #include "MantidDataHandling/LoadNexusProcessed.h"
@@ -43,7 +44,7 @@ Mantid::API::Algorithm_sptr set_up_alg(const std::string &input_ws_name, const s
 void assert_peak_centres_equal(const Mantid::API::ITableWorkspace_sptr &resultWs,
                                std::vector<double> &expectedPeakCentres) {
   const auto colNames = resultWs->getColumnNames();
-  for (int i = resultWs->columnCount() - 1; i >= 0; i--) {
+  for (int i = static_cast<int>(resultWs->columnCount()) - 1; i >= 0; i--) {
     std::string colName{colNames[i]};
     if (colName.find("PeakCentre") != std::string::npos) {
       double cellValue{resultWs->Double(0, i)};
@@ -154,6 +155,6 @@ public:
     auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
     alg->setProperty("EstimatedPeakExtent", "100");
     alg->setProperty("EstimatedPeakExtentNBins", "100");
-    TS_ASSERT_THROWS(alg->execute(), std::invalid_argument);
+    TS_ASSERT_THROWS(alg->execute(), std::invalid_argument &);
   }
 };

--- a/Framework/Algorithms/test/FindPeaksConvolveTest.h
+++ b/Framework/Algorithms/test/FindPeaksConvolveTest.h
@@ -59,20 +59,6 @@ public:
     }
   }
 
-  void test_peak_number_and_position_mismatch() {
-    auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
-    alg->setProperty("NumberOfPeaks", "3");
-    alg->setProperty("PeakPositions", "1, 2, 3, 4");
-    TS_ASSERT_THROWS(alg->execute(), std::invalid_argument)
-  }
-
-  void test_FWHM_specific_and_range_both_specified() {
-    auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
-    alg->setProperty("EstimatedPeakExtent", "15");
-    alg->setProperty("PeakExtentRange", "10,20");
-    TS_ASSERT_THROWS(alg->execute(), std::invalid_argument)
-  }
-
   void test_exec() {
     // auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
     int64_t nhist = 1;

--- a/Framework/Algorithms/test/FindPeaksConvolveTest.h
+++ b/Framework/Algorithms/test/FindPeaksConvolveTest.h
@@ -100,6 +100,22 @@ public:
     assert_peak_centres_equal(resultWs, expectedPeakCentres);
   }
 
+  void test_execCreateIntermediateWorkspaces() {
+    auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
+    alg->setProperty("EstimatedPeakExtentNBins", "25");
+    alg->setProperty("IOverSigmaThreshold", "3");
+    alg->setProperty("CreateIntermediateWorkspaces", true);
+    TS_ASSERT_THROWS_NOTHING(alg->execute(););
+    TS_ASSERT(alg->isExecuted());
+    size_t matches{0};
+    for (const auto &name : Mantid::API::AnalysisDataService::Instance().getObjectNames()) {
+      if (name == "FindPeaksConvolveTest_input_iOverSigma_0" || name == "FindPeaksConvolveTest_input_kernel_0") {
+        matches++;
+      }
+    }
+    TS_ASSERT(matches == 2);
+  }
+
   void test_execHighestDataPoint() {
     auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
     alg->setProperty("EstimatedPeakExtent", "100");

--- a/Framework/Algorithms/test/FindPeaksConvolveTest.h
+++ b/Framework/Algorithms/test/FindPeaksConvolveTest.h
@@ -10,6 +10,8 @@
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAlgorithms/FindPeaksConvolve.h"
 #include "MantidDataHandling/LoadNexusProcessed.h"
 

--- a/Framework/Algorithms/test/FindPeaksConvolveTest.h
+++ b/Framework/Algorithms/test/FindPeaksConvolveTest.h
@@ -70,6 +70,7 @@ public:
     // Load data file into ADS once
     loadNexusProcessed("ENGINX_277208_focused_bank_2.nxs", INPUT_TEST_WS_NAME);
     loadNexusProcessed("VesuvioCalibSpec177.nxs", INPUT_TEST_WS_NAME + "_noisy");
+    loadNexusProcessed("focussed.nxs", INPUT_TEST_WS_NAME + "_focussed");
   }
 
   void test_exec() {
@@ -177,5 +178,39 @@ public:
   void test_execSpecifyNoPeakExtentAndBins() {
     auto alg = set_up_alg(INPUT_TEST_WS_NAME, OUTPUT_TEST_WS_NAME);
     TS_ASSERT_THROWS(alg->execute(), std::invalid_argument &);
+  }
+
+  void test_execIndexEndLessThanIndexStart() {
+    auto alg = set_up_alg(INPUT_TEST_WS_NAME + "_focussed", OUTPUT_TEST_WS_NAME + "_focussed");
+    alg->setProperty("EstimatedPeakExtent", "0.2");
+    alg->setProperty("StartWorkspaceIndex", "2");
+    alg->setProperty("EndWorkspaceIndex", "1");
+    TS_ASSERT_THROWS(alg->execute(), std::invalid_argument &);
+  }
+
+  void test_execIndexOutOfRange() {
+    auto alg = set_up_alg(INPUT_TEST_WS_NAME + "_focussed", OUTPUT_TEST_WS_NAME + "_focussed");
+    alg->setProperty("EstimatedPeakExtent", "0.2");
+    alg->setProperty("StartWorkspaceIndex", "20");
+    alg->setProperty("EndWorkspaceIndex", "21");
+    TS_ASSERT_THROWS(alg->execute(), std::invalid_argument &);
+  }
+
+  void test_execValidRange() {
+    auto alg = set_up_alg(INPUT_TEST_WS_NAME + "_focussed", OUTPUT_TEST_WS_NAME + "_focussed");
+    alg->setProperty("EstimatedPeakExtent", "0.2");
+    alg->setProperty("StartWorkspaceIndex", "1");
+    alg->setProperty("EndWorkspaceIndex", "2");
+    TS_ASSERT_THROWS_NOTHING(alg->execute());
+    const Mantid::API::ITableWorkspace_sptr resultWs = alg->getProperty("OutputWorkspace");
+    TS_ASSERT_EQUALS(resultWs->rowCount(), 2);
+  }
+
+  void test_execNoRange() {
+    auto alg = set_up_alg(INPUT_TEST_WS_NAME + "_focussed", OUTPUT_TEST_WS_NAME + "_focussed");
+    alg->setProperty("EstimatedPeakExtent", "0.2");
+    TS_ASSERT_THROWS_NOTHING(alg->execute());
+    const Mantid::API::ITableWorkspace_sptr resultWs = alg->getProperty("OutputWorkspace");
+    TS_ASSERT_EQUALS(resultWs->rowCount(), 6);
   }
 };

--- a/Testing/Data/UnitTest/VesuvioCalibSpec177.nxs.md5
+++ b/Testing/Data/UnitTest/VesuvioCalibSpec177.nxs.md5
@@ -1,0 +1,1 @@
+e7ccbe100b3a57b96dea82d7c091ced2

--- a/docs/source/algorithms/FindPeaksConvolve-v1.rst
+++ b/docs/source/algorithms/FindPeaksConvolve-v1.rst
@@ -1,0 +1,46 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+TODO: Enter a full rst-markup description of your algorithm here.
+
+
+Usage
+-----
+..  Try not to use files in your examples,
+    but if you cannot avoid it then the (small) files must be added to
+    autotestdata\UsageData and the following tag unindented
+    .. include:: ../usagedata-note.txt
+
+**Example - FindPeaksConvolve**
+
+.. testcode:: FindPeaksConvolveExample
+
+   # Create a host workspace
+   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
+   or
+   ws = CreateSampleWorkspace()
+
+   wsOut = FindPeaksConvolve()
+
+   # Print the result
+   print "The output workspace has %%i spectra" %% wsOut.getNumberHistograms()
+
+Output:
+
+.. testoutput:: FindPeaksConvolveExample
+
+  The output workspace has ?? spectra
+
+.. categories::
+
+.. sourcelink::
+

--- a/docs/source/algorithms/FindPeaksConvolve-v1.rst
+++ b/docs/source/algorithms/FindPeaksConvolve-v1.rst
@@ -10,35 +10,14 @@
 Description
 -----------
 
-TODO: Enter a full rst-markup description of your algorithm here.
+Finds peak centres using convolution with a shoebox kernel to approximate the second derivative, taking maxima above an I/Sigma threshold.
+Algorithm designed by Richard Waite and implemented by Mial Lewis.
 
 
 Usage
 -----
-..  Try not to use files in your examples,
-    but if you cannot avoid it then the (small) files must be added to
-    autotestdata\UsageData and the following tag unindented
-    .. include:: ../usagedata-note.txt
-
-**Example - FindPeaksConvolve**
-
-.. testcode:: FindPeaksConvolveExample
-
-   # Create a host workspace
-   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
-   or
-   ws = CreateSampleWorkspace()
-
-   wsOut = FindPeaksConvolve()
-
-   # Print the result
-   print "The output workspace has %%i spectra" %% wsOut.getNumberHistograms()
 
 Output:
-
-.. testoutput:: FindPeaksConvolveExample
-
-  The output workspace has ?? spectra
 
 .. categories::
 


### PR DESCRIPTION
### Description of work

#### Summary of work
This PR introduces a new algorithm `FindPeaksConvolve`. This is only an initial PR to get the basic functionality of the algorithm into Mantid. Additional functionality, documentation and release note etc. will be added in subsequent PRs.

It is hoped that this algorithm will provide a better "general" peak finder than current algorithms that are in place.

*There is no associated issue.*

### To test:

1) Load the `ENGINX_277208_focused_bank_2.nxs` dataset from the unit test data.
2) Using the `Algorithms` widget, execute the `FindPeaksConvolve` algorithm with `EstimatedPeakExtent` set to `200` and `OutputWorkspace` set to `output`.
3) Run the script below and inspect the found peaks.
4) Play around with options, try different datasets with different numbers of spectra (let me know if you find anything interesting or it struggles/excels at certain datasets).

```
from mantid.simpleapi import *

import matplotlib.pyplot as plt
from mantid.plots.utility import MantidAxType
from mantid.api import AnalysisDataService as ADS

ws = ADS.retrieve('ENGINX_277208_focused_bank_2')
ws_iOverSigma = ADS.retrieve('iOverSigma0')
tbl = mtd['output']

fig, axes = plt.subplots(2, 1, sharex = True, edgecolor='#ffffff', num='ws-1', subplot_kw={'projection': 'mantid'})
axes[0].plot(ws, color='#1f77b4', label='ws: Data', wkspIndex=0)
axes[0].tick_params(axis='x', which='major', **{'gridOn': False, 'tick1On': True, 'tick2On': False, 'label1On': True, 'label2On': False, 'size': 6, 'tickdir': 'out', 'width': 1})
axes[0].tick_params(axis='y', which='major', **{'gridOn': False, 'tick1On': True, 'tick2On': False, 'label1On': True, 'label2On': False, 'size': 6, 'tickdir': 'out', 'width': 1})
axes[0].set_title('ws')
axes[0].set_xlabel('Time-of-flight ($\\mu s$)')
axes[0].set_ylabel('(microsecond)$^{-1}$')
legend = axes[0].legend(fontsize=8.0).set_draggable(True).legend

axes[1].plot(ws_iOverSigma, color='k', label='ws_iOverSigma: Data', wkspIndex=0)

colCount = tbl.columnCount()
colNames = tbl.getColumnNames()
tblRow = tbl.row(0)
for ax in axes:
    for i in range(colCount):
        if "PeakCentre" in colNames[i]:
            cen = list(tblRow.items())[i][1]
            ax.axvline(cen, ls='-', color='r')
ax.axhline(2, ls='--', color='c')
fig.show()
```


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
