### PR TITLE
Improves usage of symmetrise tab in Data Manipulation Interface.

### DIFF
--- a/docs/source/interfaces/inelastic/Inelastic Data Manipulation.rst
+++ b/docs/source/interfaces/inelastic/Inelastic Data Manipulation.rst
@@ -105,7 +105,7 @@ Preview
 ~~~~~~~
 
 The preview section shows what a given spectra in the input will look like after
-it has been symmetrised and gives an idea of how well the value of :math:`Elow` fits the
+it has been symmetrised and gives an idea of how well the value of :math:`E_{low}` fits the
 curve on both sides of the peak.
 
 Negative Y

--- a/docs/source/interfaces/inelastic/Inelastic Data Manipulation.rst
+++ b/docs/source/interfaces/inelastic/Inelastic Data Manipulation.rst
@@ -44,17 +44,23 @@ Symmetrise
 This tab allows you to take an asymmetric reduced file (*_red.nxs*) and symmetrise it about
 the Y axis.
 
-The curve can be symmetrised using two methods depending on the value of **Reflect Type**:
+The center of energy in the Y axis (*E=0*) is indicated by a solid red line. Two green vertical dashed
+lines can be moved to change the value of :math:`E_{low}` and :math:`E_{high}`, which is the range of energies used to symmetrise
+the spectra. Additionally, two horizontal blue dotted lines can be moved to help in selecting a range that prevents rigged curves
+when the spectra is symmetrised.
 
-1. *Positive to Negative* (default): the range of the positive values between :math:`EMin`
-and :math:`EMax` are reflected about the Y axis and replaces the negative values
-in the range :math:`-EMax` to :math:`-EMin`, the curve between :math:`-EMin` and
-:math:`EMin` is not modified.
+The curve can be symmetrised using either side of the spectra by changing the *Reflect Type* property. This choice influences
+the direction onto which the spectra is symmetrised. Note that :math:`E_{low}` represents
+the lowest value on the range, so when the spectra is on the positive side, :math:`E_{low}` will be closer to the centre
+while in the negative side :math:`E_{low}` will be farther from the centre. The following methods are available on the *Reflect Type* property:
 
-2. *Negative to Positive*: the range of the negative values between :math:`-EMax`
-and :math:`EMin` are reflected about the Y axis and replaces the positive values
-in the range :math:`EMin` to :math:`-EMax`, the curve between :math:`-EMin` and
-:math:`EMin` is not modified.
+1. *Positive to Negative* (default): the range of the positive values between :math:`E_{low}` and :math:`E_{high}`
+   is reflected about the Y axis and replaces the corresponding values in the negative side of the spectra.
+   The curve which ranges between :math:`\pm|E_{low}|` is not modified.
+
+2. *Negative to Positive*: the range of the negative values between :math:`-E_{low}` and :math:`-E_{high}`
+   is reflected about the Y axis and replaces the corresponding values in the positive side of the spectra.
+   The curve which ranges between :math:`\pm|E_{high}|` is not modified.
 
 .. interface:: Data Manipulation
   :widget: tabSymmetrise
@@ -66,7 +72,7 @@ Input
   Allows you to select a reduced NeXus file (*_red.nxs*) or workspace (*_red*) as the
   input to the algorithm.
 
-EMin & EMax
+ELow & EHigh
   Sets the energy range that is to be reflected about :math:`y=0`.
 
 Reflect Type
@@ -99,14 +105,14 @@ Preview
 ~~~~~~~
 
 The preview section shows what a given spectra in the input will look like after
-it has been symmetrised and gives an idea of how well the value of EMin fits the
+it has been symmetrised and gives an idea of how well the value of :math:`Elow` fits the
 curve on both sides of the peak.
 
 Negative Y
-  The value of :math:`y` at :math:`x=-EMin`.
+  The value of :math:`y` at :math:`x=-|E_{low}|` on  *Positive to Negative* or at :math:`x=-|E_{high}|` on *Negative to Positive*.
 
 Positive Y
-  The value of :math:`y` at :math:`x=EMin`.
+  The value of :math:`y` at :math:`x=|E_{low}|` on  *Positive to Negative* or at :math:`x=|E_{high}|` on *Negative to Positive*.
 
 Delta Y
   The difference between Negative and Positive Y. Typically this should be as
@@ -124,7 +130,7 @@ produce this file is IRIS, the analyser is graphite and the reflection is 002. S
 1. In the **Input** box, load the file named ``iris26176_graphite002_red``. This will
    automatically plot the data on the first mini-plot.
 
-2. Move the green slider located at x = -0.5 to be at x = -0.4.
+2. Move the green slider located at x = 0.5 to be at x = 0.4.
 
 3. Click **Preview**. This will update the :ref:`Preview properties <preview-properties>` and
    the neighbouring mini-plot.

--- a/docs/source/release/v6.9.0/Inelastic/New_features/36480.rst
+++ b/docs/source/release/v6.9.0/Inelastic/New_features/36480.rst
@@ -1,0 +1,1 @@
+-  The tab :ref:`Symmetrise <inelastic-symmetrise>` of the :ref:`Inelastic Data Manipulation Interface <interface-inelastic-data-manipulation>` has been modified with better input data validation. Selection markers can be moved to negative spectra side upon change of ReflectType property and the central marker is fixed.

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.cpp
@@ -79,7 +79,7 @@ void InelasticDataManipulationSymmetriseTab::run() {
   // Handle algorithm completion signal
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
 
-  // Execute algorithm on separated thread
+  // Execute the algorithm on a separated thread
   m_batchAlgoRunner->executeBatchAsync();
 }
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.cpp
@@ -43,6 +43,9 @@ InelasticDataManipulationSymmetriseTab::InelasticDataManipulationSymmetriseTab(Q
   // Handle running, plotting and saving
   connect(m_view.get(), SIGNAL(runClicked()), this, SLOT(runClicked()));
   connect(m_view.get(), SIGNAL(saveClicked()), this, SLOT(saveClicked()));
+  connect(m_view.get(), SIGNAL(showMessageBox(const QString &)), this, SIGNAL(showMessageBox(const QString &)));
+
+  m_model->setIsPositiveReflect(true);
   m_view->setDefaults();
 }
 
