### PR TITLE
StartX and EndX columns in Data Analysis tabs are automatically formatted to a precision of six digits

### DIFF
--- a/docs/source/release/v6.9.0/Inelastic/Bugfixes/35714.rst
+++ b/docs/source/release/v6.9.0/Inelastic/Bugfixes/35714.rst
@@ -1,0 +1,1 @@
+- Numeric input in <StartX, EndX> columns for the Data tables in tabs of the :ref:`Data Analysis <interface-inelastic-data-analysis>` are formatted to a precision of six digit. Additionally, incorrect inputs are not anymore accepted by the table cells.

--- a/docs/source/release/v6.9.0/Inelastic/Bugfixes/35714.rst
+++ b/docs/source/release/v6.9.0/Inelastic/Bugfixes/35714.rst
@@ -1,1 +1,1 @@
-- Numeric input in <StartX, EndX> columns for the Data tables in tabs of the :ref:`Data Analysis <interface-inelastic-data-analysis>` are formatted to a precision of six digit. Additionally, incorrect inputs are not anymore accepted by the table cells.
+- Numeric input in <StartX, EndX> columns for the Data tables in tabs of the :ref:`Data Analysis <interface-inelastic-data-analysis>` interface are formatted to a precision of six digits. Additionally, incorrect inputs are not anymore accepted by the table cells.

--- a/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataView.cpp
@@ -32,14 +32,6 @@ ConvFitDataView::ConvFitDataView(const QStringList &headers, QWidget *parent) : 
   header->setSectionResizeMode(1, QHeaderView::Stretch);
 }
 
