### PR TITLE
Allow Selection of Beam Centre Adjustment Values Based on Selected Detector in ISIS SANS

### DIFF
--- a/docs/source/release/v6.9.0/SANS/New_features/35957.rst
+++ b/docs/source/release/v6.9.0/SANS/New_features/35957.rst
@@ -1,0 +1,2 @@
+- All beam centre settings can now be left uncommented in the TOML file. The appropriate beam centre values will now be
+  selected based on the ``selected_detector`` setting from the TOML file or ``Reduction Mode`` setting on the GUI.

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -177,7 +177,7 @@ class StateGuiModel(ModelCommon):
     @undo_selective_view_scaling
     def front_pos_2(self, value):
         if DetectorType.HAB.value in self._all_states.move.detectors:
-            self._all_states.move.detectors[DetectorType.HAB.value].sample_centre_pos1 = value
+            self._all_states.move.detectors[DetectorType.HAB.value].sample_centre_pos2 = value
 
     # ==================================================================================================================
     # ==================================================================================================================

--- a/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
@@ -122,21 +122,18 @@ class BeamCentrePresenter(object):
         """
         Copies rear / front positions from an external model
         """
-        rear_pos_1 = getattr(state_model, "rear_pos_1")
-        rear_pos_2 = getattr(state_model, "rear_pos_2")
+        self._beam_centre_model.rear_pos_1 = getattr(state_model, "rear_pos_1")
+        self._beam_centre_model.rear_pos_2 = getattr(state_model, "rear_pos_2")
 
-        self._beam_centre_model.rear_pos_1 = rear_pos_1
-        self._beam_centre_model.rear_pos_2 = rear_pos_2
-
-        self._beam_centre_model.front_pos_1 = getattr(state_model, "front_pos_1") if getattr(state_model, "front_pos_1") else rear_pos_1
-        self._beam_centre_model.front_pos_2 = getattr(state_model, "front_pos_2") if getattr(state_model, "front_pos_2") else rear_pos_2
+        self._beam_centre_model.front_pos_1 = getattr(state_model, "front_pos_1")
+        self._beam_centre_model.front_pos_2 = getattr(state_model, "front_pos_2")
 
     def update_centre_positions(self):
         rear_pos_1 = self._beam_centre_model.rear_pos_1
         rear_pos_2 = self._beam_centre_model.rear_pos_2
 
-        front_pos_1 = self._beam_centre_model.front_pos_1 if self._beam_centre_model.front_pos_1 != "" else rear_pos_1
-        front_pos_2 = self._beam_centre_model.front_pos_2 if self._beam_centre_model.front_pos_2 != "" else rear_pos_2
+        front_pos_1 = self._beam_centre_model.front_pos_1
+        front_pos_2 = self._beam_centre_model.front_pos_2
 
         self._view.rear_pos_1 = self._round(rear_pos_1)
         self._view.rear_pos_2 = self._round(rear_pos_2)

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -1133,6 +1133,8 @@ class RunTabPresenter(PresenterCommon):
             # Beam Centre
             self._beam_centre_presenter.set_on_state_model("rear_pos_1", state_model)
             self._beam_centre_presenter.set_on_state_model("rear_pos_2", state_model)
+            self._beam_centre_presenter.set_on_state_model("front_pos_1", state_model)
+            self._beam_centre_presenter.set_on_state_model("front_pos_2", state_model)
         except (RuntimeError, ValueError) as e:
             self.display_warning_box(title="Invalid Settings Entered", text=str(e), detailed_text=str(e))
 

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
@@ -169,12 +169,18 @@ class _TomlV1ParserImpl(TomlParserImplBase):
         rear = self.get_val("rear_centre", det_config_dict)
         front = self.get_val("front_centre", det_config_dict)
         all = self.get_val("all_centre", det_config_dict)
-        if (front or rear) and all:
-            raise ValueError("front_centre, rear_centre and all_centre were all specified together.")
 
-        update_translations(DetectorType.LAB, next((i for i in [rear, all] if i), None))
-        if DetectorType.HAB.value in self.move.detectors:
-            update_translations(DetectorType.HAB, next((i for i in [front, all] if i), None))
+        if self.reduction_mode.reduction_mode is ReductionMode.LAB:
+            update_translations(DetectorType.LAB, rear)
+        elif self.reduction_mode.reduction_mode is ReductionMode.HAB:
+            update_translations(DetectorType.HAB, front)
+        elif self.reduction_mode.reduction_mode in [ReductionMode.ALL, ReductionMode.MERGED]:
+            if self.instrument is SANSInstrument.LOQ:
+                update_translations(DetectorType.LAB, rear)
+                update_translations(DetectorType.HAB, front)
+            else:
+                update_translations(DetectorType.LAB, all)
+                update_translations(DetectorType.HAB, all)
 
     def _parse_detector(self):
         detector_dict = self.get_val("detector")

