### PR TITLE
hb2c group reduction update

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
@@ -147,7 +147,11 @@ class LoadWAND(DataProcessorAlgorithm):
             if len(runs) == 1:
                 RenameWorkspace("__tmp_load", outWS, EnableLogging=False)
             else:
-                temp_val = mtd["__tmp_load"].run().getTimeAveragedValue("HB2C:SE:SampleTemp")
+                try:
+                    temp_val = mtd["__tmp_load"].run().getTimeAveragedValue("HB2C:SE:SampleTemp")
+                except RuntimeError as _:
+                    temp_val = 300.0
+
                 if temp_val == 0.0:
                     temp_val = 300.0
                 temp_val = "{:.1F}".format(temp_val).replace(".", "p")

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
@@ -152,7 +152,7 @@ class LoadWAND(DataProcessorAlgorithm):
                 except RuntimeError:
                     temp_val = 300.0
 
-                if temp_val == 0.0:
+                if temp_val == 0.0 or np.isnan(temp_val):
                     temp_val = 300.0
                 temp_val = "{:.1F}".format(temp_val).replace(".", "p")
                 outName = outWS + "_" + str(mtd["__tmp_load"].getRunNumber()) + f"_T{temp_val}K"

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
@@ -147,7 +147,11 @@ class LoadWAND(DataProcessorAlgorithm):
             if len(runs) == 1:
                 RenameWorkspace("__tmp_load", outWS, EnableLogging=False)
             else:
-                outName = outWS + "_" + str(mtd["__tmp_load"].getRunNumber())
+                temp_val = mtd["__tmp_load"].run().getTimeAveragedValue("HB2C:SE:SampleTemp")
+                if temp_val == 0.0:
+                    temp_val = 300.0
+                temp_val = "{:.1F}".format(temp_val).replace(".", "p")
+                outName = outWS + "_" + str(mtd["__tmp_load"].getRunNumber()) + f"_T{temp_val}K"
                 group_names.append(outName)
                 RenameWorkspace("__tmp_load", outName, EnableLogging=False)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
@@ -149,7 +149,7 @@ class LoadWAND(DataProcessorAlgorithm):
             else:
                 try:
                     temp_val = mtd["__tmp_load"].run().getTimeAveragedValue("HB2C:SE:SampleTemp")
-                except RuntimeError as _:
+                except RuntimeError:
                     temp_val = 300.0
 
                 if temp_val == 0.0:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
@@ -427,7 +427,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
         for n, in_wksp in enumerate(input_workspaces):
             try:
                 temp_val = mtd[in_wksp].run().getTimeAveragedValue("HB2C:SE:SampleTemp")
-            except RuntimeError as _:
+            except RuntimeError:
                 temp_val = 300.0
 
             if temp_val == 0.0:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
@@ -423,7 +423,14 @@ class WANDPowderReduction(DataProcessorAlgorithm):
         # such that all data can be binned exactly the same way.
 
         # BEGIN_FOR: located_global_xMin&xMax
-        output_workspaces = [f"{outname}{n+1}" for n in range(len(input_workspaces))]
+        output_workspaces = list()
+        for n, in_wksp in enumerate(input_workspaces):
+            temp_val = mtd[in_wksp].run().getTimeAveragedValue("HB2C:SE:SampleTemp")
+            if temp_val == 0.0:
+                temp_val = 300.0
+            temp_val = "{:.1F}".format(temp_val).replace(".", "p")
+            out_tmp = f"{outname}{n+1}_T{temp_val}K"
+            output_workspaces.append(out_tmp)
         mask_workspaces = []
         for n, (_wksp_in, _wksp_out) in enumerate(zip(input_workspaces, output_workspaces)):
             _wksp_in = str(_wksp_in)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
@@ -425,7 +425,11 @@ class WANDPowderReduction(DataProcessorAlgorithm):
         # BEGIN_FOR: located_global_xMin&xMax
         output_workspaces = list()
         for n, in_wksp in enumerate(input_workspaces):
-            temp_val = mtd[in_wksp].run().getTimeAveragedValue("HB2C:SE:SampleTemp")
+            try:
+                temp_val = mtd[in_wksp].run().getTimeAveragedValue("HB2C:SE:SampleTemp")
+            except RuntimeError as _:
+                temp_val = 300.0
+
             if temp_val == 0.0:
                 temp_val = 300.0
             temp_val = "{:.1F}".format(temp_val).replace(".", "p")

--- a/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36485.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36485.rst
@@ -1,0 +1,1 @@
+- Add temperature from sample log to the workspace title when using the :ref:`LoadWAND <algm-LoadWAND>` or :ref:`WANDPowderReduction <algm-WANDPowderReduction>` algorithm to process a group of datasets for HB2C (a.k.a. WAND^2) at HFIR.


### PR DESCRIPTION
### Description of work

#### Summary of work

Small update in the reduction routine for HB2C (WAND^2) concerning the reduction of multiple datasets. The temperature value from the sample log will be included in the workspace title when using either `LoadWAND` or `WANDPowderReduction ` algorithm. This feature was requested by the HB2C team and it will benefit users in terms of better recognizing the reduced workspace title and its correspondence with the real-life variables (e.g., temperature).

### To test:

Just follow the test in the doc page for each algorithm to test it out.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
