### PR TITLE
IndirectFitPlotPresenter no longer a QObject

### DIFF
--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitPlotView.h
@@ -88,8 +88,6 @@ public slots:
   virtual void setHWHMRange(double minimum, double maximum) = 0;
 
 signals:
-  void startXChanged(double /*_t1*/);
-  void endXChanged(double /*_t1*/);
   void backgroundChanged(double /*_t1*/);
 };
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitPlotView.h
@@ -86,9 +86,6 @@ public slots:
   virtual void clearBottomPreview() = 0;
   virtual void clearPreviews() = 0;
   virtual void setHWHMRange(double minimum, double maximum) = 0;
-
-signals:
-  void backgroundChanged(double /*_t1*/);
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitPlotView.h
@@ -65,7 +65,6 @@ public:
   virtual void setHWHMRangeVisible(bool visible) = 0;
 
   virtual void displayMessage(const std::string &message) const = 0;
-  virtual void disableSpectrumPlotSelection() = 0;
 
   virtual void allowRedraws(bool state) = 0;
   virtual void redrawPlots() = 0;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitPlotView.h
@@ -18,12 +18,16 @@ namespace CustomInterfaces {
 namespace IDA {
 using namespace MantidWidgets;
 
+class IIndirectFitPlotPresenter;
+
 class MANTIDQT_INELASTIC_DLL IIndirectFitPlotView : public API::MantidWidget {
   Q_OBJECT
 
 public:
   IIndirectFitPlotView(QWidget *parent = nullptr) : API::MantidWidget(parent){};
   virtual ~IIndirectFitPlotView(){};
+
+  virtual void subscribePresenter(IIndirectFitPlotPresenter *presenter) = 0;
 
   virtual void watchADS(bool watch) = 0;
 
@@ -74,25 +78,18 @@ public:
   virtual void allowRedraws(bool state) = 0;
   virtual void redrawPlots() = 0;
 
+  virtual void setHWHMMinimum(double minimum) = 0;
+  virtual void setHWHMMaximum(double maximum) = 0;
+
 public slots:
   virtual void clearTopPreview() = 0;
   virtual void clearBottomPreview() = 0;
   virtual void clearPreviews() = 0;
   virtual void setHWHMRange(double minimum, double maximum) = 0;
-  virtual void setHWHMMaximum(double minimum) = 0;
-  virtual void setHWHMMinimum(double maximum) = 0;
 
 signals:
-  void selectedFitDataChanged(WorkspaceID /*_t1*/);
-  void plotCurrentPreview();
-  void plotSpectrumChanged(WorkspaceIndex /*_t1*/);
-  void plotGuessChanged(bool /*_t1*/);
-  void fitSelectedSpectrum();
   void startXChanged(double /*_t1*/);
   void endXChanged(double /*_t1*/);
-  void hwhmMinimumChanged(double /*_t1*/);
-  void hwhmMaximumChanged(double /*_t1*/);
-  void hwhmChanged(double /*_t1*/, double /*_t2*/);
   void backgroundChanged(double /*_t1*/);
 };
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitPlotView.h
@@ -7,11 +7,8 @@
 #pragma once
 
 #include "DllConfig.h"
-#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
-#include "MantidQtWidgets/Common/MantidWidget.h"
-
-#include <QObject>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -20,13 +17,8 @@ using namespace MantidWidgets;
 
 class IIndirectFitPlotPresenter;
 
-class MANTIDQT_INELASTIC_DLL IIndirectFitPlotView : public API::MantidWidget {
-  Q_OBJECT
-
+class MANTIDQT_INELASTIC_DLL IIndirectFitPlotView {
 public:
-  IIndirectFitPlotView(QWidget *parent = nullptr) : API::MantidWidget(parent){};
-  virtual ~IIndirectFitPlotView(){};
-
   virtual void subscribePresenter(IIndirectFitPlotPresenter *presenter) = 0;
 
   virtual void watchADS(bool watch) = 0;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitPlotView.h
@@ -80,12 +80,9 @@ public:
 
   virtual void setHWHMMinimum(double minimum) = 0;
   virtual void setHWHMMaximum(double maximum) = 0;
-
-public slots:
-  virtual void clearTopPreview() = 0;
-  virtual void clearBottomPreview() = 0;
-  virtual void clearPreviews() = 0;
   virtual void setHWHMRange(double minimum, double maximum) = 0;
+
+  virtual void clearPreviews() = 0;
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
@@ -77,7 +77,6 @@ void IndirectDataAnalysisTab::setup() {
   updateResultOptions();
 
   connectDataPresenter();
-  connectPlotPresenter();
   connectFitPropertyBrowser();
 }
 
@@ -94,19 +93,6 @@ void IndirectDataAnalysisTab::connectDataPresenter() {
   connect(m_dataPresenter.get(), SIGNAL(dataAdded(IAddWorkspaceDialog const *)), this,
           SLOT(respondToDataAdded(IAddWorkspaceDialog const *)));
   connect(m_dataPresenter.get(), SIGNAL(dataRemoved()), this, SLOT(respondToDataRemoved()));
-}
-
-void IndirectDataAnalysisTab::connectPlotPresenter() {
-  connect(m_plotPresenter.get(), SIGNAL(fitSingleSpectrum(WorkspaceID, WorkspaceIndex)), this,
-          SLOT(singleFit(WorkspaceID, WorkspaceIndex)));
-  connect(m_plotPresenter.get(), SIGNAL(startXChanged(double)), this, SLOT(handleStartXChanged(double)));
-  connect(m_plotPresenter.get(), SIGNAL(endXChanged(double)), this, SLOT(handleEndXChanged(double)));
-
-  connect(m_plotPresenter.get(), SIGNAL(selectedFitDataChanged(WorkspaceID)), this,
-          SLOT(respondToPlotSpectrumChanged()));
-  connect(m_plotPresenter.get(), SIGNAL(plotSpectrumChanged()), this, SLOT(respondToPlotSpectrumChanged()));
-  connect(m_plotPresenter.get(), SIGNAL(fwhmChanged(double)), this, SLOT(respondToFwhmChanged(double)));
-  connect(m_plotPresenter.get(), SIGNAL(backgroundChanged(double)), this, SLOT(respondToBackgroundChanged(double)));
 }
 
 void IndirectDataAnalysisTab::connectFitPropertyBrowser() {
@@ -378,7 +364,7 @@ void IndirectDataAnalysisTab::updateFitStatus() {
 /**
  * Plots the spectra corresponding to the selected parameters
  */
-void IndirectDataAnalysisTab::plotSelectedSpectra() {
+void IndirectDataAnalysisTab::handlePlotSelectedSpectra() {
   enableFitButtons(false);
   plotSelectedSpectra(m_outOptionsPresenter->getSpectraToPlot());
   enableFitButtons(true);
@@ -425,9 +411,9 @@ std::vector<std::string> IndirectDataAnalysisTab::getFitParameterNames() const {
 /**
  * Executes the single fit algorithm defined in this indirect fit analysis tab.
  */
-void IndirectDataAnalysisTab::singleFit() { singleFit(getSelectedDataIndex(), getSelectedSpectrum()); }
+void IndirectDataAnalysisTab::singleFit() { handleSingleFitClicked(getSelectedDataIndex(), getSelectedSpectrum()); }
 
-void IndirectDataAnalysisTab::singleFit(WorkspaceID workspaceID, WorkspaceIndex spectrum) {
+void IndirectDataAnalysisTab::handleSingleFitClicked(WorkspaceID workspaceID, WorkspaceIndex spectrum) {
   if (validate()) {
     m_activeSpectrumIndex = spectrum;
     m_plotPresenter->setFitSingleSpectrumIsFitting(true);
@@ -652,18 +638,18 @@ void IndirectDataAnalysisTab::respondToDataRemoved() {
   updateParameterEstimationData();
 }
 
-void IndirectDataAnalysisTab::respondToPlotSpectrumChanged() {
+void IndirectDataAnalysisTab::handlePlotSpectrumChanged() {
   auto const index = m_plotPresenter->getSelectedDomainIndex();
   m_fitPropertyBrowser->setCurrentDataset(index);
 }
 
-void IndirectDataAnalysisTab::respondToFwhmChanged(double fwhm) {
+void IndirectDataAnalysisTab::handleFwhmChanged(double fwhm) {
   m_fittingModel->setFWHM(fwhm, m_plotPresenter->getActiveWorkspaceID());
   updateFitBrowserParameterValues();
   m_plotPresenter->updateGuess();
 }
 
-void IndirectDataAnalysisTab::respondToBackgroundChanged(double value) {
+void IndirectDataAnalysisTab::handleBackgroundChanged(double value) {
   m_fittingModel->setBackground(value, m_plotPresenter->getActiveWorkspaceID());
   m_fitPropertyBrowser->setBackgroundA0(value);
   setModelFitFunction();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
@@ -121,7 +121,8 @@ void IndirectDataAnalysisTab::setupOutputOptionsPresenter(bool const editResults
 }
 
 void IndirectDataAnalysisTab::setupPlotView(std::optional<std::pair<double, double>> const &xPlotBounds) {
-  m_plotPresenter = std::make_unique<IndirectFitPlotPresenter>(m_uiForm->dockArea->m_fitPlotView);
+  auto model = std::make_unique<IndirectFitPlotModel>();
+  m_plotPresenter = std::make_unique<IndirectFitPlotPresenter>(m_uiForm->dockArea->m_fitPlotView, std::move(model));
   m_plotPresenter->setFittingData(m_dataPresenter->getFittingData());
   m_plotPresenter->setFitOutput(m_fittingModel->getFitOutput());
   if (xPlotBounds) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
@@ -122,7 +122,8 @@ void IndirectDataAnalysisTab::setupOutputOptionsPresenter(bool const editResults
 
 void IndirectDataAnalysisTab::setupPlotView(std::optional<std::pair<double, double>> const &xPlotBounds) {
   auto model = std::make_unique<IndirectFitPlotModel>();
-  m_plotPresenter = std::make_unique<IndirectFitPlotPresenter>(m_uiForm->dockArea->m_fitPlotView, std::move(model));
+  m_plotPresenter =
+      std::make_unique<IndirectFitPlotPresenter>(this, m_uiForm->dockArea->m_fitPlotView, std::move(model));
   m_plotPresenter->setFittingData(m_dataPresenter->getFittingData());
   m_plotPresenter->setFitOutput(m_fittingModel->getFitOutput());
   if (xPlotBounds) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
@@ -35,7 +35,16 @@ namespace IDA {
 
 class MANTIDQT_INELASTIC_DLL IIndirectDataAnalysisTab {
 public:
-  virtual void plotSelectedSpectra() = 0;
+  // Used by FitPlotPresenter
+  virtual void handleSingleFitClicked(WorkspaceID workspaceID, WorkspaceIndex workspaceIndex) = 0;
+  virtual void handleStartXChanged(double startX) = 0;
+  virtual void handleEndXChanged(double endX) = 0;
+  virtual void handlePlotSpectrumChanged() = 0;
+  virtual void handleFwhmChanged(double fwhm) = 0;
+  virtual void handleBackgroundChanged(double background) = 0;
+
+  // Used by FitOutputOptionsPresenter
+  virtual void handlePlotSelectedSpectra() = 0;
 };
 
 class MANTIDQT_INELASTIC_DLL IndirectDataAnalysisTab : public IndirectTab, public IIndirectDataAnalysisTab {
@@ -82,7 +91,16 @@ public:
   bool hasResolution() const noexcept { return m_hasResolution; }
   void setFileExtensionsByName(bool filter);
 
-  void plotSelectedSpectra() override;
+  void handleSingleFitClicked(WorkspaceID workspaceID, WorkspaceIndex workspaceIndex) override;
+  void handlePlotSpectrumChanged() override;
+  void handleFwhmChanged(double fwhm) override;
+  void handleBackgroundChanged(double background) override;
+
+  void handlePlotSelectedSpectra() override;
+
+public slots:
+  void handleStartXChanged(double startX) override;
+  void handleEndXChanged(double endX) override;
 
 protected:
   IndirectFittingModel *getFittingModel() const;
@@ -114,7 +132,6 @@ protected:
 private:
   void setup() override;
   bool validate() override;
-  void connectPlotPresenter();
   void connectFitPropertyBrowser();
   void connectDataPresenter();
   void plotSelectedSpectra(std::vector<SpectrumToPlot> const &spectra);
@@ -141,13 +158,10 @@ protected slots:
   void setModelEndX(double endX);
   void tableStartXChanged(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum);
   void tableEndXChanged(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum);
-  void handleStartXChanged(double startX);
-  void handleEndXChanged(double endX);
   void updateFitOutput(bool error);
   void updateSingleFitOutput(bool error);
   void fitAlgorithmComplete(bool error);
   void singleFit();
-  void singleFit(WorkspaceID workspaceID, WorkspaceIndex spectrum);
   void executeFit();
   void updateParameterValues();
   void updateParameterValues(const std::unordered_map<std::string, ParameterValue> &parameters);
@@ -164,9 +178,6 @@ private slots:
   void respondToDataChanged();
   void respondToDataAdded(IAddWorkspaceDialog const *dialog);
   void respondToDataRemoved();
-  void respondToPlotSpectrumChanged();
-  void respondToFwhmChanged(double);
-  void respondToBackgroundChanged(double value);
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitOutputOptionsPresenter.cpp
@@ -66,7 +66,7 @@ void IndirectFitOutputOptionsPresenter::handlePlotClicked() {
   setPlotting(true);
   try {
     plotResult(m_view->getSelectedGroupWorkspace());
-    m_tab->plotSelectedSpectra();
+    m_tab->handlePlotSelectedSpectra();
   } catch (std::runtime_error const &ex) {
     displayWarning(ex.what());
   }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
@@ -7,7 +7,6 @@
 #include "IndirectFitPlotPresenter.h"
 #include "IndirectSettingsHelper.h"
 
-#include <QSignalBlocker>
 #include <QTimer>
 
 #include <utility>
@@ -118,7 +117,6 @@ void IndirectFitPlotPresenter::appendLastDataToSelection(std::vector<std::string
 }
 
 void IndirectFitPlotPresenter::updateDataSelection(std::vector<std::string> displayNames) {
-  QSignalBlocker blocker(m_view);
   m_view->clearDataSelection();
   const auto workspaceCount = displayNames.size();
   for (size_t i = 0; i < workspaceCount; ++i) {
@@ -216,7 +214,6 @@ void IndirectFitPlotPresenter::plotDifference(MatrixWorkspace_sptr workspace, Wo
 }
 
 void IndirectFitPlotPresenter::updatePlotRange(const std::pair<double, double> &range) {
-  QSignalBlocker blocker(m_view);
   m_view->setFitRange(range.first, range.second);
   m_view->setHWHMRange(range.first, range.second);
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectFitPlotPresenter.h"
+#include "IndirectDataAnalysisTab.h"
 #include "IndirectSettingsHelper.h"
 
 #include <QTimer>
@@ -27,9 +28,9 @@ struct HoldRedrawing {
 
 using namespace Mantid::API;
 
-IndirectFitPlotPresenter::IndirectFitPlotPresenter(IIndirectFitPlotView *view,
+IndirectFitPlotPresenter::IndirectFitPlotPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitPlotView *view,
                                                    std::unique_ptr<IndirectFitPlotModel> model)
-    : m_view(view), m_model(std::move(model)), m_plotter(std::make_unique<ExternalPlotter>()) {
+    : m_tab(tab), m_view(view), m_model(std::move(model)), m_plotter(std::make_unique<ExternalPlotter>()) {
   m_view->subscribePresenter(this);
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
@@ -39,13 +39,13 @@ void IndirectFitPlotPresenter::handleSelectedFitDataChanged(WorkspaceID workspac
   updateAvailableSpectra();
   updatePlots();
   updateGuess();
-  emit selectedFitDataChanged(workspaceID);
+  m_tab->handlePlotSpectrumChanged();
 }
 
 void IndirectFitPlotPresenter::handlePlotSpectrumChanged(WorkspaceIndex spectrum) {
   setActiveSpectrum(spectrum);
   updatePlots();
-  emit plotSpectrumChanged();
+  m_tab->handlePlotSpectrumChanged();
 }
 
 void IndirectFitPlotPresenter::watchADS(bool watch) { m_view->watchADS(watch); }
@@ -86,9 +86,9 @@ void IndirectFitPlotPresenter::updateRangeSelectors() {
   updateHWHMSelector();
 }
 
-void IndirectFitPlotPresenter::handleStartXChanged(double value) { emit startXChanged(value); }
+void IndirectFitPlotPresenter::handleStartXChanged(double value) { m_tab->handleStartXChanged(value); }
 
-void IndirectFitPlotPresenter::handleEndXChanged(double value) { emit endXChanged(value); }
+void IndirectFitPlotPresenter::handleEndXChanged(double value) { m_tab->handleEndXChanged(value); }
 
 void IndirectFitPlotPresenter::handleHWHMMaximumChanged(double minimum) {
   m_view->setHWHMMaximum(m_model->calculateHWHMMaximum(minimum));
@@ -119,7 +119,7 @@ void IndirectFitPlotPresenter::updateDataSelection(std::vector<std::string> disp
   setActiveIndex(WorkspaceID{0});
   setActiveSpectrum(WorkspaceIndex{0});
   updateAvailableSpectra();
-  emitSelectedFitDataChanged();
+  m_tab->handlePlotSpectrumChanged();
 }
 
 void IndirectFitPlotPresenter::updateAvailableSpectra() {
@@ -295,18 +295,13 @@ void IndirectFitPlotPresenter::plotSpectrum(WorkspaceIndex spectrum) const {
 }
 
 void IndirectFitPlotPresenter::handleFitSingleSpectrum() {
-  emit fitSingleSpectrum(m_model->getActiveWorkspaceID(), m_model->getActiveWorkspaceIndex());
+  m_tab->handleSingleFitClicked(m_model->getActiveWorkspaceID(), m_model->getActiveWorkspaceIndex());
 }
 
 void IndirectFitPlotPresenter::handleFWHMChanged(double minimum, double maximum) {
-  emit fwhmChanged(maximum - minimum);
+  m_tab->handleFwhmChanged(maximum - minimum);
 }
 
-void IndirectFitPlotPresenter::handleBackgroundChanged(double value) { emit backgroundChanged(value); }
-
-void IndirectFitPlotPresenter::emitSelectedFitDataChanged() {
-  const auto index = m_view->getSelectedDataIndex();
-  emit selectedFitDataChanged(index);
-}
+void IndirectFitPlotPresenter::handleBackgroundChanged(double value) { m_tab->handleBackgroundChanged(value); }
 
 } // namespace MantidQt::CustomInterfaces::IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
@@ -32,12 +32,6 @@ IndirectFitPlotPresenter::IndirectFitPlotPresenter(IIndirectFitPlotView *view,
                                                    std::unique_ptr<IndirectFitPlotModel> model)
     : m_view(view), m_model(std::move(model)), m_plotter(std::make_unique<ExternalPlotter>()) {
   m_view->subscribePresenter(this);
-
-  connect(m_view, SIGNAL(backgroundChanged(double)), this, SIGNAL(backgroundChanged(double)));
-
-  // updatePlots();
-  // updateRangeSelectors();
-  // updateAvailableSpectra();
 }
 
 void IndirectFitPlotPresenter::handleSelectedFitDataChanged(WorkspaceID workspaceID) {
@@ -316,6 +310,8 @@ void IndirectFitPlotPresenter::handleFitSingleSpectrum() {
 void IndirectFitPlotPresenter::handleFWHMChanged(double minimum, double maximum) {
   emit fwhmChanged(maximum - minimum);
 }
+
+void IndirectFitPlotPresenter::handleBackgroundChanged(double value) { emit backgroundChanged(value); }
 
 void IndirectFitPlotPresenter::emitSelectedFitDataChanged() {
   const auto index = m_view->getSelectedDataIndex();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
@@ -80,11 +80,6 @@ void IndirectFitPlotPresenter::setFittingData(std::vector<IndirectFitData> *fitt
 
 void IndirectFitPlotPresenter::setFitOutput(IIndirectFitOutput *fitOutput) { m_model->setFitOutput(fitOutput); }
 
-void IndirectFitPlotPresenter::updatePlotSpectrum(WorkspaceIndex spectrum) {
-  setActiveSpectrum(spectrum);
-  updatePlots();
-}
-
 void IndirectFitPlotPresenter::updateRangeSelectors() {
   updateBackgroundSelector();
   updateHWHMSelector();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
@@ -28,8 +28,9 @@ struct HoldRedrawing {
 
 using namespace Mantid::API;
 
-IndirectFitPlotPresenter::IndirectFitPlotPresenter(IIndirectFitPlotView *view)
-    : m_model(new IndirectFitPlotModel()), m_view(view), m_plotter(std::make_unique<ExternalPlotter>()) {
+IndirectFitPlotPresenter::IndirectFitPlotPresenter(IIndirectFitPlotView *view,
+                                                   std::unique_ptr<IndirectFitPlotModel> model)
+    : m_view(view), m_model(std::move(model)), m_plotter(std::make_unique<ExternalPlotter>()) {
   connect(m_view, SIGNAL(selectedFitDataChanged(WorkspaceID)), this, SLOT(handleSelectedFitDataChanged(WorkspaceID)));
 
   connect(m_view, SIGNAL(plotSpectrumChanged(WorkspaceIndex)), this, SLOT(handlePlotSpectrumChanged(WorkspaceIndex)));

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
@@ -33,9 +33,6 @@ IndirectFitPlotPresenter::IndirectFitPlotPresenter(IIndirectFitPlotView *view,
     : m_view(view), m_model(std::move(model)), m_plotter(std::make_unique<ExternalPlotter>()) {
   m_view->subscribePresenter(this);
 
-  connect(m_view, SIGNAL(startXChanged(double)), this, SIGNAL(startXChanged(double)));
-  connect(m_view, SIGNAL(endXChanged(double)), this, SIGNAL(endXChanged(double)));
-
   connect(m_view, SIGNAL(backgroundChanged(double)), this, SIGNAL(backgroundChanged(double)));
 
   // updatePlots();
@@ -101,6 +98,10 @@ void IndirectFitPlotPresenter::updateRangeSelectors() {
   updateBackgroundSelector();
   updateHWHMSelector();
 }
+
+void IndirectFitPlotPresenter::handleStartXChanged(double value) { emit startXChanged(value); }
+
+void IndirectFitPlotPresenter::handleEndXChanged(double value) { emit endXChanged(value); }
 
 void IndirectFitPlotPresenter::handleHWHMMaximumChanged(double minimum) {
   m_view->setHWHMMaximum(m_model->calculateHWHMMaximum(minimum));

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
@@ -66,9 +66,9 @@ void IndirectFitPlotPresenter::setActiveSpectrum(WorkspaceIndex spectrum) {
   m_view->setPlotSpectrum(spectrum);
 }
 
-void IndirectFitPlotPresenter::setStartX(double startX) { m_view->setFitRangeMinimum(startX); }
+void IndirectFitPlotPresenter::setStartX(double value) { m_view->setFitRangeMinimum(value); }
 
-void IndirectFitPlotPresenter::setEndX(double endX) { m_view->setFitRangeMaximum(endX); }
+void IndirectFitPlotPresenter::setEndX(double value) { m_view->setFitRangeMaximum(value); }
 
 void IndirectFitPlotPresenter::setXBounds(std::pair<double, double> const &bounds) {
   m_view->setFitRangeBounds(bounds);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
@@ -6,9 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectFitPlotPresenter.h"
 #include "IndirectDataAnalysisTab.h"
+#include "IndirectFitPlotView.h"
 #include "IndirectSettingsHelper.h"
-
-#include <QTimer>
 
 #include <utility>
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.cpp
@@ -66,8 +66,6 @@ void IndirectFitPlotPresenter::setActiveSpectrum(WorkspaceIndex spectrum) {
   m_view->setPlotSpectrum(spectrum);
 }
 
-void IndirectFitPlotPresenter::disableSpectrumPlotSelection() { m_view->disableSpectrumPlotSelection(); }
-
 void IndirectFitPlotPresenter::setStartX(double startX) { m_view->setFitRangeMinimum(startX); }
 
 void IndirectFitPlotPresenter::setEndX(double endX) { m_view->setFitRangeMaximum(endX); }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
@@ -85,8 +85,6 @@ public slots:
   void updateGuess();
   void updateGuessAvailability();
 
-  void disableSpectrumPlotSelection();
-
 signals:
   void selectedFitDataChanged(WorkspaceID /*_t1*/);
   void plotSpectrumChanged();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
@@ -25,6 +25,9 @@ public:
   virtual void handlePlotGuess(bool doPlotGuess) = 0;
   virtual void handleFitSingleSpectrum() = 0;
 
+  virtual void handleStartXChanged(double value) = 0;
+  virtual void handleEndXChanged(double value) = 0;
+
   virtual void handleHWHMMinimumChanged(double maximum) = 0;
   virtual void handleHWHMMaximumChanged(double minimum) = 0;
 
@@ -57,6 +60,9 @@ public:
   void handlePlotCurrentPreview() override;
   void handlePlotGuess(bool doPlotGuess) override;
   void handleFitSingleSpectrum() override;
+
+  void handleStartXChanged(double value) override;
+  void handleEndXChanged(double value) override;
 
   void handleHWHMMinimumChanged(double maximum) override;
   void handleHWHMMaximumChanged(double minimum) override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
@@ -87,15 +87,6 @@ public:
   void handleFWHMChanged(double minimum, double maximum) override;
   void handleBackgroundChanged(double value) override;
 
-signals:
-  void selectedFitDataChanged(WorkspaceID /*_t1*/);
-  void plotSpectrumChanged();
-  void fitSingleSpectrum(WorkspaceID /*_t1*/, WorkspaceIndex /*_t2*/);
-  void startXChanged(double /*_t1*/);
-  void endXChanged(double /*_t1*/);
-  void fwhmChanged(double /*_t1*/);
-  void backgroundChanged(double /*_t1*/);
-
 private:
   void disableAllDataSelection();
   void enableAllDataSelection();
@@ -112,7 +103,6 @@ private:
   void setHWHM(double value);
   void updateBackgroundSelector();
   void updateFitRangeSelector();
-  void emitSelectedFitDataChanged();
   void setActiveIndex(WorkspaceID workspaceID);
 
   void plotSpectrum(WorkspaceIndex spectrum) const;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
@@ -114,8 +114,8 @@ private:
 
   void plotSpectrum(WorkspaceIndex spectrum) const;
 
-  std::unique_ptr<IndirectFitPlotModel> m_model;
   IIndirectFitPlotView *m_view;
+  std::unique_ptr<IndirectFitPlotModel> m_model;
 
   std::unique_ptr<Widgets::MplCpp::ExternalPlotter> m_plotter;
 };

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
@@ -17,7 +17,21 @@ namespace CustomInterfaces {
 namespace IDA {
 using namespace MantidWidgets;
 
-class MANTIDQT_INELASTIC_DLL IndirectFitPlotPresenter : public QObject {
+class MANTIDQT_INELASTIC_DLL IIndirectFitPlotPresenter {
+public:
+  virtual void handleSelectedFitDataChanged(WorkspaceID workspaceID) = 0;
+  virtual void handlePlotSpectrumChanged(WorkspaceIndex spectrum) = 0;
+  virtual void handlePlotCurrentPreview() = 0;
+  virtual void handlePlotGuess(bool doPlotGuess) = 0;
+  virtual void handleFitSingleSpectrum() = 0;
+
+  virtual void handleHWHMMinimumChanged(double maximum) = 0;
+  virtual void handleHWHMMaximumChanged(double minimum) = 0;
+
+  virtual void handleFWHMChanged(double minimum, double maximum) = 0;
+};
+
+class MANTIDQT_INELASTIC_DLL IndirectFitPlotPresenter : public QObject, public IIndirectFitPlotPresenter {
   Q_OBJECT
 
 public:
@@ -37,6 +51,17 @@ public:
   void setFitSingleSpectrumEnabled(bool enable);
 
   void setXBounds(std::pair<double, double> const &bounds);
+
+  void handleSelectedFitDataChanged(WorkspaceID workspaceID) override;
+  void handlePlotSpectrumChanged(WorkspaceIndex spectrum) override;
+  void handlePlotCurrentPreview() override;
+  void handlePlotGuess(bool doPlotGuess) override;
+  void handleFitSingleSpectrum() override;
+
+  void handleHWHMMinimumChanged(double maximum) override;
+  void handleHWHMMaximumChanged(double minimum) override;
+
+  void handleFWHMChanged(double minimum, double maximum) override;
 
 public slots:
   void setStartX(double /*startX*/);
@@ -65,15 +90,7 @@ signals:
 
 private slots:
   void setActiveIndex(WorkspaceID workspaceID);
-  void setHWHMMaximum(double minimum);
-  void setHWHMMinimum(double maximum);
-  void plotGuess(bool doPlotGuess);
   void updateFitRangeSelector();
-  void plotCurrentPreview();
-  void emitFitSingleSpectrum();
-  void emitFWHMChanged(double minimum, double maximum);
-  void handleSelectedFitDataChanged(WorkspaceID workspaceID);
-  void handlePlotSpectrumChanged(WorkspaceIndex spectrum);
 
 private:
   void disableAllDataSelection();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
@@ -56,6 +56,19 @@ public:
 
   void setXBounds(std::pair<double, double> const &bounds);
 
+  void setActiveSpectrum(WorkspaceIndex spectrum);
+  void updateRangeSelectors();
+
+  void setStartX(double value);
+  void setEndX(double value);
+  void appendLastDataToSelection(std::vector<std::string> displayNames);
+  void updateDataSelection(std::vector<std::string> displayNames);
+  void updateAvailableSpectra();
+  void updatePlots();
+  void updateFit();
+  void updateGuess();
+  void updateGuessAvailability();
+
   void handleSelectedFitDataChanged(WorkspaceID workspaceID) override;
   void handlePlotSpectrumChanged(WorkspaceIndex spectrum) override;
   void handlePlotCurrentPreview() override;
@@ -72,18 +85,7 @@ public:
   void handleBackgroundChanged(double value) override;
 
 public slots:
-  void setStartX(double /*startX*/);
-  void setEndX(double /*endX*/);
-  void setActiveSpectrum(WorkspaceIndex spectrum);
   void updatePlotSpectrum(WorkspaceIndex spectrum);
-  void updateRangeSelectors();
-  void appendLastDataToSelection(std::vector<std::string> displayNames);
-  void updateDataSelection(std::vector<std::string> displayNames);
-  void updateAvailableSpectra();
-  void updatePlots();
-  void updateFit();
-  void updateGuess();
-  void updateGuessAvailability();
 
 signals:
   void selectedFitDataChanged(WorkspaceID /*_t1*/);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
@@ -17,6 +17,8 @@ namespace CustomInterfaces {
 namespace IDA {
 using namespace MantidWidgets;
 
+class IIndirectDataAnalysisTab;
+
 class MANTIDQT_INELASTIC_DLL IIndirectFitPlotPresenter {
 public:
   virtual void handleSelectedFitDataChanged(WorkspaceID workspaceID) = 0;
@@ -39,7 +41,8 @@ class MANTIDQT_INELASTIC_DLL IndirectFitPlotPresenter : public QObject, public I
   Q_OBJECT
 
 public:
-  IndirectFitPlotPresenter(IIndirectFitPlotView *view, std::unique_ptr<IndirectFitPlotModel> model);
+  IndirectFitPlotPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitPlotView *view,
+                           std::unique_ptr<IndirectFitPlotModel> model);
 
   void watchADS(bool watch);
 
@@ -114,6 +117,7 @@ private:
 
   void plotSpectrum(WorkspaceIndex spectrum) const;
 
+  IIndirectDataAnalysisTab *m_tab;
   IIndirectFitPlotView *m_view;
   std::unique_ptr<IndirectFitPlotModel> m_model;
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
@@ -36,7 +36,7 @@ public:
   virtual void handleBackgroundChanged(double value) = 0;
 };
 
-class MANTIDQT_INELASTIC_DLL IndirectFitPlotPresenter : public IIndirectFitPlotPresenter {
+class MANTIDQT_INELASTIC_DLL IndirectFitPlotPresenter final : public IIndirectFitPlotPresenter {
 
 public:
   IndirectFitPlotPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitPlotView *view,

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "IndirectFitPlotModel.h"
-#include "IndirectFitPlotView.h"
 
 #include "DllConfig.h"
 #include "MantidQtWidgets/Plotting/ExternalPlotter.h"
@@ -15,9 +14,9 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
-using namespace MantidWidgets;
 
 class IIndirectDataAnalysisTab;
+class IIndirectFitPlotView;
 
 class MANTIDQT_INELASTIC_DLL IIndirectFitPlotPresenter {
 public:
@@ -37,8 +36,7 @@ public:
   virtual void handleBackgroundChanged(double value) = 0;
 };
 
-class MANTIDQT_INELASTIC_DLL IndirectFitPlotPresenter : public QObject, public IIndirectFitPlotPresenter {
-  Q_OBJECT
+class MANTIDQT_INELASTIC_DLL IndirectFitPlotPresenter : public IIndirectFitPlotPresenter {
 
 public:
   IndirectFitPlotPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitPlotView *view,

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
@@ -84,9 +84,6 @@ public:
   void handleFWHMChanged(double minimum, double maximum) override;
   void handleBackgroundChanged(double value) override;
 
-public slots:
-  void updatePlotSpectrum(WorkspaceIndex spectrum);
-
 signals:
   void selectedFitDataChanged(WorkspaceID /*_t1*/);
   void plotSpectrumChanged();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
@@ -21,7 +21,7 @@ class MANTIDQT_INELASTIC_DLL IndirectFitPlotPresenter : public QObject {
   Q_OBJECT
 
 public:
-  IndirectFitPlotPresenter(IIndirectFitPlotView *view);
+  IndirectFitPlotPresenter(IIndirectFitPlotView *view, std::unique_ptr<IndirectFitPlotModel> model);
 
   void watchADS(bool watch);
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotPresenter.h
@@ -32,6 +32,7 @@ public:
   virtual void handleHWHMMaximumChanged(double minimum) = 0;
 
   virtual void handleFWHMChanged(double minimum, double maximum) = 0;
+  virtual void handleBackgroundChanged(double value) = 0;
 };
 
 class MANTIDQT_INELASTIC_DLL IndirectFitPlotPresenter : public QObject, public IIndirectFitPlotPresenter {
@@ -68,6 +69,7 @@ public:
   void handleHWHMMaximumChanged(double minimum) override;
 
   void handleFWHMChanged(double minimum, double maximum) override;
+  void handleBackgroundChanged(double value) override;
 
 public slots:
   void setStartX(double /*startX*/);
@@ -94,10 +96,6 @@ signals:
   void fwhmChanged(double /*_t1*/);
   void backgroundChanged(double /*_t1*/);
 
-private slots:
-  void setActiveIndex(WorkspaceID workspaceID);
-  void updateFitRangeSelector();
-
 private:
   void disableAllDataSelection();
   void enableAllDataSelection();
@@ -113,7 +111,9 @@ private:
   void updateHWHMSelector();
   void setHWHM(double value);
   void updateBackgroundSelector();
+  void updateFitRangeSelector();
   void emitSelectedFitDataChanged();
+  void setActiveIndex(WorkspaceID workspaceID);
 
   void plotSpectrum(WorkspaceIndex spectrum) const;
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.cpp
@@ -272,8 +272,8 @@ void IndirectFitPlotView::addFitRangeSelector() {
   auto fitRangeSelector = m_topPlot->addRangeSelector("FitRange");
   fitRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
 
-  connect(fitRangeSelector, SIGNAL(minValueChanged(double)), this, SIGNAL(startXChanged(double)));
-  connect(fitRangeSelector, SIGNAL(maxValueChanged(double)), this, SIGNAL(endXChanged(double)));
+  connect(fitRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(notifyStartXChanged(double)));
+  connect(fitRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(notifyEndXChanged(double)));
 }
 
 void IndirectFitPlotView::addBackgroundRangeSelector() {
@@ -357,6 +357,10 @@ void IndirectFitPlotView::notifyPlotGuessChanged(int doPlotGuess) {
 void IndirectFitPlotView::notifyPlotCurrentPreview() { m_presenter->handlePlotCurrentPreview(); }
 
 void IndirectFitPlotView::notifyFitSelectedSpectrum() { m_presenter->handleFitSingleSpectrum(); }
+
+void IndirectFitPlotView::notifyStartXChanged(double value) { m_presenter->handleStartXChanged(value); }
+
+void IndirectFitPlotView::notifyEndXChanged(double value) { m_presenter->handleEndXChanged(value); }
 
 void IndirectFitPlotView::notifyHWHMMinimumChanged(double value) { m_presenter->handleHWHMMinimumChanged(value); }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.cpp
@@ -333,7 +333,7 @@ void IndirectFitPlotView::notifySelectedFitDataChanged(int index) {
 // Required due to a bug in qt causing the valueChanged signal to be emitted
 // twice due to the long amount of time taken to complete the necessary actions
 void IndirectFitPlotView::notifyDelayedPlotSpectrumChanged() {
-  QTimer::singleShot(150, this, SLOT(emitPlotSpectrumChanged()));
+  QTimer::singleShot(150, this, SLOT(notifyPlotSpectrumChanged()));
 }
 
 void IndirectFitPlotView::notifyPlotSpectrumChanged() {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.cpp
@@ -283,7 +283,7 @@ void IndirectFitPlotView::addBackgroundRangeSelector() {
   backRangeSelector->setLowerBound(0.0);
   backRangeSelector->setUpperBound(10.0);
 
-  connect(backRangeSelector, SIGNAL(valueChanged(double)), this, SIGNAL(backgroundChanged(double)));
+  connect(backRangeSelector, SIGNAL(valueChanged(double)), this, SLOT(notifyBackgroundChanged(double)));
   connect(backRangeSelector, SIGNAL(resetScientificBounds()), this, SLOT(setBackgroundBounds()));
 }
 
@@ -369,5 +369,7 @@ void IndirectFitPlotView::notifyHWHMMaximumChanged(double value) { m_presenter->
 void IndirectFitPlotView::notifyFWHMChanged(double minimum, double maximum) {
   m_presenter->handleFWHMChanged(minimum, maximum);
 }
+
+void IndirectFitPlotView::notifyBackgroundChanged(double value) { m_presenter->handleBackgroundChanged(value); }
 
 } // namespace MantidQt::CustomInterfaces::IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.cpp
@@ -32,7 +32,7 @@ namespace MantidQt::CustomInterfaces::IDA {
 using namespace MantidWidgets;
 
 IndirectFitPlotView::IndirectFitPlotView(QWidget *parent)
-    : IIndirectFitPlotView(parent), m_plotForm(new Ui::IndirectFitPreviewPlot), m_presenter() {
+    : API::MantidWidget(parent), m_plotForm(new Ui::IndirectFitPreviewPlot), m_presenter() {
   m_plotForm->setupUi(this);
 
   connect(m_plotForm->cbDataSelection, SIGNAL(currentIndexChanged(int)), this, SLOT(notifySelectedFitDataChanged(int)));
@@ -205,7 +205,10 @@ void IndirectFitPlotView::setNameInDataSelection(const std::string &dataName, Wo
   m_plotForm->cbDataSelection->setItemText(static_cast<int>(workspaceID.value), QString::fromStdString(dataName));
 }
 
-void IndirectFitPlotView::clearDataSelection() { m_plotForm->cbDataSelection->clear(); }
+void IndirectFitPlotView::clearDataSelection() {
+  QSignalBlocker blocker(m_plotForm->cbDataSelection);
+  m_plotForm->cbDataSelection->clear();
+}
 
 void IndirectFitPlotView::plotInTopPreview(const QString &name, Mantid::API::MatrixWorkspace_sptr workspace,
                                            WorkspaceIndex spectrum, Qt::GlobalColor colour) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.cpp
@@ -162,11 +162,6 @@ void IndirectFitPlotView::setPlotSpectrum(WorkspaceIndex spectrum) {
   m_plotForm->cbPlotSpectrum->setCurrentIndex(index);
 }
 
-void IndirectFitPlotView::disableSpectrumPlotSelection() {
-  m_plotForm->spPlotSpectrum->setEnabled(false);
-  m_plotForm->cbPlotSpectrum->setEnabled(false);
-}
-
 void IndirectFitPlotView::setBackgroundLevel(double value) {
   auto selector = m_topPlot->getSingleSelector("Background");
   QSignalBlocker blocker(selector);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.h
@@ -134,7 +134,9 @@ private slots:
 
   void notifyHWHMMinimumChanged(double value);
   void notifyHWHMMaximumChanged(double value);
+
   void notifyFWHMChanged(double minimum, double maximum);
+  void notifyBackgroundChanged(double value);
 
 private:
   void createSplitterWithPlots();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.h
@@ -111,12 +111,9 @@ public:
 
   void setHWHMMinimum(double minimum) override;
   void setHWHMMaximum(double maximum) override;
-
-public slots:
-  void clearTopPreview() override;
-  void clearBottomPreview() override;
-  void clearPreviews() override;
   void setHWHMRange(double minimum, double maximum) override;
+
+  void clearPreviews() override;
 
 private slots:
   void setBackgroundBounds();
@@ -153,6 +150,9 @@ private:
   void addFitRangeSelector();
   void addBackgroundRangeSelector();
   void addHWHMRangeSelector();
+
+  void clearTopPreview();
+  void clearBottomPreview();
 
   std::unique_ptr<Ui::IndirectFitPreviewPlot> m_plotForm;
   std::unique_ptr<MantidQt::MantidWidgets::PreviewPlot> m_topPlot;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.h
@@ -129,6 +129,9 @@ private slots:
   void notifyPlotCurrentPreview();
   void notifyFitSelectedSpectrum();
 
+  void notifyStartXChanged(double value);
+  void notifyEndXChanged(double value);
+
   void notifyHWHMMinimumChanged(double value);
   void notifyHWHMMaximumChanged(double value);
   void notifyFWHMChanged(double minimum, double maximum);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.h
@@ -11,6 +11,7 @@
 #include "DllConfig.h"
 #include "IIndirectFitPlotView.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidQtWidgets/Common/MantidWidget.h"
 #include "MantidQtWidgets/Plotting/PreviewPlot.h"
 
 #include <QIcon>
@@ -51,12 +52,12 @@ private:
   QIcon m_icon;
 };
 
-class MANTIDQT_INELASTIC_DLL IndirectFitPlotView : public IIndirectFitPlotView {
+class MANTIDQT_INELASTIC_DLL IndirectFitPlotView : public API::MantidWidget, public IIndirectFitPlotView {
   Q_OBJECT
 
 public:
   IndirectFitPlotView(QWidget *parent = nullptr);
-  virtual ~IndirectFitPlotView() override;
+  virtual ~IndirectFitPlotView();
 
   void subscribePresenter(IIndirectFitPlotPresenter *presenter) override;
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.h
@@ -58,6 +58,8 @@ public:
   IndirectFitPlotView(QWidget *parent = nullptr);
   virtual ~IndirectFitPlotView() override;
 
+  void subscribePresenter(IIndirectFitPlotPresenter *presenter) override;
+
   void watchADS(bool watch) override;
 
   WorkspaceIndex getSelectedSpectrum() const override;
@@ -107,22 +109,29 @@ public:
   void allowRedraws(bool state) override;
   void redrawPlots() override;
 
+  void setHWHMMinimum(double minimum) override;
+  void setHWHMMaximum(double maximum) override;
+
 public slots:
   void clearTopPreview() override;
   void clearBottomPreview() override;
   void clearPreviews() override;
   void setHWHMRange(double minimum, double maximum) override;
-  void setHWHMMaximum(double minimum) override;
-  void setHWHMMinimum(double maximum) override;
 
 private slots:
   void setBackgroundBounds();
 
-  void emitDelayedPlotSpectrumChanged();
-  void emitPlotSpectrumChanged();
-  void emitPlotSpectrumChanged(const QString &spectrum);
-  void emitSelectedFitDataChanged(int /*index*/);
-  void emitPlotGuessChanged(int /*doPlotGuess*/);
+  void notifyDelayedPlotSpectrumChanged();
+  void notifyPlotSpectrumChanged();
+  void notifyPlotSpectrumChanged(const QString &spectrum);
+  void notifySelectedFitDataChanged(int /*index*/);
+  void notifyPlotGuessChanged(int /*doPlotGuess*/);
+  void notifyPlotCurrentPreview();
+  void notifyFitSelectedSpectrum();
+
+  void notifyHWHMMinimumChanged(double value);
+  void notifyHWHMMaximumChanged(double value);
+  void notifyFWHMChanged(double minimum, double maximum);
 
 private:
   void createSplitterWithPlots();
@@ -144,6 +153,7 @@ private:
   std::unique_ptr<MantidQt::MantidWidgets::PreviewPlot> m_topPlot;
   std::unique_ptr<MantidQt::MantidWidgets::PreviewPlot> m_bottomPlot;
   std::unique_ptr<QSplitter> m_splitter;
+  IIndirectFitPlotPresenter *m_presenter;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPlotView.h
@@ -105,7 +105,6 @@ public:
   void setHWHMRangeVisible(bool visible) override;
 
   void displayMessage(const std::string &message) const override;
-  void disableSpectrumPlotSelection() override;
 
   void allowRedraws(bool state) override;
   void redrawPlots() override;

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -85,7 +85,6 @@ set(MOC_FILES
     Analysis/IndirectFitDataView.h
     Analysis/IndirectFitOutputOptionsView.h
     Analysis/IndirectFitPlotView.h
-    Analysis/IndirectFitPlotPresenter.h
     Analysis/IndirectFitPropertyBrowser.h
     Analysis/FunctionBrowser/ConvTemplateBrowser.h
     Analysis/FunctionBrowser/ConvTemplatePresenter.h
@@ -133,6 +132,7 @@ set(INC_FILES
     Analysis/IndirectFitOutputOptionsModel.h
     Analysis/IndirectFitOutputOptionsPresenter.h
     Analysis/IndirectFitPlotModel.h
+    Analysis/IndirectFitPlotPresenter.h
     Analysis/IndirectFittingModel.h
     Analysis/ParameterEstimation.h
     Analysis/FunctionBrowser/ConvFunctionModel.h

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -79,7 +79,6 @@ set(MOC_FILES
     Analysis/FunctionTemplateBrowser.h
     Analysis/IIndirectFitDataView.h
     Analysis/IIndirectFitOutputOptionsView.h
-    Analysis/IIndirectFitPlotView.h
     Analysis/IndirectDockWidgetArea.h
     Analysis/IndirectEditResultsDialog.h
     Analysis/IndirectFitDataPresenter.h
@@ -127,6 +126,7 @@ set(INC_FILES
     Analysis/IndirectFitDataModel.h
     Analysis/IIndirectFitOutput.h
     Analysis/IIndirectFitOutputOptionsModel.h
+    Analysis/IIndirectFitPlotView.h
     Analysis/IIndirectFittingModel.h
     Analysis/IndirectFitData.h
     Analysis/IndirectFitOutput.h

--- a/qt/scientific_interfaces/Inelastic/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/test/CMakeLists.txt
@@ -25,6 +25,8 @@ set(TEST_FILES
     InelasticDataManipulationSymmetriseTabModelTest.h
 )
 
+set(TEST_HELPERS ../../Indirect/IndirectDataValidationHelper.cpp DataAnalysisMockObjects.h)
+
 set(CXXTEST_EXTRA_HEADER_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/InterfacesInelasticTestInitialization.h)
 
 mtd_add_qt_tests(
@@ -32,7 +34,7 @@ mtd_add_qt_tests(
   QT_VERSION 5
   SRC ${TEST_FILES}
   INCLUDE_DIRS ../../../../Framework/DataObjects/inc ../
-  TEST_HELPER_SRCS ../../Indirect/IndirectDataValidationHelper.cpp
+  TEST_HELPER_SRCS ${TEST_HELPERS}
   LINK_LIBS ${CORE_MANTIDLIBS}
             Mantid::DataObjects
             gmock

--- a/qt/scientific_interfaces/Inelastic/test/ConvFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/ConvFitDataPresenterTest.h
@@ -13,11 +13,11 @@
 #include "Analysis/ConvFitDataPresenter.h"
 #include "Analysis/ConvFitModel.h"
 #include "Analysis/IIndirectFitDataView.h"
+#include "DataAnalysisMockObjects.h"
 #include "IndirectAddWorkspaceDialog.h"
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h"
-#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid::API;
 using namespace Mantid::IndirectFitDataCreationHelper;
@@ -36,83 +36,6 @@ std::unique_ptr<QTableWidget> createEmptyTableWidget(int columns, int rows) {
 }
 } // namespace
 
-GNU_DIAG_OFF_SUGGEST_OVERRIDE
-
-/// Mock object to mock the view
-class MockConvFitDataView : public IIndirectFitDataView {
-public:
-  /// Signals
-  void emitResolutionLoaded(QString const &workspaceName) { emit resolutionLoaded(workspaceName); }
-
-  /// Public Methods
-  MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
-  MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
-  MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
-  MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
-  MOCK_METHOD1(getColumnIndexFromName, int(QString ColName));
-  MOCK_METHOD0(clearTable, void());
-  MOCK_CONST_METHOD2(getText, QString(int row, int column));
-  MOCK_CONST_METHOD0(getSelectedIndexes, QModelIndexList());
-
-  /// Public slots
-  MOCK_METHOD1(displayWarning, void(std::string const &warning));
-};
-
-/// Mock object to mock the model
-class MockIndirectFitDataModel : public IIndirectFitDataModel {
-public:
-  /// Public Methods
-  MOCK_METHOD0(getFittingData, std::vector<IndirectFitData> *());
-  MOCK_METHOD2(addWorkspace, void(const std::string &workspaceName, const std::string &spectra));
-  MOCK_METHOD2(addWorkspace, void(const std::string &workspaceName, const FunctionModelSpectra &spectra));
-  MOCK_METHOD2(addWorkspace, void(MatrixWorkspace_sptr workspace, const FunctionModelSpectra &spectra));
-  MOCK_CONST_METHOD1(getWorkspace, MatrixWorkspace_sptr(WorkspaceID workspaceID));
-  MOCK_CONST_METHOD1(getWorkspace, MatrixWorkspace_sptr(FitDomainIndex index));
-  MOCK_CONST_METHOD0(getWorkspaceNames, std::vector<std::string>());
-  MOCK_CONST_METHOD0(getNumberOfWorkspaces, WorkspaceID());
-  MOCK_CONST_METHOD1(hasWorkspace, bool(std::string const &workspaceName));
-
-  MOCK_METHOD2(setSpectra, void(const std::string &spectra, WorkspaceID workspaceID));
-  MOCK_METHOD2(setSpectra, void(FunctionModelSpectra &&spectra, WorkspaceID workspaceID));
-  MOCK_METHOD2(setSpectra, void(const FunctionModelSpectra &spectra, WorkspaceID workspaceID));
-  MOCK_CONST_METHOD1(getSpectra, FunctionModelSpectra(WorkspaceID workspaceID));
-  MOCK_CONST_METHOD1(getSpectrum, size_t(FitDomainIndex index));
-  MOCK_CONST_METHOD1(getNumberOfSpectra, size_t(WorkspaceID workspaceID));
-
-  MOCK_METHOD0(clear, void());
-
-  MOCK_CONST_METHOD0(getNumberOfDomains, size_t());
-  MOCK_CONST_METHOD2(getDomainIndex, FitDomainIndex(WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_CONST_METHOD1(getSubIndices, std::pair<WorkspaceID, WorkspaceIndex>(FitDomainIndex));
-
-  MOCK_CONST_METHOD0(getQValuesForData, std::vector<double>());
-  MOCK_CONST_METHOD0(getResolutionsForFit, std::vector<std::pair<std::string, size_t>>());
-  MOCK_CONST_METHOD1(createDisplayName, std::string(WorkspaceID workspaceID));
-
-  MOCK_METHOD1(removeWorkspace, void(WorkspaceID workspaceID));
-  MOCK_METHOD1(removeDataByIndex, void(FitDomainIndex fitDomainIndex));
-
-  MOCK_METHOD3(setStartX, void(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_METHOD2(setStartX, void(double startX, WorkspaceID workspaceID));
-  MOCK_METHOD2(setStartX, void(double startX, FitDomainIndex fitDomainIndex));
-  MOCK_METHOD3(setEndX, void(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_METHOD2(setEndX, void(double endX, WorkspaceID workspaceID));
-  MOCK_METHOD2(setEndX, void(double endX, FitDomainIndex fitDomainIndex));
-  MOCK_METHOD3(setExcludeRegion, void(const std::string &exclude, WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_METHOD2(setExcludeRegion, void(const std::string &exclude, FitDomainIndex index));
-  MOCK_METHOD1(removeSpecialValues, void(const std::string &name));
-  MOCK_METHOD1(setResolution, bool(const std::string &name));
-  MOCK_METHOD2(setResolution, bool(const std::string &name, WorkspaceID workspaceID));
-  MOCK_CONST_METHOD2(getFittingRange, std::pair<double, double>(WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_CONST_METHOD1(getFittingRange, std::pair<double, double>(FitDomainIndex index));
-  MOCK_CONST_METHOD2(getExcludeRegion, std::string(WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_CONST_METHOD1(getExcludeRegion, std::string(FitDomainIndex index));
-  MOCK_CONST_METHOD2(getExcludeRegionVector, std::vector<double>(WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_CONST_METHOD1(getExcludeRegionVector, std::vector<double>(FitDomainIndex index));
-};
-
-GNU_DIAG_ON_SUGGEST_OVERRIDE
-
 class ConvFitDataPresenterTest : public CxxTest::TestSuite {
 public:
   /// Needed to make sure everything is initialized
@@ -123,7 +46,7 @@ public:
   static void destroySuite(ConvFitDataPresenterTest *suite) { delete suite; }
 
   void setUp() override {
-    m_view = std::make_unique<NiceMock<MockConvFitDataView>>();
+    m_view = std::make_unique<NiceMock<MockFitDataView>>();
     m_model = std::make_unique<NiceMock<MockIndirectFitDataModel>>();
 
     m_dataTable = createEmptyTableWidget(6, 6);
@@ -196,7 +119,7 @@ public:
 private:
   std::unique_ptr<QTableWidget> m_dataTable;
 
-  std::unique_ptr<MockConvFitDataView> m_view;
+  std::unique_ptr<MockFitDataView> m_view;
   std::unique_ptr<MockIndirectFitDataModel> m_model;
   std::unique_ptr<ConvFitDataPresenter> m_presenter;
   MatrixWorkspace_sptr m_workspace;

--- a/qt/scientific_interfaces/Inelastic/test/DataAnalysisMockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/DataAnalysisMockObjects.h
@@ -1,0 +1,151 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+#include "MantidKernel/WarningSuppressions.h"
+
+#include "Analysis/IIndirectFitOutputOptionsModel.h"
+#include "Analysis/IIndirectFitOutputOptionsView.h"
+#include "Analysis/IndirectDataAnalysisTab.h"
+
+using namespace MantidQt::CustomInterfaces::IDA;
+
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
+
+class MockIndirectDataAnalysisTab : public IIndirectDataAnalysisTab {
+public:
+  MOCK_METHOD0(plotSelectedSpectra, void());
+};
+
+class MockIndirectFitPlotView final : public IIndirectFitPlotView {
+public:
+  MOCK_METHOD1(subscribePresenter, void(IIndirectFitPlotPresenter *presenter));
+
+  MOCK_METHOD1(watchADS, void(bool watch));
+
+  MOCK_CONST_METHOD0(getSelectedSpectrum, WorkspaceIndex());
+  MOCK_CONST_METHOD0(getSelectedSpectrumIndex, FitDomainIndex());
+  MOCK_CONST_METHOD0(getSelectedDataIndex, WorkspaceID());
+  MOCK_CONST_METHOD0(dataSelectionSize, WorkspaceID());
+  MOCK_CONST_METHOD0(isPlotGuessChecked, bool());
+
+  MOCK_METHOD2(setAvailableSpectra, void(WorkspaceIndex minimum, WorkspaceIndex maximum));
+  MOCK_METHOD2(setAvailableSpectra, void(std::vector<WorkspaceIndex>::const_iterator const &from,
+                                         std::vector<WorkspaceIndex>::const_iterator const &to));
+
+  MOCK_METHOD1(setMinimumSpectrum, void(int minimum));
+  MOCK_METHOD1(setMaximumSpectrum, void(int maximum));
+  MOCK_METHOD1(setPlotSpectrum, void(WorkspaceIndex spectrum));
+  MOCK_METHOD1(appendToDataSelection, void(std::string const &dataName));
+  MOCK_METHOD2(setNameInDataSelection, void(std::string const &dataName, WorkspaceID workspaceID));
+  MOCK_METHOD0(clearDataSelection, void());
+
+  MOCK_METHOD4(plotInTopPreview, void(QString const &name, Mantid::API::MatrixWorkspace_sptr workspace,
+                                      WorkspaceIndex spectrum, Qt::GlobalColor colour));
+  MOCK_METHOD4(plotInBottomPreview, void(QString const &name, Mantid::API::MatrixWorkspace_sptr workspace,
+                                         WorkspaceIndex spectrum, Qt::GlobalColor colour));
+
+  MOCK_METHOD1(removeFromTopPreview, void(QString const &name));
+  MOCK_METHOD1(removeFromBottomPreview, void(QString const &name));
+
+  MOCK_METHOD1(enableFitSingleSpectrum, void(bool enable));
+  MOCK_METHOD1(enablePlotGuess, void(bool enable));
+  MOCK_METHOD1(enableSpectrumSelection, void(bool enable));
+  MOCK_METHOD1(enableFitRangeSelection, void(bool enable));
+
+  MOCK_METHOD1(setFitSingleSpectrumText, void(QString const &text));
+  MOCK_METHOD1(setFitSingleSpectrumEnabled, void(bool enable));
+
+  MOCK_METHOD1(setBackgroundLevel, void(double value));
+
+  MOCK_METHOD2(setFitRange, void(double minimum, double maximum));
+  MOCK_METHOD1(setFitRangeMinimum, void(double minimum));
+  MOCK_METHOD1(setFitRangeMaximum, void(double maximum));
+  MOCK_METHOD1(setFitRangeBounds, void(std::pair<double, double> const &bounds));
+
+  MOCK_METHOD1(setBackgroundRangeVisible, void(bool visible));
+  MOCK_METHOD1(setHWHMRangeVisible, void(bool visible));
+
+  MOCK_METHOD1(allowRedraws, void(bool state));
+  MOCK_METHOD0(redrawPlots, void());
+
+  MOCK_CONST_METHOD1(displayMessage, void(std::string const &message));
+
+  MOCK_METHOD1(setHWHMMinimum, void(double minimum));
+  MOCK_METHOD1(setHWHMMaximum, void(double maximum));
+  MOCK_METHOD2(setHWHMRange, void(double minimum, double maximum));
+
+  MOCK_METHOD0(clearPreviews, void());
+};
+
+class MockIndirectFitOutputOptionsView final : public IIndirectFitOutputOptionsView {
+public:
+  MOCK_METHOD1(subscribePresenter, void(IIndirectFitOutputOptionsPresenter *presenter));
+
+  MOCK_METHOD1(setGroupWorkspaceComboBoxVisible, void(bool visible));
+  MOCK_METHOD1(setWorkspaceComboBoxVisible, void(bool visible));
+
+  MOCK_METHOD0(clearPlotWorkspaces, void());
+  MOCK_METHOD0(clearPlotTypes, void());
+  MOCK_METHOD1(setAvailablePlotWorkspaces, void(std::vector<std::string> const &workspaceNames));
+  MOCK_METHOD1(setAvailablePlotTypes, void(std::vector<std::string> const &parameterNames));
+
+  MOCK_METHOD1(setPlotGroupWorkspaceIndex, void(int index));
+  MOCK_METHOD1(setPlotWorkspacesIndex, void(int index));
+  MOCK_METHOD1(setPlotTypeIndex, void(int index));
+
+  MOCK_CONST_METHOD0(getSelectedGroupWorkspace, std::string());
+  MOCK_CONST_METHOD0(getSelectedWorkspace, std::string());
+  MOCK_CONST_METHOD0(getSelectedPlotType, std::string());
+
+  MOCK_METHOD1(setPlotText, void(std::string const &text));
+  MOCK_METHOD1(setSaveText, void(std::string const &text));
+
+  MOCK_METHOD1(setPlotExtraOptionsEnabled, void(bool enable));
+  MOCK_METHOD1(setPlotEnabled, void(bool enable));
+  MOCK_METHOD1(setEditResultEnabled, void(bool enable));
+  MOCK_METHOD1(setSaveEnabled, void(bool enable));
+
+  MOCK_METHOD1(setEditResultVisible, void(bool visible));
+
+  MOCK_METHOD1(displayWarning, void(std::string const &message));
+};
+
+class MockIndirectFitOutputOptionsModel : public IIndirectFitOutputOptionsModel {
+public:
+  MOCK_METHOD1(setResultWorkspace, void(WorkspaceGroup_sptr groupWorkspace));
+  MOCK_METHOD1(setPDFWorkspace, void(WorkspaceGroup_sptr groupWorkspace));
+  MOCK_CONST_METHOD0(getResultWorkspace, WorkspaceGroup_sptr());
+  MOCK_CONST_METHOD0(getPDFWorkspace, WorkspaceGroup_sptr());
+
+  MOCK_METHOD0(removePDFWorkspace, void());
+
+  MOCK_CONST_METHOD1(isSelectedGroupPlottable, bool(std::string const &selectedGroup));
+  MOCK_CONST_METHOD0(isResultGroupPlottable, bool());
+  MOCK_CONST_METHOD0(isPDFGroupPlottable, bool());
+
+  MOCK_METHOD0(clearSpectraToPlot, void());
+  MOCK_CONST_METHOD0(getSpectraToPlot, std::vector<SpectrumToPlot>());
+
+  MOCK_METHOD1(plotResult, void(std::string const &plotType));
+  MOCK_METHOD2(plotPDF, void(std::string const &workspaceName, std::string const &plotType));
+
+  MOCK_CONST_METHOD0(saveResult, void());
+
+  MOCK_CONST_METHOD1(getWorkspaceParameters, std::vector<std::string>(std::string const &selectedGroup));
+  MOCK_CONST_METHOD0(getPDFWorkspaceNames, std::vector<std::string>());
+
+  MOCK_CONST_METHOD1(isResultGroupSelected, bool(std::string const &selectedGroup));
+
+  MOCK_METHOD3(replaceFitResult,
+               void(std::string const &inputName, std::string const &singleBinName, std::string const &outputName));
+};
+
+GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/Inelastic/test/DataAnalysisMockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/DataAnalysisMockObjects.h
@@ -21,7 +21,14 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockIndirectDataAnalysisTab : public IIndirectDataAnalysisTab {
 public:
-  MOCK_METHOD0(plotSelectedSpectra, void());
+  MOCK_METHOD2(handleSingleFitClicked, void(WorkspaceID workspaceID, WorkspaceIndex workspaceIndex));
+  MOCK_METHOD1(handleStartXChanged, void(double startX));
+  MOCK_METHOD1(handleEndXChanged, void(double endX));
+  MOCK_METHOD0(handlePlotSpectrumChanged, void());
+  MOCK_METHOD1(handleFwhmChanged, void(double fwhm));
+  MOCK_METHOD1(handleBackgroundChanged, void(double background));
+
+  MOCK_METHOD0(handlePlotSelectedSpectra, void());
 };
 
 class MockIndirectFitPlotView final : public IIndirectFitPlotView {

--- a/qt/scientific_interfaces/Inelastic/test/DataAnalysisMockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/DataAnalysisMockObjects.h
@@ -10,10 +10,16 @@
 #include <gmock/gmock.h>
 
 #include "MantidKernel/WarningSuppressions.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
 
+#include "Analysis/IIndirectFitDataView.h"
 #include "Analysis/IIndirectFitOutputOptionsModel.h"
 #include "Analysis/IIndirectFitOutputOptionsView.h"
 #include "Analysis/IndirectDataAnalysisTab.h"
+
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace MantidQt::CustomInterfaces::IDA;
 
@@ -153,6 +159,72 @@ public:
 
   MOCK_METHOD3(replaceFitResult,
                void(std::string const &inputName, std::string const &singleBinName, std::string const &outputName));
+};
+
+class MockIndirectFitDataModel : public IIndirectFitDataModel {
+public:
+  MOCK_METHOD0(getFittingData, std::vector<IndirectFitData> *());
+  MOCK_METHOD2(addWorkspace, void(const std::string &workspaceName, const std::string &spectra));
+  MOCK_METHOD2(addWorkspace, void(const std::string &workspaceName, const FunctionModelSpectra &spectra));
+  MOCK_METHOD2(addWorkspace, void(MatrixWorkspace_sptr workspace, const FunctionModelSpectra &spectra));
+  MOCK_CONST_METHOD1(getWorkspace, MatrixWorkspace_sptr(WorkspaceID workspaceID));
+  MOCK_CONST_METHOD1(getWorkspace, MatrixWorkspace_sptr(FitDomainIndex index));
+  MOCK_CONST_METHOD0(getWorkspaceNames, std::vector<std::string>());
+  MOCK_CONST_METHOD0(getNumberOfWorkspaces, WorkspaceID());
+  MOCK_CONST_METHOD1(hasWorkspace, bool(std::string const &workspaceName));
+
+  MOCK_METHOD2(setSpectra, void(const std::string &spectra, WorkspaceID workspaceID));
+  MOCK_METHOD2(setSpectra, void(FunctionModelSpectra &&spectra, WorkspaceID workspaceID));
+  MOCK_METHOD2(setSpectra, void(const FunctionModelSpectra &spectra, WorkspaceID workspaceID));
+  MOCK_CONST_METHOD1(getSpectra, FunctionModelSpectra(WorkspaceID workspaceID));
+  MOCK_CONST_METHOD1(getSpectrum, size_t(FitDomainIndex index));
+  MOCK_CONST_METHOD1(getNumberOfSpectra, size_t(WorkspaceID workspaceID));
+
+  MOCK_METHOD0(clear, void());
+
+  MOCK_CONST_METHOD0(getNumberOfDomains, size_t());
+  MOCK_CONST_METHOD2(getDomainIndex, FitDomainIndex(WorkspaceID workspaceID, WorkspaceIndex spectrum));
+  MOCK_CONST_METHOD1(getSubIndices, std::pair<WorkspaceID, WorkspaceIndex>(FitDomainIndex));
+
+  MOCK_CONST_METHOD0(getQValuesForData, std::vector<double>());
+  MOCK_CONST_METHOD0(getResolutionsForFit, std::vector<std::pair<std::string, size_t>>());
+  MOCK_CONST_METHOD1(createDisplayName, std::string(WorkspaceID workspaceID));
+
+  MOCK_METHOD1(removeWorkspace, void(WorkspaceID workspaceID));
+  MOCK_METHOD1(removeDataByIndex, void(FitDomainIndex fitDomainIndex));
+
+  MOCK_METHOD3(setStartX, void(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
+  MOCK_METHOD2(setStartX, void(double startX, WorkspaceID workspaceID));
+  MOCK_METHOD2(setStartX, void(double startX, FitDomainIndex fitDomainIndex));
+  MOCK_METHOD3(setEndX, void(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
+  MOCK_METHOD2(setEndX, void(double endX, WorkspaceID workspaceID));
+  MOCK_METHOD2(setEndX, void(double endX, FitDomainIndex fitDomainIndex));
+  MOCK_METHOD3(setExcludeRegion, void(const std::string &exclude, WorkspaceID workspaceID, WorkspaceIndex spectrum));
+  MOCK_METHOD2(setExcludeRegion, void(const std::string &exclude, FitDomainIndex index));
+  MOCK_METHOD1(removeSpecialValues, void(const std::string &name));
+  MOCK_METHOD1(setResolution, bool(const std::string &name));
+  MOCK_METHOD2(setResolution, bool(const std::string &name, WorkspaceID workspaceID));
+  MOCK_CONST_METHOD2(getFittingRange, std::pair<double, double>(WorkspaceID workspaceID, WorkspaceIndex spectrum));
+  MOCK_CONST_METHOD1(getFittingRange, std::pair<double, double>(FitDomainIndex index));
+  MOCK_CONST_METHOD2(getExcludeRegion, std::string(WorkspaceID workspaceID, WorkspaceIndex spectrum));
+  MOCK_CONST_METHOD1(getExcludeRegion, std::string(FitDomainIndex index));
+  MOCK_CONST_METHOD2(getExcludeRegionVector, std::vector<double>(WorkspaceID workspaceID, WorkspaceIndex spectrum));
+  MOCK_CONST_METHOD1(getExcludeRegionVector, std::vector<double>(FitDomainIndex index));
+};
+
+class MockFitDataView : public IIndirectFitDataView {
+public:
+  MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
+  MOCK_METHOD1(validate, MantidQt::CustomInterfaces::UserInputValidator &(
+                             MantidQt::CustomInterfaces::UserInputValidator &validator));
+  MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
+  MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
+  MOCK_METHOD1(getColumnIndexFromName, int(QString ColName));
+  MOCK_METHOD0(clearTable, void());
+  MOCK_CONST_METHOD2(getText, QString(int row, int column));
+  MOCK_CONST_METHOD0(getSelectedIndexes, QModelIndexList());
+
+  MOCK_METHOD1(displayWarning, void(std::string const &warning));
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/Inelastic/test/FqFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/FqFitDataPresenterTest.h
@@ -14,11 +14,11 @@
 #include "Analysis/FqFitModel.h"
 #include "Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h"
 #include "Analysis/IndirectFitDataView.h"
+#include "DataAnalysisMockObjects.h"
 #include "IndirectAddWorkspaceDialog.h"
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h"
-#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid::API;
 using namespace Mantid::IndirectFitDataCreationHelper;
@@ -47,82 +47,6 @@ std::unique_ptr<QTableWidget> createEmptyTableWidget(int columns, int rows) {
 
 } // namespace
 
-GNU_DIAG_OFF_SUGGEST_OVERRIDE
-
-/// Mock object to mock the view
-class MockFqFitDataView : public IIndirectFitDataView {
-public:
-  /// Public Methods
-  MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
-  MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
-  MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
-  MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
-  MOCK_METHOD1(getColumnIndexFromName, int(QString ColName));
-  MOCK_METHOD0(clearTable, void());
-  MOCK_CONST_METHOD2(getText, QString(int row, int column));
-  MOCK_CONST_METHOD0(getSelectedIndexes, QModelIndexList());
-  /// Public slots
-  MOCK_METHOD1(displayWarning, void(std::string const &warning));
-};
-
-/// Mock object to mock the model
-class MockIndirectFitDataModel : public IIndirectFitDataModel {
-public:
-  /// Public Methods
-  MOCK_METHOD0(getFittingData, std::vector<IndirectFitData> *());
-  MOCK_METHOD2(addWorkspace, void(const std::string &workspaceName, const std::string &spectra));
-  MOCK_METHOD2(addWorkspace, void(const std::string &workspaceName, const FunctionModelSpectra &spectra));
-  MOCK_METHOD2(addWorkspace, void(MatrixWorkspace_sptr workspace, const FunctionModelSpectra &spectra));
-  MOCK_CONST_METHOD1(getWorkspace, MatrixWorkspace_sptr(WorkspaceID workspaceID));
-  MOCK_CONST_METHOD1(getWorkspace, MatrixWorkspace_sptr(FitDomainIndex index));
-  MOCK_CONST_METHOD0(getWorkspaceNames, std::vector<std::string>());
-  MOCK_CONST_METHOD0(getNumberOfWorkspaces, WorkspaceID());
-  MOCK_CONST_METHOD1(hasWorkspace, bool(std::string const &workspaceName));
-
-  MOCK_METHOD2(setSpectra, void(const std::string &spectra, WorkspaceID workspaceID));
-  MOCK_METHOD2(setSpectra, void(FunctionModelSpectra &&spectra, WorkspaceID workspaceID));
-  MOCK_METHOD2(setSpectra, void(const FunctionModelSpectra &spectra, WorkspaceID workspaceID));
-  MOCK_CONST_METHOD1(getSpectra, FunctionModelSpectra(WorkspaceID workspaceID));
-  MOCK_CONST_METHOD1(getSpectrum, size_t(FitDomainIndex index));
-  MOCK_CONST_METHOD1(getNumberOfSpectra, size_t(WorkspaceID workspaceID));
-
-  MOCK_METHOD0(clear, void());
-
-  MOCK_CONST_METHOD0(getNumberOfDomains, size_t());
-  MOCK_CONST_METHOD2(getDomainIndex, FitDomainIndex(WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_CONST_METHOD1(getSubIndices, std::pair<WorkspaceID, WorkspaceIndex>(FitDomainIndex));
-
-  MOCK_CONST_METHOD0(getQValuesForData, std::vector<double>());
-  MOCK_CONST_METHOD0(getResolutionsForFit, std::vector<std::pair<std::string, size_t>>());
-  MOCK_CONST_METHOD1(createDisplayName, std::string(WorkspaceID workspaceID));
-
-  MOCK_METHOD1(removeWorkspace, void(WorkspaceID workspaceID));
-  MOCK_METHOD1(removeDataByIndex, void(FitDomainIndex fitDomainIndex));
-
-  MOCK_METHOD3(setStartX, void(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_METHOD2(setStartX, void(double startX, WorkspaceID workspaceID));
-  MOCK_METHOD2(setStartX, void(double startX, FitDomainIndex fitDomainIndex));
-  MOCK_METHOD3(setEndX, void(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_METHOD2(setEndX, void(double endX, WorkspaceID workspaceID));
-  MOCK_METHOD2(setEndX, void(double endX, FitDomainIndex fitDomainIndex));
-  MOCK_METHOD3(setExcludeRegion, void(const std::string &exclude, WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_METHOD2(setExcludeRegion, void(const std::string &exclude, FitDomainIndex index));
-  MOCK_METHOD1(removeSpecialValues, void(const std::string &name));
-  MOCK_METHOD1(setResolution, bool(const std::string &name));
-  MOCK_METHOD2(setResolution, bool(const std::string &name, WorkspaceID workspaceID));
-  MOCK_CONST_METHOD2(getFittingRange, std::pair<double, double>(WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_CONST_METHOD1(getFittingRange, std::pair<double, double>(FitDomainIndex index));
-  MOCK_CONST_METHOD2(getExcludeRegion, std::string(WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_CONST_METHOD1(getExcludeRegion, std::string(FitDomainIndex index));
-  MOCK_CONST_METHOD2(getExcludeRegionVector, std::vector<double>(WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_CONST_METHOD1(getExcludeRegionVector, std::vector<double>(FitDomainIndex index));
-};
-
-/// Mock object to mock the model
-class MockFqFitModel : public FqFitModel {};
-
-GNU_DIAG_ON_SUGGEST_OVERRIDE
-
 class FqFitDataPresenterTest : public CxxTest::TestSuite {
 public:
   /// Needed to make sure everything is initialized
@@ -133,7 +57,7 @@ public:
   static void destroySuite(FqFitDataPresenterTest *suite) { delete suite; }
 
   void setUp() override {
-    m_view = std::make_unique<NiceMock<MockFqFitDataView>>();
+    m_view = std::make_unique<NiceMock<MockFitDataView>>();
     m_model = std::make_unique<NiceMock<MockIndirectFitDataModel>>();
 
     m_dataTable = createEmptyTableWidget(6, 5);
@@ -203,7 +127,7 @@ public:
 private:
   std::unique_ptr<QTableWidget> m_dataTable;
 
-  std::unique_ptr<MockFqFitDataView> m_view;
+  std::unique_ptr<MockFitDataView> m_view;
   std::unique_ptr<MockIndirectFitDataModel> m_model;
   std::unique_ptr<FqFitDataPresenter> m_presenter;
 

--- a/qt/scientific_interfaces/Inelastic/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/IndirectFitDataPresenterTest.h
@@ -15,6 +15,7 @@
 #include "Analysis/IndirectFitDataView.h"
 #include "Analysis/IndirectFittingModel.h"
 #include "Analysis/ParameterEstimation.h"
+#include "DataAnalysisMockObjects.h"
 #include "IndirectAddWorkspaceDialog.h"
 
 #include "MantidAPI/FrameworkManager.h"
@@ -67,76 +68,6 @@ public:
 
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
-/// Mock object to mock the view
-class MockIIndirectFitDataView : public IIndirectFitDataView {
-public:
-  /// Public Methods
-  MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
-  MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
-  MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
-  MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
-  MOCK_METHOD1(getColumnIndexFromName, int(QString ColName));
-  MOCK_METHOD0(clearTable, void());
-  MOCK_CONST_METHOD2(getText, QString(int row, int column));
-  MOCK_CONST_METHOD0(getSelectedIndexes, QModelIndexList());
-
-  /// Public slots
-  MOCK_METHOD1(displayWarning, void(std::string const &warning));
-};
-
-/// Mock object to mock the model
-class MockIndirectFitDataModel : public IIndirectFitDataModel {
-public:
-  /// Public Methods
-  MOCK_METHOD0(getFittingData, std::vector<IndirectFitData> *());
-  MOCK_METHOD2(addWorkspace, void(const std::string &workspaceName, const std::string &spectra));
-  MOCK_METHOD2(addWorkspace, void(const std::string &workspaceName, const FunctionModelSpectra &spectra));
-  MOCK_METHOD2(addWorkspace, void(MatrixWorkspace_sptr workspace, const FunctionModelSpectra &spectra));
-  MOCK_CONST_METHOD1(getWorkspace, MatrixWorkspace_sptr(WorkspaceID workspaceID));
-  MOCK_CONST_METHOD1(getWorkspace, MatrixWorkspace_sptr(FitDomainIndex index));
-  MOCK_CONST_METHOD0(getWorkspaceNames, std::vector<std::string>());
-  MOCK_CONST_METHOD0(getNumberOfWorkspaces, WorkspaceID());
-  MOCK_CONST_METHOD1(hasWorkspace, bool(std::string const &workspaceName));
-
-  MOCK_METHOD2(setSpectra, void(const std::string &spectra, WorkspaceID workspaceID));
-  MOCK_METHOD2(setSpectra, void(FunctionModelSpectra &&spectra, WorkspaceID workspaceID));
-  MOCK_METHOD2(setSpectra, void(const FunctionModelSpectra &spectra, WorkspaceID workspaceID));
-  MOCK_CONST_METHOD1(getSpectra, FunctionModelSpectra(WorkspaceID workspaceID));
-  MOCK_CONST_METHOD1(getSpectrum, size_t(FitDomainIndex index));
-  MOCK_CONST_METHOD1(getNumberOfSpectra, size_t(WorkspaceID workspaceID));
-
-  MOCK_METHOD0(clear, void());
-
-  MOCK_CONST_METHOD0(getNumberOfDomains, size_t());
-  MOCK_CONST_METHOD2(getDomainIndex, FitDomainIndex(WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_CONST_METHOD1(getSubIndices, std::pair<WorkspaceID, WorkspaceIndex>(FitDomainIndex));
-
-  MOCK_CONST_METHOD0(getQValuesForData, std::vector<double>());
-  MOCK_CONST_METHOD0(getResolutionsForFit, std::vector<std::pair<std::string, size_t>>());
-  MOCK_CONST_METHOD1(createDisplayName, std::string(WorkspaceID workspaceID));
-
-  MOCK_METHOD1(removeWorkspace, void(WorkspaceID workspaceID));
-  MOCK_METHOD1(removeDataByIndex, void(FitDomainIndex fitDomainIndex));
-
-  MOCK_METHOD3(setStartX, void(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_METHOD2(setStartX, void(double startX, WorkspaceID workspaceID));
-  MOCK_METHOD2(setStartX, void(double startX, FitDomainIndex fitDomainIndex));
-  MOCK_METHOD3(setEndX, void(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_METHOD2(setEndX, void(double endX, WorkspaceID workspaceID));
-  MOCK_METHOD2(setEndX, void(double endX, FitDomainIndex fitDomainIndex));
-  MOCK_METHOD3(setExcludeRegion, void(const std::string &exclude, WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_METHOD2(setExcludeRegion, void(const std::string &exclude, FitDomainIndex index));
-  MOCK_METHOD1(removeSpecialValues, void(const std::string &name));
-  MOCK_METHOD1(setResolution, bool(const std::string &name));
-  MOCK_METHOD2(setResolution, bool(const std::string &name, WorkspaceID workspaceID));
-  MOCK_CONST_METHOD2(getFittingRange, std::pair<double, double>(WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_CONST_METHOD1(getFittingRange, std::pair<double, double>(FitDomainIndex index));
-  MOCK_CONST_METHOD2(getExcludeRegion, std::string(WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_CONST_METHOD1(getExcludeRegion, std::string(FitDomainIndex index));
-  MOCK_CONST_METHOD2(getExcludeRegionVector, std::vector<double>(WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_CONST_METHOD1(getExcludeRegionVector, std::vector<double>(FitDomainIndex index));
-};
-
 MATCHER_P(NoCheck, selector, "") { return arg != selector; }
 
 EstimationDataSelector getEstimationDataSelector() {
@@ -178,7 +109,7 @@ public:
   static void destroySuite(IndirectFitDataPresenterTest *suite) { delete suite; }
 
   void setUp() override {
-    m_view = std::make_unique<NiceMock<MockIIndirectFitDataView>>();
+    m_view = std::make_unique<NiceMock<MockFitDataView>>();
     m_model = std::make_unique<NiceMock<MockIndirectFitDataModel>>();
     m_table = createEmptyTableWidget(5, 5);
     ON_CALL(*m_view, getDataTable()).WillByDefault(Return(m_table.get()));
@@ -308,7 +239,7 @@ private:
 
   std::unique_ptr<QTableWidget> m_table;
 
-  std::unique_ptr<MockIIndirectFitDataView> m_view;
+  std::unique_ptr<MockFitDataView> m_view;
   std::unique_ptr<MockIndirectFitDataModel> m_model;
   std::unique_ptr<IndirectFitDataPresenter> m_presenter;
 

--- a/qt/scientific_interfaces/Inelastic/test/IndirectFitOutputOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/IndirectFitOutputOptionsPresenterTest.h
@@ -14,10 +14,10 @@
 #include "Analysis/IndirectDataAnalysisTab.h"
 #include "Analysis/IndirectFitOutputOptionsPresenter.h"
 #include "Analysis/IndirectFitOutputOptionsView.h"
+#include "DataAnalysisMockObjects.h"
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h"
-#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid::API;
 using namespace Mantid::IndirectFitDataCreationHelper;
@@ -29,82 +29,6 @@ namespace {
 std::vector<std::string> getThreeParameters() { return {"Amplitude", "HWHM", "PeakCentre"}; }
 
 } // namespace
-
-GNU_DIAG_OFF_SUGGEST_OVERRIDE
-
-class MockIndirectDataAnalysisTab : public IIndirectDataAnalysisTab {
-public:
-  MOCK_METHOD0(plotSelectedSpectra, void());
-};
-
-/// Mock object to mock the view
-class MockIndirectFitOutputOptionsView final : public IIndirectFitOutputOptionsView {
-public:
-  /// Public Methods
-  MOCK_METHOD1(subscribePresenter, void(IIndirectFitOutputOptionsPresenter *presenter));
-
-  MOCK_METHOD1(setGroupWorkspaceComboBoxVisible, void(bool visible));
-  MOCK_METHOD1(setWorkspaceComboBoxVisible, void(bool visible));
-
-  MOCK_METHOD0(clearPlotWorkspaces, void());
-  MOCK_METHOD0(clearPlotTypes, void());
-  MOCK_METHOD1(setAvailablePlotWorkspaces, void(std::vector<std::string> const &workspaceNames));
-  MOCK_METHOD1(setAvailablePlotTypes, void(std::vector<std::string> const &parameterNames));
-
-  MOCK_METHOD1(setPlotGroupWorkspaceIndex, void(int index));
-  MOCK_METHOD1(setPlotWorkspacesIndex, void(int index));
-  MOCK_METHOD1(setPlotTypeIndex, void(int index));
-
-  MOCK_CONST_METHOD0(getSelectedGroupWorkspace, std::string());
-  MOCK_CONST_METHOD0(getSelectedWorkspace, std::string());
-  MOCK_CONST_METHOD0(getSelectedPlotType, std::string());
-
-  MOCK_METHOD1(setPlotText, void(std::string const &text));
-  MOCK_METHOD1(setSaveText, void(std::string const &text));
-
-  MOCK_METHOD1(setPlotExtraOptionsEnabled, void(bool enable));
-  MOCK_METHOD1(setPlotEnabled, void(bool enable));
-  MOCK_METHOD1(setEditResultEnabled, void(bool enable));
-  MOCK_METHOD1(setSaveEnabled, void(bool enable));
-
-  MOCK_METHOD1(setEditResultVisible, void(bool visible));
-
-  MOCK_METHOD1(displayWarning, void(std::string const &message));
-};
-
-/// Mock object to mock the model
-class MockIndirectFitOutputOptionsModel : public IIndirectFitOutputOptionsModel {
-public:
-  /// Public Methods
-  MOCK_METHOD1(setResultWorkspace, void(WorkspaceGroup_sptr groupWorkspace));
-  MOCK_METHOD1(setPDFWorkspace, void(WorkspaceGroup_sptr groupWorkspace));
-  MOCK_CONST_METHOD0(getResultWorkspace, WorkspaceGroup_sptr());
-  MOCK_CONST_METHOD0(getPDFWorkspace, WorkspaceGroup_sptr());
-
-  MOCK_METHOD0(removePDFWorkspace, void());
-
-  MOCK_CONST_METHOD1(isSelectedGroupPlottable, bool(std::string const &selectedGroup));
-  MOCK_CONST_METHOD0(isResultGroupPlottable, bool());
-  MOCK_CONST_METHOD0(isPDFGroupPlottable, bool());
-
-  MOCK_METHOD0(clearSpectraToPlot, void());
-  MOCK_CONST_METHOD0(getSpectraToPlot, std::vector<SpectrumToPlot>());
-
-  MOCK_METHOD1(plotResult, void(std::string const &plotType));
-  MOCK_METHOD2(plotPDF, void(std::string const &workspaceName, std::string const &plotType));
-
-  MOCK_CONST_METHOD0(saveResult, void());
-
-  MOCK_CONST_METHOD1(getWorkspaceParameters, std::vector<std::string>(std::string const &selectedGroup));
-  MOCK_CONST_METHOD0(getPDFWorkspaceNames, std::vector<std::string>());
-
-  MOCK_CONST_METHOD1(isResultGroupSelected, bool(std::string const &selectedGroup));
-
-  MOCK_METHOD3(replaceFitResult,
-               void(std::string const &inputName, std::string const &singleBinName, std::string const &outputName));
-};
-
-GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 class IndirectFitOutputOptionsPresenterTest : public CxxTest::TestSuite {
 public:

--- a/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
@@ -50,10 +50,6 @@ MultiDomainFunction_sptr getFunctionWithWorkspaceName(std::string const &workspa
 class MockIndirectFitPlotView : public IIndirectFitPlotView {
 public:
   /// Signals
-  void emitStartXChanged(double startX) { emit startXChanged(startX); }
-
-  void emitEndXChanged(double endX) { emit endXChanged(endX); }
-
   void emitBackgroundChanged(double value) { emit backgroundChanged(value); }
 
   /// Public methods

--- a/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
@@ -49,10 +49,6 @@ MultiDomainFunction_sptr getFunctionWithWorkspaceName(std::string const &workspa
 /// Mock object to mock the view
 class MockIndirectFitPlotView : public IIndirectFitPlotView {
 public:
-  /// Signals
-  void emitBackgroundChanged(double value) { emit backgroundChanged(value); }
-
-  /// Public methods
   MOCK_METHOD1(subscribePresenter, void(IIndirectFitPlotPresenter *presenter));
 
   MOCK_METHOD1(watchADS, void(bool watch));

--- a/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
@@ -104,13 +104,9 @@ public:
 
   MOCK_METHOD1(setHWHMMinimum, void(double minimum));
   MOCK_METHOD1(setHWHMMaximum, void(double maximum));
-
-  /// Public Slots
-  MOCK_METHOD0(clearTopPreview, void());
-  MOCK_METHOD0(clearBottomPreview, void());
-  MOCK_METHOD0(clearPreviews, void());
-
   MOCK_METHOD2(setHWHMRange, void(double minimum, double maximum));
+
+  MOCK_METHOD0(clearPreviews, void());
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
@@ -14,20 +14,18 @@
 #include "Analysis/IndirectFitPlotPresenter.h"
 #include "Analysis/IndirectFitPlotView.h"
 #include "Analysis/IndirectFittingModel.h"
+#include "DataAnalysisMockObjects.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h"
-#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid::API;
 using namespace Mantid::IndirectFitDataCreationHelper;
 using namespace MantidQt::CustomInterfaces;
 using namespace MantidQt::CustomInterfaces::IDA;
 using namespace testing;
-
-GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 namespace {
 MultiDomainFunction_sptr getFunction(std::string const &functionString) {
@@ -46,70 +44,6 @@ MultiDomainFunction_sptr getFunctionWithWorkspaceName(std::string const &workspa
 }
 } // namespace
 
-/// Mock object to mock the view
-class MockIndirectFitPlotView final : public IIndirectFitPlotView {
-public:
-  MOCK_METHOD1(subscribePresenter, void(IIndirectFitPlotPresenter *presenter));
-
-  MOCK_METHOD1(watchADS, void(bool watch));
-
-  MOCK_CONST_METHOD0(getSelectedSpectrum, WorkspaceIndex());
-  MOCK_CONST_METHOD0(getSelectedSpectrumIndex, FitDomainIndex());
-  MOCK_CONST_METHOD0(getSelectedDataIndex, WorkspaceID());
-  MOCK_CONST_METHOD0(dataSelectionSize, WorkspaceID());
-  MOCK_CONST_METHOD0(isPlotGuessChecked, bool());
-
-  MOCK_METHOD2(setAvailableSpectra, void(WorkspaceIndex minimum, WorkspaceIndex maximum));
-  MOCK_METHOD2(setAvailableSpectra, void(std::vector<WorkspaceIndex>::const_iterator const &from,
-                                         std::vector<WorkspaceIndex>::const_iterator const &to));
-
-  MOCK_METHOD1(setMinimumSpectrum, void(int minimum));
-  MOCK_METHOD1(setMaximumSpectrum, void(int maximum));
-  MOCK_METHOD1(setPlotSpectrum, void(WorkspaceIndex spectrum));
-  MOCK_METHOD1(appendToDataSelection, void(std::string const &dataName));
-  MOCK_METHOD2(setNameInDataSelection, void(std::string const &dataName, WorkspaceID workspaceID));
-  MOCK_METHOD0(clearDataSelection, void());
-
-  MOCK_METHOD4(plotInTopPreview, void(QString const &name, Mantid::API::MatrixWorkspace_sptr workspace,
-                                      WorkspaceIndex spectrum, Qt::GlobalColor colour));
-  MOCK_METHOD4(plotInBottomPreview, void(QString const &name, Mantid::API::MatrixWorkspace_sptr workspace,
-                                         WorkspaceIndex spectrum, Qt::GlobalColor colour));
-
-  MOCK_METHOD1(removeFromTopPreview, void(QString const &name));
-  MOCK_METHOD1(removeFromBottomPreview, void(QString const &name));
-
-  MOCK_METHOD1(enableFitSingleSpectrum, void(bool enable));
-  MOCK_METHOD1(enablePlotGuess, void(bool enable));
-  MOCK_METHOD1(enableSpectrumSelection, void(bool enable));
-  MOCK_METHOD1(enableFitRangeSelection, void(bool enable));
-
-  MOCK_METHOD1(setFitSingleSpectrumText, void(QString const &text));
-  MOCK_METHOD1(setFitSingleSpectrumEnabled, void(bool enable));
-
-  MOCK_METHOD1(setBackgroundLevel, void(double value));
-
-  MOCK_METHOD2(setFitRange, void(double minimum, double maximum));
-  MOCK_METHOD1(setFitRangeMinimum, void(double minimum));
-  MOCK_METHOD1(setFitRangeMaximum, void(double maximum));
-  MOCK_METHOD1(setFitRangeBounds, void(std::pair<double, double> const &bounds));
-
-  MOCK_METHOD1(setBackgroundRangeVisible, void(bool visible));
-  MOCK_METHOD1(setHWHMRangeVisible, void(bool visible));
-
-  MOCK_METHOD1(allowRedraws, void(bool state));
-  MOCK_METHOD0(redrawPlots, void());
-
-  MOCK_CONST_METHOD1(displayMessage, void(std::string const &message));
-
-  MOCK_METHOD1(setHWHMMinimum, void(double minimum));
-  MOCK_METHOD1(setHWHMMaximum, void(double maximum));
-  MOCK_METHOD2(setHWHMRange, void(double minimum, double maximum));
-
-  MOCK_METHOD0(clearPreviews, void());
-};
-
-GNU_DIAG_ON_SUGGEST_OVERRIDE
-
 class IndirectFitPlotPresenterTest : public CxxTest::TestSuite {
 public:
   /// Needed to make sure everything is initialized
@@ -124,9 +58,10 @@ public:
     /// Presenter takes an IndirectFittingModel. This means the
     /// IndirectFittingModel is mocked instead - which is a good
     /// substitute anyway
+    m_tab = std::make_unique<NiceMock<MockIndirectDataAnalysisTab>>();
     auto model = std::make_unique<IndirectFitPlotModel>();
     m_view = std::make_unique<MockIndirectFitPlotView>();
-    m_presenter = std::make_unique<IndirectFitPlotPresenter>(m_view.get(), std::move(model));
+    m_presenter = std::make_unique<IndirectFitPlotPresenter>(m_tab.get(), m_view.get(), std::move(model));
 
     m_workspace = createWorkspaceWithInstrument(6, 5);
     m_ads = std::make_unique<SetUpADSWithWorkspace>("WorkspaceName", m_workspace);
@@ -431,6 +366,7 @@ public:
   }
 
 private:
+  std::unique_ptr<NiceMock<MockIndirectDataAnalysisTab>> m_tab;
   std::unique_ptr<MockIndirectFitPlotView> m_view;
   std::unique_ptr<IndirectFitPlotPresenter> m_presenter;
 

--- a/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
@@ -52,7 +52,6 @@ public:
   MOCK_METHOD1(subscribePresenter, void(IIndirectFitPlotPresenter *presenter));
 
   MOCK_METHOD1(watchADS, void(bool watch));
-  MOCK_METHOD0(disableSpectrumPlotSelection, void());
 
   MOCK_CONST_METHOD0(getSelectedSpectrum, WorkspaceIndex());
   MOCK_CONST_METHOD0(getSelectedSpectrumIndex, FitDomainIndex());

--- a/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
@@ -47,7 +47,7 @@ MultiDomainFunction_sptr getFunctionWithWorkspaceName(std::string const &workspa
 } // namespace
 
 /// Mock object to mock the view
-class MockIndirectFitPlotView : public IIndirectFitPlotView {
+class MockIndirectFitPlotView final : public IIndirectFitPlotView {
 public:
   MOCK_METHOD1(subscribePresenter, void(IIndirectFitPlotPresenter *presenter));
 
@@ -125,7 +125,7 @@ public:
     /// IndirectFittingModel is mocked instead - which is a good
     /// substitute anyway
     auto model = std::make_unique<IndirectFitPlotModel>();
-    m_view = std::make_unique<NiceMock<MockIndirectFitPlotView>>();
+    m_view = std::make_unique<MockIndirectFitPlotView>();
     m_presenter = std::make_unique<IndirectFitPlotPresenter>(m_view.get(), std::move(model));
 
     m_workspace = createWorkspaceWithInstrument(6, 5);

--- a/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
@@ -146,8 +146,9 @@ public:
     /// Presenter takes an IndirectFittingModel. This means the
     /// IndirectFittingModel is mocked instead - which is a good
     /// substitute anyway
+    auto model = std::make_unique<IndirectFitPlotModel>();
     m_view = std::make_unique<NiceMock<MockIndirectFitPlotView>>();
-    m_presenter = std::make_unique<IndirectFitPlotPresenter>(std::move(m_view.get()));
+    m_presenter = std::make_unique<IndirectFitPlotPresenter>(m_view.get(), std::move(model));
 
     m_workspace = createWorkspaceWithInstrument(6, 5);
     m_ads = std::make_unique<SetUpADSWithWorkspace>("WorkspaceName", m_workspace);

--- a/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/IndirectFitPlotPresenterTest.h
@@ -325,14 +325,6 @@ public:
     m_presenter->setEndX(3.0);
   }
 
-  void test_updatePlotSpectrum_calls_correct_slots() {
-    EXPECT_CALL(*m_view, setPlotSpectrum(WorkspaceIndex{3})).Times(1);
-    EXPECT_CALL(*m_view, clearPreviews()).Times(1);
-    m_presenter->updatePlotSpectrum(WorkspaceIndex{3});
-
-    TS_ASSERT_EQUALS(m_presenter->getSelectedDomainIndex(), FitDomainIndex{3});
-  }
-
   void test_that_updateRangeSelectors_will_update_the_background_selector() {
     auto const fitFunction = getFunctionWithWorkspaceName("WorkspaceName");
     m_presenter->setFitFunction(fitFunction);


### PR DESCRIPTION
### Description of work
This PR refactors the IndirectFitPlotPresenter so that it no longer has a QObject dependency. This makes it easier to test the presenter, and also makes it possible to replace the presenter in the future if necessary. It also makes sure that the model is passed into the constructor of the presenter as an argument. This also means it is easier to write a new model that conforms to a particular interface and replace the old one in the future, easily, if necessary.

Part of #36325

### To test:
1. Load the following data into the Data Analysis IqtFit tab

Input file: [irs26176_graphite002_iqt.zip](https://github.com/mantidproject/mantid/files/2361062/irs26176_graphite002_iqt.zip)
2. `Stretched Exponential`
3. `Flat background`
4. Drag the EndX on the graph to the left a bit to miss the noise (`0.15` I think)
5. Click Run and wait
6. Change the plotted spectrum and check the plot updates each time you change the spectrum
7. Turn on plot guess
8. Try plot current preview


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
