### PR TITLE
Fix Slice Viewer spin box for peaks when outside of data range

### DIFF
--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -35,6 +35,9 @@ from mantid.simpleapi import (
     SaveMD,
     AddSampleLog,
     SetMDFrame,
+    CreatePeaksWorkspace,
+    CopySample,
+    AddPeakHKL,
 )
 from mantid.api import AnalysisDataService
 from mantidqt.utils.qt.testing import get_application
@@ -682,6 +685,35 @@ class SliceViewerTestCreateMDHisto(systemtesting.MantidSystemTest, HelperTesting
         pres = SliceViewer(binned_ws)
         self.assertListEqual(pres.get_proj_matrix().tolist(), [[0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]])
         pres.view.close()
+
+
+class SliceViewerTestPeakOutsideOfDataRange(systemtesting.MantidSystemTest, HelperTestingClass):
+    def runTest(self):
+        HelperTestingClass.__init__(self)
+        ws_4D = CreateMDWorkspace(
+            Dimensions=4,
+            Extents=[-1, 1, -1, 1, -1, 1, -1, 1],
+            Names="H,K,L,E",
+            Frames="HKL,HKL,HKL,General Frame",
+            Units="r.l.u.,r.l.u.,r.l.u.,meV",
+        )
+        FakeMDEventData(ws_4D, UniformParams=1e6)
+        expt_info_4D = CreateSampleWorkspace()
+        ws_4D.addExperimentInfo(expt_info_4D)
+        SetUB(ws_4D, 1, 1, 2, 90, 90, 120)
+        CreatePeaksWorkspace(InstrumentWorkspace="ws_4D", NumberOfPeaks=0, OutputWorkspace="peaks")
+        CopySample(
+            InputWorkspace="ws_4D", OutputWorkspace="peaks", CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False
+        )
+        AddPeakHKL(Workspace="peaks", HKL="1,2,3")
+        sv = SliceViewer(ws_4D)
+        sv._create_peaks_presenter_if_necessary().overlay_peaksworkspaces(["peaks"])
+        sv.set_slicepoint([None, None, 3.0, 0.0])
+        l_spinbox = sv.get_dimensions().dims[2].spinbox
+        self.assertEqual(l_spinbox.value(), 3.0)
+        self.assertEqual(l_spinbox.minimum(), -0.99)
+        self.assertEqual(l_spinbox.maximum(), 3.0)
+        sv.view.close()
 
 
 # private helper functions

--- a/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/33952.rst
+++ b/docs/source/release/v6.9.0/Workbench/SliceViewer/Bugfixes/33952.rst
@@ -1,0 +1,1 @@
+- Fixed spin box showing an incorrect value when a peak was selected that was outside the range of the data.

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -131,6 +131,7 @@ set(PYTHON_WIDGET_QT5_ONLY_TESTS
     mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
     mantidqt/widgets/sliceviewer/test/test_sliceviewer_transform.py
     mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
+    mantidqt/widgets/sliceviewer/test/test_sliceviewer_dimensionwidget.py
     mantidqt/widgets/sliceviewer/test/test_sliceviewer_zoom.py
     mantidqt/widgets/sliceviewer/test/test_workspace_info.py
     mantidqt/widgets/sliceviewer/test/test_roi.py

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dimensionwidget.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dimensionwidget.py
@@ -1,0 +1,45 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import unittest
+from typing import Dict
+
+from mantidqt.widgets.sliceviewer.views.dimensionwidget import DimensionWidget
+from mantidqt.utils.qt.testing import start_qapplication
+
+
+@start_qapplication
+class DimensionWidgetTest(unittest.TestCase):
+    def setUp(self):
+        dimensions = ["H", "K", "L", "E"]
+        self.dim_info = [self.generate_dim_info(d) for d in dimensions]
+
+    def generate_dim_info(self, dimension: str) -> Dict:
+        return {
+            "minimum": -1.0,
+            "maximum": 1.0,
+            "number_of_bins": 1,
+            "width": 2.0,
+            "name": dimension,
+            "units": "r.l.u.",
+            "type": "MDE",
+            "can_rebin": True,
+            "qdim": True,
+        }
+
+    def test_spinbox_updated_for_slicepoint_outside_range(self):
+        dimension_widget = DimensionWidget(self.dim_info)
+        spinbox = dimension_widget.dims[2].spinbox
+        self.assertEqual(spinbox.value(), 0.0)
+        dimension_widget.set_slicepoint([None, None, 3.0, 0.0])
+        self.assertEqual(spinbox.value(), 3.0)
+        self.assertEqual(spinbox.minimum(), -0.99)
+        self.assertEqual(spinbox.maximum(), 3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
@@ -214,7 +214,7 @@ class Dimension(QWidget):
 
         self.spinbox = QDoubleSpinBox()
         self.spinbox.setDecimals(3)
-        self.spinbox.setRange(self.get_bin_center(0), self.get_bin_center(self.nbins - 1))
+        self.spinbox.setRange(self.spinbox_default_min(), self.spinbox_default_max())
         self.spinbox.setSingleStep(self.width)
         value = 0 if self.spinbox.minimum() < 0 and self.spinbox.maximum() > 0 else self.spinbox.minimum()
         self.set_value(value)
@@ -268,6 +268,12 @@ class Dimension(QWidget):
             self.spinbox.setDisabled(True)
             self.units.show()
 
+    def spinbox_default_min(self) -> float:
+        return self.get_bin_center(0)
+
+    def spinbox_default_max(self) -> float:
+        return self.get_bin_center(self.nbins - 1)
+
     def get_state(self):
         return self.state
 
@@ -302,6 +308,12 @@ class Dimension(QWidget):
         self.slider.setValue(int(min(max(i, 0), self.nbins - 1)))
 
     def update_spinbox(self):
+        if self.spinbox_default_min() <= self.value <= self.spinbox_default_max():
+            self.spinbox.setRange(self.spinbox_default_min(), self.spinbox_default_max())
+        else:
+            spin_min = min(self.value, self.spinbox.minimum())
+            spin_max = max(self.value, self.spinbox.maximum())
+            self.spinbox.setRange(spin_min, spin_max)
         self.spinbox.setValue(self.value)
 
     def set_value(self, value):


### PR DESCRIPTION
Overlaying a peak in Slice Viewer will now always result in the corresponding spin boxes at the top of the interface showing the value of that dimension that corresponds to the peak, even if the peak is outside the range of the data. Previously these boxed were clipped to the min/max of the data.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
- Extended range of spin box to cover peak when necessary

Fixes #33952. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
See #33952 for original issue. Other peak overlaying and dimension-changing behaviour in Slice Viewer should be unaffected.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
