### PR TITLE
Set parent of algorithm help window

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36096.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36096.rst
@@ -1,0 +1,1 @@
+- Fixed bug where the help window appeared behind the algorithm dialog when running on Linux or MacOS.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/HelpWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/HelpWindow.h
@@ -8,6 +8,7 @@
 
 #include "MantidQtWidgets/Common/DllOption.h"
 #include <QString>
+#include <QWidget>
 #include <string>
 
 // forward declarations

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/HelpWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/HelpWindow.h
@@ -22,7 +22,7 @@ public:
   static void showPage(const QString &url);
   static void showPage(const QUrl &url);
   static void showAlgorithm(const std::string &name = std::string(), const int version = -1);
-  static void showAlgorithm(const QString &name, const int version = -1);
+  static void showAlgorithm(const QString &name, const int version = -1, QWidget *parent = nullptr);
   static void showConcept(const std::string &name = std::string());
   static void showConcept(const QString &name);
   static void showFitFunction(const std::string &name = std::string());

--- a/qt/widgets/common/src/AlgorithmDialog.cpp
+++ b/qt/widgets/common/src/AlgorithmDialog.cpp
@@ -711,7 +711,7 @@ void AlgorithmDialog::helpClicked() {
     version = m_algorithm->version();
 
   // bring up the help window
-  HelpWindow::showAlgorithm(m_algName, version);
+  HelpWindow::showAlgorithm(m_algName, version, this);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/qt/widgets/common/src/HelpWindow.cpp
+++ b/qt/widgets/common/src/HelpWindow.cpp
@@ -57,6 +57,7 @@ void HelpWindow::showAlgorithm(const QString &name, const int version, QWidget *
   if (gui) {
     if (parent != nullptr)
       gui->setParent(parent);
+    gui->setWindowModality(Qt::WindowModal);
     gui->showAlgorithm(name, version);
   } else {
     // Open online help

--- a/qt/widgets/common/src/HelpWindow.cpp
+++ b/qt/widgets/common/src/HelpWindow.cpp
@@ -51,10 +51,12 @@ void HelpWindow::showAlgorithm(const std::string &name, const int version) {
   showAlgorithm(QString(name.c_str()), version);
 }
 
-void HelpWindow::showAlgorithm(const QString &name, const int version) {
+void HelpWindow::showAlgorithm(const QString &name, const int version, QWidget *parent) {
   InterfaceManager interfaceManager;
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {
+    if (parent != nullptr)
+      gui->setParent(parent);
     gui->showAlgorithm(name, version);
   } else {
     // Open online help

--- a/qt/widgets/common/src/HelpWindow.cpp
+++ b/qt/widgets/common/src/HelpWindow.cpp
@@ -56,8 +56,7 @@ void HelpWindow::showAlgorithm(const QString &name, const int version, QWidget *
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {
     if (parent != nullptr)
-      gui->setParent(parent);
-    gui->setWindowModality(Qt::WindowModal);
+      gui->setParent(parent, Qt::Dialog);
     gui->showAlgorithm(name, version);
   } else {
     // Open online help


### PR DESCRIPTION
Added optional argument to allow setting the parent of the help window, which should prevent it from appearing behind the algorithm dialog (since the algorithm dialog will now be its parent widget).

Fixes #36096 

### To test:

Help button in the algorithm dialog still works. and the help window no longer appears behind the algorithm dialog on Linux and macOS. To do that you'll need to use the package build, otherwise clicking the help button will load a website.

https://builds.mantidproject.org/job/build_packages_from_branch/716/

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
