### PR TITLE
Bugfix for pan/zoom/rotate not releasing in plots when double click dialog opens

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36106.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36106.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where double clicking a 3D plot to edit an axis label would grab hold of the plot for rotation and not release when the dialog was closed.

--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36384.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36384.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where double clicking a plot to open the settings dialog would not end a pan/zoom event if either tool was selected.

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -655,6 +655,7 @@ class FigureInteractionTest(unittest.TestCase):
 
         interactor._show_axis_editor = MagicMock()
         interactor.on_mouse_button_press(mouse_event)
+        interactor.on_mouse_button_release(event=MagicMock())
         interactor._show_axis_editor.assert_called_once()
 
     @mock.patch("workbench.plotting.figureinteraction.XAxisEditor")

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -677,7 +677,7 @@ class FigureInteractionTest(unittest.TestCase):
         mock_y_editor.assert_called_once()
 
     @mock.patch("workbench.plotting.figureinteraction.XAxisEditor")
-    def test_click_x_axes_tick_lable_launches_x_axes_editor(self, mock_x_editor):
+    def test_click_x_axes_tick_label_launches_x_axes_editor(self, mock_x_editor):
         self.interactor.canvas.figure = MagicMock()
         axes = self._create_axes_for_axes_editor_test(mouse_over="xaxis_tick")
         self.interactor.canvas.figure.get_axes.return_value = axes
@@ -686,7 +686,7 @@ class FigureInteractionTest(unittest.TestCase):
         mock_x_editor.assert_called_once()
 
     @mock.patch("workbench.plotting.figureinteraction.YAxisEditor")
-    def test_click_y_axes_tick_lable_launches_y_axes_editor(self, mock_y_editor):
+    def test_click_y_axes_tick_label_launches_y_axes_editor(self, mock_y_editor):
         self.interactor.canvas.figure = MagicMock()
         axes = self._create_axes_for_axes_editor_test(mouse_over="yaxis_tick")
         self.interactor.canvas.figure.get_axes.return_value = axes

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -647,6 +647,35 @@ class FigureInteractionTest(unittest.TestCase):
         interactor.on_mouse_button_release(mouse_event)
         interactor._add_all_marker_annotations.assert_called_once()
 
+    def test_open_double_click_dialog_called_on_mouse_release(self):
+        """
+        The logic for opening dialogs by double-clicking is inside the mouse release callback.
+        """
+        fig_manager = self._create_mock_fig_manager_to_accept_left_click()
+        fig_manager.fit_browser.tool = None
+        interactor = FigureInteraction(fig_manager)
+        mouse_event = self._create_mock_double_left_click()
+
+        interactor._open_double_click_dialog = MagicMock()
+        interactor.on_mouse_button_press(mouse_event)
+        interactor.on_mouse_button_release(event=MagicMock())
+
+        interactor._open_double_click_dialog.assert_called_once()
+
+    def test_open_double_click_dialog_not_called_on_mouse_release_when_no_double_click(self):
+        """
+        The function that opens the settings dialogs after a double click should not
+        be called if there wasn't a double click.
+        """
+        fig_manager = self._create_mock_fig_manager_to_accept_left_click()
+        fig_manager.fit_browser.tool = None
+        interactor = FigureInteraction(fig_manager)
+
+        interactor._open_double_click_dialog = MagicMock()
+        interactor.on_mouse_button_release(event=MagicMock())
+
+        interactor._open_double_click_dialog.assert_not_called()
+
     def test_double_left_click_calls_show_axis_editor(self):
         fig_manager = self._create_mock_fig_manager_to_accept_left_click()
         fig_manager.fit_browser.tool = None


### PR DESCRIPTION
### Description of work
Fixes a couple of related bugs to do with opening dialogs by double clicking on plots.

#### Summary of work
- The double click event is handled on the second press of the mouse button, and not the second release.
- Pan/zoom/rotate events end on mouse release.
- If a dialog is opened, and then closed, the release event does not register.
The above three conditions resulted in buggy behaviour when the pan/zoom tool were activated and a double click opened a dialog. On 3D plots, the rotate "tool" is always active, so the bug was much more prevalent.
Moving the logic double-click dialog opening logic into the mouse release callback solves the issue.

Fixes #36384 
Fixes #36106 


### To test:
**Part 1**
1. Load some data and open a spectrum plot
2. Add a marker to the plot using the right click context menu
3. Activate the pan tool on the toolbar
4. Double click on the marker, which opens a marker settings dialog. Close it and move the mouse around to verify that panning has been released.
5. Double click on the main plot area (away from the marker) to open the plot settings dialog. Close it and move the mouse around to verify that panning has been released.
6. Activate the zoom tool on the toolbar and repeat steps 4 and 5.

**Part 2**
1. Load some data and open a surface plot
2. Double click an axis label to open the label editor
3. Close the editor and make sure that the plot doesn't rotate when you move the mouse.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
