### PR TITLE
Improve handling of cvalue information in SANSTubeCalibration algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSTubeCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSTubeCalibration.py
@@ -11,6 +11,7 @@ import os.path
 from pathlib import Path
 import sys
 from enum import Enum
+from typing import Tuple
 
 import numpy as np
 
@@ -450,7 +451,7 @@ class SANSTubeCalibration(DataProcessorAlgorithm):
         return self._detector_name + "-detector/" + side + str(tube_side_num)
 
     @staticmethod
-    def _get_tube_module_and_number(tube_id):
+    def _get_tube_module_and_number(tube_id: int) -> Tuple[int, int]:
         """Get the tube module and number based on the id given"""
         module = int(tube_id / DetectorInfo.NUM_TUBES_PER_MODULE) + 1
         tube_num = tube_id % DetectorInfo.NUM_TUBES_PER_MODULE
@@ -1029,7 +1030,7 @@ class SANSTubeCalibration(DataProcessorAlgorithm):
         for i in range(len(cvalues.dataY(0))):
             cvalue = cvalues.dataY(0)[i]
             if cvalue > threshold:
-                module, tube_num = self._get_tube_module_and_number(cvalues.dataX(0)[i])
+                module, tube_num = self._get_tube_module_and_number(int(cvalues.dataX(0)[i]))
                 msg = f"Module {module}, tube {tube_num} has cvalue {cvalue}"
                 cvalues_above_threshold.append(msg + "\n")
                 self.log().notice(msg)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSTubeCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSTubeCalibration.py
@@ -80,7 +80,7 @@ class SANSTubeCalibration(DataProcessorAlgorithm):
     _SAVED_INPUT_DATA_PREFIX = "tubeCalibSaved_"
     _TUBE_PLOT_WS = "__TubePlot"
     _FIT_DATA_WS = "__FittedData"
-    _C_VALUES_WS = "cvalues"
+    _C_VALUES_WS_PREFIX = "cvalues_"
     _SCALED_WS_SUFFIX = "_scaled"
     _CAL_TABLE_ID_COL = "Detector ID"
     _CAL_TABLE_POS_COL = "Detector Position"
@@ -301,7 +301,9 @@ class SANSTubeCalibration(DataProcessorAlgorithm):
             meanCvalue.append(meanC)
 
         self._apply_calibration(result, caltable)
-        cvalues = self._create_workspace(data_x=list(diagnostic_output.keys()), data_y=meanCvalue, output_ws_name=self._C_VALUES_WS)
+        cvalues = self._create_workspace(
+            data_x=list(diagnostic_output.keys()), data_y=meanCvalue, output_ws_name=f"{self._C_VALUES_WS_PREFIX}{self._detector_name}"
+        )
 
         self._save_calibrated_ws_as_nexus(result)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSTubeCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSTubeCalibration.py
@@ -433,6 +433,13 @@ class SANSTubeCalibration(DataProcessorAlgorithm):
         tube_side_num = tube_id // 2  # Round down to get integer name for tube
         return self._detector_name + "-detector/" + side + str(tube_side_num)
 
+    @staticmethod
+    def _get_tube_module_and_number(tube_id):
+        """Get the tube module and number based on the id given"""
+        module = int(tube_id / DetectorInfo.NUM_TUBES_PER_MODULE) + 1
+        tube_num = tube_id % DetectorInfo.NUM_TUBES_PER_MODULE
+        return module, tube_num
+
     def _get_tube_data(self, tube_id, ws):
         """Return an array of all counts for the given tube"""
         tube_name = self._get_tube_name(tube_id)
@@ -962,8 +969,7 @@ class SANSTubeCalibration(DataProcessorAlgorithm):
         diagnostic_workspaces = []
 
         first_pixel_pos = TubeSide.get_first_pixel_position(tube_id)
-        module = int(tube_id / DetectorInfo.NUM_TUBES_PER_MODULE) + 1
-        tube_num = tube_id % DetectorInfo.NUM_TUBES_PER_MODULE
+        module, tube_num = self._get_tube_module_and_number(tube_id)
         ws_suffix = f"{tube_id}_{module}_{tube_num}"
 
         diagnostic_workspaces.append(self._rename_workspace(self._FIT_DATA_WS, f"Fit{ws_suffix}"))
@@ -1007,7 +1013,8 @@ class SANSTubeCalibration(DataProcessorAlgorithm):
             cvalue = cvalues.dataY(0)[i]
             if cvalue > threshold:
                 all_cvalues_ok = False
