### PR TITLE
Elwin tab presenter is no longer a QObject and View is passed to constructor.

### DIFF
--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -402,7 +402,7 @@ void ISISCalibration::setDefaultInstDetails(QMap<QString, QString> const &instru
   QFileInfo fi(filename);
   QString wsname = fi.baseName();
   if (!Mantid::API::AnalysisDataService::Instance().doesExist(wsname.toStdString())) {
-    loadFile(filename, wsname, spectraMin, spectraMax);
+    loadFile(filename.toStdString(), wsname.toStdString(), spectraMin, spectraMax);
   }
   const auto input =
       std::dynamic_pointer_cast<MatrixWorkspace>(AnalysisDataService::Instance().retrieve(wsname.toStdString()));
@@ -448,7 +448,7 @@ void ISISCalibration::calPlotRaw() {
   int const specMin = hasInstrumentDetail("spectra-min") ? getInstrumentDetail("spectra-min").toInt() : -1;
   int const specMax = hasInstrumentDetail("spectra-max") ? getInstrumentDetail("spectra-max").toInt() : -1;
 
-  if (!loadFile(filename, wsname, specMin, specMax)) {
+  if (!loadFile(filename.toStdString(), wsname.toStdString(), specMin, specMax)) {
     emit showMessageBox("Unable to load file.\nCheck whether your file exists "
                         "and matches the selected instrument in the Energy "
                         "Transfer tab.");

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.cpp
@@ -279,7 +279,7 @@ void ISISDiagnostics::handleNewFile() {
   int specMin = static_cast<int>(m_dblManager->value(m_properties["SpecMin"]));
   int specMax = static_cast<int>(m_dblManager->value(m_properties["SpecMax"]));
 
-  if (!loadFile(filename, wsname, specMin, specMax)) {
+  if (!loadFile(filename.toStdString(), wsname.toStdString(), specMin, specMax)) {
     emit showMessageBox("Unable to load file.\nCheck whether your file exists "
                         "and matches the selected instrument in the "
                         "EnergyTransfer tab.");

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -197,14 +197,14 @@ void IndirectTab::exportPythonScript() {
  * @param specMax :: Upper spectra bound
  * @return If the algorithm was successful
  */
-bool IndirectTab::loadFile(const QString &filename, const QString &outputName, const int specMin, const int specMax,
-                           bool loadHistory) {
+bool IndirectTab::loadFile(const std::string &filename, const std::string &outputName, const int specMin,
+                           const int specMax, bool loadHistory) {
   const auto algName = loadHistory ? "Load" : "LoadNexusProcessed";
 
   auto loader = AlgorithmManager::Instance().createUnmanaged(algName, -1);
   loader->initialize();
-  loader->setProperty("Filename", filename.toStdString());
-  loader->setProperty("OutputWorkspace", outputName.toStdString());
+  loader->setProperty("Filename", filename);
+  loader->setProperty("OutputWorkspace", outputName);
   setPropertyIf(loader, "SpectrumMin", castToString(specMin), specMin != -1);
   setPropertyIf(loader, "SpectrumMax", castToString(specMax), specMax != -1);
   setPropertyIf(loader, "LoadHistory", loadHistory ? "1" : "0", !loadHistory);

--- a/qt/scientific_interfaces/Indirect/IndirectTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.h
@@ -86,8 +86,8 @@ public:
 
 protected:
   /// Run the load algorithms
-  bool loadFile(const QString &filename, const QString &outputName, const int specMin = -1, const int specMax = -1,
-                bool loadHistory = true);
+  bool loadFile(const std::string &filename, const std::string &outputName, const int specMin = -1,
+                const int specMax = -1, bool loadHistory = true);
 
   /// Add a SaveNexusProcessed step to the batch queue
   void addSaveWorkspaceToQueue(const std::string &wsName, const std::string &filename = "");

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -158,6 +158,7 @@ set(INC_FILES
     Manipulation/ISqwView.h
     Manipulation/IMomentsView.h
     Manipulation/ISymmetriseView.h
+    Manipulation/IElwinView.h
 )
 
 set(UI_FILES

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
@@ -44,8 +44,8 @@ public:
   virtual void newInputFilesFromDialog(IDA::IAddWorkspaceDialog const *dialog) = 0;
   virtual void clearPreviewFile() = 0;
   virtual void clearInputFiles() = 0;
-  virtual void setRunIsRunning(const bool &running) = 0;
-  virtual void setSaveResultEnabled(const bool &enabled) = 0;
+  virtual void setRunIsRunning(const bool running) = 0;
+  virtual void setSaveResultEnabled(const bool enabled) = 0;
   virtual int getPreviewSpec() = 0;
   virtual std::string getPreviewWorkspaceName(int index) const = 0;
   virtual std::string getPreviewFilename(int index) const = 0;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
@@ -9,6 +9,8 @@
 #include "DllConfig.h"
 #include "IAddWorkspaceDialog.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidQtWidgets/Common/FileFinderWidget.h"
+#include <QModelIndexList>
 #include <QStringList>
 
 #include <memory>
@@ -35,7 +37,7 @@ public:
 
   virtual void newPreviewFileSelected(const Mantid::API::MatrixWorkspace_sptr &workspace) = 0;
   virtual int getCurrentInputIndex() = 0;
-  virtual API::FileFinderWidget *getFileFinderWidget() = 0;
+  virtual MantidQt::API::FileFinderWidget *getFileFinderWidget() = 0;
 
   virtual void plotInput(Mantid::API::MatrixWorkspace_sptr inputWS, int spectrum) = 0;
   virtual void newInputFiles() = 0;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
@@ -1,0 +1,81 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllConfig.h"
+#include "IAddWorkspaceDialog.h"
+#include "MantidAPI/MatrixWorkspace_fwd.h"
+#include <QStringList>
+
+#include <memory>
+#include <string>
+#include <tuple>
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class IndirectPlotOptionsView;
+class IElwinPresenter;
+
+class MANTIDQT_INELASTIC_DLL IElwinView {
+
+public:
+  virtual void subscribePresenter(IElwinPresenter *presenter) = 0;
+  virtual void setup() = 0;
+  virtual IndirectPlotOptionsView *getPlotOptions() const = 0;
+  virtual void setFBSuffixes(QStringList const &suffix) = 0;
+
+  virtual void setAvailableSpectra(MantidWidgets::WorkspaceIndex minimum, MantidWidgets::WorkspaceIndex maximum) = 0;
+  virtual void setAvailableSpectra(const std::vector<MantidWidgets::WorkspaceIndex>::const_iterator &from,
+                                   const std::vector<MantidWidgets::WorkspaceIndex>::const_iterator &to) = 0;
+
+  virtual void newPreviewFileSelected(const Mantid::API::MatrixWorkspace_sptr &workspace) = 0;
+  virtual int getCurrentInputIndex() = 0;
+  virtual API::FileFinderWidget *getFileFinderWidget() = 0;
+
+  virtual void plotInput(Mantid::API::MatrixWorkspace_sptr inputWS, int spectrum) = 0;
+  virtual void newInputFiles() = 0;
+  virtual void newInputFilesFromDialog(IDA::IAddWorkspaceDialog const *dialog) = 0;
+  virtual void clearPreviewFile() = 0;
+  virtual void clearInputFiles() = 0;
+  virtual void setRunIsRunning(const bool &running) = 0;
+  virtual void setSaveResultEnabled(const bool &enabled) = 0;
+  virtual int getPreviewSpec() = 0;
+  virtual std::string getPreviewWorkspaceName(int index) const = 0;
+  virtual std::string getPreviewFilename(int index) const = 0;
+  virtual std::string getCurrentPreview() const = 0;
+  virtual QStringList getInputFilenames() = 0;
+
+  // controls for dataTable
+  virtual void clearDataTable() = 0;
+  virtual void addTableEntry(int row, std::string const &name, int spectrum) = 0;
+
+  virtual QModelIndexList getSelectedData() = 0;
+
+  // boolean flags for LoadHistory/GroupInput Checkboxes
+  virtual bool isLoadHistory() = 0;
+  virtual bool isGroupInput() = 0;
+
+  // getters/setters for m_properties
+  virtual bool getNormalise() = 0;
+  virtual bool getBackgroundSubtraction() = 0;
+  virtual std::string getLogName() = 0;
+  virtual std::string getLogValue() = 0;
+  virtual void setIntegrationStart(double value) = 0;
+  virtual void setIntegrationEnd(double value) = 0;
+  virtual void setBackgroundStart(double value) = 0;
+  virtual void setBackgroundEnd(double value) = 0;
+
+  virtual double getIntegrationStart() = 0;
+  virtual double getIntegrationEnd() = 0;
+  virtual double getBackgroundStart() = 0;
+  virtual double getBackgroundEnd() = 0;
+
+  virtual void showMessageBox(std::string const &message) const = 0;
+};
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulation.cpp
@@ -62,13 +62,13 @@ void InelasticDataManipulation::initLayout() {
   addMVPTab<InelasticDataManipulationSymmetriseTab, InelasticDataManipulationSymmetriseTabView>("Symmetrise");
   addMVPTab<InelasticDataManipulationSqwTab, InelasticDataManipulationSqwTabView>("S(Q, w)");
   addMVPTab<InelasticDataManipulationMomentsTab, InelasticDataManipulationMomentsTabView>("Moments");
-  addTab<InelasticDataManipulationElwinTab>("Elwin");
+  addMVPTab<InelasticDataManipulationElwinTab, InelasticDataManipulationElwinTabView>("Elwin");
   addTab<InelasticDataManipulationIqtTab>("Iqt");
 
   connect(m_uiForm.pbSettings, SIGNAL(clicked()), this, SLOT(settings()));
   // Connect "?" (Help) Button
   connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
-  // Connect the Python export buton
+  // Connect the Python export button
   connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this, SLOT(exportTabPython()));
   // Connect the "Manage User Directories" Button
   connect(m_uiForm.pbManageDirectories, SIGNAL(clicked()), this, SLOT(manageUserDirectories()));

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
@@ -122,9 +122,9 @@ void InelasticDataManipulationElwinTab::runFileInput() {
   std::string inputGroupWsName = "IDA_Elwin_Input";
 
   QFileInfo firstFileInfo(inputFilenames[0]);
-  const auto filename = firstFileInfo.baseName();
+  const auto filename = firstFileInfo.baseName().toStdString();
 
-  auto workspaceBaseName = filename.left(filename.lastIndexOf("_"));
+  auto workspaceBaseName = filename.substr(0, filename.find_last_of("_"));
 
   if (inputFilenames.size() > 1) {
     QFileInfo fileInfo(inputFilenames[inputFilenames.length() - 1]);
@@ -140,10 +140,10 @@ void InelasticDataManipulationElwinTab::runFileInput() {
     }
     // reassemble workspace base name with additional run number
     runNumber = runNumber.substr(runNumberStart, strLength);
-    auto baseName = firstFileInfo.baseName();
-    const auto prefix = baseName.left(baseName.indexOf("_"));
-    const auto suffix = baseName.right(baseName.length() - baseName.indexOf("_"));
-    workspaceBaseName = prefix + QString::fromStdString("-" + runNumber) + suffix;
+    auto baseName = firstFileInfo.baseName().toStdString();
+    const auto prefix = baseName.substr(baseName.find_last_of("_"));
+    const auto suffix = baseName.substr(baseName.length() - baseName.find_last_of("_"));
+    workspaceBaseName = prefix + "-" + runNumber + suffix;
   }
 
   // Load input files
@@ -163,7 +163,7 @@ void InelasticDataManipulationElwinTab::runFileInput() {
   m_batchAlgoRunner->executeBatchAsync();
 
   // Set the result workspace for Python script export
-  m_pythonExportWsName = (workspaceBaseName + "_elwin_eq2").toStdString();
+  m_pythonExportWsName = workspaceBaseName + "_elwin_eq2";
 }
 
 void InelasticDataManipulationElwinTab::runWorkspaceInput() {
@@ -348,9 +348,6 @@ void InelasticDataManipulationElwinTab::newPreviewWorkspaceSelected(const std::s
 void InelasticDataManipulationElwinTab::handlePreviewSpectrumChanged(int spectrum) {
   if (m_view->getPreviewSpec())
     setSelectedSpectrum(spectrum);
-  std::cout << "Spectrum " << spectrum << std::endl;
-  std::cout << "Preview Spectrum " << m_view->getPreviewSpec() << std::endl;
-  std::cout << getInputWorkspace() << "  selected: " << getSelectedSpectrum() << std::endl;
   m_view->plotInput(getInputWorkspace(), getSelectedSpectrum());
 }
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
@@ -325,7 +325,7 @@ void InelasticDataManipulationElwinTab::handlePreviewIndexChanged(int index) {
 void InelasticDataManipulationElwinTab::newPreviewFileSelected(const std::string &workspaceName,
                                                                const std::string &filename) {
   auto loadHistory = m_view->isLoadHistory();
-  if (loadFile(QString::fromStdString(filename), QString::fromStdString(workspaceName), -1, -1, loadHistory)) {
+  if (loadFile(filename, workspaceName, -1, -1, loadHistory)) {
     auto const workspace = getADSMatrixWorkspace(workspaceName);
 
     setInputWorkspace(workspace);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
@@ -426,7 +426,6 @@ void InelasticDataManipulationElwinTab::handleAddDataFromFile(IAddWorkspaceDialo
     if (suffixes.size() < 1) {
       uiv.addErrorMessage("The input files must be all _red or all _sqw.");
       m_view->clearInputFiles();
-      // m_view->CloseDialog();
     }
     std::string error = uiv.generateErrorMessage().toStdString();
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
@@ -96,9 +96,9 @@ private:
   IElwinView *m_view;
   std::unique_ptr<InelasticDataManipulationElwinTabModel> m_model;
   std::unique_ptr<IndirectFitDataModel> m_dataModel;
+  int m_selectedSpectrum;
   std::weak_ptr<MatrixWorkspace> m_previewPlotWorkspace;
   MatrixWorkspace_sptr m_inputWorkspace;
-  int m_selectedSpectrum;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
@@ -19,87 +19,86 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+
 using namespace Mantid::API;
 using namespace MantidWidgets;
 using namespace IDA;
 
-class MANTIDQT_INELASTIC_DLL InelasticDataManipulationElwinTab : public InelasticDataManipulationTab {
-  Q_OBJECT
-
+class IElwinPresenter {
 public:
-  InelasticDataManipulationElwinTab(QWidget *parent = nullptr);
+  virtual void handleValueChanged(std::string const &propName, double value) = 0;
+  virtual void handleValueChanged(std::string const &propName, bool value) = 0;
+  virtual void handleRunClicked() = 0;
+  virtual void handleSaveClicked() = 0;
+  virtual void handlePlotPreviewClicked() = 0;
+  virtual void handleFilesFound() = 0;
+  virtual void handlePreviewSpectrumChanged(int spectrum) = 0;
+  virtual void handlePreviewIndexChanged(int index) = 0;
+  virtual void handleAddData(IAddWorkspaceDialog const *dialog) = 0;
+  virtual void handleAddDataFromFile(IAddWorkspaceDialog const *dialog) = 0;
+  virtual void handleRemoveSelectedData() = 0;
+  virtual void updateAvailableSpectra() = 0;
+};
+
+class MANTIDQT_INELASTIC_DLL InelasticDataManipulationElwinTab : public InelasticDataManipulationTab,
+                                                                 public IElwinPresenter {
+public:
+  InelasticDataManipulationElwinTab(QWidget *parent, IElwinView *view);
   ~InelasticDataManipulationElwinTab();
 
-public slots:
-  void removeSelectedData();
-  void updateAvailableSpectra();
+  // base Manipulation tab methods
+  void run() override;
+  void setup() override;
+  bool validate() override;
+
+  // Elwin interface methods
+  void handleValueChanged(std::string const &propName, double) override;
+  void handleValueChanged(std::string const &propName, bool) override;
+  void handleRunClicked() override;
+  void handleSaveClicked() override;
+  void handlePlotPreviewClicked() override;
+  void handleFilesFound() override;
+  void handlePreviewSpectrumChanged(int spectrum) override;
+  void handlePreviewIndexChanged(int index) override;
+  void handleAddData(IAddWorkspaceDialog const *dialog) override;
+  void handleAddDataFromFile(IAddWorkspaceDialog const *dialog) override;
+  void handleRemoveSelectedData() override;
+  void updateAvailableSpectra() override;
 
 protected:
-  void addData(IAddWorkspaceDialog const *dialog);
-  void checkData(IAddWorkspaceDialog const *dialog);
-  void addDataFromFile(IAddWorkspaceDialog const *dialog);
+  void runComplete(bool error) override;
   void newInputFilesFromDialog(IAddWorkspaceDialog const *dialog);
   virtual void addDataToModel(IAddWorkspaceDialog const *dialog);
 
-protected slots:
-  void showAddWorkspaceDialog();
-  virtual void closeDialog();
-
-signals:
-  void dataAdded();
-  void dataRemoved();
-  void dataChanged();
-
 private:
-  void run() override;
   void runFileInput();
   void runWorkspaceInput();
-  void setup() override;
-  bool validate() override;
+
   void setFileExtensionsByName(bool filter) override;
   void updateTableFromModel();
-
-  int getSelectedSpectrum() const;
-  virtual void setSelectedSpectrum(int spectrum);
-  MatrixWorkspace_sptr getInputWorkspace() const;
-  void setInputWorkspace(MatrixWorkspace_sptr inputWorkspace);
-
-  void checkForELTWorkspace();
-
-  std::vector<std::string> getOutputWorkspaceNames();
-  QString getOutputBasename();
-
-  virtual std::unique_ptr<IAddWorkspaceDialog> getAddWorkspaceDialog(QWidget *parent) const;
-  MatrixWorkspace_sptr getPreviewPlotWorkspace();
-  void setPreviewPlotWorkspace(const MatrixWorkspace_sptr &previewPlotWorkspace);
-
-  std::unique_ptr<InelasticDataManipulationElwinTabView> m_view;
-  std::unique_ptr<InelasticDataManipulationElwinTabModel> m_model;
-  InelasticDataManipulation *m_parent;
-  std::unique_ptr<IndirectFitDataModel> m_dataModel;
-  std::unique_ptr<IAddWorkspaceDialog> m_addWorkspaceDialog;
-  std::weak_ptr<MatrixWorkspace> m_previewPlotWorkspace;
-  int m_selectedSpectrum;
-  MatrixWorkspace_sptr m_inputWorkspace;
-
-  void newPreviewFileSelected(const QString &workspaceName, const QString &filename);
-  void newPreviewWorkspaceSelected(const QString &workspaceName);
-  size_t findWorkspaceID();
   void newInputFiles();
   void updateIntegrationRange();
 
-private slots:
-  void handleValueChanged(QtProperty *, double);
-  void handleValueChanged(QtProperty *, bool);
-  void checkNewPreviewSelected(int index);
-  void handlePreviewSpectrumChanged(int spectrum);
-  void unGroupInput(bool error);
-  void runClicked();
-  void saveClicked();
-  void addData();
-  void checkLoadedFiles();
-  void plotCurrentPreview();
-};
+  int getSelectedSpectrum() const;
+  virtual void setSelectedSpectrum(int spectrum);
 
+  std::vector<std::string> getOutputWorkspaceNames();
+  std::string getOutputBasename();
+  MatrixWorkspace_sptr getInputWorkspace() const;
+  MatrixWorkspace_sptr getPreviewPlotWorkspace();
+  void checkForELTWorkspace();
+  void setInputWorkspace(MatrixWorkspace_sptr inputWorkspace);
+  void setPreviewPlotWorkspace(const MatrixWorkspace_sptr &previewPlotWorkspace);
+  void newPreviewFileSelected(const std::string &workspaceName, const std::string &filename);
+  void newPreviewWorkspaceSelected(const std::string &workspaceName);
+  size_t findWorkspaceID();
+
+  IElwinView *m_view;
+  std::unique_ptr<InelasticDataManipulationElwinTabModel> m_model;
+  std::unique_ptr<IndirectFitDataModel> m_dataModel;
+  std::weak_ptr<MatrixWorkspace> m_previewPlotWorkspace;
+  MatrixWorkspace_sptr m_inputWorkspace;
+  int m_selectedSpectrum;
+};
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
@@ -49,16 +49,16 @@ void InelasticDataManipulationElwinTabModel::setupGroupAlgorithm(MantidQt::API::
 }
 
 void InelasticDataManipulationElwinTabModel::setupElasticWindowMultiple(
-    MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, QString workspaceBaseName,
+    MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::string const &workspaceBaseName,
     std::string const &inputGroupWsName, std::string const &sampleEnvironmentLogName,
     std::string const &sampleEnvironmentLogValue) {
 
-  workspaceBaseName += "_elwin_";
+  auto elwinSuffix = "_elwin_";
 
-  auto const qWorkspace = (workspaceBaseName + "eq").toStdString();
-  auto const qSquaredWorkspace = (workspaceBaseName + "eq2").toStdString();
-  auto const elfWorkspace = (workspaceBaseName + "elf").toStdString();
-  auto const eltWorkspace = (workspaceBaseName + "elt").toStdString();
+  auto const qWorkspace = (workspaceBaseName + elwinSuffix + "eq");
+  auto const qSquaredWorkspace = (workspaceBaseName + elwinSuffix + "eq2");
+  auto const elfWorkspace = (workspaceBaseName + elwinSuffix + "elf");
+  auto const eltWorkspace = (workspaceBaseName + elwinSuffix + "elt");
 
   // Configure ElasticWindowMultiple algorithm
   auto elwinMultAlg = AlgorithmManager::Instance().create("ElasticWindowMultiple");

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.h
@@ -29,8 +29,9 @@ public:
   std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra spectra);
   void setupGroupAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
                            std::string const &inputWorkspacesString, std::string const &inputGroupWsName);
-  void setupElasticWindowMultiple(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, QString workspaceBaseName,
-                                  std::string const &inputGroupWsName, std::string const &sampleEnvironmentLogName,
+  void setupElasticWindowMultiple(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
+                                  std::string const &workspaceBaseName, std::string const &inputGroupWsName,
+                                  std::string const &sampleEnvironmentLogName,
                                   std::string const &sampleEnvironmentLogValue);
   void ungroupAlgorithm(std::string const &InputWorkspace);
   void setIntegrationStart(double integrationStart);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
@@ -565,20 +565,20 @@ void InelasticDataManipulationElwinTabView::setRangeSelectorMax(QtProperty *minP
     m_dblManager->setValue(maxProperty, rangeSelector->getMaximum());
 }
 
-void InelasticDataManipulationElwinTabView::setRunIsRunning(const bool &running) {
+void InelasticDataManipulationElwinTabView::setRunIsRunning(const bool running) {
   m_uiForm.pbRun->setText(running ? "Running..." : "Run");
   setButtonsEnabled(!running);
   m_uiForm.ppPlot->watchADS(!running);
 }
 
-void InelasticDataManipulationElwinTabView::setButtonsEnabled(const bool &enabled) {
+void InelasticDataManipulationElwinTabView::setButtonsEnabled(const bool enabled) {
   setRunEnabled(enabled);
   setSaveResultEnabled(enabled);
 }
 
-void InelasticDataManipulationElwinTabView::setRunEnabled(const bool &enabled) { m_uiForm.pbRun->setEnabled(enabled); }
+void InelasticDataManipulationElwinTabView::setRunEnabled(const bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
 
-void InelasticDataManipulationElwinTabView::setSaveResultEnabled(const bool &enabled) {
+void InelasticDataManipulationElwinTabView::setSaveResultEnabled(const bool enabled) {
   m_uiForm.pbSave->setEnabled(enabled);
 }
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
@@ -289,7 +289,9 @@ QModelIndexList InelasticDataManipulationElwinTabView::getSelectedData() {
   return m_uiForm.tbElwinData->selectionModel()->selectedIndexes();
 }
 
-API::FileFinderWidget *InelasticDataManipulationElwinTabView::getFileFinderWidget() { return m_uiForm.dsInputFiles; }
+MantidQt::API::FileFinderWidget *InelasticDataManipulationElwinTabView::getFileFinderWidget() {
+  return m_uiForm.dsInputFiles;
+}
 
 void InelasticDataManipulationElwinTabView::setFBSuffixes(QStringList const &suffix) {
   m_uiForm.dsInputFiles->setFileExtensions(suffix);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
@@ -218,6 +218,7 @@ void InelasticDataManipulationElwinTabView::showAddWorkspaceDialog() {
   m_addWorkspaceDialog->setWSSuffices(getSampleWSSuffices());
   m_addWorkspaceDialog->setFBSuffices(getSampleFBSuffices());
   m_addWorkspaceDialog->updateSelectedSpectra();
+  m_addWorkspaceDialog->setAttribute(Qt::WA_DeleteOnClose);
   m_addWorkspaceDialog->show();
   connect(m_addWorkspaceDialog.get(), SIGNAL(addData()), this, SLOT(notifyAddData()));
   connect(m_addWorkspaceDialog.get(), SIGNAL(closeDialog()), this, SLOT(notifyCloseDialog()));

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
@@ -32,6 +32,16 @@ QPair<double, double> getXRangeFromWorkspace(const Mantid::API::MatrixWorkspace_
   return QPair<double, double>(xValues.front(), xValues.back());
 }
 
+QStringList getSampleWSSuffices() {
+  QStringList const wsSampleSuffixes{"red", "sqw"};
+  return wsSampleSuffixes;
+}
+
+QStringList getSampleFBSuffices() {
+  QStringList const fbSampleSuffixes{"red.*", "sqw.*"};
+  return fbSampleSuffixes;
+}
+
 namespace Regexes {
 const QString EMPTY = "^$";
 const QString SPACE = "(\\s)*";
@@ -67,11 +77,13 @@ public:
     editor->setGeometry(option.rect);
   }
 };
+
 } // namespace
 
 namespace MantidQt::CustomInterfaces {
 using namespace IDA;
-InelasticDataManipulationElwinTabView::InelasticDataManipulationElwinTabView(QWidget *parent) : m_elwTree(nullptr) {
+InelasticDataManipulationElwinTabView::InelasticDataManipulationElwinTabView(QWidget *parent)
+    : m_presenter(), m_elwTree(nullptr), m_addWorkspaceDialog(nullptr) {
 
   // Create Editor Factories
   m_dblEdFac = new DoubleEditorFactory(this);
@@ -81,10 +93,6 @@ InelasticDataManipulationElwinTabView::InelasticDataManipulationElwinTabView(QWi
   m_grpManager = new QtGroupPropertyManager();
 
   m_uiForm.setupUi(parent);
-  connect(m_uiForm.wkspAdd, SIGNAL(clicked()), this, SIGNAL(addDataClicked()));
-  connect(m_uiForm.wkspRemove, SIGNAL(clicked()), this, SIGNAL(removeDataClicked()));
-
-  setup();
 }
 
 InelasticDataManipulationElwinTabView::~InelasticDataManipulationElwinTabView() {
@@ -129,35 +137,39 @@ void InelasticDataManipulationElwinTabView::setup() {
   m_elwTree->addProperty(m_properties["Normalise"]);
 
   // We always want one range selector... the second one can be controlled from
-  // within the elwinTwoRanges(bool state) function
+
   auto integrationRangeSelector = m_uiForm.ppPlot->addRangeSelector("ElwinIntegrationRange");
   integrationRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
-  connect(integrationRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(minChanged(double)));
-  connect(integrationRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(maxChanged(double)));
+  connect(integrationRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(notifyMinChanged(double)));
+  connect(integrationRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(notifyMaxChanged(double)));
   // create the second range
   auto backgroundRangeSelector = m_uiForm.ppPlot->addRangeSelector("ElwinBackgroundRange");
   backgroundRangeSelector->setColour(Qt::darkGreen); // dark green for background
   backgroundRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
+
   connect(integrationRangeSelector, SIGNAL(selectionChanged(double, double)), backgroundRangeSelector,
           SLOT(setRange(double, double)));
-  connect(backgroundRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(minChanged(double)));
-  connect(backgroundRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(maxChanged(double)));
+  connect(backgroundRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(notifyMinChanged(double)));
+  connect(backgroundRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(notifyMaxChanged(double)));
 
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateRS(QtProperty *, double)));
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SIGNAL(valueChanged(QtProperty *, double)));
-  connect(m_blnManager, SIGNAL(valueChanged(QtProperty *, bool)), this, SLOT(twoRanges(QtProperty *, bool)));
-  connect(m_blnManager, SIGNAL(valueChanged(QtProperty *, bool)), this, SIGNAL(valueChanged(QtProperty *, bool)));
-  twoRanges(m_properties["BackgroundSubtraction"], false);
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(notifyDoubleValueChanged(QtProperty *, double)));
+  connect(m_blnManager, SIGNAL(valueChanged(QtProperty *, bool)), this,
+          SLOT(notifyCheckboxValueChanged(QtProperty *, bool)));
+  notifyCheckboxValueChanged(m_properties["BackgroundSubtraction"], false);
 
-  connect(m_uiForm.dsInputFiles, SIGNAL(filesFound()), this, SIGNAL(filesFound()));
-  connect(m_uiForm.cbPreviewFile, SIGNAL(currentIndexChanged(int)), this, SIGNAL(previewIndexChanged(int)));
-  connect(m_uiForm.spPlotSpectrum, SIGNAL(valueChanged(int)), this, SIGNAL(selectedSpectrumChanged(int)));
-  connect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this, SIGNAL(selectedSpectrumChanged(int)));
+  connect(m_uiForm.wkspAdd, SIGNAL(clicked()), this, SLOT(notifyAddWorkspaceDialog()));
+  connect(m_uiForm.wkspRemove, SIGNAL(clicked()), this, SLOT(notifyRemoveDataClicked()));
+
+  connect(m_uiForm.dsInputFiles, SIGNAL(filesFound()), this, SLOT(notifyFilesFound()));
+  connect(m_uiForm.cbPreviewFile, SIGNAL(currentIndexChanged(int)), this, SLOT(notifyPreviewIndexChanged(int)));
+  connect(m_uiForm.spPlotSpectrum, SIGNAL(valueChanged(int)), this, SLOT(notifySelectedSpectrumChanged(int)));
+  connect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this, SLOT(notifySelectedSpectrumChanged(int)));
 
   // Handle plot and save
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SIGNAL(runClicked()));
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SIGNAL(saveClicked()));
-  connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this, SIGNAL(plotPreviewClicked()));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(notifyRunClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
+  connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this, SLOT(notifyPlotPreviewClicked()));
 
   // Set any default values
   m_dblManager->setValue(m_properties["IntegrationStart"], -0.02);
@@ -169,7 +181,77 @@ void InelasticDataManipulationElwinTabView::setup() {
   setHorizontalHeaders();
 }
 
-IndirectPlotOptionsView *InelasticDataManipulationElwinTabView::getPlotOptions() { return m_uiForm.ipoPlotOptions; }
+IndirectPlotOptionsView *InelasticDataManipulationElwinTabView::getPlotOptions() const {
+  return m_uiForm.ipoPlotOptions;
+}
+
+void InelasticDataManipulationElwinTabView::subscribePresenter(IElwinPresenter *presenter) { m_presenter = presenter; }
+
+void InelasticDataManipulationElwinTabView::notifyRunClicked() { m_presenter->handleRunClicked(); }
+
+void InelasticDataManipulationElwinTabView::notifySaveClicked() { m_presenter->handleSaveClicked(); }
+
+void InelasticDataManipulationElwinTabView::notifyPlotPreviewClicked() { m_presenter->handlePlotPreviewClicked(); }
+
+void InelasticDataManipulationElwinTabView::notifyFilesFound() { m_presenter->handleFilesFound(); }
+
+void InelasticDataManipulationElwinTabView::notifySelectedSpectrumChanged(int index) {
+  m_presenter->handlePreviewSpectrumChanged(index);
+}
+
+void InelasticDataManipulationElwinTabView::notifyPreviewIndexChanged(int index) {
+  m_presenter->handlePreviewIndexChanged(index);
+}
+
+void InelasticDataManipulationElwinTabView::notifyRemoveDataClicked() { m_presenter->handleRemoveSelectedData(); }
+
+void InelasticDataManipulationElwinTabView::notifyAddWorkspaceDialog() { showAddWorkspaceDialog(); }
+
+std::unique_ptr<IAddWorkspaceDialog>
+InelasticDataManipulationElwinTabView::getAddWorkspaceDialog(QWidget *parent) const {
+  return std::make_unique<IndirectAddWorkspaceDialog>(parent);
+}
+
+void InelasticDataManipulationElwinTabView::showAddWorkspaceDialog() {
+  if (!m_addWorkspaceDialog)
+    m_addWorkspaceDialog = getAddWorkspaceDialog(this->parentWidget());
+  m_addWorkspaceDialog->setWSSuffices(getSampleWSSuffices());
+  m_addWorkspaceDialog->setFBSuffices(getSampleFBSuffices());
+  m_addWorkspaceDialog->updateSelectedSpectra();
+  m_addWorkspaceDialog->show();
+  connect(m_addWorkspaceDialog.get(), SIGNAL(addData()), this, SLOT(notifyAddData()));
+  connect(m_addWorkspaceDialog.get(), SIGNAL(closeDialog()), this, SLOT(notifyCloseDialog()));
+}
+
+void InelasticDataManipulationElwinTabView::notifyCloseDialog() {
+  disconnect(m_addWorkspaceDialog.get(), SIGNAL(addData()), this, SLOT(notifyAddData()));
+  disconnect(m_addWorkspaceDialog.get(), SIGNAL(closeDialog()), this, SLOT(notifyCloseDialog()));
+  m_addWorkspaceDialog->close();
+  m_addWorkspaceDialog = nullptr;
+}
+
+void InelasticDataManipulationElwinTabView::notifyAddData() { addDataWksOrFile(m_addWorkspaceDialog.get()); }
+
+/** This method checks whether a Workspace or a File is being uploaded through the AddWorkspaceDialog
+ * A File requires additional checks to ensure a file of the correct type is being loaded. The Workspace list is
+ * already filtered.
+ */
+void InelasticDataManipulationElwinTabView::addDataWksOrFile(IAddWorkspaceDialog const *dialog) {
+  try {
+    const auto indirectDialog = dynamic_cast<IndirectAddWorkspaceDialog const *>(dialog);
+    if (indirectDialog) {
+      // getFileName will be empty if the addWorkspaceDialog is set to Workspace instead of File.
+      if (indirectDialog->getFileName().empty()) {
+        m_presenter->handleAddData(dialog);
+      } else
+        m_presenter->handleAddDataFromFile(dialog);
+    } else
+      (throw std::invalid_argument("Unable to access IndirectAddWorkspaceDialog"));
+
+  } catch (const std::runtime_error &ex) {
+    QMessageBox::warning(this->parentWidget(), "Warning! ", ex.what());
+  }
+}
 
 void InelasticDataManipulationElwinTabView::setHorizontalHeaders() {
   QStringList headers;
@@ -209,7 +291,7 @@ QModelIndexList InelasticDataManipulationElwinTabView::getSelectedData() {
 
 API::FileFinderWidget *InelasticDataManipulationElwinTabView::getFileFinderWidget() { return m_uiForm.dsInputFiles; }
 
-void InelasticDataManipulationElwinTabView::setFBSuffixes(QStringList const suffix) {
+void InelasticDataManipulationElwinTabView::setFBSuffixes(QStringList const &suffix) {
   m_uiForm.dsInputFiles->setFileExtensions(suffix);
 }
 
@@ -312,7 +394,10 @@ void InelasticDataManipulationElwinTabView::plotInput(MatrixWorkspace_sptr input
   setDefaultSampleLog(inputWS);
 }
 
-void InelasticDataManipulationElwinTabView::twoRanges(QtProperty *prop, bool enabled) {
+void InelasticDataManipulationElwinTabView::notifyCheckboxValueChanged(QtProperty *prop, bool enabled) {
+
+  m_presenter->handleValueChanged(prop->propertyName().toStdString(), enabled);
+
   if (prop == m_properties["BackgroundSubtraction"]) {
     auto integrationRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange");
     auto backgroundRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange");
@@ -330,29 +415,32 @@ void InelasticDataManipulationElwinTabView::twoRanges(QtProperty *prop, bool ena
   }
 }
 
-void InelasticDataManipulationElwinTabView::minChanged(double val) {
+void InelasticDataManipulationElwinTabView::notifyMinChanged(double val) {
   auto integrationRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange");
   auto backgroundRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange");
 
   MantidWidgets::RangeSelector *from = qobject_cast<MantidWidgets::RangeSelector *>(sender());
 
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateRS(QtProperty *, double)));
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+             SLOT(notifyDoubleValueChanged(QtProperty *, double)));
   if (from == integrationRangeSelector) {
     m_dblManager->setValue(m_properties["IntegrationStart"], val);
   } else if (from == backgroundRangeSelector) {
     m_dblManager->setValue(m_properties["BackgroundStart"], val);
   }
 
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateRS(QtProperty *, double)));
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(notifyDoubleValueChanged(QtProperty *, double)));
 }
 
-void InelasticDataManipulationElwinTabView::maxChanged(double val) {
+void InelasticDataManipulationElwinTabView::notifyMaxChanged(double val) {
   auto integrationRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange");
   auto backgroundRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange");
 
   MantidWidgets::RangeSelector *from = qobject_cast<MantidWidgets::RangeSelector *>(sender());
 
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateRS(QtProperty *, double)));
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+             SLOT(notifyDoubleValueChanged(QtProperty *, double)));
 
   if (from == integrationRangeSelector) {
     m_dblManager->setValue(m_properties["IntegrationEnd"], val);
@@ -360,14 +448,18 @@ void InelasticDataManipulationElwinTabView::maxChanged(double val) {
     m_dblManager->setValue(m_properties["BackgroundEnd"], val);
   }
 
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateRS(QtProperty *, double)));
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(notifyDoubleValueChanged(QtProperty *, double)));
 }
 
-void InelasticDataManipulationElwinTabView::updateRS(QtProperty *prop, double val) {
+void InelasticDataManipulationElwinTabView::notifyDoubleValueChanged(QtProperty *prop, double val) {
   auto integrationRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange");
   auto backgroundRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange");
 
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateRS(QtProperty *, double)));
+  m_presenter->handleValueChanged(prop->propertyName().toStdString(), val);
+
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+             SLOT(notifyDoubleValueChanged(QtProperty *, double)));
 
   if (prop == m_properties["IntegrationStart"])
     setRangeSelectorMin(m_properties["IntegrationStart"], m_properties["IntegrationEnd"], integrationRangeSelector,
@@ -380,7 +472,8 @@ void InelasticDataManipulationElwinTabView::updateRS(QtProperty *prop, double va
   else if (prop == m_properties["BackgroundEnd"])
     setRangeSelectorMax(m_properties["BackgroundStart"], m_properties["BackgroundEnd"], backgroundRangeSelector, val);
 
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateRS(QtProperty *, double)));
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(notifyDoubleValueChanged(QtProperty *, double)));
 }
 
 void InelasticDataManipulationElwinTabView::setIntegrationStart(double value) {
@@ -487,11 +580,6 @@ void InelasticDataManipulationElwinTabView::setSaveResultEnabled(const bool &ena
   m_uiForm.pbSave->setEnabled(enabled);
 }
 
-std::unique_ptr<IAddWorkspaceDialog>
-InelasticDataManipulationElwinTabView::getAddWorkspaceDialog(QWidget *parent) const {
-  return std::make_unique<IndirectAddWorkspaceDialog>(parent);
-}
-
 void InelasticDataManipulationElwinTabView::clearInputFiles() { m_uiForm.dsInputFiles->clear(); }
 
 void InelasticDataManipulationElwinTabView::setAvailableSpectra(WorkspaceIndex minimum, WorkspaceIndex maximum) {
@@ -502,28 +590,31 @@ void InelasticDataManipulationElwinTabView::setAvailableSpectra(WorkspaceIndex m
 
 void InelasticDataManipulationElwinTabView::setAvailableSpectra(const std::vector<WorkspaceIndex>::const_iterator &from,
                                                                 const std::vector<WorkspaceIndex>::const_iterator &to) {
-  disconnect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this, SIGNAL(selectedSpectrumChanged(int)));
+  disconnect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this,
+             SIGNAL(notifySelectedSpectrumChanged(int)));
   m_uiForm.elwinPreviewSpec->setCurrentIndex(1);
   m_uiForm.cbPlotSpectrum->clear();
 
   for (auto spectrum = from; spectrum < to; ++spectrum)
     m_uiForm.cbPlotSpectrum->addItem(QString::number(spectrum->value));
-  connect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this, SIGNAL(selectedSpectrumChanged(int)));
+  connect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this, SIGNAL(notifySelectedSpectrumChanged(int)));
 }
 
 int InelasticDataManipulationElwinTabView::getCurrentInputIndex() { return m_uiForm.inputChoice->currentIndex(); }
 
-QString InelasticDataManipulationElwinTabView::getPreviewWorkspaceName(int index) {
-  return m_uiForm.cbPreviewFile->itemText(index);
+std::string InelasticDataManipulationElwinTabView::getPreviewWorkspaceName(int index) const {
+  return m_uiForm.cbPreviewFile->itemText(index).toStdString();
 }
 
-QString InelasticDataManipulationElwinTabView::getPreviewFilename(int index) {
-  return m_uiForm.cbPreviewFile->itemData(index).toString();
+std::string InelasticDataManipulationElwinTabView::getPreviewFilename(int index) const {
+  return m_uiForm.cbPreviewFile->itemData(index).toString().toStdString();
 }
 
-int InelasticDataManipulationElwinTabView::getPreviewSpec() { return m_uiForm.elwinPreviewSpec->currentIndex(); }
+int InelasticDataManipulationElwinTabView::getPreviewSpec() { return m_uiForm.spPlotSpectrum->value(); }
 
-QString InelasticDataManipulationElwinTabView::getCurrentPreview() { return m_uiForm.cbPreviewFile->currentText(); }
+std::string InelasticDataManipulationElwinTabView::getCurrentPreview() const {
+  return m_uiForm.cbPreviewFile->currentText().toStdString();
+}
 
 QStringList InelasticDataManipulationElwinTabView::getInputFilenames() { return m_uiForm.dsInputFiles->getFilenames(); }
 
@@ -543,4 +634,7 @@ std::string InelasticDataManipulationElwinTabView::getLogValue() {
   return m_uiForm.leLogValue->currentText().toStdString();
 }
 
+void InelasticDataManipulationElwinTabView::showMessageBox(std::string const &message) const {
+  QMessageBox::information(parentWidget(), this->windowTitle(), QString::fromStdString(message));
+}
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
@@ -83,7 +83,7 @@ public:
 
   void showMessageBox(std::string const &message) const override;
 
-public slots:
+private slots:
   void notifyMinChanged(double val);
   void notifyMaxChanged(double val);
   void notifyDoubleValueChanged(QtProperty *, double);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
@@ -49,8 +49,8 @@ public:
   void newInputFilesFromDialog(IAddWorkspaceDialog const *dialog) override;
   void clearPreviewFile() override;
   void clearInputFiles() override;
-  void setRunIsRunning(const bool &running) override;
-  void setSaveResultEnabled(const bool &enabled) override;
+  void setRunIsRunning(const bool running) override;
+  void setSaveResultEnabled(const bool enabled) override;
   int getPreviewSpec() override;
   std::string getPreviewWorkspaceName(int index) const override;
   std::string getPreviewFilename(int index) const override;
@@ -115,8 +115,8 @@ private:
                            MantidWidgets::RangeSelector *rangeSelector, double newValue);
   void showAddWorkspaceDialog();
   void setPreviewToDefault();
-  void setButtonsEnabled(const bool &enabled);
-  void setRunEnabled(const bool &enabled);
+  void setButtonsEnabled(const bool enabled);
+  void setRunEnabled(const bool enabled);
   void setCell(std::unique_ptr<QTableWidgetItem> cell, int row, int column);
   void addDataWksOrFile(IAddWorkspaceDialog const *dialog);
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
@@ -42,10 +42,10 @@ public:
 
   void newPreviewFileSelected(const MatrixWorkspace_sptr &workspace) override;
   int getCurrentInputIndex() override;
-  API::FileFinderWidget *getFileFinderWidget() override;
+  MantidQt::API::FileFinderWidget *getFileFinderWidget() override;
 
-  void plotInput(MatrixWorkspace_sptr inputWS, int spectrum);
-  void newInputFiles();
+  void plotInput(MatrixWorkspace_sptr inputWS, int spectrum) override;
+  void newInputFiles() override;
   void newInputFilesFromDialog(IAddWorkspaceDialog const *dialog) override;
   void clearPreviewFile() override;
   void clearInputFiles() override;
@@ -123,9 +123,10 @@ private:
   virtual std::unique_ptr<IAddWorkspaceDialog> getAddWorkspaceDialog(QWidget *parent) const;
 
   IElwinPresenter *m_presenter;
-  Ui::InelasticDataManipulationElwinTab m_uiForm;
-  std::unique_ptr<IAddWorkspaceDialog> m_addWorkspaceDialog;
   QtTreePropertyBrowser *m_elwTree;
+  std::unique_ptr<IAddWorkspaceDialog> m_addWorkspaceDialog;
+
+  Ui::InelasticDataManipulationElwinTab m_uiForm;
   QtDoublePropertyManager *m_dblManager;
   QtBoolPropertyManager *m_blnManager;
   QtGroupPropertyManager *m_grpManager;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
@@ -7,7 +7,10 @@
 #pragma once
 
 #include "Analysis/IndirectFitDataModel.h"
+
 #include "IAddWorkspaceDialog.h"
+#include "IElwinView.h"
+#include "InelasticDataManipulationElwinTab.h"
 #include "InelasticDataManipulationTab.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -20,74 +23,83 @@ namespace CustomInterfaces {
 using namespace IDA;
 using namespace Mantid::API;
 
-class MANTIDQT_INELASTIC_DLL InelasticDataManipulationElwinTabView : public QWidget {
+class MANTIDQT_INELASTIC_DLL InelasticDataManipulationElwinTabView : public QWidget, public IElwinView {
   Q_OBJECT
 
 public:
   InelasticDataManipulationElwinTabView(QWidget *parent = nullptr);
   ~InelasticDataManipulationElwinTabView();
-  IndirectPlotOptionsView *getPlotOptions();
 
-  void setAvailableSpectra(WorkspaceIndex minimum, WorkspaceIndex maximum);
+  void subscribePresenter(IElwinPresenter *presenter) override;
+  void setup() override;
+
+  IndirectPlotOptionsView *getPlotOptions() const override;
+  void setFBSuffixes(QStringList const &suffix) override;
+
+  void setAvailableSpectra(WorkspaceIndex minimum, WorkspaceIndex maximum) override;
   void setAvailableSpectra(const std::vector<WorkspaceIndex>::const_iterator &from,
-                           const std::vector<WorkspaceIndex>::const_iterator &to);
-  bool isLoadHistory();
-  bool isGroupInput();
-  void setFBSuffixes(QStringList const suffix);
-  void newPreviewFileSelected(const MatrixWorkspace_sptr &workspace);
-  int getCurrentInputIndex();
-  API::FileFinderWidget *getFileFinderWidget();
-  QString getPreviewWorkspaceName(int index);
-  QString getPreviewFilename(int index);
-  QStringList getInputFilenames();
+                           const std::vector<WorkspaceIndex>::const_iterator &to) override;
+
+  void newPreviewFileSelected(const MatrixWorkspace_sptr &workspace) override;
+  int getCurrentInputIndex() override;
+  API::FileFinderWidget *getFileFinderWidget() override;
+
   void plotInput(MatrixWorkspace_sptr inputWS, int spectrum);
-  int getPreviewSpec();
-  QString getCurrentPreview();
   void newInputFiles();
-  void newInputFilesFromDialog(IAddWorkspaceDialog const *dialog);
-  void clearPreviewFile();
-  void setRunIsRunning(const bool &running);
-  void setSaveResultEnabled(const bool &enabled);
-  void clearInputFiles();
+  void newInputFilesFromDialog(IAddWorkspaceDialog const *dialog) override;
+  void clearPreviewFile() override;
+  void clearInputFiles() override;
+  void setRunIsRunning(const bool &running) override;
+  void setSaveResultEnabled(const bool &enabled) override;
+  int getPreviewSpec() override;
+  std::string getPreviewWorkspaceName(int index) const override;
+  std::string getPreviewFilename(int index) const override;
+  std::string getCurrentPreview() const override;
+  QStringList getInputFilenames() override;
 
   // controls for dataTable
-  void clearDataTable();
-  void addTableEntry(int row, std::string const &name, int spectrum);
-  void setCell(std::unique_ptr<QTableWidgetItem> cell, int row, int column);
-  QModelIndexList getSelectedData();
+  void clearDataTable() override;
+  void addTableEntry(int row, std::string const &name, int spectrum) override;
+  QModelIndexList getSelectedData() override;
+
+  // boolean flags for LoadHistory/GroupInput Checkboxes
+  bool isLoadHistory() override;
+  bool isGroupInput() override;
 
   // getters/setters for m_properties
-  bool getNormalise();
-  bool getBackgroundSubtraction();
-  std::string getLogName();
-  std::string getLogValue();
-  void setIntegrationStart(double value);
-  double getIntegrationStart();
-  void setIntegrationEnd(double value);
-  double getIntegrationEnd();
-  void setBackgroundStart(double value);
-  double getBackgroundStart();
-  void setBackgroundEnd(double value);
-  double getBackgroundEnd();
+  bool getNormalise() override;
+  bool getBackgroundSubtraction() override;
+  std::string getLogName() override;
+  std::string getLogValue() override;
+  void setIntegrationStart(double value) override;
+  void setIntegrationEnd(double value) override;
+  void setBackgroundStart(double value) override;
+  void setBackgroundEnd(double value) override;
 
-signals:
-  void removeDataClicked();
-  void addDataClicked();
-  void dataAdded();
-  void dataRemoved();
-  void dataChanged();
-  void showMessageBox(const QString &message);
-  void runClicked();
-  void saveClicked();
-  void plotPreviewClicked();
-  void selectedSpectrumChanged(int);
-  void previewIndexChanged(int);
-  void filesFound();
-  void valueChanged(QtProperty *, double);
-  void valueChanged(QtProperty *, bool);
+  double getIntegrationStart() override;
+  double getIntegrationEnd() override;
+  double getBackgroundStart() override;
+  double getBackgroundEnd() override;
+
+  void showMessageBox(std::string const &message) const override;
+
+public slots:
+  void notifyMinChanged(double val);
+  void notifyMaxChanged(double val);
+  void notifyDoubleValueChanged(QtProperty *, double);
+  void notifyCheckboxValueChanged(QtProperty *, bool);
+  void notifyPlotPreviewClicked();
+  void notifyRunClicked();
+  void notifySaveClicked();
+  void notifyFilesFound();
+  void notifySelectedSpectrumChanged(int);
+  void notifyPreviewIndexChanged(int);
+  void notifyAddWorkspaceDialog();
+  void notifyAddData();
+  void notifyRemoveDataClicked();
+  void notifyCloseDialog();
 
 private:
-  void setup();
   void setHorizontalHeaders();
   void setDefaultSampleLog(const Mantid::API::MatrixWorkspace_const_sptr &ws);
 
@@ -101,13 +113,18 @@ private:
   /// Sets the max of the range selector if it is more than the min
   void setRangeSelectorMax(QtProperty *minProperty, QtProperty *maxProperty,
                            MantidWidgets::RangeSelector *rangeSelector, double newValue);
+  void showAddWorkspaceDialog();
   void setPreviewToDefault();
   void setButtonsEnabled(const bool &enabled);
   void setRunEnabled(const bool &enabled);
+  void setCell(std::unique_ptr<QTableWidgetItem> cell, int row, int column);
+  void addDataWksOrFile(IAddWorkspaceDialog const *dialog);
 
   virtual std::unique_ptr<IAddWorkspaceDialog> getAddWorkspaceDialog(QWidget *parent) const;
 
+  IElwinPresenter *m_presenter;
   Ui::InelasticDataManipulationElwinTab m_uiForm;
+  std::unique_ptr<IAddWorkspaceDialog> m_addWorkspaceDialog;
   QtTreePropertyBrowser *m_elwTree;
   QtDoublePropertyManager *m_dblManager;
   QtBoolPropertyManager *m_blnManager;
@@ -115,13 +132,6 @@ private:
   DoubleEditorFactory *m_dblEdFac;
   QtCheckBoxFactory *m_blnEdFac;
   QMap<QString, QtProperty *> m_properties;
-
-private slots:
-  void twoRanges(QtProperty *prop, bool enabled);
-  void minChanged(double val);
-  void maxChanged(double val);
-  void updateRS(QtProperty *prop, double val);
 };
-
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/test/Manipulation/InelasticDataManipulationElwinTabModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Manipulation/InelasticDataManipulationElwinTabModelTest.h
@@ -85,7 +85,7 @@ public:
 
   void test_algorithm_set_up() {
     MantidQt::API::BatchAlgorithmRunner batch;
-    QString wsBaseName = "Workspace_name";
+    std::string wsBaseName = "Workspace_name";
     // The ElasticWindowMultiple algorithm is a python algorithm and so can not be called in c++ tests
     m_workspace = WorkspaceCreationHelper::create2DWorkspace(5, 4);
     Mantid::API::AnalysisDataService::Instance().addOrReplace("Workspace_name_sqw", m_workspace);


### PR DESCRIPTION
### Description of work
This PR removes the Qt dependency of the presenter of the Elwin tab. The implementation follows very closely the layout set in #36478 , and more justification for the changes can be found therein. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Part of  #36477  . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
- This tab in particular had a tightly bound presenter/view, as the presenter additionally held a workspace dialog interface. This dialog has been moved to the view. This has required to refactor the functions calling the interface from the presenter to the view.
- Additionally, an unspotted bug which prevented the spectrum from being updated when the index was raised or lowered from the QSpinbox element has been fixed. 
### To test:
1. Open `Data Manipulation -> Elwin`
2. Open a test file `irs2673_graphite002_red.nxs` : either from file or adding as a workspace
3. Check all view options work as intended: checkbox, edits, graph widgets.
4. Run the algorithm with appropriate input parameters. 
5. Check output is valid and as expected. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.

