### PR TITLE
change needed for snspowderreduction abs pre-calc

### DIFF
--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -91,6 +91,10 @@ def __get_cache_name(
     cache_filenames = []
     if cache_dirs:
         # generate the property string for hashing
+        try:
+            height_val_tmp = ws.run()["BL11A:CS:ITEMS:HeightInContainer"].lastValue()
+        except (RuntimeError, AttributeError) as _:
+            height_val_tmp = ws.run()["BL11A:CS:ITEMS:HeightInContainer"].value
         property_string = [
             f"{key}={val}"
             for key, val in {
@@ -100,7 +104,7 @@ def __get_cache_name(
                 "sample_formula": ws.run()["SampleFormula"].lastValue().strip(),
                 "mass_density": ws.run()["SampleDensity"].lastValue(),
                 "height_unit": ws.run()["BL11A:CS:ITEMS:HeightInContainerUnits"].lastValue(),
-                "height": ws.run()["BL11A:CS:ITEMS:HeightInContainer"].lastValue(),
+                "height": height_val_tmp,
                 "sample_container": ws.run()["SampleContainer"].lastValue().replace(" ", ""),
                 "abs_method": abs_method,
                 "ms_method": ms_method,

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -92,7 +92,7 @@ def __get_cache_name(
     if cache_dirs:
         # generate the property string for hashing
         try:
-            height_val_tmp = ws.run()["BL11A:CS:ITEMS:HeightInContainer"].lastValue()
+            height_val_tmp = ws.run().getTimeAveragedValue("BL11A:CS:ITEMS:HeightInContainer")
         except (RuntimeError, AttributeError) as _:
             height_val_tmp = ws.run()["BL11A:CS:ITEMS:HeightInContainer"].value
         property_string = [

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -93,6 +93,7 @@ def __get_cache_name(
         # generate the property string for hashing
         try:
             height_val_tmp = ws.run().getTimeAveragedValue("BL11A:CS:ITEMS:HeightInContainer")
+            height_unit_tmp = ws.run()["BL11A:CS:ITEMS:HeightInContainerUnits"].lastValue()
         except RuntimeError as e:
             raise RuntimeError("Currently only configured for POWGEN") from e
 
@@ -104,7 +105,7 @@ def __get_cache_name(
                 "num_wl_bins": len(ws.readX(0)) - 1,
                 "sample_formula": ws.run()["SampleFormula"].lastValue().strip(),
                 "mass_density": ws.run()["SampleDensity"].lastValue(),
-                "height_unit": ws.run()["BL11A:CS:ITEMS:HeightInContainerUnits"].lastValue(),
+                "height_unit": height_unit_tmp,
                 "height": height_val_tmp,
                 "sample_container": ws.run()["SampleContainer"].lastValue().replace(" ", ""),
                 "abs_method": abs_method,

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -93,8 +93,9 @@ def __get_cache_name(
         # generate the property string for hashing
         try:
             height_val_tmp = ws.run().getTimeAveragedValue("BL11A:CS:ITEMS:HeightInContainer")
-        except (RuntimeError, AttributeError) as _:
-            height_val_tmp = ws.run()["BL11A:CS:ITEMS:HeightInContainer"].value
+        except RuntimeError as e:
+            raise RuntimeError("Currently only configured for POWGEN") from e
+
         property_string = [
             f"{key}={val}"
             for key, val in {

--- a/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36448.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36448.rst
@@ -1,1 +1,1 @@
-- Allow the passing of height information to the donor workspace :ref:`absorptioncorrutils <mantid.utils.absorptioncorrutils>` so that the absorption calculation calculation can be performed without the experimental data.
+- Allow the passing of height information to the donor workspace ``mantid.utils.absorptioncorrutils`` so that the absorption calculation calculation can be performed without the experimental data.

--- a/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36448.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36448.rst
@@ -1,0 +1,1 @@
+- Allow the passing of height information to the donor workspace :ref:`absorptioncorrutils <mantid.utils.absorptioncorrutils>` so that the absorption calculation calculation can be performed without the experimental data.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

We are developing a routine to perform the absorption calculation before the experiment is happening, i. e., before the data is available. However, given the current caching mechanism implemented, the routine will always try to read the height information from the sample log. With the current PR, we will be trying to read in the sample log first and if failed, we will be trying to find the passed in height information.

We will pass the height information through the donor workspace by first checking the sample height log is available or not, and if not, we will pass a float value to the corresponding sample log which then later on will be loaded in.

### To test:

Test has been performed locally with the absorption pre-calculation routine deployed on analysis cluster. One can log in analysis and execute, e. g., `abs_pre_calc PG3 30141` to test out.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
