### PR TITLE
Contour Plot Widget in S(Q, w) tab of Data Manipulation Interface updates plot limits correctly.

### DIFF
--- a/docs/source/release/v6.9.0/Inelastic/Bugfixes/36490.rst
+++ b/docs/source/release/v6.9.0/Inelastic/Bugfixes/36490.rst
@@ -1,0 +1,1 @@
+- When opening consecutive files in the tab :ref:`S(Q,w) <inelastic-sqw>` of the :ref:`Inelastic Data Manipulation Interface <interface-inelastic-data-manipulation>`, the limits of the contour plot for the newest data file opened are updated to fit the plot widget size.

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSqwTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSqwTabView.cpp
@@ -120,6 +120,7 @@ void InelasticDataManipulationSqwTabView::setEnableOutputOptions(bool const enab
 }
 
 void InelasticDataManipulationSqwTabView::plotRqwContour(MatrixWorkspace_sptr rqwWorkspace) {
+  m_uiForm.rqwPlot2D->clearPlot();
   m_uiForm.rqwPlot2D->setWorkspace(rqwWorkspace);
 }
 

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ContourPreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ContourPreviewPlot.h
@@ -40,6 +40,7 @@ public:
   void setCanvasColour(QColor const &colour);
 
   void setWorkspace(const Mantid::API::MatrixWorkspace_sptr &workspace);
+  void clearPlot();
 
   std::tuple<double, double> getAxisRange(AxisID axisID) const;
 

--- a/qt/widgets/plotting/src/ContourPreviewPlot.cpp
+++ b/qt/widgets/plotting/src/ContourPreviewPlot.cpp
@@ -102,8 +102,8 @@ void ContourPreviewPlot::setCanvasColour(QColor const &colour) { m_canvas->gcf()
 void ContourPreviewPlot::setWorkspace(const MatrixWorkspace_sptr &workspace) {
   if (workspace) {
     auto axes = m_canvas->gca<MantidAxes>();
+    axes.relim();
     axes.pcolormesh(workspace);
-
     m_canvas->draw();
   } else {
     g_log.warning("Cannot plot a null workspace.");

--- a/qt/widgets/plotting/src/ContourPreviewPlot.cpp
+++ b/qt/widgets/plotting/src/ContourPreviewPlot.cpp
@@ -90,6 +90,11 @@ void ContourPreviewPlot::onWorkspaceReplaced(Mantid::API::WorkspaceBeforeReplace
 }
 
 /**
+ * Clears current contour plot held in the MantidAxes
+ */
+void ContourPreviewPlot::clearPlot() { m_canvas->gca<MantidAxes>().clear(); }
+
+/**
  * Set the face colour for the canvas
  * @param colour A new colour for the figure facecolor
  */
@@ -102,7 +107,6 @@ void ContourPreviewPlot::setCanvasColour(QColor const &colour) { m_canvas->gcf()
 void ContourPreviewPlot::setWorkspace(const MatrixWorkspace_sptr &workspace) {
   if (workspace) {
     auto axes = m_canvas->gca<MantidAxes>();
-    axes.relim();
     axes.pcolormesh(workspace);
     m_canvas->draw();
   } else {


### PR DESCRIPTION
### Description of work
As described in #36490, the S(Q, w) tab of the data manipulation interface plots a colorfill (contour plot) when a new `_red` file is added to the interface before converting to `_sqw`. After opening a file and plotting the contour for that file, if a second file is opened without closing the interface, the newest contour plot won't clear the previous one, also the limits won't be updated, giving the effect of a collage paste of plots on top of other plots. This tab should hold only one contour plot in the plot widget at a time. Therefore before adding the new plot to the widget the previous one is now cleared. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36490 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1. Open Inelastic -> Data Manipulation interface and go to S(Q, w) tab. 
2.  On File, select and open `irs26176_graphite002_red.nxs` file, it should plot as a contour. 
3.  Select and open the  `osiris97944_graphite002_red.nxs`. It will update the contour plot, without any trace of previous plot.
4. Select and open again `irs26176_graphite002_red.nxs`. It should replot the first plot, without any trace of the previous one again.
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
