### PR TITLE
Change information message to warning in ConvertUnits

### DIFF
--- a/Framework/Algorithms/src/ConvertAxisByFormula.cpp
+++ b/Framework/Algorithms/src/ConvertAxisByFormula.cpp
@@ -178,8 +178,8 @@ void ConvertAxisByFormula::exec() {
         prog.report();
       }
       if (failedDetectorCount != 0) {
-        g_log.information() << "Unable to calculate sample-detector distance for " << failedDetectorCount
-                            << " spectra. Masking spectrum.\n";
+        g_log.warning() << "Unable to calculate sample-detector distance for " << failedDetectorCount
+                        << " spectra. Masking spectrum.\n";
       }
     } else {
       // common bins - we only have to calculate once

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -479,8 +479,8 @@ MatrixWorkspace_sptr ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUni
   PARALLEL_CHECK_INTERRUPT_REGION
 
   if (failedDetectorCount != 0) {
-    g_log.information() << "Unable to calculate sample-detector distance for " << failedDetectorCount
-                        << " spectra. Masking spectrum.\n";
+    g_log.warning() << "Unable to calculate sample-detector distance for " << failedDetectorCount
+                    << " spectra. Masking spectrum.\n";
   }
   if (m_inputEvents)
     eventWS->clearMRU();

--- a/docs/source/release/v6.9.0/Framework/Algorithms/Bugfixes/34256.rst
+++ b/docs/source/release/v6.9.0/Framework/Algorithms/Bugfixes/34256.rst
@@ -1,0 +1,1 @@
+- Added warning message when ``ConvertUnits`` or ``ConvertAxisByFormula`` fails to do the conversion for certain detectors. Previously the warning was an information message.


### PR DESCRIPTION
Added warning message when ``ConvertUnits`` or ``ConvertAxisByFormula`` fails to do the conversion for certain detectors. Previously the warning was an information message.

Fixes #34256 

### To test:

See #34256 for an example of ``ConvertUnits`` not working because there is no instrument.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
