### PR TITLE
Improve Usability of the SANS Beam Centre Finder

### DIFF
--- a/docs/source/release/v6.9.0/SANS/Bugfixes/36518.rst
+++ b/docs/source/release/v6.9.0/SANS/Bugfixes/36518.rst
@@ -1,0 +1,3 @@
+- The Beam Centre Finder's bank selector has been simplified to remove unneeded checkboxes.
+- When the instrument is set to LARMOR, the Beam Centre Finder's position labels now indicate that the given values
+  should be in meters (m).

--- a/scripts/Interface/ui/sans_isis/beam_centre.py
+++ b/scripts/Interface/ui/sans_isis/beam_centre.py
@@ -152,13 +152,9 @@ class BeamCentre(QtWidgets.QWidget, Ui_BeamCentre):
     def enable_update_rear(self, enabled):
         self.update_rear_radio.setChecked(enabled)
 
-    def set_scale_millimeters(self):
-        self.rear_centre_label.setText("Centre Position - Rear (mm)")
-        self.front_centre_label.setText("Centre Position - Front (mm)")
-
-    def set_scale_meters(self):
-        self.rear_centre_label.setText("Centre Position - Rear (m)")
-        self.front_centre_label.setText("Centre Position - Front (m)")
+    def set_position_unit(self, unit: str):
+        self.rear_centre_label.setText(f"Centre Position - Rear ({unit})")
+        self.front_centre_label.setText(f"Centre Position - Front ({unit})")
 
     # ------------------------------------------------------------------------------------------------------------------
     # Properties

--- a/scripts/Interface/ui/sans_isis/beam_centre.py
+++ b/scripts/Interface/ui/sans_isis/beam_centre.py
@@ -8,7 +8,7 @@ from abc import ABCMeta, abstractmethod
 from qtpy import QtGui, QtCore, QtWidgets
 from mantidqt.utils.qt import load_ui
 from mantidqt.widgets import messagedisplay
-from sans.gui_logic.gui_common import get_detector_from_gui_selection, get_detector_strings_for_gui, get_string_for_gui_from_reduction_mode
+from sans.gui_logic.gui_common import get_detector_strings_for_gui
 
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
@@ -102,15 +102,14 @@ class BeamCentre(QtWidgets.QWidget, Ui_BeamCentre):
     def on_update_instrument(self, instrument):
         self.instrument = instrument
         component_list = get_detector_strings_for_gui(self.instrument)
-        self.set_component_options(component_list)
         if len(component_list) < 2:
             self.front_pos_1_line_edit.setEnabled(False)
             self.front_pos_2_line_edit.setEnabled(False)
-            self.update_front_check_box.setEnabled(False)
+            self.update_front_radio.setEnabled(False)
         else:
             self.front_pos_1_line_edit.setEnabled(True)
             self.front_pos_2_line_edit.setEnabled(True)
-            self.update_front_check_box.setEnabled(True)
+            self.update_front_radio.setEnabled(True)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Actions
@@ -148,10 +147,10 @@ class BeamCentre(QtWidgets.QWidget, Ui_BeamCentre):
         self.run_button.setEnabled(True)
 
     def enable_update_front(self, enabled):
-        self.update_front_check_box.setChecked(enabled)
+        self.update_front_radio.setChecked(enabled)
 
     def enable_update_rear(self, enabled):
-        self.update_rear_check_box.setChecked(enabled)
+        self.update_rear_radio.setChecked(enabled)
 
     def set_scale_millimeters(self):
         self.rear_centre_label.setText("Centre Position - Rear (mm)")
@@ -277,46 +276,17 @@ class BeamCentre(QtWidgets.QWidget, Ui_BeamCentre):
         self.update_simple_line_edit_field(line_edit="front_pos_2_line_edit", value=value)
 
     @property
