### PR TITLE
Added warning for ADS.clear()

### DIFF
--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
@@ -117,6 +117,8 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
    * @param self A reference to the calling object
    */
   static void clearItems(SvcType &self) {
+    PyErr_Warn(PyExc_Warning, "Running ADS.clear() also removes all hidden workspaces.\n"
+                              "Mantid interfaces might still need some of these, for instance, MSlice.");
     ReleaseGlobalInterpreterLock releaseGIL;
     self.clear();
   }

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1118,7 +1118,7 @@ unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/kernel/src/Exp
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/IsNone.h:26
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Muon/src/PlotAsymmetryByLogValue.cpp:216
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp:109
-constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:153
+constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:155
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp:23
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp:34
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp:30

--- a/docs/source/release/v6.9.0/Framework/Data_Objects/New_features/36548.rst
+++ b/docs/source/release/v6.9.0/Framework/Data_Objects/New_features/36548.rst
@@ -1,0 +1,1 @@
+- The ``clear()`` function for the ADS now displays a warning that workspaces might get removed that are still used by one of the interfaces.


### PR DESCRIPTION
### Description of work
Calling `clear()` for the ADS now displays a warning.

Occasionally, users call `clear()` for the ADS in order to get rid of temporary workspaces. This can cause problems for some of our interfaces, as there might be hidden workspaces that are still in use by the interface. One example of this is MSlice: https://github.com/mantidproject/mslice/issues/839

*There is no associated issue.*


### To test:

Run the following script and check that the warning makes sense:

```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from mantid import mtd

mtd.clear()
```

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
