### PR TITLE
Add MinimumPeakTotalCount to PDCalibration and FitPeaks.

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
@@ -327,6 +327,7 @@ private:
 
   // Criteria for rejecting non-peaks or weak peaks from fitting
   double m_minSignalToNoiseRatio;
+  double m_minPeakTotalCount;
 
   /// flag for high background
   bool m_highBackground;

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -930,8 +930,8 @@ void FitPeaks::processInputPeakTolerance() {
   if (m_minPeakHeight > 0 && m_minPeakTotalCount == 0) {
     std::ostringstream os;
     os << "PDCalibration property " << PropertyNames::PEAK_MIN_HEIGHT
-       << " is used for validating peaks after fitting. "
-          "Consider validating peaks before fitting as well using "
+       << " is used for checking peak height only. "
+          "Consider checking peak window total count as well using "
        << PropertyNames::PEAK_MIN_TOTAL_COUNT << ".\n";
     logNoOffset(4 /*warning*/, os.str());
   }

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -393,7 +393,7 @@ void FitPeaks::init() {
                   "If there is only one value given, then ");
 
   declareProperty(PropertyNames::PEAK_MIN_HEIGHT, 0.,
-                  "Used by FitPeaks for validating peaks before and after fitting. If a peak's observed/estimated or "
+                  "Used for validating peaks before and after fitting. If a peak's observed/estimated or "
                   "fitted height is under this value, "
                   "the peak will be marked as error.");
 

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1724,11 +1724,9 @@ double FitPeaks::fitFunctionSD(const IAlgorithm_sptr &fit, const API::IPeakFunct
 
   // Estimate peak profile parameter
   peak_function->setCentre(expected_peak_center); // set expected position first
-  // int result = estimatePeakParameters(histogram, peak_index_window, peak_function, bkgd_function,
-  // estimate_peak_width,
-  //                                     m_peakWidthEstimateApproach, m_peakWidthPercentage, m_minPeakHeight);
   int result = estimatePeakParameters(histogram, peak_index_window, peak_function, bkgd_function, estimate_peak_width,
-                                      m_peakWidthEstimateApproach, m_peakWidthPercentage, 0);
+                                      m_peakWidthEstimateApproach, m_peakWidthPercentage, m_minPeakHeight);
+
   if (result != GOOD) {
     peak_function->setCentre(expected_peak_center);
     if (result == NOSIGNAL || result == LOWPEAK) {

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -239,10 +239,8 @@ void PDCalibration::init() {
                   "center value, in d-spacing or TOF units.");
 
   declareProperty("MinimumPeakHeight", 2.,
-                  "Minimum peak height such that all the fitted peaks with "
-                  "height under this value will be excluded. The same property is used "
-                  "for pre-checking peaks before fitting, such that all the peaks with the total Y-count "
-                  "under this value will be excluded.");
+                  "Used for validating peaks after fitting. If the fitted height is under this value, "
+                  "the peak will be excluded from calibration.");
 
   declareProperty("MaxChiSq", 100., "Maximum chisq value for individual peak fit allowed. (Default: 100)");
 
@@ -286,6 +284,11 @@ void PDCalibration::init() {
       std::make_unique<WorkspaceProperty<API::WorkspaceGroup>>("DiagnosticWorkspaces", "", Direction::Output),
       "Workspaces to promote understanding of calibration results");
 
+  declareProperty("MinimumPeakTotalCount", 0.,
+                  "Used for validating peaks before fitting. If the total peak Y-value count "
+                  "is under this value, the peak will be excluded from fitting and calibration. "
+                  "The recommended value is 20.");
+
   // make group for Input properties
   std::string inputGroup("Input Options");
   setPropertyGroup("InputWorkspace", inputGroup);
@@ -306,6 +309,7 @@ void PDCalibration::init() {
   setPropertyGroup("PeakWidthPercent", fitPeaksGroup);
   setPropertyGroup("MinimumPeakHeight", fitPeaksGroup);
   setPropertyGroup("MinimumSignalToNoiseRatio", fitPeaksGroup);
+  setPropertyGroup("MinimumPeakTotalCount", fitPeaksGroup);
   setPropertyGroup("HighBackground", fitPeaksGroup);
   setPropertyGroup("MaxChiSq", fitPeaksGroup);
   setPropertyGroup("ConstrainPeakPositions", fitPeaksGroup);
@@ -446,6 +450,7 @@ void PDCalibration::exec() {
   }
 
   const double minPeakHeight = getProperty("MinimumPeakHeight");
+  const double minPeakTotalCount = getProperty("MinimumPeakTotalCount");
   const double minSignalToNoiseRatio = getProperty("MinimumSignalToNoiseRatio");
   const double maxChiSquared = getProperty("MaxChiSq");
 
@@ -530,6 +535,7 @@ void PDCalibration::exec() {
   algFitPeaks->setProperty("FitPeakWindowWorkspace", tof_peak_window_ws);
   algFitPeaks->setProperty("PeakWidthPercent", peak_width_percent);
   algFitPeaks->setProperty("MinimumPeakHeight", minPeakHeight);
+  algFitPeaks->setProperty("MinimumPeakTotalCount", minPeakTotalCount);
   algFitPeaks->setProperty("MinimumSignalToNoiseRatio", minSignalToNoiseRatio);
   // some fitting strategy
   algFitPeaks->setProperty("FitFromRight", true);

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -287,8 +287,7 @@ void PDCalibration::init() {
 
   declareProperty("MinimumPeakTotalCount", 0.,
                   "Used for validating peaks before fitting. If the total peak Y-value count "
-                  "is under this value, the peak will be excluded from fitting and calibration. "
-                  "The recommended value is 20.");
+                  "is under this value, the peak will be excluded from fitting and calibration.");
 
   // make group for Input properties
   std::string inputGroup("Input Options");

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -285,8 +285,8 @@ void PDCalibration::init() {
       std::make_unique<WorkspaceProperty<API::WorkspaceGroup>>("DiagnosticWorkspaces", "", Direction::Output),
       "Workspaces to promote understanding of calibration results");
 
-  declareProperty("MinimumPeakTotalCount", 0.,
-                  "Used for validating peaks before fitting. If the total peak Y-value count "
+  declareProperty("MinimumPeakTotalCount", EMPTY_DBL(),
+                  "Used for validating peaks before fitting. If the total peak window Y-value count "
                   "is under this value, the peak will be excluded from fitting and calibration.");
 
   // make group for Input properties

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -239,8 +239,9 @@ void PDCalibration::init() {
                   "center value, in d-spacing or TOF units.");
 
   declareProperty("MinimumPeakHeight", 2.,
-                  "Used for validating peaks after fitting. If the fitted height is under this value, "
-                  "the peak will be excluded from calibration.");
+                  "Used for validating peaks before and after fitting. If a peak's observed/estimated or "
+                  "fitted height is under this value, "
+                  "the peak will be marked as error.");
 
   declareProperty("MaxChiSq", 100., "Maximum chisq value for individual peak fit allowed. (Default: 100)");
 

--- a/Framework/Algorithms/test/FitPeaksTest.h
+++ b/Framework/Algorithms/test/FitPeaksTest.h
@@ -1263,10 +1263,11 @@ public:
       // 1 peak fitted
       const auto &fitted_positions_0 = peak_params_ws->histogram(0).y();
       TS_ASSERT_EQUALS(fitted_positions_0.size(), 1);
-      // if the "minimum peak height" check fails in estimatePeakParameters before fitting, FitPeaks sets the peak
-      // position to -4. if the "minimum peak height" check fails after fitting, FitPeaks sets the peak position to -3.
-      bool expected_peak_error = fitted_positions_0[0] == -4 || fitted_positions_0[0] == -3;
-      TS_ASSERT(expected_peak_error);
+
+      // If the "minimum peak height" check fails in estimatePeakParameters before fitting, FitPeaks sets the peak
+      // position to -4. If the check fails after fitting, the peak position is set to -3.
+      // In this particular test the check fails in estimatePeakParameters.
+      TS_ASSERT_DELTA(fitted_positions_0[0], -4, 0);
 
       // clean algorithm-generated workspaces
       API::AnalysisDataService::Instance().remove("PeakPositionsWS3");

--- a/Framework/Algorithms/test/FitPeaksTest.h
+++ b/Framework/Algorithms/test/FitPeaksTest.h
@@ -1581,7 +1581,7 @@ public:
     return;
   }
 
-  void createGaussParameters(vector<string> &parnames, vector<double> &parvalues, const double peakCenter = 10.0) {
+  void createGaussParameters(vector<string> &parnames, vector<double> &parvalues) {
     parnames.clear();
     parvalues.clear();
 
@@ -1592,7 +1592,7 @@ public:
     parvalues.emplace_back(0.1);
 
     parnames.emplace_back("PeakCentre");
-    parvalues.emplace_back(peakCenter);
+    parvalues.emplace_back(10.0);
   }
 
   //----------------------------------------------------------------------------------------------

--- a/Framework/Algorithms/test/FitPeaksTest.h
+++ b/Framework/Algorithms/test/FitPeaksTest.h
@@ -1072,6 +1072,210 @@ public:
   }
 
   //----------------------------------------------------------------------------------------------
+  /** Test that FitPeaks rejects a peak when
+   * the total count in the peak window is too low
+   * @brief test_lowPeakTotalCount
+   */
+  void test_lowPeakTotalCount() {
+    g_log.notice() << "TEST LOW PEAK TOTAL COUNT";
+    // generate an input workspace
+    const std::string data_ws_name("data_lptc");
+    generateTestDataGaussian(data_ws_name, 1 /*spectra*/, 300 /*data points*/, 1 /*peaks*/);
+
+    // create peak-center and fit-window workspaces for the peak generated above (X=5)
+    std::vector<int> peak_index_vec{0};
+    const std::string peak_center_ws_name = genPeakCenterWorkspace(peak_index_vec, "peakcenter_lptc", 1 /*spectra*/);
+    const std::string fit_window_ws_name =
+        genFitWindowWorkspace(peak_index_vec, "peakwindow_lptc", 1 /*spectra*/, 1.0 /*fit window halfwidth*/);
+
+    // initialize FitPeaks
+    FitPeaks fitpeaks;
+    fitpeaks.initialize();
+    fitpeaks.setRethrows(true);
+    TS_ASSERT(fitpeaks.isInitialized());
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("InputWorkspace", data_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StartWorkspaceIndex", 0));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StopWorkspaceIndex", 0));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakFunction", "Gaussian"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakCentersWorkspace", peak_center_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FitPeakWindowWorkspace", fit_window_ws_name));
+    TS_ASSERT_THROWS_NOTHING(
+        fitpeaks.setProperty("MinimumPeakTotalCount", 60.)); // higher than ~55, the total count in the peak window
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MaxFitIterations", 200));
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
+    TS_ASSERT(fitpeaks.isExecuted());
+    if (fitpeaks.isExecuted()) {
+      // check output workspaces
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakPositionsWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakParametersWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("FittedPeaksWS3"));
+
+      // retrieve fitted parameters
+      API::MatrixWorkspace_sptr peak_params_ws =
+          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS3"));
+      TS_ASSERT(peak_params_ws);
+      // 1 input spectrum
+      TS_ASSERT_EQUALS(peak_params_ws->getNumberHistograms(), 1);
+      // 1 input peak
+      TS_ASSERT_EQUALS(peak_params_ws->histogram(0).x().size(), 1);
+      // 1 peak fitted
+      const auto &fitted_positions_0 = peak_params_ws->histogram(0).y();
+      TS_ASSERT_EQUALS(fitted_positions_0.size(), 1);
+      // when the "minimum peak window count" check fails on an individual peak, FitPeaks sets the peak position to -4.
+      TS_ASSERT_DELTA(fitted_positions_0[0], -4, 0);
+
+      // clean algorithm-generated workspaces
+      API::AnalysisDataService::Instance().remove("PeakPositionsWS3");
+      API::AnalysisDataService::Instance().remove("PeakParametersWS3");
+      API::AnalysisDataService::Instance().remove("FittedPeaksWS3");
+    }
+
+    // clean input workspaces
+    API::AnalysisDataService::Instance().remove(peak_center_ws_name);
+    API::AnalysisDataService::Instance().remove(fit_window_ws_name);
+  }
+
+  //----------------------------------------------------------------------------------------------
+  /** Test that FitPeaks rejects the whole spectrum when
+   * the total count in the spectrum is too low
+   * @brief test_lowSpectrumTotalCount
+   */
+  void test_lowSpectrumTotalCount() {
+    g_log.notice() << "TEST LOW SPECTRUM TOTAL COUNT";
+    // generate an input workspace
+    const std::string data_ws_name("data_lstc");
+    generateTestDataGaussian(data_ws_name, 1 /*spectra*/, 300 /*data points*/, 2 /*peaks*/);
+
+    // create peak-center and fit-window workspaces for the 2 peaks generated above (at X=5 and X=10)
+    std::vector<int> peak_index_vec{0, 1};
+    const std::string peak_center_ws_name = genPeakCenterWorkspace(peak_index_vec, "peakcenter_lstc", 1 /*spectra*/);
+    const std::string fit_window_ws_name =
+        genFitWindowWorkspace(peak_index_vec, "peakwindow_lstc", 1 /*spectra*/, 1.0 /*fit window halfwidth*/);
+
+    // initialize FitPeaks
+    FitPeaks fitpeaks;
+    fitpeaks.initialize();
+    fitpeaks.setRethrows(true);
+    TS_ASSERT(fitpeaks.isInitialized());
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("InputWorkspace", data_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StartWorkspaceIndex", 0));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StopWorkspaceIndex", 1));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakFunction", "Gaussian"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakCentersWorkspace", peak_center_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FitPeakWindowWorkspace", fit_window_ws_name));
+    TS_ASSERT_THROWS_NOTHING(
+        fitpeaks.setProperty("MinimumPeakTotalCount", 500.)); // higher than ~320, the total count in the spectrum
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MaxFitIterations", 200));
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
+    TS_ASSERT(fitpeaks.isExecuted());
+    if (fitpeaks.isExecuted()) {
+      // check output workspaces
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakPositionsWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakParametersWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("FittedPeaksWS3"));
+
+      // retrieve fitted parameters
+      API::MatrixWorkspace_sptr peak_params_ws =
+          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS3"));
+      TS_ASSERT(peak_params_ws);
+      // 1 input spectrum
+      TS_ASSERT_EQUALS(peak_params_ws->getNumberHistograms(), 1);
+      // 2 input peaks
+      TS_ASSERT_EQUALS(peak_params_ws->histogram(0).x().size(), 2);
+      // 2 peaks fitting results
+      const auto &fitted_positions_0 = peak_params_ws->histogram(0).y();
+      TS_ASSERT_EQUALS(fitted_positions_0.size(), 2);
+      // when the "minimum peak window count" check fails on the whole spectrum, FitPeaks sets all peak position in the
+      // spectrum to -1.
+      TS_ASSERT_DELTA(fitted_positions_0[0], -1, 0);
+      TS_ASSERT_DELTA(fitted_positions_0[1], -1, 0);
+
+      // clean algorithm-generated workspaces
+      API::AnalysisDataService::Instance().remove("PeakPositionsWS3");
+      API::AnalysisDataService::Instance().remove("PeakParametersWS3");
+      API::AnalysisDataService::Instance().remove("FittedPeaksWS3");
+    }
+
+    // clean input workspaces
+    API::AnalysisDataService::Instance().remove(peak_center_ws_name);
+    API::AnalysisDataService::Instance().remove(fit_window_ws_name);
+  }
+
+  //----------------------------------------------------------------------------------------------
+  /** Test that FitPeaks rejects a peak when
+   * the observed or fitted peak height is too low
+   * @brief test_lowPeakHeight
+   */
+  void test_lowPeakHeight() {
+    g_log.notice() << "TEST LOW PEAK HEIGHT";
+    // generate an input workspace
+    const std::string data_ws_name("data_lpfh");
+    generateTestDataGaussian(data_ws_name, 1 /*spectra*/, 300 /*data points*/, 1 /*peaks*/, 0.05 /*resolution*/);
+
+    // initialize FitPeaks
+    FitPeaks fitpeaks;
+    fitpeaks.initialize();
+    fitpeaks.setRethrows(true);
+    TS_ASSERT(fitpeaks.isInitialized());
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("InputWorkspace", data_ws_name));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StartWorkspaceIndex", 0));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StopWorkspaceIndex", 1));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakFunction", "Gaussian"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakCenters", "5.0"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FitWindowBoundaryList", "2.5, 6.5"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("HighBackground", false));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MinimumPeakHeight", 3.)); // higher than ~2, the input peak height
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MaxFitIterations", 200));
+
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
+    TS_ASSERT(fitpeaks.isExecuted());
+    if (fitpeaks.isExecuted()) {
+      // check output workspaces
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakPositionsWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("PeakParametersWS3"));
+      TS_ASSERT(API::AnalysisDataService::Instance().doesExist("FittedPeaksWS3"));
+
+      // retrieve fitted parameters
+      API::MatrixWorkspace_sptr peak_params_ws =
+          std::dynamic_pointer_cast<API::MatrixWorkspace>(AnalysisDataService::Instance().retrieve("PeakPositionsWS3"));
+      TS_ASSERT(peak_params_ws);
+      // 1 input spectrum
+      TS_ASSERT_EQUALS(peak_params_ws->getNumberHistograms(), 1);
+      // 1 input peak
+      TS_ASSERT_EQUALS(peak_params_ws->histogram(0).x().size(), 1);
+      // 1 peak fitted
+      const auto &fitted_positions_0 = peak_params_ws->histogram(0).y();
+      TS_ASSERT_EQUALS(fitted_positions_0.size(), 1);
+      // if the "minimum peak height" check fails in estimatePeakParameters before fitting, FitPeaks sets the peak
+      // position to -4. if the "minimum peak height" check fails after fitting, FitPeaks sets the peak position to -3.
+      bool expected_peak_error = fitted_positions_0[0] == -4 || fitted_positions_0[0] == -3;
+      TS_ASSERT(expected_peak_error);
+
+      // clean algorithm-generated workspaces
+      API::AnalysisDataService::Instance().remove("PeakPositionsWS3");
+      API::AnalysisDataService::Instance().remove("PeakParametersWS3");
+      API::AnalysisDataService::Instance().remove("FittedPeaksWS3");
+    }
+  }
+
+  //----------------------------------------------------------------------------------------------
   /** Test that FitPeaks rejects a peak which has a signal-to-noise ratio below threshold
    * @brief test_signalToNoiseRatio
    */
