### PR TITLE
Fix shadow variable cppcheck warning

### DIFF
--- a/qt/scientific_interfaces/Inelastic/Analysis/IDAFunctionParameterEstimation.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IDAFunctionParameterEstimation.cpp
@@ -68,8 +68,8 @@ void IDAFunctionParameterEstimation::estimateFunctionParameters(Mantid::API::IFu
 
   if (auto composite = std::dynamic_pointer_cast<Mantid::API::CompositeFunction>(function)) {
     for (auto i = 0u; i < composite->nFunctions(); ++i) {
-      auto function = composite->getFunction(i);
-      estimateSingleFunctionParameters(function, estimationData, composite, i);
+      auto childFunction = composite->getFunction(i);
+      estimateSingleFunctionParameters(childFunction, estimationData, composite, i);
     }
   } else {
     estimateSingleFunctionParameters(function, estimationData);


### PR DESCRIPTION
### Description of work
This PR fixes a cppcheck warning which has somehow snuck into main. The warning is to do with a shadow variable which has the same name as a variable in an outer scope.

This PR is marked high priority because the issue is causing other PRs to fail.

*There is no associated issue.*


### To test:
Make sure the cppcheck PR job passes.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
