### PR TITLE
Replaces Plot Contour Option in Indirect/Inelastic interfaces with opening Slice Viewer.

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -342,7 +342,7 @@ constVariable:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/BankTextureBuild
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/MiniPlotMpl.cpp:154
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/MiniPlotMpl.cpp:164
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/MiniPlotMpl.cpp:325
-unusedScopedObject:${CMAKE_SOURCE_DIR}/qt/widgets/plotting/src/ExternalPlotter.cpp:46
+unusedScopedObject:${CMAKE_SOURCE_DIR}/qt/widgets/plotting/src/ExternalPlotter.cpp:47
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:300
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:352
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:394

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -342,7 +342,6 @@ constVariable:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/BankTextureBuild
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/MiniPlotMpl.cpp:154
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/MiniPlotMpl.cpp:164
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/MiniPlotMpl.cpp:325
-unusedScopedObject:${CMAKE_SOURCE_DIR}/qt/widgets/plotting/src/ExternalPlotter.cpp:47
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:300
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:352
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:394

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -342,7 +342,7 @@ constVariable:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/BankTextureBuild
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/MiniPlotMpl.cpp:154
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/MiniPlotMpl.cpp:164
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/MiniPlotMpl.cpp:325
-unusedScopedObject:${CMAKE_SOURCE_DIR}/qt/widgets/plotting/src/ExternalPlotter.cpp:47
+unusedScopedObject:${CMAKE_SOURCE_DIR}/qt/widgets/plotting/src/ExternalPlotter.cpp:46
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:300
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:352
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:394

--- a/dev-docs/source/Testing/IndirectInelastic/IndirectInelasticAcceptanceTests.rst
+++ b/dev-docs/source/Testing/IndirectInelastic/IndirectInelasticAcceptanceTests.rst
@@ -73,7 +73,7 @@ Data reduction
 #. Click ``Run``. An ``_sqw`` workspace should be created.
 #. Check ``Rebin in energy``
 #. Click ``Run``
-#. Within the ``Output`` section, click the down arrow on the ``Plot Spectra`` button and then select ``Plot Contour``, this should result in a 2D contour plot
+#. Within the ``Output`` section, click the down arrow on the ``Plot Spectra`` button and then select ``Open Slice Viewer``, this should open a slice viewer window.
 #. Click ``Manage User Directories`` and set the default save location
 #. Click ``Save Result``
 #. Check that the ``.nxs`` file was created in the correct location

--- a/docs/source/interfaces/indirect/Indirect Corrections.rst
+++ b/docs/source/interfaces/indirect/Indirect Corrections.rst
@@ -78,8 +78,8 @@ Run
 Plot Spectra
   If enabled, it will plot the selected workspace indices in the selected output workspace.
 
-Plot Contour
-  If enabled, it will plot the selected output workspace as a contour plot.
+Open Slice Viewer
+  If enabled, it will open the slice viewer for the selected output workspace.
 
 Save Result
   If enabled the result will be saved as a NeXus file in the default save directory.
@@ -493,8 +493,8 @@ Run
 Plot Spectra
   If enabled, it will plot the selected workspace indices in the selected output workspace.
 
-Plot Contour
-  If enabled, it will plot the selected output workspace as a contour plot.
+Open Slice Viewer
+  If enabled, it will open the slice viewer for the selected output workspace.
 
 Save Result
   If enabled the result will be saved as a NeXus file in the default save directory.

--- a/docs/source/interfaces/indirect/Indirect Data Reduction.rst
+++ b/docs/source/interfaces/indirect/Indirect Data Reduction.rst
@@ -138,8 +138,8 @@ Run
 Plot Spectra
   If enabled, it will plot the selected workspace indices in the selected output workspace.
 
-Plot Contour
-  If enabled, it will plot the selected output workspace as a contour plot.
+Open Slice Viewer
+  If enabled, it will open the slice viewer for the selected output workspace.
 
 Group Output
   This will place the output reduced files from a reduction into a group workspace.

--- a/docs/source/interfaces/indirect/Indirect Diffraction.rst
+++ b/docs/source/interfaces/indirect/Indirect Diffraction.rst
@@ -71,8 +71,8 @@ Run
 Plot Spectra
   If enabled, it will plot the selected workspace indices in the selected output workspace.
 
