### PR TITLE
Improve Slice Viewer colour bar memory leak

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/36428.rst
+++ b/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/36428.rst
@@ -1,0 +1,1 @@
+- Fixed a memory leak in the Slice Viewer colour bar.

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -139,7 +139,8 @@ class ColorbarWidget(QWidget):
         if parent:
             # Set facecolor to match parent
             self.canvas.figure.set_facecolor(parent.palette().window().color().getRgbF())
-        self.ax = self.canvas.figure.add_axes([0.0, 0.02, 0.2, 0.97])
+        self.ax = None
+        self._reset_figure_axes()
 
         # layout
         self.layout = QVBoxLayout(self)
@@ -154,16 +155,29 @@ class ColorbarWidget(QWidget):
         self.layout.addWidget(self.autoscale)
         self.layout.addLayout(self.auto_layout)
 
+    def _reset_figure_axes(self):
+        """
+        Adds axes to the figure. If axes already exist then these are removed and replaced with new ones.
+        """
+        if self.ax:
+            self.ax.clear()
+            self.canvas.figure.delaxes(self.ax)
+        self.ax = self.canvas.figure.add_axes([0.0, 0.02, 0.2, 0.97])
+
     def set_mappable(self, mappable):
         """
         When a new plot is created this method should be called with the new mappable
         """
-        self.ax.clear()
+        # The matplotlib.Colorbar doesn't seem to be garbage collected very reliably. If we recreate the axes then
+        # this seems to improve the garbage collection.
+        self._reset_figure_axes()
+
         try:  # Use current cmap
             cmap = get_current_cmap(self.colorbar)
         except AttributeError:
             # else use default
             cmap = ConfigService.getString("plots.images.Colormap")
+
         self.colorbar = Colorbar(ax=self.ax, mappable=mappable)
         self.cmin_value, self.cmax_value = mappable.get_clim()
         self.update_clim_text()


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
It seems that matplotlib use quite a few circular references when creating plots. This can make it tricky to know when you have released all references to an object. From investigating the code, it looks like we're leaking memory from the colour bar in the Slice Viewer. Recreating the colour bar axes when the mapped data is set seems to improve things significantly.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36428. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
This is difficult to test without leaving it running for a long time. The garbage collection doesn't happen straight away, so memory usage still goes up and down. I have performed a few long-running tests and have seen improvements in memory usage, though - previously the Mantid memory would reach 95% capacity after about 435 updates to an INTER workspace on IDAaaS. With this change, memory usage was at about 7% after over 2000 updates, which is within the range of normal fluctuation due to garbage collection delays.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
As mentioned above, this is difficult to test without leaving it running for a long time - there are instructions on the linked issue if you're keen to give this a try. Perhaps the most important (and realistic) test for this at PR stage is to make sure that existing Slice Viewer functionality is not broken:

- Make sure that the Slice Viewer can be left open when live data is running and that it updates correctly.
- Use the [Slice Viewer manual testing instructions](https://developer.mantidproject.org/Testing/SliceViewer/SliceViewer.html) to check that there are no regressions in existing functionality compared to version 6.8.

Note that I've been noticing some errors that I can replicate on main and have opened issue #36467 for this. It's worth being aware of this when testing.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
