### PR TITLE
Mandatory email address for error reports

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/New_features/36482.rst
+++ b/docs/source/release/v6.9.0/Workbench/New_features/36482.rst
@@ -1,0 +1,1 @@
+- An email is now required to submit an error report.

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/errorreport.ui
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/errorreport.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>925</width>
-    <height>759</height>
+    <width>1000</width>
+    <height>850</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -394,7 +394,7 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The majority of error reports without an email address are not actionable by us since we can't follow up to ask for further details. We also can't contact the user to tell them that the issue has been fixed in later versions. Currently, we are working on overhauling the error reporting system so progress on fixes is more visible to the user as well as improving our own storage and analysis of error reports. When this is done, submitting an error report without an email will be an option again.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Error reports without an email address are not actionable as we cannot ask for further details to resolve the issue. We are also unable to contact the user to inform them that the issue has been fixed in later versions. If you have any queries or concerns about this please contact us at mantid-help@mantidproject.org.&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;As per our new data policy, emails and names will be deleted from our records 1 year after submission. You can also request to have your data removed at any time.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/errorreport.ui
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/errorreport.ui
@@ -297,19 +297,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="nonIDShareButton">
-       <property name="focusPolicy">
-        <enum>Qt::ClickFocus</enum>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Information about your system architecture and mantid version are shared as well as a hashed user ID. For a full list see the privacy policy linked above.&lt;/p&gt;&lt;p&gt;The additional info box entered above is also shared, but the name and email are not.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Share non-identifiable information</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QPushButton" name="noShareButton">
        <property name="focusPolicy">
         <enum>Qt::ClickFocus</enum>

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/errorreport.ui
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/errorreport.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>773</width>
-    <height>644</height>
+    <width>925</width>
+    <height>759</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,136 +20,12 @@
    <string>Error Report</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="1" column="0" colspan="2">
-    <widget class="QTextBrowser" name="requestTextBrowser">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="focusPolicy">
-      <enum>Qt::ClickFocus</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <property name="verticalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
-     </property>
-     <property name="html">
-      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.SF NS Text'; font-size:12pt; color:#000000;&quot;&gt;We are really sorry that Mantid is not behaving as it should and are aware how frustrating this is. We'd be very grateful if you could provide us with some details about your problems. The more information you can give, the quicker we can fix this issue.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-     <property name="openLinks">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QTextEdit" name="input_free_text">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>400</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="autoFillBackground">
-      <bool>false</bool>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="fullShareButton">
-       <property name="focusPolicy">
-        <enum>Qt::ClickFocus</enum>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Information about your system architecture and mantid version are shared as well as a hashed user ID. For a full list see the privacy policy linked above.&lt;/p&gt;&lt;p&gt;The name, email and additional info entered in the boxes above are also shared.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Yes, share information</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="nonIDShareButton">
-       <property name="focusPolicy">
-        <enum>Qt::ClickFocus</enum>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Information about your system architecture and mantid version are shared as well as a hashed user ID. For a full list see the privacy policy linked above.&lt;/p&gt;&lt;p&gt;The additional info box entered above is also shared, but the name and email are not.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Share non-identifiable information</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="noShareButton">
-       <property name="focusPolicy">
-        <enum>Qt::ClickFocus</enum>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No error report is sent.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Don't share any information</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="moreDetailsButton">
-       <property name="focusPolicy">
-        <enum>Qt::ClickFocus</enum>
-       </property>
-       <property name="text">
-        <string>Show more details</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="5" column="0" colspan="2">
     <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="input_email_line_edit">
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="input_name_line_edit">
        <property name="maxLength">
         <number>128</number>
-       </property>
-       <property name="frame">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Name (optional)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Email (optional)</string>
        </property>
       </widget>
      </item>
@@ -181,29 +57,6 @@ p, li { white-space: pre-wrap; }
        </property>
       </widget>
      </item>