-                self.log().notice(f"Tube {cvalues.dataX(0)[i]} has cvalue {cvalue}")
+                module, tube_num = self._get_tube_module_and_number(cvalues.dataX(0)[i])
+                self.log().notice(f"Module {module}, tube {tube_num} has cvalue {cvalue}")
 
         if all_cvalues_ok:
             self.log().notice(f"CValues for all tubes were below threshold {threshold}")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/sans/SANSTubeCalibrationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/sans/SANSTubeCalibrationTest.py
@@ -6,6 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 import unittest
+from tempfile import NamedTemporaryFile
+from pathlib import Path
 
 from mantid.api import AnalysisDataService
 from testhelpers import create_algorithm
@@ -66,6 +68,19 @@ class SANSTubeCalibrationTest(unittest.TestCase):
         }
         alg = self._setup_front_detector_calibration(args)
         self._assert_raises_error("The ending pixel must be less than or equal to", alg)
+
+    def test_cvalues_filepath_plus_extension_matching_existing_file_throws_error(self):
+        with NamedTemporaryFile(suffix=".txt") as cvalues_filepath:
+            args = {Prop.STRIP_POSITIONS: [920], Prop.DATA_FILES: ["test_SANS_calibration_ws"], Prop.CVALUE_FILE: cvalues_filepath.name}
+            alg = self._setup_front_detector_calibration(args)
+            self._assert_raises_error("CValues file already exists", alg)
+
+    def test_cvalues_filepath_minus_extension_matching_existing_file_throws_error(self):
+        with NamedTemporaryFile(suffix=".txt") as cvalues_filepath:
+            filepath_without_ext = str(Path(cvalues_filepath.name).with_suffix(""))
+            args = {Prop.STRIP_POSITIONS: [920], Prop.DATA_FILES: ["test_SANS_calibration_ws"], Prop.CVALUE_FILE: filepath_without_ext}
+            alg = self._setup_front_detector_calibration(args)
+            self._assert_raises_error("CValues file already exists", alg)
 
     def _setup_front_detector_calibration(self, args):
         default_args = {Prop.ENCODER: 474.2, Prop.REAR_DET: False}

--- a/Testing/SystemTests/tests/framework/ISIS/SANS/SANS2D/SANS2DTubeCalibrationTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS/SANS/SANS2D/SANS2DTubeCalibrationTest.py
@@ -17,7 +17,7 @@ from collections import Counter
 
 class SANS2DTubeCalibrationTest:
     _OUTPUT_WS_NAME = "result"
-    _CVALUES_WS_NAME = "cvalues"
+    _CVALUES_WS_PREFIX = "cvalues_"
     _DATA_FILES = ["SANS2D00069117.nxs", "SANS2D00069118.nxs", "SANS2D00069119.nxs", "SANS2D00069120.nxs", "SANS2D00069116.nxs"]
     _NUM_TUBES = 120
 
@@ -71,6 +71,7 @@ class SANS2DTubeCalibrationTest:
 class SANS2DTubeCalibrationRearDetectorTest(systemtesting.MantidSystemTest, SANS2DTubeCalibrationTest):
     _REFERENCE_FILE = "SANS2DTubeMerge_rear.nxs"
     _CVALUES_REF_FILE = "SANS2DTubeCalibration_cvalues_rear.nxs"
+    _DETECTOR_NAME = "rear"
 
     def requiredFile(self):
         return self._DATA_FILES + [self._REFERENCE_FILE, self._CVALUES_REF_FILE]
