### PR TITLE
Fix bug where dragging a group workspace onto a plot would cause an unhandled exception

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36458.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36458.rst
@@ -1,0 +1,1 @@
+- Fixed bug where overplotting group workspaces would cause an unhandled exception.

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -20,7 +20,7 @@ from qtpy.QtWidgets import QMainWindow
 # local imports
 from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.widgets.observers.observing_view import ObservingView
-from mantid.api import AnalysisDataServiceImpl
+from mantid.api import AnalysisDataServiceImpl, WorkspaceGroup
 import mantid.kernel
 
 
@@ -35,6 +35,8 @@ def _validate_workspaces(names: List[str]) -> List[bool]:
     for name in names:
         result = False
         ws = ads.retrieve(name)
+        if type(ws) == WorkspaceGroup:
+            return _validate_workspaces(ws.getNames())
         try:
             result = ws.blocksize() > 1
         except RuntimeError:

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -35,7 +35,7 @@ def _validate_workspaces(names: List[str]) -> List[bool]:
     for name in names:
         result = False
         ws = ads.retrieve(name)
-        if type(ws) == WorkspaceGroup:
+        if isinstance(ws, WorkspaceGroup):
             return _validate_workspaces(ws.getNames())
         try:
             result = ws.blocksize() > 1


### PR DESCRIPTION
### Description of work

In a previous PR I added some validation for overplotting (not allowing single valued workspaces) but didn't consider group workspaces. This pr adds a check.

Found through an error report:
```
Name: Not provided  Email: Not provided
        Additional text:
        Not provided
        Stack Trace:
        Traceback (most recent call last):
  File "/opt/mantidworkbench6.8/lib/python3.10/site-packages/workbench/plotting/figurewindow.py", line 130, in dropEvent
    self._plot_on_here(workspace_names, ax)
  File "/opt/mantidworkbench6.8/lib/python3.10/site-packages/workbench/plotting/figurewindow.py", line 155, in _plot_on_here
    if not all(_validate_workspaces(names)):
  File "/opt/mantidworkbench6.8/lib/python3.10/site-packages/workbench/plotting/figurewindow.py", line 39, in _validate_workspaces
    result = ws.blocksize() > 1
AttributeError: 'WorkspaceGroup' object has no attribute 'blocksize'
```

*There is no associated issue.*

### To test:

 - From the training course data, load `164198.nxs`
 - Then load `164199.nxs` and `164200.nxs` together, in a group workspace
 - Plot a spectrum of `164198`
 - Drag the group workspace onto the plot and you should be able to overplot as normal

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
