### PR TITLE
Save and load mod UB information from OrientedLattice in NeXus

### DIFF
--- a/Framework/Geometry/test/OrientedLatticeTest.h
+++ b/Framework/Geometry/test/OrientedLatticeTest.h
@@ -81,6 +81,20 @@ public:
     th.createFile("OrientedLatticeTest.nxs");
     DblMatrix U(3, 3, true);
     OrientedLattice u(1, 2, 3, 90, 89, 88);
+    u.setMaxOrder(1);
+
+    DblMatrix modUB(3, 3);
+    modUB[0][0] = 1.;
+    modUB[1][0] = 2.;
+    modUB[2][0] = 3.;
+    modUB[0][1] = 4.;
+    modUB[1][1] = 5.;
+    modUB[2][1] = 6.;
+    modUB[0][2] = 7.;
+    modUB[1][2] = 8.;
+    modUB[2][2] = 9.;
+    u.setModUB(modUB);
+
     u.saveNexus(th.file.get(), "lattice");
     th.reopenFile();
 
@@ -93,6 +107,8 @@ public:
     TS_ASSERT_DELTA(u2.alpha(), 90.0, 1e-5);
     TS_ASSERT_DELTA(u2.beta(), 89.0, 1e-5);
     TS_ASSERT_DELTA(u2.gamma(), 88.0, 1e-5);
+    TS_ASSERT_EQUALS(u2.getMaxOrder(), 1);
+    TS_ASSERT_EQUALS(u2.getModUB(), modUB);
   }
 
   /** @author Alex Buts, fixed by Andrei Savici */

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -797,7 +797,7 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/Compos
 cppcheckError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/ReflectometryTransform.cpp:0
 cppcheckError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/FakeMD.cpp:0
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/WorkspaceSingleValue.cpp:93
-shadowVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/OrientedLattice.cpp:234
+shadowVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/OrientedLattice.cpp:236
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/NiggliCell.cpp:233
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/SpaceGroup.cpp:54
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/ScalarUtils.cpp:389

--- a/docs/source/release/v6.9.0/Framework/Data_Handling/Bugfixes/36557.rst
+++ b/docs/source/release/v6.9.0/Framework/Data_Handling/Bugfixes/36557.rst
@@ -1,0 +1,1 @@
+- Fixed modulation information in oriented lattice not being saved and loaded to NeXus files


### PR DESCRIPTION
### Description of work

The mod UB information wasn't saved or loaded when written to nexus, so SaveNexus then LoadNexus would effectly remove the mod UB. This fixes that.

There is no standard entry in the nexus format [NXCrystal](https://manual.nexusformat.org/classes/base_classes/NXcrystal.html) for the modulation information so I made my best judgement.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [EWM3251](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3251)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Previously this would give all zeros after loading but now it should be correct.

```python

ws = CreateSampleWorkspace()
SetUB(ws, 5, 5, 5)

ol = ws.sample().getOrientedLattice()
ol.setModUB(np.array([[0.01,0,0],[-0.01,0,0],[0.2,0,0]]))
ol.setMaxOrder(1)

SaveNexus(ws, "/tmp/ws.nxs")
loaded = LoadNexus("/tmp/ws.nxs")
ol2 = loaded.sample().getOrientedLattice()
print(ol2.getMaxOrder())
print(ol2.getModUB())
print(ol2.getModHKL())
```
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
