### PR TITLE
Unsquish widgets on the Indirect/Inelastic GUI's

### DIFF
--- a/docs/source/release/v6.9.0/Indirect/Bugfixes/36382.rst
+++ b/docs/source/release/v6.9.0/Indirect/Bugfixes/36382.rst
@@ -1,1 +1,1 @@
-- A bug where the ``Run`` and ``Ouput Options`` appeared squished on Indirect interfaces has been fixed.
+- A bug where the ``Run`` and ``Output Options`` appeared squished on Indirect interfaces has been fixed.

--- a/docs/source/release/v6.9.0/Indirect/Bugfixes/36382.rst
+++ b/docs/source/release/v6.9.0/Indirect/Bugfixes/36382.rst
@@ -1,0 +1,1 @@
+- A bug where the ``Run`` and ``Ouput Options`` appeared squished on Indirect interfaces has been fixed.

--- a/docs/source/release/v6.9.0/Inelastic/Bugfixes/36382.rst
+++ b/docs/source/release/v6.9.0/Inelastic/Bugfixes/36382.rst
@@ -1,1 +1,1 @@
-- A bug where the ``Run`` and ``Ouput Options`` appeared squished on Inelastic interfaces has been fixed.
+- A bug where the ``Run`` and ``Output Options`` appeared squished on Inelastic interfaces has been fixed.

--- a/docs/source/release/v6.9.0/Inelastic/Bugfixes/36382.rst
+++ b/docs/source/release/v6.9.0/Inelastic/Bugfixes/36382.rst
@@ -1,0 +1,1 @@
+- A bug where the ``Run`` and ``Ouput Options`` appeared squished on Inelastic interfaces has been fixed.

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.ui
@@ -1252,18 +1252,6 @@
        </item>
        <item>
         <widget class="QGroupBox" name="gbRun">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>45</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>45</height>
-          </size>
-         </property>
          <property name="title">
           <string>Run</string>
          </property>
@@ -1318,12 +1306,6 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>56</height>
-          </size>
-         </property>
          <property name="title">
           <string>Output Options</string>
          </property>
@@ -1371,15 +1353,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
+  </customwidget>
+  <customwidget>
    <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>IndirectPlotOptionsView.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.ui
@@ -23,9 +23,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-139</y>
-        <width>710</width>
-        <height>863</height>
+        <y>0</y>
+        <width>717</width>
+        <height>829</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -316,18 +316,6 @@
        </item>
        <item>
         <widget class="QGroupBox" name="gbRun">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>45</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>45</height>
-          </size>
-         </property>
          <property name="title">
           <string>Run</string>
          </property>
@@ -376,12 +364,6 @@
        </item>
        <item>
         <widget class="QGroupBox" name="gbOutput">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>56</height>
-          </size>
-         </property>
          <property name="title">
           <string>Output Options</string>
          </property>
@@ -429,6 +411,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
+  </customwidget>
+  <customwidget>
    <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>IndirectPlotOptionsView.h</header>
@@ -439,11 +426,6 @@
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Plotting/PreviewPlot.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.ui
+++ b/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.ui
@@ -119,12 +119,6 @@
        </item>
        <item>
         <widget class="QGroupBox" name="corrDetails">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>93</height>
-          </size>
-         </property>
          <property name="toolTip">
           <string>Correction computation details. By default will be set automatically from the instrument parameters of the input workspace. Modify to override.</string>
          </property>
@@ -692,12 +686,6 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>97</height>
-          </size>
-         </property>
          <property name="title">
           <string>Sample Details</string>
          </property>
@@ -979,12 +967,6 @@
         <widget class="QGroupBox" name="gbCanDetails">
          <property name="enabled">
           <bool>false</bool>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>97</height>
-          </size>
          </property>
          <property name="title">
           <string>Container Details</string>

--- a/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.ui
+++ b/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.ui
@@ -1247,18 +1247,6 @@
        </item>
        <item>
         <widget class="QGroupBox" name="gbRun">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>45</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>45</height>
-          </size>
-         </property>
          <property name="title">
           <string>Run</string>
          </property>
@@ -1307,12 +1295,6 @@
        </item>
        <item>
         <widget class="QGroupBox" name="gbOutput">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>56</height>
-          </size>
-         </property>
          <property name="title">
           <string>Output Options</string>
          </property>
