### PR TITLE
Save Scaled Background Subtraction Metadata to Subtracted Files

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/NXcanSASDefinitions.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/NXcanSASDefinitions.h
@@ -134,6 +134,8 @@ const std::string sasProcessTermSampleTrans = "sample_trans_run";
 const std::string sasProcessTermSampleDirect = "sample_direct_run";
 const std::string sasProcessTermCanScatter = "can_scatter_run";
 const std::string sasProcessTermCanDirect = "can_direct_run";
+const std::string sasProcessTermScaledBgSubWorkspace = "scaled_bgsub_workspace";
+const std::string sasProcessTermScaledBgSubScaleFactor = "scaled_bgsub_scale_factor";
 
 // SAStransmission_spectrum
 const std::string sasTransmissionSpectrumClassAttr = "SAStransmission_spectrum";

--- a/Framework/DataHandling/src/SaveCanSAS1D.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D.cpp
@@ -98,6 +98,13 @@ void SaveCanSAS1D::init() {
                   "file (IDF)]]. \nIDFs are located in the instrument "
                   "sub-directory of the Mantid install directory.");
 
+  declareProperty(
+      "BackgroundSubtractionWorkspace", "",
+      "The name of the workspace used in the scaled background subtraction, to be included in the metadata. Optional.");
+  declareProperty(
+      "BackgroundSubtractionScaleFactor", "",
+      "The scale factor used in the scaled background subtraction, to be included in the metadata. Optional.");
+
   // Collimation information
   std::vector<std::string> collimationGeometry{
       "Cylinder", "FlatPlate", "Flat plate", "Disc", "Unknown",

--- a/Framework/DataHandling/src/SaveCanSAS1D.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D.cpp
@@ -98,13 +98,6 @@ void SaveCanSAS1D::init() {
                   "file (IDF)]]. \nIDFs are located in the instrument "
                   "sub-directory of the Mantid install directory.");
 
-  declareProperty(
-      "BackgroundSubtractionWorkspace", "",
-      "The name of the workspace used in the scaled background subtraction, to be included in the metadata. Optional.");
-  declareProperty(
-      "BackgroundSubtractionScaleFactor", "",
-      "The scale factor used in the scaled background subtraction, to be included in the metadata. Optional.");
-
   // Collimation information
   std::vector<std::string> collimationGeometry{
       "Cylinder", "FlatPlate", "Flat plate", "Disc", "Unknown",

--- a/Framework/DataHandling/src/SaveCanSAS1D2.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D2.cpp
@@ -304,9 +304,9 @@ void SaveCanSAS1D2::createSASProcessElement(std::string &sasProcess) {
   auto const &bgsubWsName = getPropertyValue("BackgroundSubtractionWorkspace");
   auto const &bgsubScaleFactor = getPropertyValue("BackgroundSubtractionScaleFactor");
   if (!bgsubWsName.empty()) {
-    sasProcess += "\n\t\t\t<term name=\"scaled_background_subtraction_workspace\">";
+    sasProcess += "\n\t\t\t<term name=\"scaled_bgsub_workspace\">";
     sasProcess += bgsubWsName + "</term>";
-    sasProcess += "\n\t\t\t<term name=\"scaled_background_subtraction_scale_factor\">";
+    sasProcess += "\n\t\t\t<term name=\"scaled_bgsub_scale_factor\">";
     sasProcess += bgsubScaleFactor + "</term>";
   }
 

--- a/Framework/DataHandling/src/SaveCanSAS1D2.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D2.cpp
@@ -82,7 +82,7 @@ void SaveCanSAS1D2::init() {
       "BackgroundSubtractionWorkspace", "",
       "The name of the workspace used in the scaled background subtraction, to be included in the metadata. Optional.");
   declareProperty(
-      "BackgroundSubtractionScaleFactor", "",
+      "BackgroundSubtractionScaleFactor", 0.0,
       "The scale factor used in the scaled background subtraction, to be included in the metadata. Optional.");
 }
 
@@ -298,6 +298,16 @@ void SaveCanSAS1D2::createSASProcessElement(std::string &sasProcess) {
     const auto can_direct_run = getPropertyValue("CanDirectRunNumber");
     sasProcess += "\n\t\t\t<term name=\"can_direct_run\">";
     sasProcess += can_direct_run + "</term>";
+  }
+
+  // Scaled Background Subtraction information.
+  auto const &bgsubWsName = getPropertyValue("BackgroundSubtractionWorkspace");
+  auto const &bgsubScaleFactor = getPropertyValue("BackgroundSubtractionScaleFactor");
+  if (!bgsubWsName.empty()) {
+    sasProcess += "\n\t\t\t<term name=\"scaled_background_subtraction_workspace\">";
+    sasProcess += bgsubWsName + "</term>";
+    sasProcess += "\n\t\t\t<term name=\"scaled_background_subtraction_scale_factor\">";
+    sasProcess += bgsubScaleFactor + "</term>";
   }
 
   // Reduction process note, if available

--- a/Framework/DataHandling/src/SaveCanSAS1D2.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D2.cpp
@@ -77,6 +77,13 @@ void SaveCanSAS1D2::init() {
   declareProperty("CanScatterRunNumber", "", "The run number for the can scatter workspace. Optional.");
   declareProperty("CanDirectRunNumber", "", "The run number for the can direct workspace. Optional.");
   declareProperty("OneSpectrumPerFile", false, "If true, each spectrum will be saved in an invididual file");
+
+  declareProperty(
+      "BackgroundSubtractionWorkspace", "",
+      "The name of the workspace used in the scaled background subtraction, to be included in the metadata. Optional.");
+  declareProperty(
+      "BackgroundSubtractionScaleFactor", "",
+      "The scale factor used in the scaled background subtraction, to be included in the metadata. Optional.");
 }
 
 /// Overwrites Algorithm method

--- a/Framework/DataHandling/src/SaveCanSAS1D2.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D2.cpp
@@ -278,7 +278,7 @@ void SaveCanSAS1D2::createSASProcessElement(std::string &sasProcess) {
   if (m_transcan_ws) {
     std::string can_run;
     if (m_transcan_ws->run().hasProperty("run_number")) {
-      Kernel::Property *logP = m_transcan_ws->run().getLogData("run_number");
+      Kernel::Property const *const logP = m_transcan_ws->run().getLogData("run_number");
       can_run = logP->value();
     } else {
       g_log.debug() << "Didn't find RunNumber log in workspace. Writing "

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -795,6 +795,13 @@ void SaveNXcanSAS::init() {
   declareProperty("CanScatterRunNumber", "", "The run number for the can scatter workspace. Optional.");
   declareProperty("CanDirectRunNumber", "", "The run number for the can direct workspace. Optional.");
 
+  declareProperty(
+      "BackgroundSubtractionWorkspace", "",
+      "The name of the workspace used in the scaled background subtraction, to be included in the metadata. Optional.");
+  declareProperty(
+      "BackgroundSubtractionScaleFactor", "",
+      "The scale factor used in the scaled background subtraction, to be included in the metadata. Optional.");
+
   std::vector<std::string> const geometryOptions{"Cylinder", "FlatPlate", "Flat plate", "Disc", "Unknown"};
   declareProperty("Geometry", "Unknown", std::make_shared<Kernel::StringListValidator>(geometryOptions),
                   "The geometry type of the collimation.");

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -799,7 +799,7 @@ void SaveNXcanSAS::init() {
       "BackgroundSubtractionWorkspace", "",
       "The name of the workspace used in the scaled background subtraction, to be included in the metadata. Optional.");
   declareProperty(
-      "BackgroundSubtractionScaleFactor", "",
+      "BackgroundSubtractionScaleFactor", 0.0,
       "The scale factor used in the scaled background subtraction, to be included in the metadata. Optional.");
 
   std::vector<std::string> const geometryOptions{"Cylinder", "FlatPlate", "Flat plate", "Disc", "Unknown"};
@@ -896,6 +896,11 @@ void SaveNXcanSAS::exec() {
   const auto canScatterRun = getPropertyValue("CanScatterRunNumber");
   const auto canDirectRun = getPropertyValue("CanDirectRunNumber");
 
+  // Get scaled background subtraction information
+
+  const auto scaledBgSubWorkspace = getPropertyValue("BackgroundSubtractionWorkspace");
+  const auto scaledBgSubScaleFactor = getPropertyValue("BackgroundSubtractionScaleFactor");
+
   // Add the process information
   progress.report("Adding process information.");
   if (transmissionCan) {
@@ -911,6 +916,14 @@ void SaveNXcanSAS::exec() {
     if (transmissionSample)
       addNoteToProcess(sasEntry, sasProcessTermSampleTrans, sampleTransmissionRun, sasProcessTermSampleDirect,
                        sampleDirectRun);
+  }
+
+  if (!scaledBgSubWorkspace.empty()) {
+    progress.report("Adding scaled background subtraction information.");
+    auto process = sasEntry.openGroup(sasProcessGroupName);
+    auto note = process.openGroup(sasNoteGroupName);
+    Mantid::DataHandling::H5Util::write(note, sasProcessTermScaledBgSubWorkspace, scaledBgSubWorkspace);
+    Mantid::DataHandling::H5Util::write(note, sasProcessTermScaledBgSubScaleFactor, scaledBgSubScaleFactor);
   }
 
   // Add the transmissions for sample

--- a/Framework/DataHandling/test/NXcanSASTestHelper.h
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.h
@@ -47,8 +47,11 @@ struct NXcanSASTestParameters {
   std::string sampleDirectRun;
   std::string canScatterRun;
   std::string canDirectRun;
+  std::string scaledBgSubWorkspace;
+  double scaledBgSubScaleFactor;
   bool hasCanRuns{false};
   bool hasSampleRuns{false};
+  bool hasBgSub{false};
 };
 
 struct NXcanSASTestTransmissionParameters {

--- a/Framework/DataHandling/test/SaveCanSAS1dTest2.h
+++ b/Framework/DataHandling/test/SaveCanSAS1dTest2.h
@@ -247,6 +247,27 @@ public:
     TS_ASSERT(savealg.isExecuted());
   }
 
+  void testCanSetScaledBackgroundSubtractionMetadataAsProperties() {
+    // Initialize alg
+    SaveCanSAS1D2 savealg;
+
+    TS_ASSERT_THROWS_NOTHING(savealg.initialize());
+    TS_ASSERT(savealg.isInitialized());
+    savealg.setPropertyValue("InputWorkspace", m_workspace1);
+    savealg.setPropertyValue("Filename", m_filename);
+    savealg.setPropertyValue("DetectorNames", "HAB");
+
+    // Set the additional run number properties
+    TSM_ASSERT_THROWS_NOTHING("Should be able to set BackgroundSubtractionWorkspace property",
+                              savealg.setProperty("BackgroundSubtractionWorkspace", "a_workspace"));
+    TSM_ASSERT_THROWS_NOTHING("Should be able to set BackgroundSubtractionScaleFactor property",
+                              savealg.setProperty("BackgroundSubtractionScaleFactor", 1.5));
+
+    // Execute
+    TS_ASSERT_THROWS_NOTHING(savealg.execute());
+    TS_ASSERT(savealg.isExecuted());
+  }
+
   void testGroup() {
     // do the save, the results of which we'll test
     SaveCanSAS1D2 savealg;

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -206,6 +206,40 @@ public:
     removeFile(parameters.filename);
   }
 
+  void test_that_sample_bgsub_values_included_if_properties_are_set() {
+    NXcanSASTestParameters parameters;
+    removeFile(parameters.filename);
+
+    parameters.detectors.emplace_back("front-detector");
+    parameters.detectors.emplace_back("rear-detector");
+    parameters.invalidDetectors = false;
+    parameters.scaledBgSubWorkspace = "a_workspace";
+    parameters.scaledBgSubScaleFactor = 1.5;
+    parameters.hasBgSub = true;
+
+    auto ws = provide1DWorkspace(parameters);
+    setXValuesOn1DWorkspace(ws, parameters.xmin, parameters.xmax);
+
+    parameters.idf = getIDFfromWorkspace(ws);
+
+    // Create transmission can
+    NXcanSASTestTransmissionParameters transmissionParameters;
+    transmissionParameters.name = sasTransmissionSpectrumNameSampleAttrValue;
+    transmissionParameters.usesTransmission = true;
+
+    auto transmission = getTransmissionWorkspace(transmissionParameters);
+    setXValuesOn1DWorkspace(transmission, transmissionParameters.xmin, transmissionParameters.xmax);
+
+    // Act
+    save_file_no_issues(ws, parameters, transmission, nullptr);
+
+    // Assert
+    do_assert(parameters);
+
+    // Clean up
+    removeFile(parameters.filename);
+  }
+
   void test_that_unknown_detector_names_are_not_saved() {
     // Arrange
     NXcanSASTestParameters parameters;
@@ -386,6 +420,8 @@ private:
     saveAlg->setProperty("SampleDirectRunNumber", parameters.sampleDirectRun);
     saveAlg->setProperty("CanScatterRunNumber", parameters.canScatterRun);
     saveAlg->setProperty("CanDirectRunNumber", parameters.canDirectRun);
+    saveAlg->setProperty("BackgroundSubtractionWorkspace", parameters.scaledBgSubWorkspace);
+    saveAlg->setProperty("BackgroundSubtractionScaleFactor", parameters.scaledBgSubScaleFactor);
 
     TSM_ASSERT_THROWS_NOTHING("Should not throw anything", saveAlg->execute());
     TSM_ASSERT("Should have executed", saveAlg->isExecuted());
@@ -559,7 +595,8 @@ private:
 
   void do_assert_process(H5::Group &process, const bool &hasSampleRuns, const bool &hasCanRuns,
                          const std::string &userFile, const std::string &sampleDirectRun,
-                         const std::string &canDirectRun) {
+                         const std::string &canDirectRun, const bool &hasBgSub, const std::string &scaledBgSubWorkspace,
+                         const double &scaledBgSubScaleFactor) {
     auto numAttributes = process.getNumAttrs();
     TSM_ASSERT_EQUALS("Should have 2 attribute", 2, numAttributes);
 
@@ -588,14 +625,16 @@ private:
     TSM_ASSERT_EQUALS("Should have the Mantid NXcanSAS process name", userFileValue, userFile);
 
     // Check note
-    if (hasSampleRuns || hasCanRuns) {
+    if (hasSampleRuns || hasCanRuns || hasBgSub) {
       auto note = process.openGroup(sasNoteGroupName);
-      do_assert_process_note(note, hasSampleRuns, hasCanRuns, sampleDirectRun, canDirectRun);
+      do_assert_process_note(note, hasSampleRuns, hasCanRuns, hasBgSub, sampleDirectRun, canDirectRun,
+                             scaledBgSubWorkspace, scaledBgSubScaleFactor);
     }
   }
 
-  void do_assert_process_note(H5::Group &note, const bool &hasSampleRuns, const bool &hasCanRuns,
-                              const std::string &sampleDirectRun, const std::string &canDirectRun) {
+  void do_assert_process_note(H5::Group &note, const bool &hasSampleRuns, const bool &hasCanRuns, const bool &hasBgSub,
+                              const std::string &sampleDirectRun, const std::string &canDirectRun,
+                              const std::string &scaledBgSubWorkspace, const double &scaledBgSubScaleFactor) {
     auto numAttributes = note.getNumAttrs();
     TSM_ASSERT_EQUALS("Should have 2 attributes", 2, numAttributes);
 
@@ -616,6 +655,17 @@ private:
       auto canDirectRunDataSet = note.openDataSet(sasProcessTermCanDirect);
       auto canDirectRunValue = Mantid::DataHandling::H5Util::readString(canDirectRunDataSet);
       TSM_ASSERT_EQUALS("Should have correct can direct run number", canDirectRunValue, canDirectRun);
+    }
+
+    if (hasBgSub) {
+      auto scaledBgSubWorkspaceDataSet = note.openDataSet(sasProcessTermScaledBgSubWorkspace);
+      auto scaledBgSubWorkspaceValue = Mantid::DataHandling::H5Util::readString(scaledBgSubWorkspaceDataSet);
+      TSM_ASSERT_EQUALS("Should have correct scaled background subtraction workspace", scaledBgSubWorkspaceValue,
+                        scaledBgSubWorkspace);
+      auto scaledBgSubScaleFactorDataSet = note.openDataSet(sasProcessTermScaledBgSubScaleFactor);
+      auto scaledBgSubScaleFactorValue = Mantid::DataHandling::H5Util::readString(scaledBgSubScaleFactorDataSet);
+      TSM_ASSERT_EQUALS("Should have correct scaled background subtraction scale factor",
+                        stod(scaledBgSubScaleFactorValue), scaledBgSubScaleFactor);
     }
   }
 
@@ -896,7 +946,8 @@ private:
     // Check process
     auto process = entry.openGroup(sasProcessGroupName);
     do_assert_process(process, parameters.hasSampleRuns, parameters.hasCanRuns, parameters.userFile,
-                      parameters.sampleDirectRun, parameters.canDirectRun);
+                      parameters.sampleDirectRun, parameters.canDirectRun, parameters.hasBgSub,
+                      parameters.scaledBgSubWorkspace, parameters.scaledBgSubScaleFactor);
 
     // Check data
     auto data = entry.openGroup(sasDataGroupName);

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -130,6 +130,18 @@ class SANSSave(DataProcessorAlgorithm):
             direction=Direction.Input,
             doc="The run number for the Can Direct workspace used in the reduction. Can be blank.",
         )
+        self.declareProperty(
+            "BackgroundSubtractionWorkspace",
+            "",
+            direction=Direction.Input,
+            doc="The workspace used to perform a scaled background subtraction on the reduced workspace. Can be blank.",
+        )
+        self.declareProperty(
+            "BackgroundSubtractionScaleFactor",
+            "",
+            direction=Direction.Input,
+            doc="The scale factor the BackgroundSubtractionWorkspace is multiplied by before subtraction. Can be blank.",
+        )
 
     def PyExec(self):
         use_zero_error_free = self.getProperty("UseZeroErrorFree").value
@@ -163,6 +175,8 @@ class SANSSave(DataProcessorAlgorithm):
             "SampleHeight": height,
             "SampleWidth": width,
             "SampleThickness": thickness,
+            "BackgroundSubtractionWorkspace": self.getProperty("BackgroundSubtractionWorkspace").value,
+            "BackgroundSubtractionScaleFactor": self.getProperty("BackgroundSubtractionScaleFactor").value,
         }
         if maybe_geometry is not None:
             additional_properties["Geometry"] = maybe_geometry.value

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -138,7 +138,7 @@ class SANSSave(DataProcessorAlgorithm):
         )
         self.declareProperty(
             "BackgroundSubtractionScaleFactor",
-            "",
+            0.0,
             direction=Direction.Input,
             doc="The scale factor the BackgroundSubtractionWorkspace is multiplied by before subtraction. Can be blank.",
         )

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -708,7 +708,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCanSAS
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCanSAS1D.cpp:397
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveAscii2.cpp:416
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCanSAS1D2.cpp:24
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCanSAS1D2.cpp:274
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveDiffCal.cpp:125
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveDiffCal.cpp:164
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveFullprofResolution.cpp:153

--- a/docs/source/release/v6.9.0/SANS/New_features/35939.rst
+++ b/docs/source/release/v6.9.0/SANS/New_features/35939.rst
@@ -1,0 +1,3 @@
+- Metadata indicating the subtracted workspace and the scale factor is now saved to CanSAS1D and NXCanSAS subtracted
+  output files when a :ref:`ISIS_SANS_scaled_background-ref` has been performed. This information is located in
+  ``SASprocess``.

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -181,9 +181,9 @@ def single_reduction_for_batch(state, use_optimizations, output_mode, plot_resul
         "BackgroundSubtractionWorkspace": ""
         if state.background_subtraction.workspace is None
         else str(state.background_subtraction.workspace),
-        "BackgroundSubtractionScaleFactor": ""
+        "BackgroundSubtractionScaleFactor": 0.0
         if state.background_subtraction.scale_factor is None
-        else str(state.background_subtraction.scale_factor),
+        else float(state.background_subtraction.scale_factor),
     }
 
     # --------------------------------

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -33,6 +33,7 @@ from sans.common.constants import (
     REDUCED_HAB_AND_LAB_WORKSPACE_FOR_MERGED_REDUCTION,
     CAN_COUNT_AND_NORM_FOR_OPTIMIZATION,
     CAN_AND_SAMPLE_WORKSPACE,
+    SCALED_BGSUB_SUFFIX,
 )
 from sans.common.file_information import get_extension_for_file_type, SANSFileInformationFactory
 from sans.gui_logic.plotting import get_plotting_module
@@ -1633,7 +1634,7 @@ def save_workspace_to_file(
     save_options = {"InputWorkspace": workspace_name}
     save_options.update({"Filename": file_name, "Transmission": transmission_name, "TransmissionCan": transmission_can_name})
     save_options.update(additional_run_numbers)
-    if workspace_name.endswith("_bgsub"):
+    if workspace_name.endswith(SCALED_BGSUB_SUFFIX):
         save_options.update(additional_metadata)
 
     if SaveType.NEXUS in file_formats:
@@ -1655,7 +1656,7 @@ def save_workspace_to_file(
 
 def subtract_scaled_background(reduction_package, scaled_ws_name: str):
     def run_minus_alg():
-        output_name = ws_name + "_bgsub"
+        output_name = ws_name + SCALED_BGSUB_SUFFIX
         minus_options["LHSWorkspace"] = ws_name
         minus_options["OutputWorkspace"] = output_name
         minus_alg = create_unmanaged_algorithm(minus_name, **minus_options)

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -1633,7 +1633,8 @@ def save_workspace_to_file(
     save_options = {"InputWorkspace": workspace_name}
     save_options.update({"Filename": file_name, "Transmission": transmission_name, "TransmissionCan": transmission_can_name})
     save_options.update(additional_run_numbers)
-    save_options.update(additional_metadata)
+    if workspace_name.endswith("_bgsub"):
+        save_options.update(additional_metadata)
 
     if SaveType.NEXUS in file_formats:
         save_options.update({"Nexus": True})

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -584,6 +584,7 @@ def check_for_background_workspace_in_ads(state, reduction_package):
     )
 
     if AnalysisDataService.doesExist(full_name):
+        state.background_subtraction.workspace = full_name
         return full_name
     else:
         raise ValueError(f"BackgroundWorkspace: The workspace '{background_ws_name}' or '{full_name}' could not be found in the ADS.")

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -577,7 +577,7 @@ def check_for_background_workspace_in_ads(state, reduction_package):
     )
 
     if AnalysisDataService.doesExist(full_name):
-        state.background_subtraction.workspace = full_name
+        reduction_package.state.background_subtraction.workspace = full_name
         return full_name
     else:
         raise ValueError(f"BackgroundWorkspace: The workspace '{background_ws_name}' or '{full_name}' could not be found in the ADS.")

--- a/scripts/SANS/sans/common/constants.py
+++ b/scripts/SANS/sans/common/constants.py
@@ -63,6 +63,8 @@ HAB_CAN_COUNT_SUFFIX = "_hab_can_count"
 HAB_CAN_NORM_SUFFIX = "_hab_can_norm"
 HAB_SAMPLE_SUFFIX = "_hab_sample"
 
+SCALED_BGSUB_SUFFIX = "_bgsub"
+
 REDUCED_HAB_AND_LAB_WORKSPACE_FOR_MERGED_REDUCTION = "LAB_and_HAB_workspaces_from_merged_reduction"
 REDUCED_CAN_AND_PARTIAL_CAN_FOR_OPTIMIZATION = "reduced_can_and_partial_can_workspaces"
 CAN_COUNT_AND_NORM_FOR_OPTIMIZATION = "optimization"

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -336,8 +336,25 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         mock_alg_manager.assert_called_once_with("SANSSave", **expected_options)
 
     @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
-    def test_that_save_workspace_to_file_includes_metadata_in_options(self, mock_alg_manager):
+    def test_that_non_subtracted_save_workspace_to_file_does_not_include_metadata_in_options(self, mock_alg_manager):
         ws_name = "wsName"
+        filename = "fileName"
+        additional_run_numbers = {}
+        additional_metadata = {"BackgroundSubtractionWorkspace": "tobesubtracted", "BackgroundSubtractionScaleFactor": "1.25"}
+
+        save_workspace_to_file(ws_name, [], filename, additional_run_numbers, additional_metadata)
+
+        expected_options = {
+            "InputWorkspace": ws_name,
+            "Filename": filename,
+            "Transmission": "",
+            "TransmissionCan": "",
+        }
+        mock_alg_manager.assert_called_once_with("SANSSave", **expected_options)
+
+    @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
+    def test_that_subtracted_save_workspace_to_file_does_include_metadata_in_options(self, mock_alg_manager):
+        ws_name = "wsName_bgsub"
         filename = "fileName"
         additional_run_numbers = {}
         additional_metadata = {"BackgroundSubtractionWorkspace": "tobesubtracted", "BackgroundSubtractionScaleFactor": "1.25"}

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -319,8 +319,9 @@ class GetAllNamesToSaveTest(unittest.TestCase):
             "CanScatterRunNumber": "7",
             "CanDirectRunNumber": "8",
         }
+        additional_metadata = {}
 
-        save_workspace_to_file(ws_name, [], filename, additional_run_numbers)
+        save_workspace_to_file(ws_name, [], filename, additional_run_numbers, additional_metadata)
 
         expected_options = {
             "InputWorkspace": ws_name,
@@ -335,13 +336,33 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         mock_alg_manager.assert_called_once_with("SANSSave", **expected_options)
 
     @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
+    def test_that_save_workspace_to_file_includes_metadata_in_options(self, mock_alg_manager):
+        ws_name = "wsName"
+        filename = "fileName"
+        additional_run_numbers = {}
+        additional_metadata = {"BackgroundSubtractionWorkspace": "tobesubtracted", "BackgroundSubtractionScaleFactor": "1.25"}
+
+        save_workspace_to_file(ws_name, [], filename, additional_run_numbers, additional_metadata)
+
+        expected_options = {
+            "InputWorkspace": ws_name,
+            "Filename": filename,
+            "Transmission": "",
+            "TransmissionCan": "",
+            "BackgroundSubtractionWorkspace": "tobesubtracted",
+            "BackgroundSubtractionScaleFactor": "1.25",
+        }
+        mock_alg_manager.assert_called_once_with("SANSSave", **expected_options)
+
+    @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
     def test_that_save_workspace_to_file_can_set_file_types(self, mock_alg_manager):
         ws_name = "wsName"
         filename = "fileName"
         additional_run_numbers = {}
+        additional_metadata = {}
         file_types = [SaveType.NEXUS, SaveType.CAN_SAS, SaveType.NX_CAN_SAS, SaveType.NIST_QXY, SaveType.RKH, SaveType.CSV]
 
-        save_workspace_to_file(ws_name, file_types, filename, additional_run_numbers)
+        save_workspace_to_file(ws_name, file_types, filename, additional_run_numbers, additional_metadata)
 
         expected_options = {
             "InputWorkspace": ws_name,
@@ -362,6 +383,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         ws_name = "wsName"
         filename = "fileName"
         additional_run_numbers = {}
+        additional_metadata = {}
         file_types = []
         transmission_name = "transName"
         transmission_can_name = "transCanName"
@@ -371,6 +393,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
             file_types,
             filename,
             additional_run_numbers,
+            additional_metadata,
             transmission_name=transmission_name,
             transmission_can_name=transmission_can_name,
         )

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -336,23 +336,6 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         mock_alg_manager.assert_called_once_with("SANSSave", **expected_options)
 
     @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
-    def test_that_non_subtracted_save_workspace_to_file_does_not_include_metadata_in_options(self, mock_alg_manager):
-        ws_name = "wsName"
-        filename = "fileName"
-        additional_run_numbers = {}
-        additional_metadata = {"BackgroundSubtractionWorkspace": "tobesubtracted", "BackgroundSubtractionScaleFactor": "1.25"}
-
-        save_workspace_to_file(ws_name, [], filename, additional_run_numbers, additional_metadata)
-
-        expected_options = {
-            "InputWorkspace": ws_name,
-            "Filename": filename,
-            "Transmission": "",
-            "TransmissionCan": "",
-        }
-        mock_alg_manager.assert_called_once_with("SANSSave", **expected_options)
-
-    @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
     def test_that_subtracted_save_workspace_to_file_does_include_metadata_in_options(self, mock_alg_manager):
         ws_name = "wsName_bgsub"
         filename = "fileName"

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -358,7 +358,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
 
     @mock.patch("sans.algorithm_detail.batch_execution.get_all_names_to_save")
     @mock.patch("sans.algorithm_detail.batch_execution.save_workspace_to_file")
-    def test_that_subtracted_save_to_file_does_not_includes_metadata_in_options(self, mock_save_func, mock_names_func):
+    def test_that_subtracted_save_to_file_includes_metadata_in_options(self, mock_save_func, mock_names_func):
         state = mock.MagicMock()
         save_info_mock = mock.MagicMock()
         scaled_bg_mock = mock.MagicMock()


### PR DESCRIPTION
### Description of work

#### Summary of work
When saving out background subtracted workspaces using the recently added (#35811) scaled background subtraction work, the name of the workspace used and the scale factor it was multiplied by are now saved to the NX and CanSAS1D output files. 

Fixes: #35939


**Report to:** @smk78 


#### Further detail of work
- Since the scaled background subtraction saves out the non-subtracted workspaces as well, these files do not include the additional metadata.

### To test:
1. In your Manage User Directories window, ensure that your save location is somewhere sensible. Ideally a new empty directory as it'll make finding the files you need much easier. 
2. Open the ISIS SANS Interface
3. Load the batch and user files from the loqdemo in the Training Course Data. 
4. Switch the reduction mode to HAB in the Settings tab and run the reduction. 
5. Take note of one of the output workspaces produced.
6. Make a copy of one of the lines currently in the runs table.
7. Give it a new output name. 
8. Tick the Scaled Background Subtraction checkbox
9. In your new row, enter in the name of the workspace in your workspace column
10. Enter a decimal value in the scale factor column (0.5 is what I generally use)
11. Check that the reduction mode is still HAB
12. Change the save options to output both NXCanSAS and CanSAS1D formats
13. Run the reduction for your new line
14. In your save directory, check that the values you entered in the table for scaled background workspace and scale factor are present in the process notes section of the output bgsub xml file. 
15. Use [HDFView](https://www.hdfgroup.org/downloads/hdfview/) to do the same for the `.h5` files. 

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
