### PR TITLE
Add background estimation to PEARLTransfit and option to manually specify them

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
@@ -220,9 +220,11 @@ class PEARLTransfit(PythonAlgorithm):
             wsBgGuess = mtd[fileName_monitor]
             if estimate_backround:
                 bg1guess, bg0guess = estimate_linear_background_and_peak_position(wsBgGuess.readX(0), wsBgGuess.readY(0))
+                bg2guess = 0.0
             else:
-                bg0guess = 0.86 * wsBgGuess.readY(0)[0]
-                bg1guess = 0.0063252
+                bg0guess = 0.84 * wsBgGuess.readY(0)[0]
+                bg1guess = 0.0173252
+                bg2guess = 0.0000004
             # New Voigt function as from Igor pro function
             Fit(
                 Function="name=PEARLTransVoigt,Position="
@@ -235,7 +237,9 @@ class PEARLTransfit(PythonAlgorithm):
                 + str(bg0guess)
                 + ",Bg1="
                 + str(bg1guess)
-                + ",Bg2=0,constraints=(1<LorentzianFWHM,"
+                + ",Bg2="
+                + str(bg2guess)
+                + ",constraints=(1<LorentzianFWHM,"
                 + str(width_300)
                 + "<GaussianFWHM)",
                 InputWorkspace=fileName_monitor,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
@@ -17,6 +17,16 @@ class PEARLTransfitTest(unittest.TestCase):
         PEARLTransfit(Files="PEARL00112777", Calibration=True)
         self.assertIn("S_fit_Parameters", mtd)
         self.assertIn("S_fit_Workspace", mtd)
+        # assert fit converged by checking cost function value at minimum
+        self.assertAlmostEqual(mtd["S_fit_Parameters"].column("Value")[-1], 0.16, delta=0.01)
+
+    def test_calibration_run_single_run_backgorund_params_provided(self):
+        # Provide very bad background params and show fit doesn't converge (would do if parameters estimated)
+        PEARLTransfit(Files="PEARL00112777", Calibration=True, EstimateBackground=False, Bg0guessFraction=0.0, Bg1guess=-1.0, Bg2guess=1.0)
+        self.assertIn("S_fit_Parameters", mtd)
+        self.assertIn("S_fit_Workspace", mtd)
+        # assert fit not converged by checking cost function value at minimum
+        self.assertGreater(mtd["S_fit_Parameters"].column("Value")[-1], 1)
 
     def test_calibration_run_multi_run(self):
         # Test that the calibration run produces the correct workspaces for multiple runs

--- a/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36497.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36497.rst
@@ -1,0 +1,1 @@
+- Add new options to estimate background parameters or manually set them in :ref:`PEARLTransfit <algm-PEARLTransfit>`


### PR DESCRIPTION
### Description of work

Add background estimation to `PEARLTransfit` and option to manually specify them. 
Previous default values are no longer suited to the instrument after changes were made to the PEARL monitors.

![image](https://github.com/mantidproject/mantid/assets/55979119/2542d5d9-79f4-44a6-986b-aab8ca87e767)
Note this data is with the old monitor configuration

The simple background estimation works by calculating the gradient and slope given the average x and y values of the front and back 3 points - if there are less than 6 points in the data it returns 0s - but this isn't expected given the user is trying to fit a function with 7 parameters! 

![image](https://github.com/mantidproject/mantid/assets/55979119/310903e1-99da-4955-b3d2-7fe21bfc4a4f)

Fixes #36492 


**Report to:** Chris Ridley (PEARL)

### To test:

(1) Open the `PEARLTransfit` algorithm GUI
(2) Set Files to `PEARL00112777`
(3) Check `Calibration=True`
(4) Run with `EstimateBackground = True` and `False` - for both cases the fit should converge (see `S_fit_Workspace`)
![image](https://github.com/mantidproject/mantid/assets/55979119/92ea4f34-9538-4cab-8042-24f54735e2e9)



<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
