### PR TITLE
IndirectPlotOptionsPresenter is no longer a QObject

### DIFF
--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -64,7 +64,6 @@ set(MOC_FILES
     IndirectInstrumentConfig.h
     IndirectInterface.h
     IndirectMolDyn.h
-    IndirectPlotOptionsPresenter.h
     IndirectPlotOptionsView.h
     IndirectSassena.h
     IndirectSettings.h
@@ -90,6 +89,7 @@ set(INC_FILES
     DllConfig.h
     IndirectDataValidationHelper.h
     IndirectPlotOptionsModel.h
+    IndirectPlotOptionsPresenter.h
     IndirectSettingsHelper.h
     Notifier.h
     Reduction/ISISEnergyTransferData.h

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
@@ -111,14 +111,14 @@ void IndirectPlotOptionsPresenter::onWorkspaceReplaced(WorkspaceBeforeReplaceNot
   if (auto const newWorkspace = std::dynamic_pointer_cast<MatrixWorkspace>(nf->newObject())) {
     auto const newName = newWorkspace->getName();
     if (newName == m_view->selectedWorkspace().toStdString())
-      notifyWorkspaceChanged(newName);
+      handleWorkspaceChanged(newName);
   }
 }
 
 void IndirectPlotOptionsPresenter::setWorkspaces(std::vector<std::string> const &workspaces) {
   auto const workspaceNames = m_model->getAllWorkspaceNames(workspaces);
   m_view->setWorkspaces(workspaceNames);
-  notifyWorkspaceChanged(workspaceNames.front());
+  handleWorkspaceChanged(workspaceNames.front());
 }
 
 void IndirectPlotOptionsPresenter::setWorkspace(std::string const &plotWorkspace) {
@@ -143,20 +143,20 @@ void IndirectPlotOptionsPresenter::setUnit(std::string const &unit) {
 void IndirectPlotOptionsPresenter::setIndices() {
   auto const selectedIndices = m_view->selectedIndices().toStdString();
   if (auto const indices = m_model->indices())
-    notifySelectedIndicesChanged(indices.get());
+    handleSelectedIndicesChanged(indices.get());
   else if (!selectedIndices.empty())
-    notifySelectedIndicesChanged(selectedIndices);
+    handleSelectedIndicesChanged(selectedIndices);
   else
-    notifySelectedIndicesChanged("0");
+    handleSelectedIndicesChanged("0");
 }
 
-void IndirectPlotOptionsPresenter::notifyWorkspaceChanged(std::string const &workspaceName) {
+void IndirectPlotOptionsPresenter::handleWorkspaceChanged(std::string const &workspaceName) {
   setWorkspace(workspaceName);
 }
 
-void IndirectPlotOptionsPresenter::notifySelectedUnitChanged(std::string const &unit) { setUnit(unit); }
+void IndirectPlotOptionsPresenter::handleSelectedUnitChanged(std::string const &unit) { setUnit(unit); }
 
-void IndirectPlotOptionsPresenter::notifySelectedIndicesChanged(std::string const &indices) {
+void IndirectPlotOptionsPresenter::handleSelectedIndicesChanged(std::string const &indices) {
   auto const formattedIndices = m_model->formatIndices(indices);
   m_view->setIndices(QString::fromStdString(formattedIndices));
   m_view->setIndicesErrorLabelVisible(!m_model->setIndices(formattedIndices));
@@ -165,7 +165,7 @@ void IndirectPlotOptionsPresenter::notifySelectedIndicesChanged(std::string cons
     m_view->addIndicesSuggestion(QString::fromStdString(formattedIndices));
 }
 
-void IndirectPlotOptionsPresenter::notifyPlotSpectraClicked() {
+void IndirectPlotOptionsPresenter::handlePlotSpectraClicked() {
   if (validateWorkspaceSize(MantidAxis::Spectrum)) {
     setPlotting(true);
     m_model->plotSpectra();
@@ -173,7 +173,7 @@ void IndirectPlotOptionsPresenter::notifyPlotSpectraClicked() {
   }
 }
 
-void IndirectPlotOptionsPresenter::notifyPlotBinsClicked() {
+void IndirectPlotOptionsPresenter::handlePlotBinsClicked() {
   if (validateWorkspaceSize(MantidAxis::Bin)) {
     auto const indicesString = m_view->selectedIndices().toStdString();
     if (m_model->validateIndices(indicesString, MantidAxis::Bin)) {
@@ -186,13 +186,13 @@ void IndirectPlotOptionsPresenter::notifyPlotBinsClicked() {
   }
 }
 
-void IndirectPlotOptionsPresenter::notifyPlotContourClicked() {
+void IndirectPlotOptionsPresenter::handlePlotContourClicked() {
   setPlotting(true);
   m_model->plotContour();
   setPlotting(false);
 }
 
-void IndirectPlotOptionsPresenter::notifyPlotTiledClicked() {
+void IndirectPlotOptionsPresenter::handlePlotTiledClicked() {
   if (validateWorkspaceSize(MantidAxis::Spectrum)) {
     setPlotting(true);
     m_model->plotTiled();

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
@@ -56,6 +56,7 @@ IndirectPlotOptionsPresenter::~IndirectPlotOptionsPresenter() { watchADS(false);
 
 void IndirectPlotOptionsPresenter::setupPresenter(PlotWidget const &plotType, std::string const &fixedIndices) {
   watchADS(true);
+  m_view->subscribePresenter(this);
 
   m_view->setIndicesRegex(QString::fromStdString(Regexes::WORKSPACE_INDICES));
   m_view->setPlotType(plotType, m_model->availableActions());
@@ -64,7 +65,6 @@ void IndirectPlotOptionsPresenter::setupPresenter(PlotWidget const &plotType, st
 
   m_plotType = plotType;
   setOptionsEnabled(false);
-  m_view->subscribePresenter(this);
 }
 
 void IndirectPlotOptionsPresenter::watchADS(bool on) {

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
@@ -37,7 +37,7 @@ namespace MantidQt::CustomInterfaces {
 IndirectPlotOptionsPresenter::IndirectPlotOptionsPresenter(
     IIndirectPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
     boost::optional<std::map<std::string, std::string>> const &availableActions)
-    : QObject(nullptr), m_wsRemovedObserver(*this, &IndirectPlotOptionsPresenter::onWorkspaceRemoved),
+    : m_wsRemovedObserver(*this, &IndirectPlotOptionsPresenter::onWorkspaceRemoved),
       m_wsReplacedObserver(*this, &IndirectPlotOptionsPresenter::onWorkspaceReplaced), m_view(view),
       m_model(std::make_unique<IndirectPlotOptionsModel>(availableActions)) {
   setupPresenter(plotType, fixedIndices);
@@ -47,7 +47,7 @@ IndirectPlotOptionsPresenter::IndirectPlotOptionsPresenter(
 IndirectPlotOptionsPresenter::IndirectPlotOptionsPresenter(IIndirectPlotOptionsView *view,
                                                            IndirectPlotOptionsModel *model, PlotWidget const &plotType,
                                                            std::string const &fixedIndices)
-    : QObject(nullptr), m_wsRemovedObserver(*this, &IndirectPlotOptionsPresenter::onWorkspaceRemoved),
+    : m_wsRemovedObserver(*this, &IndirectPlotOptionsPresenter::onWorkspaceRemoved),
       m_wsReplacedObserver(*this, &IndirectPlotOptionsPresenter::onWorkspaceReplaced), m_view(view), m_model(model) {
   setupPresenter(plotType, fixedIndices);
 }

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
@@ -35,7 +35,7 @@ std::string const WORKSPACE_INDICES = "(" + NATURAL_OR_RANGE + "(" + COMMA + NAT
 namespace MantidQt::CustomInterfaces {
 
 IndirectPlotOptionsPresenter::IndirectPlotOptionsPresenter(
-    IndirectPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
+    IIndirectPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
     boost::optional<std::map<std::string, std::string>> const &availableActions)
     : QObject(nullptr), m_wsRemovedObserver(*this, &IndirectPlotOptionsPresenter::onWorkspaceRemoved),
       m_wsReplacedObserver(*this, &IndirectPlotOptionsPresenter::onWorkspaceReplaced), m_view(view),
@@ -44,7 +44,7 @@ IndirectPlotOptionsPresenter::IndirectPlotOptionsPresenter(
 }
 
 /// Used by the unit tests so that m_plotter can be mocked
-IndirectPlotOptionsPresenter::IndirectPlotOptionsPresenter(IndirectPlotOptionsView *view,
+IndirectPlotOptionsPresenter::IndirectPlotOptionsPresenter(IIndirectPlotOptionsView *view,
                                                            IndirectPlotOptionsModel *model, PlotWidget const &plotType,
                                                            std::string const &fixedIndices)
     : QObject(nullptr), m_wsRemovedObserver(*this, &IndirectPlotOptionsPresenter::onWorkspaceRemoved),

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
@@ -50,6 +50,7 @@ IndirectPlotOptionsPresenter::IndirectPlotOptionsPresenter(IndirectPlotOptionsVi
     : QObject(nullptr), m_wsRemovedObserver(*this, &IndirectPlotOptionsPresenter::onWorkspaceRemoved),
       m_wsReplacedObserver(*this, &IndirectPlotOptionsPresenter::onWorkspaceReplaced), m_view(view), m_model(model) {
   setupPresenter(plotType, fixedIndices);
+  m_view->subscribePresenter(this);
 }
 
 IndirectPlotOptionsPresenter::~IndirectPlotOptionsPresenter() { watchADS(false); }

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
@@ -58,8 +58,6 @@ IndirectPlotOptionsPresenter::~IndirectPlotOptionsPresenter() { watchADS(false);
 void IndirectPlotOptionsPresenter::setupPresenter(PlotWidget const &plotType, std::string const &fixedIndices) {
   watchADS(true);
 
-  connect(m_view, SIGNAL(selectedWorkspaceChanged(std::string const &)), this,
-          SLOT(workspaceChanged(std::string const &)));
   connect(m_view, SIGNAL(selectedUnitChanged(std::string const &)), this, SLOT(unitChanged(std::string const &)));
   connect(m_view, SIGNAL(selectedIndicesChanged(std::string const &)), this, SLOT(indicesChanged(std::string const &)));
 
@@ -121,14 +119,14 @@ void IndirectPlotOptionsPresenter::onWorkspaceReplaced(WorkspaceBeforeReplaceNot
   if (auto const newWorkspace = std::dynamic_pointer_cast<MatrixWorkspace>(nf->newObject())) {
     auto const newName = newWorkspace->getName();
     if (newName == m_view->selectedWorkspace().toStdString())
-      workspaceChanged(newName);
+      notifyWorkspaceChanged(newName);
   }
 }
 
 void IndirectPlotOptionsPresenter::setWorkspaces(std::vector<std::string> const &workspaces) {
   auto const workspaceNames = m_model->getAllWorkspaceNames(workspaces);
   m_view->setWorkspaces(workspaceNames);
-  workspaceChanged(workspaceNames.front());
+  notifyWorkspaceChanged(workspaceNames.front());
 }
 
 void IndirectPlotOptionsPresenter::setWorkspace(std::string const &plotWorkspace) {
@@ -160,7 +158,9 @@ void IndirectPlotOptionsPresenter::setIndices() {
     indicesChanged("0");
 }
 
-void IndirectPlotOptionsPresenter::workspaceChanged(std::string const &workspaceName) { setWorkspace(workspaceName); }
+void IndirectPlotOptionsPresenter::notifyWorkspaceChanged(std::string const &workspaceName) {
+  setWorkspace(workspaceName);
+}
 
 void IndirectPlotOptionsPresenter::unitChanged(std::string const &unit) { setUnit(unit); }
 

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
@@ -20,13 +20,13 @@ namespace CustomInterfaces {
 
 class MANTIDQT_INDIRECT_DLL IIndirectPlotOptionsPresenter {
 public:
-  virtual void notifyWorkspaceChanged(std::string const &workspaceName) = 0;
-  virtual void notifySelectedUnitChanged(std::string const &unit) = 0;
-  virtual void notifySelectedIndicesChanged(std::string const &indices) = 0;
-  virtual void notifyPlotSpectraClicked() = 0;
-  virtual void notifyPlotBinsClicked() = 0;
-  virtual void notifyPlotContourClicked() = 0;
-  virtual void notifyPlotTiledClicked() = 0;
+  virtual void handleWorkspaceChanged(std::string const &workspaceName) = 0;
+  virtual void handleSelectedUnitChanged(std::string const &unit) = 0;
+  virtual void handleSelectedIndicesChanged(std::string const &indices) = 0;
+  virtual void handlePlotSpectraClicked() = 0;
+  virtual void handlePlotBinsClicked() = 0;
+  virtual void handlePlotContourClicked() = 0;
+  virtual void handlePlotTiledClicked() = 0;
 };
 
 class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsPresenter final : public IIndirectPlotOptionsPresenter {
@@ -41,13 +41,13 @@ public:
                                PlotWidget const &plotType = PlotWidget::Spectra, std::string const &fixedIndices = "");
   ~IndirectPlotOptionsPresenter();
 
-  void notifyWorkspaceChanged(std::string const &workspaceName) override;
-  void notifySelectedUnitChanged(std::string const &unit) override;
-  void notifySelectedIndicesChanged(std::string const &indices) override;
-  void notifyPlotSpectraClicked() override;
-  void notifyPlotBinsClicked() override;
-  void notifyPlotContourClicked() override;
-  void notifyPlotTiledClicked() override;
+  void handleWorkspaceChanged(std::string const &workspaceName) override;
+  void handleSelectedUnitChanged(std::string const &unit) override;
+  void handleSelectedIndicesChanged(std::string const &indices) override;
+  void handlePlotSpectraClicked() override;
+  void handlePlotBinsClicked() override;
+  void handlePlotContourClicked() override;
+  void handlePlotTiledClicked() override;
 
   void setPlotType(PlotWidget const &plotType);
 

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
@@ -20,7 +20,12 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsPresenter : public QObject {
+class MANTIDQT_INDIRECT_DLL IIndirectPlotOptionsPresenter {
+public:
+  virtual void notifyWorkspaceChanged(std::string const &workspaceName) = 0;
+};
+
+class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsPresenter : public QObject, IIndirectPlotOptionsPresenter {
   Q_OBJECT
 
 public:
@@ -32,6 +37,8 @@ public:
   IndirectPlotOptionsPresenter(IndirectPlotOptionsView *view, IndirectPlotOptionsModel *model,
                                PlotWidget const &plotType = PlotWidget::Spectra, std::string const &fixedIndices = "");
   ~IndirectPlotOptionsPresenter() override;
+
+  void notifyWorkspaceChanged(std::string const &workspaceName) override{};
 
   void setPlotType(PlotWidget const &plotType);
 

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
@@ -38,7 +38,7 @@ public:
                                PlotWidget const &plotType = PlotWidget::Spectra, std::string const &fixedIndices = "");
   ~IndirectPlotOptionsPresenter() override;
 
-  void notifyWorkspaceChanged(std::string const &workspaceName) override{};
+  void notifyWorkspaceChanged(std::string const &workspaceName) override;
 
   void setPlotType(PlotWidget const &plotType);
 
@@ -46,7 +46,6 @@ public:
   void clearWorkspaces();
 
 private slots:
-  void workspaceChanged(std::string const &workspaceName);
   void unitChanged(std::string const &unit);
   void indicesChanged(std::string const &indices);
   void plotSpectra();

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
@@ -15,8 +15,6 @@
 
 #include <Poco/NObserver.h>
 
-#include <QObject>
-
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -31,8 +29,7 @@ public:
   virtual void notifyPlotTiledClicked() = 0;
 };
 
-class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsPresenter : public QObject, public IIndirectPlotOptionsPresenter {
-  Q_OBJECT
+class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsPresenter : public IIndirectPlotOptionsPresenter {
 
 public:
   IndirectPlotOptionsPresenter(
@@ -42,7 +39,7 @@ public:
   /// Used by the unit tests so that the view and model can be mocked
   IndirectPlotOptionsPresenter(IIndirectPlotOptionsView *view, IndirectPlotOptionsModel *model,
                                PlotWidget const &plotType = PlotWidget::Spectra, std::string const &fixedIndices = "");
-  ~IndirectPlotOptionsPresenter() override;
+  ~IndirectPlotOptionsPresenter();
 
   void notifyWorkspaceChanged(std::string const &workspaceName) override;
   void notifySelectedUnitChanged(std::string const &unit) override;

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
@@ -23,6 +23,12 @@ namespace CustomInterfaces {
 class MANTIDQT_INDIRECT_DLL IIndirectPlotOptionsPresenter {
 public:
   virtual void notifyWorkspaceChanged(std::string const &workspaceName) = 0;
+  virtual void notifySelectedUnitChanged(std::string const &unit) = 0;
+  virtual void notifySelectedIndicesChanged(std::string const &indices) = 0;
+  virtual void notifyPlotSpectraClicked() = 0;
+  virtual void notifyPlotBinsClicked() = 0;
+  virtual void notifyPlotContourClicked() = 0;
+  virtual void notifyPlotTiledClicked() = 0;
 };
 
 class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsPresenter : public QObject, IIndirectPlotOptionsPresenter {
@@ -39,19 +45,17 @@ public:
   ~IndirectPlotOptionsPresenter() override;
 
   void notifyWorkspaceChanged(std::string const &workspaceName) override;
+  void notifySelectedUnitChanged(std::string const &unit) override;
+  void notifySelectedIndicesChanged(std::string const &indices) override;
+  void notifyPlotSpectraClicked() override;
+  void notifyPlotBinsClicked() override;
+  void notifyPlotContourClicked() override;
+  void notifyPlotTiledClicked() override;
 
   void setPlotType(PlotWidget const &plotType);
 
   void setWorkspaces(std::vector<std::string> const &workspaces);
   void clearWorkspaces();
-
-private slots:
-  void unitChanged(std::string const &unit);
-  void indicesChanged(std::string const &indices);
-  void plotSpectra();
-  void plotBins();
-  void plotContour();
-  void plotTiled();
 
 private:
   void setupPresenter(PlotWidget const &plotType, std::string const &fixedIndices);

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
@@ -29,7 +29,7 @@ public:
   virtual void notifyPlotTiledClicked() = 0;
 };
 
-class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsPresenter : public IIndirectPlotOptionsPresenter {
+class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsPresenter final : public IIndirectPlotOptionsPresenter {
 
 public:
   IndirectPlotOptionsPresenter(

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
@@ -31,16 +31,16 @@ public:
   virtual void notifyPlotTiledClicked() = 0;
 };
 
-class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsPresenter : public QObject, IIndirectPlotOptionsPresenter {
+class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsPresenter : public QObject, public IIndirectPlotOptionsPresenter {
   Q_OBJECT
 
 public:
   IndirectPlotOptionsPresenter(
-      IndirectPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
+      IIndirectPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
       std::string const &fixedIndices = "",
       boost::optional<std::map<std::string, std::string>> const &availableActions = boost::none);
   /// Used by the unit tests so that the view and model can be mocked
-  IndirectPlotOptionsPresenter(IndirectPlotOptionsView *view, IndirectPlotOptionsModel *model,
+  IndirectPlotOptionsPresenter(IIndirectPlotOptionsView *view, IndirectPlotOptionsModel *model,
                                PlotWidget const &plotType = PlotWidget::Spectra, std::string const &fixedIndices = "");
   ~IndirectPlotOptionsPresenter() override;
 
@@ -77,7 +77,7 @@ private:
   Poco::NObserver<IndirectPlotOptionsPresenter, Mantid::API::WorkspacePreDeleteNotification> m_wsRemovedObserver;
   Poco::NObserver<IndirectPlotOptionsPresenter, Mantid::API::WorkspaceBeforeReplaceNotification> m_wsReplacedObserver;
 
-  IndirectPlotOptionsView *m_view;
+  IIndirectPlotOptionsView *m_view;
   std::unique_ptr<IndirectPlotOptionsModel> m_model;
   PlotWidget m_plotType;
 };

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectPlotOptionsView.h"
+#include "IndirectPlotOptionsPresenter.h"
 
 #include "MantidQtIcons/Icon.h"
 
@@ -73,7 +74,7 @@ IndirectPlotOptionsView::~IndirectPlotOptionsView() = default;
 
 void IndirectPlotOptionsView::setupView() {
   connect(m_plotOptions->cbWorkspace, SIGNAL(currentTextChanged(QString const &)), this,
-          SLOT(emitSelectedWorkspaceChanged(QString const &)));
+          SLOT(notifySelectedWorkspaceChanged(QString const &)));
 
   connect(m_plotOptions->cbPlotUnit, SIGNAL(currentTextChanged(QString const &)), this,
           SLOT(emitSelectedUnitChanged(QString const &)));
@@ -94,8 +95,8 @@ void IndirectPlotOptionsView::setupView() {
 
 void IndirectPlotOptionsView::subscribePresenter(IIndirectPlotOptionsPresenter *presenter) { m_presenter = presenter; }
 
-void IndirectPlotOptionsView::emitSelectedWorkspaceChanged(QString const &workspaceName) {
-  emit selectedWorkspaceChanged(workspaceName.toStdString());
+void IndirectPlotOptionsView::notifySelectedWorkspaceChanged(QString const &workspaceName) {
+  m_presenter->notifyWorkspaceChanged(workspaceName.toStdString());
 }
 
 void IndirectPlotOptionsView::emitSelectedUnitChanged(QString const &unit) {

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -94,43 +94,43 @@ void IndirectPlotOptionsView::setupView() {
 void IndirectPlotOptionsView::subscribePresenter(IIndirectPlotOptionsPresenter *presenter) { m_presenter = presenter; }
 
 void IndirectPlotOptionsView::notifySelectedWorkspaceChanged(QString const &workspaceName) {
-  m_presenter->notifyWorkspaceChanged(workspaceName.toStdString());
+  m_presenter->handleWorkspaceChanged(workspaceName.toStdString());
 }
 
 void IndirectPlotOptionsView::notifySelectedUnitChanged(QString const &unit) {
   if (!unit.isEmpty()) {
-    m_presenter->notifySelectedUnitChanged(displayStrToUnitId.at(unit.toStdString()));
+    m_presenter->handleSelectedUnitChanged(displayStrToUnitId.at(unit.toStdString()));
   }
 }
 
 void IndirectPlotOptionsView::notifySelectedIndicesChanged() {
-  m_presenter->notifySelectedIndicesChanged(selectedIndices().toStdString());
+  m_presenter->handleSelectedIndicesChanged(selectedIndices().toStdString());
 }
 
 void IndirectPlotOptionsView::notifySelectedIndicesChanged(QString const &spectra) {
   if (spectra.isEmpty()) {
-    m_presenter->notifySelectedIndicesChanged(spectra.toStdString());
+    m_presenter->handleSelectedIndicesChanged(spectra.toStdString());
   }
 }
 
 void IndirectPlotOptionsView::notifyPlotSpectraClicked() {
   notifySelectedIndicesChanged();
-  m_presenter->notifyPlotSpectraClicked();
+  m_presenter->handlePlotSpectraClicked();
 }
 
 void IndirectPlotOptionsView::notifyPlotBinsClicked() {
   notifySelectedIndicesChanged();
-  m_presenter->notifyPlotBinsClicked();
+  m_presenter->handlePlotBinsClicked();
 }
 
 void IndirectPlotOptionsView::notifyPlotContourClicked() {
   notifySelectedIndicesChanged();
-  m_presenter->notifyPlotContourClicked();
+  m_presenter->handlePlotContourClicked();
 }
 
 void IndirectPlotOptionsView::notifyPlotTiledClicked() {
   notifySelectedIndicesChanged();
-  m_presenter->notifyPlotTiledClicked();
+  m_presenter->handlePlotTiledClicked();
 }
 
 void IndirectPlotOptionsView::setPlotType(PlotWidget const &plotType,

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -92,6 +92,8 @@ void IndirectPlotOptionsView::setupView() {
   m_plotOptions->leIndices->setCompleter(m_completer.get());
 }
 
+void IndirectPlotOptionsView::subscribePresenter(IIndirectPlotOptionsPresenter *presenter) { m_presenter = presenter; }
+
 void IndirectPlotOptionsView::emitSelectedWorkspaceChanged(QString const &workspaceName) {
   emit selectedWorkspaceChanged(workspaceName.toStdString());
 }

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -70,8 +70,6 @@ IndirectPlotOptionsView::IndirectPlotOptionsView(QWidget *parent)
   setupView();
 }
 
-IndirectPlotOptionsView::~IndirectPlotOptionsView() = default;
-
 void IndirectPlotOptionsView::setupView() {
   connect(m_plotOptions->cbWorkspace, SIGNAL(currentTextChanged(QString const &)), this,
           SLOT(notifySelectedWorkspaceChanged(QString const &)));

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -77,13 +77,13 @@ void IndirectPlotOptionsView::setupView() {
           SLOT(notifySelectedWorkspaceChanged(QString const &)));
 
   connect(m_plotOptions->cbPlotUnit, SIGNAL(currentTextChanged(QString const &)), this,
-          SLOT(emitSelectedUnitChanged(QString const &)));
+          SLOT(notifySelectedUnitChanged(QString const &)));
 
-  connect(m_plotOptions->leIndices, SIGNAL(editingFinished()), this, SLOT(emitSelectedIndicesChanged()));
+  connect(m_plotOptions->leIndices, SIGNAL(editingFinished()), this, SLOT(notifySelectedIndicesChanged()));
   connect(m_plotOptions->leIndices, SIGNAL(textEdited(QString const &)), this,
-          SLOT(emitSelectedIndicesChanged(QString const &)));
+          SLOT(notifySelectedIndicesChanged(QString const &)));
 
-  connect(m_plotOptions->pbPlotSpectra, SIGNAL(clicked()), this, SLOT(emitPlotSpectraClicked()));
+  connect(m_plotOptions->pbPlotSpectra, SIGNAL(clicked()), this, SLOT(notifyPlotSpectraClicked()));
 
   setIndicesErrorLabelVisible(false);
 
@@ -99,40 +99,40 @@ void IndirectPlotOptionsView::notifySelectedWorkspaceChanged(QString const &work
   m_presenter->notifyWorkspaceChanged(workspaceName.toStdString());
 }
 
-void IndirectPlotOptionsView::emitSelectedUnitChanged(QString const &unit) {
+void IndirectPlotOptionsView::notifySelectedUnitChanged(QString const &unit) {
   if (!unit.isEmpty()) {
-    emit selectedUnitChanged(displayStrToUnitId.at(unit.toStdString()));
+    m_presenter->notifySelectedUnitChanged(displayStrToUnitId.at(unit.toStdString()));
   }
 }
 
-void IndirectPlotOptionsView::emitSelectedIndicesChanged() {
-  emit selectedIndicesChanged(selectedIndices().toStdString());
+void IndirectPlotOptionsView::notifySelectedIndicesChanged() {
+  m_presenter->notifySelectedIndicesChanged(selectedIndices().toStdString());
 }
 
-void IndirectPlotOptionsView::emitSelectedIndicesChanged(QString const &spectra) {
+void IndirectPlotOptionsView::notifySelectedIndicesChanged(QString const &spectra) {
   if (spectra.isEmpty()) {
-    emit selectedIndicesChanged(spectra.toStdString());
+    m_presenter->notifySelectedIndicesChanged(spectra.toStdString());
   }
 }
 
-void IndirectPlotOptionsView::emitPlotSpectraClicked() {
-  emitSelectedIndicesChanged();
-  emit plotSpectraClicked();
+void IndirectPlotOptionsView::notifyPlotSpectraClicked() {
+  notifySelectedIndicesChanged();
+  m_presenter->notifyPlotSpectraClicked();
 }
 
-void IndirectPlotOptionsView::emitPlotBinsClicked() {
-  emitSelectedIndicesChanged();
-  emit plotBinsClicked();
+void IndirectPlotOptionsView::notifyPlotBinsClicked() {
+  notifySelectedIndicesChanged();
+  m_presenter->notifyPlotBinsClicked();
 }
 
-void IndirectPlotOptionsView::emitPlotContourClicked() {
-  emitSelectedIndicesChanged();
-  emit plotContourClicked();
+void IndirectPlotOptionsView::notifyPlotContourClicked() {
+  notifySelectedIndicesChanged();
+  m_presenter->notifyPlotContourClicked();
 }
 
-void IndirectPlotOptionsView::emitPlotTiledClicked() {
-  emitSelectedIndicesChanged();
-  emit plotTiledClicked();
+void IndirectPlotOptionsView::notifyPlotTiledClicked() {
+  notifySelectedIndicesChanged();
+  m_presenter->notifyPlotTiledClicked();
 }
 
 void IndirectPlotOptionsView::setPlotType(PlotWidget const &plotType,
@@ -148,10 +148,10 @@ void IndirectPlotOptionsView::setPlotType(PlotWidget const &plotType,
   auto plotTiledAction = new QAction(getAction(availableActions, "Plot Tiled"), this);
   plotTiledAction->setIcon(plotTiledIcon());
 
-  connect(plotSpectraAction, SIGNAL(triggered()), this, SLOT(emitPlotSpectraClicked()));
-  connect(plotBinAction, SIGNAL(triggered()), this, SLOT(emitPlotBinsClicked()));
-  connect(plotContourAction, SIGNAL(triggered()), this, SLOT(emitPlotContourClicked()));
-  connect(plotTiledAction, SIGNAL(triggered()), this, SLOT(emitPlotTiledClicked()));
+  connect(plotSpectraAction, SIGNAL(triggered()), this, SLOT(notifyPlotSpectraClicked()));
+  connect(plotBinAction, SIGNAL(triggered()), this, SLOT(notifyPlotBinsClicked()));
+  connect(plotContourAction, SIGNAL(triggered()), this, SLOT(notifyPlotContourClicked()));
+  connect(plotTiledAction, SIGNAL(triggered()), this, SLOT(notifyPlotTiledClicked()));
 
   m_plotOptions->tbPlot->setVisible(true);
   m_plotOptions->pbPlotSpectra->setVisible(true);

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -65,7 +65,7 @@ namespace MantidQt::CustomInterfaces {
 IndirectPlotOptionsView::IndirectPlotOptionsView(QWidget *parent)
     : API::MantidWidget(parent), m_suggestionsModel(std::make_unique<QStringListModel>(indicesSuggestions())),
       m_completer(std::make_unique<QCompleter>(m_suggestionsModel.get(), this)),
-      m_plotOptions(new Ui::IndirectPlotOptions) {
+      m_plotOptions(new Ui::IndirectPlotOptions), m_presenter() {
   m_plotOptions->setupUi(this);
   setupView();
 }

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
@@ -22,6 +22,8 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
+class IIndirectPlotOptionsPresenter;
+
 enum PlotWidget { Spectra, SpectraBin, SpectraContour, SpectraTiled, SpectraUnit, SpectraContourUnit };
 
 class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsView : public API::MantidWidget {
@@ -30,6 +32,8 @@ class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsView : public API::MantidWidget {
 public:
   IndirectPlotOptionsView(QWidget *parent = nullptr);
   virtual ~IndirectPlotOptionsView() override;
+
+  void subscribePresenter(IIndirectPlotOptionsPresenter *presenter);
 
   virtual void setPlotType(PlotWidget const &plotType, std::map<std::string, std::string> const &availableActions);
   virtual void setWorkspaceComboBoxEnabled(bool enable);
@@ -84,6 +88,8 @@ private:
   std::unique_ptr<QStringListModel> m_suggestionsModel;
   std::unique_ptr<QCompleter> m_completer;
   std::unique_ptr<Ui::IndirectPlotOptions> m_plotOptions;
+
+  IIndirectPlotOptionsPresenter *m_presenter;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
@@ -60,23 +60,15 @@ public:
 
   virtual void displayWarning(QString const &message);
 
-signals:
-  void selectedUnitChanged(std::string const &unit);
-  void selectedIndicesChanged(std::string const &indices);
-  void plotSpectraClicked();
-  void plotBinsClicked();
-  void plotContourClicked();
-  void plotTiledClicked();
-
 private slots:
   void notifySelectedWorkspaceChanged(QString const &workspaceName);
-  void emitSelectedUnitChanged(QString const &unit);
-  void emitSelectedIndicesChanged();
-  void emitSelectedIndicesChanged(QString const &indices);
-  void emitPlotSpectraClicked();
-  void emitPlotBinsClicked();
-  void emitPlotContourClicked();
-  void emitPlotTiledClicked();
+  void notifySelectedUnitChanged(QString const &unit);
+  void notifySelectedIndicesChanged();
+  void notifySelectedIndicesChanged(QString const &indices);
+  void notifyPlotSpectraClicked();
+  void notifyPlotBinsClicked();
+  void notifyPlotContourClicked();
+  void notifyPlotTiledClicked();
 
 private:
   void setupView();

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
@@ -61,7 +61,7 @@ class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsView final : public API::MantidWi
 
 public:
   IndirectPlotOptionsView(QWidget *parent = nullptr);
-  virtual ~IndirectPlotOptionsView() override;
+  ~IndirectPlotOptionsView() = default;
 
   void subscribePresenter(IIndirectPlotOptionsPresenter *presenter) override;
 

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
@@ -61,7 +61,6 @@ public:
   virtual void displayWarning(QString const &message);
 
 signals:
-  void selectedWorkspaceChanged(std::string const &workspaceName);
   void selectedUnitChanged(std::string const &unit);
   void selectedIndicesChanged(std::string const &indices);
   void plotSpectraClicked();
@@ -70,7 +69,7 @@ signals:
   void plotTiledClicked();
 
 private slots:
-  void emitSelectedWorkspaceChanged(QString const &workspaceName);
+  void notifySelectedWorkspaceChanged(QString const &workspaceName);
   void emitSelectedUnitChanged(QString const &unit);
   void emitSelectedIndicesChanged();
   void emitSelectedIndicesChanged(QString const &indices);

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
@@ -26,39 +26,69 @@ class IIndirectPlotOptionsPresenter;
 
 enum PlotWidget { Spectra, SpectraBin, SpectraContour, SpectraTiled, SpectraUnit, SpectraContourUnit };
 
-class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsView : public API::MantidWidget {
+class MANTIDQT_INDIRECT_DLL IIndirectPlotOptionsView {
+public:
+  virtual void subscribePresenter(IIndirectPlotOptionsPresenter *presenter) = 0;
+
+  virtual void setPlotType(PlotWidget const &plotType, std::map<std::string, std::string> const &availableActions) = 0;
+  virtual void setWorkspaceComboBoxEnabled(bool enable) = 0;
+  virtual void setUnitComboBoxEnabled(bool enable) = 0;
+  virtual void setIndicesLineEditEnabled(bool enable) = 0;
+  virtual void setPlotButtonEnabled(bool enable) = 0;
+  virtual void setPlotButtonText(QString const &text) = 0;
+
+  virtual void setIndicesRegex(QString const &regex) = 0;
+
+  virtual QString selectedWorkspace() const = 0;
+  virtual void setWorkspaces(std::vector<std::string> const &workspaces) = 0;
+
+  virtual int numberOfWorkspaces() const = 0;
+
+  virtual void removeWorkspace(QString const &workspaceName) = 0;
+  virtual void clearWorkspaces() = 0;
+
+  virtual QString selectedIndices() const = 0;
+  virtual void setIndices(QString const &indices) = 0;
+  virtual void setIndicesErrorLabelVisible(bool visible) = 0;
+
+  virtual void addIndicesSuggestion(QString const &spectra) = 0;
+
+  virtual void displayWarning(QString const &message) = 0;
+};
+
+class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsView final : public API::MantidWidget, public IIndirectPlotOptionsView {
   Q_OBJECT
 
 public:
   IndirectPlotOptionsView(QWidget *parent = nullptr);
   virtual ~IndirectPlotOptionsView() override;
 
-  void subscribePresenter(IIndirectPlotOptionsPresenter *presenter);
+  void subscribePresenter(IIndirectPlotOptionsPresenter *presenter) override;
 
-  virtual void setPlotType(PlotWidget const &plotType, std::map<std::string, std::string> const &availableActions);
-  virtual void setWorkspaceComboBoxEnabled(bool enable);
-  virtual void setUnitComboBoxEnabled(bool enable);
-  virtual void setIndicesLineEditEnabled(bool enable);
-  virtual void setPlotButtonEnabled(bool enable);
-  void setPlotButtonText(QString const &text);
+  void setPlotType(PlotWidget const &plotType, std::map<std::string, std::string> const &availableActions) override;
+  void setWorkspaceComboBoxEnabled(bool enable) override;
+  void setUnitComboBoxEnabled(bool enable) override;
+  void setIndicesLineEditEnabled(bool enable) override;
+  void setPlotButtonEnabled(bool enable) override;
+  void setPlotButtonText(QString const &text) override;
 
-  virtual void setIndicesRegex(QString const &regex);
+  void setIndicesRegex(QString const &regex) override;
 
-  QString selectedWorkspace() const;
-  virtual void setWorkspaces(std::vector<std::string> const &workspaces);
+  QString selectedWorkspace() const override;
+  void setWorkspaces(std::vector<std::string> const &workspaces) override;
 
-  virtual int numberOfWorkspaces() const;
+  int numberOfWorkspaces() const override;
 
-  void removeWorkspace(QString const &workspaceName);
-  virtual void clearWorkspaces();
+  void removeWorkspace(QString const &workspaceName) override;
+  void clearWorkspaces() override;
 
-  QString selectedIndices() const;
-  virtual void setIndices(QString const &indices);
-  virtual void setIndicesErrorLabelVisible(bool visible);
+  QString selectedIndices() const override;
+  void setIndices(QString const &indices) override;
+  void setIndicesErrorLabelVisible(bool visible) override;
 
-  virtual void addIndicesSuggestion(QString const &spectra);
+  void addIndicesSuggestion(QString const &spectra) override;
 
-  virtual void displayWarning(QString const &message);
+  void displayWarning(QString const &message) override;
 
 private slots:
   void notifySelectedWorkspaceChanged(QString const &workspaceName);

--- a/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsPresenterTest.h
@@ -148,7 +148,7 @@ public:
 
   void test_that_notifyWorkspaceChanged_set_the_workspace_stored_by_the_model() {
     EXPECT_CALL(*m_model, setWorkspace(WORKSPACE_NAME)).Times(1);
-    m_presenter->notifyWorkspaceChanged(WORKSPACE_NAME);
+    m_presenter->handleWorkspaceChanged(WORKSPACE_NAME);
   }
 
   void test_that_the_view_widgets_are_enabled_when_the_workspace_being_set_in_the_model_is_valid() {
@@ -156,7 +156,7 @@ public:
 
     setExpectationsForWidgetEnabling(true);
 
-    m_presenter->notifyWorkspaceChanged(WORKSPACE_NAME);
+    m_presenter->handleWorkspaceChanged(WORKSPACE_NAME);
   }
 
   void test_that_the_view_widgets_are_disabled_when_the_workspace_being_set_in_the_model_is_invalid() {
@@ -164,7 +164,7 @@ public:
 
     setExpectationsForWidgetEnabling(false);
 
-    m_presenter->notifyWorkspaceChanged(WORKSPACE_NAME);
+    m_presenter->handleWorkspaceChanged(WORKSPACE_NAME);
   }
 
   void test_that_the_indices_are_formatted_when_they_are_changed_before_being_set_in_the_view_and_model() {
@@ -176,7 +176,7 @@ public:
     EXPECT_CALL(*m_model, setIndices(WORKSPACE_INDICES)).Times(1);
     EXPECT_CALL(*m_view, setIndicesErrorLabelVisible(false)).Times(1);
 
-    m_presenter->notifySelectedIndicesChanged(WORKSPACE_INDICES);
+    m_presenter->handleSelectedIndicesChanged(WORKSPACE_INDICES);
   }
 
   void test_that_the_indicesErrorLabel_is_set_to_visible_when_the_indices_are_invalid() {
@@ -187,7 +187,7 @@ public:
     EXPECT_CALL(*m_model, setIndices(WORKSPACE_INDICES)).Times(1);
     EXPECT_CALL(*m_view, setIndicesErrorLabelVisible(true)).Times(1);
 
-    m_presenter->notifySelectedIndicesChanged(WORKSPACE_INDICES);
+    m_presenter->handleSelectedIndicesChanged(WORKSPACE_INDICES);
   }
 
   void test_that_a_new_indice_suggestion_is_set_when_the_formatted_indices_are_not_empty() {
@@ -196,7 +196,7 @@ public:
     EXPECT_CALL(*m_model, formatIndices(WORKSPACE_INDICES)).Times(1);
     EXPECT_CALL(*m_view, addIndicesSuggestion(QString::fromStdString(WORKSPACE_INDICES))).Times(1);
 
-    m_presenter->notifySelectedIndicesChanged(WORKSPACE_INDICES);
+    m_presenter->handleSelectedIndicesChanged(WORKSPACE_INDICES);
   }
 
   void test_that_a_new_indice_suggestion_is_not_set_when_the_formatted_indices_are_empty() {
@@ -205,7 +205,7 @@ public:
     EXPECT_CALL(*m_model, formatIndices("")).Times(1);
     EXPECT_CALL(*m_view, addIndicesSuggestion(QString::fromStdString(""))).Times(0);
 
-    m_presenter->notifySelectedIndicesChanged("");
+    m_presenter->handleSelectedIndicesChanged("");
   }
 
   void test_that_the_plotSpectraClicked_signal_will_attempt_to_plot_the_spectra() {
@@ -213,7 +213,7 @@ public:
     EXPECT_CALL(*m_model, plotSpectra()).Times(1);
     setExpectationsForWidgetEnabling(true);
 
-    m_presenter->notifyPlotSpectraClicked();
+    m_presenter->handlePlotSpectraClicked();
   }
 
   void test_that_the_plotBinsClicked_signal_will_attempt_to_plot_the_bins_when_the_bin_indices_are_valid() {
@@ -223,7 +223,7 @@ public:
     EXPECT_CALL(*m_model, plotBins(_)).Times(1);
     setExpectationsForWidgetEnabling(true);
 
-    m_presenter->notifyPlotBinsClicked();
+    m_presenter->handlePlotBinsClicked();
   }
 
   void test_that_the_plotBinsClicked_signal_will_display_a_warning_message_if_the_bin_indices_are_invalid() {
@@ -231,7 +231,7 @@ public:
 
     EXPECT_CALL(*m_view, displayWarning(QString("Plot Bins failed: Invalid bin indices provided."))).Times(1);
 
-    m_presenter->notifyPlotBinsClicked();
+    m_presenter->handlePlotBinsClicked();
   }
 
   void test_that_the_plotContourClicked_signal_will_attempt_to_plot_a_contour() {
@@ -239,7 +239,7 @@ public:
     EXPECT_CALL(*m_model, plotContour()).Times(1);
     setExpectationsForWidgetEnabling(true);
 
-    m_presenter->notifyPlotContourClicked();
+    m_presenter->handlePlotContourClicked();
   }
 
   void test_that_the_plotTiledClicked_signal_will_attempt_to_plot_tiled_spectra() {
@@ -247,7 +247,7 @@ public:
     EXPECT_CALL(*m_model, plotTiled()).Times(1);
     setExpectationsForWidgetEnabling(true);
 
-    m_presenter->notifyPlotTiledClicked();
+    m_presenter->handlePlotTiledClicked();
   }
 
   ///----------------------------------------------------------------------

--- a/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsPresenterTest.h
@@ -42,35 +42,30 @@ constructActions(boost::optional<std::map<std::string, std::string>> const &avai
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 /// Mock object to mock the view
-class MockIndirectPlotOptionsView : public IndirectPlotOptionsView {
+class MockIndirectPlotOptionsView : public IIndirectPlotOptionsView {
 public:
-  void emitSelectedWorkspaceChanged(std::string const &workspaceName) { emit selectedWorkspaceChanged(workspaceName); }
+  MOCK_METHOD1(subscribePresenter, void(IIndirectPlotOptionsPresenter *));
 
-  void emitSelectedIndicesChanged(std::string const &indices) { emit selectedIndicesChanged(indices); }
-
-  void emitPlotSpectraClicked() { emit plotSpectraClicked(); }
-
-  void emitPlotBinsClicked() { emit plotBinsClicked(); }
-
-  void emitPlotContourClicked() { emit plotContourClicked(); }
-
-  void emitPlotTiledClicked() { emit plotTiledClicked(); }
-
-  /// Public Methods
   MOCK_METHOD2(setPlotType,
                void(PlotWidget const &plotType, std::map<std::string, std::string> const &availableActions));
 
   MOCK_METHOD1(setIndicesRegex, void(QString const &regex));
 
+  MOCK_CONST_METHOD0(selectedWorkspace, QString());
   MOCK_METHOD1(setWorkspaces, void(std::vector<std::string> const &workspaces));
+
+  MOCK_METHOD1(removeWorkspace, void(QString const &workspaceName));
   MOCK_METHOD0(clearWorkspaces, void());
 
+  MOCK_CONST_METHOD0(selectedIndices, QString());
   MOCK_METHOD1(setIndices, void(QString const &indices));
   MOCK_METHOD1(setIndicesErrorLabelVisible, void(bool visible));
 
   MOCK_METHOD1(setWorkspaceComboBoxEnabled, void(bool enable));
+  MOCK_METHOD1(setUnitComboBoxEnabled, void(bool enable));
   MOCK_METHOD1(setIndicesLineEditEnabled, void(bool enable));
   MOCK_METHOD1(setPlotButtonEnabled, void(bool enable));
+  MOCK_METHOD1(setPlotButtonText, void(QString const &text));
 
   MOCK_CONST_METHOD0(numberOfWorkspaces, int());
 
@@ -151,9 +146,9 @@ public:
   /// Unit Tests that test the signals emitted from the view
   ///----------------------------------------------------------------------
 
-  void test_that_the_workspace_stored_by_the_model_is_changed_when_it_is_altered_in_the_view() {
+  void test_that_notifyWorkspaceChanged_set_the_workspace_stored_by_the_model() {
     EXPECT_CALL(*m_model, setWorkspace(WORKSPACE_NAME)).Times(1);
-    m_view->emitSelectedWorkspaceChanged(WORKSPACE_NAME);
+    m_presenter->notifyWorkspaceChanged(WORKSPACE_NAME);
   }
 
   void test_that_the_view_widgets_are_enabled_when_the_workspace_being_set_in_the_model_is_valid() {
@@ -161,7 +156,7 @@ public:
 
     setExpectationsForWidgetEnabling(true);
 
-    m_view->emitSelectedWorkspaceChanged(WORKSPACE_NAME);
+    m_presenter->notifyWorkspaceChanged(WORKSPACE_NAME);
   }
 
   void test_that_the_view_widgets_are_disabled_when_the_workspace_being_set_in_the_model_is_invalid() {
@@ -169,7 +164,7 @@ public:
 
     setExpectationsForWidgetEnabling(false);
 
-    m_view->emitSelectedWorkspaceChanged(WORKSPACE_NAME);
+    m_presenter->notifyWorkspaceChanged(WORKSPACE_NAME);
   }
 
   void test_that_the_indices_are_formatted_when_they_are_changed_before_being_set_in_the_view_and_model() {
@@ -181,7 +176,7 @@ public:
     EXPECT_CALL(*m_model, setIndices(WORKSPACE_INDICES)).Times(1);
     EXPECT_CALL(*m_view, setIndicesErrorLabelVisible(false)).Times(1);
 
-    m_view->emitSelectedIndicesChanged(WORKSPACE_INDICES);
+    m_presenter->notifySelectedIndicesChanged(WORKSPACE_INDICES);
   }
 
   void test_that_the_indicesErrorLabel_is_set_to_visible_when_the_indices_are_invalid() {
@@ -192,7 +187,7 @@ public:
     EXPECT_CALL(*m_model, setIndices(WORKSPACE_INDICES)).Times(1);
     EXPECT_CALL(*m_view, setIndicesErrorLabelVisible(true)).Times(1);
 
-    m_view->emitSelectedIndicesChanged(WORKSPACE_INDICES);
+    m_presenter->notifySelectedIndicesChanged(WORKSPACE_INDICES);
   }
 
   void test_that_a_new_indice_suggestion_is_set_when_the_formatted_indices_are_not_empty() {
@@ -201,7 +196,7 @@ public:
     EXPECT_CALL(*m_model, formatIndices(WORKSPACE_INDICES)).Times(1);
     EXPECT_CALL(*m_view, addIndicesSuggestion(QString::fromStdString(WORKSPACE_INDICES))).Times(1);
 
-    m_view->emitSelectedIndicesChanged(WORKSPACE_INDICES);
+    m_presenter->notifySelectedIndicesChanged(WORKSPACE_INDICES);
   }
 
   void test_that_a_new_indice_suggestion_is_not_set_when_the_formatted_indices_are_empty() {
@@ -210,7 +205,7 @@ public:
     EXPECT_CALL(*m_model, formatIndices("")).Times(1);
     EXPECT_CALL(*m_view, addIndicesSuggestion(QString::fromStdString(""))).Times(0);
 
-    m_view->emitSelectedIndicesChanged("");
+    m_presenter->notifySelectedIndicesChanged("");
   }
 
   void test_that_the_plotSpectraClicked_signal_will_attempt_to_plot_the_spectra() {
@@ -218,7 +213,7 @@ public:
     EXPECT_CALL(*m_model, plotSpectra()).Times(1);
     setExpectationsForWidgetEnabling(true);
 
-    m_view->emitPlotSpectraClicked();
+    m_presenter->notifyPlotSpectraClicked();
   }
 
   void test_that_the_plotBinsClicked_signal_will_attempt_to_plot_the_bins_when_the_bin_indices_are_valid() {
@@ -228,7 +223,7 @@ public:
     EXPECT_CALL(*m_model, plotBins(_)).Times(1);
     setExpectationsForWidgetEnabling(true);
 
-    m_view->emitPlotBinsClicked();
+    m_presenter->notifyPlotBinsClicked();
   }
 
   void test_that_the_plotBinsClicked_signal_will_display_a_warning_message_if_the_bin_indices_are_invalid() {
@@ -236,7 +231,7 @@ public:
 
     EXPECT_CALL(*m_view, displayWarning(QString("Plot Bins failed: Invalid bin indices provided."))).Times(1);
 
-    m_view->emitPlotBinsClicked();
+    m_presenter->notifyPlotBinsClicked();
   }
 
   void test_that_the_plotContourClicked_signal_will_attempt_to_plot_a_contour() {
@@ -244,7 +239,7 @@ public:
     EXPECT_CALL(*m_model, plotContour()).Times(1);
     setExpectationsForWidgetEnabling(true);
 
-    m_view->emitPlotContourClicked();
+    m_presenter->notifyPlotContourClicked();
   }
 
   void test_that_the_plotTiledClicked_signal_will_attempt_to_plot_tiled_spectra() {
@@ -252,7 +247,7 @@ public:
     EXPECT_CALL(*m_model, plotTiled()).Times(1);
     setExpectationsForWidgetEnabling(true);
 
-    m_view->emitPlotTiledClicked();
+    m_presenter->notifyPlotTiledClicked();
   }
 
   ///----------------------------------------------------------------------

--- a/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsPresenterTest.h
@@ -42,7 +42,7 @@ constructActions(boost::optional<std::map<std::string, std::string>> const &avai
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 /// Mock object to mock the view
-class MockIndirectPlotOptionsView : public IIndirectPlotOptionsView {
+class MockIndirectPlotOptionsView final : public IIndirectPlotOptionsView {
 public:
   MOCK_METHOD1(subscribePresenter, void(IIndirectPlotOptionsPresenter *));
 
@@ -75,7 +75,7 @@ public:
 };
 
 /// Mock object to mock an IndirectTab
-class MockIndirectPlotOptionsModel : public IndirectPlotOptionsModel {
+class MockIndirectPlotOptionsModel final : public IndirectPlotOptionsModel {
 public:
   /// Public Methods
   MOCK_METHOD1(setWorkspace, bool(std::string const &workspaceName));
@@ -105,8 +105,8 @@ public:
   static void destroySuite(IndirectPlotOptionsPresenterTest *suite) { delete suite; }
 
   void setUp() override {
-    m_view = std::make_unique<NiceMock<MockIndirectPlotOptionsView>>();
-    m_model = new NiceMock<MockIndirectPlotOptionsModel>();
+    m_view = std::make_unique<MockIndirectPlotOptionsView>();
+    m_model = new MockIndirectPlotOptionsModel();
 
     m_presenter = std::make_unique<IndirectPlotOptionsPresenter>(m_view.get(), m_model);
   }
@@ -131,8 +131,8 @@ public:
 
   void test_that_the_expected_setup_is_performed_when_instantiating_the_presenter() {
     tearDown();
-    m_view = std::make_unique<NiceMock<MockIndirectPlotOptionsView>>();
-    m_model = new NiceMock<MockIndirectPlotOptionsModel>();
+    m_view = std::make_unique<MockIndirectPlotOptionsView>();
+    m_model = new MockIndirectPlotOptionsModel();
 
     EXPECT_CALL(*m_view, setIndicesRegex(_)).Times(1);
     EXPECT_CALL(*m_view, setPlotType(PlotWidget::Spectra, constructActions(boost::none))).Times(1);


### PR DESCRIPTION
### Description of work
This PR removes the Qt dependency of the IndirectPlotOptionsPresenter. Removing this dependency simplifies the code slightly and makes the presenter easier to test due to the better separation of concerns. To make this separation possible, the presenter is now subscribed to the view using a non-owning raw pointer, and then the view will notify the presenter whenever there is an event.

I have created an interface class for the View and Presenter to make this new pattern possible.

Part of #36325

### To test:
Open Inelastic Data Manipulation
Go to the Iqt tab
Load `ExternalData/Testing/Data/UnitTest/iris26176_graphite002_red.nxs` as sample
Load `ExternalData/Testing/Data/UnitTest/iris26173_graphite002_res.nxs` as resolution
Click run
Try to `Plot Spectra` 0 at the bottom
Try to `Plot Tiled` for 0-5 at the bottom

*This does not require release notes* because **the change is not visible to the user**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
