### PR TITLE
Support configurable branch names in jenkins config when using the nightly pipeline jenkinsfile

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -428,7 +428,13 @@ pipeline {
 
 def git_branch_name() {
   name = scm.branches[0].name
-  if(name.contains("*/")) {
+  // Some jobs define a BRANCH_NAME parameter to allow customisable builds.
+  // In this case the value of scm.branches[0].name will literally be
+  // $BRANCH_NAME and instead we have to get it from the environment.
+  if(name.contains('$BRANCH_NAME')) {
+    name = env.BRANCH_NAME
+  }
+  else if(name.contains("*/")) {
     name = name.split("\\*/")[1]
   }
   return name


### PR DESCRIPTION
### Description of work
Fix a problem when using the branch name to determine default parameter values in the case when a `BRANCH_NAME` parameter is used to allow configurable branch names in a Jenkins job that uses the `nightly_build_and_deploy.jenkinsfile`.

#### Summary of work
Detect whether the branch name is `$BRANCH_NAME` and if it is, use `env.BRANCH_NAME`, otherwise revert to the previous behaviour.

#### Purpose of work
To fix the ornl publishing pipeline job.

*There is no associated issue.*


#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
I added the name of my test branch to the switch case containing ornl branch names and tested whether it entered the correct case. If it did, then it should print:
`We're inside the ornl case`
and if the branch name was read correctly, it should print
`git branch:pipeline_test`
Verify that this happened in both of these scenarios:
1. I changed the Jenkins config to allow a user to specify the `BRANCH_NAME` parameter in this build:
https://builds.mantidproject.org/job/Core_Team_test_pipeline/59/consoleFull

2. I hard-coded the branch name (as we do in the `main` and `release-next` builds) in this build:
https://builds.mantidproject.org/job/Core_Team_test_pipeline/59/consoleFull
note that in this case the environment variable `BRANCH_NAME` is `null`, as expected because it's not defined in the job configuration.

*This does not require release notes* because **it's a change to our Jenkins pipeline**


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
