### PR TITLE
Fix order of output spectra in VesuvioCalculateGammaBackground

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateGammaBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateGammaBackground.h
@@ -11,7 +11,7 @@
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/IDTypes.h"
 
-#include <unordered_map>
+#include <map>
 
 namespace Mantid {
 
@@ -88,7 +88,7 @@ private:
   /// Input TOF data
   API::MatrixWorkspace_const_sptr m_inputWS;
   /// Sorted indices to correct
-  std::unordered_map<size_t, size_t> m_indices;
+  std::map<size_t, size_t> m_indices;
   /// Function that defines the mass profile
   std::string m_profileFunction;
   /// The number of peaks in spectrum

--- a/docs/source/release/v6.9.0/Inelastic/Algorithms/Bugfixes/36512.rst
+++ b/docs/source/release/v6.9.0/Inelastic/Algorithms/Bugfixes/36512.rst
@@ -1,0 +1,1 @@
+- Fixed a bug in the :ref:`VesuvioCalculateGammaBackground <algm-VesuvioCalculateGammaBackground>` algorithm that meant the order of the output spectra was not guarenteed. This largely affected instances of mantid on linux machines.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

It has been observed that on Linux, the order of the output spectra from the `VesuvioCalculateGammaBackground` is inconsistent. This is not the expected behaviour, and if the workspace is subsequently accessed by Index can easily lead to errors.

It turns out that the algorithm has a member variable `m_indicies` which is expected to be sorted, but is an `unordered_map`. Changing this to a map fixes the issue.

If you provide a workspace index list, the order of the spectra is preserved as per the list, which is the current behaviour on windows.

### To test:

On linux, run the following script:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
tof_ws = CreateSimulationWorkspace(Instrument='Vesuvio',BinParams=[50,0.5,562],UnitX='TOF')
tof_ws = ConvertToPointData(tof_ws)
SetInstrumentParameter(tof_ws, ParameterName='t0',ParameterType='Number',Value='0.5')
SetInstrumentParameter(tof_ws, ParameterName='sigma_l1', ParameterType='Number', Value='0.021')
SetInstrumentParameter(tof_ws, ParameterName='sigma_l2', ParameterType='Number', Value='0.023')
SetInstrumentParameter(tof_ws, ParameterName='sigma_tof', ParameterType='Number', Value='0.3')
SetInstrumentParameter(tof_ws, ParameterName='sigma_theta', ParameterType='Number', Value='0.028')
SetInstrumentParameter(tof_ws, ParameterName='hwhm_lorentz', ParameterType='Number', Value='73.0')
SetInstrumentParameter(tof_ws, ParameterName='sigma_gauss', ParameterType='Number', Value='24.0')
mass_function = "name=GaussianComptonProfile,Mass=1.0079,Width=0.4,Intensity=1.1"
corrected, background = VesuvioCalculateGammaBackground(tof_ws, ComptonFunction=mass_function)
```

Check the order of the output spectra in the `corrected` workspace.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
