### PR TITLE
Limit what is printed in the sample logs viewer for large arrays

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36449.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36449.rst
@@ -1,0 +1,1 @@
+- Fix issue when displaying large array properies in the sample logs viewer

--- a/qt/python/mantidqt/mantidqt/widgets/samplelogs/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/samplelogs/model.py
@@ -75,7 +75,7 @@ def get_value(log):
     else:
         # convert to numpy array to fix some issues converting _kernel.std_vector_dbl to string
         opt = np.get_printoptions()
-        np.set_printoptions(threshold=np.inf, linewidth=np.inf)
+        np.set_printoptions(threshold=500, edgeitems=50, linewidth=np.inf)
         s = str(np.array(log.value))
         np.set_printoptions(**opt)  # reset the default options
         return s


### PR DESCRIPTION
### Description of work

Limit what is printed in the sample logs viewer for large arrays

The previous value of infinity were causing issues when the arrays are very long, >1000. You could never expand the window large enough to see all the value, so set some appropriate limits.

This adjusts what was implemented in #34870 while achieving the same result but with a realistic limit


#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [2902](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2902)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Follow the steps to reproduce in issue. Right-click on workspace -> "Show Sample Logs", should now open very quickly and be responsive.

Or load [this file](https://www.dropbox.com/scl/fi/ol1sxf5qs3h8il5tw6nao/file.nxs?rlkey=dgkffgv61k9srhael2pn060ks&dl=0) and "Show Sample Logs"

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
