### PR TITLE
Fix deadlock when closing plot while processing

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/34751.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/34751.rst
@@ -1,0 +1,1 @@
+- Fixed bug where Workbench can hang if you close a plot while an algorithm is processing.

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -317,7 +317,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         if self.toolbar:
             self.toolbar.destroy()
 
-        self._ads_observer.observeAll(False)
         self._ads_observer = None
         # disconnect window events before calling GlobalFigureManager.destroy. window.close is not guaranteed to
         # delete the object and do this for us. On macOS it was observed that closing the figure window


### PR DESCRIPTION


### Description of work
The observers are removed from the notification centre in the destructor of the AnalysisDataServiceObserver class, so no need to do it here as well. Doing it inside the FigureManagerWorkbench.destroy method can result in a deadlock if an algorithm has done something to a workspace while a plot is open, then the plot is closed. Both the algorithm (inside the plot callbacks) and the destroy method will be waiting for the same mutex in Poco.

Fixes #34751. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
See #34751 for original steps to reproduce. Using those steps will sometimes result in an error appearing in the logs because the plot callbacks are trying to do operations on a plot that's been deleted. Trying to e.g. lock to prevent this will result in the original deadlock. At least those messages won't affect your ability to use Workbench, unlike a deadlock.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
