### PR TITLE
Improve error message when failing to disassemble version number

### DIFF
--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -504,21 +504,28 @@ void AlignAndFocusPowder::exec() {
   if (xmin >= 0. || xmax > 0.) {
     getTofRange(m_outputW, tofmin, tofmax);
 
-    g_log.information() << "running CropWorkspace(TOFmin=" << xmin << ", TOFmax=" << xmax << ") started at "
-                        << Types::Core::DateAndTime::getCurrentTime() << "\n";
     API::IAlgorithm_sptr cropAlg = createChildAlgorithm("CropWorkspace");
     cropAlg->setProperty("InputWorkspace", m_outputW);
     cropAlg->setProperty("OutputWorkspace", m_outputW);
+    bool setxmin = false;
     if ((xmin >= 0.) && (xmin > tofmin)) {
       cropAlg->setProperty("Xmin", xmin);
       tofmin = xmin; // increase value
+      setxmin = true;
     }
+    bool setxmax = false;
     if ((xmax > 0.) && (xmax < tofmax)) {
       cropAlg->setProperty("Xmax", xmax);
       tofmax = xmax;
+      setxmax = true;
     }
-    cropAlg->executeAsChildAlg();
-    m_outputW = cropAlg->getProperty("OutputWorkspace");
+    // only run if either xmin or xmax was set
+    if (setxmin || setxmax) {
+      g_log.information() << "running CropWorkspace(TOFmin=" << xmin << ", TOFmax=" << xmax << ") started at "
+                          << Types::Core::DateAndTime::getCurrentTime() << "\n";
+      cropAlg->executeAsChildAlg();
+      m_outputW = cropAlg->getProperty("OutputWorkspace");
+    }
   }
   m_progress->report();
 

--- a/buildconfig/CMake/VersionNumber.cmake
+++ b/buildconfig/CMake/VersionNumber.cmake
@@ -52,7 +52,9 @@ message(STATUS "Minor: ${VERSION_MINOR}")
 message(STATUS "Patch: ${VERSION_PATCH}")
 message(STATUS "Tweak: ${VERSION_TWEAK}")
 if(NOT _version_str STREQUAL "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_TWEAK}")
-  message(FATAL_ERROR "Error when extracting version information from version string: ${_version_str}")
+  message(WARNING "most recent git tag found by versioningit is ${_version_str} which is not pep440 compliant")
+  message(WARNING "try git fetch --prune --prune-tags from mantidproject/mantid remote")
+  message(FATAL_ERROR "Error when extracting version information from version string ${_version_str}")
 endif()
 
 # Revision information

--- a/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36474.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36474.rst
@@ -1,0 +1,1 @@
+- Only crop in time-of-flight if a finite range is supplied in :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>`. The time difference is minimal, but users will no longer see a log for a function that isn't being run.


### PR DESCRIPTION
cmake determines the version number from versioningit which will fail with an unhelpful error message if the most recent git tag is not pep440 compliant. This makes the error message clearer and offers a solution.

*There is no associated issue.*

### To test:

1. Either create a tag that isn't [pep440](https://peps.python.org/pep-0440/) compliant (e.g. `v6.8.0-1`) or pull bad tags from an existing fork of mantid
2. re-run cmake
3. see the new messages

*This does not require release notes* because it is error messages for developers.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
