### PR TITLE
Only load test data once for BayesStretch2Test

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretch2Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretch2Test.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
-from mantid.simpleapi import Load, DeleteWorkspace, CreateWorkspace, CompareWorkspaces, GroupWorkspaces
+from mantid.simpleapi import Load, CreateWorkspace, CompareWorkspaces, GroupWorkspaces
 import numpy as np
 from mantid import AnalysisDataService
 from mantid.utils.pip import package_installed
@@ -34,19 +34,22 @@ if package_installed("quickBayes"):
         Going to test each method in isolation.
         """
 
+        @classmethod
+        def setUpClass(cls):
+            cls._res_ws = Load(Filename="irs26173_graphite002_res.nxs", OutputWorkspace=RES_NAME)
+            cls._sample_ws = Load(Filename="irs26176_graphite002_red.nxs", OutputWorkspace=SAMPLE_NAME)
+            cls._N_hist = 1
+
         def setUp(self):
-            self._res_ws = Load(Filename="irs26173_graphite002_res.nxs", OutputWorkspace=RES_NAME)
-            self._sample_ws = Load(Filename="irs26176_graphite002_red.nxs", OutputWorkspace=SAMPLE_NAME)
             self._alg = BayesStretch2()
             self._alg.initialize()
-            self._N_hist = 1
 
-        def tearDown(self):
+        @classmethod
+        def tearDownClass(cls):
             """
             Remove workspaces from ADS.
             """
-            DeleteWorkspace(self._sample_ws)
-            DeleteWorkspace(self._res_ws)
+            AnalysisDataService.clear()
 
         def assert_mock_called_with(self, mock_object, N_calls, call_number, **kargs):
             self.assertEqual(N_calls, mock_object.call_count)
@@ -89,7 +92,6 @@ if package_installed("quickBayes"):
                 unit = axis.getUnit()
                 self.assertEqual(unit.caption(), label[i])
                 np.testing.assert_equal(axis.extractValues(), axis_values[i])
-            DeleteWorkspace(ws)
 
         def test_make_slice_ws(self):
             x = np.linspace(0.8, 1.0, 3)
@@ -116,7 +118,6 @@ if package_installed("quickBayes"):
                 unit = axis.getUnit()
                 self.assertEqual(unit.caption(), label[i])
                 np.testing.assert_equal(axis.extractValues(), axis_values[i])
-            DeleteWorkspace(ws)
 
         def test_make_results(self):
             def slice(slice_list, x_data, x_unit, name):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretch2Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretch2Test.py
@@ -134,7 +134,7 @@ if package_installed("quickBayes"):
             x_data = [9]
 
             self._alg.make_results(beta_list, FWHM_list, x_data, "MomentumTransfer", "test")
-            self._alg.group_ws.assert_called_once_with([beta_list, FWHM_list], "test")
+            self._alg.group_ws.assert_called_once_with(["test_Stretch_Beta", "test_Stretch_FWHM"], "test")
 
             self.assert_mock_called_with(
                 self._alg.make_slice_ws,
@@ -154,9 +154,7 @@ if package_installed("quickBayes"):
                 x_unit="FWHM",
                 name="test_Stretch_FWHM",
             )
-            self.assert_mock_called_with(
-                self._alg.set_label, N_calls=2, call_number=2, ws_str="test_Stretch_Beta", label="beta", unit="MomentumTransfer"
-            )
+            self.assert_mock_called_with(self._alg.set_label, N_calls=2, call_number=2, ws_str="test_Stretch_Beta", label="beta", unit="")
             self.assert_mock_called_with(self._alg.set_label, N_calls=2, call_number=1, ws_str="test_Stretch_FWHM", label="FWHM", unit="eV")
 
         def test_do_one_spec(self):


### PR DESCRIPTION
### Description of work
This PR makes a minor improvement to the BayesStretch2Test so that it only loads the test data once for the whole test suite, rather than loading the data once per test.

It also updates the `test_make_result` test which stopped working after this PR was merged #36199 . The `BayesStretch2Test` is not currently run by our CI because we do not have gofit or quickbayes installed in our conda environments. To test this, you will therefore need to run this test locally within an environment with these two packages installed.

Fixes #36019

### To test:
Checkout this branch locally
```
git test-pr origin 36353
```
Make sure your conda environment is activated, and install gofit and quickbayes from pip:
```
pip install gofit==0.4
pip install quickbayes==1.0.0b18
```
Run the following test
```
ctest -R BayesStretch2Test -V
```

It should pass

*This does not require release notes* because **no visible changes were made**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
