### PR TITLE
Add nightly pipeline to publish packages to mantid-ornl channel

### DIFF
--- a/buildconfig/CMake/VersionNumber.cmake
+++ b/buildconfig/CMake/VersionNumber.cmake
@@ -36,13 +36,13 @@ execute_process(
 )
 
 # Expect format defined as in comments above. Major.Minor.Patch(.Patch)(.devN|rcN)(+abc)
-if(_version_str MATCHES "([0-9]+)\\.([0-9]+)\\.([0-9]+(\\.[0-9]+)*)(\\.dev[0-9]+|rc[0-9]+)?(\\+[A-Za-z0-9.]+)?")
+if(_version_str MATCHES "([0-9]+)\\.([0-9]+)\\.([0-9]+(\\.[0-9]+)*)(rc[0-9]+)?(\\.dev[0-9]+)?(\\+[A-Za-z0-9.]+)?")
   # Version components
   set(VERSION_MAJOR ${CMAKE_MATCH_1})
   set(VERSION_MINOR ${CMAKE_MATCH_2})
   set(VERSION_PATCH ${CMAKE_MATCH_3})
   # Ignore group 4 because it's contained within group 3.
-  set(VERSION_TWEAK ${CMAKE_MATCH_5}${CMAKE_MATCH_6})
+  set(VERSION_TWEAK ${CMAKE_MATCH_5}${CMAKE_MATCH_6}${CMAKE_MATCH_7})
 else()
   message(FATAL_ERROR "Error extracting version elements from: ${_version_str}\n${_error}")
 endif()