--- a/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
@@ -165,10 +165,6 @@ class BeamCentrePresenterTest(unittest.TestCase):
         for attr in rear_attr:
             self.assertEqual(getattr(mocked_external_model, attr), getattr(self.presenter._beam_centre_model, attr))
 
-        # When front isn't present we should take rear values
-        for front_attr, rear_attr in zip(front_list, rear_attr):
-            self.assertEqual(getattr(mocked_external_model, rear_attr), getattr(self.presenter._beam_centre_model, front_attr))
-
     def test_on_update_rows_updates_centres(self):
         # As the rear centres can update when the rows change (due to different run number groups)
         # we should always update from the model
@@ -187,18 +183,6 @@ class BeamCentrePresenterTest(unittest.TestCase):
         self.assertEqual(1.2, self.view.rear_pos_2)
         self.assertEqual(2.1, self.view.front_pos_1)
         self.assertEqual(2.2, self.view.front_pos_2)
-
-    def test_update_center_positions_with_empty_front(self):
-        self.BeamCentreModel.rear_pos_1 = 1.1
-        self.BeamCentreModel.rear_pos_2 = 1.2
-        self.BeamCentreModel.front_pos_1 = ""
-        self.BeamCentreModel.front_pos_2 = ""
-        self.presenter.update_centre_positions()
-
-        self.assertEqual(1.1, self.view.rear_pos_1)
-        self.assertEqual(1.2, self.view.rear_pos_2)
-        self.assertEqual(self.BeamCentreModel.rear_pos_1, self.view.front_pos_1)
-        self.assertEqual(self.BeamCentreModel.rear_pos_2, self.view.front_pos_2)
 
     def test_update_center_positions_with_zero_front(self):
         self.BeamCentreModel.rear_pos_1 = 1.1

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -544,6 +544,23 @@ class StateGuiModelTest(unittest.TestCase):
         self.assertEqual(state_gui_model.mask_files, ["file.txt", "file2.txt"])
 
     # ------------------------------------------------------------------------------------------------------------------
+    # Beam Centre
+    # ------------------------------------------------------------------------------------------------------------------
+
+    def test_setters_are_working_correctly(self):
+        state = AllStates()
+        state.move.detectors = {DetectorType.LAB.value: StateMoveDetectors(), DetectorType.HAB.value: StateMoveDetectors()}
+        state_gui_model = StateGuiModel(state)
+        state_gui_model.rear_pos_1 = 21.5
+        state_gui_model.rear_pos_2 = 17.8
+        state_gui_model.front_pos_1 = 25.1
+        state_gui_model.front_pos_2 = 16.9
+        self.assertEqual(state_gui_model.rear_pos_1, 21.5)
+        self.assertEqual(state_gui_model.rear_pos_2, 17.8)
+        self.assertEqual(state_gui_model.front_pos_1, 25.1)
+        self.assertEqual(state_gui_model.front_pos_2, 16.9)
+
+    # ------------------------------------------------------------------------------------------------------------------
     # User files - focus on fields that are displayed in mm and stored in m
     # ------------------------------------------------------------------------------------------------------------------
     def test_that_user_file_items_interpreted_correctly(self):

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
@@ -125,22 +125,70 @@ class TomlV1ParserTest(unittest.TestCase):
         self.assertEqual((2, 3), get_beam_position(state_move, DetectorType.LAB))
 
     def test_all_centre_entry(self):
-        input_dict = {"detector": {"configuration": {"all_centre": {"x": 2, "y": 3.4}}}}
+        input_dict = {
+            "detector": {"configuration": {"all_centre": {"x": 2, "y": 3.4}, "selected_detector": "all"}},
+            "instrument": {"name": "SANS2D"},
+        }
         parser = self._setup_parser(input_dict)
         for i in [ReductionMode.HAB, ReductionMode.LAB]:
             move = parser.get_state_move(None)
             self.assertEqual(2, move.detectors[i.value].sample_centre_pos1)
             self.assertEqual(3.4, move.detectors[i.value].sample_centre_pos2)
 
