### PR TITLE
Moments presenter is no longer QObject and View is passed to constructor.

### DIFF
--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -144,6 +144,7 @@ set(INC_FILES
     Manipulation/InelasticDataManipulationSqwTabModel.h
     Manipulation/InelasticDataManipulationSymmetriseTabModel.h
     Manipulation/ISqwView.h
+    Manipulation/IMomentsView.h
 )
 
 set(UI_FILES

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IMomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IMomentsView.h
@@ -1,0 +1,51 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllConfig.h"
+
+#include <QStringList>
+#include <memory>
+#include <string>
+#include <tuple>
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class IndirectPlotOptionsView;
+class IMomentsPresenter;
+
+class MANTIDQT_INELASTIC_DLL IMomentsView {
+
+public:
+  virtual void subscribePresenter(IMomentsPresenter *presenter) = 0;
+
+  virtual void setupProperties() = 0;
+  virtual IndirectPlotOptionsView *getPlotOptions() const = 0;
+  virtual std::string getDataName() const = 0;
+
+  virtual bool validate() = 0;
+  virtual void showMessageBox(std::string const &message) const = 0;
+
+  virtual void setFBSuffixes(QStringList const &suffix) = 0;
+  virtual void setWSSuffixes(QStringList const &suffix) = 0;
+
+  /// Function to set the range limits of the plot
+  virtual void setPlotPropertyRange(const QPair<double, double> &bounds) = 0;
+  /// Function to set the range selector on the mini plot
+  virtual void setRangeSelector(const QPair<double, double> &bounds) = 0;
+  /// Sets the min of the range selector if it is less than the max
+  virtual void setRangeSelectorMin(double newValue) = 0;
+  /// Sets the max of the range selector if it is more than the min
+  virtual void setRangeSelectorMax(double newValue) = 0;
+
+  virtual void plotNewData(std::string const &filename) = 0;
+  virtual void replot() = 0;
+  virtual void plotOutput(QString outputWorkspace) = 0;
+};
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IMomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IMomentsView.h
@@ -45,7 +45,7 @@ public:
 
   virtual void plotNewData(std::string const &filename) = 0;
   virtual void replot() = 0;
-  virtual void plotOutput(QString outputWorkspace) = 0;
+  virtual void plotOutput(std::string const &outputWorkspace) = 0;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.cpp
@@ -61,7 +61,7 @@ void InelasticDataManipulation::initLayout() {
   // Create the tabs
   addTab<InelasticDataManipulationSymmetriseTab>("Symmetrise");
   addMVPTab<InelasticDataManipulationSqwTab, InelasticDataManipulationSqwTabView>("S(Q, w)");
-  addTab<InelasticDataManipulationMomentsTab>("Moments");
+  addMVPTab<InelasticDataManipulationMomentsTab, InelasticDataManipulationMomentsTabView>("Moments");
   addTab<InelasticDataManipulationElwinTab>("Elwin");
   addTab<InelasticDataManipulationIqtTab>("Iqt");
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTab.cpp
@@ -103,7 +103,7 @@ void InelasticDataManipulationMomentsTab::runComplete(bool error) {
 
   setOutputPlotOptionsWorkspaces({m_model->getOutputWorkspace()});
 
-  m_view->plotOutput(QString::fromStdString(m_model->getOutputWorkspace()));
+  m_view->plotOutput(m_model->getOutputWorkspace());
   m_view->getPlotOptions()->setIndicesLineEditEnabled(true);
 }
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTab.cpp
@@ -78,7 +78,7 @@ void InelasticDataManipulationMomentsTab::plotNewData(std::string const &filenam
  * @param propName :: The property being updated
  * @param val :: The new value for the property
  */
-void InelasticDataManipulationMomentsTab::handleValueChanged(std::string &propName, double value) {
+void InelasticDataManipulationMomentsTab::handleValueChanged(std::string const &propName, double value) {
   if (propName == "EMin") {
     m_model->setEMin(value);
   } else if (propName == "EMax") {

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTab.cpp
@@ -104,6 +104,7 @@ void InelasticDataManipulationMomentsTab::runComplete(bool error) {
   setOutputPlotOptionsWorkspaces({m_model->getOutputWorkspace()});
 
   m_view->plotOutput(QString::fromStdString(m_model->getOutputWorkspace()));
+  m_view->getPlotOptions()->setIndicesLineEditEnabled(true);
 }
 
 void InelasticDataManipulationMomentsTab::setFileExtensionsByName(bool filter) {

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTab.h
@@ -25,7 +25,7 @@ public:
 
   virtual void handleScaleChanged(bool state) = 0;
   virtual void handleScaleValueChanged(double const value) = 0;
-  virtual void handleValueChanged(std::string &propName, double value) = 0;
+  virtual void handleValueChanged(std::string const &propName, double value) = 0;
 
   virtual void handleRunClicked() = 0;
   virtual void handleSaveClicked() = 0;
@@ -52,13 +52,13 @@ public:
 
   void handleScaleChanged(bool state) override;
   void handleScaleValueChanged(double const value) override;
-  void handleValueChanged(std::string &propName, double value) override;
+  void handleValueChanged(std::string const &propName, double value) override;
 
   void handleRunClicked() override;
   void handleSaveClicked() override;
 
 protected:
-  void runComplete(bool error);
+  void runComplete(bool error) override;
 
 private:
   void plotNewData(std::string const &filename);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTab.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "IMomentsView.h"
 #include "InelasticDataManipulationMomentsTabModel.h"
 #include "InelasticDataManipulationMomentsTabView.h"
 #include "InelasticDataManipulationTab.h"
@@ -17,6 +18,18 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+
+class IMomentsPresenter {
+public:
+  virtual void handleDataReady(std::string const &dataName) = 0;
+
+  virtual void handleScaleChanged(bool state) = 0;
+  virtual void handleScaleValueChanged(double const value) = 0;
+  virtual void handleValueChanged(std::string &propName, double value) = 0;
+
+  virtual void handleRunClicked() = 0;
+  virtual void handleSaveClicked() = 0;
+};
 /** InelasticDataManipulationMomentsTab : Calculates the S(Q,w) Moments of the provided data with
   the user specified range and scale factor
 
@@ -24,36 +37,34 @@ namespace CustomInterfaces {
   @author Samuel Jackson
   @date 13/08/2013
 */
-class MANTIDQT_INELASTIC_DLL InelasticDataManipulationMomentsTab : public InelasticDataManipulationTab {
-  Q_OBJECT
+class MANTIDQT_INELASTIC_DLL InelasticDataManipulationMomentsTab : public InelasticDataManipulationTab,
+                                                                   public IMomentsPresenter {
 
 public:
-  InelasticDataManipulationMomentsTab(QWidget *parent = nullptr);
+  InelasticDataManipulationMomentsTab(QWidget *parent, IMomentsView *view);
   ~InelasticDataManipulationMomentsTab() = default;
 
   void setup() override;
   void run() override;
   bool validate() override;
 
-protected slots:
-  /// Slot to update the guides when the range properties change
-  void updateProperties(QtProperty *prop, double val);
-  /// Called when the algorithm completes to update preview plot
-  void momentsAlgComplete(bool error);
-  /// Slots for plot and save
-  void runClicked();
-  void saveClicked();
+  void handleDataReady(std::string const &dataName) override;
 
-private slots:
-  void handleDataReady(QString const &dataName) override;
-  void handleScaleChanged(int state);
-  void handleScaleValueChanged(double value);
+  void handleScaleChanged(bool state) override;
+  void handleScaleValueChanged(double const value) override;
+  void handleValueChanged(std::string &propName, double value) override;
+
+  void handleRunClicked() override;
+  void handleSaveClicked() override;
+
+protected:
+  void runComplete(bool error);
 
 private:
-  void plotNewData(QString const &filename);
+  void plotNewData(std::string const &filename);
   void setFileExtensionsByName(bool filter) override;
   std::unique_ptr<InelasticDataManipulationMomentsTabModel> m_model;
-  std::unique_ptr<InelasticDataManipulationMomentsTabView> m_view;
+  IMomentsView *m_view;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTabView.cpp
@@ -233,12 +233,12 @@ MantidWidgets::RangeSelector *InelasticDataManipulationMomentsTabView::getRangeS
   return m_uiForm.ppRawPlot->getRangeSelector("XRange");
 }
 
-void InelasticDataManipulationMomentsTabView::plotOutput(QString outputWorkspace) {
+void InelasticDataManipulationMomentsTabView::plotOutput(std::string const &outputWorkspace) {
   // Plot each spectrum
   m_uiForm.ppMomentsPreview->clear();
-  m_uiForm.ppMomentsPreview->addSpectrum("M0", outputWorkspace, 0, Qt::green);
-  m_uiForm.ppMomentsPreview->addSpectrum("M1", outputWorkspace, 1, Qt::black);
-  m_uiForm.ppMomentsPreview->addSpectrum("M2", outputWorkspace, 2, Qt::red);
+  m_uiForm.ppMomentsPreview->addSpectrum("M0", QString(outputWorkspace.data()), 0, Qt::green);
+  m_uiForm.ppMomentsPreview->addSpectrum("M1", QString(outputWorkspace.data()), 1, Qt::black);
+  m_uiForm.ppMomentsPreview->addSpectrum("M2", QString(outputWorkspace.data()), 2, Qt::red);
   m_uiForm.ppMomentsPreview->resizeX();
 
   // Enable plot and save buttons

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTabView.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "InelasticDataManipulationMomentsTabView.h"
 #include "IndirectDataValidationHelper.h"
+#include "InelasticDataManipulationMomentsTab.h"
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -23,7 +24,7 @@ namespace MantidQt::CustomInterfaces {
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-InelasticDataManipulationMomentsTabView::InelasticDataManipulationMomentsTabView(QWidget *parent) {
+InelasticDataManipulationMomentsTabView::InelasticDataManipulationMomentsTabView(QWidget *parent) : m_presenter() {
   m_uiForm.setupUi(parent);
   m_dblManager = new QtDoublePropertyManager();
   m_dblEdFac = new DoubleEditorFactory(this);
@@ -32,21 +33,27 @@ InelasticDataManipulationMomentsTabView::InelasticDataManipulationMomentsTabView
   m_uiForm.ppMomentsPreview->setCanvasColour(QColor(240, 240, 240));
 
   MantidWidgets::RangeSelector *xRangeSelector = m_uiForm.ppRawPlot->addRangeSelector("XRange");
-  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
 
-  connect(m_uiForm.dsInput, SIGNAL(dataReady(QString const &)), this, SIGNAL(dataReady(const QString &)));
-  connect(m_uiForm.ckScale, SIGNAL(stateChanged(int)), this, SIGNAL(scaleChanged(int)));
-  connect(m_uiForm.spScale, SIGNAL(valueChanged(double)), this, SIGNAL(scaleValueChanged(double)));
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SIGNAL(runClicked()));
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SIGNAL(saveClicked()));
+  connect(m_uiForm.dsInput, SIGNAL(dataReady(QString const &)), this, SLOT(notifyDataReady(const QString &)));
+  connect(m_uiForm.ckScale, SIGNAL(stateChanged(int)), this, SLOT(notifyScaleChanged(int)));
+  connect(m_uiForm.spScale, SIGNAL(valueChanged(double)), this, SLOT(notifyScaleValueChanged(double)));
 
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SIGNAL(valueChanged(QtProperty *, double)));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(notifyRunClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
+
+  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyRangeChanged(double, double)));
+
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(notifyValueChanged(QtProperty *, double)));
 
   // Allows empty workspace selector when initially selected
   m_uiForm.dsInput->isOptional(true);
 
   // Disables searching for run files in the data archive
   m_uiForm.dsInput->isForRunFiles(false);
+
+  // setup Property tree
+  setupProperties();
 }
 
 //----------------------------------------------------------------------------------------------
@@ -56,16 +63,42 @@ InelasticDataManipulationMomentsTabView::~InelasticDataManipulationMomentsTabVie
   m_propTrees["MomentsPropTree"]->unsetFactoryForManager(m_dblManager);
 }
 
+/**Subscribes the presenter to the view.
+ *@param presenter: A pointer to the presenter to which the view is subscribed.
+ */
+void InelasticDataManipulationMomentsTabView::subscribePresenter(IMomentsPresenter *presenter) {
+  m_presenter = presenter;
+}
+
+void InelasticDataManipulationMomentsTabView::notifyDataReady(const QString &dataName) {
+  m_presenter->handleDataReady(dataName.toStdString());
+}
 /**
  * Updates the property manager when the range selector is moved.
  *
  * @param min :: The new value of the lower guide
  * @param max :: The new value of the upper guide
  */
-void InelasticDataManipulationMomentsTabView::rangeChanged(double min, double max) {
+void InelasticDataManipulationMomentsTabView::notifyRangeChanged(double min, double max) {
   m_dblManager->setValue(m_properties["EMin"], min);
   m_dblManager->setValue(m_properties["EMax"], max);
 }
+
+void InelasticDataManipulationMomentsTabView::notifyScaleChanged(int const scale) {
+  m_presenter->handleScaleChanged(scale == Qt::Checked);
+}
+
+void InelasticDataManipulationMomentsTabView::notifyScaleValueChanged(double const value) {
+  m_presenter->handleScaleValueChanged(value);
+}
+
+void InelasticDataManipulationMomentsTabView::notifyValueChanged(QtProperty *prop, double value) {
+  m_presenter->handleValueChanged(prop->propertyName().toStdString(), value);
+}
+
+void InelasticDataManipulationMomentsTabView::notifyRunClicked() { m_presenter->handleRunClicked(); }
+
+void InelasticDataManipulationMomentsTabView::notifySaveClicked() { m_presenter->handleSaveClicked(); }
 
 void InelasticDataManipulationMomentsTabView::setupProperties() {
 
@@ -83,9 +116,19 @@ void InelasticDataManipulationMomentsTabView::setupProperties() {
   m_dblManager->setDecimals(m_properties["EMax"], NUM_DECIMALS);
 }
 
-IndirectPlotOptionsView *InelasticDataManipulationMomentsTabView::getPlotOptions() { return m_uiForm.ipoPlotOptions; }
+void InelasticDataManipulationMomentsTabView::setFBSuffixes(QStringList const &suffix) {
+  m_uiForm.dsInput->setFBSuffixes(suffix);
+}
 
-std::string InelasticDataManipulationMomentsTabView::getDataName() {
+void InelasticDataManipulationMomentsTabView::setWSSuffixes(QStringList const &suffix) {
+  m_uiForm.dsInput->setWSSuffixes(suffix);
+}
+
+IndirectPlotOptionsView *InelasticDataManipulationMomentsTabView::getPlotOptions() const {
+  return m_uiForm.ipoPlotOptions;
+}
+
+std::string InelasticDataManipulationMomentsTabView::getDataName() const {
   return m_uiForm.dsInput->getCurrentDataName().toStdString();
 }
 
@@ -95,81 +138,73 @@ bool InelasticDataManipulationMomentsTabView::validate() {
 
   auto const errorMessage = uiv.generateErrorMessage();
   if (!errorMessage.isEmpty())
-    showMessageBox(errorMessage);
+    showMessageBox(errorMessage.toStdString());
   return errorMessage.isEmpty();
 }
 
 /**
  * Clears previous plot data (in both preview and raw plot) and sets the new
  * range bars
+ * @param filename :: Name of the loaded sqw workspace
  */
-void InelasticDataManipulationMomentsTabView::plotNewData(QString const &filename) {
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updateProperties(QtProperty *, double)));
+void InelasticDataManipulationMomentsTabView::plotNewData(std::string const &filename) {
   // Clears previous plotted data
   m_uiForm.ppRawPlot->clear();
   m_uiForm.ppMomentsPreview->clear();
 
   // Update plot and change data in interface
-  m_uiForm.ppRawPlot->addSpectrum("Raw", filename, 0);
-
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
+  m_uiForm.ppRawPlot->addSpectrum("Raw", QString(filename.data()), 0);
 }
 
 /**
  * Sets the edge bounds of plot to prevent the user inputting invalid values
  * Also sets limits for range selector movement
  *
- * @param min :: The lower bound property in the property browser
- * @param max :: The upper bound property in the property browser
- * @param bounds :: The upper and lower bounds to be set
+ * @param bounds :: The upper and lower bounds to be set in the property browser
  */
 void InelasticDataManipulationMomentsTabView::setPlotPropertyRange(const QPair<double, double> &bounds) {
   disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updateProperties(QtProperty *, double)));
+             SLOT(notifyValueChanged(QtProperty *, double)));
   m_dblManager->setMinimum(m_properties["EMin"], bounds.first);
   m_dblManager->setMaximum(m_properties["EMin"], bounds.second);
   m_dblManager->setMinimum(m_properties["EMax"], bounds.first);
   m_dblManager->setMaximum(m_properties["EMax"], bounds.second);
-  auto xRangeSelector = m_uiForm.ppRawPlot->getRangeSelector("XRange");
+  auto xRangeSelector = getRangeSelector();
   xRangeSelector->setBounds(bounds.first, bounds.second);
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(notifyValueChanged(QtProperty *, double)));
 }
 
 /**
  * Set the position of the range selectors on the mini plot
  *
- * @param lower :: The lower bound property in the property browser
- * @param upper :: The upper bound property in the property browser
  * @param bounds :: The upper and lower bounds to be set
- * @param range :: The range to set the range selector to.
  */
-void InelasticDataManipulationMomentsTabView::setRangeSelector(const QPair<double, double> &bounds,
-                                                               const boost::optional<QPair<double, double>> &range) {
+void InelasticDataManipulationMomentsTabView::setRangeSelector(const QPair<double, double> &bounds) {
   disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updateProperties(QtProperty *, double)));
-  m_dblManager->setValue(m_properties["EMin"], bounds.first);
-  m_dblManager->setValue(m_properties["EMax"], bounds.second);
-  auto xRangeSelector = m_uiForm.ppRawPlot->getRangeSelector("XRange");
-  if (range) {
-    xRangeSelector->setMinimum(range.get().first);
-    xRangeSelector->setMaximum(range.get().second);
-    // clamp the bounds of the selector
-    xRangeSelector->setRange(range.get().first, range.get().second);
-  } else {
-    xRangeSelector->setMinimum(bounds.first);
-    xRangeSelector->setMaximum(bounds.second);
-  }
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
+             SLOT(notifyValueChanged(QtProperty *, double)));
+
+  double deltaX = abs(bounds.second - bounds.first);
+  double lowX = bounds.first + (0.1) * deltaX;
+  double highX = bounds.second - (0.1) * deltaX;
+
+  m_dblManager->setValue(m_properties["EMin"], lowX);
+  m_dblManager->setValue(m_properties["EMax"], highX);
+
+  // connecting back so that the model is updated.
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(notifyValueChanged(QtProperty *, double)));
+
+  auto xRangeSelector = getRangeSelector();
+  xRangeSelector->setRange(bounds.first, bounds.second);
+  xRangeSelector->setMinimum(lowX);
+  xRangeSelector->setMaximum(highX);
 }
 
 /**
  * Set the minimum of a range selector if it is less than the maximum value.
  * To be used when changing the min or max via the Property table
  *
- * @param minProperty :: The property managing the minimum of the range
- * @param maxProperty :: The property managing the maximum of the range
- * @param rangeSelector :: The range selector
  * @param newValue :: The new value for the minimum
  */
 void InelasticDataManipulationMomentsTabView::setRangeSelectorMin(double newValue) {
@@ -183,9 +218,6 @@ void InelasticDataManipulationMomentsTabView::setRangeSelectorMin(double newValu
  * Set the maximum of a range selector if it is greater than the minimum value
  * To be used when changing the min or max via the Property table
  *
- * @param minProperty :: The property managing the minimum of the range
- * @param maxProperty :: The property managing the maximum of the range
- * @param rangeSelector :: The range selector
  * @param newValue :: The new value for the maximum
  */
 void InelasticDataManipulationMomentsTabView::setRangeSelectorMax(double newValue) {
@@ -213,21 +245,8 @@ void InelasticDataManipulationMomentsTabView::plotOutput(QString outputWorkspace
   m_uiForm.pbSave->setEnabled(true);
 }
 
-void InelasticDataManipulationMomentsTabView::setFBSuffixes(QStringList const suffix) {
-  m_uiForm.dsInput->setFBSuffixes(suffix);
-}
-
-void InelasticDataManipulationMomentsTabView::setWSSuffixes(QStringList const suffix) {
-  m_uiForm.dsInput->setWSSuffixes(suffix);
-}
-
-void InelasticDataManipulationMomentsTabView::updateRunButton(bool enabled, std::string const &enableOutputButtons,
-                                                              QString const &message, QString const &tooltip) {
-  m_uiForm.pbRun->setEnabled(enabled);
-  m_uiForm.pbRun->setText(message);
-  m_uiForm.pbRun->setToolTip(tooltip);
-  if (enableOutputButtons != "unchanged")
-    m_uiForm.pbSave->setEnabled(enabled);
+void InelasticDataManipulationMomentsTabView::showMessageBox(std::string const &message) const {
+  QMessageBox::information(parentWidget(), this->windowTitle(), QString::fromStdString(message));
 }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTabView.h
@@ -47,7 +47,7 @@ public:
   void setRangeSelectorMax(double newValue) override;
   void plotNewData(std::string const &filename) override;
   void replot() override;
-  void plotOutput(QString outputWorkspace) override;
+  void plotOutput(std::string const &outputWorkspace) override;
 
   void showMessageBox(const std::string &message) const override;
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationMomentsTabView.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DllConfig.h"
+#include "IMomentsView.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/DoubleEditorFactory.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/QtTreePropertyBrowser"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h"
@@ -16,45 +17,50 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-class MANTIDQT_INELASTIC_DLL InelasticDataManipulationMomentsTabView : public QWidget {
+class IMomentsPresenter;
+
+class MANTIDQT_INELASTIC_DLL InelasticDataManipulationMomentsTabView : public QWidget, public IMomentsView {
   Q_OBJECT
 
 public:
-  InelasticDataManipulationMomentsTabView(QWidget *perent = nullptr);
+  InelasticDataManipulationMomentsTabView(QWidget *parent = nullptr);
   ~InelasticDataManipulationMomentsTabView();
 
-  void setupProperties();
-  IndirectPlotOptionsView *getPlotOptions();
-  std::string getDataName();
-  bool validate();
-  void plotNewData(QString const &filename);
+  void subscribePresenter(IMomentsPresenter *presenter) override;
+
+  void setupProperties() override;
+  IndirectPlotOptionsView *getPlotOptions() const override;
+  std::string getDataName() const override;
+
+  bool validate() override;
+
+  void setFBSuffixes(QStringList const &suffix) override;
+  void setWSSuffixes(QStringList const &suffix) override;
+
   /// Function to set the range limits of the plot
-  void setPlotPropertyRange(const QPair<double, double> &bounds);
+  void setPlotPropertyRange(const QPair<double, double> &bounds) override;
   /// Function to set the range selector on the mini plot
-  void setRangeSelector(const QPair<double, double> &bounds,
-                        const boost::optional<QPair<double, double>> &range = boost::none);
+  void setRangeSelector(const QPair<double, double> &bounds) override;
   /// Sets the min of the range selector if it is less than the max
-  void setRangeSelectorMin(double newValue);
+  void setRangeSelectorMin(double newValue) override;
   /// Sets the max of the range selector if it is more than the min
-  void setRangeSelectorMax(double newValue);
-  void replot();
-  void plotOutput(QString outputWorkspace);
-  void setFBSuffixes(QStringList const suffix);
-  void setWSSuffixes(QStringList const suffix);
+  void setRangeSelectorMax(double newValue) override;
+  void plotNewData(std::string const &filename) override;
+  void replot() override;
+  void plotOutput(QString outputWorkspace) override;
 
-signals:
-  void valueChanged(QtProperty *, double);
-  void dataReady(QString const &);
-  void scaleChanged(int);
-  void scaleValueChanged(double);
-  void runClicked();
-  void saveClicked();
-  void showMessageBox(const QString &message);
+  void showMessageBox(const std::string &message) const override;
 
-public slots:
-  void rangeChanged(double min, double max);
-  void updateRunButton(bool enabled, std::string const &enableOutputButtons, QString const &message,
-                       QString const &tooltip);
+private slots:
+  void notifyDataReady(QString const &);
+  void notifyValueChanged(QtProperty *, double);
+
+  void notifyScaleChanged(int);
+  void notifyScaleValueChanged(double);
+  void notifyRangeChanged(double, double);
+
+  void notifyRunClicked();
+  void notifySaveClicked();
 
 private:
   MantidWidgets::RangeSelector *getRangeSelector();
@@ -66,6 +72,7 @@ private:
   QMap<QString, QtProperty *> m_properties;
   DoubleEditorFactory *m_dblEdFac;
   QtDoublePropertyManager *m_dblManager;
+  IMomentsPresenter *m_presenter;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt


### PR DESCRIPTION
### Description of work
This PR removes the Qt dependency of the presenter of the Moments tab. The implementation follows very closely the layout set in #36478 , and more justification for the changes can be found therein. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Part of  #36477 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1. Open `Data Manipulation -> Moments` interface. 
2. Load a `sqw` file, for example: 'iris26173_graphite002_sqw.xs'
3. Test that the interface behaves and works as before. Try changing plot limits and property limits, and run the algorithm.
4. Check that plot options are enabled once the plot is finished. 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->
*This does not require release notes as it is internal maintenance.*
<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
