### PR TITLE
Fix plot not updating in Slice Viewer

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/34403.rst
+++ b/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/34403.rst
@@ -1,1 +1,1 @@
-- Fixed bug where the plot would not update after changing plot settings until the window had been resized.
+- Fixed bug in the cut viewer where the plot would not update after changing plot settings until the window had been resized.

--- a/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/34403.rst
+++ b/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/34403.rst
@@ -1,0 +1,1 @@
+- Fixed bug where the plot would not update after changing plot settings until the window had been resized.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
@@ -176,6 +176,19 @@ class CutViewerView(QWidget):
         self.figure_layout.addWidget(toolbar)
         self.figure_layout.addWidget(self.figure.canvas)
         self.layout.addLayout(self.figure_layout)
+        self.figure.canvas.mpl_connect("draw_event", self._on_figure_canvas_draw)
+        self._is_drawing = False
+
+    # When the figure redraws after e.g. the user changing an axis to log, then
+    # for this view to see the update it requires an extra draw(). This method
+    # is connected to the draw event, so we need to check we're only drawing once
+    # and not causing a stack overflow.
+    def _on_figure_canvas_draw(self, _):
+        if self._is_drawing:
+            self._is_drawing = False
+            return
+        self._is_drawing = True
+        self.figure.canvas.draw()
 
     def _init_slice_table(self):
         for icol in range(self.table.columnCount()):


### PR DESCRIPTION
When changing plot properties on the plot in Slice Viewer, the plot will now update immediately instead of waiting until you interact with the window some other way like resizing, zooming, etc.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
- After the figure canvas draws, do a bonus call to draw to get the update to appear.

Fixes #34403. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
See #34403 for how to reproduce the original problem. Plot should still function correctly in all other ways. If you try turning the grid lines off that won't work, but that's a separate problem that's fixed in another PR (#36432).

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