-    def component(self):
-        component_as_string = self.component_combo_box.currentText()
-        return get_detector_from_gui_selection(component_as_string)
-
-    @component.setter
-    def component(self, value):
-        # There are two types of values that can be passed:
-        # String: we look for string and we set it
-        # Convert the value to the correct GUI string
-
-        # Set the correct selection of reduction modes which are available
-        component_list = get_detector_strings_for_gui(self.instrument)
-        self.set_component_options(component_list)
-
-        component_as_string = get_string_for_gui_from_reduction_mode(value, self.instrument)
-        if component_as_string:
-            index = self.reduction_mode_combo_box.findText(component_as_string)
-            if index != -1:
-                self.component_combo_box.setCurrentIndex(index)
-
-    def set_component_options(self, component_list):
-        current_index = self.component_combo_box.currentIndex()
-        self.component_combo_box.clear()
-        for element in component_list:
-            self.component_combo_box.addItem(element)
-        if current_index != -1:
-            self.component_combo_box.setCurrentIndex(current_index)
-
-    @property
     def update_front(self):
-        return self.update_front_check_box.isChecked()
+        return self.update_front_radio.isChecked()
 
     @update_front.setter
     def update_front(self, value):
-        self.update_front_check_box.setChecked(value)
+        self.update_front_radio.setChecked(value)
 
     @property
     def update_rear(self):
-        return self.update_rear_check_box.isChecked()
+        return self.update_rear_radio.isChecked()
 
     @update_rear.setter
     def update_rear(self, value):
-        self.update_front_check_box.setChecked(value)
+        self.update_rear_radio.setChecked(value)

--- a/scripts/Interface/ui/sans_isis/beam_centre.py
+++ b/scripts/Interface/ui/sans_isis/beam_centre.py
@@ -153,6 +153,14 @@ class BeamCentre(QtWidgets.QWidget, Ui_BeamCentre):
     def enable_update_rear(self, enabled):
         self.update_rear_check_box.setChecked(enabled)
 
+    def set_scale_millimeters(self):
+        self.rear_centre_label.setText("Centre Position - Rear (mm)")
+        self.front_centre_label.setText("Centre Position - Front (mm)")
+
+    def set_scale_meters(self):
+        self.rear_centre_label.setText("Centre Position - Rear (m)")
+        self.front_centre_label.setText("Centre Position - Front (m)")
+
     # ------------------------------------------------------------------------------------------------------------------
     # Properties
     # ------------------------------------------------------------------------------------------------------------------

--- a/scripts/Interface/ui/sans_isis/beam_centre.ui
+++ b/scripts/Interface/ui/sans_isis/beam_centre.ui
@@ -45,13 +45,6 @@
          <item row="3" column="1">
           <widget class="QLineEdit" name="front_pos_2_line_edit"/>
          </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="label_4">
-           <property name="text">
-            <string>Detector</string>
-           </property>
-          </widget>
-         </item>
          <item row="2" column="0">
           <widget class="QLabel" name="front_centre_label">
            <property name="text">
@@ -62,20 +55,20 @@
          <item row="1" column="1">
           <widget class="QLineEdit" name="rear_pos_2_line_edit"/>
          </item>
-         <item row="5" column="0">
-          <widget class="QComboBox" name="component_combo_box"/>
-         </item>
-         <item row="4" column="1">
-          <widget class="QCheckBox" name="update_rear_check_box">
+         <item row="4" column="0" colspan="2">
+          <widget class="QRadioButton" name="update_rear_radio">
            <property name="text">
-            <string>Use Rear Centre in Reduction</string>
+            <string>Find Rear Centre</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
-         <item row="5" column="1">
-          <widget class="QCheckBox" name="update_front_check_box">
+         <item row="5" column="0" colspan="2">
+          <widget class="QRadioButton" name="update_front_radio">
            <property name="text">
-            <string>Use Front Centre in Reduction</string>
+            <string>Find Front Centre</string>
            </property>
           </widget>
          </item>
@@ -322,9 +315,8 @@
   <tabstop>rear_pos_2_line_edit</tabstop>
   <tabstop>front_pos_1_line_edit</tabstop>
   <tabstop>front_pos_2_line_edit</tabstop>
-  <tabstop>component_combo_box</tabstop>
-  <tabstop>update_rear_check_box</tabstop>
-  <tabstop>update_front_check_box</tabstop>
+  <tabstop>update_rear_radio</tabstop>
+  <tabstop>update_front_radio</tabstop>
   <tabstop>r_min_line_edit</tabstop>
   <tabstop>r_max_line_edit</tabstop>
   <tabstop>q_min_line_edit</tabstop>

