### PR TITLE
SaveDiffCal - Add the ability for the calibration workspace to be optional

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/SaveDiffCal.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveDiffCal.h
@@ -33,11 +33,16 @@ private:
   void exec() override;
   std::map<std::string, std::string> validateInputs() override;
 
+  void writeDoubleFieldZeros(H5::Group &group, const std::string &name);
+
   void writeDoubleFieldFromTable(H5::Group &group, const std::string &name);
   void writeIntFieldFromTable(H5::Group &group, const std::string &name);
+  void writeDetIdsfromSVWS(H5::Group &group, const std::string &name,
+                           const DataObjects::SpecialWorkspace2D_const_sptr &ws);
   void writeIntFieldFromSVWS(H5::Group &group, const std::string &name,
                              const DataObjects::SpecialWorkspace2D_const_sptr &ws);
   void generateDetidToIndex();
+  void generateDetidToIndex(const DataObjects::SpecialWorkspace2D_const_sptr &ws);
   bool tableHasColumn(const std::string &ColumnName) const;
 
   // minimum of (CalibrationWorkspace_row_count,

--- a/Framework/DataHandling/src/SaveDiffCal.cpp
+++ b/Framework/DataHandling/src/SaveDiffCal.cpp
@@ -255,31 +255,23 @@ void SaveDiffCal::exec() {
   MaskWorkspace_const_sptr maskWS = getProperty("MaskWorkspace");
 
   // Get a starting number of values to work with that will be refined below
-  // Also initialize the mapping of detid to row number to make getting information
-  // from the table faster.
   // THE ORDER OF THE IF/ELSE TREE MATTERS
+  m_numValues = std::numeric_limits<std::size_t>::max();
+  if (m_calibrationWS)
+    m_numValues = std::min(m_numValues, m_calibrationWS->rowCount());
+  if (groupingWS)
+    m_numValues = std::min(m_numValues, groupingWS->getNumberHistograms());
+  if (maskWS)
+    m_numValues = std::min(m_numValues, maskWS->getNumberHistograms());
+
+  // Initialize the mapping of detid to row number to make getting information
+  // from the table faster. ORDER MATTERS
   if (m_calibrationWS) {
-    m_numValues = m_calibrationWS->rowCount();
     this->generateDetidToIndex();
   } else if (groupingWS) {
-    m_numValues = groupingWS->getNumberHistograms();
     this->generateDetidToIndex(groupingWS);
   } else if (maskWS) {
-    m_numValues = maskWS->getNumberHistograms();
     this->generateDetidToIndex(maskWS);
-  }
-
-  if (groupingWS && groupingWS->isDetectorIDMappingEmpty())
-    groupingWS->buildDetectorIDMapping();
-
-  // initialize `m_numValues` as the minimum of (CalibrationWorkspace_row_count,
-  // GroupingWorkspace_histogram_count, MaskWorkspace_histogram_count).
-  // This will skip any workspaces that are missing.
-  if (bool(groupingWS) && groupingWS->getNumberHistograms() < m_numValues) {
-    m_numValues = groupingWS->getNumberHistograms();
-  }
-  if (bool(maskWS) && maskWS->getNumberHistograms() < m_numValues) {
-    m_numValues = maskWS->getNumberHistograms();
   }
 
   // delete the file if it already exists

--- a/Framework/DataHandling/src/SaveDiffCal.cpp
+++ b/Framework/DataHandling/src/SaveDiffCal.cpp
@@ -274,6 +274,9 @@ void SaveDiffCal::exec() {
     this->generateDetidToIndex(maskWS);
   }
 
+  if (groupingWS && groupingWS->isDetectorIDMappingEmpty())
+    groupingWS->buildDetectorIDMapping();
+
   // delete the file if it already exists
   std::string filename = getProperty("Filename");
   if (Poco::File(filename).exists()) {

--- a/Framework/DataHandling/test/SaveDiffCalTest.h
+++ b/Framework/DataHandling/test/SaveDiffCalTest.h
@@ -87,6 +87,16 @@ public:
     return wksp;
   }
 
+  void test_no_wksp() {
+    // test that not supplying any workspaces is a problem
+    SaveDiffCal alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", FILENAME));
+    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
+    TS_ASSERT(!alg.isExecuted());
+  }
+
   void test_no_cal_wksp() {
     Instrument_sptr inst = createInstrument();
     GroupingWorkspace_sptr groupWS = createGrouping(inst);
@@ -98,8 +108,16 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", groupWS));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaskWorkspace", maskWS));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", FILENAME));
-    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
-    TS_ASSERT(!alg.isExecuted());
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    // confirm that it exists
+    std::string filename = alg.getPropertyValue("Filename");
+    TS_ASSERT(Poco::File(filename).exists());
+
+    // cleanup
+    if (Poco::File(filename).exists())
+      Poco::File(filename).remove();
   }
 
   void test_empty_cal_wksp() {

--- a/docs/source/algorithms/SaveDiffCal-v1.rst
+++ b/docs/source/algorithms/SaveDiffCal-v1.rst
@@ -10,23 +10,24 @@
 Description
 -----------
 
-This algorithm saves a :ref:`diffraction calibration workspace
-<DiffractionCalibrationWorkspace>`, ``MaskWorkspace``, and
-``GroupingWorkspace`` to a HDF5 file.
+This algorithm saves a :ref:`diffraction calibration workspace <DiffractionCalibrationWorkspace>`, ``MaskWorkspace``, and ``GroupingWorkspace`` to a HDF5 file.
 
 The hierarchy of the HDF5 file is as follows:
 
 | calibration
 |   detid
 |   dasid (only if present in CalibrationWorkspace)
-|   difa
-|   tzero
+|   difc
+|   difa (only if not all values are zero)
+|   tzero (only if not all values are zero)
 |   group
 |   use ("0" if detector is not successfully calibrated, "1" otherwise)
 |   offset (only if present in CalibrationWorkspace)
 |   instrument
 |     name
 |     instrument_source (absolute path to the instrument definition file)
+
+This can be used in an alternate mode without a ``CalibrationWorkspace`` to write out the grouping workspace with the ``difc`` values all set to zero.
 
 .. categories::
 

--- a/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36361.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36361.rst
@@ -1,0 +1,1 @@
+- Add ability to :ref:`SaveDiffCal <algm-SaveDiffCal>` to not supply a ``CalibrationWorkspace``. It can be used in this mode to save the grouping information.


### PR DESCRIPTION
### Description of work

In snapred, the function [SaveGroupingDefinition](https://github.com/neutrons/SNAPRed/blob/next/src/snapred/backend/recipe/algorithm/SaveGroupingDefinition.py) spends a ton of time making a TableWorkspace with calibration information that will be ignored. This modifies ``SaveDiffCal`` to make the calibration table optional.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

*There is no associated issue,* but it is associated with [EWM2852](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2852)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

```python
from mantid.simpleapi import *
from time import sleep

direc='/home/pf9/build/mantid/snapcalib/'

grouping_wksp = 'SNAP_group'
filename=direc + 'SNAP_57514.lite.nxs.h5' # to test lite files
filename=direc + 'SNAP_57480.nxs.h5' # currently testing full file since it has more pixels

# create a detector grouping
LoadEventNexus(Filename=filename, OutputWorkspace="instrument", MetaDataOnly=True)
CreateGroupingWorkspace(InputWorkspace="instrument", GroupDetectorsBy="Column",
                        OutputWorkspace=grouping_wksp)

# save the grouping
grp_file=direc + 'grouping.h5'
SaveDiffCal(GroupingWorkspace=grouping_wksp,
            Filename=grp_file)

# load the grouping back in and compare
LoadDiffCal(InputWorkspace="instrument", Filename=grp_file, WorkspaceName="snapA")
print(CompareWorkspaces(grouping_wksp, "snapA_group"))
```
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