-    def test_throws_when_all_and_rear_specified(self):
-        input_dict = {"detector": {"configuration": {"all_centre": {"x": 2, "y": 3.4}, "rear_centre": {"x": 2}}}}
-        with self.assertRaisesRegex(ValueError, "front_centre"):
-            self._setup_parser(input_dict)
+    def test_loq_uses_front_and_rear_not_all_centre(self):
+        input_dict = {
+            "detector": {
+                "configuration": {
+                    "all_centre": {"x": 2, "y": 3.4},
+                    "front_centre": {"x": 2.1, "y": 3.5},
+                    "rear_centre": {"x": 2.2, "y": 3.6},
+                    "selected_detector": "all",
+                }
+            },
+            "instrument": {"name": "LOQ"},
+        }
+        parser = self._setup_parser(input_dict)
+        move = parser.get_state_move(None)
+        self.assertEqual(2.1, move.detectors[ReductionMode.HAB.value].sample_centre_pos1)
+        self.assertEqual(3.5, move.detectors[ReductionMode.HAB.value].sample_centre_pos2)
+        self.assertEqual(2.2, move.detectors[ReductionMode.LAB.value].sample_centre_pos1)
+        self.assertEqual(3.6, move.detectors[ReductionMode.LAB.value].sample_centre_pos2)
 
-    def test_throws_when_all_and_front_specified(self):
-        input_dict = {"detector": {"configuration": {"all_centre": {"x": 2, "y": 3.4}, "front_centre": {"x": 2}}}}
-        with self.assertRaisesRegex(ValueError, "front_centre"):
-            self._setup_parser(input_dict)
+    def test_sets_rear_centre_when_rear_detector_selected(self):
+        input_dict = {
+            "detector": {
+                "configuration": {
+                    "all_centre": {"x": 2, "y": 3.4},
+                    "front_centre": {"x": 2.1, "y": 3.5},
+                    "rear_centre": {"x": 2.2, "y": 3.6},
+                    "selected_detector": "rear",
+                }
+            }
+        }
+        parser = self._setup_parser(input_dict)
+        move = parser.get_state_move(None)
+        self.assertEqual(0.0, move.detectors[ReductionMode.HAB.value].sample_centre_pos1)
+        self.assertEqual(0.0, move.detectors[ReductionMode.HAB.value].sample_centre_pos2)
+        self.assertEqual(2.2, move.detectors[ReductionMode.LAB.value].sample_centre_pos1)
+        self.assertEqual(3.6, move.detectors[ReductionMode.LAB.value].sample_centre_pos2)
+
+    def test_sets_front_centre_when_front_detector_selected(self):
+        input_dict = {
+            "detector": {
+                "configuration": {
+                    "all_centre": {"x": 2, "y": 3.4},
+                    "front_centre": {"x": 2.1, "y": 3.5},
+                    "rear_centre": {"x": 2.2, "y": 3.6},
+                    "selected_detector": "front",
+                }
+            }
+        }
+        parser = self._setup_parser(input_dict)
+        move = parser.get_state_move(None)
+        self.assertEqual(2.1, move.detectors[ReductionMode.HAB.value].sample_centre_pos1)
+        self.assertEqual(3.5, move.detectors[ReductionMode.HAB.value].sample_centre_pos2)
+        self.assertEqual(0.0, move.detectors[ReductionMode.LAB.value].sample_centre_pos1)
+        self.assertEqual(0.0, move.detectors[ReductionMode.LAB.value].sample_centre_pos2)
 
     def test_rear_front_maps_to_enum_correctly(self):
         for user_input, enum_val in [


### PR DESCRIPTION
### Description of work

#### Summary of work
Adjusts the parsing of the TOML-based User Files in the ISIS SANS GUI so that all of the beam centre values can be left uncommented and only the relevant ones are loaded into the state used in the reduction.

#### Purpose of Work
Fixes #35957 
**Report to:** Steve King


#### Further detail of work
- Changes to the TOML parsing that is the main change to complete the issue can be found in `toml_v1_parser.py`
- The work also revealed a couple of other bugs:
  - When loading the User File, loading just the rear would also populate the front, and vice versa
  - The "Sans State" (the massive multi-level dict structure that allows the entire GUI state to be passed to the reduction algorithms) wasn't being set properly for the front beam centre values due to a typo. This has now been fixed by the changes to the `state_gui_model.py`. 

### To test:
1. Boot workbench and navigate to the ISIS SANS GUI.
2. In your file browser, edit the `MaskFile.toml` from the `loqdemo` (you may want to make a copy instead)
    1.  Uncomment the values for `front_centre`, `rear_centre`, and `all_centre`
    2. Change the values for each so they're easy to distinguish from each other
    3. Change the `selected_detector` to `"front"`
4. Load this user file into the SANS GUI
5. Check the correct beam centre value has been loaded. 
6. Back in the TOML file, change the selected detector to `all`
7. Reload the file into the SANS GUI
8. When the instrument is set in the TOML to `LOQ`, the beam centre tab's values should match the front and rear from the toml
9. When the instrument is set in the TOML to `SANS2D`, the GUI should match the `all_centre` value from the toml. 

Note: The checkboxes on the Beam Centre Finder are changed according to the loaded User File, but they don't seem to do anything at the moment. There's an issue to investigate this here #36435

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
