### PR TITLE
AlignAndFocusPowder - only crop in tof if there is a finite range set

### DIFF
--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -504,21 +504,28 @@ void AlignAndFocusPowder::exec() {
   if (xmin >= 0. || xmax > 0.) {
     getTofRange(m_outputW, tofmin, tofmax);
 
-    g_log.information() << "running CropWorkspace(TOFmin=" << xmin << ", TOFmax=" << xmax << ") started at "
-                        << Types::Core::DateAndTime::getCurrentTime() << "\n";
     API::IAlgorithm_sptr cropAlg = createChildAlgorithm("CropWorkspace");
     cropAlg->setProperty("InputWorkspace", m_outputW);
     cropAlg->setProperty("OutputWorkspace", m_outputW);
+    bool setxmin = false;
     if ((xmin >= 0.) && (xmin > tofmin)) {
       cropAlg->setProperty("Xmin", xmin);
       tofmin = xmin; // increase value
+      setxmin = true;
     }
+    bool setxmax = false;
     if ((xmax > 0.) && (xmax < tofmax)) {
       cropAlg->setProperty("Xmax", xmax);
       tofmax = xmax;
+      setxmax = true;
     }
-    cropAlg->executeAsChildAlg();
-    m_outputW = cropAlg->getProperty("OutputWorkspace");
+    // only run if either xmin or xmax was set
+    if (setxmin || setxmax) {
+      g_log.information() << "running CropWorkspace(TOFmin=" << xmin << ", TOFmax=" << xmax << ") started at "
+                          << Types::Core::DateAndTime::getCurrentTime() << "\n";
+      cropAlg->executeAsChildAlg();
+      m_outputW = cropAlg->getProperty("OutputWorkspace");
+    }
   }
   m_progress->report();
 

--- a/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36474.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36474.rst
@@ -1,0 +1,1 @@
+- Only crop in time-of-flight if a finite range is supplied in :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>`. The time difference is minimal, but users will no longer see a log for a function that isn't being run.


### PR DESCRIPTION
This adds a check in `AlignAndFocusPowder` to see if there is a need to `CropWorkspace` in time-of-flight. While `CropWorkspace`. This will have little to no effect on performance but will clean up the algorithm history and logging.

*There is no associated issue.*

### To test:

It is better to review the code than test in this case and the changes should be clear. All existing automated tests should continue to pass.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
