### PR TITLE
Iqt presenter is no longer a QObject and view is passed to constructor.

### DIFF
--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -130,15 +130,10 @@ set(MOC_FILES
     Corrections/Corrections.h
     Corrections/CorrectionsTab.h
     Manipulation/InelasticDataManipulation.h
-    Manipulation/InelasticDataManipulationElwinTab.h
     Manipulation/InelasticDataManipulationElwinTabView.h
-    Manipulation/InelasticDataManipulationIqtTab.h
     Manipulation/InelasticDataManipulationIqtTabView.h
-    Manipulation/InelasticDataManipulationMomentsTab.h
     Manipulation/InelasticDataManipulationMomentsTabView.h
-    Manipulation/InelasticDataManipulationSqwTab.h
     Manipulation/InelasticDataManipulationSqwTabView.h
-    Manipulation/InelasticDataManipulationSymmetriseTab.h
     Manipulation/InelasticDataManipulationSymmetriseTabView.h
     Manipulation/InelasticDataManipulationTab.h
 )
@@ -176,10 +171,15 @@ set(INC_FILES
     Common/SettingsHelper.h
     Common/SettingsPresenter.h
     Manipulation/InelasticDataManipulationElwinTabModel.h
+    Manipulation/InelasticDataManipulationElwinTab.h
     Manipulation/InelasticDataManipulationIqtTabModel.h
+    Manipulation/InelasticDataManipulationIqtTab.h
     Manipulation/InelasticDataManipulationMomentsTabModel.h
+    Manipulation/InelasticDataManipulationMomentsTab.h
     Manipulation/InelasticDataManipulationSqwTabModel.h
+    Manipulation/InelasticDataManipulationSqwTab.h
     Manipulation/InelasticDataManipulationSymmetriseTabModel.h
+    Manipulation/InelasticDataManipulationSymmetriseTab.h
     Manipulation/ISqwView.h
     Manipulation/IMomentsView.h
     Manipulation/ISymmetriseView.h

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -184,6 +184,7 @@ set(INC_FILES
     Manipulation/IMomentsView.h
     Manipulation/ISymmetriseView.h
     Manipulation/IElwinView.h
+    Manipulation/IIqtView.h
 )
 
 set(UI_FILES

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IIqtView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IIqtView.h
@@ -1,0 +1,49 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllConfig.h"
+#include "MantidAPI/MatrixWorkspace_fwd.h"
+
+#include <QStringList>
+
+#include <memory>
+#include <string>
+#include <tuple>
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class IndirectPlotOptionsView;
+class IIqtPresenter;
+
+class MANTIDQT_INELASTIC_DLL IIqtView {
+
+public:
+  virtual void subscribePresenter(IIqtPresenter *presenter) = 0;
+
+  virtual IndirectPlotOptionsView *getPlotOptions() const = 0;
+  virtual void plotInput(Mantid::API::MatrixWorkspace_sptr inputWS, int spectrum) = 0;
+  virtual void setPreviewSpectrumMaximum(int value) = 0;
+  virtual void updateDisplayedBinParameters() = 0;
+  virtual void setRangeSelectorDefault(const Mantid::API::MatrixWorkspace_sptr inputWorkspace,
+                                       const QPair<double, double> &range) = 0;
+  virtual bool validate() = 0;
+  virtual void setSampleFBSuffixes(const QStringList &suffix) = 0;
+  virtual void setSampleWSSuffixes(const QStringList &suffix) = 0;
+  virtual void setResolutionFBSuffixes(const QStringList &suffix) = 0;
+  virtual void setResolutionWSSuffixes(const QStringList &suffix) = 0;
+  virtual void setRunEnabled(bool enabled) = 0;
+  virtual void setSaveResultEnabled(bool enabled) = 0;
+  virtual void setRunText(bool running) = 0;
+  virtual void setWatchADS(bool watch) = 0;
+  virtual void setup() = 0;
+  virtual void showMessageBox(const std::string &message) const = 0;
+  virtual std::string getSampleName() const = 0;
+};
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IIqtView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IIqtView.h
@@ -18,7 +18,7 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-class IndirectPlotOptionsView;
+class OutputPlotOptionsView;
 class IIqtPresenter;
 
 class MANTIDQT_INELASTIC_DLL IIqtView {
@@ -26,7 +26,7 @@ class MANTIDQT_INELASTIC_DLL IIqtView {
 public:
   virtual void subscribePresenter(IIqtPresenter *presenter) = 0;
 
-  virtual IndirectPlotOptionsView *getPlotOptions() const = 0;
+  virtual OutputPlotOptionsView *getPlotOptions() const = 0;
   virtual void plotInput(Mantid::API::MatrixWorkspace_sptr inputWS, int spectrum) = 0;
   virtual void setPreviewSpectrumMaximum(int value) = 0;
   virtual void updateDisplayedBinParameters() = 0;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.cpp
@@ -62,8 +62,8 @@ void InelasticDataManipulation::initLayout() {
   addMVPTab<InelasticDataManipulationSymmetriseTab, InelasticDataManipulationSymmetriseTabView>("Symmetrise");
   addMVPTab<InelasticDataManipulationSqwTab, InelasticDataManipulationSqwTabView>("S(Q, w)");
   addMVPTab<InelasticDataManipulationMomentsTab, InelasticDataManipulationMomentsTabView>("Moments");
+  addMVPTab<InelasticDataManipulationIqtTab, InelasticDataManipulationIqtTabView>("Iqt");
   addMVPTab<InelasticDataManipulationElwinTab, InelasticDataManipulationElwinTabView>("Elwin");
-  addTab<InelasticDataManipulationIqtTab>("Iqt");
 
   connect(m_uiForm.pbSettings, SIGNAL(clicked()), this, SLOT(settings()));
   // Connect "?" (Help) Button

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.cpp
@@ -62,8 +62,8 @@ void InelasticDataManipulation::initLayout() {
   addMVPTab<InelasticDataManipulationSymmetriseTab, InelasticDataManipulationSymmetriseTabView>("Symmetrise");
   addMVPTab<InelasticDataManipulationSqwTab, InelasticDataManipulationSqwTabView>("S(Q, w)");
   addMVPTab<InelasticDataManipulationMomentsTab, InelasticDataManipulationMomentsTabView>("Moments");
-  addMVPTab<InelasticDataManipulationIqtTab, InelasticDataManipulationIqtTabView>("Iqt");
   addMVPTab<InelasticDataManipulationElwinTab, InelasticDataManipulationElwinTabView>("Elwin");
+  addMVPTab<InelasticDataManipulationIqtTab, InelasticDataManipulationIqtTabView>("Iqt");
 
   connect(m_uiForm.pbSettings, SIGNAL(clicked()), this, SLOT(settings()));
   // Connect "?" (Help) Button

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.h
@@ -74,40 +74,13 @@ private:
   void closeEvent(QCloseEvent *close) override;
 
   /**
-   * Adds a tab to the cache of tabs that can be shown.
+   * Adds an MVP tab to the cache of tabs that can be shown.
    *
-   * THis method is used to ensure that the tabs are always loaded and their
+   * This method is used to ensure that the tabs are always loaded and their
    * layouts setup for the sake of screenshoting them for documentation.
    *
    * @param name Name to be displayed on tab
    */
-  template <typename TabPresenter> void addTab(const QString &name) {
-    QWidget *tabWidget = new QWidget(m_uiForm.twIDRTabs);
-    QVBoxLayout *tabLayout = new QVBoxLayout(tabWidget);
-    tabWidget->setLayout(tabLayout);
-
-    QScrollArea *tabScrollArea = new QScrollArea(tabWidget);
-    tabLayout->addWidget(tabScrollArea);
-    tabScrollArea->setWidgetResizable(true);
-
-    QWidget *tabContent = new QWidget(tabScrollArea);
-    tabContent->setObjectName("tab" + QString(name).remove(QRegExp("[ ,()]")));
-    tabScrollArea->setWidget(tabContent);
-    tabScrollArea->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-
-    InelasticDataManipulationTab *tabIDRContent = new TabPresenter(tabContent);
-
-    tabIDRContent->setupTab();
-    tabContent->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-
-    connect(tabIDRContent, SIGNAL(showMessageBox(const QString &)), this, SLOT(showMessageBox(const QString &)));
-
-    // Add to the cache
-    m_tabs[name] = qMakePair(tabWidget, tabIDRContent);
-
-    // Add all tabs to UI initially
-    m_uiForm.twIDRTabs->addTab(tabWidget, name);
-  }
 
   template <typename TabPresenter, typename TabView> void addMVPTab(const QString &name) {
     QWidget *tabWidget = new QWidget(m_uiForm.twIDRTabs);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.cpp
@@ -29,7 +29,7 @@ namespace CustomInterfaces {
 
 InelasticDataManipulationIqtTab::InelasticDataManipulationIqtTab(QWidget *parent, IIqtView *view)
     : InelasticDataManipulationTab(parent), m_view(view),
-      m_model(std::make_unique<InelasticDataManipulationIqtTabModel>()), m_iqtResFileType(), m_selectedSpectrum(0) {
+      m_model(std::make_unique<InelasticDataManipulationIqtTabModel>()), m_selectedSpectrum(0) {
   m_view->subscribePresenter(this);
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraTiled));

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.cpp
@@ -24,35 +24,97 @@ namespace {
 Mantid::Kernel::Logger g_log("Iqt");
 } // namespace
 
-namespace MantidQt::CustomInterfaces::IDA {
-InelasticDataManipulationIqtTab::InelasticDataManipulationIqtTab(QWidget *parent)
-    : InelasticDataManipulationTab(parent), m_view(std::make_unique<InelasticDataManipulationIqtTabView>(parent)),
+namespace MantidQt {
+namespace CustomInterfaces {
+
+InelasticDataManipulationIqtTab::InelasticDataManipulationIqtTab(QWidget *parent, IIqtView *view)
+    : InelasticDataManipulationTab(parent), m_view(view),
       m_model(std::make_unique<InelasticDataManipulationIqtTabModel>()), m_iqtResFileType(), m_selectedSpectrum(0) {
+  m_view->subscribePresenter(this);
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraTiled));
 }
 
-InelasticDataManipulationIqtTab::~InelasticDataManipulationIqtTab() {}
+void InelasticDataManipulationIqtTab::setup() { m_view->setup(); }
 
-void InelasticDataManipulationIqtTab::setup() {
-  // signals / slots & validators
-  connect(m_view.get(), SIGNAL(sampDataReady(const QString &)), this, SLOT(plotInput(const QString &)));
-  connect(m_view.get(), SIGNAL(resDataReady(const QString &)), this, SLOT(handleResDataReady(const QString &)));
-  connect(m_view.get(), SIGNAL(iterationsChanged(int)), this, SLOT(handleIterationsChanged(int)));
-  connect(m_view.get(), SIGNAL(errorsClicked(int)), this, SLOT(handleErrorsClicked(int)));
-  connect(m_view.get(), SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(handleValueChanged(QtProperty *, double)));
+void InelasticDataManipulationIqtTab::handleSampDataReady(const std::string &wsname) {
+  MatrixWorkspace_sptr workspace;
+  try {
+    workspace = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsname);
+    setInputWorkspace(workspace);
+  } catch (Mantid::Kernel::Exception::NotFoundError &) {
+    m_view->showMessageBox("Unable to retrieve workspace: " + wsname);
+    m_view->setPreviewSpectrumMaximum(0);
+    return;
+  }
 
-  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
+  m_view->setPreviewSpectrumMaximum(static_cast<int>(getInputWorkspace()->getNumberHistograms()) - 1);
+  m_view->plotInput(getInputWorkspace(), getSelectedSpectrum());
+  m_view->setRangeSelectorDefault(getInputWorkspace(), getXRangeFromWorkspace(getInputWorkspace()));
+  m_view->updateDisplayedBinParameters();
+}
 
-  connect(m_view.get(), SIGNAL(showMessageBox(const QString &)), this, SIGNAL(showMessageBox(const QString &)));
-  connect(m_view.get(), SIGNAL(runClicked()), this, SLOT(runClicked()));
-  connect(m_view.get(), SIGNAL(saveClicked()), this, SLOT(saveClicked()));
-  connect(m_view.get(), SIGNAL(plotCurrentPreview()), this, SLOT(plotCurrentPreview()));
+void InelasticDataManipulationIqtTab::handleResDataReady(const std::string &resWorkspace) {
+  m_view->updateDisplayedBinParameters();
+  m_model->setResWorkspace(resWorkspace);
+}
 
-  connect(m_view.get(), SIGNAL(previewSpectrumChanged(int)), this, SLOT(handlePreviewSpectrumChanged(int)));
+void InelasticDataManipulationIqtTab::handleIterationsChanged(int iterations) {
+  m_model->setNIterations(std::to_string(iterations));
+}
 
-  m_view->setup();
+void InelasticDataManipulationIqtTab::handleRunClicked() {
+  clearOutputPlotOptionsWorkspaces();
+  runTab();
+}
+/**
+ * Handle saving of workspace
+ */
+void InelasticDataManipulationIqtTab::handleSaveClicked() {
+  checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
+  addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
+  m_batchAlgoRunner->executeBatchAsync();
+}
+
+/**
+ * Plots the current preview workspace, if none is set, plots
+ * the selected spectrum of the current input workspace.
+ */
+void InelasticDataManipulationIqtTab::handlePlotCurrentPreview() {
+  auto previewWs = getPreviewPlotWorkspace();
+  auto inputWs = getInputWorkspace();
+  auto index = boost::numeric_cast<size_t>(m_selectedSpectrum);
+  auto const errorBars = SettingsHelper::externalPlotErrorBars();
+
+  // Check a workspace has been selected
+  if (previewWs) {
+
+    if (inputWs && previewWs->getName() == inputWs->getName()) {
+      m_plotter->plotSpectra(previewWs->getName(), std::to_string(index), errorBars);
+    } else {
+      m_plotter->plotSpectra(previewWs->getName(), "0-2", errorBars);
+    }
+  } else if (inputWs && index < inputWs->getNumberHistograms()) {
+    m_plotter->plotSpectra(inputWs->getName(), std::to_string(index), errorBars);
+  } else
+    m_view->showMessageBox("Workspace not found - data may not be loaded.");
+}
+
+void InelasticDataManipulationIqtTab::handleErrorsClicked(int state) { m_model->setCalculateErrors(state); }
+
+void InelasticDataManipulationIqtTab::handleValueChanged(std::string const &propName, double value) {
+  if (propName == "ELow") {
+    m_model->setEnergyMin(value);
+  } else if (propName == "EHigh") {
+    m_model->setEnergyMax(value);
+  } else if (propName == "SampleBinning") {
+    m_model->setNumBins(value);
+  }
+}
+
+void InelasticDataManipulationIqtTab::handlePreviewSpectrumChanged(int spectra) {
+  setSelectedSpectrum(spectra);
+  m_view->plotInput(getInputWorkspace(), getSelectedSpectrum());
 }
 
 void InelasticDataManipulationIqtTab::run() {
@@ -62,8 +124,9 @@ void InelasticDataManipulationIqtTab::run() {
   m_view->updateDisplayedBinParameters();
 
   // Construct the result workspace for Python script export
-  QString const sampleName = QString::fromStdString(m_view->getSampleName());
-  m_pythonExportWsName = sampleName.left(sampleName.lastIndexOf("_")).toStdString() + "_iqt";
+  std::string sampleName = m_view->getSampleName();
+  m_pythonExportWsName = sampleName.replace(sampleName.find_last_of("_"), sampleName.size(), "_iqt");
+  // m_pythonExportWsName = sampleName.left(sampleName.find_last_of("_")). + "_iqt";
   m_model->setupTransformToIqt(m_batchAlgoRunner, m_pythonExportWsName);
   m_batchAlgoRunner->executeBatchAsync();
 }
@@ -73,27 +136,13 @@ void InelasticDataManipulationIqtTab::run() {
  *
  * @param error If the algorithm failed
  */
-void InelasticDataManipulationIqtTab::algorithmComplete(bool error) {
+void InelasticDataManipulationIqtTab::runComplete(bool error) {
   m_view->setWatchADS(true);
   setRunIsRunning(false);
   if (error)
     m_view->setSaveResultEnabled(false);
   else
     setOutputPlotOptionsWorkspaces({m_pythonExportWsName});
-}
-
-/**
- * Handle saving of workspace
- */
-void InelasticDataManipulationIqtTab::saveClicked() {
-  checkADSForPlotSaveWorkspace(m_pythonExportWsName, false);
-  addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
-  m_batchAlgoRunner->executeBatchAsync();
-}
-
-void InelasticDataManipulationIqtTab::runClicked() {
-  clearOutputPlotOptionsWorkspaces();
-  runTab();
 }
 
 /**
@@ -104,32 +153,6 @@ void InelasticDataManipulationIqtTab::runClicked() {
  */
 bool InelasticDataManipulationIqtTab::validate() { return m_view->validate(); }
 
-void InelasticDataManipulationIqtTab::handleResDataReady(const QString &resWorkspace) {
-  m_view->updateDisplayedBinParameters();
-  m_model->setResWorkspace(resWorkspace.toStdString());
-}
-
-void InelasticDataManipulationIqtTab::handleIterationsChanged(int iterations) {
-  m_model->setNIterations(std::to_string(iterations));
-}
-
-void InelasticDataManipulationIqtTab::handleValueChanged(QtProperty *prop, double value) {
-  if (prop->propertyName() == "ELow") {
-    m_model->setEnergyMin(value);
-  } else if (prop->propertyName() == "EHigh") {
-    m_model->setEnergyMax(value);
-  } else if (prop->propertyName() == "SampleBinning") {
-    m_model->setNumBins(value);
-  }
-}
-
-void InelasticDataManipulationIqtTab::handleErrorsClicked(int state) { m_model->setCalculateErrors(state); }
-
-void InelasticDataManipulationIqtTab::handlePreviewSpectrumChanged(int spectra) {
-  setSelectedSpectrum(spectra);
-  m_view->plotInput(getInputWorkspace(), getSelectedSpectrum());
-}
-
 void InelasticDataManipulationIqtTab::setFileExtensionsByName(bool filter) {
   QStringList const noSuffixes{""};
   auto const tabName("Iqt");
@@ -137,23 +160,6 @@ void InelasticDataManipulationIqtTab::setFileExtensionsByName(bool filter) {
   m_view->setSampleWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
   m_view->setResolutionFBSuffixes(filter ? getResolutionFBSuffixes(tabName) : getExtensions(tabName));
   m_view->setResolutionWSSuffixes(filter ? getResolutionWSSuffixes(tabName) : noSuffixes);
-}
-
-void InelasticDataManipulationIqtTab::plotInput(const QString &wsname) {
-  MatrixWorkspace_sptr workspace;
-  try {
-    workspace = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsname.toStdString());
-    setInputWorkspace(workspace);
-  } catch (Mantid::Kernel::Exception::NotFoundError &) {
-    showMessageBox(QString("Unable to retrieve workspace: " + wsname));
-    m_view->setPreviewSpectrumMaximum(0);
-    return;
-  }
-
-  m_view->setPreviewSpectrumMaximum(static_cast<int>(getInputWorkspace()->getNumberHistograms()) - 1);
-  m_view->plotInput(getInputWorkspace(), getSelectedSpectrum());
-  m_view->setRangeSelectorDefault(getInputWorkspace(), getXRangeFromWorkspace(getInputWorkspace()));
-  m_view->updateDisplayedBinParameters();
 }
 
 void InelasticDataManipulationIqtTab::setButtonsEnabled(bool enabled) {
@@ -198,30 +204,6 @@ void InelasticDataManipulationIqtTab::setInputWorkspace(MatrixWorkspace_sptr inp
 }
 
 /**
- * Plots the current preview workspace, if none is set, plots
- * the selected spectrum of the current input workspace.
- */
-void InelasticDataManipulationIqtTab::plotCurrentPreview() {
-  auto previewWs = getPreviewPlotWorkspace();
-  auto inputWs = getInputWorkspace();
-  auto index = boost::numeric_cast<size_t>(m_selectedSpectrum);
-  auto const errorBars = SettingsHelper::externalPlotErrorBars();
-
-  // Check a workspace has been selected
-  if (previewWs) {
-
-    if (inputWs && previewWs->getName() == inputWs->getName()) {
-      m_plotter->plotSpectra(previewWs->getName(), std::to_string(index), errorBars);
-    } else {
-      m_plotter->plotSpectra(previewWs->getName(), "0-2", errorBars);
-    }
-  } else if (inputWs && index < inputWs->getNumberHistograms()) {
-    m_plotter->plotSpectra(inputWs->getName(), std::to_string(index), errorBars);
-  } else
-    showMessageBox("Workspace not found - data may not be loaded.");
-}
-
-/**
  * Retrieves the workspace containing the data to be displayed in
  * the preview plot.
  *
@@ -241,5 +223,5 @@ MatrixWorkspace_sptr InelasticDataManipulationIqtTab::getPreviewPlotWorkspace() 
 void InelasticDataManipulationIqtTab::setPreviewPlotWorkspace(const MatrixWorkspace_sptr &previewPlotWorkspace) {
   m_previewPlotWorkspace = previewPlotWorkspace;
 }
-
-} // namespace MantidQt::CustomInterfaces::IDA
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.cpp
@@ -126,7 +126,6 @@ void InelasticDataManipulationIqtTab::run() {
   // Construct the result workspace for Python script export
   std::string sampleName = m_view->getSampleName();
   m_pythonExportWsName = sampleName.replace(sampleName.find_last_of("_"), sampleName.size(), "_iqt");
-  // m_pythonExportWsName = sampleName.left(sampleName.find_last_of("_")). + "_iqt";
   m_model->setupTransformToIqt(m_batchAlgoRunner, m_pythonExportWsName);
   m_batchAlgoRunner->executeBatchAsync();
 }

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.h
@@ -68,7 +68,6 @@ private:
   IIqtView *m_view;
   std::unique_ptr<InelasticDataManipulationIqtTabModel> m_model;
 
-  bool m_iqtResFileType;
   int m_selectedSpectrum;
 
   /// Retrieve input workspace

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.h
@@ -65,6 +65,9 @@ private:
   void setButtonsEnabled(bool enabled);
   void setRunIsRunning(bool running);
 
+  IIqtView *m_view;
+  std::unique_ptr<InelasticDataManipulationIqtTabModel> m_model;
+
   bool m_iqtResFileType;
   int m_selectedSpectrum;
 
@@ -73,9 +76,6 @@ private:
   MatrixWorkspace_sptr getPreviewPlotWorkspace();
   std::weak_ptr<MatrixWorkspace> m_previewPlotWorkspace;
   MatrixWorkspace_sptr m_inputWorkspace;
-
-  IIqtView *m_view;
-  std::unique_ptr<InelasticDataManipulationIqtTabModel> m_model;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTab.h
@@ -6,62 +6,76 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "IIqtView.h"
 #include "InelasticDataManipulationIqtTabModel.h"
 #include "InelasticDataManipulationIqtTabView.h"
 #include "InelasticDataManipulationTab.h"
 #include "ui_InelasticDataManipulationIqtTab.h"
+
 namespace MantidQt {
 namespace CustomInterfaces {
-namespace IDA {
+
+class IIqtPresenter {
+public:
+  virtual void handleSampDataReady(const std::string &wsname) = 0;
+  virtual void handleResDataReady(const std::string &resWorkspace) = 0;
+  virtual void handleIterationsChanged(int iterations) = 0;
+  virtual void handleRunClicked() = 0;
+  virtual void handleSaveClicked() = 0;
+  virtual void handlePlotCurrentPreview() = 0;
+  virtual void handleErrorsClicked(int state) = 0;
+  virtual void handleValueChanged(std::string const &propName, double value) = 0;
+  virtual void handlePreviewSpectrumChanged(int spectra) = 0;
+};
+
 using namespace Mantid::API;
-class MANTIDQT_INELASTIC_DLL InelasticDataManipulationIqtTab : public InelasticDataManipulationTab {
-  Q_OBJECT
+class MANTIDQT_INELASTIC_DLL InelasticDataManipulationIqtTab : public InelasticDataManipulationTab,
+                                                               public IIqtPresenter {
 
 public:
-  InelasticDataManipulationIqtTab(QWidget *parent = nullptr);
-  ~InelasticDataManipulationIqtTab();
+  InelasticDataManipulationIqtTab(QWidget *parent, IIqtView *view);
+  ~InelasticDataManipulationIqtTab() = default;
+
+  void setup() override;
+  void run() override;
+  bool validate() override;
+
+  void handleSampDataReady(const std::string &wsname) override;
+  void handleResDataReady(const std::string &resWorkspace) override;
+  void handleIterationsChanged(int iterations) override;
+  void handleRunClicked() override;
+  void handleSaveClicked() override;
+  void handlePlotCurrentPreview() override;
+  void handleErrorsClicked(int state) override;
+  void handleValueChanged(std::string const &propName, double value) override;
+  void handlePreviewSpectrumChanged(int spectra) override;
+
+protected:
+  void runComplete(bool error) override;
 
 private:
-  void run() override;
-  void setup() override;
-  bool validate() override;
   void setFileExtensionsByName(bool filter) override;
-
   /// Retrieve the selected spectrum
   int getSelectedSpectrum() const;
   /// Sets the selected spectrum
   virtual void setSelectedSpectrum(int spectrum);
-
-  MatrixWorkspace_sptr getPreviewPlotWorkspace();
   void setPreviewPlotWorkspace(const MatrixWorkspace_sptr &previewPlotWorkspace);
-  std::weak_ptr<MatrixWorkspace> m_previewPlotWorkspace;
-
-  /// Retrieve input workspace
-  Mantid::API::MatrixWorkspace_sptr getInputWorkspace() const;
   /// Set input workspace
   void setInputWorkspace(Mantid::API::MatrixWorkspace_sptr inputWorkspace);
-
   void setButtonsEnabled(bool enabled);
   void setRunIsRunning(bool running);
 
-  std::unique_ptr<InelasticDataManipulationIqtTabView> m_view;
-  std::unique_ptr<InelasticDataManipulationIqtTabModel> m_model;
   bool m_iqtResFileType;
   int m_selectedSpectrum;
-  Mantid::API::MatrixWorkspace_sptr m_inputWorkspace;
 
-private slots:
-  void algorithmComplete(bool error);
-  void handleResDataReady(const QString &resWorkspace);
-  void handleIterationsChanged(int iterations);
-  void handleErrorsClicked(int state);
-  void handleValueChanged(QtProperty *, double);
-  void handlePreviewSpectrumChanged(int spectra);
-  void plotInput(const QString &wsname);
-  void runClicked();
-  void saveClicked();
-  void plotCurrentPreview();
+  /// Retrieve input workspace
+  MatrixWorkspace_sptr getInputWorkspace() const;
+  MatrixWorkspace_sptr getPreviewPlotWorkspace();
+  std::weak_ptr<MatrixWorkspace> m_previewPlotWorkspace;
+  MatrixWorkspace_sptr m_inputWorkspace;
+
+  IIqtView *m_view;
+  std::unique_ptr<InelasticDataManipulationIqtTabModel> m_model;
 };
-} // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTabView.cpp
@@ -4,10 +4,14 @@
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
+
 #include "InelasticDataManipulationIqtTabView.h"
+#include "InelasticDataManipulationIqtTab.h"
+
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AlgorithmRuntimeProps.h"
 #include "MantidAPI/ITableWorkspace.h"
+
 #include "MantidGeometry/Instrument.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
@@ -72,8 +76,9 @@ std::tuple<bool, float, int, int> calculateBinParameters(std::string const &wsNa
 } // namespace
 
 namespace MantidQt::CustomInterfaces {
-using namespace IDA;
-InelasticDataManipulationIqtTabView::InelasticDataManipulationIqtTabView(QWidget *parent) : m_iqtTree(nullptr) {
+
+InelasticDataManipulationIqtTabView::InelasticDataManipulationIqtTabView(QWidget *parent)
+    : m_presenter(), m_iqtTree(nullptr) {
   m_uiForm.setupUi(parent);
   m_dblEdFac = new DoubleEditorFactory(this);
   m_dblManager = new QtDoublePropertyManager();
@@ -83,7 +88,7 @@ InelasticDataManipulationIqtTabView::~InelasticDataManipulationIqtTabView() {
   m_iqtTree->unsetFactoryForManager(m_dblManager);
 }
 
-OutputPlotOptionsView *InelasticDataManipulationIqtTabView::getPlotOptions() { return m_uiForm.ipoPlotOptions; }
+OutputPlotOptionsView *InelasticDataManipulationIqtTabView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
 
 void InelasticDataManipulationIqtTabView::setup() {
   m_iqtTree = new QtTreePropertyBrowser();
@@ -133,26 +138,143 @@ void InelasticDataManipulationIqtTabView::setup() {
   xRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
 
   // signals / slots & validators
-  connect(m_uiForm.dsInput, SIGNAL(dataReady(const QString &)), this, SIGNAL(sampDataReady(const QString &)));
-  connect(m_uiForm.dsResolution, SIGNAL(dataReady(const QString &)), this, SIGNAL(resDataReady(const QString &)));
-  connect(m_uiForm.spIterations, SIGNAL(valueChanged(int)), this, SIGNAL(iterationsChanged(int)));
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SIGNAL(runClicked()));
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SIGNAL(saveClicked()));
-  connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this, SIGNAL(plotCurrentPreview()));
-  connect(m_uiForm.cbCalculateErrors, SIGNAL(stateChanged(int)), this, SIGNAL(errorsClicked(int)));
-  connect(m_uiForm.cbCalculateErrors, SIGNAL(stateChanged(int)), this, SLOT(handleErrorsClicked(int)));
-  connect(m_uiForm.spPreviewSpec, SIGNAL(valueChanged(int)), this, SIGNAL(previewSpectrumChanged(int)));
-  connect(m_uiForm.ckSymmetricEnergy, SIGNAL(stateChanged(int)), this, SLOT(updateEnergyRange(int)));
-  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
+  connect(m_uiForm.dsInput, SIGNAL(dataReady(const QString &)), this, SLOT(notifySampDataReady(const QString &)));
+  connect(m_uiForm.dsResolution, SIGNAL(dataReady(const QString &)), this, SLOT(notifyResDataReady(const QString &)));
+  connect(m_uiForm.spIterations, SIGNAL(valueChanged(int)), this, SLOT(notifyIterationsChanged(int)));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(notifyRunClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
+  connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this, SLOT(notifyPlotCurrentPreview()));
+  connect(m_uiForm.cbCalculateErrors, SIGNAL(stateChanged(int)), this, SLOT(notifyErrorsClicked(int)));
+  connect(m_uiForm.spPreviewSpec, SIGNAL(valueChanged(int)), this, SLOT(notifyPreviewSpectrumChanged(int)));
+  connect(m_uiForm.ckSymmetricEnergy, SIGNAL(stateChanged(int)), this, SLOT(notifyUpdateEnergyRange(int)));
+  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyRangeChanged(double, double)));
   connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(updateRangeSelector(QtProperty *, double)));
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SIGNAL(valueChanged(QtProperty *, double)));
+          SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(notifyValueChanged(QtProperty *, double)));
 
   m_uiForm.dsInput->isOptional(true);
   m_uiForm.dsResolution->isOptional(true);
-  iterationsChanged(m_uiForm.spIterations->value());
-  errorsClicked(1);
+  notifyIterationsChanged(m_uiForm.spIterations->value());
+  notifyErrorsClicked(1);
   m_dblManager->setValue(m_properties["SampleBinning"], 10);
+}
+
+void InelasticDataManipulationIqtTabView::subscribePresenter(IIqtPresenter *presenter) { m_presenter = presenter; }
+
+void InelasticDataManipulationIqtTabView::notifySampDataReady(const QString &filename) {
+  m_presenter->handleSampDataReady(filename.toStdString());
+}
+
+void InelasticDataManipulationIqtTabView::notifyResDataReady(const QString &resFilename) {
+  m_presenter->handleResDataReady(resFilename.toStdString());
+}
+
+void InelasticDataManipulationIqtTabView::notifyIterationsChanged(int iterations) {
+  m_presenter->handleIterationsChanged(iterations);
+}
+
+void InelasticDataManipulationIqtTabView::notifyRunClicked() { m_presenter->handleRunClicked(); }
+
+void InelasticDataManipulationIqtTabView::notifySaveClicked() { m_presenter->handleSaveClicked(); }
+
+void InelasticDataManipulationIqtTabView::notifyPlotCurrentPreview() { m_presenter->handlePlotCurrentPreview(); }
+
+void InelasticDataManipulationIqtTabView::notifyErrorsClicked(int state) {
+  m_uiForm.spIterations->setEnabled(state);
+  m_presenter->handleErrorsClicked(state);
+}
+
+void InelasticDataManipulationIqtTabView::notifyPreviewSpectrumChanged(int spectra) {
+  m_presenter->handlePreviewSpectrumChanged(spectra);
+}
+
+void InelasticDataManipulationIqtTabView::notifyUpdateEnergyRange(int state) {
+  if (state != 0) {
+    auto const value = m_dblManager->value(m_properties["ELow"]);
+    m_dblManager->setValue(m_properties["EHigh"], -value);
+  }
+}
+
+void InelasticDataManipulationIqtTabView::notifyValueChanged(QtProperty *prop, double value) {
+  m_presenter->handleValueChanged(prop->propertyName().toStdString(), value);
+}
+
+/**
+ * Updates the range selectors and properties when range selector is moved.
+ *
+ * @param min Range selector min value
+ * @param max Range selector max value
+ */
+void InelasticDataManipulationIqtTabView::notifyRangeChanged(double min, double max) {
+  double oldMin = m_dblManager->value(m_properties["ELow"]);
+  double oldMax = m_dblManager->value(m_properties["EHigh"]);
+
+  auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
+
+  disconnect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyRangeChanged(double, double)));
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+             SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
+
+  if (fabs(oldMin - min) > 0.0000001) {
+    m_dblManager->setValue(m_properties["ELow"], min);
+    xRangeSelector->setMinimum(min);
+    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
+      m_dblManager->setValue(m_properties["EHigh"], -min);
+      xRangeSelector->setMaximum(-min);
+    }
+  }
+
+  if (fabs(oldMax - max) > 0.0000001) {
+    m_dblManager->setValue(m_properties["EHigh"], max);
+    xRangeSelector->setMaximum(max);
+    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
+      m_dblManager->setValue(m_properties["ELow"], -max);
+      xRangeSelector->setMinimum(-max);
+    }
+  }
+
+  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyRangeChanged(double, double)));
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
+
+  updateDisplayedBinParameters();
+}
+
+/**
+ * Updates the range selectors when the ELow or EHigh property is changed in the
+ * table.
+ *
+ * @param prop The property which has been changed
+ * @param val The new position for the range selector
+ */
+void InelasticDataManipulationIqtTabView::notifyUpdateRangeSelector(QtProperty *prop, double val) {
+  auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
+
+  disconnect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyRangeChanged(double, double)));
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+             SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
+
+  if (prop == m_properties["ELow"]) {
+    setRangeSelectorMin(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, val);
+    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
+      m_dblManager->setValue(m_properties["EHigh"], -val);
+      setRangeSelectorMax(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, -val);
+    }
+
+  } else if (prop == m_properties["EHigh"]) {
+    setRangeSelectorMax(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, val);
+    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
+      m_dblManager->setValue(m_properties["ELow"], -val);
+      setRangeSelectorMin(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, -val);
+    }
+  }
+
+  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyRangeChanged(double, double)));
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
+
+  updateDisplayedBinParameters();
 }
 
 void InelasticDataManipulationIqtTabView::setPreviewSpectrumMaximum(int value) {
@@ -178,24 +300,25 @@ bool InelasticDataManipulationIqtTabView::validate() {
     uiv.addErrorMessage("ELow must be less than EHigh.\n");
 
   auto const message = uiv.generateErrorMessage();
-  showMessageBox(message);
+  if (!message.isEmpty())
+    showMessageBox(message.toStdString());
 
   return message.isEmpty();
 }
 
-void InelasticDataManipulationIqtTabView::setSampleFBSuffixes(QStringList const suffix) {
+void InelasticDataManipulationIqtTabView::setSampleFBSuffixes(const QStringList &suffix) {
   m_uiForm.dsInput->setFBSuffixes(suffix);
 }
 
-void InelasticDataManipulationIqtTabView::setSampleWSSuffixes(QStringList const suffix) {
+void InelasticDataManipulationIqtTabView::setSampleWSSuffixes(const QStringList &suffix) {
   m_uiForm.dsInput->setWSSuffixes(suffix);
 }
 
-void InelasticDataManipulationIqtTabView::setResolutionFBSuffixes(QStringList const suffix) {
+void InelasticDataManipulationIqtTabView::setResolutionFBSuffixes(const QStringList &suffix) {
   m_uiForm.dsResolution->setFBSuffixes(suffix);
 }
 
-void InelasticDataManipulationIqtTabView::setResolutionWSSuffixes(QStringList const suffix) {
+void InelasticDataManipulationIqtTabView::setResolutionWSSuffixes(const QStringList &suffix) {
   m_uiForm.dsResolution->setWSSuffixes(suffix);
 }
 
@@ -218,47 +341,6 @@ void InelasticDataManipulationIqtTabView::plotInput(MatrixWorkspace_sptr inputWS
   if (inputWS && inputWS->x(spectrum).size() > 1) {
     m_uiForm.ppPlot->addSpectrum("Sample", inputWS, spectrum);
   }
-}
-
-/**
- * Updates the range selectors and properties when range selector is moved.
- *
- * @param min Range selector min value
- * @param max Range selector max value
- */
-void InelasticDataManipulationIqtTabView::rangeChanged(double min, double max) {
-  double oldMin = m_dblManager->value(m_properties["ELow"]);
-  double oldMax = m_dblManager->value(m_properties["EHigh"]);
-
-  auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
-
-  disconnect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updateRangeSelector(QtProperty *, double)));
-
-  if (fabs(oldMin - min) > 0.0000001) {
-    m_dblManager->setValue(m_properties["ELow"], min);
-    xRangeSelector->setMinimum(min);
-    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
-      m_dblManager->setValue(m_properties["EHigh"], -min);
-      xRangeSelector->setMaximum(-min);
-    }
-  }
-
-  if (fabs(oldMax - max) > 0.0000001) {
-    m_dblManager->setValue(m_properties["EHigh"], max);
-    xRangeSelector->setMaximum(max);
-    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
-      m_dblManager->setValue(m_properties["ELow"], -max);
-      xRangeSelector->setMinimum(-max);
-    }
-  }
-
-  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(updateRangeSelector(QtProperty *, double)));
-
-  updateDisplayedBinParameters();
 }
 
 void InelasticDataManipulationIqtTabView::setRangeSelectorDefault(const MatrixWorkspace_sptr workspace,
@@ -306,86 +388,6 @@ void InelasticDataManipulationIqtTabView::setRangeSelectorDefault(const MatrixWo
 }
 
 /**
- * Updates the range selectors when the ELow or EHigh property is changed in the
- * table.
- *
- * @param prop The property which has been changed
- * @param val The new position for the range selector
- */
-void InelasticDataManipulationIqtTabView::updateRangeSelector(QtProperty *prop, double val) {
-  auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
-
-  disconnect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updateRangeSelector(QtProperty *, double)));
-
-  if (prop == m_properties["ELow"]) {
-    setRangeSelectorMin(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, val);
-    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
-      m_dblManager->setValue(m_properties["EHigh"], -val);
-      setRangeSelectorMax(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, -val);
-    }
-
-  } else if (prop == m_properties["EHigh"]) {
-    setRangeSelectorMax(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, val);
-    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
-      m_dblManager->setValue(m_properties["ELow"], -val);
-      setRangeSelectorMin(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, -val);
-    }
-  }
-
-  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(updateRangeSelector(QtProperty *, double)));
-
-  updateDisplayedBinParameters();
-}
-
-/**
- * Calculates binning parameters.
- */
-void InelasticDataManipulationIqtTabView::updateDisplayedBinParameters() {
-  auto const sampleName = m_uiForm.dsInput->getCurrentDataName().toStdString();
-  auto const resolutionName = m_uiForm.dsResolution->getCurrentDataName().toStdString();
-
-  auto &ads = AnalysisDataService::Instance();
-  if (!ads.doesExist(sampleName) || !ads.doesExist(resolutionName))
-    return;
-
-  double energyMin = m_dblManager->value(m_properties["ELow"]);
-  double energyMax = m_dblManager->value(m_properties["EHigh"]);
-  double numBins = m_dblManager->value(m_properties["SampleBinning"]);
-
-  if (numBins == 0)
-    return;
-  if (energyMin == 0 && energyMax == 0)
-    return;
-
-  bool success(false);
-  float energyWidth(0.0f);
-  int resolutionBins(0), sampleBins(0);
-  std::tie(success, energyWidth, sampleBins, resolutionBins) =
-      calculateBinParameters(sampleName, resolutionName, energyMin, energyMax, numBins);
-  if (success) {
-    disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-               SLOT(updateRangeSelector(QtProperty *, double)));
-
-    // Update data in property editor
-    m_dblManager->setValue(m_properties["EWidth"], energyWidth);
-    m_dblManager->setValue(m_properties["ResolutionBins"], resolutionBins);
-    m_dblManager->setValue(m_properties["SampleBins"], sampleBins);
-
-    connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-            SLOT(updateRangeSelector(QtProperty *, double)));
-
-    // Warn for low number of resolution bins
-    if (resolutionBins < 5)
-      showMessageBox("Results may be inaccurate as ResolutionBins is "
-                     "less than 5.\nLower the SampleBinning.");
-  }
-}
-
-/**
  * Set the minimum of a range selector if it is less than the maximum value.
  * To be used when changing the min or max via the Property table
  *
@@ -419,17 +421,56 @@ void InelasticDataManipulationIqtTabView::setRangeSelectorMax(QtProperty *minPro
     m_dblManager->setValue(maxProperty, rangeSelector->getMaximum());
 }
 
-void InelasticDataManipulationIqtTabView::updateEnergyRange(int state) {
-  if (state != 0) {
-    auto const value = m_dblManager->value(m_properties["ELow"]);
-    m_dblManager->setValue(m_properties["EHigh"], -value);
+/**
+ * Calculates binning parameters.
+ */
+void InelasticDataManipulationIqtTabView::updateDisplayedBinParameters() {
+  auto const sampleName = m_uiForm.dsInput->getCurrentDataName().toStdString();
+  auto const resolutionName = m_uiForm.dsResolution->getCurrentDataName().toStdString();
+
+  auto &ads = AnalysisDataService::Instance();
+  if (!ads.doesExist(sampleName) || !ads.doesExist(resolutionName))
+    return;
+
+  double energyMin = m_dblManager->value(m_properties["ELow"]);
+  double energyMax = m_dblManager->value(m_properties["EHigh"]);
+  double numBins = m_dblManager->value(m_properties["SampleBinning"]);
+
+  if (numBins == 0)
+    return;
+  if (energyMin == 0 && energyMax == 0)
+    return;
+
+  bool success(false);
+  float energyWidth(0.0f);
+  int resolutionBins(0), sampleBins(0);
+  std::tie(success, energyWidth, sampleBins, resolutionBins) =
+      calculateBinParameters(sampleName, resolutionName, energyMin, energyMax, numBins);
+  if (success) {
+    disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+               SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
+
+    // Update data in property editor
+    m_dblManager->setValue(m_properties["EWidth"], energyWidth);
+    m_dblManager->setValue(m_properties["ResolutionBins"], resolutionBins);
+    m_dblManager->setValue(m_properties["SampleBins"], sampleBins);
+
+    connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+            SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
+
+    // Warn for low number of resolution bins
+    if (resolutionBins < 5)
+      showMessageBox("Results may be inaccurate as ResolutionBins is "
+                     "less than 5.\nLower the SampleBinning.");
   }
 }
 