-Plot Contour
-  If enabled, it will plot the selected output workspace as a contour plot.
+Open Slice Viewer
+  If enabled, it will open the slice viewer for the selected output workspace.
 
 Save Formats
   Select a range of save formats to save the reduced data as, in all cases the

--- a/docs/source/interfaces/indirect/Indirect Simulation.rst
+++ b/docs/source/interfaces/indirect/Indirect Simulation.rst
@@ -68,8 +68,8 @@ Run
 Plot Spectra
   If enabled, it will plot the selected workspace indices in the selected output workspace.
 
-Plot Contour
-  If enabled, it will plot the selected output workspace as a contour plot.
+Open Slice Viewer
+  If enabled, it will open the slice viewer for the selected output workspace.
 
 Save Result
   Saves the result in the default save directory.

--- a/docs/source/interfaces/inelastic/Inelastic Data Manipulation.rst
+++ b/docs/source/interfaces/inelastic/Inelastic Data Manipulation.rst
@@ -176,8 +176,8 @@ Run
 Plot Spectra
   If enabled, it will plot the selected workspace indices in the selected output workspace.
 
-Plot Contour
-  If enabled, it will plot the selected output workspace as a contour plot.
+Open Slice Viewer
+  If enabled, it will open the slice viewer for the selected output workspace.
 
 Save Result
   If enabled the result will be saved as a NeXus file in the default save directory.
@@ -209,8 +209,8 @@ produce this file is IRIS, the analyser is graphite and the reflection is 002. S
 6. Enter a list of workspace indices in the output options (e.g. 0-2,4,6-7) and then click
    **Plot Spectra** to plot spectra from the output workspace.
 
-6. Click the down arrow on the **Plot Spectra** button, and select **Plot Contour**. This will
-   produce a contour plot of the output workspace.
+6. Click the down arrow on the **Plot Spectra** button, and select **Open Slice Viewer**. This will
+   open a slice viewer window for the output workspace.
 
 7. Choose a default save directory and then click **Save Result** to save the output workspace.
    The _sqw file is used in the :ref:`moments-example-workflow`.

--- a/docs/source/release/v6.9.0/Indirect/New_features/36344.rst
+++ b/docs/source/release/v6.9.0/Indirect/New_features/36344.rst
@@ -1,0 +1,1 @@
+-  The slice viewer can be opened instead of a contour in the external plot options of the Inelastic/Indirect Interfaces with a plot contour option.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/__init__.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/__init__.py
@@ -9,12 +9,15 @@
 #
 # Can be launch from python by _e.g_
 #
+# Uncomment this line if called from jupyter notebook
+##%matplotlib nbagg
 #
-# from mantidqt.widgets.sliceviewer.presenter import SliceViewer
+# from mantidqt.widgets.sliceviewer.presenters.presenter import SliceViewer
 # from mantid.simpleapi import LoadMD
 # from qtpy.QtWidgets import QApplication
+#
 # ws = LoadMD('ExternalData/Testing/SystemTests/tests/analysis/reference/ConvertWANDSCDtoQTest_HKL.nxs')
 # app = QApplication([])
 # window = SliceViewer(ws)
-# window.show()
+# window.view.show()
 # app.exec_()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -49,7 +49,6 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
             else SliceViewerView(self, Dimensions.get_dimensions_info(ws), model.can_normalize_workspace(), parent, window_flags, conf)
         )
         super().__init__(ws, self.view.data_view, model)
-
         self._logger = Logger("SliceViewer")
         self._peaks_presenter: PeaksViewerCollectionPresenter = None
         self._cutviewer_presenter = None
@@ -422,6 +421,9 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
             self.new_plot()
         finally:
             ws.unlock()
+
+    def show_view(self):
+        self.view.show()
 
     def rename_workspace(self, old_name, new_name):
         if self.model.workspace_equals(old_name):

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -36,7 +36,7 @@ ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent) : Correc
   m_spectra = 0;
   m_uiForm.setupUi(parent);
   setOutputPlotOptionsPresenter(
-      std::make_unique<IndirectPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraContour));
+      std::make_unique<IndirectPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSlice));
 
   connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this, SLOT(newSample(const QString &)));
   connect(m_uiForm.dsContainer, SIGNAL(dataReady(const QString &)), this, SLOT(newContainer(const QString &)));