-     <item row="2" column="0" colspan="3">
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="input_name_line_edit">
-       <property name="maxLength">
-        <number>128</number>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="2">
       <widget class="QCheckBox" name="rememberContactInfoCheckbox">
        <property name="focusPolicy">
@@ -217,35 +70,83 @@ p, li { white-space: pre-wrap; }
        </property>
       </widget>
      </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="input_email_line_edit">
+       <property name="maxLength">
+        <number>128</number>
+       </property>
+       <property name="frame">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="text">
+        <string>Email</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Name (optional)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
-   <item row="3" column="1">
-    <widget class="QLabel" name="icon">
-     <property name="enabled">
-      <bool>true</bool>
+   <item row="6" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="leftMargin">
+      <number>0</number>
      </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+     <property name="topMargin">
+      <number>0</number>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>75</width>
-       <height>161</height>
-      </size>
+     <property name="rightMargin">
+      <number>0</number>
      </property>
-     <property name="text">
-      <string/>
+     <property name="bottomMargin">
+      <number>0</number>
      </property>
-     <property name="pixmap">
-      <pixmap>../../../../mantid-xcode/mantid/images/crying_mantid.png</pixmap>
-     </property>
-     <property name="scaledContents">
-      <bool>true</bool>
-     </property>
-    </widget>
+     <item>
+      <widget class="QLabel" name="email_notice_text">
+       <property name="text">
+        <string>Notice: An email adress is currently required to submit an error report.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="email_notice_button">
+       <property name="text">
+        <string>Read More</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item row="0" column="0" colspan="2">
     <widget class="QFrame" name="continue_terminate_frame">
@@ -348,10 +249,167 @@ p, li { white-space: pre-wrap; }
      </layout>
     </widget>
    </item>
+   <item row="3" column="0">
+    <widget class="QTextEdit" name="input_free_text">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>400</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="placeholderText">
+      <string/>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="free_text_length_label">
      <property name="text">
       <string>Place Holder Text</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="fullShareButton">
+       <property name="focusPolicy">
+        <enum>Qt::ClickFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Information about your system architecture and mantid version are shared as well as a hashed user ID. For a full list see the privacy policy linked above.&lt;/p&gt;&lt;p&gt;The name, email and additional info entered in the boxes above are also shared.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Yes, share information</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="nonIDShareButton">
+       <property name="focusPolicy">
+        <enum>Qt::ClickFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Information about your system architecture and mantid version are shared as well as a hashed user ID. For a full list see the privacy policy linked above.&lt;/p&gt;&lt;p&gt;The additional info box entered above is also shared, but the name and email are not.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Share non-identifiable information</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="noShareButton">
+       <property name="focusPolicy">
+        <enum>Qt::ClickFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No error report is sent.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Don't share any information</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="moreDetailsButton">
+       <property name="focusPolicy">
+        <enum>Qt::ClickFocus</enum>
+       </property>
+       <property name="text">
+        <string>Show more details</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="icon">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>75</width>
+       <height>161</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="pixmap">
+      <pixmap>../../../../mantid-xcode/mantid/images/crying_mantid.png</pixmap>
+     </property>
+     <property name="scaledContents">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QTextBrowser" name="requestTextBrowser">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="focusPolicy">
+      <enum>Qt::ClickFocus</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="html">
+      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.SF NS Text'; font-size:12pt; color:#000000;&quot;&gt;We are really sorry that Mantid is not behaving as it should and are aware how frustrating this is. We'd be very grateful if you could provide us with some details about your problems. The more information you can give, the quicker we can fix this issue.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+     <property name="openLinks">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QTextBrowser" name="email_notice_expanded_text">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="html">
+      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The majority of error reports without an email address are not actionable by us since we can't follow up to ask for further details. We also can't contact the user to tell them that the issue has been fixed in later versions. Currently, we are working on overhauling the error reporting system so progress on fixes is more visible to the user as well as improving our own storage and analysis of error reports. When this is done, submitting an error report without an email will be an option again.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;As per our new data policy, emails and names will be deleted from our records 1 year after submission. You can also request to have your data removed at any time.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/presenter.py
@@ -56,15 +56,6 @@ class ErrorReporterPresenter(object):
             self.forget_contact_info()
         return -1
 