--- a/scripts/SANS/sans/gui_logic/models/beam_centre_model.py
+++ b/scripts/SANS/sans/gui_logic/models/beam_centre_model.py
@@ -220,19 +220,3 @@ class BeamCentreModel(object):
     @component.setter
     def component(self, value):
         self._component = value
-
-    @property
-    def update_front(self):
-        return self._update_front
-
-    @update_front.setter
-    def update_front(self, value):
-        self._update_front = value
-
-    @property
-    def update_rear(self):
-        return self._update_rear
-
-    @update_rear.setter
-    def update_rear(self, value):
-        self._update_rear = value

--- a/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
@@ -130,11 +130,11 @@ class BeamCentrePresenter(object):
         self._beam_centre_model.front_pos_1 = getattr(state_model, "front_pos_1")
         self._beam_centre_model.front_pos_2 = getattr(state_model, "front_pos_2")
 
-    def set_scale_to_meters(self, enable: bool) -> None:
-        if enable:
-            self._view.set_scale_meters()
+    def set_meters_mode_enabled(self, is_meters: bool) -> None:
+        if is_meters:
+            self._view.set_position_unit("m")
             return
-        self._view.set_scale_millimeters()
+        self._view.set_position_unit("mm")
 
     def update_centre_positions(self):
         rear_pos_1 = self._beam_centre_model.rear_pos_1

--- a/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
@@ -7,6 +7,7 @@
 import copy
 from typing import Dict
 
+from sans.common.enums import DetectorType
 from mantid import UsageService
 from mantid.kernel import FeatureType
 from mantid.kernel import Logger
@@ -114,9 +115,10 @@ class BeamCentrePresenter(object):
         self._beam_centre_model.front_pos_2 = self._view.front_pos_2
         self._beam_centre_model.q_min = self._view.q_min
         self._beam_centre_model.q_max = self._view.q_max