@@ -1360,15 +1342,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
+  </customwidget>
+  <customwidget>
    <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>IndirectPlotOptionsView.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/qt/scientific_interfaces/Indirect/ContainerSubtraction.ui
+++ b/qt/scientific_interfaces/Indirect/ContainerSubtraction.ui
@@ -23,9 +23,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-97</y>
-        <width>966</width>
-        <height>807</height>
+        <y>0</y>
+        <width>973</width>
+        <height>776</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -276,12 +276,6 @@
        </item>
        <item>
         <widget class="QGroupBox" name="gbRun">
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>45</height>
-          </size>
-         </property>
          <property name="title">
           <string>Run</string>
          </property>
@@ -330,12 +324,6 @@
        </item>
        <item>
         <widget class="QGroupBox" name="gbOutput">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>56</height>
-          </size>
-         </property>
          <property name="title">
           <string>Output Options</string>
          </property>
@@ -383,6 +371,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
+  </customwidget>
+  <customwidget>
    <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>IndirectPlotOptionsView.h</header>
@@ -393,11 +386,6 @@
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Plotting/PreviewPlot.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qt/scientific_interfaces/Indirect/DensityOfStates.ui
+++ b/qt/scientific_interfaces/Indirect/DensityOfStates.ui
@@ -58,7 +58,7 @@
         <x>0</x>
         <y>0</y>
         <width>480</width>
-        <height>328</height>
+        <height>329</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -576,12 +576,6 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>56</height>
-      </size>
-     </property>
      <property name="title">
       <string>Output Options</string>
      </property>
@@ -625,14 +619,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::API::FileFinderWidget</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>IndirectPlotOptionsView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::API::FileFinderWidget</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.ui
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.ui
@@ -346,12 +346,6 @@
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>56</height>
-      </size>
-     </property>
      <property name="title">
       <string>Output</string>
      </property>

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.ui
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>524</width>
-    <height>633</height>
+    <height>634</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -269,12 +269,6 @@
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>56</height>
-      </size>
-     </property>
      <property name="title">
       <string>Output</string>
      </property>

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.ui
@@ -41,7 +41,7 @@
          <x>0</x>
          <y>0</y>
          <width>547</width>
-         <height>663</height>
+         <height>579</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout">
@@ -635,7 +635,7 @@
               <bool>false</bool>
              </property>
              <property name="minimum">
-                <number>1</number>
+              <number>1</number>
              </property>
             </widget>
            </item>
@@ -657,18 +657,6 @@
         </item>
         <item>
          <widget class="QGroupBox" name="groupBox">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>50</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>50</height>
-           </size>
-          </property>
           <property name="title">
            <string>Run</string>
           </property>
@@ -729,12 +717,6 @@
         </item>
         <item>
          <widget class="QGroupBox" name="gbOutput">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>56</height>
-           </size>
-          </property>
           <property name="title">
            <string>Output</string>
           </property>

--- a/qt/scientific_interfaces/Indirect/IndirectInstrumentConfig.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectInstrumentConfig.ui
@@ -16,23 +16,20 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="minimumSize">
-   <size>
-    <width>200</width>
-    <height>25</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>16777215</width>
-    <height>25</height>
-   </size>
-  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>

--- a/qt/scientific_interfaces/Indirect/IndirectMolDyn.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectMolDyn.ui
@@ -331,12 +331,6 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>56</height>
-      </size>
-     </property>
      <property name="title">
       <string>Output Options</string>
      </property>
@@ -380,11 +374,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::API::FileFinderWidget</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>MantidQt::MantidWidgets::DataSelector</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/DataSelector.h</header>
@@ -393,6 +382,12 @@
    <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>IndirectPlotOptionsView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::API::FileFinderWidget</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptions.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptions.ui
@@ -52,18 +52,6 @@
         <property name="enabled">
          <bool>false</bool>
         </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>22</height>
-         </size>
-        </property>
         <property name="toolTip">
          <string>Select a workspace</string>
         </property>
@@ -82,18 +70,6 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>75</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>75</width>
-          <height>22</height>
-         </size>
         </property>
         <property name="toolTip">
          <string>Select workspace indices (e.g. 0-2,4,6-8)</string>
@@ -124,36 +100,12 @@
         <property name="enabled">
          <bool>false</bool>
         </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>22</height>
-         </size>
-        </property>
        </widget>
       </item>
       <item>
        <widget class="QPushButton" name="pbPlotSpectra">
         <property name="enabled">
          <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>24</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>24</height>
