### PR TITLE
If StoreInADS False then set OutputWorkspace property optional

### DIFF
--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -153,6 +153,7 @@ set(SRC_FILES
     src/WorkspaceNearestNeighbours.cpp
     src/WorkspaceOpOverloads.cpp
     src/WorkspaceProperty.cpp
+    src/WorkspacePropertyUtils.cpp
     src/WorkspaceUnitValidator.cpp
 )
 
@@ -364,6 +365,7 @@ set(INC_FILES
     inc/MantidAPI/WorkspaceOpOverloads.h
     inc/MantidAPI/WorkspaceProperty.h
     inc/MantidAPI/WorkspaceProperty.tcc
+    inc/MantidAPI/WorkspacePropertyUtils.h
     inc/MantidAPI/WorkspaceUnitValidator.h
     inc/MantidAPI/Workspace_fwd.h
 )

--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -491,6 +491,7 @@ set(TEST_FILES
     WorkspaceNearestNeighboursTest.h
     WorkspaceOpOverloadsTest.h
     WorkspacePropertyTest.h
+    WorkspacePropertyUtilsTest.h
     WorkspaceUnitValidatorTest.h
 )
 

--- a/Framework/API/inc/MantidAPI/IWorkspaceProperty.h
+++ b/Framework/API/inc/MantidAPI/IWorkspaceProperty.h
@@ -13,6 +13,12 @@
 
 namespace Mantid {
 namespace API {
+
+/// Enumeration for a mandatory/optional property
+struct PropertyMode {
+  enum Type { Mandatory, Optional };
+};
+
 /** An interface that is implemented by WorkspaceProperty.
     Used for non templated workspace operations.
 
@@ -28,6 +34,8 @@ public:
   virtual void clear() = 0;
   /// Get a pointer to the workspace
   virtual Workspace_sptr getWorkspace() const = 0;
+  /// Set the property mode as Mandatory or Optional
+  virtual void setPropertyMode(const PropertyMode::Type &optional) = 0;
   /// Is the input workspace property optional (can be blank)?
   virtual bool isOptional() const = 0;
   /// Will the workspace be locked when starting an algorithm?

--- a/Framework/API/inc/MantidAPI/WorkspaceProperty.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceProperty.h
@@ -20,10 +20,6 @@ namespace API {
 class MatrixWorkspace;
 class WorkspaceGroup;
 
-/// Enumeration for a mandatory/optional property
-struct PropertyMode {
-  enum Type { Mandatory, Optional };
-};
 /// Enumeration for locking behaviour
 struct LockMode {
   enum Type { Lock, NoLock };
@@ -91,6 +87,8 @@ public:
   std::string setValueFromJson(const Json::Value &value) override;
 
   std::string setDataItem(const std::shared_ptr<Kernel::DataItem> &value) override;
+
+  void setPropertyMode(const PropertyMode::Type &optional) override;
 
   std::string isValid() const override;
 

--- a/Framework/API/inc/MantidAPI/WorkspaceProperty.tcc
+++ b/Framework/API/inc/MantidAPI/WorkspaceProperty.tcc
@@ -190,6 +190,13 @@ std::string WorkspaceProperty<TYPE>::setDataItem(const std::shared_ptr<Kernel::D
   return isValid();
 }
 
+/** Set the property mode of the property e.g. Mandatory or Optional
+ *  @param optional :: Property mode Mandatory or Optional
+ */
+template <typename TYPE> void WorkspaceProperty<TYPE>::setPropertyMode(const PropertyMode::Type &optional) {
+  m_optional = optional;
+}
+
 /** Checks whether the entered workspace is valid.
  *  To be valid, in addition to satisfying the conditions of any validators,
  *  an output property must not have an empty name and an input one must point

--- a/Framework/API/inc/MantidAPI/WorkspacePropertyUtils.h
+++ b/Framework/API/inc/MantidAPI/WorkspacePropertyUtils.h
@@ -6,14 +6,16 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidAPI/DllConfig.h"
+
 #include "MantidAPI/IWorkspaceProperty.h"
-#include "MantidKernel/PropertyWithValue.h"
-#include "MantidKernel/System.h"
+#include "MantidKernel/Property.h"
 
 namespace Mantid {
 namespace API {
 
-void setPropertyModeForWorkspaceProperty(Mantid::Kernel::Property *prop, const PropertyMode::Type &optional);
+MANTID_API_DLL void setPropertyModeForWorkspaceProperty(Mantid::Kernel::Property *prop,
+                                                        const PropertyMode::Type &optional);
 
 }
 } // namespace Mantid

--- a/Framework/API/inc/MantidAPI/WorkspacePropertyUtils.h
+++ b/Framework/API/inc/MantidAPI/WorkspacePropertyUtils.h
@@ -1,0 +1,19 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/IWorkspaceProperty.h"
+#include "MantidKernel/PropertyWithValue.h"
+#include "MantidKernel/System.h"
+
+namespace Mantid {
+namespace API {
+
+void setPropertyModeForWorkspaceProperty(Mantid::Kernel::Property *prop, const PropertyMode::Type &optional);
+
+}
+} // namespace Mantid

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -14,6 +14,7 @@
 #include "MantidAPI/IWorkspaceProperty.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAPI/WorkspaceHistory.h"
+#include "MantidAPI/WorkspacePropertyUtils.h"
 
 #include "MantidJson/Json.h"
 #include "MantidKernel/CompositeValidator.h"
@@ -178,7 +179,16 @@ void Algorithm::enableHistoryRecordingForChild(const bool on) { m_recordHistoryF
  *
  * @param doStore :: always store in ADS
  */
-void Algorithm::setAlwaysStoreInADS(const bool doStore) { m_alwaysStoreInADS = doStore; }
+void Algorithm::setAlwaysStoreInADS(const bool doStore) {
+  m_alwaysStoreInADS = doStore;
+
+  // Set OutputWorkspace as an optional property in the case where alwaysStoreInADS is false. In
+  // this case, the output workspace name is not always required.
+  if (!m_alwaysStoreInADS && m_properties.existsProperty("OutputWorkspace")) {
+    Property *property = m_properties.getPointerToProperty("OutputWorkspace");
+    setPropertyModeForWorkspaceProperty(property, PropertyMode::Type::Optional);
+  }
+}
 
 /** Returns true if we always store in the AnalysisDataService.
  *  @return true if output is saved to the AnalysisDataService.

--- a/Framework/API/src/WorkspacePropertyUtils.cpp
+++ b/Framework/API/src/WorkspacePropertyUtils.cpp
@@ -36,7 +36,8 @@ void setPropertyModeForWorkspaceProperties(Mantid::Kernel::Property *prop,
 namespace Mantid {
 namespace API {
 
-void setPropertyModeForWorkspaceProperty(Mantid::Kernel::Property *prop, const PropertyMode::Type &optional) {
+void MANTID_API_DLL setPropertyModeForWorkspaceProperty(Mantid::Kernel::Property *prop,
+                                                        const PropertyMode::Type &optional) {
   setPropertyModeForWorkspaceProperties<API::Workspace, API::MatrixWorkspace, API::HistoWorkspace, API::WorkspaceGroup,
                                         API::IEventWorkspace, API::IMDHistoWorkspace, API::IPeaksWorkspace,
                                         API::ITableWorkspace>(prop, optional);

--- a/Framework/API/src/WorkspacePropertyUtils.cpp
+++ b/Framework/API/src/WorkspacePropertyUtils.cpp
@@ -1,0 +1,46 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidAPI/HistoWorkspace.h"
+#include "MantidAPI/IEventWorkspace.h"
+#include "MantidAPI/IMDHistoWorkspace.h"
+#include "MantidAPI/IPeaksWorkspace.h"
+#include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Workspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceProperty.h"
+
+namespace {
+
+template <typename T>
+void setPropertyModeForWorkspaceProperties(Mantid::Kernel::Property *prop,
+                                           const Mantid::API::PropertyMode::Type &optional) {
+  if (auto workspaceProperty = dynamic_cast<Mantid::API::WorkspaceProperty<T> *>(prop)) {
+    workspaceProperty->setPropertyMode(optional);
+  }
+}
+
+template <typename T, typename... Ts, typename = std::enable_if_t<sizeof...(Ts) != 0>>
+void setPropertyModeForWorkspaceProperties(Mantid::Kernel::Property *prop,
+                                           const Mantid::API::PropertyMode::Type &optional) {
+  setPropertyModeForWorkspaceProperties<T>(prop, optional);
+  setPropertyModeForWorkspaceProperties<Ts...>(prop, optional);
+}
+
+} // namespace
+
+namespace Mantid {
+namespace API {
+
+void setPropertyModeForWorkspaceProperty(Mantid::Kernel::Property *prop, const PropertyMode::Type &optional) {
+  setPropertyModeForWorkspaceProperties<API::Workspace, API::MatrixWorkspace, API::HistoWorkspace, API::WorkspaceGroup,
+                                        API::IEventWorkspace, API::IMDHistoWorkspace, API::IPeaksWorkspace,
+                                        API::ITableWorkspace>(prop, optional);
+}
+
+} // namespace API
+} // namespace Mantid

--- a/Framework/API/test/WorkspacePropertyUtilsTest.h
+++ b/Framework/API/test/WorkspacePropertyUtilsTest.h
@@ -1,0 +1,68 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/IEventWorkspace.h"
+#include "MantidAPI/IMDHistoWorkspace.h"
+#include "MantidAPI/IPeaksWorkspace.h"
+#include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Workspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceProperty.h"
+#include "MantidAPI/WorkspacePropertyUtils.h"
+#include "MantidKernel/Property.h"
+
+using namespace Mantid::API;
+using namespace Mantid::Kernel;
+
+class WorkspacePropertyUtilsTest : public CxxTest::TestSuite {
+
+public:
+  static WorkspacePropertyUtilsTest *createSuite() { return new WorkspacePropertyUtilsTest(); }
+
+  static void destroySuite(WorkspacePropertyUtilsTest *suite) { delete suite; }
+
+  void test_set_property_mode_mandatory_for_different_workspace_types() {
+    assertSetPropertyModeMandatory<Mantid::API::Workspace>();
+    assertSetPropertyModeMandatory<Mantid::API::MatrixWorkspace>();
+    assertSetPropertyModeMandatory<Mantid::API::WorkspaceGroup>();
+    assertSetPropertyModeMandatory<Mantid::API::IEventWorkspace>();
+    assertSetPropertyModeMandatory<Mantid::API::IMDHistoWorkspace>();
+    assertSetPropertyModeMandatory<Mantid::API::IPeaksWorkspace>();
+    assertSetPropertyModeMandatory<Mantid::API::ITableWorkspace>();
+  }
+
+  void test_set_property_mode_optional_for_different_workspace_types() {
+    assertSetPropertyModeOptional<Mantid::API::Workspace>();
+    assertSetPropertyModeOptional<Mantid::API::MatrixWorkspace>();
+    assertSetPropertyModeOptional<Mantid::API::WorkspaceGroup>();
+    assertSetPropertyModeOptional<Mantid::API::IEventWorkspace>();
+    assertSetPropertyModeOptional<Mantid::API::IMDHistoWorkspace>();
+    assertSetPropertyModeOptional<Mantid::API::IPeaksWorkspace>();
+    assertSetPropertyModeOptional<Mantid::API::ITableWorkspace>();
+  }
+
+private:
+  template <typename T> void assertSetPropertyModeMandatory() {
+    auto prop = std::make_unique<WorkspaceProperty<T>>("Name", "", Direction::Output, PropertyMode::Type::Optional);
+    TS_ASSERT(prop->isOptional());
+
+    Mantid::API::setPropertyModeForWorkspaceProperty(prop.get(), PropertyMode::Type::Mandatory);
+    TS_ASSERT(!prop->isOptional());
+  }
+
+  template <typename T> void assertSetPropertyModeOptional() {
+    auto prop = std::make_unique<WorkspaceProperty<T>>("Name", "", Direction::Output);
+    TS_ASSERT(!prop->isOptional());
+
+    Mantid::API::setPropertyModeForWorkspaceProperty(prop.get(), PropertyMode::Type::Optional);
+    TS_ASSERT(prop->isOptional());
+  }
+};

--- a/docs/source/release/v6.9.0/Framework/Algorithms/New_features/36368.rst
+++ b/docs/source/release/v6.9.0/Framework/Algorithms/New_features/36368.rst
@@ -1,0 +1,1 @@
+- When the `StoreInADS` algorithm property is False, it is now optional to provide a value for `OutputWorkspace`.


### PR DESCRIPTION
### Description of work
When StoreInADS is False, the output workspace from an algorithm tends to not be put into the ADS. Also, a workspace does not actually have a name until it is put into the ADS. Therefore, providing a value to the `OutputWorkspace` property of an algorithm should be optional when StoreInADS is False, because the output workspace name is not used when the output is not placed into the ADS.

Making this behavioural change will allow developers to decouple their interface code from the ADS, whilst still allowing project recovery/project save/generating scripts from algorithm history to work (something that was not previously possible - you had to choose one or the other). This is an enabler PR that will allow me to fix #28666 - because I will no longer need to store intermediate workspaces in the ADS in order to ensure generating scripts from algorithm history will work.

To stop algorithms outputing to the ADS, you will need to:
```
alg->setAlwaysStoreInADS(false);
```

Then to make sure algorithm script history works, you will need to pass actual workspaces into the properties of the algorithms (rather than just names), and also you will need to remove any line that attempts to set the `OutputWorkspace` property to a workspace name.

Part of #28666

### To test:
1. Run the following script - it should produce an error about missing "OutputWorkspace" property

```py
from mantid.simpleapi import *

ws = Load(Filename='IRS26176.raw', StoreInADS=False)
ExtractSpectra(InputWorkspace=ws, EndWorkspaceIndex=0)
```

2. Clear the ADS
3. Run the following script - it should run without error. There should be no workspace in ADS

```py
from mantid.simpleapi import *

ws = Load(Filename='IRS26176.raw', StoreInADS=False)
result = ExtractSpectra(InputWorkspace=ws, EndWorkspaceIndex=0, StoreInADS=False)
```

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
