### PR TITLE
Save and load mod UB information from OrientedLattice in NeXus - ornl-next

### DIFF
--- a/Framework/Geometry/test/OrientedLatticeTest.h
+++ b/Framework/Geometry/test/OrientedLatticeTest.h
@@ -81,6 +81,20 @@ public:
     th.createFile("OrientedLatticeTest.nxs");
     DblMatrix U(3, 3, true);
     OrientedLattice u(1, 2, 3, 90, 89, 88);
+    u.setMaxOrder(1);
+
+    DblMatrix modUB(3, 3);
+    modUB[0][0] = 1.;
+    modUB[1][0] = 2.;
+    modUB[2][0] = 3.;
+    modUB[0][1] = 4.;
+    modUB[1][1] = 5.;
+    modUB[2][1] = 6.;
+    modUB[0][2] = 7.;
+    modUB[1][2] = 8.;
+    modUB[2][2] = 9.;
+    u.setModUB(modUB);
+
     u.saveNexus(th.file.get(), "lattice");
     th.reopenFile();
 
@@ -93,6 +107,8 @@ public:
     TS_ASSERT_DELTA(u2.alpha(), 90.0, 1e-5);
     TS_ASSERT_DELTA(u2.beta(), 89.0, 1e-5);
     TS_ASSERT_DELTA(u2.gamma(), 88.0, 1e-5);
+    TS_ASSERT_EQUALS(u2.getMaxOrder(), 1);
+    TS_ASSERT_EQUALS(u2.getModUB(), modUB);
   }
 
   /** @author Alex Buts, fixed by Andrei Savici */

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -939,7 +939,7 @@ cppcheckError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/ReflectometryTransfo
 cppcheckError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/FakeMD.cpp:0
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/WorkspaceSingleValue.cpp:93
 shadowFunction:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/CrystalStructure.cpp:100
-shadowVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/OrientedLattice.cpp:234
+shadowVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/OrientedLattice.cpp:236
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/NiggliCell.cpp:233
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/SpaceGroup.cpp:54
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/ScalarUtils.cpp:389

--- a/docs/source/release/v6.9.0/Framework/Data_Handling/Bugfixes/36557.rst
+++ b/docs/source/release/v6.9.0/Framework/Data_Handling/Bugfixes/36557.rst
@@ -1,0 +1,1 @@
+- Fixed modulation information in oriented lattice not being saved and loaded to NeXus files


### PR DESCRIPTION
This is the version of #36557 into `ornl-next`.