@@ -86,13 +87,14 @@ class SANS2DTubeCalibrationRearDetectorTest(systemtesting.MantidSystemTest, SANS
         self.disableChecking.append("SpectraMap")
         self.disableChecking.append("Axes")
 
-        return self._OUTPUT_WS_NAME, self._REFERENCE_FILE, self._CVALUES_WS_NAME, self._CVALUES_REF_FILE
+        return self._OUTPUT_WS_NAME, self._REFERENCE_FILE, f"{self._CVALUES_WS_PREFIX}{self._DETECTOR_NAME}", self._CVALUES_REF_FILE
 
 
 @ISISSansSystemTest(SANSInstrument.SANS2D)
 class SANS2DTubeCalibrationFrontDetectorTest(systemtesting.MantidSystemTest, SANS2DTubeCalibrationTest):
     _REFERENCE_FILE = "SANS2DTubeMerge_front.nxs"
     _CVALUES_REF_FILE = "SANS2DTubeCalibration_cvalues_front.nxs"
+    _DETECTOR_NAME = "front"
 
     def requiredFile(self):
         return self._DATA_FILES + [self._REFERENCE_FILE, self._CVALUES_REF_FILE]
@@ -112,4 +114,4 @@ class SANS2DTubeCalibrationFrontDetectorTest(systemtesting.MantidSystemTest, SAN
         self.disableChecking.append("SpectraMap")
         self.disableChecking.append("Axes")
 
-        return self._OUTPUT_WS_NAME, self._REFERENCE_FILE, self._CVALUES_WS_NAME, self._CVALUES_REF_FILE
+        return self._OUTPUT_WS_NAME, self._REFERENCE_FILE, f"{self._CVALUES_WS_PREFIX}{self._DETECTOR_NAME}", self._CVALUES_REF_FILE

--- a/docs/source/algorithms/SANSTubeCalibration-v1.rst
+++ b/docs/source/algorithms/SANSTubeCalibration-v1.rst
@@ -50,9 +50,12 @@ Correcting the Detector Pixel Locations
 Once the corrected pixel positions have been calculated for all tubes, :ref:`ApplyCalibration <algm-ApplyCalibration>` is called to move all the detector pixels in the workspace to their correct positions.
 On completion of the calibration, there will be a workspace in the ADS called ``result`` that contains these corrected detector positions.
 If a value has been provided for the ``OutputFile`` property, then this workspace is automatically saved out as a Nexus file to the specified location.
+
 A workspace called ``cvalues`` gives the average resolution of the fit parameter for each tube, giving an indication of the quality of the calibration.
 When the algorithm completes, a notice will be printed in the messages pane for any tube with an average resolution greater than the value specified in the ``CValueThreshold`` property. These tubes are considered to have a poor quality calibration.
-If ``SkipTubesOnError`` was set to ``True``, then warnings will also be printed when the algorithm completes detailing any tubes that were not calibrated and stating the reasons why.
+This list can be written out to a text file by passing a filepath to the ``CValueOutputFile`` property.
+
+If ``SkipTubesOnError`` was set to ``True``, then warnings will be printed when the algorithm completes detailing any tubes that were not calibrated and stating the reasons why.
 
 A number of other diagnostic workspaces are output to the ADS during the calibration. These allow closer inspection of the results from the fitting and other calibration steps for each tube.
 They provide the following information:

--- a/docs/source/release/v6.9.0/SANS/New_features/35981.rst
+++ b/docs/source/release/v6.9.0/SANS/New_features/35981.rst
@@ -1,0 +1,1 @@
+- The :ref:`algm-SANSTubeCalibration` algorithm now takes a filepath to optionally save out the list of calibrated tubes that exceed the cvalue threshold. Additionally, the cvalues workspace in the Workspaces list is now suffixed with the detector name.


### PR DESCRIPTION
### Description of work
Improve how cvalues are output from the `SANSTubeCalibration` algorithm.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
This PR makes the following changes:

- The cvalue information logged at the end of the algorithm now prints the module and tube number rather than the tube ID to refer to tubes that exceed the threshold (prevents users having to convert this for themselves).
- The logged information is also output to a text file, if a file path is provided for this.
- The cvalue workspace is suffixed with the detector name (`front`/`rear`) to avoid it being overwritten when front and rear calibrations are run in succession.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Refs #35981. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
1) Search for the `SANSTubeCalibration` algorithm from the Algorithm pane and click Execute.
1) In the dialog box, set the following parameters:
      - `StripPositions`: 920,755,590,425,260
      - `DataFiles`: SANS2D00069117.nxs,SANS2D00069118.nxs,SANS2D00069119.nxs,SANS2D00069120.nxs,SANS2D00069116.nxs
      - `Rear`: unticked
      - `Threshold`: 1000 (this threshold should result in the calibration succeeding but with cvalue notifications for some tubes)
      - `SkipTubesOnError`: ticked
      - `CValueOutputFile`: set a path on your machine for saving out the cvalue text file
      -  `SaveIntegratedWorkspaces`: ticked - this is not essential but recommended. The algorithm takes a long time to run and loading and normalising the data is very slow. Selecting this parameter means that the normalised workspaces will be saved (to the default save location specified in your Mantid user settings) and can be picked up for future runs of the algorithm, which saves a lot of time. Another tip for saving time when testing is not to clear the ADS between test runs, as the normalised workspaces will be picked up from the ADS if available.
1) Run the calibration. This will take several minutes and will log a lot of information.
1) Once the algorithm has completed there should be a notice in the logs (at the very end) listing the tubes with cvalues that are too high. Check that the tubes are identified by module and tube number rather than tube ID (see first bullet point on linked issue for more clarification about this, if needed).
1) Check that a text file has been output to the location specified in `CValueOutputFile` containing the same information as was logged.
1) Check that the cvalues workspace in the ADS is named `cvalues_front`. You can check that the suffix changes to `rear` when calibrating the rear detector by changing the following parameters and re-running the algorithm:
    - `Rear`: ticked
    - `Threshold`: 500 (this threshold should result in the calibration succeeding with no cvalue notifications)

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
