### PR TITLE
Remove RegisterPython from mambaforge install script

### DIFF
--- a/buildconfig/Jenkins/Conda/download-and-install-mambaforge
+++ b/buildconfig/Jenkins/Conda/download-and-install-mambaforge
@@ -74,7 +74,7 @@ if [ ! -f $EXPECTED_MAMBA_EXE ]; then
 
     if [[ $OSTYPE == 'msys'* ]]; then
         # Replace all / with \ for windows batch support before passing in $EXPECTED_MAMBAFORGE_PATH
-        cmd.exe /C "START /wait "" $MAMBAFORGE_SCRIPT_NAME /InstallationType=JustMe /S /D=${EXPECTED_MAMBAFORGE_PATH////\\}"
+        cmd.exe /C "CALL $MAMBAFORGE_SCRIPT_NAME /InstallationType=JustMe /S /D=${EXPECTED_MAMBAFORGE_PATH////\\}"
         # The paths in the Conda environment shell environments are Windows style. Convert to cygwin style
         cp $EXPECTED_MAMBAFORGE_PATH/etc/profile.d/conda.sh{,.orig}
         cat $EXPECTED_MAMBAFORGE_PATH/etc/profile.d/conda.sh.orig | \

--- a/buildconfig/Jenkins/Conda/download-and-install-mambaforge
+++ b/buildconfig/Jenkins/Conda/download-and-install-mambaforge
@@ -74,7 +74,7 @@ if [ ! -f $EXPECTED_MAMBA_EXE ]; then
 
     if [[ $OSTYPE == 'msys'* ]]; then
         # Replace all / with \ for windows batch support before passing in $EXPECTED_MAMBAFORGE_PATH
-        cmd.exe /C "START /wait "" $MAMBAFORGE_SCRIPT_NAME /InstallationType=JustMe /RegisterPython=0 /S /D=${EXPECTED_MAMBAFORGE_PATH////\\}"
+        cmd.exe /C "START /wait "" $MAMBAFORGE_SCRIPT_NAME /InstallationType=JustMe /S /D=${EXPECTED_MAMBAFORGE_PATH////\\}"
         # The paths in the Conda environment shell environments are Windows style. Convert to cygwin style
         cp $EXPECTED_MAMBAFORGE_PATH/etc/profile.d/conda.sh{,.orig}
         cat $EXPECTED_MAMBAFORGE_PATH/etc/profile.d/conda.sh.orig | \

--- a/buildconfig/Jenkins/Conda/download-and-install-mambaforge
+++ b/buildconfig/Jenkins/Conda/download-and-install-mambaforge
@@ -74,7 +74,7 @@ if [ ! -f $EXPECTED_MAMBA_EXE ]; then
 
     if [[ $OSTYPE == 'msys'* ]]; then
         # Replace all / with \ for windows batch support before passing in $EXPECTED_MAMBAFORGE_PATH
-        cmd.exe /C "CALL $MAMBAFORGE_SCRIPT_NAME /InstallationType=JustMe /S /D=${EXPECTED_MAMBAFORGE_PATH////\\}"
+        cmd.exe //C "START /wait "" $MAMBAFORGE_SCRIPT_NAME /InstallationType=JustMe /S /D=${EXPECTED_MAMBAFORGE_PATH////\\}"
         # The paths in the Conda environment shell environments are Windows style. Convert to cygwin style
         cp $EXPECTED_MAMBAFORGE_PATH/etc/profile.d/conda.sh{,.orig}
         cat $EXPECTED_MAMBAFORGE_PATH/etc/profile.d/conda.sh.orig | \


### PR DESCRIPTION
### Description of work

#### Summary of work

Locally, and on renewed windows builder images, the mambaforge install script does not work. This is due to the way `/RegisterPython` is interpreted by the command line.

Checking the installer, the `RegisterPython` option defaults to 0 when `/InstallationType=JustMe` , so it is safe to just remove this.

For some god forsaken reason, we now on newer windows systems need to use `//C` to call a command using `cmd`. Why this wasn't the case before, I have no idea:  https://stackoverflow.com/questions/21357813/bash-in-git-for-windows-weirdness-when-running-a-command-with-cmd-exe-c-with-a

*There is no associated issue.*

### To test:

See tests pass and that the following package build passes: https://builds.mantidproject.org/job/build_packages_from_branch/676/

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
