### PR TITLE
Fixes Crash in ApplyAbsorptionCorrections if Corrections file incomplete

### DIFF
--- a/docs/source/release/v6.9.0/Indirect/Bugfixes/36391.rst
+++ b/docs/source/release/v6.9.0/Indirect/Bugfixes/36391.rst
@@ -1,0 +1,1 @@
+-  Fixed a bug where clicking 'Run' on the :ref:`Apply Absorption Corrections<indirect_apply_absorp_correct>` Tab in the :ref:`Corrections<interface-indirect-corrections>` GUI with non-grouped Corrections workspace would close Mantid. A Warning is shown instead if wrong entry workspace.

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -425,18 +425,17 @@ bool ApplyAbsorptionCorrections::validate() {
   // Check input not empty
   uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
   uiv.checkDataSelectorIsValid("Corrections", m_uiForm.dsCorrections);
+  // Validate the container workspace
+  if (m_uiForm.ckUseCan->isChecked())
+    validateDataIsOneOf(uiv, m_uiForm.dsContainer, "Container", DataType::Red, {DataType::Sqw});
+
+  // Validate the sample workspace
+  validateDataIsOneOf(uiv, m_uiForm.dsSample, "Sample", DataType::Red, {DataType::Sqw});
+
+  // Validate the corrections workspace
+  validateDataIsOfType(uiv, m_uiForm.dsCorrections, "Corrections", DataType::Corrections);
 
   if (uiv.isAllInputValid()) {
-    // Validate the sample workspace
-    validateDataIsOneOf(uiv, m_uiForm.dsSample, "Sample", DataType::Red, {DataType::Sqw});
-
-    // Validate the container workspace
-    if (m_uiForm.ckUseCan->isChecked())
-      validateDataIsOneOf(uiv, m_uiForm.dsContainer, "Container", DataType::Red, {DataType::Sqw});
-
-    // Validate the corrections workspace
-    validateDataIsOfType(uiv, m_uiForm.dsCorrections, "Corrections", DataType::Corrections);
-
     // Check sample has the same number of Histograms as each of the workspaces in the corrections group
     m_correctionsGroupName = m_uiForm.dsCorrections->getCurrentDataName().toStdString();
     if (AnalysisDataService::Instance().doesExist(m_correctionsGroupName)) {


### PR DESCRIPTION
### Description of work
Fixes a bug that crashes the workbench abruptly when trying to apply a correction in the Corrections interface. 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
For reproducing this issue: 

1. In the workbench, make sure that ISIS is the facility and IRIS is the instrument.
2. Open the ```Indirect->Corrections``` interface.
3. In the second tab, `Calculate Paalman Pings`, choose the Sample property by browsing to an IRIS test file, e.g. `ExternalData/Testing/Data/UnitTest/irs26176_graphite002_red.nxs`. Then, modify the Sample Thickness so it's not 0,  e.g. `0.1` cm, and set the Chemical Formula to `C`. 
4. Press `Run` button. A number of workspaces should be created, including the correction one called `irs26176_graphite002_FlatPlate_PP_Corrections_ass`.
5. Save the corrections workspace with a name that the `FileFinder` for Corrections property in the `Apply Absorption Corrections` tab can recognize it (`*_Corrections.nxs` seems to be the way)
6. Pick the Sample property either from a file or already loaded workspace, and select Corrections property by browsing to the freshly saved file.
7. Try to Run. Mantid should abruptly close with no error message.

     The issue was caused when creating a correction workspace group with only one workspace (like the  ``A,ss`` contribution). If that workspace is saved as a nexus file, the SaveNexus algorithm detects that the workspace group has only one member and saves it as a single workspace instead of as a group. If that workspace is loaded again, and the apply corrections algorithm tried to load, the '_Corrections' key will lead the prompt to select the workspace, but as it is not a group, it retrieves a null pointer for the validator. Provoking the crash.
     
     Now, the validator function checks that corrections is a group before processing it. The warning dialog catches the error and prompts the user to change it to a group. 

     While this PR solves the issue of crashing, the default behaviour for saving a corrections group with only one member should be to store it as a group. As that makes part of meddling with SaveNexus algorithm, or perhaps invoking a transform algorithm within the apply corrections interface, it may be best to open a new issue to change that behaviour when saving corrections. 



<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #34232 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
