### PR TITLE
Fixed a connection warning in the Iqt Tab of Data Manipulation interface.

### DIFF
--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.cpp
@@ -105,6 +105,7 @@ void InelasticDataManipulationIqtTab::runClicked() {
 bool InelasticDataManipulationIqtTab::validate() { return m_view->validate(); }
 
 void InelasticDataManipulationIqtTab::handleResDataReady(const QString &resWorkspace) {
+  m_view->updateDisplayedBinParameters();
   m_model->setResWorkspace(resWorkspace.toStdString());
 }
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTabView.cpp
@@ -135,7 +135,6 @@ void InelasticDataManipulationIqtTabView::setup() {
   // signals / slots & validators
   connect(m_uiForm.dsInput, SIGNAL(dataReady(const QString &)), this, SIGNAL(sampDataReady(const QString &)));
   connect(m_uiForm.dsResolution, SIGNAL(dataReady(const QString &)), this, SIGNAL(resDataReady(const QString &)));
-  connect(m_uiForm.dsResolution, SIGNAL(dataReady(const QString &)), this, SLOT(updateDisplayedBinParameters()));
   connect(m_uiForm.spIterations, SIGNAL(valueChanged(int)), this, SIGNAL(iterationsChanged(int)));
   connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SIGNAL(runClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SIGNAL(saveClicked()));


### PR DESCRIPTION
### Description of work
This PR fixes a warning produced in the python interpreter whenever the Data Manipulation interface was loaded. The warning was produced by a missing connection from `dsResolution` widget to `updateDisplayBinParameters` slot. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
When opening the Data Manipulation interface, the following warning is issued: 
```
QObject::connect: No such slot MantidQt::CustomInterfaces::InelasticDataManipulationIqtTabView::updateDisplayedBinParameters()
QObject::connect:  (sender name:   'dsResolution')
```
I believe the warning is produced because the 'dsResolution' data selector widget emits a signal whenever a file is loaded succesfully, passing a QString with the file name.  In the IqtTab this signal was connected to another signal on the presenter and to the slot `updateDisplayBinParameters`. I think the intention of the author of this connection on this interface is to pass the resolution file information to the model (via the presenter) and subsequentely to update the plot and the fit parameters with updated binning information. The slot was not found because the signal is emitted with one argument and the slot has no input arguments. (I think signals and slot need to have a minimum number of equal arguments) 
What I have done in this PR is to eliminate the connection to the signal and the slot, and call the function updateDisplayedBinParameters() from the slot on the presenter that handles that signal. 
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36436 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1. Launch workbench from miniforge-prompt or other conda prompt, or launch workbench from any IDE. (So that you can see python interpreter output)
2. Open Inelastic/Data Manipulation interface and check Python output. No warning should be issued. 
3. Open 'irs26173_graphite002_red.nxs' on sample field and 'irs26173_graphite002_res.nxs' on resolution field. Upon opening the resolution file, you should see that the SampleBins and ResolutionBins properties are updated (as UpdateDisplayBinParameters() is now called).
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
