### PR TITLE
Set figure grid enabled option in all cases

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36432.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36432.rst
@@ -1,0 +1,1 @@
+- Fixed bug where it was not possible to remove the grid lines on a plot once they had been added.

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -199,9 +199,7 @@ class AxisEditor(PropertiesEditorBase):
         self.lim_setter(self.limit_min, self.limit_max)
         self._set_tick_format()
         which = "both" if hasattr(axes, "show_minor_gridlines") and axes.show_minor_gridlines else "major"
-        # visible will always be True if you pass axis or which argument into axes.grid due to matplotlib
-        if self.ui.gridBox.isChecked():
-            axes.grid(visible=True, axis=self.axis_id, which=which)
+        axes.grid(visible=self.ui.gridBox.isChecked(), axis=self.axis_id, which=which)
 
     def error_occurred(self, exc):
         # revert


### PR DESCRIPTION
Fixes bug where one cannot turn off the grid lines on a figure. The grid visibility option needs to be set whether or not the box is checked, because otherwise once you've turned the grid on, you'll never be able to turn it off again.

*There is no associated issue.*

To reproduce, plot a spectrum, double-click on one of the axes, turn the grid on. Now try and turn the grid off using the same process.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
Test that turning the grid on/off functions correctly in plots.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
