### PR TITLE
36503 resolving fit properties out of sync behaviour in EngDiff fitting tab

### DIFF
--- a/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/36503.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/36503.rst
@@ -1,0 +1,1 @@
+- Resolved the out of sync observation between the fit algorithm parameters returned by the :ref:`Fitting tab <ui engineering fitting>` of the :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` and the Parameters table after completing a fitting.

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1636,10 +1636,10 @@ void FitPropertyBrowser::doFit(int maxIterations) {
     }
     observeFinish(alg);
     Poco::ActiveResult<bool> result(alg->executeAsync());
-    m_fitAlgParameters = alg->toString();
     while (!result.available()) {
       QCoreApplication::processEvents();
     }
+    m_fitAlgParameters = alg->toString();
     if (!result.error().empty()) {
       emit algorithmFailed();
     }


### PR DESCRIPTION
### Description of work
It was observed that the fit properties for the function parameters returned by the fit algorithm->getFitAlgorithmParameters() were not equal to the real fit properties represented in the fit tables and the *_Parameters workspace created by the Fit at the time of a fit done event received by the FitPropertyBrowser. This was because the fit parameters string was updated before the fitting results were available. After this fix, the FWHM parameter calculation for a peak function becomes simplified because now the calculation can simply depend on the fitting properties of the function string rather than on the _Parameters table workspace.

Fixes #36503. 

### To test:

1. Follow the test instructions of the fitting tab of EngDiff UI Test 4
 https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html#id8
3. Click Fit button on top of the fitting plot to open the property browser.
4. Right Click and select Add Peak which will enable user to mark peak points with the selected peak function type. user can change the default peak function selecting via "Select peak type" on right click on the plot.
5. Add as many peak functions with/without other functions
6. Select "Fit->Fit" in the property browser to do a single fit or click on Serial Fit/Sequential Fit for multiple fits.
7. Compare the parameter values and errors under the grouped workspace created with "*_fits" and the table workspace with "*_Parameters"

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
