### PR TITLE
Load data as group option for DataSelector

### DIFF
--- a/Framework/API/inc/MantidAPI/AnalysisDataService.h
+++ b/Framework/API/inc/MantidAPI/AnalysisDataService.h
@@ -98,7 +98,7 @@ public:
   /// workspace object is renamed
   virtual void rename(const std::string &oldName, const std::string &newName);
   /// Overridden remove member to delete its name held by the workspace itself
-  virtual void remove(const std::string &name);
+  virtual Workspace_sptr remove(const std::string &name);
   /// Random generated unique workspace name
   const std::string uniqueName(const int n = 5, const std::string &prefix = "", const std::string &suffix = "");
   /// Random generated unique hidden workspace name

--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -154,8 +154,9 @@ void AnalysisDataServiceImpl::rename(const std::string &oldName, const std::stri
  * Overridden remove member to delete its name held by the workspace itself.
  * It is important to do if the workspace isn't deleted after removal.
  * @param name The name of a workspace to remove.
+ * @return The workspace being removed from the ADS
  */
-void AnalysisDataServiceImpl::remove(const std::string &name) {
+Workspace_sptr AnalysisDataServiceImpl::remove(const std::string &name) {
   Workspace_sptr ws;
   try {
     ws = retrieve(name);
@@ -166,6 +167,7 @@ void AnalysisDataServiceImpl::remove(const std::string &name) {
   if (ws) {
     ws->setName("");
   }
+  return ws;
 }
 
 /**

--- a/Framework/API/test/AnalysisDataServiceTest.h
+++ b/Framework/API/test/AnalysisDataServiceTest.h
@@ -180,6 +180,19 @@ public:
     // Remove should not throw but give a warning in the log file, changed by
     // LCC 05/2008
     TS_ASSERT_THROWS_NOTHING(ads.remove("ttttt"));
+    TS_ASSERT(!ads.remove("ttttt"));
+  }
+
+  void testRemoveReturnsTheWorkspaceSptr() {
+    const std::string name("MySpace");
+    addToADS(name);
+    auto const workspace = ads.remove(name);
+    TS_ASSERT(workspace);
+    TS_ASSERT_EQUALS("MockWorkspace", workspace->id());
+
+    TS_ASSERT_THROWS_NOTHING(ads.remove("ttttt"));
+    // Should return a nullptr as the workspace does not exist
+    TS_ASSERT(!ads.remove("ttttt"));
   }
 
   void testRetrieve() {

--- a/Framework/Algorithms/inc/MantidAlgorithms/GroupWorkspaces.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GroupWorkspaces.h
@@ -46,7 +46,7 @@ private:
   /// overridden execute method
   void exec() override;
   /// Add a list of names to the new group
-  void addToGroup(const std::vector<std::string> &names);
+  void addToGroup(const std::vector<std::string> &names, const std::string &outputName = "");
   /// Add a workspace to the new group, checking for a WorkspaceGroup and
   /// unrolling it
   void addToGroup(const API::Workspace_sptr &workspace);

--- a/Framework/Algorithms/src/GroupWorkspaces.cpp
+++ b/Framework/Algorithms/src/GroupWorkspaces.cpp
@@ -38,12 +38,13 @@ void GroupWorkspaces::exec() {
   const std::vector<std::string> inputWorkspaces = getProperty("InputWorkspaces");
 
   const std::string globExpression = getProperty("GlobExpression");
+  std::string outputWorkspace = getProperty("OutputWorkspace");
 
   // Clear WorkspaceGroup in case algorithm instance is reused.
   m_group = nullptr;
 
   if (!inputWorkspaces.empty())
-    addToGroup(inputWorkspaces);
+    addToGroup(inputWorkspaces, outputWorkspace);
   if (!globExpression.empty())
     addToGroup(globExpression);
   if ((m_group == nullptr) || m_group->isEmpty())
@@ -58,16 +59,6 @@ std::map<std::string, std::string> GroupWorkspaces::validateInputs() {
   const std::vector<std::string> inputWorkspaces = getProperty("InputWorkspaces");
   std::string globExpression = getProperty("GlobExpression");
   std::string outputWorkspace = getProperty("OutputWorkspace");
-
-  // Peform a check that inputworkspaces cannot contain a workspace with the
-  // same name as the group/output workspace
-  for (const auto &ws : inputWorkspaces) {
-    if (ws == outputWorkspace) {
-      if (!AnalysisDataService::Instance().retrieve(ws)->isGroup())
-        results["OutputWorkspace"] = "The output workspace has the same name as "
-                                     "one of the input workspaces";
-    }
-  }
 
   for (auto it = globExpression.begin(); it < globExpression.end(); ++it) {
     if (*it == '\\') {
@@ -121,12 +112,11 @@ void GroupWorkspaces::addToGroup(const std::string &globExpression) {
  * Add a list of names to the new group
  * @param names The list of names to add from the ADS
  */
-void GroupWorkspaces::addToGroup(const std::vector<std::string> &names) {
+void GroupWorkspaces::addToGroup(const std::vector<std::string> &names, const std::string &outputName) {
 
-  const AnalysisDataServiceImpl &ads = AnalysisDataService::Instance();
+  AnalysisDataServiceImpl &ads = AnalysisDataService::Instance();
   for (const auto &name : names) {
-    auto workspace = ads.retrieve(name);
-    addToGroup(workspace);
+    addToGroup(name != outputName ? ads.retrieve(name) : ads.remove(name));
   }
 }
 
@@ -136,10 +126,13 @@ void GroupWorkspaces::addToGroup(const std::vector<std::string> &names) {
  */
 void GroupWorkspaces::addToGroup(const API::Workspace_sptr &workspace) {
   auto localGroup = std::dynamic_pointer_cast<WorkspaceGroup>(workspace);
+  auto &ads = AnalysisDataService::Instance();
   if (localGroup) {
     addToGroup(localGroup->getNames());
-    // Remove the group from the ADS
-    AnalysisDataService::Instance().remove(workspace->getName());
+    if (ads.doesExist(workspace->getName())) {
+      // Remove the group from the ADS
+      ads.remove(workspace->getName());
+    }
   } else {
     if (!m_group)
       m_group = std::make_shared<WorkspaceGroup>();

--- a/Framework/Algorithms/src/GroupWorkspaces.cpp
+++ b/Framework/Algorithms/src/GroupWorkspaces.cpp
@@ -111,6 +111,7 @@ void GroupWorkspaces::addToGroup(const std::string &globExpression) {
 /**
  * Add a list of names to the new group
  * @param names The list of names to add from the ADS
+ * @param outputName The name to give the group workspace
  */
 void GroupWorkspaces::addToGroup(const std::vector<std::string> &names, const std::string &outputName) {
 

--- a/Framework/Algorithms/test/GroupWorkspacesTest.h
+++ b/Framework/Algorithms/test/GroupWorkspacesTest.h
@@ -352,7 +352,7 @@ public:
     removeFromADS("", inputs);
   }
 
-  void test_OutputGroup_cannot_contain_workspaces_from_the_ADS() {
+  void test_OutputGroup_can_supplant_a_workspace_with_the_same_name_in_the_ADS() {
     std::vector<std::string> inputs{"ws1", "ws2"};
     addTestMatrixWorkspacesToADS(inputs);
     Mantid::Algorithms::GroupWorkspaces alg;
@@ -360,9 +360,14 @@ public:
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", inputs));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "ws1"));
-    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
-    TS_ASSERT(!alg.isExecuted());
-    removeFromADS("", inputs);
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    auto &ads = Mantid::API::AnalysisDataService::Instance();
+    TS_ASSERT(ads.doesExist("ws1"));
+    TS_ASSERT(ads.doesExist("ws2"));
+    TS_ASSERT(ads.doesExist("ws1_1"));
+    removeFromADS("ws1", {"ws1_1", "ws2"});
   }
 
   void test_OutputWorkspace_can_overwrite_input_group_workspaces() {

--- a/docs/source/release/v6.9.0/Framework/Algorithms/New_features/36426.rst
+++ b/docs/source/release/v6.9.0/Framework/Algorithms/New_features/36426.rst
@@ -1,0 +1,1 @@
+- The ``OutputWorkspace`` for the :ref:`GroupWorkspaces <algm-GroupWorkspaces>` algorithm is now allowed to be the same name as one of the ``InputWorkspaces``. In this case, the new group workspace will supplant the old workspace, and ``_1`` will be appended to the name of the old workspace.

--- a/docs/source/release/v6.9.0/Indirect/Bugfixes/36410.rst
+++ b/docs/source/release/v6.9.0/Indirect/Bugfixes/36410.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where ApplyAbsorptionCorrections would not load a *_Corrections* file if it only contained a single correction component.

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -187,7 +187,7 @@ void ApplyAbsorptionCorrections::run() {
 
   // get Sample Workspace
   auto const sampleWs = getADSWorkspace(m_sampleWorkspaceName);
-  absCorProps->setProperty("SampleWorkspace", sampleWs);
+  absCorProps->setProperty("SampleWorkspace", m_sampleWorkspaceName);
 
   const bool useCan = m_uiForm.ckUseCan->isChecked();
   // Get Can and Clone

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -55,6 +55,7 @@ ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent) : Correc
   m_uiForm.dsSample->isOptional(true);
   m_uiForm.dsContainer->isOptional(true);
   m_uiForm.dsCorrections->isOptional(true);
+  m_uiForm.dsCorrections->setAlwaysLoadAsGroup(true);
 
   m_uiForm.spPreviewSpec->setMinimum(0);
   m_uiForm.spPreviewSpec->setMaximum(0);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
@@ -107,6 +107,8 @@ public:
   QString getLoadBtnText() const;
   /// Sets the load button text
   void setLoadBtnText(const QString & /*text*/);
+  /// Sets the DataSelector to always load data inside a WorkspaceGroup
+  void setAlwaysLoadAsGroup(bool const loadAsGroup);
 
   // These are accessors/modifiers of the child FileFinderWidget
   /**
@@ -371,6 +373,8 @@ private:
   bool m_showLoad;
   /// Flag if optional
   bool m_isOptional;
+  /// Flag to always load data, placing it inside a WorkspaceGroup, even if there is 1 entry
+  bool m_alwaysLoadAsGroup;
 };
 
 } /* namespace MantidWidgets */

--- a/qt/widgets/common/src/DataSelector.cpp
+++ b/qt/widgets/common/src/DataSelector.cpp
@@ -60,7 +60,7 @@ void loadFile(std::string const &filename, std::string const &workspaceName) {
 namespace MantidQt::MantidWidgets {
 
 DataSelector::DataSelector(QWidget *parent)
-    : API::MantidWidget(parent), m_algRunner(), m_autoLoad(true), m_showLoad(true) {
+    : API::MantidWidget(parent), m_algRunner(), m_autoLoad(true), m_showLoad(true), m_alwaysLoadAsGroup(false) {
   m_uiForm.setupUi(this);
   connect(m_uiForm.cbInputType, SIGNAL(currentIndexChanged(int)), this, SLOT(handleViewChanged(int)));
   connect(m_uiForm.pbLoadFile, SIGNAL(clicked()), this, SIGNAL(loadClicked()));
@@ -363,6 +363,14 @@ QString DataSelector::getLoadBtnText() const { return m_uiForm.pbLoadFile->text(
  * @param text :: The text to display on the button
  */
 void DataSelector::setLoadBtnText(const QString &text) { m_uiForm.pbLoadFile->setText(text); }
+
+/**
+ * Sets the DataSelector to always make sure the loaded data is a WorkspaceGroup. If only one entry is loaded from a
+ * NeXus file, then this entry is added to a WorkspaceGroup.
+ *
+ * @param loadAsGroup :: Whether to load the data as a workspace group.
+ */
+void DataSelector::setAlwaysLoadAsGroup(bool const loadAsGroup) { m_alwaysLoadAsGroup = loadAsGroup; }
 
 /**
  * Read settings from the given group

--- a/qt/widgets/common/src/DataSelector.cpp
+++ b/qt/widgets/common/src/DataSelector.cpp
@@ -228,6 +228,9 @@ void DataSelector::autoLoadFile(const QString &filepath) {
  */
 void DataSelector::handleAutoLoadComplete(bool error) {
   if (!error) {
+    if (m_alwaysLoadAsGroup) {
+      AnalysisDataService::Instance().makeGroup(getWsNameFromFiles().toStdString());
+    }
 
     // emit that we got a valid workspace/file to work with
     emit dataReady(getWsNameFromFiles());

--- a/qt/widgets/common/src/DataSelector.cpp
+++ b/qt/widgets/common/src/DataSelector.cpp
@@ -56,6 +56,17 @@ void loadFile(std::string const &filename, std::string const &workspaceName) {
   loadAlg->execute();
 }
 
+void makeGroup(std::string const &workspaceName) {
+  auto const &ads = AnalysisDataService::Instance();
+  if (!ads.retrieveWS<WorkspaceGroup>(workspaceName)) {
+    const auto groupAlg = AlgorithmManager::Instance().createUnmanaged("GroupWorkspaces");
+    groupAlg->initialize();
+    groupAlg->setProperty("InputWorkspaces", workspaceName);
+    groupAlg->setProperty("OutputWorkspace", workspaceName);
+    groupAlg->execute();
+  }
+}
+
 } // namespace
 
 namespace MantidQt::MantidWidgets {
@@ -229,15 +240,8 @@ void DataSelector::autoLoadFile(const QString &filepath) {
  */
 void DataSelector::handleAutoLoadComplete(bool error) {
   if (!error) {
-    auto &ads = AnalysisDataService::Instance();
-    auto workspaceName = getWsNameFromFiles().toStdString();
-
-    if (m_alwaysLoadAsGroup && !ads.retrieveWS<WorkspaceGroup>(workspaceName)) {
-      const auto groupAlg = AlgorithmManager::Instance().createUnmanaged("GroupWorkspaces");
-      groupAlg->initialize();
-      groupAlg->setProperty("InputWorkspaces", workspaceName);
-      groupAlg->setProperty("OutputWorkspace", workspaceName);
-      groupAlg->execute();
+    if (m_alwaysLoadAsGroup) {
+      makeGroup(getWsNameFromFiles().toStdString());
     }
 
     // emit that we got a valid workspace/file to work with


### PR DESCRIPTION
### Description of work
The NeXus file format does not allow you to specify if a workspace was part of a workspace group at the point of saving the workspace in Mantid. As a consequence, when saving a WorkspaceGroup that only contains one entry, there is no information saved to say that this workspace should be loaded into a WorkspaceGroup when loaded back into Mantid. This was causing issues in the Indirect Corrections interface which expects a WorkspaceGroup for the *_Corrections* file.

To fix this issue, I decided it would be a bad idea to mess around with the NeXus file format by adding an attribute to indicate when a WorkspaceGroup is saved. I believe the "WorkspaceGroup" concept found in Mantid is not a concept which translates to NeXus files, so adding an attribute to our files along this line might bastardise the format.

The solution I went for was to add an option to the `DataSelector` widget which indicates that you should always expect a WorkspaceGroup to be loaded into this particular data selector. This means that if a single workspace entry is loaded, this entry will be placed inside a WorkspaceGroup and then the WorkspaceGroup is returned for processing. If the data is already loaded as a WorkspaceGroup, then no additional steps are taken.

Fixes #36410

### To test:
Open Indirect Corrections
Go to Tab 2 Calculate PP
Load `ExternalData/Testing/Data/UnitTest/iris26176_graphite002_red.nxs` as sample.
Select thickness as 0.1, and set the chemical formula as `C`
Click `Run`. It will create a Group called *Corrections with single ws inside
Save the group workspace to a file ending in *_Corrections*
Go to Apply Absorption Corrections tab
Load same sample as before
Load the corrections file you just saved in the Corrections field
Then click `Run`
It should run successfully and the preview plot should update with a blue line.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
