### PR TITLE
Pin openblas away from 0.3.25 to fix system test failure

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -66,9 +66,9 @@ hdf5:
 gsl:
   - 2.7
 
-# v0.3.23 causes a hang on osx for some systemtests, v0.3.24 causes a unit test failure that needs investigation.
+# v0.3.23 causes a hang on osx for some systemtests, v0.3.24 causes a unit test failure that needs investigation, v0.3.25 causes a system test failure on linux
 libopenblas:
-  - '!=0.3.23,!=0.3.24'
+  - '!=0.3.23,!=0.3.24,!=0.3.25'
 
 euphonic:
   - '>=1.2.1,<2.0'

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -17,7 +17,7 @@ dependencies:
   - hdf5>=1.12,<1.13
   - jemalloc=5.2.0 # We have noticed 5.2.1 can cause a hang on older glibc versions (Cent OS 7, Ubuntu 18.04). Observed with import CaChannel and also our MeierTest.
   - jsoncpp>=1.9.4,<2
-  - libopenblas!=0.3.23,!=0.3.24 # pinned the same as macOS for consistency
+  - libopenblas!=0.3.23,!=0.3.24,!=0.3.25 # v0.3.25 causing system test failures on linux. Others are for macOS consistency.
   - librdkafka>=1.6.0
   - matplotlib=3.7.*
   - muparser>=2.3.2

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -16,7 +16,7 @@ dependencies:
   - hdf5>=1.12,<1.13
   - jemalloc>=5.2.1
   - jsoncpp>=1.9.4,<2
-  - libopenblas!=0.3.23,!=0.3.24 # v0.3.23 causes a hang for the system tests on OSX, v0.3.24 causing unit test failure - investigation needed.
+  - libopenblas!=0.3.23,!=0.3.24,!=0.3.25 # v0.3.23 causes a hang for the system tests on OSX, v0.3.24 causing unit test failure - investigation needed, v0.3.25 causing a system test failure.
   - librdkafka>=1.6.0
   - muparser>=2.3.2
   - matplotlib=3.7.*


### PR DESCRIPTION
### Description of work

#### Purpose of work
A system test is failing that is stopping builds. It seems to be related to a new minor version of `libopenblas` so this pin should revert the dependency back to the last working version. 


*This does not require release notes* because **it is only making a change to the developer environment.**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
