### PR TITLE
Fix mpl deprecation warning from the slice viewer

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/representation/painter.py
@@ -143,7 +143,7 @@ class MplPainter:
         :param angle: Angle in degrees w.r.t X axis
         :param kwargs: Additional matplotlib properties to pass to the call
         """
-        return self.axes.add_patch(Ellipse((x, y), width, height, angle, **kwargs))
+        return self.axes.add_patch(Ellipse((x, y), width, height, angle=angle, **kwargs))
 
     def elliptical_shell(self, x, y, outer_width, outer_height, frac_thick, angle=0.0, **kwargs):
         """Draw an ellipse at the given location


### PR DESCRIPTION
### Description of work

The `angle` argument for the `matplotlib.patches.Ellipse` class will become keyword only in version 3.8
https://github.com/matplotlib/matplotlib/blob/v3.7.3/lib/matplotlib/patches.py#L1522

Added the keyword in to stop it warning us.

I also checked for any other positional patch arguments in the codebase which are deprecated, but this seems to be the only one.

Fixes #35580 

### To test:

The issue was spotted during manual testing (see issue #35580) but I could never replicate it (I just looked for similar cases online then through the source code). So I can't recommend doing all the slice viewer manual tests to check it doesn't appear, since it never seemed to for me.
I think a code review is all that's needed.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
