### PR TITLE
Load data into a single bin in SNSPowderReduction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -777,7 +777,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                     chunk["FilterByTimeStop"] = filter_wall[1]
 
         # Call Mantid's Load algorithm to load complete or partial data
-        api.Load(Filename=filename, OutputWorkspace=out_ws_name, **chunk)
+        api.Load(Filename=filename, OutputWorkspace=out_ws_name, NumberOfBins=1, **chunk)
 
         # Log output
         if is_event_workspace(out_ws_name):


### PR DESCRIPTION
By default, `LoadEventNexus` loads data into 500 bins. Since the workflow will rebin the data at some point later, do not bin the data on loading. This will shrink the memory footprint for converting units by ~498xnumber of spectra.

This is already done in most places in `AlignAndFocusPowderFromFiles`, but this one location in `SNSPowderReduction` got missed.

*There is no associated issue.*

### To test:

All of the automated tests should continue to pass.

*This does not require release notes* because it is a very minor reduction in memory (and increase in performance).

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