--- a/qt/scientific_interfaces/Indirect/ContainerSubtraction.cpp
+++ b/qt/scientific_interfaces/Indirect/ContainerSubtraction.cpp
@@ -26,7 +26,7 @@ namespace MantidQt::CustomInterfaces {
 ContainerSubtraction::ContainerSubtraction(QWidget *parent) : CorrectionsTab(parent), m_spectra(0) {
   m_uiForm.setupUi(parent);
   setOutputPlotOptionsPresenter(
-      std::make_unique<IndirectPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraContour));
+      std::make_unique<IndirectPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSlice));
 
   connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this, SLOT(newSample(const QString &)));
   connect(m_uiForm.dsContainer, SIGNAL(dataReady(const QString &)), this, SLOT(newContainer(const QString &)));

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
@@ -813,7 +813,7 @@ void IndirectDiffractionReduction::manualGroupingToggled(int state) {
     m_plotOptionsPresenter->setPlotType(PlotWidget::SpectraUnit);
     break;
   case Qt::Checked:
-    m_plotOptionsPresenter->setPlotType(PlotWidget::SpectraContourUnit);
+    m_plotOptionsPresenter->setPlotType(PlotWidget::SpectraSliceUnit);
     break;
   default:
     return;

--- a/qt/scientific_interfaces/Indirect/IndirectMolDyn.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMolDyn.cpp
@@ -19,7 +19,7 @@ namespace MantidQt::CustomInterfaces {
 IndirectMolDyn::IndirectMolDyn(QWidget *parent) : IndirectSimulationTab(parent) {
   m_uiForm.setupUi(parent);
   setOutputPlotOptionsPresenter(
-      std::make_unique<IndirectPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraContour, "0"));
+      std::make_unique<IndirectPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSlice, "0"));
 
   connect(m_uiForm.ckCropEnergy, SIGNAL(toggled(bool)), m_uiForm.dspMaxEnergy, SLOT(setEnabled(bool)));
   connect(m_uiForm.ckResolution, SIGNAL(toggled(bool)), m_uiForm.dsResolution, SLOT(setEnabled(bool)));

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.cpp
@@ -100,7 +100,7 @@ constructActions(boost::optional<std::map<std::string, std::string>> const &avai
     actions = availableActions.get();
   actions.insert({"Plot Spectra", "Plot Spectra"});
   actions.insert({"Plot Bins", "Plot Bins"});
-  actions.insert({"Plot Contour", "Plot Contour"});
+  actions.insert({"Open Slice Viewer", "Open Slice Viewer"});
   actions.insert({"Plot Tiled", "Plot Tiled"});
   return actions;
 }
@@ -224,13 +224,13 @@ void IndirectPlotOptionsModel::plotBins(std::string const &binIndices) {
     m_plotter->plotBins(workspaceName.get(), binIndices, IndirectSettingsHelper::externalPlotErrorBars());
 }
 
