### PR TITLE
Fix graph limits not updated in elwin workspace tab

### DIFF
--- a/docs/source/release/v6.9.0/Indirect/Bugfixes/36433.rst
+++ b/docs/source/release/v6.9.0/Indirect/Bugfixes/36433.rst
@@ -1,0 +1,1 @@
+- Fixed a problem with integration and background limits not updated correctly from IPF in workspace input tab in :ref:`Elwin Tab <elwin>`

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
@@ -561,7 +561,6 @@ void InelasticDataManipulationElwinTab::checkLoadedFiles() {
   if (validate()) {
     newInputFiles();
     m_view->plotInput(getInputWorkspace(), getSelectedSpectrum());
-    updateIntegrationRange();
   }
 }
 
@@ -593,6 +592,7 @@ MatrixWorkspace_sptr InelasticDataManipulationElwinTab::getInputWorkspace() cons
  */
 void InelasticDataManipulationElwinTab::setInputWorkspace(MatrixWorkspace_sptr inputWorkspace) {
   m_inputWorkspace = std::move(inputWorkspace);
+  updateIntegrationRange();
 }
 
 /**


### PR DESCRIPTION
### Description of work
This PR fixes graph limits in the plot of the Elwin tab that is not updated with the resolution parameters from the instrument parameter files (IPF). The plot limits were only updated correctly if you are using the file tab.
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

Fixes #36307. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
The `updateIntegrationRange` function is now called whenever the input workspace is updated, instead of only when the file tab is loaded.
### To test:
1- Make sure you have the sample data
2- Navigate to Interfaces->Inelastic->Data Manipulation->Elwin
3- Load the iris26176_graphite002_red.nxs using the file tab
4- Notice the values of the integration and background limits
5- Reopen the Elwin tab again
5- Go to the workspace tab then add iris26176_graphite002_red.nxs workspace
6- Notice the values of the integration and background limits
7- The values from the two methods should be the same
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