-int ConvFitDataView::workspaceIndexColumn() const { return 2; }
-
-int ConvFitDataView::startXColumn() const { return 3; }
-
-int ConvFitDataView::endXColumn() const { return 4; }
-
-int ConvFitDataView::excludeColumn() const { return 5; }
-
 void ConvFitDataView::addTableEntry(size_t row, FitDataRow newRow) {
   IndirectFitDataView::addTableEntry(row, newRow);
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataView.h
@@ -23,10 +23,6 @@ class MANTIDQT_INELASTIC_DLL ConvFitDataView : public IndirectFitDataView {
 public:
   ConvFitDataView(QWidget *parent = nullptr);
   void addTableEntry(size_t row, FitDataRow newRow) override;
-  int workspaceIndexColumn() const override;
-  int startXColumn() const override;
-  int endXColumn() const override;
-  int excludeColumn() const override;
 
 protected:
   ConvFitDataView(const QStringList &headers, QWidget *parent = nullptr);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.cpp
@@ -32,14 +32,6 @@ FqFitDataView::FqFitDataView(const QStringList &headers, QWidget *parent) : Indi
   header->setSectionResizeMode(1, QHeaderView::Stretch);
 }
 
-int FqFitDataView::workspaceIndexColumn() const { return 2; }
-
-int FqFitDataView::startXColumn() const { return 3; }
-
-int FqFitDataView::endXColumn() const { return 4; }
-
-int FqFitDataView::excludeColumn() const { return 5; }
-
 void FqFitDataView::addTableEntry(size_t row, FitDataRow newRow) {
   IndirectFitDataView::addTableEntry(row, newRow);
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.h
@@ -23,10 +23,6 @@ class MANTIDQT_INELASTIC_DLL FqFitDataView : public IndirectFitDataView {
 public:
   FqFitDataView(QWidget *parent = nullptr);
   void addTableEntry(size_t row, FitDataRow newRow) override;
-  int workspaceIndexColumn() const override;
-  int startXColumn() const override;
-  int endXColumn() const override;
-  int excludeColumn() const override;
 
 protected:
   FqFitDataView(const QStringList &headers, QWidget *parent = nullptr);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
@@ -39,6 +39,7 @@ public:
 
   virtual UserInputValidator &validate(UserInputValidator &validator) = 0;
   virtual void addTableEntry(size_t row, FitDataRow newRow) = 0;
+  virtual void updateNumCellEntry(double numEntry, size_t row, size_t column) = 0;
   virtual int workspaceIndexColumn() const = 0;
   virtual int startXColumn() const = 0;
   virtual int endXColumn() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
@@ -40,10 +40,7 @@ public:
   virtual UserInputValidator &validate(UserInputValidator &validator) = 0;
   virtual void addTableEntry(size_t row, FitDataRow newRow) = 0;
   virtual void updateNumCellEntry(double numEntry, size_t row, size_t column) = 0;
-  virtual int workspaceIndexColumn() const = 0;
-  virtual int startXColumn() const = 0;
-  virtual int endXColumn() const = 0;
-  virtual int excludeColumn() const = 0;
+  virtual int getColumnIndexFromName(QString ColName) = 0;
   virtual void clearTable() = 0;
   virtual QString getText(int row, int column) const = 0;
   virtual QModelIndexList getSelectedIndexes() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
@@ -203,40 +203,24 @@ void IndirectFitDataPresenter::handleCellChanged(int row, int column) {
   }
 
   if (m_view->startXColumn() == column) {
-    setTableStartXAndEmit(m_view->getText(row, column), row, column);
+    setTableStartXAndEmit(m_view->getText(row, column).toDouble(), row, column);
   } else if (m_view->endXColumn() == column) {
-    setTableEndXAndEmit(m_view->getText(row, column), row, column);
+    setTableEndXAndEmit(m_view->getText(row, column).toDouble(), row, column);
   } else if (m_view->excludeColumn() == column) {
     setModelExcludeAndEmit(m_view->getText(row, column).toStdString(), row);
   }
 }
 
-void IndirectFitDataPresenter::setTableStartXAndEmit(QString currentCellStr, int row, int column) {
-  bool ok;
-  double X;
+void IndirectFitDataPresenter::setTableStartXAndEmit(double X, int row, int column) {
   auto subIndices = m_model->getSubIndices(row);
-  auto FitRange = m_model->getFittingRange(row);
-
-  X = currentCellStr.toDouble(&ok);
-  if (!ok) {
-    X = FitRange.first;
-  };
 
   m_model->setStartX(X, subIndices.first, subIndices.second);
   m_view->updateNumCellEntry(m_model->getFittingRange(row).first, row, column);
   emit startXChanged(m_model->getFittingRange(row).first, subIndices.first, subIndices.second);
 }
 
-void IndirectFitDataPresenter::setTableEndXAndEmit(QString currentCellStr, int row, int column) {
-  bool ok;
-  double X;
+void IndirectFitDataPresenter::setTableEndXAndEmit(double X, int row, int column) {
   auto subIndices = m_model->getSubIndices(row);
-  auto FitRange = m_model->getFittingRange(row);
-
-  X = currentCellStr.toDouble(&ok);
-  if (!ok) {
-    X = FitRange.second;
-  };
 
   m_model->setEndX(X, subIndices.first, subIndices.second);
   m_view->updateNumCellEntry(m_model->getFittingRange(row).second, row, column);
@@ -245,12 +229,14 @@ void IndirectFitDataPresenter::setTableEndXAndEmit(QString currentCellStr, int r
 
 void IndirectFitDataPresenter::setModelStartXAndEmit(double startX, FitDomainIndex row) {
   auto subIndices = m_model->getSubIndices(row);
+
   m_model->setStartX(startX, subIndices.first, subIndices.second);
   emit startXChanged(startX, subIndices.first, subIndices.second);
 }
 
 void IndirectFitDataPresenter::setModelEndXAndEmit(double endX, FitDomainIndex row) {
   auto subIndices = m_model->getSubIndices(row);
+
   m_model->setEndX(endX, subIndices.first, subIndices.second);
   emit endXChanged(endX, subIndices.first, subIndices.second);
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
@@ -216,7 +216,6 @@ void IndirectFitDataPresenter::setTableStartXAndEmit(QString currentCellStr, int
   double X;
   auto subIndices = m_model->getSubIndices(row);
   auto FitRange = m_model->getFittingRange(row);
-  auto spectra = m_model->getSpectra(row);
 
   X = currentCellStr.toDouble(&ok);
   if (!ok) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
@@ -203,12 +203,45 @@ void IndirectFitDataPresenter::handleCellChanged(int row, int column) {
   }
 
   if (m_view->startXColumn() == column) {
-    setModelStartXAndEmit(m_view->getText(row, column).toDouble(), row);
+    setTableStartXAndEmit(m_view->getText(row, column), row, column);
   } else if (m_view->endXColumn() == column) {
-    setModelEndXAndEmit(m_view->getText(row, column).toDouble(), row);
+    setTableEndXAndEmit(m_view->getText(row, column), row, column);
   } else if (m_view->excludeColumn() == column) {
     setModelExcludeAndEmit(m_view->getText(row, column).toStdString(), row);
   }
+}
+
+void IndirectFitDataPresenter::setTableStartXAndEmit(QString currentCellStr, int row, int column) {
+  bool ok;
+  double X;
+  auto subIndices = m_model->getSubIndices(row);
+  auto FitRange = m_model->getFittingRange(row);
+  auto spectra = m_model->getSpectra(row);
+
+  X = currentCellStr.toDouble(&ok);
+  if (!ok) {
+    X = FitRange.first;
+  };
+
+  m_model->setStartX(X, subIndices.first, subIndices.second);
+  m_view->updateNumCellEntry(m_model->getFittingRange(row).first, row, column);
+  emit startXChanged(m_model->getFittingRange(row).first, subIndices.first, subIndices.second);
+}
+
+void IndirectFitDataPresenter::setTableEndXAndEmit(QString currentCellStr, int row, int column) {
+  bool ok;
+  double X;
+  auto subIndices = m_model->getSubIndices(row);
+  auto FitRange = m_model->getFittingRange(row);
+
+  X = currentCellStr.toDouble(&ok);
+  if (!ok) {
+    X = FitRange.second;
+  };
+
+  m_model->setEndX(X, subIndices.first, subIndices.second);
+  m_view->updateNumCellEntry(m_model->getFittingRange(row).second, row, column);
+  emit endXChanged(m_model->getFittingRange(row).second, subIndices.first, subIndices.second);
 }
 
 void IndirectFitDataPresenter::setModelStartXAndEmit(double startX, FitDomainIndex row) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
@@ -202,11 +202,11 @@ void IndirectFitDataPresenter::handleCellChanged(int row, int column) {
     return;
   }
 
-  if (m_view->startXColumn() == column) {
+  if (m_view->getColumnIndexFromName("StartX") == column) {
     setTableStartXAndEmit(m_view->getText(row, column).toDouble(), row, column);
-  } else if (m_view->endXColumn() == column) {
+  } else if (m_view->getColumnIndexFromName("EndX") == column) {
     setTableEndXAndEmit(m_view->getText(row, column).toDouble(), row, column);
-  } else if (m_view->excludeColumn() == column) {
+  } else if (m_view->getColumnIndexFromName("Mask X Range") == column) {
     setModelExcludeAndEmit(m_view->getText(row, column).toStdString(), row);
   }
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -109,6 +109,8 @@ private:
   virtual std::unique_ptr<IAddWorkspaceDialog> getAddWorkspaceDialog(QWidget *parent) const;
   void setModelStartXAndEmit(double startX, FitDomainIndex row);
   void setModelEndXAndEmit(double endX, FitDomainIndex row);
+  void setTableStartXAndEmit(QString currentCellStr, int row, int column);
+  void setTableEndXAndEmit(QString currentCellStr, int row, int column);
   void setModelExcludeAndEmit(const std::string &exclude, FitDomainIndex row);
   std::unique_ptr<IAddWorkspaceDialog> m_addWorkspaceDialog;
   std::map<int, QModelIndex> getUniqueIndices(const QModelIndexList &selectedIndices);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -109,8 +109,8 @@ private:
   virtual std::unique_ptr<IAddWorkspaceDialog> getAddWorkspaceDialog(QWidget *parent) const;
   void setModelStartXAndEmit(double startX, FitDomainIndex row);
   void setModelEndXAndEmit(double endX, FitDomainIndex row);
-  void setTableStartXAndEmit(QString currentCellStr, int row, int column);
-  void setTableEndXAndEmit(QString currentCellStr, int row, int column);
+  void setTableStartXAndEmit(double X, int row, int column);
+  void setTableEndXAndEmit(double X, int row, int column);
   void setModelExcludeAndEmit(const std::string &exclude, FitDomainIndex row);
   std::unique_ptr<IAddWorkspaceDialog> m_addWorkspaceDialog;
   std::map<int, QModelIndex> getUniqueIndices(const QModelIndexList &selectedIndices);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -114,9 +114,9 @@ void IndirectFitDataView::setHorizontalHeaders(const QStringList &headers) {
   auto header = m_uiForm->tbFitData->horizontalHeader();
   header->setSectionResizeMode(0, QHeaderView::Stretch);
 
-  m_uiForm->tbFitData->setItemDelegateForColumn(startXColumn(), std::make_unique<NumericInputDelegate>().release());
-  m_uiForm->tbFitData->setItemDelegateForColumn(endXColumn(), std::make_unique<NumericInputDelegate>().release());
-  m_uiForm->tbFitData->setItemDelegateForColumn(excludeColumn(), std::make_unique<ExcludeRegionDelegate>().release());
+  m_uiForm->tbFitData->setItemDelegateForColumn(headers.indexOf("StartX"), new NumericInputDelegate);
+  m_uiForm->tbFitData->setItemDelegateForColumn(headers.indexOf("EndX"), new NumericInputDelegate);
+  m_uiForm->tbFitData->setItemDelegateForColumn(headers.size() - 1, new ExcludeRegionDelegate);
 
   m_uiForm->tbFitData->verticalHeader()->setVisible(false);
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -49,7 +49,7 @@ public:
   }
 };
 
-QString makeNumber(double d) { return QString::number(d, 'g', 6); }
+QString makeNumber(double d) { return QString::number(d, 'f', 6); }
 
 QStringList defaultHeaders() {
   QStringList headers;
@@ -125,6 +125,15 @@ void IndirectFitDataView::addTableEntry(size_t row, FitDataRow newRow) {
   cell = std::make_unique<QTableWidgetItem>(QString::fromStdString(newRow.exclude));
   setCell(std::move(cell), row, excludeColumn());
 }
+
+void IndirectFitDataView::updateNumCellEntry(double numEntry, size_t row, size_t column) {
+  QTableWidgetItem *selectedItem;
+  selectedItem = m_uiForm->tbFitData->item(static_cast<int>(row), static_cast<int>(column));
+  if ((!selectedItem->isSelected())) {
+    return;
+  }
+  selectedItem->setText(makeNumber(numEntry));
+};
 
 bool IndirectFitDataView::isTableEmpty() const { return m_uiForm->tbFitData->rowCount() == 0; }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -13,6 +13,8 @@
 
 using namespace Mantid::API;
 
+constexpr auto NUMERICAL_PRECISION = 6;
+
 namespace {
 
 namespace Regexes {
@@ -25,7 +27,7 @@ const QString REAL_RANGE = "(" + REAL_NUMBER + COMMA + REAL_NUMBER + ")";
 const QString MASK_LIST = "(" + REAL_RANGE + "(" + COMMA + REAL_RANGE + ")*" + ")|" + EMPTY;
 } // namespace Regexes
 
-QString makeNumber(double d) { return QString::number(d, 'f', 6); }
+QString makeNumber(double d) { return QString::number(d, 'f', NUMERICAL_PRECISION); }
 
 class ExcludeRegionDelegate : public QItemDelegate {
 public:
@@ -58,14 +60,14 @@ class NumericInputDelegate : public QStyledItemDelegate {
 public:
   QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &) const override {
 
-    auto lineEdit = std::make_unique<QLineEdit>(parent);
-    auto validator = std::make_unique<QDoubleValidator>(parent);
+    auto lineEdit = new QLineEdit(parent);
+    auto validator = new QDoubleValidator(parent);
 
-    validator->setDecimals(6);
+    validator->setDecimals(NUMERICAL_PRECISION);
     validator->setNotation(QDoubleValidator::StandardNotation);
-    lineEdit->setValidator(validator.release());
+    lineEdit->setValidator(validator);
 
-    return lineEdit.release();
+    return lineEdit;
   }
 
   void setEditorData(QWidget *editor, const QModelIndex &index) const override {
@@ -112,12 +114,9 @@ void IndirectFitDataView::setHorizontalHeaders(const QStringList &headers) {
   auto header = m_uiForm->tbFitData->horizontalHeader();
   header->setSectionResizeMode(0, QHeaderView::Stretch);
 
-  m_uiForm->tbFitData->setItemDelegateForColumn(headers.indexOf("StartX"),
-                                                std::make_unique<NumericInputDelegate>().release());
-  m_uiForm->tbFitData->setItemDelegateForColumn(headers.indexOf("EndX"),
-                                                std::make_unique<NumericInputDelegate>().release());
-  m_uiForm->tbFitData->setItemDelegateForColumn(headers.size() - 1,
-                                                std::make_unique<ExcludeRegionDelegate>().release());
+  m_uiForm->tbFitData->setItemDelegateForColumn(startXColumn(), std::make_unique<NumericInputDelegate>().release());
+  m_uiForm->tbFitData->setItemDelegateForColumn(endXColumn(), std::make_unique<NumericInputDelegate>().release());
+  m_uiForm->tbFitData->setItemDelegateForColumn(excludeColumn(), std::make_unique<ExcludeRegionDelegate>().release());
 
   m_uiForm->tbFitData->verticalHeader()->setVisible(false);
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -110,13 +110,14 @@ QTableWidget *IndirectFitDataView::getDataTable() const { return m_uiForm->tbFit
 void IndirectFitDataView::setHorizontalHeaders(const QStringList &headers) {
   m_uiForm->tbFitData->setColumnCount(headers.size());
   m_uiForm->tbFitData->setHorizontalHeaderLabels(headers);
+  HeaderLabels = headers;
 
   auto header = m_uiForm->tbFitData->horizontalHeader();
   header->setSectionResizeMode(0, QHeaderView::Stretch);
 
-  m_uiForm->tbFitData->setItemDelegateForColumn(headers.indexOf("StartX"), new NumericInputDelegate);
-  m_uiForm->tbFitData->setItemDelegateForColumn(headers.indexOf("EndX"), new NumericInputDelegate);
-  m_uiForm->tbFitData->setItemDelegateForColumn(headers.size() - 1, new ExcludeRegionDelegate);
+  m_uiForm->tbFitData->setItemDelegateForColumn(getColumnIndexFromName("StartX"), new NumericInputDelegate);
+  m_uiForm->tbFitData->setItemDelegateForColumn(getColumnIndexFromName("EndX"), new NumericInputDelegate);
+  m_uiForm->tbFitData->setItemDelegateForColumn(getColumnIndexFromName("Mask X Range"), new ExcludeRegionDelegate);
 
   m_uiForm->tbFitData->verticalHeader()->setVisible(false);
 }
@@ -142,16 +143,16 @@ void IndirectFitDataView::addTableEntry(size_t row, FitDataRow newRow) {
 
   cell = std::make_unique<QTableWidgetItem>(QString::number(newRow.workspaceIndex));
   cell->setFlags(flags);
-  setCell(std::move(cell), row, workspaceIndexColumn());
+  setCell(std::move(cell), row, getColumnIndexFromName("WS Index"));
 
   cell = std::make_unique<QTableWidgetItem>(makeNumber(newRow.startX));
-  setCell(std::move(cell), row, startXColumn());
+  setCell(std::move(cell), row, getColumnIndexFromName("StartX"));
 
   cell = std::make_unique<QTableWidgetItem>(makeNumber(newRow.endX));
-  setCell(std::move(cell), row, endXColumn());
+  setCell(std::move(cell), row, getColumnIndexFromName("EndX"));
 
   cell = std::make_unique<QTableWidgetItem>(QString::fromStdString(newRow.exclude));
-  setCell(std::move(cell), row, excludeColumn());
+  setCell(std::move(cell), row, getColumnIndexFromName("Mask X Range"));
 }
 
 void IndirectFitDataView::updateNumCellEntry(double numEntry, size_t row, size_t column) {
@@ -162,13 +163,7 @@ void IndirectFitDataView::updateNumCellEntry(double numEntry, size_t row, size_t
 
 bool IndirectFitDataView::isTableEmpty() const { return m_uiForm->tbFitData->rowCount() == 0; }
 
-int IndirectFitDataView::workspaceIndexColumn() const { return 1; }
-
-int IndirectFitDataView::startXColumn() const { return 2; }
-
-int IndirectFitDataView::endXColumn() const { return 3; }
-
-int IndirectFitDataView::excludeColumn() const { return 4; }
+int IndirectFitDataView::getColumnIndexFromName(QString ColName) { return HeaderLabels.indexOf(ColName); }
 
 void IndirectFitDataView::clearTable() { m_uiForm->tbFitData->setRowCount(0); }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -110,7 +110,7 @@ QTableWidget *IndirectFitDataView::getDataTable() const { return m_uiForm->tbFit
 void IndirectFitDataView::setHorizontalHeaders(const QStringList &headers) {
   m_uiForm->tbFitData->setColumnCount(headers.size());
   m_uiForm->tbFitData->setHorizontalHeaderLabels(headers);
-  HeaderLabels = headers;
+  m_HeaderLabels = headers;
 
   auto header = m_uiForm->tbFitData->horizontalHeader();
   header->setSectionResizeMode(0, QHeaderView::Stretch);
@@ -163,7 +163,7 @@ void IndirectFitDataView::updateNumCellEntry(double numEntry, size_t row, size_t
 
 bool IndirectFitDataView::isTableEmpty() const { return m_uiForm->tbFitData->rowCount() == 0; }
 
-int IndirectFitDataView::getColumnIndexFromName(QString ColName) { return HeaderLabels.indexOf(ColName); }
+int IndirectFitDataView::getColumnIndexFromName(QString ColName) { return m_HeaderLabels.indexOf(ColName); }
 
 void IndirectFitDataView::clearTable() { m_uiForm->tbFitData->setRowCount(0); }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -158,7 +158,7 @@ void IndirectFitDataView::updateNumCellEntry(double numEntry, size_t row, size_t
   QTableWidgetItem *selectedItem;
   selectedItem = m_uiForm->tbFitData->item(static_cast<int>(row), static_cast<int>(column));
   selectedItem->setText(makeNumber(numEntry));
-};
+}
 
 bool IndirectFitDataView::isTableEmpty() const { return m_uiForm->tbFitData->rowCount() == 0; }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
@@ -46,7 +46,7 @@ protected:
   void setCell(std::unique_ptr<QTableWidgetItem> cell, size_t row, size_t column);
 
 private:
-  QStringList HeaderLabels;
+  QStringList m_HeaderLabels;
   void setHorizontalHeaders(const QStringList &headers);
 };
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
@@ -32,10 +32,7 @@ public:
   UserInputValidator &validate(UserInputValidator &validator) override;
   virtual void addTableEntry(size_t row, FitDataRow newRow) override;
   virtual void updateNumCellEntry(double numEntry, size_t row, size_t column) override;
-  virtual int workspaceIndexColumn() const override;
-  virtual int startXColumn() const override;
-  virtual int endXColumn() const override;
-  virtual int excludeColumn() const override;
+  virtual int getColumnIndexFromName(QString ColName) override;
   void clearTable() override;
   QString getText(int row, int column) const override;
   QModelIndexList getSelectedIndexes() const override;
@@ -49,6 +46,7 @@ protected:
   void setCell(std::unique_ptr<QTableWidgetItem> cell, size_t row, size_t column);
 
 private:
+  QStringList HeaderLabels;
   void setHorizontalHeaders(const QStringList &headers);
 };
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
@@ -31,6 +31,7 @@ public:
 
   UserInputValidator &validate(UserInputValidator &validator) override;
   virtual void addTableEntry(size_t row, FitDataRow newRow) override;
+  virtual void updateNumCellEntry(double numEntry, size_t row, size_t column) override;
   virtual int workspaceIndexColumn() const override;
   virtual int startXColumn() const override;
   virtual int endXColumn() const override;

--- a/qt/scientific_interfaces/Inelastic/test/ConvFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/ConvFitDataPresenterTest.h
@@ -47,10 +47,7 @@ public:
   MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
   MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
   MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
-  MOCK_CONST_METHOD0(workspaceIndexColumn, int());
-  MOCK_CONST_METHOD0(startXColumn, int());
-  MOCK_CONST_METHOD0(endXColumn, int());
-  MOCK_CONST_METHOD0(excludeColumn, int());
+  MOCK_METHOD1(getColumnIndexFromName, int(QString ColName));
   MOCK_METHOD0(clearTable, void());
   MOCK_CONST_METHOD2(getText, QString(int row, int column));
   MOCK_CONST_METHOD0(getSelectedIndexes, QModelIndexList());

--- a/qt/scientific_interfaces/Inelastic/test/ConvFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/ConvFitDataPresenterTest.h
@@ -46,6 +46,7 @@ public:
   MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
   MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
   MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
+  MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
   MOCK_CONST_METHOD0(workspaceIndexColumn, int());
   MOCK_CONST_METHOD0(startXColumn, int());
   MOCK_CONST_METHOD0(endXColumn, int());

--- a/qt/scientific_interfaces/Inelastic/test/FqFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/FqFitDataPresenterTest.h
@@ -54,6 +54,7 @@ public:
   MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
   MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
   MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
+  MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
   MOCK_CONST_METHOD0(workspaceIndexColumn, int());
   MOCK_CONST_METHOD0(startXColumn, int());
   MOCK_CONST_METHOD0(endXColumn, int());

--- a/qt/scientific_interfaces/Inelastic/test/FqFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/FqFitDataPresenterTest.h
@@ -55,10 +55,7 @@ public:
   MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
   MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
   MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
-  MOCK_CONST_METHOD0(workspaceIndexColumn, int());
-  MOCK_CONST_METHOD0(startXColumn, int());
-  MOCK_CONST_METHOD0(endXColumn, int());
-  MOCK_CONST_METHOD0(excludeColumn, int());
+  MOCK_METHOD1(getColumnIndexFromName, int(QString ColName));
   MOCK_METHOD0(clearTable, void());
   MOCK_CONST_METHOD2(getText, QString(int row, int column));
   MOCK_CONST_METHOD0(getSelectedIndexes, QModelIndexList());

--- a/qt/scientific_interfaces/Inelastic/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/IndirectFitDataPresenterTest.h
@@ -61,6 +61,7 @@ public:
   MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
   MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
   MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
+  MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
   MOCK_CONST_METHOD0(workspaceIndexColumn, int());
   MOCK_CONST_METHOD0(startXColumn, int());
   MOCK_CONST_METHOD0(endXColumn, int());

--- a/qt/scientific_interfaces/Inelastic/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/IndirectFitDataPresenterTest.h
@@ -62,10 +62,7 @@ public:
   MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
   MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
   MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
-  MOCK_CONST_METHOD0(workspaceIndexColumn, int());
-  MOCK_CONST_METHOD0(startXColumn, int());
-  MOCK_CONST_METHOD0(endXColumn, int());
-  MOCK_CONST_METHOD0(excludeColumn, int());
+  MOCK_METHOD1(getColumnIndexFromName, int(QString ColName));
   MOCK_METHOD0(clearTable, void());
   MOCK_CONST_METHOD2(getText, QString(int row, int column));
   MOCK_CONST_METHOD0(getSelectedIndexes, QModelIndexList());


### PR DESCRIPTION
### Description of work
As described in #35714, currently when any data is input in columns StartX and EndX of any of the data analysis tabs, the cell does not validate whether the data is correct. For example, you could input a special character ($£"$), it will be internally converted to 0 but not updated in the cell. This PR fixes that behaviour. 
Currently, there is no function in the data analysis view that can edit or change individual cells, it is all updated at once. In this PR I have added a function to just update individually the data in a single numeric cell. 
Also, if the input value format is wrong, the cell is automatically converted to the last valid value of Start/EndX stored by the model. 
Finally, both columns are reformatted with a numeric precision of 6 digits.  

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #35714 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1- Go to Interfaces > Indirect > Data Analysis
2- Go to the Conv Fit tab
3- Click Add Workspace
4- With the combo boxes set to File
5- Click browse and load the irs26176_graphite002_red.nxs file from the sample data
6- Click browse and load the resolution file irs26173_graphite002_res.nxs from the sample data
7- Click Add and close the dialogue.
8- Try to enter any keyboard character in the StartX and EndX columns. It should be formatted to a valid (within fitting range)number with a precision of 6.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