--- a/buildconfig/CMake/VersionNumber.cmake
+++ b/buildconfig/CMake/VersionNumber.cmake
@@ -28,7 +28,7 @@
 
 # Use versioningit to compute version number to match conda-build
 execute_process(
-  COMMAND "${Python_EXECUTABLE}" -c "import setup;print(setup.get_version())"
+  COMMAND "${Python_EXECUTABLE}" -m versioningit
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   OUTPUT_VARIABLE _version_str
   ERROR_VARIABLE _error

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -381,7 +381,7 @@ pipeline {
       steps {
         checkoutSource("${GIT_SHA}")
         sh "${CISCRIPT_DIR}/delete-old-packages.sh ${WORKSPACE}" + ' ${ANACONDA_TOKEN} ' +\
-         "--channel mantid --label ${ANACONDA_CHANNEL_LABEL} mantid mantidqt mantiddocs mantidworkbench"
+         "--channel ${ANACONDA_CHANNEL} --label ${ANACONDA_CHANNEL_LABEL} mantid mantidqt mantiddocs mantidworkbench"
       }
     }
 

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -7,6 +7,9 @@
 // Determine default values of parameters. Some are based on the branch.
 ANACONDA_CHANNEL_DEFAULT = 'mantid'
 GITHUB_RELEASES_REPO_DEFAULT = 'mantidproject/mantid'
+// The github tag is usually only specified for release candidates. If it's left blank
+// a nightly tag is generated.
+GITHUB_RELEASES_TAG_DEFAULT = ''
 GIT_BRANCH = git_branch_name()
 // Only Publish one of main or release-next by default. BRANCH_TO_PUBLISH is a global
 // environment variable set in the Jenkins system configuration global properties.
@@ -19,13 +22,11 @@ switch(GIT_BRANCH) {
   case ['main', 'release-next']:
     PACKAGE_SUFFIX_DEFAULT = 'Nightly'
     ANACONDA_CHANNEL_LABEL_DEFAULT = 'nightly'
-    GITHUB_RELEASES_TAG_DEFAULT = ''
     PLATFORM_CHOICES = ['all']
     break
   default:
     PACKAGE_SUFFIX_DEFAULT = 'Unstable'
     ANACONDA_CHANNEL_LABEL_DEFAULT = 'unstable'
-    GITHUB_RELEASES_TAG_DEFAULT = ''
     PLATFORM_CHOICES = ['none', 'all', 'linux-64', 'win-64', 'osx-64']
     break
 }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -17,6 +17,9 @@ PUBLISH_PACKAGES_DEFAULT = (GIT_BRANCH == "${BRANCH_TO_PUBLISH}")
 // Allow the freedom to specify GitHub and Anaconda publishing separately.
 PUBLISH_TO_ANACONDA_DEFAULT = PUBLISH_PACKAGES_DEFAULT
 PUBLISH_TO_GITHUB_DEFAULT = PUBLISH_PACKAGES_DEFAULT
+// If required, switch off the mantiddocs conda package build. This is deliberately not listed in the
+// pipeline parameters because it's only switched off for ornl-next anaconda publishing.
+BUILD_MANTIDDOCS_PACKAGE = true
 
 switch(GIT_BRANCH) {
   case ['main', 'release-next']:
@@ -31,6 +34,7 @@ switch(GIT_BRANCH) {
     PUBLISH_TO_GITHUB_DEFAULT = false
     PUBLISH_TO_ANACONDA_DEFAULT = true
     ANACONDA_CHANNEL_DEFAULT = 'mantid-ornl'
+    BUILD_MANTIDDOCS_PACKAGE = false
     break
   default:
     PACKAGE_SUFFIX_DEFAULT = 'Unstable'
@@ -200,7 +204,11 @@ pipeline {
             // in parallel
             package_conda('linux-64', 'base')
             archive_conda_packages('linux-64')
-            archive_conda_packages('noarch')
+            script {
+              if(env.BUILD_MANTIDDOCS_PACKAGE) {
+                archive_conda_packages('noarch')
+              }
+            }
           }
           post {
             always {
@@ -477,7 +485,7 @@ def package_conda_options(platform, base_or_workbench) {
   package_flags = ""
   if(base_or_workbench == 'base') {
     docs_flags = ""
-    if(platform.startsWith('linux')) {
+    if(platform.startsWith('linux') && BUILD_MANTIDDOCS_PACKAGE) {
       docs_flags = "--build-docs"
     }
     package_flags = "--build-mantid --build-qt ${docs_flags}"

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -24,6 +24,14 @@ switch(GIT_BRANCH) {
     ANACONDA_CHANNEL_LABEL_DEFAULT = 'nightly'
     PLATFORM_CHOICES = ['all']
     break
+  case 'ornl-next':
+    PACKAGE_SUFFIX_DEFAULT = 'Nightly'
+    ANACONDA_CHANNEL_LABEL_DEFAULT = 'nightly'
+    PLATFORM_CHOICES = ['linux-64']
+    PUBLISH_TO_GITHUB_DEFAULT = false
+    PUBLISH_TO_ANACONDA_DEFAULT = true
+    ANACONDA_CHANNEL_DEFAULT = 'mantid-ornl'
+    break
   default:
     PACKAGE_SUFFIX_DEFAULT = 'Unstable'
     ANACONDA_CHANNEL_LABEL_DEFAULT = 'unstable'

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -27,8 +27,7 @@ switch(GIT_BRANCH) {
     ANACONDA_CHANNEL_LABEL_DEFAULT = 'nightly'
     PLATFORM_CHOICES = ['all']
     break
-  // Change this back to 'ornl-next' after testing is complete.
-  case 'nightly_pipeline_ornl-next':
+  case 'ornl-next':
     PACKAGE_SUFFIX_DEFAULT = 'Nightly'
     ANACONDA_CHANNEL_LABEL_DEFAULT = 'nightly'
     PLATFORM_CHOICES = ['linux-64']
@@ -198,7 +197,7 @@ pipeline {
             // Clean up conda-bld before we start to avoid any
             // confusion with old packages
             dir('conda-bld') {
-               deleteDir()
+              deleteDir()
             }
             checkoutSource("${GIT_SHA}")
             // Build the base set of packages (ones not required for mantidworkbench)
@@ -235,7 +234,7 @@ pipeline {
             // Clean up conda-bld before we start to avoid any
             // confusion with old packages
             dir('conda-bld') {
-               deleteDir()
+              deleteDir()
             }
             checkoutSource("${GIT_SHA}")
             // Build the base set of packages (ones not required for mantidworkbench)
@@ -267,7 +266,7 @@ pipeline {
             // Clean up conda-bld before we start to avoid any
             // confusion with old packages
             dir('conda-bld') {
-               deleteDir()
+              deleteDir()
             }
             checkoutSource("${GIT_SHA}")
             // Build the base set of packages (ones not required for mantidworkbench)
@@ -299,7 +298,7 @@ pipeline {
               anyOf {
                   expression { env.BUILD_PACKAGE == "${PLATFORM}" }
                   expression { env.BUILD_PACKAGE == 'all' }
-               }
+              }
             }
             agent { label "${PLATFORM}" }
             options {
@@ -346,7 +345,7 @@ pipeline {
       options {
         timestamps ()
         retry(3)
-       }
+      }
       environment {
         ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}")
       }
@@ -381,7 +380,7 @@ pipeline {
       steps {
         checkoutSource("${GIT_SHA}")
         sh "${CISCRIPT_DIR}/delete-old-packages.sh ${WORKSPACE}" + ' ${ANACONDA_TOKEN} ' +\
-         "--channel ${ANACONDA_CHANNEL} --label ${ANACONDA_CHANNEL_LABEL} mantid mantidqt mantiddocs mantidworkbench"
+          "--channel ${ANACONDA_CHANNEL} --label ${ANACONDA_CHANNEL_LABEL} mantid mantidqt mantiddocs mantidworkbench"
       }
     }
 
@@ -398,7 +397,7 @@ pipeline {
       options {
         timestamps ()
         retry(3)
-       }
+      }
       environment {
         GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}")
       }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -8,9 +8,12 @@
 ANACONDA_CHANNEL_DEFAULT = 'mantid'
 GITHUB_RELEASES_REPO_DEFAULT = 'mantidproject/mantid'
 GIT_BRANCH = git_branch_name()
-// Only Publish one of the nightly builds by default. BRANCH_TO_PUBLISH is a global
+// Only Publish one of main or release-next by default. BRANCH_TO_PUBLISH is a global
 // environment variable set in the Jenkins system configuration global properties.
 PUBLISH_PACKAGES_DEFAULT = (GIT_BRANCH == "${BRANCH_TO_PUBLISH}")
+// Allow the freedom to specify GitHub and Anaconda publishing separately.
+PUBLISH_TO_ANACONDA_DEFAULT = PUBLISH_PACKAGES_DEFAULT
+PUBLISH_TO_GITHUB_DEFAULT = PUBLISH_PACKAGES_DEFAULT
 
 switch(GIT_BRANCH) {
   case ['main', 'release-next']:
@@ -42,8 +45,10 @@ pipeline {
               description: 'Choose a platform to build just this standalone package')
       string(name: 'PACKAGE_SUFFIX', defaultValue: PACKAGE_SUFFIX_DEFAULT,
              description: 'A string to append to the standalone package name')
-      booleanParam(name: 'PUBLISH_PACKAGES', defaultValue: PUBLISH_PACKAGES_DEFAULT,
-                   description: 'If true, publish the packages to Anaconda channel & GitHub')
+      booleanParam(name: 'PUBLISH_TO_ANACONDA', defaultValue: PUBLISH_TO_ANACONDA_DEFAULT,
+                   description: 'If true, publish the packages to the specified Anaconda channel')
+      booleanParam(name: 'PUBLISH_TO_GITHUB', defaultValue: PUBLISH_TO_GITHUB_DEFAULT,
+                   description: 'If true, publish the packages to GitHub')
       string(name: 'ANACONDA_CHANNEL', defaultValue: ANACONDA_CHANNEL_DEFAULT,
              description: 'The Anaconda channel to accept the package')
       string(name: 'ANACONDA_CHANNEL_LABEL', defaultValue: ANACONDA_CHANNEL_LABEL_DEFAULT,
@@ -66,7 +71,7 @@ pipeline {
       agent { label 'linux-64' }
       steps {
         script {
-          if(env.PUBLISH_PACKAGES == 'true') {
+          if(env.PUBLISH_TO_ANACONDA == 'true') {
             if(!env.ANACONDA_CHANNEL_LABEL.trim()) {
               error("You must specify an Anaconda label to publish packages.")
             }
@@ -317,7 +322,7 @@ pipeline {
       when {
         beforeAgent true
         beforeOptions true
-        expression { env.PUBLISH_PACKAGES == 'true' }
+        expression { env.PUBLISH_TO_ANACONDA == 'true' }
       }
       agent { label 'linux-64' } // Use linux for simplicity with shell scripts
       options {
@@ -348,7 +353,7 @@ pipeline {
         beforeAgent true
         beforeOptions true
         allOf {
-            expression { env.PUBLISH_PACKAGES == 'true' }
+            expression { env.PUBLISH_TO_ANACONDA == 'true' }
             expression { env.ANACONDA_CHANNEL_LABEL != '' }
         }
       }
@@ -367,7 +372,7 @@ pipeline {
         beforeAgent true
         beforeOptions true
         allOf {
-          expression { env.PUBLISH_PACKAGES == 'true' }
+          expression { env.PUBLISH_TO_GITHUB == 'true' }
           expression { env.GITHUB_RELEASES_REPO.trim() != '' }
         }
       }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -204,11 +204,7 @@ pipeline {
             // in parallel
             package_conda('linux-64', 'base')
             archive_conda_packages('linux-64')
-            script {
-              if(env.BUILD_MANTIDDOCS_PACKAGE) {
-                archive_conda_packages('noarch')
-              }
-            }
+            archive_conda_packages('noarch')
           }
           post {
             always {
@@ -549,10 +545,13 @@ def prerelease_option() {
 }
 
 def archive_conda_packages(platform) {
-  archiveArtifacts artifacts: "**/conda-bld/${platform}/*.tar.bz2",
-    allowEmptyArchive: false,
-    fingerprint: true,
-    onlyIfSuccessful: true
+  // Only archive the mantiddocs package if it was built.
+  if(platform != 'noarch' || BUILD_MANTIDDOCS_PACKAGE) {
+    archiveArtifacts artifacts: "**/conda-bld/${platform}/*.tar.bz2",
+      allowEmptyArchive: false,
+      fingerprint: true,
+      onlyIfSuccessful: true
+  }
 }
 
 def archive_standalone_package(platform) {

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -27,7 +27,8 @@ switch(GIT_BRANCH) {
     ANACONDA_CHANNEL_LABEL_DEFAULT = 'nightly'
     PLATFORM_CHOICES = ['all']
     break
-  case 'ornl-next':
+  // Change this back to 'ornl-next' after testing is complete.
+  case 'nightly_pipeline_ornl-next':
     PACKAGE_SUFFIX_DEFAULT = 'Nightly'
     ANACONDA_CHANNEL_LABEL_DEFAULT = 'nightly'
     PLATFORM_CHOICES = ['linux-64']

--- a/conda/recipes/mantidworkbench/meta.yaml
+++ b/conda/recipes/mantidworkbench/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - python.app  # [osx]
     - qtconsole {{ qtconsole }}
     - {{ pin_compatible("setuptools", max_pin="x.x") }}
-    # - mantiddocs {{ version }}
+    - mantiddocs {{ version }}
 
 test:
   imports:

--- a/conda/recipes/mantidworkbench/meta.yaml
+++ b/conda/recipes/mantidworkbench/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - python.app  # [osx]
     - qtconsole {{ qtconsole }}
     - {{ pin_compatible("setuptools", max_pin="x.x") }}
-    - mantiddocs {{ version }}
+    # - mantiddocs {{ version }}
 
 test:
   imports:


### PR DESCRIPTION
### Description of work

This work modifies the Jenkins conda packaging pipeline to enable nightly package publishing to mantid-ornl for `ornl-next`.

- companion PR into `ornl-next`: #36356
- IBM item: [Story 2759](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2759)

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

This PR introduces the following changes:

- separate boolean parameters for publishing to anaconda and github, allowing ornl-next to publish just to anaconda and not github
- ability to switch off building the mantiddocs package, as required in the ornl-next branch
- logic to automatically populate the Jenkins build settings for ornl-next so that only Linux packages are published to the mantid-ornl anaconda channel

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

### To test:

<!--
Go to Jenkins and use "publish package from branch" + "build with parameters" to trigger a build on `ornl-next` and publish it to `mantid-ornl`.
Once all stages are complete, you should be able to see that new packages are uploaded and old packages are pruned from the [history page](https://anaconda.org/mantid-ornl/repo/history?label=all).
-->
1. This test run of the new ornl-next pipeline should pass
https://builds.mantidproject.org/view/Nightly%20Pipelines/job/ornl-next_nightly_deployment/7/
it should NOT build the docs package, and should have uploaded the conda packages to the [mantid-ornl channel](https://anaconda.org/mantid-ornl/repo) with the `nightly` tag. Check the date in the version number against the Jenkins build artifacts.

2. Ensure that this build passes, and uploads all linux packages, **including the mantiddocs pacakge**, to the [mantid](https://anaconda.org/mantid/mantid) anaconda channel with the label `test-pipeline-changes-friday`:
https://builds.mantidproject.org/job/Core_Team_test_pipeline/46/

*This does not require release notes* because **no software functionality is affected due to this PR.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.