-void IndirectPlotOptionsModel::plotContour() {
+void IndirectPlotOptionsModel::showSliceViewer() {
   auto const workspaceName = workspace();
   auto const unitName = unit();
 
   if (workspaceName) {
     std::string plotWorkspaceName = unitName ? convertUnit(workspaceName.get(), unitName.get()) : workspaceName.get();
-    m_plotter->plotContour(plotWorkspaceName);
+    m_plotter->showSliceViewer(plotWorkspaceName);
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.h
@@ -48,8 +48,8 @@ public:
 
   virtual void plotSpectra();
   virtual void plotBins(std::string const &binIndices);
-  virtual void plotContour();
   virtual void plotTiled();
+  virtual void showSliceViewer();
 
   boost::optional<std::string> singleDataPoint(MantidAxis const &axisType) const;
 

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
@@ -57,7 +57,6 @@ IndirectPlotOptionsPresenter::~IndirectPlotOptionsPresenter() { watchADS(false);
 void IndirectPlotOptionsPresenter::setupPresenter(PlotWidget const &plotType, std::string const &fixedIndices) {
   watchADS(true);
   m_view->subscribePresenter(this);
-
   m_view->setIndicesRegex(QString::fromStdString(Regexes::WORKSPACE_INDICES));
   m_view->setPlotType(plotType, m_model->availableActions());
   m_view->setIndices(QString::fromStdString(fixedIndices));
@@ -186,9 +185,10 @@ void IndirectPlotOptionsPresenter::handlePlotBinsClicked() {
   }
 }
 
-void IndirectPlotOptionsPresenter::handlePlotContourClicked() {
+
+void IndirectPlotOptionsPresenter::handleShowSliceViewerClicked() {
   setPlotting(true);
-  m_model->plotContour();
+  m_model->showSliceViewer();
   setPlotting(false);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
@@ -134,7 +134,7 @@ void IndirectPlotOptionsPresenter::clearWorkspaces() {
 }
 
 void IndirectPlotOptionsPresenter::setUnit(std::string const &unit) {
-  if (m_plotType == PlotWidget::SpectraUnit || m_plotType == PlotWidget::SpectraContourUnit) {
+  if (m_plotType == PlotWidget::SpectraUnit || m_plotType == PlotWidget::SpectraSliceUnit) {
     m_model->setUnit(unit);
   }
 }

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
@@ -185,7 +185,6 @@ void IndirectPlotOptionsPresenter::handlePlotBinsClicked() {
   }
 }
 
-
 void IndirectPlotOptionsPresenter::handleShowSliceViewerClicked() {
   setPlotting(true);
   m_model->showSliceViewer();

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
@@ -25,7 +25,7 @@ public:
   virtual void handleSelectedIndicesChanged(std::string const &indices) = 0;
   virtual void handlePlotSpectraClicked() = 0;
   virtual void handlePlotBinsClicked() = 0;
-  virtual void handlePlotContourClicked() = 0;
+  virtual void handleShowSliceViewerClicked() = 0;
   virtual void handlePlotTiledClicked() = 0;
 };
 
@@ -46,7 +46,7 @@ public:
   void handleSelectedIndicesChanged(std::string const &indices) override;
   void handlePlotSpectraClicked() override;
   void handlePlotBinsClicked() override;
-  void handlePlotContourClicked() override;
+  void handleShowSliceViewerClicked() override;
   void handlePlotTiledClicked() override;
 
   void setPlotType(PlotWidget const &plotType);

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -54,7 +54,7 @@ QString getAction(std::map<std::string, std::string> const &actions, std::string
 
 QIcon plotCurveIcon() { return MantidQt::Icons::getIcon("mdi.chart-line"); }
 
-QIcon plotContourIcon() { return MantidQt::Icons::getIcon("mdi.chart-scatterplot-hexbin"); }
+QIcon showSliceViewerIcon() { return MantidQt::Icons::getIcon("mdi.chart-scatterplot-hexbin"); }
 
 QIcon plotTiledIcon() { return MantidQt::Icons::getIcon("mdi.chart-line-stacked"); }
 
@@ -123,9 +123,9 @@ void IndirectPlotOptionsView::notifyPlotBinsClicked() {
   m_presenter->handlePlotBinsClicked();
 }
 
-void IndirectPlotOptionsView::notifyPlotContourClicked() {
+void IndirectPlotOptionsView::notifyShowSliceViewerClicked() {
   notifySelectedIndicesChanged();
-  m_presenter->handlePlotContourClicked();
+  m_presenter->handleShowSliceViewerClicked();
 }
 
 void IndirectPlotOptionsView::notifyPlotTiledClicked() {
@@ -141,14 +141,15 @@ void IndirectPlotOptionsView::setPlotType(PlotWidget const &plotType,
   plotSpectraAction->setIcon(plotCurveIcon());
   auto plotBinAction = new QAction(getAction(availableActions, "Plot Bins"), this);
   plotBinAction->setIcon(plotCurveIcon());
-  auto plotContourAction = new QAction(getAction(availableActions, "Plot Contour"), this);
-  plotContourAction->setIcon(plotContourIcon());
+  auto showSliceViewerAction = new QAction(getAction(availableActions, "Open Slice Viewer"), this);
+  showSliceViewerAction->setIcon(showSliceViewerIcon());
   auto plotTiledAction = new QAction(getAction(availableActions, "Plot Tiled"), this);
   plotTiledAction->setIcon(plotTiledIcon());
 
+
   connect(plotSpectraAction, SIGNAL(triggered()), this, SLOT(notifyPlotSpectraClicked()));
   connect(plotBinAction, SIGNAL(triggered()), this, SLOT(notifyPlotBinsClicked()));
-  connect(plotContourAction, SIGNAL(triggered()), this, SLOT(notifyPlotContourClicked()));
+  connect(showSliceViewerAction, SIGNAL(triggered()), this, SLOT(notifyShowSliceViewerClicked()));
   connect(plotTiledAction, SIGNAL(triggered()), this, SLOT(notifyPlotTiledClicked()));
 
   m_plotOptions->tbPlot->setVisible(true);
@@ -168,7 +169,7 @@ void IndirectPlotOptionsView::setPlotType(PlotWidget const &plotType,
   case PlotWidget::SpectraContour:
     m_plotOptions->pbPlotSpectra->setVisible(false);
     plotMenu->addAction(plotSpectraAction);
-    plotMenu->addAction(plotContourAction);
+    plotMenu->addAction(showSliceViewerAction);
     break;
   case PlotWidget::SpectraTiled:
     m_plotOptions->pbPlotSpectra->setVisible(false);
@@ -183,7 +184,7 @@ void IndirectPlotOptionsView::setPlotType(PlotWidget const &plotType,
     m_plotOptions->pbPlotSpectra->setVisible(false);
     m_plotOptions->cbPlotUnit->setVisible(true);
     plotMenu->addAction(plotSpectraAction);
-    plotMenu->addAction(plotContourAction);
+    plotMenu->addAction(showSliceViewerAction);
     break;
   default:
     std::runtime_error("Plot option not found. Plot types are Spectra, "

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -146,7 +146,6 @@ void IndirectPlotOptionsView::setPlotType(PlotWidget const &plotType,
   auto plotTiledAction = new QAction(getAction(availableActions, "Plot Tiled"), this);
   plotTiledAction->setIcon(plotTiledIcon());
 
-
   connect(plotSpectraAction, SIGNAL(triggered()), this, SLOT(notifyPlotSpectraClicked()));
   connect(plotBinAction, SIGNAL(triggered()), this, SLOT(notifyPlotBinsClicked()));
   connect(showSliceViewerAction, SIGNAL(triggered()), this, SLOT(notifyShowSliceViewerClicked()));

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -165,7 +165,7 @@ void IndirectPlotOptionsView::setPlotType(PlotWidget const &plotType,
     plotMenu->addAction(plotSpectraAction);
     plotMenu->addAction(plotBinAction);
     break;
-  case PlotWidget::SpectraContour:
+  case PlotWidget::SpectraSlice:
     m_plotOptions->pbPlotSpectra->setVisible(false);
     plotMenu->addAction(plotSpectraAction);
     plotMenu->addAction(showSliceViewerAction);
@@ -179,7 +179,7 @@ void IndirectPlotOptionsView::setPlotType(PlotWidget const &plotType,
     m_plotOptions->tbPlot->setVisible(false);
     m_plotOptions->cbPlotUnit->setVisible(true);
     break;
-  case PlotWidget::SpectraContourUnit:
+  case PlotWidget::SpectraSliceUnit:
     m_plotOptions->pbPlotSpectra->setVisible(false);
     m_plotOptions->cbPlotUnit->setVisible(true);
     plotMenu->addAction(plotSpectraAction);
@@ -187,7 +187,7 @@ void IndirectPlotOptionsView::setPlotType(PlotWidget const &plotType,
     break;
   default:
     std::runtime_error("Plot option not found. Plot types are Spectra, "
-                       "SpectraContour or SpectraTiled.");
+                       "SpectraSliced or SpectraTiled.");
   }
   m_plotOptions->tbPlot->setMenu(plotMenu);
   m_plotOptions->tbPlot->setDefaultAction(plotSpectraAction);

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
@@ -97,8 +97,9 @@ private slots:
   void notifySelectedIndicesChanged(QString const &indices);
   void notifyPlotSpectraClicked();
   void notifyPlotBinsClicked();
-  void notifyPlotContourClicked();
+  void notifyShowSliceViewerClicked();
   void notifyPlotTiledClicked();
+
 
 private:
   void setupView();

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
@@ -24,7 +24,7 @@ namespace CustomInterfaces {
 
 class IIndirectPlotOptionsPresenter;
 
-enum PlotWidget { Spectra, SpectraBin, SpectraContour, SpectraTiled, SpectraUnit, SpectraContourUnit };
+enum PlotWidget { Spectra, SpectraBin, SpectraSlice, SpectraTiled, SpectraUnit, SpectraSliceUnit };
 
 class MANTIDQT_INDIRECT_DLL IIndirectPlotOptionsView {
 public:

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
@@ -100,7 +100,6 @@ private slots:
   void notifyShowSliceViewerClicked();
   void notifyPlotTiledClicked();
 
-
 private:
   void setupView();
   QValidator *createValidator(QString const &regex);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
@@ -34,7 +34,7 @@ IETPresenter::IETPresenter(IndirectDataReduction *idrUI, QWidget *parent)
       m_view(std::make_unique<IETView>(this, parent)) {
 
   setOutputPlotOptionsPresenter(
-      std::make_unique<IndirectPlotOptionsPresenter>(m_view->getPlotOptionsView(), PlotWidget::SpectraContour));
+      std::make_unique<IndirectPlotOptionsPresenter>(m_view->getPlotOptionsView(), PlotWidget::SpectraSlice));
 
   connect(this, SIGNAL(newInstrumentConfiguration()), this, SLOT(setInstrumentDefault()));
 

--- a/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsModelTest.h
@@ -91,7 +91,7 @@ public:
   MOCK_METHOD3(plotSpectra,
                void(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars));
   MOCK_METHOD3(plotBins, void(std::string const &workspaceName, std::string const &binIndices, bool errorBars));
-  MOCK_METHOD1(plotContour, void(std::string const &workspaceName));
+  MOCK_METHOD1(showSliceViewer, void(std::string const &workspaceName));
   MOCK_METHOD3(plotTiled, void(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars));
 };
 
@@ -272,13 +272,13 @@ public:
     m_model->plotBins(WORKSPACE_INDICES);
   }
 
-  void test_that_plotContour_will_call_the_plotter_plotContour_method_when_a_valid_workspace_has_been_set() {
+  void test_that_showSliceViewer_will_call_the_plotter_showSliceViewer_method_when_a_valid_workspace_has_been_set() {
     m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
     m_model->setWorkspace(WORKSPACE_NAME);
 
-    EXPECT_CALL(*m_plotter, plotContour(WORKSPACE_NAME)).Times(1);
+    EXPECT_CALL(*m_plotter, showSliceViewer(WORKSPACE_NAME)).Times(1);
 
-    m_model->plotContour();
+    m_model->showSliceViewer();
   }
 
   void test_that_plotTiled_will_call_the_plotter_plotTiled_method_when_a_valid_workspace_and_indices_have_been_set() {

--- a/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsModelTest.h
@@ -345,7 +345,7 @@ public:
     m_plotter = new NiceMock<MockExternalPlotter>();
     m_model = std::make_unique<IndirectPlotOptionsModel>(m_plotter, actions);
 
-    actions["Open Slice viewer"] = "Open Slice Viewer";
+    actions["Open Slice Viewer"] = "Open Slice Viewer";
     actions["Plot Tiled"] = "Plot Tiled";
     TS_ASSERT_EQUALS(m_model->availableActions(), actions);
   }

--- a/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsModelTest.h
@@ -64,8 +64,8 @@ constructActions(boost::optional<std::map<std::string, std::string>> const &avai
     actions["Plot Spectra"] = "Plot Spectra";
   if (actions.find("Plot Bins") == actions.end())
     actions["Plot Bins"] = "Plot Bins";
-  if (actions.find("Plot Contour") == actions.end())
-    actions["Plot Contour"] = "Plot Contour";
+  if (actions.find("Open Slice Viewer") == actions.end())
+    actions["Open Slice Viewer"] = "Open Slice Viewer";
   if (actions.find("Plot Tiled") == actions.end())
     actions["Plot Tiled"] = "Plot Tiled";
   return actions;
@@ -345,7 +345,7 @@ public:
     m_plotter = new NiceMock<MockExternalPlotter>();
     m_model = std::make_unique<IndirectPlotOptionsModel>(m_plotter, actions);
 
-    actions["Plot Contour"] = "Plot Contour";
+    actions["Open Slice viewer"] = "Open Slice Viewer";
     actions["Plot Tiled"] = "Plot Tiled";
     TS_ASSERT_EQUALS(m_model->availableActions(), actions);
   }

--- a/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsPresenterTest.h
@@ -30,8 +30,8 @@ constructActions(boost::optional<std::map<std::string, std::string>> const &avai
     actions["Plot Spectra"] = "Plot Spectra";
   if (actions.find("Plot Bins") == actions.end())
     actions["Plot Bins"] = "Plot Bins";
-  if (actions.find("Plot Contour") == actions.end())
-    actions["Plot Contour"] = "Plot Contour";
+  if (actions.find("Open Slice Viewer") == actions.end())
+    actions["Open Slice Viewer"] = "Open Slice Viewer";
   if (actions.find("Plot Tiled") == actions.end())
     actions["Plot Tiled"] = "Plot Tiled";
   return actions;
@@ -45,7 +45,6 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 class MockIndirectPlotOptionsView final : public IIndirectPlotOptionsView {
 public:
   MOCK_METHOD1(subscribePresenter, void(IIndirectPlotOptionsPresenter *));
-
   MOCK_METHOD2(setPlotType,
                void(PlotWidget const &plotType, std::map<std::string, std::string> const &availableActions));
 
@@ -92,7 +91,7 @@ public:
 
   MOCK_METHOD0(plotSpectra, void());
   MOCK_METHOD1(plotBins, void(std::string const &binIndices));
-  MOCK_METHOD0(plotContour, void());
+  MOCK_METHOD0(showSliceViewer, void());
   MOCK_METHOD0(plotTiled, void());
 };
 
@@ -234,12 +233,12 @@ public:
     m_presenter->handlePlotBinsClicked();
   }
 
-  void test_that_the_plotContourClicked_signal_will_attempt_to_plot_a_contour() {
+  void test_that_the_showSliceViewerClicked_signal_will_attempt_to_show_slice_viewer() {
     setExpectationsForWidgetEnabling(false);
-    EXPECT_CALL(*m_model, plotContour()).Times(1);
+    EXPECT_CALL(*m_model, showSliceViewer()).Times(1);
     setExpectationsForWidgetEnabling(true);
 
-    m_presenter->handlePlotContourClicked();
+    m_presenter->handleShowSliceViewerClicked();
   }
 
   void test_that_the_plotTiledClicked_signal_will_attempt_to_plot_tiled_spectra() {

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSqwTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSqwTab.cpp
@@ -34,7 +34,7 @@ InelasticDataManipulationSqwTab::InelasticDataManipulationSqwTab(QWidget *parent
     : InelasticDataManipulationTab(parent), m_model(std::make_unique<InelasticDataManipulationSqwTabModel>()),
       m_view(std::make_unique<InelasticDataManipulationSqwTabView>(parent)) {
   setOutputPlotOptionsPresenter(
-      std::make_unique<IndirectPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraContour));
+      std::make_unique<IndirectPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraSlice));
   connectSignals();
 }
 

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Plot.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Plot.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidAPI/Workspace_fwd.h"
 #include "MantidQtWidgets/Common/Python/Object.h"
 #include "MantidQtWidgets/MplCpp/DllConfig.h"
 
@@ -161,6 +162,15 @@ plotsubplots(const QStringList &workspaces, boost::optional<std::vector<int>> sp
 MANTID_MPLCPP_DLL Common::Python::Object pcolormesh(const QStringList &workspaces,
                                                     boost::optional<Common::Python::Object> fig = boost::none);
 
+/**
+ * Externall call to slice viewer GUI
+ *
+ * @param workspace A shared pointer to the target workspace
+ *
+ * @return Returns a call to the slice viewer interface show function
+ */
+
+MANTID_MPLCPP_DLL Common::Python::Object sliceviewer(const Mantid::API::Workspace_sptr &workspace);
 } // namespace MplCpp
 } // namespace Widgets
 } // namespace MantidQt

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ExternalPlotter.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ExternalPlotter.h
@@ -42,7 +42,7 @@ public:
   virtual void plotBins(std::string const &workspaceName, std::string const &binIndices, bool errorBars);
   virtual void plotContour(std::string const &workspaceName);
   virtual void plotTiled(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars);
-
+  virtual void showSliceViewer(std::string const &workspaceName);
   bool validate(std::string const &workspaceName, boost::optional<std::string> const &workspaceIndices = boost::none,
                 boost::optional<MantidAxis> const &axisType = boost::none) const;
 

--- a/qt/widgets/plotting/src/ExternalPlotter.cpp
+++ b/qt/widgets/plotting/src/ExternalPlotter.cpp
@@ -40,11 +40,13 @@ std::vector<std::string> splitStringBy(std::string const &str, std::string const
 }
 
 template <typename T> T convertToT(std::string const &num) {
-  if (std::is_same<T, std::size_t>::value)
+  if (std::is_same<T, std::size_t>::value) {
     return static_cast<std::size_t>(std::stoi(num));
-  else if (std::is_same<T, int>::value)
+  } else if (std::is_same<T, int>::value) {
     return std::stoi(num);
-  std::runtime_error("Could not convert std::string to std::size_t or int type.");
+  } else {
+    throw std::runtime_error("Could not convert std::string to std::size_t or int type.");
+  }
 }
 
 template <typename T> void addToIndicesVector(std::vector<T> &indicesVec, T const &startIndex, T const &endIndex) {

--- a/qt/widgets/plotting/src/ExternalPlotter.cpp
+++ b/qt/widgets/plotting/src/ExternalPlotter.cpp
@@ -4,12 +4,11 @@
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidQtWidgets/Plotting/ExternalPlotter.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
-
 #include "MantidKernel/Logger.h"
 #include "MantidQtWidgets/MplCpp/Plot.h"
-#include "MantidQtWidgets/Plotting/ExternalPlotter.h"
 
 #include <QHash>
 #include <QString>
@@ -195,6 +194,18 @@ void ExternalPlotter::plotBins(std::string const &workspaceName, std::string con
 void ExternalPlotter::plotContour(std::string const &workspaceName) {
   if (validate(workspaceName))
     pcolormesh(QStringList(QString::fromStdString(workspaceName)));
+}
+
+/**
+ * Produces an external call to slice viewer on the target workspace
+ *
+ * @param workspaceName The name of the workspace to use in slice viewer
+ */
+void ExternalPlotter::showSliceViewer(std::string const &workspaceName) {
+  if (validate(workspaceName)) {
+    auto workspace = AnalysisDataService::Instance().retrieveWS<Workspace>(workspaceName);
+    sliceviewer(workspace);
+  }
 }
 
 /**

--- a/qt/widgets/plotting/src/ExternalPlotter.cpp
+++ b/qt/widgets/plotting/src/ExternalPlotter.cpp
@@ -4,11 +4,12 @@
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
-#include "MantidQtWidgets/Plotting/ExternalPlotter.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
+
 #include "MantidKernel/Logger.h"
 #include "MantidQtWidgets/MplCpp/Plot.h"
+#include "MantidQtWidgets/Plotting/ExternalPlotter.h"
 
 #include <QHash>
 #include <QString>


### PR DESCRIPTION
### Description of work
From most indirect/inelastic interfaces, after running the corresponding algorithms, it is possible to directly plot the new/modified workspaces without going back to the main workspace widget. Depending on the data modification, different plots are available. For some of the interfaces, these are contour plots.  The 'Plot Contour' option runs a Colorfill plot. In this PR, the external plotting interface has been modified to redirect the calls to colorfill plots to open the Slice Viewer instead for a better user experience. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36344. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
This PR uses functions of the python/c++ interface. In particular, there is an external plotter class which is responsible for calling corresponding plot functions. The function to call slice viewer has been integrated within this class. While the slice viewer is not exactly a matplotlib figure, it is close enough to a plot that the call to the interface fits in that part of the code. 
### To test:
To quickly check that slice viewer is called instead of Plot Contour: 
1. Open ```Interfaces->Indirect->Corrections```
2. On the 'Container Subtraction' tab select Sample and Container files (Just for the purpose of the testing, you can select /`ExternalData/Testing/Data/UnitTest/irs26176_graphite002_red.nxs` as sample and `ExternalData/Testing/Data/UnitTest/irs26173_graphite002_red.nxs` as container)
3. Hit 'Run' Button
4. On the Output Options it should be possible to open a popup list on the Plot Spectra button with the choice of 'Open Slice Viewer'. Clicking on it should open a Slice Viewer window with the modified workspace.


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