-    def share_non_identifiable_information(self, continue_working, text_box):
-        uptime = UsageService.getUpTime()
-        status = self._send_report_to_server(share_identifiable=False, uptime=uptime, text_box=text_box)
-        self.error_log.notice("Sent non-identifiable information")
-        self._handle_exit(continue_working)
-        if not self._view.rememberContactInfoCheckbox.checkState():
-            self.forget_contact_info()
-        return status
-
     def share_all_information(self, continue_working, new_name, new_email, text_box):
         uptime = UsageService.getUpTime()
         status = self._send_report_to_server(share_identifiable=True, uptime=uptime, name=new_name, email=new_email, text_box=text_box)
@@ -83,16 +74,10 @@ class ErrorReporterPresenter(object):
         return status
 
     def error_handler(self, continue_working, share, name, email, text_box):
-        if share == 0:
+        if share:
             status = self.share_all_information(continue_working, name, email, text_box)
-        elif share == 1:
-            status = self.share_non_identifiable_information(continue_working, text_box)
-        elif share == 2:
-            status = self.do_not_share(continue_working)
         else:
-            self.error_log.error("Unrecognised signal in errorreporter exiting")
-            self._handle_exit(continue_working)
-            status = -2
+            status = self.do_not_share(continue_working)
 
         self._view.close_reporter(status)
 

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -4,6 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+import re
 
 from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import Signal, QSettings
@@ -74,6 +75,7 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
             self.requestTextBrowser.insertHtml(msg)
 
         self.input_name_line_edit.textChanged.connect(self.set_button_status)
+        self.input_email_line_edit.textChanged.connect(self.toggle_valid_email)
         self.input_email_line_edit.textChanged.connect(self.set_button_status)
         self.input_free_text.textChanged.connect(self.set_plain_text_edit_field)
         self.input_free_text.textChanged.connect(self.set_plain_text_length_lable)
@@ -81,6 +83,16 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
 
         self.email_notice_expanded_text.hide()
         self.email_notice_button.clicked.connect(self.expand_or_hide_email_notice_text)
+
+        # https://stackabuse.com/python-validate-email-address-with-regular-expressions-regex/
+        self.email_regex = re.compile(
+            r"([-!#-'*+/-9=?A-Z^-~]+(\.[-!#-'*+/-9=?A-Z^-~]+)*|\"([]!#-[^-~ \t]|(\\[\t -~]))+\")@"
+            r"([-!#-'*+/-9=?A-Z^-~]+(\.[-!#-'*+/-9=?A-Z^-~]+)*|\[[\t -Z^-~]*])"
+        )
+        self.valid_email = False
+
+        # setting the border colour in self.toggle_valid_email was making the height slightly less for some reason
+        self.input_email_line_edit.setFixedHeight(self.input_email_line_edit.sizeHint().height())
 
         self.privacy_policy_label.linkActivated.connect(self.launch_privacy_policy)
 
@@ -111,6 +123,7 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
             self.input_email_line_edit.setText(self.saved_email)
             self.rememberContactInfoCheckbox.setChecked(True)
 
+        self.toggle_valid_email()
         self.set_button_status()
 
     def quit(self):
@@ -156,9 +169,15 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
     def launch_privacy_policy(self, link):
         self.interface_manager.showWebPage(link)
 
+    def toggle_valid_email(self):
+        self.valid_email = re.fullmatch(self.email_regex, self.input_email)
+        if not self.valid_email:
+            self.input_email_line_edit.setStyleSheet("border: 1px solid red")
+        else:
+            self.input_email_line_edit.setStyleSheet("border: 1px solid gray")
+
     def set_button_status(self):