@@ -76,7 +79,7 @@ void InelasticDataManipulationSymmetriseTab::run() {
   // Handle algorithm completion signal
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
 
-  // Execute algorithm on seperate thread
+  // Execute algorithm on separated thread
   m_batchAlgoRunner->executeBatchAsync();
 }
 
@@ -108,9 +111,12 @@ void InelasticDataManipulationSymmetriseTab::preview() {
 
   m_view->setRawPlotWatchADS(false);
 
-  // Do nothing if no data has been laoded
+  // Do nothing if no data has been loaded
   QString workspaceName = m_view->getInputName();
   if (workspaceName.isEmpty())
+    return;
+
+  if (!m_view->verifyERange(workspaceName))
     return;
 
   long spectrumNumber = static_cast<long>(m_view->getPreviewSpec());
@@ -151,7 +157,7 @@ void InelasticDataManipulationSymmetriseTab::setFileExtensionsByName(bool filter
 }
 
 void InelasticDataManipulationSymmetriseTab::handleEnumValueChanged(QtProperty *prop, int value) {
-  if (prop->propertyName() == "Reflect Type") {
+  if (prop->propertyName() == "ReflectType") {
     m_model->setIsPositiveReflect(value == 0);
   }
 }
@@ -159,12 +165,13 @@ void InelasticDataManipulationSymmetriseTab::handleEnumValueChanged(QtProperty *
 void InelasticDataManipulationSymmetriseTab::handleDoubleValueChanged(QtProperty *prop, double value) {
   if (prop->propertyName() == "Spectrum No") {
     m_view->replotNewSpectrum(value);
-  } else if (prop->propertyName() == "EMin") {
-    m_view->verifyERange(prop, value);
-    m_model->setEMin(m_view->getEMin());
-  } else if (prop->propertyName() == "EMax") {
-    m_view->verifyERange(prop, value);
-    m_model->setEMax(m_view->getEMax());
+  } else {
+    m_view->updateRangeSelectors(prop, value);
+    if (prop->propertyName() == "Elow") {
+      m_model->getIsPositiveReflect() ? m_model->setEMin(value) : m_model->setEMax((-1) * value);
+    } else if (prop->propertyName() == "Ehigh") {
+      m_model->getIsPositiveReflect() ? m_model->setEMax(value) : m_model->setEMin((-1) * value);
+    }
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.cpp
@@ -30,12 +30,12 @@ void InelasticDataManipulationSymmetriseTabModel::setupPreviewAlgorithm(
 
   if (!m_isPositiveReflect) {
     reflectNegativeToPositive();
-  }
+  };
   // Run the algorithm on the preview spectrum only, these outputs are only for plotting in the preview window and are
   // not accessed by users directly.
   IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise");
   symmetriseAlg->initialize();
-  symmetriseAlg->setProperty("InputWorkspace", m_isPositiveReflect ? m_inputWorkspace : m_reflctedInputWorkspace);
+  symmetriseAlg->setProperty("InputWorkspace", m_isPositiveReflect ? m_inputWorkspace : m_reflectedInputWorkspace);
   symmetriseAlg->setProperty("XMin", m_eMin);
   symmetriseAlg->setProperty("XMax", m_eMax);
   symmetriseAlg->setProperty("SpectraRange", spectraRange);
@@ -57,7 +57,7 @@ std::string InelasticDataManipulationSymmetriseTabModel::setupSymmetriseAlgorith
 
   IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise");
   symmetriseAlg->initialize();
-  symmetriseAlg->setProperty("InputWorkspace", m_isPositiveReflect ? m_inputWorkspace : m_reflctedInputWorkspace);
+  symmetriseAlg->setProperty("InputWorkspace", m_isPositiveReflect ? m_inputWorkspace : m_reflectedInputWorkspace);
   symmetriseAlg->setProperty("XMin", m_eMin);
   symmetriseAlg->setProperty("XMax", m_eMax);
   symmetriseAlg->setProperty("OutputWorkspace", outputWorkspace);
@@ -73,19 +73,19 @@ void InelasticDataManipulationSymmetriseTabModel::reflectNegativeToPositive() {
   scaleXAlg->setProperty("InputWorkspace", m_inputWorkspace);
   scaleXAlg->setProperty("Operation", "Multiply");
   scaleXAlg->setProperty("Factor", -1.0);
-  scaleXAlg->setProperty("OutputWorkspace", m_reflctedInputWorkspace);
+  scaleXAlg->setProperty("OutputWorkspace", m_reflectedInputWorkspace);
   scaleXAlg->execute();
 
   IAlgorithm_sptr sortXAxisAlg = AlgorithmManager::Instance().create("SortXAxis");
   sortXAxisAlg->initialize();
-  sortXAxisAlg->setProperty("InputWorkspace", m_reflctedInputWorkspace);
-  sortXAxisAlg->setProperty("OutputWorkspace", m_reflctedInputWorkspace);
+  sortXAxisAlg->setProperty("InputWorkspace", m_reflectedInputWorkspace);
+  sortXAxisAlg->setProperty("OutputWorkspace", m_reflectedInputWorkspace);
   sortXAxisAlg->execute();
 }
 
 void InelasticDataManipulationSymmetriseTabModel::setWorkspaceName(QString workspaceName) {
   m_inputWorkspace = workspaceName.toStdString();
-  m_reflctedInputWorkspace = m_inputWorkspace + "_reflected";
+  m_reflectedInputWorkspace = m_inputWorkspace + "_reflected";
   // the last 4 characters in the workspace name are '_red' the ouput weorkspace name is inserting '_sym' before that
   // '_red'
   m_positiveOutputWorkspace =
@@ -99,5 +99,7 @@ void InelasticDataManipulationSymmetriseTabModel::setEMin(double value) { m_eMin
 void InelasticDataManipulationSymmetriseTabModel::setEMax(double value) { m_eMax = value; }
 
 void InelasticDataManipulationSymmetriseTabModel::setIsPositiveReflect(bool value) { m_isPositiveReflect = value; }
+
+bool InelasticDataManipulationSymmetriseTabModel::getIsPositiveReflect() { return m_isPositiveReflect; }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.cpp
@@ -30,7 +30,7 @@ void InelasticDataManipulationSymmetriseTabModel::setupPreviewAlgorithm(
 
   if (!m_isPositiveReflect) {
     reflectNegativeToPositive();
-  };
+  }
   // Run the algorithm on the preview spectrum only, these outputs are only for plotting in the preview window and are
   // not accessed by users directly.
   IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise");

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.cpp
@@ -100,6 +100,6 @@ void InelasticDataManipulationSymmetriseTabModel::setEMax(double value) { m_eMax
 
 void InelasticDataManipulationSymmetriseTabModel::setIsPositiveReflect(bool value) { m_isPositiveReflect = value; }
 
-bool InelasticDataManipulationSymmetriseTabModel::getIsPositiveReflect() { return m_isPositiveReflect; }
+bool InelasticDataManipulationSymmetriseTabModel::getIsPositiveReflect() const { return m_isPositiveReflect; }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.h
@@ -29,7 +29,7 @@ public:
   void setEMin(double value);
   void setEMax(double value);
   void setIsPositiveReflect(bool value);
-  bool getIsPositiveReflect();
+  bool getIsPositiveReflect() const;
 
 private:
   std::string m_inputWorkspace;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.h
@@ -29,10 +29,11 @@ public:
   void setEMin(double value);
   void setEMax(double value);
   void setIsPositiveReflect(bool value);
+  bool getIsPositiveReflect();
 
 private:
   std::string m_inputWorkspace;
-  std::string m_reflctedInputWorkspace;
+  std::string m_reflectedInputWorkspace;
   std::string m_negativeOutputWorkspace;
   std::string m_positiveOutputWorkspace;
   double m_eMin;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.cpp
@@ -24,7 +24,7 @@ constexpr auto NUMERICAL_PRECISION = 2;
 
 namespace {
 
-QString makeNumber(double value) { return QString::number(value, 'g', NUMERICAL_PRECISION); };
+QString makeNumber(double value) { return QString::number(value, 'g', NUMERICAL_PRECISION); }
 
 QPair<double, double> getXRangeFromWorkspace(const Mantid::API::MatrixWorkspace_const_sptr &workspace) {
   auto const xValues = workspace->x(0);
@@ -289,7 +289,6 @@ void InelasticDataManipulationSymmetriseTabView::plotNewData(QString const &work
 
   // Set the preview range to the maximum absolute X value
   auto const axisRange = getXRangeFromWorkspace(sampleWS);
-  double symmRange = std::max(fabs(axisRange.first), fabs(axisRange.second));
 
   // Set some default (and valid) values for E range
   resetEDefaults(m_enumManager->value(m_properties["ReflectType"]) == 0, axisRange);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.cpp
@@ -28,7 +28,7 @@ QString makeNumber(double value) { return QString::number(value, 'g', NUMERICAL_
 
 QPair<double, double> getXRangeFromWorkspace(const Mantid::API::MatrixWorkspace_const_sptr &workspace) {
   auto const xValues = workspace->x(0);
-  return QPair(xValues.front(), xValues.back());
+  return QPair<double, double>(xValues.front(), xValues.back());
 }
 } // namespace
 
@@ -198,14 +198,16 @@ void InelasticDataManipulationSymmetriseTabView::xRangeHighChanged(double value)
  */
 void InelasticDataManipulationSymmetriseTabView::resetEDefaults(bool isPositive, QPair<double, double> range) {
   auto rangeESelector = m_uiForm.ppRawPlot->getRangeSelector("rangeE");
-  auto rangeReflect = isPositive ? QPair(0.0, range.second) : QPair(range.first, 0.0);
-  auto rangeInitial =
-      isPositive ? QPair(0.1 * range.second, 0.9 * range.second) : QPair(0.9 * range.first, 0.1 * range.first);
 
+  // Set Selector range values
+  auto rangeReflect = isPositive ? QPair(0.0, range.second) : QPair(range.first, 0.0);
   rangeESelector->setBounds(rangeReflect.first, rangeReflect.second);
   m_dblManager->setRange(m_properties["Ehigh"], rangeReflect.first, rangeReflect.second);
   m_dblManager->setRange(m_properties["Elow"], rangeReflect.first, rangeReflect.second);
 
+  // Set Initial selector range values
+  auto rangeInitial =
+      isPositive ? QPair(0.1 * range.second, 0.9 * range.second) : QPair(0.9 * range.first, 0.1 * range.first);
   rangeESelector->setRange(rangeInitial.first, rangeInitial.second);
   m_dblManager->setValue(m_properties["Ehigh"], rangeInitial.second);
   m_dblManager->setValue(m_properties["Elow"], rangeInitial.first);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.cpp
@@ -199,7 +199,7 @@ void InelasticDataManipulationSymmetriseTabView::xRangeHighChanged(double value)
 void InelasticDataManipulationSymmetriseTabView::resetEDefaults(bool isPositive, QPair<double, double> range) {
   auto rangeESelector = m_uiForm.ppRawPlot->getRangeSelector("rangeE");
 
-  // Set Selector range values
+  // Set Selector range boundaries
   auto rangeReflect = isPositive ? QPair(0.0, range.second) : QPair(range.first, 0.0);
   rangeESelector->setBounds(rangeReflect.first, rangeReflect.second);
   m_dblManager->setRange(m_properties["Ehigh"], rangeReflect.first, rangeReflect.second);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.cpp
@@ -20,11 +20,15 @@
 using namespace IndirectDataValidationHelper;
 using namespace Mantid::API;
 
+constexpr auto NUMERICAL_PRECISION = 2;
+
 namespace {
+
+QString makeNumber(double value) { return QString::number(value, 'g', NUMERICAL_PRECISION); };
 
 QPair<double, double> getXRangeFromWorkspace(const Mantid::API::MatrixWorkspace_const_sptr &workspace) {
   auto const xValues = workspace->x(0);
-  return QPair<double, double>(xValues.front(), xValues.back());
+  return QPair(xValues.front(), xValues.back());
 }
 } // namespace
 
@@ -59,12 +63,12 @@ InelasticDataManipulationSymmetriseTabView::InelasticDataManipulationSymmetriseT
   m_propTrees["SymmPropTree"]->setFactoryForManager(m_enumManager, enumEditorFactory);
 
   // Raw Properties
-  m_properties["EMin"] = m_dblManager->addProperty("EMin");
-  m_dblManager->setDecimals(m_properties["EMin"], numDecimals);
-  m_propTrees["SymmPropTree"]->addProperty(m_properties["EMin"]);
-  m_properties["EMax"] = m_dblManager->addProperty("EMax");
-  m_dblManager->setDecimals(m_properties["EMax"], numDecimals);
-  m_propTrees["SymmPropTree"]->addProperty(m_properties["EMax"]);
+  m_properties["Elow"] = m_dblManager->addProperty("Elow");
+  m_dblManager->setDecimals(m_properties["Elow"], numDecimals);
+  m_propTrees["SymmPropTree"]->addProperty(m_properties["Elow"]);
+  m_properties["Ehigh"] = m_dblManager->addProperty("Ehigh");
+  m_dblManager->setDecimals(m_properties["Ehigh"], numDecimals);
+  m_propTrees["SymmPropTree"]->addProperty(m_properties["Ehigh"]);
 
   QtProperty *rawPlotProps = m_grpManager->addProperty("Raw Plot");
   m_propTrees["SymmPropTree"]->addProperty(rawPlotProps);
@@ -73,7 +77,7 @@ InelasticDataManipulationSymmetriseTabView::InelasticDataManipulationSymmetriseT
   m_dblManager->setDecimals(m_properties["PreviewSpec"], 0);
   rawPlotProps->addSubProperty(m_properties["PreviewSpec"]);
 
-  m_properties["ReflectType"] = m_enumManager->addProperty("Reflect Type");
+  m_properties["ReflectType"] = m_enumManager->addProperty("ReflectType");
   QStringList types;
   types << "Positive to Negative"
         << "Negative to Positive";
@@ -95,33 +99,21 @@ InelasticDataManipulationSymmetriseTabView::InelasticDataManipulationSymmetriseT
   m_dblManager->setDecimals(m_properties["DeltaY"], numDecimals);
   m_propTrees["SymmPVPropTree"]->addProperty(m_properties["DeltaY"]);
 
-  auto const xLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::XBottom);
-  auto const yLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::YLeft);
-
-  // Indicators for Y value at each EMin position
-  auto negativeEMinYPos =
-      m_uiForm.ppRawPlot->addSingleSelector("NegativeEMinYPos", MantidWidgets::SingleSelector::YSINGLE, 0.0);
-  negativeEMinYPos->setColour(Qt::blue);
-  negativeEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
-
-  auto positiveEMinYPos =
-      m_uiForm.ppRawPlot->addSingleSelector("PositiveEMinYPos", MantidWidgets::SingleSelector::YSINGLE, 1.0);
-  positiveEMinYPos->setColour(Qt::red);
-  positiveEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
-
   // Indicator for centre of symmetry (x=0)
-  auto centreMarkRaw = m_uiForm.ppRawPlot->addSingleSelector("CentreMark", MantidWidgets::SingleSelector::XSINGLE, 0.0);
-  centreMarkRaw->setColour(Qt::cyan);
-  centreMarkRaw->setBounds(std::get<0>(xLimits), std::get<1>(xLimits));
+  auto centreMarkRaw = m_uiForm.ppRawPlot->addSingleSelector("CentreMark", MantidWidgets::SingleSelector::XSINGLE, 0.0,
+                                                             MantidWidgets::PlotLineStyle::Solid);
+  centreMarkRaw->setColour(Qt::red);
+  centreMarkRaw->disconnectMouseSignals();
 
   // Indicators for negative and positive X range values on X axis
   // The user can use these to move the X range
-  // Note that the max and min of the negative range selector corespond to the
+  // Note that the max and min of the negative range selector correspond to the
   // opposite X value
   // i.e. RS min is X max
-
-  auto positiveERaw = m_uiForm.ppRawPlot->addRangeSelector("PositiveE");
-  positiveERaw->setColour(Qt::darkMagenta);
+  auto const xLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::XBottom);
+  auto rangeESelector = m_uiForm.ppRawPlot->addRangeSelector("rangeE");
+  rangeESelector->setColour(Qt::darkGreen);
+  rangeESelector->setBounds(0.0, std::get<1>(xLimits));
 
   // SIGNAL/SLOT CONNECTIONS
   // Validate the E range when it is changed
@@ -134,8 +126,8 @@ InelasticDataManipulationSymmetriseTabView::InelasticDataManipulationSymmetriseT
   // Preview symmetrise
   connect(m_uiForm.pbPreview, SIGNAL(clicked()), this, SIGNAL(previewClicked()));
   // X range selectors
-  connect(positiveERaw, SIGNAL(minValueChanged(double)), this, SLOT(xRangeMinChanged(double)));
-  connect(positiveERaw, SIGNAL(maxValueChanged(double)), this, SLOT(xRangeMaxChanged(double)));
+  connect(rangeESelector, SIGNAL(minValueChanged(double)), this, SLOT(xRangeLowChanged(double)));
+  connect(rangeESelector, SIGNAL(maxValueChanged(double)), this, SLOT(xRangeHighChanged(double)));
   // Handle running, plotting and saving
   connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SIGNAL(runClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SIGNAL(saveClicked()));
@@ -148,8 +140,10 @@ InelasticDataManipulationSymmetriseTabView::~InelasticDataManipulationSymmetrise
 
 void InelasticDataManipulationSymmetriseTabView::setDefaults() {
   // Set default X range values
-  m_dblManager->setValue(m_properties["EMax"], 0.5);
-  m_dblManager->setValue(m_properties["EMin"], 0.1);
+  m_dblManager->setValue(m_properties["Ehigh"], 0.5);
+  m_dblManager->setValue(m_properties["Elow"], 0.1);
+  auto rangeESelector = m_uiForm.ppRawPlot->getRangeSelector("rangeE");
+  rangeESelector->setRange(0.1, 0.5);
 
   // Set default reflection type
   m_enumManager->setValue(m_properties["ReflectType"], 0);
@@ -175,74 +169,13 @@ IndirectPlotOptionsView *InelasticDataManipulationSymmetriseTabView::getPlotOpti
 }
 
 /**
- * Verifies that the E Range is valid.
- *
- * @param prop QtProperty changed
- * @param value Value it was changed to (unused)
- */
-void InelasticDataManipulationSymmetriseTabView::verifyERange(QtProperty *prop, double value) {
-  UNUSED_ARG(value);
-
-  double eMin = m_dblManager->value(m_properties["EMin"]);
-  double eMax = m_dblManager->value(m_properties["EMax"]);
-
-  if (prop == m_properties["EMin"]) {
-    // If the value of EMin is negative try negating it to get a valid range
-    if (eMin < 0) {
-      eMin = -eMin;
-      m_dblManager->setValue(m_properties["EMin"], eMin);
-      return;
-    }
-    // If range is still invalid reset EMin to half EMax
-    else if (eMin > eMax) {
-      m_dblManager->setValue(m_properties["EMin"], eMax / 2);
-      return;
-    }
-  } else if (prop == m_properties["EMax"]) {
-    // If the value of EMax is negative try negating it to get a valid range
-    if (eMax < 0) {
-      eMax = -eMax;
-      m_dblManager->setValue(m_properties["EMax"], eMax);
-      return;
-    }
-    // If range is invalid reset EMax to double EMin
-    else if (eMin > eMax) {
-      m_dblManager->setValue(m_properties["EMax"], eMin * 2);
-      return;
-    }
-  }
-
-  // If we get this far then the E range is valid
-  // Update the range selectors with the new values.
-  updateRangeSelectors(prop, value);
-}
-
-/**
- * Updates position of XCut range selectors when used changed value of XCut.
- *
- * @param prop QtProperty changed
- * @param value Value it was changed to (unused)
- */
-void InelasticDataManipulationSymmetriseTabView::updateRangeSelectors(QtProperty *prop, double value) {
-  auto positiveERaw = m_uiForm.ppRawPlot->getRangeSelector("PositiveE");
-
-  value = fabs(value);
-
-  if (prop == m_properties["EMin"]) {
-    positiveERaw->setMinimum(value);
-  } else if (prop == m_properties["EMax"]) {
-    positiveERaw->setMaximum(value);
-  }
-}
-
-/**
  * Handles the X minimum value being changed from a range selector.
  *
  * @param value New range selector value
  */
-void InelasticDataManipulationSymmetriseTabView::xRangeMinChanged(double value) {
-  m_dblManager->setValue(m_properties["EMin"], std::abs(value));
-  m_uiForm.pbPreview->setEnabled(true);
+void InelasticDataManipulationSymmetriseTabView::xRangeLowChanged(double value) {
+  m_dblManager->setValue(m_properties["Elow"], value);
+  m_dblManager->setMinimum(m_properties["Ehigh"], value);
 }
 
 /**
@@ -250,28 +183,87 @@ void InelasticDataManipulationSymmetriseTabView::xRangeMinChanged(double value) 
  *
  * @param value New range selector value
  */
-void InelasticDataManipulationSymmetriseTabView::xRangeMaxChanged(double value) {
-  m_dblManager->setValue(m_properties["EMax"], std::abs(value));
-  m_uiForm.pbPreview->setEnabled(true);
+void InelasticDataManipulationSymmetriseTabView::xRangeHighChanged(double value) {
+  m_dblManager->setValue(m_properties["Ehigh"], value);
+  m_dblManager->setMaximum(m_properties["Elow"], value);
 }
 
+/**
+ * Updates boundaries and initial values for Selector and Data properties when changing between negative/positive side
+ * of spectrum.
+ *
+ * @param isPositive flag for spectrum positive side
+ * @param range Active spectra range
+ *
+ */
 void InelasticDataManipulationSymmetriseTabView::resetEDefaults(bool isPositive, QPair<double, double> range) {
-  if (isPositive) {
-    m_dblManager->setValue(m_properties["EMax"], range.second);
-    m_dblManager->setValue(m_properties["EMin"], range.second / 10);
-  } else {
-    m_dblManager->setValue(m_properties["EMax"], range.first);
-    m_dblManager->setValue(m_properties["EMin"], range.first / 10);
+  auto rangeESelector = m_uiForm.ppRawPlot->getRangeSelector("rangeE");
+  auto rangeReflect = isPositive ? QPair(0.0, range.second) : QPair(range.first, 0.0);
+  auto rangeInitial =
+      isPositive ? QPair(0.1 * range.second, 0.9 * range.second) : QPair(0.9 * range.first, 0.1 * range.first);
+
+  rangeESelector->setBounds(rangeReflect.first, rangeReflect.second);
+  m_dblManager->setRange(m_properties["Ehigh"], rangeReflect.first, rangeReflect.second);
+  m_dblManager->setRange(m_properties["Elow"], rangeReflect.first, rangeReflect.second);
+
+  rangeESelector->setRange(rangeInitial.first, rangeInitial.second);
+  m_dblManager->setValue(m_properties["Ehigh"], rangeInitial.second);
+  m_dblManager->setValue(m_properties["Elow"], rangeInitial.first);
+}
+
+/**
+ * Verifies that the E Range is valid. Logs message guiding user on what's wrong with selection.
+ *
+ * @param QString with current workspace name.
+ *
+ * @return true if selected E range is valid for calling the symmetrise algorithm, false otherwise.
+ */
+bool InelasticDataManipulationSymmetriseTabView::verifyERange(QString const &workspaceName) {
+  MatrixWorkspace_sptr sampleWS =
+      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName.toStdString());
+  auto axisRange = getXRangeFromWorkspace(sampleWS);
+  auto Erange = QPair(getElow(), getEhigh());
+
+  bool const reflectType = m_enumManager->value(m_properties["ReflectType"]);
+  if ((reflectType == 0) && (Erange.first > abs(axisRange.first))) {
+    emit showMessageBox("Invalid Data Range: Elow is larger than the lower limit of spectrum.\nReduce Elow to " +
+                        makeNumber(abs(axisRange.first)));
+    return false;
+  } else if ((reflectType == 1) && (abs(Erange.second) > axisRange.second)) {
+    emit showMessageBox("Invalid Data Range: Ehigh is larger than the upper limit of spectrum.\nIncrease Ehigh to " +
+                        makeNumber(axisRange.second));
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Updates position of XCut range selectors when user changed value of XCut.
+ *
+ * @param prop QtProperty changed
+ * @param value Value it was changed to (unused)
+ */
+void InelasticDataManipulationSymmetriseTabView::updateRangeSelectors(QtProperty *prop, double value) {
+  auto rangeESelector = m_uiForm.ppRawPlot->getRangeSelector("rangeE");
+
+  if (prop == m_properties["Elow"]) {
+    rangeESelector->setMinimum(value);
+  } else if (prop == m_properties["Ehigh"]) {
+    rangeESelector->setMaximum(value);
   }
 }
 
 void InelasticDataManipulationSymmetriseTabView::reflectTypeChanged(QtProperty *prop, int value) {
-  if (prop->propertyName() == "Reflect Type") {
+  if (prop->propertyName() == "ReflectType") {
     QString workspaceName = m_uiForm.dsInput->getCurrentDataName();
-    MatrixWorkspace_sptr sampleWS =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName.toStdString());
-    auto const axisRange = getXRangeFromWorkspace(sampleWS);
-    resetEDefaults(value == 0, axisRange);
+
+    if (validate()) {
+      MatrixWorkspace_sptr sampleWS =
+          AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName.toStdString());
+      auto const axisRange = getXRangeFromWorkspace(sampleWS);
+
+      resetEDefaults(value == 0, axisRange);
+    }
   }
 }
 
@@ -295,34 +287,15 @@ void InelasticDataManipulationSymmetriseTabView::plotNewData(QString const &work
   int minSpectrumRange = sampleWS->getSpectrum(0).getSpectrumNo();
   m_dblManager->setValue(m_properties["PreviewSpec"], static_cast<double>(minSpectrumRange));
 
-  updateMiniPlots();
-
   // Set the preview range to the maximum absolute X value
   auto const axisRange = getXRangeFromWorkspace(sampleWS);
   double symmRange = std::max(fabs(axisRange.first), fabs(axisRange.second));
 
-  // Set valid range for range selectors
-  auto positiveESelector = m_uiForm.ppRawPlot->getRangeSelector("PositiveE");
-  positiveESelector->setBounds(axisRange.first, axisRange.second);
-  positiveESelector->setRange(0, symmRange);
-
   // Set some default (and valid) values for E range
   resetEDefaults(m_enumManager->value(m_properties["ReflectType"]) == 0, axisRange);
-
   updateMiniPlots();
 
-  auto const xLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::XBottom);
-  auto const yLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::YLeft);
-
-  // Set indicator positions
-  auto negativeEMinYPos = m_uiForm.ppRawPlot->getSingleSelector("NegativeEMinYPos");
-  negativeEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
-
-  auto positiveEMinYPos = m_uiForm.ppRawPlot->getSingleSelector("PositiveEMinYPos");
-  positiveEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
-
-  auto centreMarkRaw = m_uiForm.ppRawPlot->getSingleSelector("CentreMark");
-  centreMarkRaw->setBounds(std::get<0>(xLimits), std::get<1>(xLimits));
+  m_uiForm.pbPreview->setEnabled(true);
 }
 
 /**
@@ -350,7 +323,7 @@ void InelasticDataManipulationSymmetriseTabView::updateMiniPlots() {
 }
 
 /**
- * Redraws mini plots when user changes previw range or spectrum.
+ * Redraws mini plots when user changes preview range or spectrum.
  *
  * @param prop QtProperty that was changed
  * @param value Value it was changed to
@@ -370,7 +343,7 @@ void InelasticDataManipulationSymmetriseTabView::replotNewSpectrum(double value)
     return;
   }
 
-  // If entered value is higer then set spectra number to highest valid value
+  // If entered value is higher then set spectra number to highest valid value
   if (value > maxSpectrumRange) {
     m_dblManager->setValue(m_properties["PreviewSpec"], maxSpectrumRange);
     return;
@@ -382,16 +355,9 @@ void InelasticDataManipulationSymmetriseTabView::replotNewSpectrum(double value)
 bool InelasticDataManipulationSymmetriseTabView::validate() {
   UserInputValidator uiv;
   validateDataIsOfType(uiv, m_uiForm.dsInput, "Sample", DataType::Red);
-
-  // EMin and EMax must be positive
-  if (m_dblManager->value(m_properties["EMin"]) <= 0.0)
-    uiv.addErrorMessage("EMin must be positive.");
-  if (m_dblManager->value(m_properties["EMax"]) <= 0.0)
-    uiv.addErrorMessage("EMax must be positive.");
-
   auto const errorMessage = uiv.generateErrorMessage();
   if (!errorMessage.isEmpty())
-    showMessageBox(errorMessage);
+    emit showMessageBox(errorMessage);
   return errorMessage.isEmpty();
 }
 
@@ -399,9 +365,9 @@ void InelasticDataManipulationSymmetriseTabView::setRawPlotWatchADS(bool watchAD
   m_uiForm.ppRawPlot->watchADS(watchADS);
 }
 
-double InelasticDataManipulationSymmetriseTabView::getEMin() { return m_dblManager->value(m_properties["EMin"]); }
+double InelasticDataManipulationSymmetriseTabView::getElow() { return m_dblManager->value(m_properties["Elow"]); }
 
-double InelasticDataManipulationSymmetriseTabView::getEMax() { return m_dblManager->value(m_properties["EMax"]); }
+double InelasticDataManipulationSymmetriseTabView::getEhigh() { return m_dblManager->value(m_properties["Ehigh"]); }
 
 double InelasticDataManipulationSymmetriseTabView::getPreviewSpec() {
   return m_dblManager->value(m_properties["PreviewSpec"]);
@@ -432,16 +398,6 @@ void InelasticDataManipulationSymmetriseTabView::previewAlgDone() {
   m_dblManager->setValue(m_properties["NegativeYValue"], negativeY);
   m_dblManager->setValue(m_properties["PositiveYValue"], positiveY);
   m_dblManager->setValue(m_properties["DeltaY"], deltaY);
-
-  auto const yLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::YLeft);
-  // Set indicator positions
-  auto const negativeEMinYPos = m_uiForm.ppRawPlot->getSingleSelector("NegativeEMinYPos");
-  negativeEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
-  negativeEMinYPos->setPosition(negativeY);
-
-  auto const positiveEMinYPos = m_uiForm.ppRawPlot->getSingleSelector("PositiveEMinYPos");
-  positiveEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
-  positiveEMinYPos->setPosition(positiveY);
 
   // Plot preview plot
   size_t spectrumIndex = symmWS->getIndexFromSpectrumNumber(spectrumNumber);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.h
@@ -32,8 +32,8 @@ public:
   void updateMiniPlots();
   bool validate();
   void setRawPlotWatchADS(bool watchADS);
-  double getEMin();
-  double getEMax();
+  double getElow();
+  double getEhigh();
   double getPreviewSpec();
   QString getInputName();
   void previewAlgDone();
@@ -41,7 +41,7 @@ public:
   void enableRun(bool save);
   void updateRangeSelectors(QtProperty *prop, double value);
   void replotNewSpectrum(double value);
-  void verifyERange(QtProperty *prop, double value);
+  bool verifyERange(QString const &workspaceName);
 
 signals:
   void doubleValueChanged(QtProperty *, double);
@@ -53,8 +53,8 @@ signals:
   void showMessageBox(const QString &message);
 
 private slots:
-  void xRangeMaxChanged(double value);
-  void xRangeMinChanged(double value);
+  void xRangeLowChanged(double value);
+  void xRangeHighChanged(double value);
   void reflectTypeChanged(QtProperty *, int value);
 
 private:

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.h
@@ -32,8 +32,8 @@ public:
   void updateMiniPlots();
   bool validate();
   void setRawPlotWatchADS(bool watchADS);
-  double getElow();
-  double getEhigh();
+  double getElow() const;
+  double getEhigh() const;
   double getPreviewSpec();
   QString getInputName();
   void previewAlgDone();
@@ -59,6 +59,8 @@ private slots:
 
 private:
   void resetEDefaults(bool isPositive, QPair<double, double> range);
+  void updateHorizontalMarkers(QPair<double, double> yrange);
+
   Ui::InelasticDataManipulationSymmetriseTab m_uiForm;
 
   /// Tree of the properties

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
@@ -68,7 +68,7 @@ public:
   RangeSelector *getRangeSelector(const QString &name) const;
 
   SingleSelector *addSingleSelector(const QString &name, SingleSelector::SelectType type = SingleSelector::XSINGLE,
-                                    double position = 0.0);
+                                    double position = 0.0, PlotLineStyle style = PlotLineStyle::Dash);
   SingleSelector *getSingleSelector(const QString &name) const;
 
   void setSelectorActive(bool active);

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/SingleSelector.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/SingleSelector.h
@@ -14,6 +14,7 @@
 namespace MantidQt {
 namespace MantidWidgets {
 class PreviewPlot;
+enum PlotLineStyle { Dash, Solid };
 
 /**
  * Displays a line for selecting a value on a previewplot in MPL
@@ -24,8 +25,8 @@ class EXPORT_OPT_MANTIDQT_PLOTTING SingleSelector : public QObject {
 public:
   enum SelectType { XSINGLE, YSINGLE };
 
-  SingleSelector(PreviewPlot *plot, SelectType type = XSINGLE, double position = 0.0, bool visible = true,
-                 const QColor &colour = Qt::black);
+  SingleSelector(PreviewPlot *plot, SelectType type = XSINGLE, double position = 0.0,
+                 PlotLineStyle style = PlotLineStyle::Dash, bool visible = true, const QColor &colour = Qt::black);
 
   void setColour(const QColor &colour);
 
@@ -40,6 +41,7 @@ public:
   void setVisible(bool visible);
 
   void detach();
+  void disconnectMouseSignals();
 
 signals:
   void resetScientificBounds();

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/SingleSelector.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/SingleSelector.h
@@ -14,7 +14,7 @@
 namespace MantidQt {
 namespace MantidWidgets {
 class PreviewPlot;
-enum PlotLineStyle { Dash, Solid };
+enum PlotLineStyle { Dash, Dotted, Solid };
 
 /**
  * Displays a line for selecting a value on a previewplot in MPL

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -201,11 +201,12 @@ RangeSelector *PreviewPlot::getRangeSelector(const QString &name) const {
  * @param type The type of the single selector
  * @return The single selector
  */
-SingleSelector *PreviewPlot::addSingleSelector(const QString &name, SingleSelector::SelectType type, double position) {
+SingleSelector *PreviewPlot::addSingleSelector(const QString &name, SingleSelector::SelectType type, double position,
+                                               PlotLineStyle style) {
   if (m_singleSelectors.contains(name))
     throw std::runtime_error("SingleSelector already exists on PreviewPlot.");
 
-  m_singleSelectors[name] = new MantidWidgets::SingleSelector(this, type, position);
+  m_singleSelectors[name] = new MantidWidgets::SingleSelector(this, type, position, style);
   return m_singleSelectors[name];
 }
 

--- a/qt/widgets/plotting/src/SingleSelector.cpp
+++ b/qt/widgets/plotting/src/SingleSelector.cpp
@@ -18,6 +18,9 @@ QHash<QString, QVariant> defaultLineKwargs(PlotLineStyle style) {
   case PlotLineStyle::Solid:
     kwargs.insert("line_style", QString("-"));
     break;
+  case PlotLineStyle::Dotted:
+    kwargs.insert("line_style", QString(":"));
+    break;
   default:
     // Dash
     kwargs.insert("line_style", QString("--"));

--- a/qt/widgets/plotting/src/SingleSelector.cpp
+++ b/qt/widgets/plotting/src/SingleSelector.cpp
@@ -11,9 +11,19 @@ using namespace MantidQt::Widgets::MplCpp;
 
 namespace {
 
-QHash<QString, QVariant> defaultLineKwargs() {
+using MantidQt::MantidWidgets::PlotLineStyle;
+QHash<QString, QVariant> defaultLineKwargs(PlotLineStyle style) {
   QHash<QString, QVariant> kwargs;
-  kwargs.insert("line_style", QString("--"));
+  switch (style) {
+  case PlotLineStyle::Solid:
+    kwargs.insert("line_style", QString("-"));
+    break;
+  default:
+    // Dash
+    kwargs.insert("line_style", QString("--"));
+    break;
+  }
+
   return kwargs;
 }
 
@@ -21,11 +31,12 @@ QHash<QString, QVariant> defaultLineKwargs() {
 
 namespace MantidQt::MantidWidgets {
 
-SingleSelector::SingleSelector(PreviewPlot *plot, SelectType type, double position, bool visible, const QColor &colour)
+SingleSelector::SingleSelector(PreviewPlot *plot, SelectType type, double position, PlotLineStyle style, bool visible,
+                               const QColor &colour)
     : QObject(), m_plot(plot),
       m_singleMarker(std::make_unique<SingleMarker>(m_plot->canvas(), colour.name(QColor::HexRgb), position,
                                                     std::get<0>(getAxisRange(type)), std::get<1>(getAxisRange(type)),
-                                                    selectTypeAsQString(type), defaultLineKwargs())),
+                                                    selectTypeAsQString(type), defaultLineKwargs(style))),
       m_type(type), m_visible(visible), m_markerMoving(false) {
 
   m_plot->canvas()->draw();
@@ -132,6 +143,12 @@ void SingleSelector::handleMouseUp(const QPoint &point) {
 void SingleSelector::redrawMarker() {
   if (m_visible)
     m_singleMarker->redraw();
+}
+
+void SingleSelector::disconnectMouseSignals() {
+  disconnect(m_plot, SIGNAL(mouseDown(QPoint)), this, SLOT(handleMouseDown(QPoint)));
+  disconnect(m_plot, SIGNAL(mouseMove(QPoint)), this, SLOT(handleMouseMove(QPoint)));
+  disconnect(m_plot, SIGNAL(mouseUp(QPoint)), this, SLOT(handleMouseUp(QPoint)));
 }
 
 } // namespace MantidQt::MantidWidgets


### PR DESCRIPTION
### Description of work
This PR  fixes some of the issues reported on #33338, in which there is a set of errors from the algorithm, but the user does not have a warning message of incorrect selected values from the GUI. Furthermore, the algorithm warning is not descriptive enough regarding the error that is produced (Incorrect range). 

While I have fixed the above problems on the GUI on this PR; There are several parts of  the symmetrise tab that could be changed to improve the user experience when attempting to invoke the algorithm from the GUI. The changes done on this GUI are summarised in the following list: 

1. The main cause of concern for non-reproducible warnings was the non-initialization of a boolean flag in the model (`m_isPositiveReflect`) that handles the symmetrise boundaries when the algorithm is called, causing undefined behaviour. This could cause the algorithm to fail seemingly randomly, as the behaviour of the algorithm depends on correct setting of the boundaries, without the user really knowing what's going on.
2. I have removed two horizontal marker lines in the embedded plot. These lines don't have any role on the algorithm parameters and could cause confusion to users (it confused me...).
3. There is a vertical line marker to indicate the centre position (E=0). This line can be moved, but it also doesn't influence the algorithm. It's a fixed marker line. The way marker lines are constructed on the mantid plot widget for C++ does not allow to change the line-style or handling of mouse events. To this end; I have added the option to include a selection of a different initial line style (dash or solid, but more could be added) from the initialization of the marker. Additionally, there is a new function in the marker class to disconnect mouse signals, so that they don't interact with mouse events, and behave simply as fixed markers. 
4. Added some handling of data validation (you can't input anymore E range values outside of the active spectra range). 
5. Up until now, whenever you change the `ReflectType` property from positive to negative, the marker lines remain on the positive side of the spectra, while only their range is changed to reflect the maximum allowed values on the negative side. But it is still possible to move markers out of range and confusing to use. I believe this is done because the symmetrise algorithm doesn't allow for negative input values, so if using negative ranges, one has to make sure they are input as absolute values. Changing this requires slightly more care when passing data from the view to the model, but I have changed the way data is sent to the model to be able to pass the markers to the negative side of the spectra when the `ReflectType` choice is set in either side (negative or positive) 
6. Error signals were not connected to the interface. Therefore showing error messages was not possible from the GUI.
7. Finally, there is a new validation step when previewing the algorithm, hinting users as to what's wrong with their selection, if they still select an invalid range.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #33338 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

1. Open `Data Manipulation->Symmetrise` tab interface. 
2. On File Selector, browse for an asymmetric spectra: `'UsageData/osiris97944_graphite002_red.nxs'`
3.  Make sure `ReflectType` property is` Positive to Negative`.
4. First spectra should open and plot. You should see a vertical solid red marker line in E=0 that can't be moved. And two vertical dash marker lines that can be moved, but not outside positive spectra range. 
5. In `Elow`, `Ehigh` property fields, try inputting wrong values: You shouldn't be able to input any value outside of positve range (`0-2.15`). You shouldn't be able to put `Elow` higher than `Ehigh` and viceversa.
6.  Click on preview button to show a preview of the algorithm. 
7.  Choose `Ehigh` to be `2.0` and `Elow` to be `1.0` and click preview. An error message should appear, asking to reduce `Elow` to maximum allowed value for that spectra (`0.93`).
8. Change `ReflectType` to `Negative to Positive`.  Marker lines should go to negative side, validation and behaviour of selection should work fine.


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