-void InelasticDataManipulationIqtTabView::handleErrorsClicked(int state) { m_uiForm.spIterations->setEnabled(state); }
-
-std::string InelasticDataManipulationIqtTabView::getSampleName() {
+std::string InelasticDataManipulationIqtTabView::getSampleName() const {
   return m_uiForm.dsInput->getCurrentDataName().toStdString();
+}
+
+void InelasticDataManipulationIqtTabView::showMessageBox(const std::string &message) const {
+  QMessageBox::information(parentWidget(), this->windowTitle(), QString::fromStdString(message));
 }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTabView.cpp
@@ -57,6 +57,7 @@ std::tuple<bool, float, int, int> calculateBinParameters(std::string const &wsNa
     toIqt->setProperty("EnergyMax", energyMax);
     toIqt->setProperty("BinReductionFactor", binReductionFactor);
     toIqt->setProperty("DryRun", true);
+    toIqt->setLogging(false);
     toIqt->execute();
     propsTable = toIqt->getProperty("ParameterWorkspace");
     // the algorithm can create output even if it failed...
@@ -64,6 +65,7 @@ std::tuple<bool, float, int, int> calculateBinParameters(std::string const &wsNa
     deleter->initialize();
     deleter->setChild(true);
     deleter->setProperty("Workspace", paramTableName);
+    deleter->setLogging(false);
     deleter->execute();
   } catch (std::exception &) {
     return std::make_tuple(false, 0.0f, 0, 0);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTabView.h
@@ -74,6 +74,9 @@ private:
                            double newValue);
 
   Ui::InelasticDataManipulationIqtTab m_uiForm;
+
+  // Presenter
+  IIqtPresenter *m_presenter;
   QtTreePropertyBrowser *m_iqtTree;
   /// Internal list of the properties
   QMap<QString, QtProperty *> m_properties;
@@ -81,8 +84,6 @@ private:
   QtDoublePropertyManager *m_dblManager;
   /// Double editor factory for the properties browser
   DoubleEditorFactory *m_dblEdFac;
-  // Presenter
-  IIqtPresenter *m_presenter;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationIqtTabView.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DllConfig.h"
+#include "IIqtView.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/DoubleEditorFactory.h"
@@ -17,45 +18,54 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+
 using namespace Mantid::API;
 using namespace MantidQt::MantidWidgets;
 
-class MANTIDQT_INELASTIC_DLL InelasticDataManipulationIqtTabView : public QWidget {
+class IIqtPresenter;
+
+class MANTIDQT_INELASTIC_DLL InelasticDataManipulationIqtTabView : public QWidget, public IIqtView {
   Q_OBJECT
 
 public:
   InelasticDataManipulationIqtTabView(QWidget *parent = nullptr);
   ~InelasticDataManipulationIqtTabView();
-  OutputPlotOptionsView *getPlotOptions();
-  void plotInput(MatrixWorkspace_sptr inputWS, int spectrum);
-  void setPreviewSpectrumMaximum(int value);
-  void updateDisplayedBinParameters();
-  void setRangeSelectorDefault(const MatrixWorkspace_sptr inputWorkspace, const QPair<double, double> &range);
-  bool validate();
-  void setSampleFBSuffixes(QStringList const suffix);
-  void setSampleWSSuffixes(QStringList const suffix);
-  void setResolutionFBSuffixes(QStringList const suffix);
-  void setResolutionWSSuffixes(QStringList const suffix);
-  void setRunEnabled(bool enabled);
-  void setSaveResultEnabled(bool enabled);
-  void setRunText(bool running);
-  void setWatchADS(bool watch);
-  void setup();
+
+  void subscribePresenter(IIqtPresenter *presenter) override;
+
+  OutputPlotOptionsView *getPlotOptions() const override;
+  void plotInput(MatrixWorkspace_sptr inputWS, int spectrum) override;
+  void setPreviewSpectrumMaximum(int value) override;
+  void updateDisplayedBinParameters() override;
+  void setRangeSelectorDefault(const MatrixWorkspace_sptr inputWorkspace, const QPair<double, double> &range) override;
+  bool validate() override;
+  void setSampleFBSuffixes(const QStringList &suffix) override;
+  void setSampleWSSuffixes(const QStringList &suffix) override;
+  void setResolutionFBSuffixes(const QStringList &suffix) override;
+  void setResolutionWSSuffixes(const QStringList &suffix) override;
+  void setRunEnabled(bool enabled) override;
+  void setSaveResultEnabled(bool enabled) override;
+  void setRunText(bool running) override;
+  void setWatchADS(bool watch) override;
+  void setup() override;
+  void showMessageBox(const std::string &message) const override;
 
   // getters for properties
-  std::string getSampleName();
+  std::string getSampleName() const override;
 
-signals:
-  void sampDataReady(const QString &);
-  void resDataReady(const QString &);
-  void iterationsChanged(int);
-  void errorsClicked(int);
-  void previewSpectrumChanged(int);
-  void runClicked();
-  void saveClicked();
-  void plotCurrentPreview();
-  void showMessageBox(const QString &message);
-  void valueChanged(QtProperty *, double);
+private slots:
+  void notifySampDataReady(const QString &filename);
+  void notifyResDataReady(const QString &resFilename);
+  void notifyIterationsChanged(int iterations);
+  void notifyRunClicked();
+  void notifySaveClicked();
+  void notifyPlotCurrentPreview();
+  void notifyErrorsClicked(int state);
+  void notifyPreviewSpectrumChanged(int spectra);
+  void notifyUpdateEnergyRange(int state);
+  void notifyValueChanged(QtProperty *prop, double value);
+  void notifyRangeChanged(double min, double max);
+  void notifyUpdateRangeSelector(QtProperty *prop, double val);
 
 private:
   void setRangeSelectorMax(QtProperty *minProperty, QtProperty *maxProperty, RangeSelector *rangeSelector,
@@ -69,14 +79,10 @@ private:
   QMap<QString, QtProperty *> m_properties;
   /// Double manager to create properties
   QtDoublePropertyManager *m_dblManager;
-  /// Double editor facotry for the properties browser
+  /// Double editor factory for the properties browser
   DoubleEditorFactory *m_dblEdFac;
-
-private slots:
-  void rangeChanged(double min, double max);
-  void updateRangeSelector(QtProperty *prop, double val);
-  void updateEnergyRange(int state);
-  void handleErrorsClicked(int);
+  // Presenter
+  IIqtPresenter *m_presenter;
 };
 
 } // namespace CustomInterfaces


### PR DESCRIPTION
### Description of work
This PR removes the Qt dependency of the presenter of the Iqt tab of the Data Manipulation Interface. The implementation follows very closely the layout set in #36478 , and more justification for the changes can be found therein. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Part of  #36477 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1. Open `Data Manipulation -> Iqt` interface. 
2. Load a `red`  and `res` file, for example: `iris26173_graphite002_red.xs` and `iris26173_graphite002_res.xs`.
3. Test that the interface behaves and works as before. Try changing plot limits and property limits, and run the algorithm.
4. Check that plot options are enabled once the plot is finished. 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->
*This does not require release notes as it is internal maintenance.*
<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
