### PR TITLE
Remove readline and filelock pins

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -70,10 +70,6 @@ gsl:
 libopenblas:
   - '!=0.3.23,!=0.3.24'
 
-# 8.2 causing segfaults in jupyter unit tests and doc builds.
-readline:
-  - <8.2
-
 euphonic:
   - '>=1.2.1,<2.0'
 

--- a/conda/recipes/mantiddocs/meta.yaml
+++ b/conda/recipes/mantiddocs/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     - sphinx_bootstrap_theme {{ sphinx_bootstrap_theme }}
     - mantidqt {{ version }}
     - versioningit
-    - readline {{ readline }}  # [linux]
 
 # there are no run requirements as it's just pure html
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,17 +18,6 @@ import mantid
 from mantid.kernel import ConfigService
 import sphinx_bootstrap_theme
 
-# Workaround a segfault importing readline with doctests and PyQt5.
-# doctest.py initializes a custom pdb to be able to redirect stdout:
-#   https://github.com/python/cpython/blob/750c5abf43b7b1627ab59ead237bef4c2314d29e/Lib/doctest.py#L367
-# and in turn this attempts to import readline:
-#   https://github.com/python/cpython/blob/750c5abf43b7b1627ab59ead237bef4c2314d29e/Lib/pdb.py#L157
-# The workaround is discussed in https://groups.google.com/forum/#!topic/leo-editor/ghiIN7irzY0
-# and simply amounts to importing readline before a QApplication is created in the screenshots
-# directive
-if sys.platform.startswith("linux") or sys.platform == "darwin":
-    import readline  # noqa: F401
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -57,7 +57,6 @@ dependencies:
   # Linux only
   - gxx_linux-64==10.3.*
   - libglu>=9.0.0
-  - readline<8.2
   - filelock<3.10.2 # Pinned to prevent a segmentation fault when running doc tests
 
   # Needed for test suite on Linux

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -57,7 +57,6 @@ dependencies:
   # Linux only
   - gxx_linux-64==10.3.*
   - libglu>=9.0.0
-  - filelock<3.10.2 # Pinned to prevent a segmentation fault when running doc tests
 
   # Needed for test suite on Linux
   - pciutils-libs-cos7-x86_64>=3.5.1

--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -7,7 +7,6 @@
 #  This file is part of the mantid workbench.
 import argparse
 import atexit
-import importlib
 import os
 import sys
 from sys import setswitchinterval
@@ -60,13 +59,6 @@ def qapplication():
 
         argv = sys.argv[:]
         argv[0] = APPNAME  # replace application name
-        # Workaround a segfault importing readline with PyQt5
-        # This is because PyQt5 messes up pystate (internal) modules_by_index
-        # so PyState_FindModule will return null instead of the module address.
-        # Readline (so far) is the only module that falls over during init as it blindly uses FindModules result
-        # The workaround mentioned in https://groups.google.com/forum/#!topic/leo-editor/ghiIN7irzY0
-        if sys.platform == "linux" or sys.platform == "linux2" or sys.platform == "darwin":
-            importlib.import_module("readline")
 
         app = QApplication(argv)
         app.setOrganizationName(ORGANIZATION)

--- a/qt/python/mantidqt/mantidqt/widgets/test/test_jupyterconsole.py
+++ b/qt/python/mantidqt/mantidqt/widgets/test/test_jupyterconsole.py
@@ -8,11 +8,6 @@
 #
 #
 # system imports
-# import readline (if available) before QApplication starts to avoid segfault with IPython 5 and Python 3
-try:
-    import readline  # noqa
-except ImportError:
-    pass
 import unittest
 from unittest.mock import patch
 


### PR DESCRIPTION
### Description of work

These pins can be removed and the previous bug with readline is fixed since we unpinned ``ipykernel`` in the python 3.10 upgrade.

Fixes #35406
Fixes #35407

### To test:

Install a package from [this build](https://builds.mantidproject.org/job/build_packages_from_branch/674/) and check some basic functionality.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
