### PR TITLE
Fix crash from adding new batches in the ISIS Reflectometry GUI

### DIFF
--- a/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
+++ b/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
@@ -30,6 +30,14 @@ Loading batch files
 - The decimal values should be shown to 2 decimal places as per the Options that we set.
 - Re-open the same batch file. You should not be prompted with any warnings (unless you changed anything).
 
+Adding and deleting batch tabs
+------------------------------
+
+- The interface should open with two batch tabs created by default.
+- Click the cross on any tab to delete it.
+- Check that if all batch tabs are deleted from the interface then a new one is automatically added.
+- Check that you can create a new batch tab using the menu ``Batch->New`` option.
+
 Changing the Default instrument
 -------------------------------
 

--- a/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
+++ b/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
@@ -177,7 +177,7 @@ Preview tab
 ---------------
 
 - Go to the Reduction Preview tab.
-- Type ``INTER45455`` into the ``Run`` input. Set the ``Angle`` to ``1`` and click ``Load``. The instrument view plot should display the data on a detector with four banks. If the plot shows only a single bank then check that you have added the path to your unit test data to your Mantid user directories (see set up instructions). Note, with this dataset, we expect an error "Detector with ID..." to be thrown at this stage.
+- Type ``INTER45455`` into the ``Run`` input. Set the ``Angle`` to ``1`` and click ``Load``. The instrument view plot should display the data on a detector with four banks. Note, with this dataset, we expect an error "Detector with ID..." to be thrown at this stage.
 - Go to the drop-down underneath the color scale next to the second (slice viewer) plot and select ``SymmetricLog10``. This should allow you to see the counts on the slice viewer plot more clearly. You should see what appear as roughly four horizontal lines of data on the plot.
 - Going back to the instrument view plot, click the rectangle-select button above it and draw a single region that selects all detector banks. The selected detector segments should be summed and the result plotted on the slice viewer, appearing as a single line of data.
 - Reduce the size of your original region on the instrument view and check that multiple regions can be added to the plot. Check that when moving and resizing regions, the slice viewer plot is updated.

--- a/docs/source/release/v6.9.0/Reflectometry/Bugfixes/36424.rst
+++ b/docs/source/release/v6.9.0/Reflectometry/Bugfixes/36424.rst
@@ -1,0 +1,1 @@
+- Fixes a regression introduced in Mantid version 6.8 where creating new batch tabs or deleting all batch tabs in the :ref:`ISIS Reflectometry Interface <interface-isis-refl>` causes Mantid to crash.

--- a/qt/widgets/mplcpp/src/FigureCanvasQt.cpp
+++ b/qt/widgets/mplcpp/src/FigureCanvasQt.cpp
@@ -72,10 +72,12 @@ QWidget *initLayout(FigureCanvasQt *cppCanvas) {
  * @param parent The owning parent widget
  */
 FigureCanvasQt::FigureCanvasQt(const int subplotspec, const QString &projection, QWidget *parent)
-    : QWidget(parent), InstanceHolder(createPyCanvas(subplotspec, projection), "draw"),
-      m_figure(Figure(Python::Object(pyobj().attr("figure")))) {
-  // Cannot use delegating constructor here as InstanceHolder needs to be
-  // initialized before the axes can be created
+    : QWidget(parent), InstanceHolder(createPyCanvas(subplotspec, projection), "draw") {
+  // Cannot use delegating constructor here as we have to ensure that we have acquired the GIL
+  // before creating the Figure...
+  GlobalInterpreterLock lock;
+  m_figure = Figure(Python::Object(pyobj().attr("figure")));
+  // ... and the InstanceHolder needs to be initialized before the axes can be created
   m_mplCanvas = initLayout(this);
 }
 


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Ensures that we have acquired the GIL when we try to create the `FigureCanvasQt` object. In Python 3.10 certain API calls now required the GIL to be held where previously this was not required - see [here](https://docs.python.org/3/c-api/dict.html#c.PyDict_GetItem) (linked from [this commit](https://github.com/mantidproject/mantid/pull/35915/commits/142d003e1a33e1735ba7338aacec9ea2a16af630)).

I have also added a step to the ISIS Reflectometry GUI manual testing instructions to check adding and deleting batch tabs to avoid this kind of issue slipping through in future.

We have agreed with our scientists that this fix can just go into the Nightly and doesn't need to be released as a patch.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36332. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
See instructions on linked issue.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