-        # Requiring email address to submit error report
-        if not self.input_email or len(self.input_text) > PLAIN_TEXT_MAX_LENGTH:
+        if not self.valid_email or len(self.input_text) > PLAIN_TEXT_MAX_LENGTH:
             self.fullShareButton.setEnabled(False)
         else:
             self.fullShareButton.setEnabled(True)

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -84,11 +84,8 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         self.email_notice_expanded_text.hide()
         self.email_notice_button.clicked.connect(self.expand_or_hide_email_notice_text)
 
-        # https://stackabuse.com/python-validate-email-address-with-regular-expressions-regex/
-        self.email_regex = re.compile(
-            r"([-!#-'*+/-9=?A-Z^-~]+(\.[-!#-'*+/-9=?A-Z^-~]+)*|\"([]!#-[^-~ \t]|(\\[\t -~]))+\")@"
-            r"([-!#-'*+/-9=?A-Z^-~]+(\.[-!#-'*+/-9=?A-Z^-~]+)*|\[[\t -Z^-~]*])"
-        )
+        # https://emailregex.com/
+        self.email_regex = re.compile(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)")
         self.valid_email = False
 
         # setting the border colour in self.toggle_valid_email was making the height slightly less for some reason

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -170,6 +170,11 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         else:
             self.fullShareButton.setEnabled(True)
 
+        # Requiring email address to submit error report
+        if not self.input_email:
+            self.fullShareButton.setEnabled(False)
+            self.nonIDShareButton.setEnabled(False)
+
     def display_message_box(self, title, message, details):
         msg = QMessageBox(self)
         msg.setIcon(QMessageBox.Warning)

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -89,7 +89,6 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
 
         #  These are the options along the bottom
         self.fullShareButton.clicked.connect(self.fullShare)
-        self.nonIDShareButton.clicked.connect(self.nonIDShare)
         self.noShareButton.clicked.connect(self.noShare)
 
         self.setWindowFlags(QtCore.Qt.CustomizeWindowHint | QtCore.Qt.WindowTitleHint | QtCore.Qt.WindowStaysOnTopHint)
@@ -118,13 +117,10 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         self.quit_signal.emit()
 
     def fullShare(self):
-        self.action.emit(self.continue_working, 0, self.input_name, self.input_email, self.input_text)
-
-    def nonIDShare(self):
-        self.action.emit(self.continue_working, 1, self.input_name, self.input_email, self.input_text)
+        self.action.emit(self.continue_working, True, self.input_name, self.input_email, self.input_text)
 
     def noShare(self):
-        self.action.emit(self.continue_working, 2, self.input_name, self.input_email, self.input_text)
+        self.action.emit(self.continue_working, False, self.input_name, self.input_email, self.input_text)
 
     def close_reporter(self, status):
         if status == 201 or status == -1:
@@ -161,23 +157,11 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         self.interface_manager.showWebPage(link)
 
     def set_button_status(self):
-        if not self.input_name and not self.input_email:
-            self.nonIDShareButton.setEnabled(True)
-        elif self.input_name == self.saved_name and self.input_email == self.saved_email:
-            self.nonIDShareButton.setEnabled(True)
-        else:
-            self.nonIDShareButton.setEnabled(False)
-
-        if len(self.input_text) > PLAIN_TEXT_MAX_LENGTH:
+        # Requiring email address to submit error report
+        if not self.input_email or len(self.input_text) > PLAIN_TEXT_MAX_LENGTH:
             self.fullShareButton.setEnabled(False)
-            self.nonIDShareButton.setEnabled(False)
         else:
             self.fullShareButton.setEnabled(True)
-
-        # Requiring email address to submit error report
-        if not self.input_email:
-            self.fullShareButton.setEnabled(False)
-            self.nonIDShareButton.setEnabled(False)
 
     def display_message_box(self, title, message, details):
         msg = QMessageBox(self)

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -79,6 +79,9 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         self.input_free_text.textChanged.connect(self.set_plain_text_length_lable)
         self.input_free_text.textChanged.connect(self.set_button_status)
 
