### PR TITLE
Symmetrise presenter is no longer QObject and View is passed to constructor.

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1767,4 +1767,3 @@ constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/An
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp:66
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp:158
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp:186
-passedByValue:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.cpp:86

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -145,6 +145,7 @@ set(INC_FILES
     Manipulation/InelasticDataManipulationSymmetriseTabModel.h
     Manipulation/ISqwView.h
     Manipulation/IMomentsView.h
+    Manipulation/ISymmetriseView.h
 )
 
 set(UI_FILES

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ISymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ISymmetriseView.h
@@ -8,7 +8,6 @@
 
 #include "DllConfig.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
-#include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 
 #include <QStringList>
 
@@ -26,7 +25,6 @@ class MANTIDQT_INELASTIC_DLL ISymmetriseView {
 
 public:
   virtual void subscribePresenter(ISymmetrisePresenter *presenter) = 0;
-  virtual void subscribeAlgoRunner(MantidQt::API::BatchAlgorithmRunner *algoRunner) = 0;
 
   virtual void setDefaults() = 0;
   virtual IndirectPlotOptionsView *getPlotOptions() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ISymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ISymmetriseView.h
@@ -1,0 +1,55 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllConfig.h"
+#include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+
+#include <QStringList>
+
+#include <memory>
+#include <string>
+#include <tuple>
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class IndirectPlotOptionsView;
+class ISymmetrisePresenter;
+
+class MANTIDQT_INELASTIC_DLL ISymmetriseView {
+
+public:
+  virtual void subscribePresenter(ISymmetrisePresenter *presenter) = 0;
+  virtual void subscribeAlgoRunner(MantidQt::API::BatchAlgorithmRunner *algoRunner) = 0;
+
+  virtual void setDefaults() = 0;
+  virtual IndirectPlotOptionsView *getPlotOptions() const = 0;
+  virtual void setFBSuffixes(QStringList const &suffix) = 0;
+  virtual void setWSSuffixes(QStringList const &suffix) = 0;
+
+  virtual double getElow() const = 0;
+  virtual double getEhigh() const = 0;
+  virtual double getPreviewSpec() = 0;
+  virtual std::string getDataName() const = 0;
+
+  virtual void plotNewData(std::string const &workspaceName) = 0;
+  virtual void updateMiniPlots() = 0;
+  virtual void replotNewSpectrum(double value) = 0;
+  virtual void updateRangeSelectors(std::string const &propName, double value) = 0;
+  virtual bool verifyERange(std::string const &workspaceName) = 0;
+  virtual void setRawPlotWatchADS(bool watchADS) = 0;
+
+  virtual void previewAlgDone() = 0;
+  virtual void enableSave(bool save) = 0;
+  virtual void enableRun(bool run) = 0;
+  virtual bool validate() = 0;
+  virtual void showMessageBox(std::string const &message) const = 0;
+};
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.cpp
@@ -59,7 +59,7 @@ void InelasticDataManipulation::initLayout() {
   m_uiForm.pbSettings->setIcon(IndirectSettings::icon());
 
   // Create the tabs
-  addTab<InelasticDataManipulationSymmetriseTab>("Symmetrise");
+  addMVPTab<InelasticDataManipulationSymmetriseTab, InelasticDataManipulationSymmetriseTabView>("Symmetrise");
   addMVPTab<InelasticDataManipulationSqwTab, InelasticDataManipulationSqwTabView>("S(Q, w)");
   addMVPTab<InelasticDataManipulationMomentsTab, InelasticDataManipulationMomentsTabView>("Moments");
   addTab<InelasticDataManipulationElwinTab>("Elwin");

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.cpp
@@ -142,7 +142,7 @@ void InelasticDataManipulationSymmetriseTab::handleDataReady(std::string const &
   if (m_view->validate()) {
     m_view->plotNewData(dataName);
   }
-  m_model->setWorkspaceName(QString(dataName.data()));
+  m_model->setWorkspaceName(dataName);
 }
 
 void InelasticDataManipulationSymmetriseTab::setIsPreview(bool preview) { m_isPreview = preview; }

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.h
@@ -40,8 +40,7 @@ public:
   virtual void handleReflectTypeChanged(int value) = 0;
   virtual void handleDoubleValueChanged(std::string const &propname, double value) = 0;
   virtual void handleDataReady(std::string const &dataName) = 0;
-  virtual void handlePreviewClicked() = 0;
-  virtual void handleRunClicked() = 0;
+  virtual void handleRunOrPreviewClicked(bool isPreview) = 0;
   virtual void handleSaveClicked() = 0;
 };
 
@@ -63,8 +62,7 @@ public:
   void handleReflectTypeChanged(int value) override;
   void handleDoubleValueChanged(std::string const &propname, double value) override;
   void handleDataReady(std::string const &dataName) override;
-  void handlePreviewClicked() override;
-  void handleRunClicked() override;
+  void handleRunOrPreviewClicked(bool isPreview) override;
   void handleSaveClicked() override;
 
   void setIsPreview(bool preview);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.h
@@ -34,38 +34,51 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+
+class ISymmetrisePresenter {
+public:
+  virtual void handleReflectTypeChanged(int value) = 0;
+  virtual void handleDoubleValueChanged(std::string const &propname, double value) = 0;
+  virtual void handleDataReady(std::string const &dataName) = 0;
+  virtual void handlePreviewClicked() = 0;
+  virtual void handleRunClicked() = 0;
+  virtual void handleSaveClicked() = 0;
+};
+
 /** InelasticDataManipulationSymmetriseTab
 
   @author Dan Nixon
   @date 23/07/2014
 */
-class MANTIDQT_INELASTIC_DLL InelasticDataManipulationSymmetriseTab : public InelasticDataManipulationTab {
-  Q_OBJECT
-
+class MANTIDQT_INELASTIC_DLL InelasticDataManipulationSymmetriseTab : public InelasticDataManipulationTab,
+                                                                      public ISymmetrisePresenter {
 public:
-  InelasticDataManipulationSymmetriseTab(QWidget *parent = nullptr);
+  InelasticDataManipulationSymmetriseTab(QWidget *parent, ISymmetriseView *view);
   ~InelasticDataManipulationSymmetriseTab() override;
 
   void setup() override;
   void run() override;
   bool validate() override;
 
-private slots:
-  void handleEnumValueChanged(QtProperty *, int);
-  void handleDoubleValueChanged(QtProperty *, double);
-  void handleDataReady(QString const &dataName) override;
-  void algorithmComplete(bool error);
-  void preview();
-  void previewAlgDone(bool error);
+  void handleReflectTypeChanged(int value) override;
+  void handleDoubleValueChanged(std::string const &propname, double value) override;
+  void handleDataReady(std::string const &dataName) override;
+  void handlePreviewClicked() override;
+  void handleRunClicked() override;
+  void handleSaveClicked() override;
 
-  void runClicked();
-  void saveClicked();
+  void setIsPreview(bool preview);
+
+protected:
+  void runComplete(bool error) override;
 
 private:
   void setFileExtensionsByName(bool filter) override;
 
+  // wether batch algorunner is running preview or run buttons
+  bool m_isPreview;
   Mantid::API::AnalysisDataServiceImpl &m_adsInstance;
-  std::unique_ptr<InelasticDataManipulationSymmetriseTabView> m_view;
+  ISymmetriseView *m_view;
   std::unique_ptr<InelasticDataManipulationSymmetriseTabModel> m_model;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTab.h
@@ -73,11 +73,11 @@ protected:
 private:
   void setFileExtensionsByName(bool filter) override;
 
-  // wether batch algorunner is running preview or run buttons
-  bool m_isPreview;
   Mantid::API::AnalysisDataServiceImpl &m_adsInstance;
   ISymmetriseView *m_view;
   std::unique_ptr<InelasticDataManipulationSymmetriseTabModel> m_model;
+  // wether batch algorunner is running preview or run buttons
+  bool m_isPreview;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.cpp
@@ -83,15 +83,15 @@ void InelasticDataManipulationSymmetriseTabModel::reflectNegativeToPositive() {
   sortXAxisAlg->execute();
 }
 
-void InelasticDataManipulationSymmetriseTabModel::setWorkspaceName(QString workspaceName) {
-  m_inputWorkspace = workspaceName.toStdString();
+void InelasticDataManipulationSymmetriseTabModel::setWorkspaceName(std::string workspaceName) {
+  m_inputWorkspace = workspaceName;
   m_reflectedInputWorkspace = m_inputWorkspace + "_reflected";
-  // the last 4 characters in the workspace name are '_red' the ouput weorkspace name is inserting '_sym' before that
+  // the last 4 characters in the workspace name are '_red' the ouput workspace name is inserting '_sym' before that
   // '_red'
-  m_positiveOutputWorkspace =
-      (workspaceName.left(workspaceName.length() - 4) + "_sym" + "_pn" + workspaceName.right(4)).toStdString();
-  m_negativeOutputWorkspace =
-      (workspaceName.left(workspaceName.length() - 4) + "_sym" + "_np" + workspaceName.right(4)).toStdString();
+  m_positiveOutputWorkspace = workspaceName.substr(0, workspaceName.size() - 4) + "_sym_pn" +
+                              workspaceName.substr(workspaceName.size() - 4, workspaceName.size());
+  m_negativeOutputWorkspace = workspaceName.substr(0, workspaceName.size() - 4) + "_sym_np" +
+                              workspaceName.substr(workspaceName.size() - 4, workspaceName.size());
 }
 
 void InelasticDataManipulationSymmetriseTabModel::setEMin(double value) { m_eMin = value; }

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.cpp
@@ -83,7 +83,7 @@ void InelasticDataManipulationSymmetriseTabModel::reflectNegativeToPositive() {
   sortXAxisAlg->execute();
 }
 
-void InelasticDataManipulationSymmetriseTabModel::setWorkspaceName(std::string workspaceName) {
+void InelasticDataManipulationSymmetriseTabModel::setWorkspaceName(std::string const &workspaceName) {
   m_inputWorkspace = workspaceName;
   m_reflectedInputWorkspace = m_inputWorkspace + "_reflected";
   // the last 4 characters in the workspace name are '_red' the ouput workspace name is inserting '_sym' before that

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.h
@@ -25,7 +25,7 @@ public:
   void setupPreviewAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::vector<long> spectraRange);
   std::string setupSymmetriseAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner);
   void reflectNegativeToPositive();
-  void setWorkspaceName(std::string workspaceName);
+  void setWorkspaceName(std::string const &workspaceName);
   void setEMin(double value);
   void setEMax(double value);
   void setIsPositiveReflect(bool value);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabModel.h
@@ -25,7 +25,7 @@ public:
   void setupPreviewAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::vector<long> spectraRange);
   std::string setupSymmetriseAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner);
   void reflectNegativeToPositive();
-  void setWorkspaceName(QString workspaceName);
+  void setWorkspaceName(std::string workspaceName);
   void setEMin(double value);
   void setEMax(double value);
   void setIsPositiveReflect(bool value);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.cpp
@@ -45,7 +45,7 @@ namespace MantidQt::CustomInterfaces {
 /** Constructor
  */
 InelasticDataManipulationSymmetriseTabView::InelasticDataManipulationSymmetriseTabView(QWidget *parent)
-    : m_presenter(), m_batchAlgoRunner() {
+    : m_presenter() {
   m_uiForm.setupUi(parent);
 
   m_dblManager = new QtDoublePropertyManager();
@@ -158,10 +158,6 @@ void InelasticDataManipulationSymmetriseTabView::subscribePresenter(ISymmetriseP
   m_presenter = presenter;
 }
 
-void InelasticDataManipulationSymmetriseTabView::subscribeAlgoRunner(MantidQt::API::BatchAlgorithmRunner *algoRunner) {
-  m_batchAlgoRunner = algoRunner;
-}
-
 void InelasticDataManipulationSymmetriseTabView::setDefaults() {
   // Set default X range values
   m_dblManager->setValue(m_properties["Ehigh"], 0.5);
@@ -200,11 +196,13 @@ void InelasticDataManipulationSymmetriseTabView::notifyDataReady(QString const &
   m_presenter->handleDataReady(dataName.toStdString());
 }
 
-void InelasticDataManipulationSymmetriseTabView::notifyRunClicked() { m_presenter->handleRunClicked(); }
+void InelasticDataManipulationSymmetriseTabView::notifyRunClicked() { m_presenter->handleRunOrPreviewClicked(false); }
+
+void InelasticDataManipulationSymmetriseTabView::notifyPreviewClicked() {
+  m_presenter->handleRunOrPreviewClicked(true);
+}
 
 void InelasticDataManipulationSymmetriseTabView::notifySaveClicked() { m_presenter->handleSaveClicked(); }
-
-void InelasticDataManipulationSymmetriseTabView::notifyPreviewClicked() { m_presenter->handlePreviewClicked(); }
 /**
  * Handles the X minimum value being changed from a range selector.
  *

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.h
@@ -10,7 +10,6 @@
 #include "ISymmetriseView.h"
 
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/DoubleEditorFactory.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/QtTreePropertyBrowser"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h"
@@ -28,7 +27,6 @@ public:
   ~InelasticDataManipulationSymmetriseTabView();
 
   void subscribePresenter(ISymmetrisePresenter *presenter) override;
-  void subscribeAlgoRunner(MantidQt::API::BatchAlgorithmRunner *algoRunner) override;
 
   void setDefaults() override;
   IndirectPlotOptionsView *getPlotOptions() const override;
@@ -78,7 +76,6 @@ private:
   QtEnumPropertyManager *m_enumManager;
 
   ISymmetrisePresenter *m_presenter;
-  MantidQt::API::BatchAlgorithmRunner *m_batchAlgoRunner;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSymmetriseTabView.h
@@ -7,7 +7,10 @@
 #pragma once
 
 #include "DllConfig.h"
+#include "ISymmetriseView.h"
+
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/DoubleEditorFactory.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/QtTreePropertyBrowser"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h"
@@ -18,44 +21,47 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-class MANTIDQT_INELASTIC_DLL InelasticDataManipulationSymmetriseTabView : public QWidget {
+class MANTIDQT_INELASTIC_DLL InelasticDataManipulationSymmetriseTabView : public QWidget, public ISymmetriseView {
   Q_OBJECT
-
 public:
-  InelasticDataManipulationSymmetriseTabView(QWidget *perent = nullptr);
+  InelasticDataManipulationSymmetriseTabView(QWidget *parent = nullptr);
   ~InelasticDataManipulationSymmetriseTabView();
-  void setDefaults();
-  IndirectPlotOptionsView *getPlotOptions();
-  void setFBSuffixes(QStringList const suffix);
-  void setWSSuffixes(QStringList const suffix);
-  void plotNewData(QString const &workspaceName);
-  void updateMiniPlots();
-  bool validate();
-  void setRawPlotWatchADS(bool watchADS);
-  double getElow() const;
-  double getEhigh() const;
-  double getPreviewSpec();
-  QString getInputName();
-  void previewAlgDone();
-  void enableSave(bool save);
-  void enableRun(bool save);
-  void updateRangeSelectors(QtProperty *prop, double value);
-  void replotNewSpectrum(double value);
-  bool verifyERange(QString const &workspaceName);
 
-signals:
-  void doubleValueChanged(QtProperty *, double);
-  void enumValueChanged(QtProperty *, int);
-  void dataReady(QString const &);
-  void previewClicked();
-  void runClicked();
-  void saveClicked();
-  void showMessageBox(const QString &message);
+  void subscribePresenter(ISymmetrisePresenter *presenter) override;
+  void subscribeAlgoRunner(MantidQt::API::BatchAlgorithmRunner *algoRunner) override;
+
+  void setDefaults() override;
+  IndirectPlotOptionsView *getPlotOptions() const override;
+  void setFBSuffixes(QStringList const &suffix) override;
+  void setWSSuffixes(QStringList const &suffix) override;
+
+  double getElow() const override;
+  double getEhigh() const override;
+  double getPreviewSpec() override;
+  std::string getDataName() const override;
+
+  void plotNewData(std::string const &workspaceName) override;
+  void updateMiniPlots() override;
+  void replotNewSpectrum(double value) override;
+  void updateRangeSelectors(std::string const &propName, double value) override;
+  bool verifyERange(std::string const &workspaceName) override;
+  void setRawPlotWatchADS(bool watchADS) override;
+
+  void previewAlgDone() override;
+  void enableSave(bool save) override;
+  void enableRun(bool run) override;
+  bool validate() override;
+  void showMessageBox(std::string const &message) const override;
 
 private slots:
-  void xRangeLowChanged(double value);
-  void xRangeHighChanged(double value);
-  void reflectTypeChanged(QtProperty *, int value);
+  void notifyDoubleValueChanged(QtProperty *, double);
+  void notifyReflectTypeChanged(QtProperty *, int value);
+  void notifyDataReady(QString const &);
+  void notifyPreviewClicked();
+  void notifyRunClicked();
+  void notifySaveClicked();
+  void notifyXrangeLowChanged(double value);
+  void notifyXrangeHighChanged(double value);
 
 private:
   void resetEDefaults(bool isPositive, QPair<double, double> range);
@@ -70,6 +76,9 @@ private:
   QtDoublePropertyManager *m_dblManager;
   QtGroupPropertyManager *m_grpManager;
   QtEnumPropertyManager *m_enumManager;
+
+  ISymmetrisePresenter *m_presenter;
+  MantidQt::API::BatchAlgorithmRunner *m_batchAlgoRunner;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/test/InelasticDataManipulationSymmetriseTabModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/InelasticDataManipulationSymmetriseTabModelTest.h
@@ -69,10 +69,10 @@ public:
   void tearDown() override { AnalysisDataService::Instance().clear(); }
 
   void test_preview_positive_setup() {
-    QString inputWS = "Workspace_name_red";
+    std::string inputWS = "Workspace_name_red";
     m_workspace = WorkspaceCreationHelper::createProcessedWorkspaceWithCylComplexInstrument(5, 6, true);
 
-    Mantid::API::AnalysisDataService::Instance().addOrReplace(inputWS.toStdString(), m_workspace);
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(inputWS, m_workspace);
     MantidQt::API::BatchAlgorithmRunner batch;
 
     m_model->setEMin(0.05);
@@ -96,10 +96,10 @@ public:
   }
 
   void test_preview_negative_setup() {
-    QString inputWS = "Workspace_name_red";
+    std::string inputWS = "Workspace_name_red";
     m_workspace = WorkspaceCreationHelper::createProcessedWorkspaceWithCylComplexInstrument(5, 6, true);
 
-    Mantid::API::AnalysisDataService::Instance().addOrReplace(inputWS.toStdString(), m_workspace);
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(inputWS, m_workspace);
     MantidQt::API::BatchAlgorithmRunner batch;
 
     m_model->setEMin(0.05);
@@ -123,10 +123,10 @@ public:
   }
 
   void test_run_positive_setup() {
-    QString inputWS = "Workspace_name_red";
+    std::string inputWS = "Workspace_name_red";
     m_workspace = WorkspaceCreationHelper::createProcessedWorkspaceWithCylComplexInstrument(5, 6, true);
 
-    Mantid::API::AnalysisDataService::Instance().addOrReplace(inputWS.toStdString(), m_workspace);
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(inputWS, m_workspace);
     MantidQt::API::BatchAlgorithmRunner batch;
 
     m_model->setEMin(0.05);
@@ -148,10 +148,10 @@ public:
   }
 
   void test_run_negative_setup() {
-    QString inputWS = "Workspace_name_red";
+    std::string inputWS = "Workspace_name_red";
     m_workspace = WorkspaceCreationHelper::createProcessedWorkspaceWithCylComplexInstrument(5, 6, true);
 
-    Mantid::API::AnalysisDataService::Instance().addOrReplace(inputWS.toStdString(), m_workspace);
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(inputWS, m_workspace);
     MantidQt::API::BatchAlgorithmRunner batch;
 
     m_model->setEMin(0.05);


### PR DESCRIPTION
### Description of work
This PR removes the Qt dependency of the presenter of the Symmetrise tab. The implementation follows very closely the layout set in #36478 , and more justification for the changes can be found therein. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Part of  #36477  . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1. Check that testing instructions of #36480 work as expected.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
