### PR TITLE
Fix for load dialog expanding off the bottom of the screen

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/34977.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/34977.rst
@@ -1,0 +1,1 @@
+- Improved behaviour of the load dialog with event workspaces so that it doesn't expand off the bottom of the screen.

--- a/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
@@ -15,6 +15,7 @@
 #include <QComboBox>
 #include <QDesktopWidget>
 #include <QFileInfo>
+#include <QScreen>
 #include <QUrl>
 
 // Mantid
@@ -284,11 +285,13 @@ void LoadDialog::createDynamicLayout() {
   m_form.propertyLayout->setEnabled(true);
   m_form.propertyLayout->activate();
 
-  const int screenHeight = QApplication::desktop()->height();
-  // If the thing won't end up too big compared to the screen height,
-  // resize the scroll area so we don't get a scroll bar
-  if (dialogHeight < 0.8 * screenHeight)
-    this->resize(this->width(), dialogHeight + 20);
+  const auto screenSize = screen()->availableSize();
+  const auto screenGeometry = screen()->availableGeometry();
+  dialogHeight = std::min(dialogHeight, static_cast<int>(screenSize.height() * 0.65));
+  this->resize(this->width(), dialogHeight);
+  const auto xPos = screenGeometry.x() + (screenSize.width() - this->width()) / 2;
+  const auto yPos = screenGeometry.y() + (screenSize.height() - this->height()) / 2;
+  this->move(xPos, yPos);
 
   // Make sure the OutputWorkspace value has been stored so that the validator
   // is cleared appropriately


### PR DESCRIPTION
When loading an event workspace, the load dialog now fits on the screen, and it centres itself so you can get to the buttons. Previously it was necessary to first shrink the top of the dialog, then drag it up. There was a previous attempt in there to remove the need for a scroll bar, but sometimes in life you're just going to have to scroll, unless you rotate your monitor to be portrait.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Clip the dialog height to some fraction of the current screen height, then position the dialog in the centre of the current screen by using its size and the screen geometry.

Fixes #34977. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
- In the recent releases of Qt, `QApplication::desktop()` is deprecated, so that had to go at some point anyway.

### To test:
Try loading different types of workspaces on different monitors, hopefully the load dialog remains on your screen.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