+        self.email_notice_expanded_text.hide()
+        self.email_notice_button.clicked.connect(self.expand_or_hide_email_notice_text)
+
         self.privacy_policy_label.linkActivated.connect(self.launch_privacy_policy)
 
         #  The options on what to do after closing the window (exit/continue)
@@ -107,8 +110,9 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         if self.saved_name or self.saved_email:
             self.input_name_line_edit.setText(self.saved_name)
             self.input_email_line_edit.setText(self.saved_email)
-            self.nonIDShareButton.setEnabled(True)
             self.rememberContactInfoCheckbox.setChecked(True)
+
+        self.set_button_status()
 
     def quit(self):
         self.quit_signal.emit()
@@ -193,6 +197,14 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
 
     def set_report_callback(self, callback):
         self.action.connect(callback)
+
+    def expand_or_hide_email_notice_text(self):
+        if self.email_notice_expanded_text.isVisible():
+            self.email_notice_expanded_text.hide()
+            self.email_notice_button.setText("Read More")
+        else:
+            self.email_notice_expanded_text.show()
+            self.email_notice_button.setText("Read Less")
 
     @property
     def input_name(self):

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_presenter.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/test/test_errorreport_presenter.py
@@ -85,7 +85,7 @@ class ErrorReportPresenterTest(unittest.TestCase):
         email = "john.smith@example.com"
         text_box = "Details about error"
         continue_working = False
-        share = 0
+        share = True
         self.error_report_presenter._send_report_to_server = mock.MagicMock(return_value=201)
         self.error_report_presenter._handle_exit = mock.MagicMock()
 
@@ -96,26 +96,12 @@ class ErrorReportPresenterTest(unittest.TestCase):
         )
         self.error_report_presenter._handle_exit.assert_called_once_with(False)
 
-    def test_error_handler_share_non_id_sunny_day_case(self):
-        name = "John Smith"
-        email = "john.smith@example.com"
-        text_box = "Details about error"
-        continue_working = True
-        share = 1
-        self.error_report_presenter._send_report_to_server = mock.MagicMock()
-        self.error_report_presenter._handle_exit = mock.MagicMock()
-
-        self.error_report_presenter.error_handler(continue_working, share, name, email, text_box)
-
-        self.error_report_presenter._send_report_to_server.called_once_with(share_identifiable=False, uptime=mock.ANY)
-        self.error_report_presenter._handle_exit.assert_called_once_with(True)
-
     def test_error_handler_share_nothing_sunny_day_case(self):
         name = "John Smith"
         email = "john.smith@example.com"
         text_box = "Details about error"
         continue_working = True
-        share = 2
+        share = False
         self.error_report_presenter._send_report_to_server = mock.MagicMock()
         self.error_report_presenter._handle_exit = mock.MagicMock()
 


### PR DESCRIPTION
### Description of work

The decision was made by @sf1919 and others that, as a temporary measure, an email address should be required to submit an error report.
Since it no longer serves a purpose, the no-id share button has been removed.

#### Summary of work

Valid email (validated with regex) is required to enable the share button. If the text is not a valid email, the box outline will be red.

A notice has been added about why we've made this change,
```
Error reports without an email address are not actionable as we cannot ask for further details to resolve the issue. We are also unable to contact the user to inform them that the issue has been fixed in later versions. If you have any queries or concerns about this please contact us at mantid-help@mantidproject.org.

As per our new data policy, emails and names will be deleted from our records 1 year after submission. You can also request to have your data removed at any time.
```

https://github.com/mantidproject/www/pull/30 must be merged first, since it contains the privacy policy changes.

Fixes #36482

### To test:

- Check the validation on the email box is working as you'd expect
  - When the email is valid, the box has a grey border and the button is enabled
  - When it is invalid, the box has a red border and the button is disabled
- Check the message to the users makes sense
- Code review

I think there will be a more expansive section in the release notes about this, but if you feel the release note in this PR should explain more, then let me know.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
