### PR TITLE
Add tracking between axis title, window title, and plot name

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/New_features/33224.rst
+++ b/docs/source/release/v6.9.0/Workbench/New_features/33224.rst
@@ -1,0 +1,1 @@
+- Editing a plot's title will now automatically update its name in the plot selector (and vice versa).

--- a/qt/applications/workbench/workbench/widgets/plotselector/model.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/model.py
@@ -136,6 +136,7 @@ class PlotSelectorModel(object):
             raise ValueError("Error renaming, could not find a plot with the number {}.".format(plot_number))
 
         figure_manager.set_window_title(new_name)
+        figure_manager.set_axes_title(new_name)
 
     # ------------------------ Plot Closing -------------------------
 

--- a/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_model.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_model.py
@@ -108,9 +108,16 @@ class PlotSelectorModelTest(unittest.TestCase):
         self.model.rename_figure(42, "NewName")
         self.figure_manager.set_window_title.assert_called_once_with("NewName")
 
+    def test_renaming_calls_set_axis_title(self):
+        self.model.rename_figure(42, "NewName")
+        self.figure_manager.set_axes_title.assert_called_once_with("NewName")
+
     def test_renaming_calls_with_invalid_number_raises_value_error(self):
-        self.assertRaises(ValueError, self.model.rename_figure, 0, "NewName")
+        self.assertRaisesRegex(
+            ValueError, "Error renaming, could not find a plot with the number 0", self.model.rename_figure, 0, "NewName"
+        )
         self.figure_manager.set_window_title.assert_not_called()
+        self.figure_manager.set_axes_title.assert_not_called()
 
     # ------------------------ Plot Closing -------------------------
 


### PR DESCRIPTION
### Description of work

When the user edits the title of a single plot (any non-tiled plot), the window name and plot name will be updated to match. This also works in reverse, if you change the plot name in the plot selector widget, it will change the window title and plot title.

#### Summary of work
I've added a callback to the axis title using the matplolib `add_callback` method so that any time it is changed a function will trigger.
Also added a method to the figuremanager to edit the axis title, so it can be called from the plot selector.

The callback is set up in the show method rather than the constructor, since upon construction there are no axes added to the plot. It also had to be contained within the figuremanager class so that this would work with script generated plots.

Fixes #33224

### To test:

- Load some data
- Plot a spectrum
- [x] This should be as before, axis title is dataset name, window and plot name are datasetname-1
- [x] Double-click the plot title and change it, window title and plot name should update
- [x] Go to the plot settings and change the title from there, window title and plot name should update
- Hide the plot using the eye icon
- Rename the plot in the plot selector (lower left)
- [x] Unhide the plot and the window and axis title should be renamed
- Do some testing with other kinds of mantid plots, check that setting a tiled plot axis name has no effect
- Test with script made plots (some good ones [here](https://matplotlib.org/stable/tutorials/pyplot.html#sphx-glr-tutorials-pyplot-py)

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