@@ -1103,15 +1307,8 @@ public:
     const std::string data_ws_name("data_s2nr");
     AnalysisDataService::Instance().addOrReplace(data_ws_name, WS);
 
-    // generate peak and background parameters
-    std::vector<string> par_names;
-    std::vector<double> par_values;
-    createGaussParameters(par_names, par_values);
-
-    // create a peak-index vector for 2 peaks (at X=5 and X=10)
+    // create peak-center and fit-window workspaces for the 2 peaks generated above (at X=5 and X=10)
     std::vector<int> peak_index_vec{0, 1};
-
-    // create peak-center and fit-window workspaces
     const std::string peak_center_ws_name = genPeakCenterWorkspace(peak_index_vec, "peakcenter_s2nr", 1 /*spectra*/);
     const std::string fit_window_ws_name =
         genFitWindowWorkspace(peak_index_vec, "peakwindow_s2nr", 1 /*spectra*/, 1.0 /*fit window halfwidth*/);
@@ -1131,10 +1328,10 @@ public:
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("HighBackground", false));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MinimumSignalToNoiseRatio", 50.));
 
-    fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3");
-    fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3");
-    fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3");
-    fitpeaks.setProperty("MaxFitIterations", 200);
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MaxFitIterations", 200));
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.execute());
     TS_ASSERT(fitpeaks.isExecuted());
