### PR TITLE
Stop the splash screen hijacking the display

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36450.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36450.rst
@@ -1,0 +1,1 @@
+- The splash screen will no longer insist on being on top of every window.

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -64,7 +64,7 @@ def _get_splash_image():
     )
 
 
-SPLASH = QSplashScreen(_get_splash_image(), Qt.WindowStaysOnTopHint)
+SPLASH = QSplashScreen(_get_splash_image())
 SPLASH.show()
 SPLASH.showMessage("Starting...", int(Qt.AlignBottom | Qt.AlignLeft | Qt.AlignAbsolute), QColor(Qt.black))
 # The event loop has not started - force event processing


### PR DESCRIPTION
The second argument to the `QSplashScreen` constructor, (`Qt.WindowStaysOnTopHint`), caused the splash screen to always stay on top of every window, so you couldn't do anything else until Workbench had loaded. Now you can switch to another window and do something else while it's loading.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

*There is no associated issue.*

### To test:
Open Workbench, free yourself from the splash screen with Alt+Tab or clicking on another window.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **probably it's too small a change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