-         </size>
         </property>
         <property name="text">
          <string/>
@@ -170,18 +122,6 @@
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>24</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>150</width>
-          <height>24</height>
-         </size>
         </property>
         <property name="text">
          <string/>

--- a/qt/scientific_interfaces/Indirect/IndirectSassena.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectSassena.ui
@@ -175,12 +175,6 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>56</height>
-      </size>
-     </property>
      <property name="title">
       <string>Output Options</string>
      </property>
@@ -224,14 +218,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::API::FileFinderWidget</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
-  </customwidget>
-  <customwidget>
    <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>IndirectPlotOptionsView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::API::FileFinderWidget</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.ui
@@ -188,12 +188,6 @@
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>56</height>
-      </size>
-     </property>
      <property name="title">
       <string>Output</string>
      </property>

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.ui
@@ -249,12 +249,6 @@
    </item>
    <item>
     <widget class="QGroupBox" name="ErrorCalc">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>65</height>
-      </size>
-     </property>
      <property name="title">
       <string>Monte Carlo Error Calculation</string>
      </property>
@@ -296,12 +290,6 @@
       </item>
       <item>
        <widget class="QLabel" name="label">
-        <property name="maximumSize">
-         <size>
-          <width>130</width>
-          <height>16777215</height>
-         </size>
-        </property>
         <property name="text">
          <string>Number of Iterations:</string>
         </property>
@@ -309,12 +297,6 @@
       </item>
       <item alignment="Qt::AlignLeft">
        <widget class="QSpinBox" name="spIterations">
-        <property name="minimumSize">
-         <size>
-          <width>60</width>
-          <height>26</height>
-         </size>
-        </property>
         <property name="toolTip">
          <string>The number of iterations to use when calculating errors.</string>
         </property>

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTab.ui
@@ -270,12 +270,6 @@
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>56</height>
-      </size>
-     </property>
      <property name="title">
       <string>Output</string>
      </property>

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSqwTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSqwTab.ui
@@ -407,18 +407,6 @@
    </item>
    <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>45</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>45</height>
-      </size>
-     </property>
      <property name="title">
       <string>Run</string>
      </property>
@@ -444,18 +432,6 @@
       </item>
       <item>
        <widget class="QPushButton" name="pbRun">
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>180</width>
-          <height>16777215</height>
-         </size>
-        </property>
         <property name="text">
          <string>Run</string>
         </property>
@@ -479,12 +455,6 @@
    </item>
    <item row="3" column="0">
     <widget class="QGroupBox" name="sqw_outputOptions">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>56</height>
-      </size>
-     </property>
      <property name="title">
       <string>Output</string>
      </property>
@@ -539,15 +509,15 @@
    <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
   <customwidget>
-   <class>MantidQt::MantidWidgets::ContourPreviewPlot</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Plotting/ContourPreviewPlot.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>IndirectPlotOptionsView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::ContourPreviewPlot</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Plotting/ContourPreviewPlot.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.ui
@@ -250,12 +250,6 @@
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>56</height>
-      </size>
-     </property>
      <property name="title">
       <string>Output</string>
      </property>


### PR DESCRIPTION
### Description of work
This PR fixes a bug where certain widgets on the Indirect/Inelastic were appearing as being "squished" on screens with high resolutions. It was caused by many of the widgets and QGroupBoxes containing the widgets having a minimum and/or maximum vertical and horizontal size set. This is a bad idea because the size is specified in pixels, and so it is not scalable for screens with larger resolutions. It also doesn't scale with the font size inside the widget.

The solution was to remove this manual setting of min and max sizes, and to just let the Qt framework to handle the sizing of widgets for different resolutions.

Fixes #36382

### To test:
It is hard to test this if you do not have a machine with high resolution. Here are screenshots to prove the widgets are no longer squished. Compare these to the images in the attached issue.
Data Reduction - ISIS Calibration
![image](https://github.com/mantidproject/mantid/assets/40830825/c17dd2a5-0fd6-470b-9f69-6acc7aac9792)

Data Manipulation - Iqt Tab
![image](https://github.com/mantidproject/mantid/assets/40830825/0bd3c245-ae01-4b5a-a8f2-c86fbd86fd2a)

Diffraction
![image](https://github.com/mantidproject/mantid/assets/40830825/8dbcd47c-0a00-4c56-afd5-e0e7ef72cf88)

A code review should be all that is needed.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
