### PR TITLE
IndirectFitOutputOptionsPresenter no longer a QObject

### DIFF
--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitOutputOptionsView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitOutputOptionsView.h
@@ -7,7 +7,9 @@
 #pragma once
 
 #include "DllConfig.h"
-#include "MantidQtWidgets/Common/MantidWidget.h"
+
+#include <string>
+#include <vector>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -15,13 +17,9 @@ namespace IDA {
 
 class IIndirectFitOutputOptionsPresenter;
 
-class MANTIDQT_INELASTIC_DLL IIndirectFitOutputOptionsView : public API::MantidWidget {
-  Q_OBJECT
+class MANTIDQT_INELASTIC_DLL IIndirectFitOutputOptionsView {
 
 public:
-  IIndirectFitOutputOptionsView(QWidget *parent = nullptr) : API::MantidWidget(parent){};
-  virtual ~IIndirectFitOutputOptionsView(){};
-
   virtual void subscribePresenter(IIndirectFitOutputOptionsPresenter *presenter) = 0;
 
   virtual void setGroupWorkspaceComboBoxVisible(bool visible) = 0;
@@ -40,8 +38,8 @@ public:
   virtual std::string getSelectedWorkspace() const = 0;
   virtual std::string getSelectedPlotType() const = 0;
 
-  virtual void setPlotText(QString const &text) = 0;
-  virtual void setSaveText(QString const &text) = 0;
+  virtual void setPlotText(std::string const &text) = 0;
+  virtual void setSaveText(std::string const &text) = 0;
 
   virtual void setPlotExtraOptionsEnabled(bool enable) = 0;
   virtual void setPlotEnabled(bool enable) = 0;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitOutputOptionsView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitOutputOptionsView.h
@@ -13,12 +13,16 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
+class IIndirectFitOutputOptionsPresenter;
+
 class MANTIDQT_INELASTIC_DLL IIndirectFitOutputOptionsView : public API::MantidWidget {
   Q_OBJECT
 
 public:
   IIndirectFitOutputOptionsView(QWidget *parent = nullptr) : API::MantidWidget(parent){};
   virtual ~IIndirectFitOutputOptionsView(){};
+
+  virtual void subscribePresenter(IIndirectFitOutputOptionsPresenter *presenter) = 0;
 
   virtual void setGroupWorkspaceComboBoxVisible(bool visible) = 0;
   virtual void setWorkspaceComboBoxVisible(bool visible) = 0;
@@ -47,12 +51,6 @@ public:
   virtual void setEditResultVisible(bool visible) = 0;
 
   virtual void displayWarning(std::string const &message) = 0;
-
-signals:
-  void groupWorkspaceChanged(std::string const &group);
-  void plotClicked();
-  void saveClicked();
-  void editResultClicked();
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
@@ -76,8 +76,6 @@ void IndirectDataAnalysisTab::setup() {
   connect(m_uiForm->pbRun, SIGNAL(clicked()), this, SLOT(runTab()));
   updateResultOptions();
 
-  connect(m_outOptionsPresenter.get(), SIGNAL(plotSpectra()), this, SLOT(plotSelectedSpectra()));
-
   connectDataPresenter();
   connectPlotPresenter();
   connectFitPropertyBrowser();
@@ -116,7 +114,7 @@ void IndirectDataAnalysisTab::connectFitPropertyBrowser() {
 }
 
 void IndirectDataAnalysisTab::setupOutputOptionsPresenter(bool const editResults) {
-  m_outOptionsPresenter = std::make_unique<IndirectFitOutputOptionsPresenter>(m_uiForm->ovOutputOptionsView);
+  m_outOptionsPresenter = std::make_unique<IndirectFitOutputOptionsPresenter>(this, m_uiForm->ovOutputOptionsView);
   m_outOptionsPresenter->setEditResultVisible(editResults);
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
@@ -114,7 +114,9 @@ void IndirectDataAnalysisTab::connectFitPropertyBrowser() {
 }
 
 void IndirectDataAnalysisTab::setupOutputOptionsPresenter(bool const editResults) {
-  m_outOptionsPresenter = std::make_unique<IndirectFitOutputOptionsPresenter>(this, m_uiForm->ovOutputOptionsView);
+  auto model = std::make_unique<IndirectFitOutputOptionsModel>();
+  m_outOptionsPresenter =
+      std::make_unique<IndirectFitOutputOptionsPresenter>(this, m_uiForm->ovOutputOptionsView, std::move(model));
   m_outOptionsPresenter->setEditResultVisible(editResults);
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
@@ -33,7 +33,12 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-class MANTIDQT_INELASTIC_DLL IndirectDataAnalysisTab : public IndirectTab {
+class MANTIDQT_INELASTIC_DLL IIndirectDataAnalysisTab {
+public:
+  virtual void plotSelectedSpectra() = 0;
+};
+
+class MANTIDQT_INELASTIC_DLL IndirectDataAnalysisTab : public IndirectTab, public IIndirectDataAnalysisTab {
   Q_OBJECT
 
 public:
@@ -77,7 +82,7 @@ public:
   bool hasResolution() const noexcept { return m_hasResolution; }
   void setFileExtensionsByName(bool filter);
 
-  void plotSelectedSpectra();
+  void plotSelectedSpectra() override;
 
 protected:
   IndirectFittingModel *getFittingModel() const;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
@@ -77,6 +77,8 @@ public:
   bool hasResolution() const noexcept { return m_hasResolution; }
   void setFileExtensionsByName(bool filter);
 
+  void plotSelectedSpectra();
+
 protected:
   IndirectFittingModel *getFittingModel() const;
   void run() override;
@@ -153,7 +155,6 @@ protected slots:
   void respondToFunctionChanged();
 
 private slots:
-  void plotSelectedSpectra();
   void respondToSingleResolutionLoaded();
   void respondToDataChanged();
   void respondToDataAdded(IAddWorkspaceDialog const *dialog);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectEditResultsDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectEditResultsDialog.cpp
@@ -15,7 +15,7 @@ IndirectEditResultsDialog::IndirectEditResultsDialog(QWidget *parent) : QDialog(
 
   connect(m_uiForm.pbPasteInputName, SIGNAL(clicked()), this, SLOT(setOutputWorkspaceName()));
   connect(m_uiForm.pbReplaceFitResult, SIGNAL(clicked()), this, SIGNAL(replaceSingleFitResult()));
-  connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SIGNAL(closeDialog()));
+  connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SLOT(close()));
 }
 
 void IndirectEditResultsDialog::setWorkspaceSelectorSuffices(QStringList const &suffices) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectEditResultsDialog.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectEditResultsDialog.h
@@ -32,7 +32,6 @@ public:
 
 signals:
   void replaceSingleFitResult();
-  void closeDialog();
 
 private slots:
   void setOutputWorkspaceName();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectFitOutputOptionsPresenter.h"
+#include "IndirectDataAnalysisTab.h"
 
 #include <utility>
 
@@ -12,25 +13,18 @@ using namespace Mantid::API;
 
 namespace MantidQt::CustomInterfaces::IDA {
 
-IndirectFitOutputOptionsPresenter::IndirectFitOutputOptionsPresenter(IIndirectFitOutputOptionsView *view)
-    : QObject(nullptr), m_model(std::make_unique<IndirectFitOutputOptionsModel>()), m_view(view) {
+IndirectFitOutputOptionsPresenter::IndirectFitOutputOptionsPresenter(IndirectDataAnalysisTab *tab,
+                                                                     IIndirectFitOutputOptionsView *view)
+    : m_tab(tab), m_view(view), m_model(std::make_unique<IndirectFitOutputOptionsModel>()) {
   setMultiWorkspaceOptionsVisible(false);
-  setUpPresenter();
   m_view->subscribePresenter(this);
 }
 
 IndirectFitOutputOptionsPresenter::IndirectFitOutputOptionsPresenter(IIndirectFitOutputOptionsModel *model,
                                                                      IIndirectFitOutputOptionsView *view)
-    : QObject(nullptr), m_model(model), m_view(view) {
+    : m_model(model), m_view(view) {
   setMultiWorkspaceOptionsVisible(false);
-  setUpPresenter();
   m_view->subscribePresenter(this);
-}
-
-IndirectFitOutputOptionsPresenter::~IndirectFitOutputOptionsPresenter() = default;
-
-void IndirectFitOutputOptionsPresenter::setUpPresenter() {
-  // connect(m_view, SIGNAL(plotClicked()), this, SIGNAL(plotSpectra()));
 }
 
 void IndirectFitOutputOptionsPresenter::setMultiWorkspaceOptionsVisible(bool visible) {
@@ -78,6 +72,7 @@ void IndirectFitOutputOptionsPresenter::handlePlotClicked() {
   setPlotting(true);
   try {
     plotResult(m_view->getSelectedGroupWorkspace());
+    m_tab->plotSelectedSpectra();
   } catch (std::runtime_error const &ex) {
     displayWarning(ex.what());
   }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.cpp
@@ -14,27 +14,23 @@ namespace MantidQt::CustomInterfaces::IDA {
 
 IndirectFitOutputOptionsPresenter::IndirectFitOutputOptionsPresenter(IIndirectFitOutputOptionsView *view)
     : QObject(nullptr), m_model(std::make_unique<IndirectFitOutputOptionsModel>()), m_view(view) {
+  setMultiWorkspaceOptionsVisible(false);
   setUpPresenter();
+  m_view->subscribePresenter(this);
 }
 
 IndirectFitOutputOptionsPresenter::IndirectFitOutputOptionsPresenter(IIndirectFitOutputOptionsModel *model,
                                                                      IIndirectFitOutputOptionsView *view)
     : QObject(nullptr), m_model(model), m_view(view) {
+  setMultiWorkspaceOptionsVisible(false);
   setUpPresenter();
+  m_view->subscribePresenter(this);
 }
 
 IndirectFitOutputOptionsPresenter::~IndirectFitOutputOptionsPresenter() = default;
 
 void IndirectFitOutputOptionsPresenter::setUpPresenter() {
-  setMultiWorkspaceOptionsVisible(false);
-
-  connect(m_view, SIGNAL(groupWorkspaceChanged(std::string const &)), this,
-          SLOT(setAvailablePlotOptions(std::string const &)));
-
-  connect(m_view, SIGNAL(plotClicked()), this, SLOT(plotResult()));
   connect(m_view, SIGNAL(plotClicked()), this, SIGNAL(plotSpectra()));
-  connect(m_view, SIGNAL(saveClicked()), this, SLOT(saveResult()));
-  connect(m_view, SIGNAL(editResultClicked()), this, SLOT(editResult()));
 }
 
 void IndirectFitOutputOptionsPresenter::setMultiWorkspaceOptionsVisible(bool visible) {
@@ -43,7 +39,7 @@ void IndirectFitOutputOptionsPresenter::setMultiWorkspaceOptionsVisible(bool vis
   m_view->setWorkspaceComboBoxVisible(false);
 }
 
-void IndirectFitOutputOptionsPresenter::setAvailablePlotOptions(std::string const &selectedGroup) {
+void IndirectFitOutputOptionsPresenter::handleGroupWorkspaceChanged(std::string const &selectedGroup) {
   auto const resultSelected = m_model->isResultGroupSelected(selectedGroup);
   setPlotTypes(selectedGroup);
   m_view->setWorkspaceComboBoxVisible(!resultSelected);
@@ -78,7 +74,7 @@ void IndirectFitOutputOptionsPresenter::setPlotTypes(std::string const &selected
 
 void IndirectFitOutputOptionsPresenter::removePDFWorkspace() { m_model->removePDFWorkspace(); }
 
-void IndirectFitOutputOptionsPresenter::plotResult() {
+void IndirectFitOutputOptionsPresenter::handlePlotClicked() {
   setPlotting(true);
   try {
     plotResult(m_view->getSelectedGroupWorkspace());
@@ -94,7 +90,7 @@ void IndirectFitOutputOptionsPresenter::plotResult(std::string const &selectedGr
     m_model->plotPDF(m_view->getSelectedWorkspace(), m_view->getSelectedPlotType());
 }
 
-void IndirectFitOutputOptionsPresenter::saveResult() {
+void IndirectFitOutputOptionsPresenter::handleSaveClicked() {
   setSaving(true);
   try {
     m_model->saveResult();
@@ -139,7 +135,7 @@ std::vector<SpectrumToPlot> IndirectFitOutputOptionsPresenter::getSpectraToPlot(
 
 void IndirectFitOutputOptionsPresenter::setEditResultVisible(bool visible) { m_view->setEditResultVisible(visible); }
 
-void IndirectFitOutputOptionsPresenter::editResult() {
+void IndirectFitOutputOptionsPresenter::handleEditResultClicked() {
   m_editResultsDialog = getEditResultsDialog(m_view->parentWidget());
   m_editResultsDialog->setWorkspaceSelectorSuffices({"_Result"});
   m_editResultsDialog->show();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.cpp
@@ -13,16 +13,10 @@ using namespace Mantid::API;
 
 namespace MantidQt::CustomInterfaces::IDA {
 
-IndirectFitOutputOptionsPresenter::IndirectFitOutputOptionsPresenter(IIndirectDataAnalysisTab *tab,
-                                                                     IIndirectFitOutputOptionsView *view)
-    : m_tab(tab), m_view(view), m_model(std::make_unique<IndirectFitOutputOptionsModel>()) {
-  setMultiWorkspaceOptionsVisible(false);
-  m_view->subscribePresenter(this);
-}
-
-IndirectFitOutputOptionsPresenter::IndirectFitOutputOptionsPresenter(IIndirectFitOutputOptionsModel *model,
-                                                                     IIndirectFitOutputOptionsView *view)
-    : m_model(model), m_view(view) {
+IndirectFitOutputOptionsPresenter::IndirectFitOutputOptionsPresenter(
+    IIndirectDataAnalysisTab *tab, IIndirectFitOutputOptionsView *view,
+    std::unique_ptr<IIndirectFitOutputOptionsModel> model)
+    : m_tab(tab), m_view(view), m_model(std::move(model)) {
   setMultiWorkspaceOptionsVisible(false);
   m_view->subscribePresenter(this);
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.cpp
@@ -30,7 +30,7 @@ IndirectFitOutputOptionsPresenter::IndirectFitOutputOptionsPresenter(IIndirectFi
 IndirectFitOutputOptionsPresenter::~IndirectFitOutputOptionsPresenter() = default;
 
 void IndirectFitOutputOptionsPresenter::setUpPresenter() {
-  connect(m_view, SIGNAL(plotClicked()), this, SIGNAL(plotSpectra()));
+  // connect(m_view, SIGNAL(plotClicked()), this, SIGNAL(plotSpectra()));
 }
 
 void IndirectFitOutputOptionsPresenter::setMultiWorkspaceOptionsVisible(bool visible) {
@@ -135,24 +135,9 @@ std::vector<SpectrumToPlot> IndirectFitOutputOptionsPresenter::getSpectraToPlot(
 
 void IndirectFitOutputOptionsPresenter::setEditResultVisible(bool visible) { m_view->setEditResultVisible(visible); }
 
-void IndirectFitOutputOptionsPresenter::handleEditResultClicked() {
-  m_editResultsDialog = getEditResultsDialog(m_view->parentWidget());
-  m_editResultsDialog->setWorkspaceSelectorSuffices({"_Result"});
-  m_editResultsDialog->show();
-  connect(m_editResultsDialog.get(), SIGNAL(replaceSingleFitResult()), this, SLOT(replaceSingleFitResult()));
-  connect(m_editResultsDialog.get(), SIGNAL(closeDialog()), this, SLOT(closeEditResultDialog()));
-}
-
-std::unique_ptr<IndirectEditResultsDialog>
-IndirectFitOutputOptionsPresenter::getEditResultsDialog(QWidget *parent) const {
-  return std::make_unique<IndirectEditResultsDialog>(parent);
-}
-
-void IndirectFitOutputOptionsPresenter::replaceSingleFitResult() {
-  auto const inputName = m_editResultsDialog->getSelectedInputWorkspaceName();
-  auto const singleBinName = m_editResultsDialog->getSelectedSingleFitWorkspaceName();
-  auto const outputName = m_editResultsDialog->getOutputWorkspaceName();
-
+void IndirectFitOutputOptionsPresenter::handleReplaceSingleFitResult(std::string const &inputName,
+                                                                     std::string const &singleBinName,
+                                                                     std::string const &outputName) {
   setEditingResult(true);
   replaceSingleFitResult(inputName, singleBinName, outputName);
   setEditingResult(false);
@@ -169,17 +154,9 @@ void IndirectFitOutputOptionsPresenter::replaceSingleFitResult(std::string const
 }
 
 void IndirectFitOutputOptionsPresenter::setEditingResult(bool editing) {
-  m_editResultsDialog->setReplaceFitResultText(editing ? "Processing..." : "Replace Fit Result");
-  m_editResultsDialog->setReplaceFitResultEnabled(!editing);
   setPlotEnabled(!editing);
   setEditResultEnabled(!editing);
   setSaveEnabled(!editing);
-}
-
-void IndirectFitOutputOptionsPresenter::closeEditResultDialog() {
-  disconnect(m_editResultsDialog.get(), SIGNAL(replaceSingleFitResult()), this, SLOT(replaceSingleFitResult()));
-  disconnect(m_editResultsDialog.get(), SIGNAL(closeDialog()), this, SLOT(closeEditResultDialog()));
-  m_editResultsDialog->close();
 }
 
 void IndirectFitOutputOptionsPresenter::displayWarning(std::string const &message) { m_view->displayWarning(message); }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.cpp
@@ -13,7 +13,7 @@ using namespace Mantid::API;
 
 namespace MantidQt::CustomInterfaces::IDA {
 
-IndirectFitOutputOptionsPresenter::IndirectFitOutputOptionsPresenter(IndirectDataAnalysisTab *tab,
+IndirectFitOutputOptionsPresenter::IndirectFitOutputOptionsPresenter(IIndirectDataAnalysisTab *tab,
                                                                      IIndirectFitOutputOptionsView *view)
     : m_tab(tab), m_view(view), m_model(std::make_unique<IndirectFitOutputOptionsModel>()) {
   setMultiWorkspaceOptionsVisible(false);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.h
@@ -16,7 +16,7 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-class IndirectDataAnalysisTab;
+class IIndirectDataAnalysisTab;
 
 class MANTIDQT_INELASTIC_DLL IIndirectFitOutputOptionsPresenter {
 public:
@@ -29,7 +29,7 @@ public:
 
 class MANTIDQT_INELASTIC_DLL IndirectFitOutputOptionsPresenter final : public IIndirectFitOutputOptionsPresenter {
 public:
-  IndirectFitOutputOptionsPresenter(IndirectDataAnalysisTab *tab, IIndirectFitOutputOptionsView *view);
+  IndirectFitOutputOptionsPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitOutputOptionsView *view);
   IndirectFitOutputOptionsPresenter(IIndirectFitOutputOptionsModel *model, IIndirectFitOutputOptionsView *view);
 
   void setMultiWorkspaceOptionsVisible(bool visible);
@@ -70,7 +70,7 @@ private:
 
   void displayWarning(std::string const &message);
 
-  IndirectDataAnalysisTab *m_tab;
+  IIndirectDataAnalysisTab *m_tab;
   IIndirectFitOutputOptionsView *m_view;
   std::unique_ptr<IIndirectFitOutputOptionsModel> m_model;
 };

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.h
@@ -12,11 +12,11 @@
 #include "DllConfig.h"
 #include "MantidAPI/WorkspaceGroup.h"
 
-#include <QObject>
-
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
+
+class IndirectDataAnalysisTab;
 
 class MANTIDQT_INELASTIC_DLL IIndirectFitOutputOptionsPresenter {
 public:
@@ -27,13 +27,10 @@ public:
                                             std::string const &outputName) = 0;
 };
 
-class MANTIDQT_INELASTIC_DLL IndirectFitOutputOptionsPresenter final : public QObject,
-                                                                       public IIndirectFitOutputOptionsPresenter {
-  Q_OBJECT
+class MANTIDQT_INELASTIC_DLL IndirectFitOutputOptionsPresenter final : public IIndirectFitOutputOptionsPresenter {
 public:
-  IndirectFitOutputOptionsPresenter(IIndirectFitOutputOptionsView *view);
+  IndirectFitOutputOptionsPresenter(IndirectDataAnalysisTab *tab, IIndirectFitOutputOptionsView *view);
   IndirectFitOutputOptionsPresenter(IIndirectFitOutputOptionsModel *model, IIndirectFitOutputOptionsView *view);
-  ~IndirectFitOutputOptionsPresenter() override;
 
   void setMultiWorkspaceOptionsVisible(bool visible);
 
@@ -62,12 +59,7 @@ public:
   void handleReplaceSingleFitResult(std::string const &inputName, std::string const &singleBinName,
                                     std::string const &outputName) override;
 
-signals:
-  void plotSpectra();
-
 private:
-  void setUpPresenter();
-
   void plotResult(std::string const &selectedGroup);
   void setSaving(bool saving);
 
@@ -78,8 +70,9 @@ private:
 
   void displayWarning(std::string const &message);
 
-  std::unique_ptr<IIndirectFitOutputOptionsModel> m_model;
+  IndirectDataAnalysisTab *m_tab;
   IIndirectFitOutputOptionsView *m_view;
+  std::unique_ptr<IIndirectFitOutputOptionsModel> m_model;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.h
@@ -29,8 +29,8 @@ public:
 
 class MANTIDQT_INELASTIC_DLL IndirectFitOutputOptionsPresenter final : public IIndirectFitOutputOptionsPresenter {
 public:
-  IndirectFitOutputOptionsPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitOutputOptionsView *view);
-  IndirectFitOutputOptionsPresenter(IIndirectFitOutputOptionsModel *model, IIndirectFitOutputOptionsView *view);
+  IndirectFitOutputOptionsPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitOutputOptionsView *view,
+                                    std::unique_ptr<IIndirectFitOutputOptionsModel> model);
 
   void setMultiWorkspaceOptionsVisible(bool visible);
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.h
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "IndirectEditResultsDialog.h"
 #include "IndirectFitOutputOptionsModel.h"
 #include "IndirectFitOutputOptionsView.h"
 
@@ -24,7 +23,8 @@ public:
   virtual void handleGroupWorkspaceChanged(std::string const &selectedGroup) = 0;
   virtual void handlePlotClicked() = 0;
   virtual void handleSaveClicked() = 0;
-  virtual void handleEditResultClicked() = 0;
+  virtual void handleReplaceSingleFitResult(std::string const &inputName, std::string const &singleBinName,
+                                            std::string const &outputName) = 0;
 };
 
 class MANTIDQT_INELASTIC_DLL IndirectFitOutputOptionsPresenter final : public QObject,
@@ -59,14 +59,11 @@ public:
   void handleGroupWorkspaceChanged(std::string const &selectedGroup) override;
   void handlePlotClicked() override;
   void handleSaveClicked() override;
-  void handleEditResultClicked() override;
+  void handleReplaceSingleFitResult(std::string const &inputName, std::string const &singleBinName,
+                                    std::string const &outputName) override;
 
 signals:
   void plotSpectra();
-
-private slots:
-  void replaceSingleFitResult();
-  void closeEditResultDialog();
 
 private:
   void setUpPresenter();
@@ -74,7 +71,6 @@ private:
   void plotResult(std::string const &selectedGroup);
   void setSaving(bool saving);
 
-  std::unique_ptr<IndirectEditResultsDialog> getEditResultsDialog(QWidget *parent) const;
   void setEditingResult(bool editing);
 
   void replaceSingleFitResult(std::string const &inputName, std::string const &singleBinName,
@@ -82,7 +78,6 @@ private:
 
   void displayWarning(std::string const &message);
 
-  std::unique_ptr<IndirectEditResultsDialog> m_editResultsDialog;
   std::unique_ptr<IIndirectFitOutputOptionsModel> m_model;
   IIndirectFitOutputOptionsView *m_view;
 };

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.h
@@ -19,7 +19,16 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-class MANTIDQT_INELASTIC_DLL IndirectFitOutputOptionsPresenter : public QObject {
+class MANTIDQT_INELASTIC_DLL IIndirectFitOutputOptionsPresenter {
+public:
+  virtual void handleGroupWorkspaceChanged(std::string const &selectedGroup) = 0;
+  virtual void handlePlotClicked() = 0;
+  virtual void handleSaveClicked() = 0;
+  virtual void handleEditResultClicked() = 0;
+};
+
+class MANTIDQT_INELASTIC_DLL IndirectFitOutputOptionsPresenter final : public QObject,
+                                                                       public IIndirectFitOutputOptionsPresenter {
   Q_OBJECT
 public:
   IndirectFitOutputOptionsPresenter(IIndirectFitOutputOptionsView *view);
@@ -47,14 +56,15 @@ public:
 
   void setEditResultVisible(bool visible);
 
+  void handleGroupWorkspaceChanged(std::string const &selectedGroup) override;
+  void handlePlotClicked() override;
+  void handleSaveClicked() override;
+  void handleEditResultClicked() override;
+
 signals:
   void plotSpectra();
 
 private slots:
-  void setAvailablePlotOptions(std::string const &selectedGroup);
-  void plotResult();
-  void saveResult();
-  void editResult();
   void replaceSingleFitResult();
   void closeEditResultDialog();
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.cpp
@@ -13,7 +13,8 @@
 namespace MantidQt::CustomInterfaces::IDA {
 
 IndirectFitOutputOptionsView::IndirectFitOutputOptionsView(QWidget *parent)
-    : API::MantidWidget(parent), m_outputOptions(std::make_unique<Ui::IndirectFitOutputOptions>()) {
+    : API::MantidWidget(parent), m_editResultsDialog(),
+      m_outputOptions(std::make_unique<Ui::IndirectFitOutputOptions>()), m_presenter() {
   m_outputOptions->setupUi(this);
 
   connect(m_outputOptions->cbGroupWorkspace, SIGNAL(currentIndexChanged(QString const &)), this,

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.cpp
@@ -24,8 +24,6 @@ IndirectFitOutputOptionsView::IndirectFitOutputOptionsView(QWidget *parent)
   connect(m_outputOptions->pbEditResult, SIGNAL(clicked()), this, SLOT(handleEditResultClicked()));
 }
 
-IndirectFitOutputOptionsView::~IndirectFitOutputOptionsView() = default;
-
 void IndirectFitOutputOptionsView::subscribePresenter(IIndirectFitOutputOptionsPresenter *presenter) {
   m_presenter = presenter;
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectFitOutputOptionsView.h"
+#include "IndirectFitOutputOptionsPresenter.h"
 
 #include <QMessageBox>
 
@@ -15,24 +16,28 @@ IndirectFitOutputOptionsView::IndirectFitOutputOptionsView(QWidget *parent)
   m_outputOptions->setupUi(this);
 
   connect(m_outputOptions->cbGroupWorkspace, SIGNAL(currentIndexChanged(QString const &)), this,
-          SLOT(emitGroupWorkspaceChanged(QString const &)));
+          SLOT(notifyGroupWorkspaceChanged(QString const &)));
 
-  connect(m_outputOptions->pbPlot, SIGNAL(clicked()), this, SLOT(emitPlotClicked()));
-  connect(m_outputOptions->pbSave, SIGNAL(clicked()), this, SLOT(emitSaveClicked()));
-  connect(m_outputOptions->pbEditResult, SIGNAL(clicked()), this, SLOT(emitEditResultClicked()));
+  connect(m_outputOptions->pbPlot, SIGNAL(clicked()), this, SLOT(notifyPlotClicked()));
+  connect(m_outputOptions->pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
+  connect(m_outputOptions->pbEditResult, SIGNAL(clicked()), this, SLOT(notifyEditResultClicked()));
 }
 
 IndirectFitOutputOptionsView::~IndirectFitOutputOptionsView() = default;
 
-void IndirectFitOutputOptionsView::emitGroupWorkspaceChanged(QString const &group) {
-  emit groupWorkspaceChanged(group.toStdString());
+void IndirectFitOutputOptionsView::subscribePresenter(IIndirectFitOutputOptionsPresenter *presenter) {
+  m_presenter = presenter;
 }
 
-void IndirectFitOutputOptionsView::emitPlotClicked() { emit plotClicked(); }
+void IndirectFitOutputOptionsView::notifyGroupWorkspaceChanged(QString const &group) {
+  m_presenter->handleGroupWorkspaceChanged(group.toStdString());
+}
 
-void IndirectFitOutputOptionsView::emitSaveClicked() { emit saveClicked(); }
+void IndirectFitOutputOptionsView::notifyPlotClicked() { m_presenter->handlePlotClicked(); }
 
-void IndirectFitOutputOptionsView::emitEditResultClicked() { emit editResultClicked(); }
+void IndirectFitOutputOptionsView::notifySaveClicked() { m_presenter->handleSaveClicked(); }
+
+void IndirectFitOutputOptionsView::notifyEditResultClicked() { m_presenter->handleEditResultClicked(); }
 
 void IndirectFitOutputOptionsView::setGroupWorkspaceComboBoxVisible(bool visible) {
   m_outputOptions->cbGroupWorkspace->setVisible(visible);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.cpp
@@ -118,16 +118,10 @@ void IndirectFitOutputOptionsView::setEditResultVisible(bool visible) {
 
 void IndirectFitOutputOptionsView::handleEditResultClicked() {
   m_editResultsDialog = new IndirectEditResultsDialog(this);
+  m_editResultsDialog->setAttribute(Qt::WA_DeleteOnClose);
   m_editResultsDialog->setWorkspaceSelectorSuffices({"_Result"});
   m_editResultsDialog->show();
   connect(m_editResultsDialog, SIGNAL(replaceSingleFitResult()), this, SLOT(notifyReplaceSingleFitResult()));
-  connect(m_editResultsDialog, SIGNAL(closeDialog()), this, SLOT(handleCloseEditResultDialog()));
-}
-
-void IndirectFitOutputOptionsView::handleCloseEditResultDialog() {
-  disconnect(m_editResultsDialog, SIGNAL(replaceSingleFitResult()), this, SLOT(notifyReplaceSingleFitResult()));
-  disconnect(m_editResultsDialog, SIGNAL(closeDialog()), this, SLOT(closeEditResultDialog()));
-  m_editResultsDialog->close();
 }
 
 void IndirectFitOutputOptionsView::displayWarning(std::string const &message) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.h
@@ -10,6 +10,7 @@
 
 #include "DllConfig.h"
 #include "IIndirectFitOutputOptionsView.h"
+#include "MantidQtWidgets/Common/MantidWidget.h"
 
 #include <memory>
 
@@ -26,7 +27,6 @@ class MANTIDQT_INELASTIC_DLL IndirectFitOutputOptionsView final : public API::Ma
 
 public:
   IndirectFitOutputOptionsView(QWidget *parent = nullptr);
-  virtual ~IndirectFitOutputOptionsView() override;
 
   void subscribePresenter(IIndirectFitOutputOptionsPresenter *presenter) override;
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.h
@@ -64,7 +64,6 @@ private slots:
   void notifySaveClicked();
   void notifyReplaceSingleFitResult();
   void handleEditResultClicked();
-  void handleCloseEditResultDialog();
 
 private:
   IndirectEditResultsDialog *m_editResultsDialog;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.h
@@ -18,8 +18,10 @@ namespace CustomInterfaces {
 namespace IDA {
 
 class IIndirectFitOutputOptionsPresenter;
+class IndirectEditResultsDialog;
 
-class MANTIDQT_INELASTIC_DLL IndirectFitOutputOptionsView final : public IIndirectFitOutputOptionsView {
+class MANTIDQT_INELASTIC_DLL IndirectFitOutputOptionsView final : public API::MantidWidget,
+                                                                  public IIndirectFitOutputOptionsView {
   Q_OBJECT
 
 public:
@@ -44,8 +46,8 @@ public:
   std::string getSelectedWorkspace() const override;
   std::string getSelectedPlotType() const override;
 
-  void setPlotText(QString const &text) override;
-  void setSaveText(QString const &text) override;
+  void setPlotText(std::string const &text) override;
+  void setSaveText(std::string const &text) override;
 
   void setPlotExtraOptionsEnabled(bool enable) override;
   void setPlotEnabled(bool enable) override;
@@ -60,9 +62,12 @@ private slots:
   void notifyGroupWorkspaceChanged(QString const &group);
   void notifyPlotClicked();
   void notifySaveClicked();
-  void notifyEditResultClicked();
+  void notifyReplaceSingleFitResult();
+  void handleEditResultClicked();
+  void handleCloseEditResultDialog();
 
 private:
+  IndirectEditResultsDialog *m_editResultsDialog;
   std::unique_ptr<Ui::IndirectFitOutputOptions> m_outputOptions;
   IIndirectFitOutputOptionsPresenter *m_presenter;
 };

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsView.h
@@ -17,12 +17,16 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-class MANTIDQT_INELASTIC_DLL IndirectFitOutputOptionsView : public IIndirectFitOutputOptionsView {
+class IIndirectFitOutputOptionsPresenter;
+
+class MANTIDQT_INELASTIC_DLL IndirectFitOutputOptionsView final : public IIndirectFitOutputOptionsView {
   Q_OBJECT
 
 public:
   IndirectFitOutputOptionsView(QWidget *parent = nullptr);
   virtual ~IndirectFitOutputOptionsView() override;
+
+  void subscribePresenter(IIndirectFitOutputOptionsPresenter *presenter) override;
 
   void setGroupWorkspaceComboBoxVisible(bool visible) override;
   void setWorkspaceComboBoxVisible(bool visible) override;
@@ -53,13 +57,14 @@ public:
   void displayWarning(std::string const &message) override;
 
 private slots:
-  void emitGroupWorkspaceChanged(QString const &group);
-  void emitPlotClicked();
-  void emitSaveClicked();
-  void emitEditResultClicked();
+  void notifyGroupWorkspaceChanged(QString const &group);
+  void notifyPlotClicked();
+  void notifySaveClicked();
+  void notifyEditResultClicked();
 
 private:
   std::unique_ptr<Ui::IndirectFitOutputOptions> m_outputOptions;
+  IIndirectFitOutputOptionsPresenter *m_presenter;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -84,7 +84,6 @@ set(MOC_FILES
     Analysis/IndirectEditResultsDialog.h
     Analysis/IndirectFitDataPresenter.h
     Analysis/IndirectFitDataView.h
-    Analysis/IndirectFitOutputOptionsPresenter.h
     Analysis/IndirectFitOutputOptionsView.h
     Analysis/IndirectFitPlotView.h
     Analysis/IndirectFitPlotPresenter.h
@@ -132,6 +131,7 @@ set(INC_FILES
     Analysis/IndirectFitData.h
     Analysis/IndirectFitOutput.h
     Analysis/IndirectFitOutputOptionsModel.h
+    Analysis/IndirectFitOutputOptionsPresenter.h
     Analysis/IndirectFitPlotModel.h
     Analysis/IndirectFittingModel.h
     Analysis/ParameterEstimation.h

--- a/qt/scientific_interfaces/Inelastic/test/IndirectFitOutputOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/IndirectFitOutputOptionsPresenterTest.h
@@ -38,7 +38,7 @@ public:
 };
 
 /// Mock object to mock the view
-class MockIndirectFitOutputOptionsView : public IIndirectFitOutputOptionsView {
+class MockIndirectFitOutputOptionsView final : public IIndirectFitOutputOptionsView {
 public:
   /// Public Methods
   MOCK_METHOD1(subscribePresenter, void(IIndirectFitOutputOptionsPresenter *presenter));
@@ -117,7 +117,7 @@ public:
 
   void setUp() override {
     m_tab = std::make_unique<NiceMock<MockIndirectDataAnalysisTab>>();
-    m_view = std::make_unique<NiceMock<MockIndirectFitOutputOptionsView>>();
+    m_view = std::make_unique<MockIndirectFitOutputOptionsView>();
     auto model = std::make_unique<NiceMock<MockIndirectFitOutputOptionsModel>>();
     m_model = model.get();
 


### PR DESCRIPTION
### Description of work
This PR refactors the IndirectFitOutputOptionsPresenter so that it no longer has a QObject dependency. This makes it easier to test the presenter, and also makes it possible to replace the presenter in the future if necessary. It also makes sure that the model is passed into the constructor of the presenter as an argument. This also means it is easier to write a new model that conforms to a particular interface and replace the old one in the future, easily, if necessary.

Part of #36325

### To test:

1. Load the following data into the Data Analysis IqtFit tab

Input file: [irs26176_graphite002_iqt.zip](https://github.com/mantidproject/mantid/files/2361062/irs26176_graphite002_iqt.zip)
2. `Stretched Exponential`
3. `Flat background`
4. Drag the EndX on the graph to the left a bit to miss the noise (`0.15` I think)
5. Click Run and wait
6. Try the output options. E.g. 
 - Plotting the resulting data
 - `Save Result` - saves the result to your default save directory

*This does not require release notes* because **its an internal change**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