-        self._beam_centre_model.component = self._view.component
-        self._beam_centre_model.update_front = self._view.update_front
-        self._beam_centre_model.update_rear = self._view.update_rear
+        self._beam_centre_model.component = self._get_selected_component()
+
+    def _get_selected_component(self):
+        return DetectorType.HAB if self._view.update_front else DetectorType.LAB
 
     def copy_centre_positions(self, state_model):
         """

--- a/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
@@ -128,6 +128,12 @@ class BeamCentrePresenter(object):
         self._beam_centre_model.front_pos_1 = getattr(state_model, "front_pos_1")
         self._beam_centre_model.front_pos_2 = getattr(state_model, "front_pos_2")
 
+    def set_scale_to_meters(self, enable: bool) -> None:
+        if enable:
+            self._view.set_scale_meters()
+            return
+        self._view.set_scale_millimeters()
+
     def update_centre_positions(self):
         rear_pos_1 = self._beam_centre_model.rear_pos_1
         rear_pos_2 = self._beam_centre_model.rear_pos_2

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -396,6 +396,7 @@ class RunTabPresenter(PresenterCommon):
 
             self._beam_centre_presenter.copy_centre_positions(self._model)
             self._beam_centre_presenter.update_centre_positions()
+            self._beam_centre_presenter.set_scale_to_meters(self._view.instrument == SANSInstrument.LARMOR)
 
             self._masking_table_presenter.on_update_rows()
             self._workspace_diagnostic_presenter.on_user_file_load(user_file_path)

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -396,7 +396,7 @@ class RunTabPresenter(PresenterCommon):
 
             self._beam_centre_presenter.copy_centre_positions(self._model)
             self._beam_centre_presenter.update_centre_positions()
-            self._beam_centre_presenter.set_scale_to_meters(self._view.instrument == SANSInstrument.LARMOR)
+            self._beam_centre_presenter.set_meters_mode_enabled(self._view.instrument == SANSInstrument.LARMOR)
 
             self._masking_table_presenter.on_update_rows()
             self._workspace_diagnostic_presenter.on_user_file_load(user_file_path)

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
@@ -170,9 +170,8 @@ class _TomlV1ParserImpl(TomlParserImplBase):
         front = self.get_val("front_centre", det_config_dict)
         all = self.get_val("all_centre", det_config_dict)
 
-        if self.reduction_mode.reduction_mode is ReductionMode.LAB:
+        if self.reduction_mode.reduction_mode in [ReductionMode.LAB, ReductionMode.HAB]:
             update_translations(DetectorType.LAB, rear)
-        elif self.reduction_mode.reduction_mode is ReductionMode.HAB:
             update_translations(DetectorType.HAB, front)
         elif self.reduction_mode.reduction_mode in [ReductionMode.ALL, ReductionMode.MERGED]:
             if self.instrument is SANSInstrument.LOQ:

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 from sans.common.enums import SANSInstrument, ReductionMode, DetectorType, RangeStepType, FitModeForMerge, DataType, FitType, RebinType
-from sans.common.general_functions import get_bank_for_spectrum_number
+from sans.common.general_functions import get_bank_for_spectrum_number, get_detector_types_from_instrument
 from sans.state.IStateParser import IStateParser
 from sans.state.StateObjects.StateAdjustment import StateAdjustment
 from sans.state.StateObjects.StateCalculateTransmission import get_calculate_transmission
@@ -172,7 +172,8 @@ class _TomlV1ParserImpl(TomlParserImplBase):
 
         if self.reduction_mode.reduction_mode in [ReductionMode.LAB, ReductionMode.HAB]:
             update_translations(DetectorType.LAB, rear)
-            update_translations(DetectorType.HAB, front)
+            if DetectorType.HAB in get_detector_types_from_instrument(self.instrument):
+                update_translations(DetectorType.HAB, front)
         elif self.reduction_mode.reduction_mode in [ReductionMode.ALL, ReductionMode.MERGED]:
             if self.instrument is SANSInstrument.LOQ:
                 update_translations(DetectorType.LAB, rear)

--- a/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
@@ -166,12 +166,12 @@ class BeamCentrePresenterTest(unittest.TestCase):
             self.assertEqual(getattr(mocked_external_model, attr), getattr(self.presenter._beam_centre_model, attr))
 
     def test_set_scale_to_meters_on(self):
-        self.presenter.set_scale_to_meters(True)
-        self.view.set_scale_meters.assert_called_once()
+        self.presenter.set_meters_mode_enabled(True)
+        self.view.set_position_unit.assert_called_with("m")
 
     def test_set_scale_to_meters_off(self):
-        self.presenter.set_scale_to_meters(False)
-        self.view.set_scale_millimeters.assert_called_once()
+        self.presenter.set_meters_mode_enabled(False)
+        self.view.set_position_unit.assert_called_with("mm")
 
     def test_on_update_rows_updates_centres(self):
         # As the rear centres can update when the rows change (due to different run number groups)

--- a/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
@@ -165,6 +165,14 @@ class BeamCentrePresenterTest(unittest.TestCase):
         for attr in rear_attr:
             self.assertEqual(getattr(mocked_external_model, attr), getattr(self.presenter._beam_centre_model, attr))
 
+    def test_set_scale_to_meters_on(self):
+        self.presenter.set_scale_to_meters(True)
+        self.view.set_scale_meters.assert_called_once()
+
+    def test_set_scale_to_meters_off(self):
+        self.presenter.set_scale_to_meters(False)
+        self.view.set_scale_millimeters.assert_called_once()
+
     def test_on_update_rows_updates_centres(self):
         # As the rear centres can update when the rows change (due to different run number groups)
         # we should always update from the model

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
@@ -190,6 +190,24 @@ class TomlV1ParserTest(unittest.TestCase):
         self.assertEqual(2.2, move.detectors[ReductionMode.LAB.value].sample_centre_pos1)
         self.assertEqual(3.6, move.detectors[ReductionMode.LAB.value].sample_centre_pos2)
 
+    def test_loaded_correctly_when_on_single_bank_instrument(self):
+        input_dict = {
+            "instrument": {"name": "LARMOR"},
+            "detector": {
+                "configuration": {
+                    "all_centre": {"x": 2, "y": 3.4},
+                    "front_centre": {"x": 2.1, "y": 3.5},
+                    "rear_centre": {"x": 2.2, "y": 3.6},
+                    "selected_detector": "front",
+                }
+            },
+        }
+        parser = self._setup_parser(input_dict)
+        move = parser.get_state_move(None)
+        self.assertTrue(ReductionMode.HAB.value not in move.detectors.keys())
+        self.assertEqual(2.2, move.detectors[ReductionMode.LAB.value].sample_centre_pos1)
+        self.assertEqual(3.6, move.detectors[ReductionMode.LAB.value].sample_centre_pos2)
+
     def test_rear_front_maps_to_enum_correctly(self):
         for user_input, enum_val in [
             ("rear", ReductionMode.LAB),

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
@@ -154,7 +154,7 @@ class TomlV1ParserTest(unittest.TestCase):
         self.assertEqual(2.2, move.detectors[ReductionMode.LAB.value].sample_centre_pos1)
         self.assertEqual(3.6, move.detectors[ReductionMode.LAB.value].sample_centre_pos2)
 
-    def test_sets_rear_centre_when_rear_detector_selected(self):
+    def test_sets_rear_and_front_centre_when_rear_detector_selected(self):
         input_dict = {
             "detector": {
                 "configuration": {
@@ -167,12 +167,12 @@ class TomlV1ParserTest(unittest.TestCase):
         }
         parser = self._setup_parser(input_dict)
         move = parser.get_state_move(None)
-        self.assertEqual(0.0, move.detectors[ReductionMode.HAB.value].sample_centre_pos1)
-        self.assertEqual(0.0, move.detectors[ReductionMode.HAB.value].sample_centre_pos2)
+        self.assertEqual(2.1, move.detectors[ReductionMode.HAB.value].sample_centre_pos1)
+        self.assertEqual(3.5, move.detectors[ReductionMode.HAB.value].sample_centre_pos2)
         self.assertEqual(2.2, move.detectors[ReductionMode.LAB.value].sample_centre_pos1)
         self.assertEqual(3.6, move.detectors[ReductionMode.LAB.value].sample_centre_pos2)
 
-    def test_sets_front_centre_when_front_detector_selected(self):
+    def test_sets_front_and_rear_centre_when_front_detector_selected(self):
         input_dict = {
             "detector": {
                 "configuration": {
@@ -187,8 +187,8 @@ class TomlV1ParserTest(unittest.TestCase):
         move = parser.get_state_move(None)
         self.assertEqual(2.1, move.detectors[ReductionMode.HAB.value].sample_centre_pos1)
         self.assertEqual(3.5, move.detectors[ReductionMode.HAB.value].sample_centre_pos2)
-        self.assertEqual(0.0, move.detectors[ReductionMode.LAB.value].sample_centre_pos1)
-        self.assertEqual(0.0, move.detectors[ReductionMode.LAB.value].sample_centre_pos2)
+        self.assertEqual(2.2, move.detectors[ReductionMode.LAB.value].sample_centre_pos1)
+        self.assertEqual(3.6, move.detectors[ReductionMode.LAB.value].sample_centre_pos2)
 
     def test_rear_front_maps_to_enum_correctly(self):
         for user_input, enum_val in [


### PR DESCRIPTION
### Description of work

#### Summary of work
Improve the usability of a few features in the SANS Beam Centre Finder. 

Fixes #36518 
Fixes #36435 

**Report to:** @smk78 

#### Further detail of work
1. LARMOR sets it's beam centres on the GUI in meters (in comparison to the other instruments, which use mm), so the GUI now automatically updates the labels to indicate the correct unit. 
2. The confusing check box and combobox combination has now been replaced by a pair of radio buttons for selecting which of the two banks the beam centre should be found for. 
3. Both the front and rear values are loaded into the GUI from the user file when the reduction mode is set to `front` or `rear`. The behaviour for `all` and `merged` is unchanged. 

### To test:
1. Open the SANS GUI and load the user file from the `loqdemo` in the Training Course Data
    1. In this user file, the `selected_detector` should be set to `front`.
1. The values for both front and rear should have been loaded in from the user file into the beam centre finder. 
2. Check that the radio button has automatically selected the Find Front option. 
3. Run the beam centre finder and check that the output value (in the log on the right) matches the one set in the BCF's text boxes. 
4. Edit the user file to change the instrument from `LOQ` to `LARMOR` 
5. Reload the user file and navigate back to the BCF. The labels above the coordinate boxes should now be in meters rather than mm. 

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