@@ -1156,7 +1353,7 @@ public:
       const auto &fitted_positions_0 = peak_params_ws->histogram(0).y();
       TS_ASSERT_EQUALS(fitted_positions_0.size(), 2); // with 2 peaks to fit
 
-      // If a check, such as signal-to-noise, fails, FitPeaks sets the peak position to -4.
+      // When the "signal-to-noise" check fails, FitPeaks sets the peak position to -4.
       TS_ASSERT_DELTA(fitted_positions_0[0], -4, 0);
       TS_ASSERT_DELTA(fitted_positions_0[1], 10.0, 1.E-2);
 
@@ -1315,7 +1512,7 @@ public:
     return;
   }
 
-  void createGaussParameters(vector<string> &parnames, vector<double> &parvalues) {
+  void createGaussParameters(vector<string> &parnames, vector<double> &parvalues, const double peakCenter = 10.0) {
     parnames.clear();
     parvalues.clear();
 
@@ -1326,9 +1523,7 @@ public:
     parvalues.emplace_back(0.1);
 
     parnames.emplace_back("PeakCentre");
-    parvalues.emplace_back(10.0);
-
-    return;
+    parvalues.emplace_back(peakCenter);
   }
 
   //----------------------------------------------------------------------------------------------

--- a/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36392.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36392.rst
@@ -1,0 +1,1 @@
+- Add a new property ``MinimumPeakTotalCount`` to :ref:`PDCalibration <algm-PDCalibration>` and :ref:`FitPeaks <algm-FitPeaks>`. This relieves ``MinimumPeakHeight`` property from checking the total count and limits it to just checking the peak height.


### PR DESCRIPTION
#### Description of work
Required by [EWM2963](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2963).

The current `PDCalibration/FitPeaks` property `MinimumPeakHeight` is heavily overloaded. It is used in _four_ different contexts with _two_ different meanings:
- before spectrum fitting, it is used as the minimum acceptable total Y-value over the spectrum, background included
- before single peak fitting, it is used as the minimum acceptable total Y-value over the peak window, background included
- after pre-fit estimating of the peak parameters, it is used as the minimum acceptable peak height, background not included
- after fitting peak parameters, it is used as the minimum acceptable fitted peak height, background not included

We need to limit `MinimumPeakHeight` responsibilities to do just the height checking. Correspondingly, we need to add a new property `MinimumPeakTotalCount` to take over the total count checking.

#### To test:
ctest -R FitPeaksTest

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
