### PR TITLE
Stop 3D plot shrinking on colorbar change

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -1272,7 +1272,6 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
 
     if image.colorbar:
         colorbar = image.colorbar
-        label = colorbar.ax.get_ylabel()
         locator = None
         if scale == LogNorm:
             locator = LogLocator(subs=np.arange(1, 10))
@@ -1282,7 +1281,6 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
                     "Minor ticks on colorbar scale cannot be shown " "as the range between min value and max value is too large"
                 )
             colorbar.set_ticks(locator)
-        colorbar.set_label(label)
 
 
 def add_colorbar_label(colorbar, axes):

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -1271,8 +1271,8 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
     image.set_norm(scale(vmin=vmin, vmax=vmax))
 
     if image.colorbar:
-        label = image.colorbar.ax.get_ylabel()
-        image.colorbar.remove()
+        colorbar = image.colorbar
+        label = colorbar.ax.get_ylabel()
         locator = None
         if scale == LogNorm:
             locator = LogLocator(subs=np.arange(1, 10))
@@ -1281,7 +1281,7 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
                 mantid.kernel.logger.warning(
                     "Minor ticks on colorbar scale cannot be shown " "as the range between min value and max value is too large"
                 )
-        colorbar = figure.colorbar(image, ax=figure.axes, ticks=locator, pad=0.05)
+            colorbar.set_ticks(locator)
         colorbar.set_label(label)
 
 

--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36388.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36388.rst
@@ -1,0 +1,1 @@
+- Fixed bug where a 3D plot would shrink every time you changed a property of the colorbar.


### PR DESCRIPTION
### Description of work
When scaling the colorbar (e.g. linear or log), then just set the ticks on the existing colorbar instead of deleting the old one and then replacing it. Deleting the old colorbar will hide it but leave the axes there, so each time you do this the plot area will shrink due to an increasing number of empty colorbar axes. The other option would be to delete the axes as well as the colorbar, then add a new one.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->
Fixes problem with 3D plots shrinking every time you change a property on the colorbar.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
Try changing colorbar properties on a 3D plot, the plot area shouldn't shrink.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
