### PR TITLE
Change exception type and message to mimic python

### DIFF
--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -656,7 +656,8 @@ def _get_mandatory_args(func_name, required_args, *args, **kwargs):
             val = dict_containing_key[key]
             return val
         except KeyError:
-            raise RuntimeError("%s argument not supplied to %s function" % (str(key), func_name))
+            # raise TypeError similar to python
+            raise TypeError(f"{func_name} missing required argument: '{key}'")
 
     nrequired = len(required_args)
     npositional = len(args)
@@ -936,10 +937,12 @@ def set_properties(alg_object, *args, **kwargs):
             else:
                 alg_object.setProperty(key, new_value)
         except (RuntimeError, TypeError, ValueError) as e:
-            if str(e).startswith("Unknown property search object"):
+            if str(e).startswith("Unknown property search object") or "is an invalid keyword argument for" in str(e):
+                # raise TypeError similar to python
                 msg = f"'{name}' is an invalid keyword argument for {alg_object.name()}-v{alg_object.version()}"
                 raise TypeError(msg)
             else:
+                # re-raise the error with clearer message
                 msg = 'Problem setting "{}" in {}-v{}: {}'.format(name, alg_object.name(), alg_object.version(), str(e))
                 raise e.__class__(msg) from e
 

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -478,7 +478,8 @@ def CutMD(*args, **kwargs):  # noqa: C901
     # Now check that all the kwargs we've got are correct
     for key in kwargs.keys():
         if key not in algm:
-            raise RuntimeError("Unknown property: {0}".format(key))
+            msg = f"'{key}' is an invalid keyword argument for {algm.name()}-v{algm.version()}"
+            raise TypeError(msg)
 
     # We're now going to build to_process, which is the list of workspaces we want to process.
     to_process = list()
@@ -935,8 +936,12 @@ def set_properties(alg_object, *args, **kwargs):
             else:
                 alg_object.setProperty(key, new_value)
         except (RuntimeError, TypeError, ValueError) as e:
-            msg = 'Problem setting "{}" in {}-v{}: {}'.format(name, alg_object.name(), alg_object.version(), str(e))
-            raise e.__class__(msg) from e
+            if str(e).startswith("Unknown property search object"):
+                msg = f"'{name}' is an invalid keyword argument for {alg_object.name()}-v{alg_object.version()}"
+                raise TypeError(msg)
+            else:
+                msg = 'Problem setting "{}" in {}-v{}: {}'.format(name, alg_object.name(), alg_object.version(), str(e))
+                raise e.__class__(msg) from e
 
     # end
     if len(args) > 0:

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -704,10 +704,16 @@ def _check_mandatory_args(algorithm, _algm_object, error, *args, **kwargs):
         if len(valid_str) > 0 and p not in kwargs.keys():
             missing_arg_list.append(p)
     if len(missing_arg_list) != 0:
-        raise RuntimeError("%s argument(s) not supplied to %s" % (missing_arg_list, algorithm))
+        # raise TypeError similar to python
+        missing_arg_list = [f"'{arg}'" for arg in missing_arg_list]
+        raise TypeError(f"{algorithm} missing required arguments: " + ", ".join(missing_arg_list))
     # If the error was not caused by missing property the algorithm specific error should suffice
     else:
-        raise RuntimeError(str(error))
+        msg = f"in running {algorithm}: {str(error)}"
+        if "Some invalid Properties found" in str(error):
+            raise TypeError(msg)
+        else:
+            raise RuntimeError(msg)
 
 
 # ------------------------ General simple function calls ----------------------

--- a/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
+++ b/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
@@ -110,7 +110,7 @@ class SimpleAPITest(unittest.TestCase):
 
     def test_function_call_raises_RuntimeError_when_passed_incorrect_args(self):
         for func_call in (simpleapi.LoadNexus, simpleapi.Load):
-            self.assertRaises(RuntimeError, func_call, NotAProperty=1)
+            self.assertRaises(TypeError, func_call, NotAProperty=1)
 
     def test_function_call_returns_tuple_when_a_single_argument_is_provided(self):
         dataX = numpy.linspace(start=1, stop=3, num=11)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
@@ -80,7 +80,7 @@ class AbinsBasicTest(unittest.TestCase):
         )
 
         # no name for workspace
-        self.assertRaises(RuntimeError, Abins, VibrationalOrPhononFile=self._si2 + ".phonon", TemperatureInKelvin=self._temperature)
+        self.assertRaises(TypeError, Abins, VibrationalOrPhononFile=self._si2 + ".phonon", TemperatureInKelvin=self._temperature)
 
         # keyword total in the name of the workspace
         self.assertRaisesRegex(

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateFullTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateFullTest.py
@@ -10,7 +10,6 @@ from mantid.api import *
 
 
 class EnggCalibrateFullTest(unittest.TestCase):
-
     _data_ws = None
 
     # Note not using @classmethod setUpClass / tearDownClass because that's not supported in the old
@@ -28,19 +27,19 @@ class EnggCalibrateFullTest(unittest.TestCase):
         """
 
         # No Filename property (required)
-        self.assertRaises(RuntimeError, EnggCalibrateFull, Input="foo", Bank="1")
+        self.assertRaises(TypeError, EnggCalibrateFull, Input="foo", Bank="1")
 
         # Wrong workspace name
         self.assertRaises(ValueError, EnggCalibrateFull, Workspace="this_ws_is_not_there.not", Bank="2")
 
         # mispelled ExpectedPeaks
-        self.assertRaises(RuntimeError, EnggCalibrateFull, Workspace=self.__class__._data_ws, Bank="2", Peaks="2")
+        self.assertRaises(TypeError, EnggCalibrateFull, Workspace=self.__class__._data_ws, Bank="2", Peaks="2")
 
         # mispelled OutDetPosFilename
-        self.assertRaises(RuntimeError, EnggCalibrateFull, OutDetPosFile="any.csv", Workspace=self.__class__._data_ws, Bank="2", Peaks="2")
+        self.assertRaises(TypeError, EnggCalibrateFull, OutDetPosFile="any.csv", Workspace=self.__class__._data_ws, Bank="2", Peaks="2")
 
         # all fine, except missing OutDetPosTable (output)
-        self.assertRaises(RuntimeError, EnggCalibrateFull, Workspace=self.__class__._data_ws, Bank="2")
+        self.assertRaises(TypeError, EnggCalibrateFull, Workspace=self.__class__._data_ws, Bank="2")
 
         # all fine, except Bank should be a string
         self.assertRaises(TypeError, EnggCalibrateFull, Workspace=self.__class__._data_ws, OutDetPosTable="det_pos_tbl", Bank=2)
@@ -58,7 +57,7 @@ class EnggCalibrateFullTest(unittest.TestCase):
         # This should produce fitting 'given peak center ... is outside of data range'
         # warnings and finally raise after a 'some peaks not found' error
         self.assertRaises(
-            RuntimeError,
+            TypeError,
             EnggCalibrateFull,
             Workspace=self.__class__._data_ws,
             ExpectedPeaks=[0.01],
@@ -76,7 +75,7 @@ class EnggCalibrateFullTest(unittest.TestCase):
         # a correct fit is included in system tests
         tbl_name = "det_peaks_tbl"
         self.assertRaises(
-            RuntimeError,
+            TypeError,
             EnggCalibrateFull,
             Workspace=self.__class__._data_ws,
             Bank="2",

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateTest.py
@@ -11,7 +11,6 @@ import mantid.simpleapi as sapi
 
 
 class EnggCalibrateTest(unittest.TestCase):
-
     _data_ws = None
     _van_curves_ws = None
     _van_integ_tbl = None
@@ -42,22 +41,20 @@ class EnggCalibrateTest(unittest.TestCase):
         """
 
         # No InputWorkspace property (required)
-        self.assertRaises(RuntimeError, sapi.EnggCalibrate, File="foo", Bank="1")
+        self.assertRaises(TypeError, sapi.EnggCalibrate, File="foo", Bank="1")
 
         # Wrong (mispelled) InputWorkspace property
-        self.assertRaises(RuntimeError, sapi.EnggCalibrate, InputWorkpace="anything_goes", Bank="2")
+        self.assertRaises(TypeError, sapi.EnggCalibrate, InputWorkpace="anything_goes", Bank="2")
 
         # mispelled ExpectedPeaks
         tbl = sapi.CreateEmptyTableWorkspace(OutputWorkspace="test_table")
-        self.assertRaises(
-            RuntimeError, sapi.EnggCalibrate, Inputworkspace=self.__class__._data_ws, DetectorPositions=tbl, Bank="2", Peaks="2"
-        )
+        self.assertRaises(TypeError, sapi.EnggCalibrate, Inputworkspace=self.__class__._data_ws, DetectorPositions=tbl, Bank="2", Peaks="2")
 
         # mispelled DetectorPositions
-        self.assertRaises(RuntimeError, sapi.EnggCalibrate, InputWorkspace=self.__class__._data_ws, Detectors=tbl, Bank="2", Peaks="2")
+        self.assertRaises(TypeError, sapi.EnggCalibrate, InputWorkspace=self.__class__._data_ws, Detectors=tbl, Bank="2", Peaks="2")
 
         # There's no output workspace
-        self.assertRaises(RuntimeError, sapi.EnggCalibrate, InputWorkspace=self.__class__._data_ws, Bank="1")
+        self.assertRaises(TypeError, sapi.EnggCalibrate, InputWorkspace=self.__class__._data_ws, Bank="1")
 
     def test_fails_gracefully(self):
         """
@@ -66,7 +63,7 @@ class EnggCalibrateTest(unittest.TestCase):
 
         # This should produce 'given peak center ... is outside of data range' warnings
         # and finally raise after a 'some peaks not found' error
-        self.assertRaises(RuntimeError, sapi.EnggCalibrate, InputWorkspace=self.__class__._data_ws, ExpectedPeaks=[0.2, 0.4], Bank="2")
+        self.assertRaises(TypeError, sapi.EnggCalibrate, InputWorkspace=self.__class__._data_ws, ExpectedPeaks=[0.2, 0.4], Bank="2")
 
     def test_runs_ok_without_reliable_peaks(self):
         """

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
@@ -29,16 +29,16 @@ class EnggFitPeaksTest(unittest.TestCase):
         )
 
         # No InputWorkspace property (required)
-        self.assertRaises(RuntimeError, EnggFitPeaks, WorkspaceIndex=0, ExpectedPeaks="0.51, 0.72")
+        self.assertRaises(TypeError, EnggFitPeaks, WorkspaceIndex=0, ExpectedPeaks="0.51, 0.72")
 
         # Wrong WorkspaceIndex value
-        self.assertRaises(RuntimeError, EnggFitPeaks, InputWorkspace=ws_name, WorkspaceIndex=-3, ExpectedPeaks="0.51, 0.72")
+        self.assertRaises(TypeError, EnggFitPeaks, InputWorkspace=ws_name, WorkspaceIndex=-3, ExpectedPeaks="0.51, 0.72")
 
         # Wrong property
-        self.assertRaises(RuntimeError, EnggFitPeaks, InputWorkspace=ws_name, BankPixelFoo=33, WorkspaceIndex=0, ExpectedPeaks="0.51, 0.72")
+        self.assertRaises(TypeError, EnggFitPeaks, InputWorkspace=ws_name, BankPixelFoo=33, WorkspaceIndex=0, ExpectedPeaks="0.51, 0.72")
 
         # missing FittedPeaks output property
-        self.assertRaises(RuntimeError, EnggFitPeaks, InputWorkspace=ws_name, WorkspaceIndex=0, ExpectedPeaks="0.51, 0.72")
+        self.assertRaises(TypeError, EnggFitPeaks, InputWorkspace=ws_name, WorkspaceIndex=0, ExpectedPeaks="0.51, 0.72")
 
         # Wrong ExpectedPeaks value
         self.assertRaises(ValueError, EnggFitPeaks, InputWorkspace=ws_name, WorkspaceIndex=0, ExpectedPeaks="a")
@@ -130,9 +130,9 @@ class EnggFitPeaksTest(unittest.TestCase):
             Random=1,
         )
         # these should raise because of issues with the peak center - data range
-        self.assertRaises(RuntimeError, EnggFitPeaks, sws, 0, [0.5, 2.5])
+        self.assertRaises(TypeError, EnggFitPeaks, sws, 0, [0.5, 2.5])
         EditInstrumentGeometry(Workspace=sws, L2=[1.0], Polar=[90], PrimaryFlightPath=50)
-        self.assertRaises(RuntimeError, EnggFitPeaks, sws, 0, [1.1, 3])
+        self.assertRaises(TypeError, EnggFitPeaks, sws, 0, [1.1, 3])
 
         # this should fail because of nan/infinity issues
         peak_def = "name=BackToBackExponential, I=12000, A=1, B=1.5, X0=10000, S=350"
@@ -140,7 +140,7 @@ class EnggFitPeaksTest(unittest.TestCase):
             Function="User Defined", UserDefinedFunction=peak_def, NumBanks=1, BankPixelWidth=1, XMin=10000, XMax=30000, BinWidth=10
         )
         EditInstrumentGeometry(Workspace=sws, L2=[1.0], Polar=[35], PrimaryFlightPath=35)
-        self.assertRaises(RuntimeError, EnggFitPeaks, sws, 0, [1, 2.3, 3])
+        self.assertRaises(TypeError, EnggFitPeaks, sws, 0, [1, 2.3, 3])
 
         # this should fail because FindPeaks doesn't initialize/converge well
         peak_def = "name=BackToBackExponential, I=90000, A=0.1, B=0.5, X0=5000, S=400"
@@ -148,7 +148,7 @@ class EnggFitPeaksTest(unittest.TestCase):
             Function="User Defined", UserDefinedFunction=peak_def, NumBanks=1, BankPixelWidth=1, XMin=2000, XMax=30000, BinWidth=10
         )
         EditInstrumentGeometry(Workspace=sws, L2=[1.0], Polar=[90], PrimaryFlightPath=50)
-        self.assertRaises(RuntimeError, EnggFitPeaks, sws, 0, [0.6])
+        self.assertRaises(TypeError, EnggFitPeaks, sws, 0, [0.6])
 
     def test_fails_ok_1peak(self):
         """
@@ -159,7 +159,7 @@ class EnggFitPeaksTest(unittest.TestCase):
             Function="User Defined", UserDefinedFunction=peak_def, NumBanks=1, BankPixelWidth=1, XMin=0, XMax=25000, BinWidth=10
         )
         EditInstrumentGeometry(Workspace=sws, L2=[1.5], Polar=[90], PrimaryFlightPath=45)
-        self.assertRaises(RuntimeError, EnggFitPeaks, sws, WorkspaceIndex=0, ExpectedPeaks="0.542")
+        self.assertRaises(TypeError, EnggFitPeaks, sws, WorkspaceIndex=0, ExpectedPeaks="0.542")
 
     def test_2peaks_fails_1(self):
         """

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitTOFFromPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitTOFFromPeaksTest.py
@@ -15,11 +15,11 @@ class EnggFitTOFFromPeaksTest(unittest.TestCase):
         Handle in/out property issues appropriately.
         """
         # No InputWorkspace property (required)
-        self.assertRaises(RuntimeError, EnggFitTOFFromPeaks, OutParametersTable="param_table")
+        self.assertRaises(TypeError, EnggFitTOFFromPeaks, OutParametersTable="param_table")
 
         table = CreateEmptyTableWorkspace(OutputWorkspace="some_tbl_name")
         # This property doesn't belong here
-        self.assertRaises(RuntimeError, EnggFitTOFFromPeaks, FittedPeaks=table, ExpectedPeaks="0.6, 0.9")
+        self.assertRaises(TypeError, EnggFitTOFFromPeaks, FittedPeaks=table, ExpectedPeaks="0.6, 0.9")
 
     def test_runs_ok_3peaks(self):
         """

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFocusTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFocusTest.py
@@ -60,20 +60,20 @@ class EnggFocusTest(unittest.TestCase):
         """
 
         # No InputWorkspace property
-        self.assertRaises(RuntimeError, EnggFocus, Bank="1", OutputWorkspace="nop")
+        self.assertRaises(TypeError, EnggFocus, Bank="1", OutputWorkspace="nop")
 
         # Mispelled InputWorkspace prop
-        self.assertRaises(RuntimeError, EnggFocus, InputWrkspace="anything_goes", Bank="1", OutputWorkspace="nop")
+        self.assertRaises(TypeError, EnggFocus, InputWrkspace="anything_goes", Bank="1", OutputWorkspace="nop")
 
         # Wrong InputWorkspace name
         self.assertRaises(ValueError, EnggFocus, InputWorkspace="foo_is_not_there", Bank="1", OutputWorkspace="nop")
 
         # mispelled bank
-        self.assertRaises(RuntimeError, EnggFocus, InputWorkspace=self.__class__._data_ws, bnk="2", OutputWorkspace="nop")
+        self.assertRaises(TypeError, EnggFocus, InputWorkspace=self.__class__._data_ws, bnk="2", OutputWorkspace="nop")
 
         # mispelled DetectorsPosition
         tbl = CreateEmptyTableWorkspace()
-        self.assertRaises(RuntimeError, EnggFocus, InputWorkspace=self.__class__._data_ws, Detectors=tbl, OutputWorkspace="nop")
+        self.assertRaises(TypeError, EnggFocus, InputWorkspace=self.__class__._data_ws, Detectors=tbl, OutputWorkspace="nop")
 
         # bank and indices list clash. This starts as a ValueError but the managers is raising a RuntimeError
         self.assertRaisesRegex(

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggVanadiumCorrectionsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggVanadiumCorrectionsTest.py
@@ -10,7 +10,6 @@ import mantid.simpleapi as sapi
 
 
 class EnggVanadiumCorrectionsTest(unittest.TestCase):
-
     _data_ws = None
     _van_integ_tbl = None
     _van_curves_ws = None
@@ -45,14 +44,14 @@ class EnggVanadiumCorrectionsTest(unittest.TestCase):
         """
 
         # absolutely wrong properties passed
-        self.assertRaises(RuntimeError, sapi.EnggVanadiumCorrections, File="foo", Bank="1")
+        self.assertRaises(TypeError, sapi.EnggVanadiumCorrections, File="foo", Bank="1")
 
         # Wrong (mispelled) Workspace property
-        self.assertRaises(RuntimeError, sapi.EnggVanadiumCorrections, InputWorkspace="anything_goes")
+        self.assertRaises(TypeError, sapi.EnggVanadiumCorrections, InputWorkspace="anything_goes")
 
         # mispelled VanadiumWorkspace
         self.assertRaises(
-            RuntimeError,
+            TypeError,
             sapi.EnggVanadiumCorrections,
             VanWorkspace=self.__class__._data_ws,
             IntegrationWorkspace=self.__class__._van_integ_tbl,
@@ -61,7 +60,7 @@ class EnggVanadiumCorrectionsTest(unittest.TestCase):
 
         # mispelled CurvesWorkspace
         self.assertRaises(
-            RuntimeError,
+            TypeError,
             sapi.EnggVanadiumCorrections,
             IntegrationWorkspace=self.__class__._van_integ_tbl,
             CurveWorkspace=self.__class__._van_curves_ws,
@@ -69,7 +68,7 @@ class EnggVanadiumCorrectionsTest(unittest.TestCase):
 
         # mispelled IntegrationWorkspace
         self.assertRaises(
-            RuntimeError,
+            TypeError,
             sapi.EnggVanadiumCorrections,
             IntegWorkspace=self.__class__._van_integ_tbl,
             CurvesWorkspace=self.__class__._van_curves_ws,
@@ -77,7 +76,7 @@ class EnggVanadiumCorrectionsTest(unittest.TestCase):
 
         # mispelled SplineBreakPoints
         self.assertRaises(
-            RuntimeError,
+            TypeError,
             sapi.EnggVanadiumCorrections,
             BreakPoints=self.__class__._van_integ_tbl,
             IntegrationWorkspace=self.__class__._van_integ_tbl,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PoldiCreatePeaksFromFileTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PoldiCreatePeaksFromFileTest.py
@@ -129,9 +129,9 @@ class PoldiCreatePeaksFromFileTest(unittest.TestCase):
                                                   }"""
         )
 
-        self.assertRaises(RuntimeError, PoldiCreatePeaksFromFile, *(fhLatticeMissing.getName(), 0.7, 10.0, "ws"))
-        self.assertRaises(RuntimeError, PoldiCreatePeaksFromFile, *(fhNoLattice.getName(), 0.7, 10.0, "ws"))
-        self.assertRaises(RuntimeError, PoldiCreatePeaksFromFile, *(fhInvalidLattice.getName(), 0.7, 10.0, "ws"))
+        self.assertRaises(TypeError, PoldiCreatePeaksFromFile, *(fhLatticeMissing.getName(), 0.7, 10.0, "ws"))
+        self.assertRaises(TypeError, PoldiCreatePeaksFromFile, *(fhNoLattice.getName(), 0.7, 10.0, "ws"))
+        self.assertRaises(TypeError, PoldiCreatePeaksFromFile, *(fhInvalidLattice.getName(), 0.7, 10.0, "ws"))
 
     def test_FileFaultySpaceGroupStrings(self):
         fhSgMissing = TemporaryFileHelper(
@@ -153,8 +153,8 @@ class PoldiCreatePeaksFromFileTest(unittest.TestCase):
                                                   }"""
         )
 
-        self.assertRaises(RuntimeError, PoldiCreatePeaksFromFile, *(fhSgMissing.getName(), 0.7, 10.0, "ws"))
-        self.assertRaises(RuntimeError, PoldiCreatePeaksFromFile, *(fhSgInvalid.getName(), 0.7, 10.0, "ws"))
+        self.assertRaises(TypeError, PoldiCreatePeaksFromFile, *(fhSgMissing.getName(), 0.7, 10.0, "ws"))
+        self.assertRaises(TypeError, PoldiCreatePeaksFromFile, *(fhSgInvalid.getName(), 0.7, 10.0, "ws"))
 
     def test_FileFaultyAtomStrings(self):
         fhAtomsMissing = TemporaryFileHelper(
@@ -180,9 +180,9 @@ class PoldiCreatePeaksFromFileTest(unittest.TestCase):
                                                   }"""
         )
 
-        self.assertRaises(RuntimeError, PoldiCreatePeaksFromFile, *(fhAtomsMissing.getName(), 0.7, 10.0, "ws"))
-        self.assertRaises(RuntimeError, PoldiCreatePeaksFromFile, *(fhAtomsNoBraces.getName(), 0.7, 10.0, "ws"))
-        self.assertRaises(RuntimeError, PoldiCreatePeaksFromFile, *(fhAtomsEmpty.getName(), 0.7, 10.0, "ws"))
+        self.assertRaises(TypeError, PoldiCreatePeaksFromFile, *(fhAtomsMissing.getName(), 0.7, 10.0, "ws"))
+        self.assertRaises(TypeError, PoldiCreatePeaksFromFile, *(fhAtomsNoBraces.getName(), 0.7, 10.0, "ws"))
+        self.assertRaises(TypeError, PoldiCreatePeaksFromFile, *(fhAtomsEmpty.getName(), 0.7, 10.0, "ws"))
 
     def _tablesAreEqual(self, lhs, rhs):
         self.assertEqual(lhs.rowCount(), rhs.rowCount(), msg="Row count of tables is different")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -170,7 +170,7 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         self._check_history(workspace, expected)
 
     def test_missing_inputs(self):
-        self.assertRaises(RuntimeError, ReflectometryReductionOneLiveData)
+        self.assertRaises(TypeError, ReflectometryReductionOneLiveData)
 
     def test_invalid_input_workspace(self):
         self.assertRaises(ValueError, ReflectometryReductionOneLiveData, InputWorkspace="bad")
@@ -180,7 +180,7 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
 
     def test_invalid_property(self):
         self.assertRaises(
-            RuntimeError,
+            TypeError,
             ReflectometryReductionOneLiveData,
             InputWorkspace=self.__class__._input_ws,
             OutputWorkspace="output",

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/FindPeakAutomaticTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/FindPeakAutomaticTest.py
@@ -100,7 +100,7 @@ class FindPeaksAutomaticTest(unittest.TestCase):
             raise Exception("Expected {}, got {}. Difference greater than tolerance {}".format(sigma, peak_params["sigma"], tolerance))
 
     def test_algorithm_with_no_input_workspace_raises_exception(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(TypeError):
             FindPeaksAutomatic()
 
     def test_algorithm_with_negative_acceptance_threshold_throws(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/InterpolateBackgroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/InterpolateBackgroundTest.py
@@ -31,13 +31,13 @@ class InterpolateBackgroundTest(unittest.TestCase):
 
     def test_bad_input(self):
         # Test raises Runtime error if a workspace is missing SampleTemp property
-        with self.assertRaisesRegex(RuntimeError, "invalid Properties"):
+        with self.assertRaisesRegex(TypeError, "invalid Properties"):
             InterpolateBackground(self.wsGroup, self.interpo)
         self.ws2 = CreateWorkspace(dataX=self.dataX, dataY=self.dataY2, nspec=2, OutputWorkspace="ws2")
         self.ws1.getRun().addProperty("SampleTemp", "100", False)
         self.ws2.getRun().addProperty("SampleTemp", "400", False)
         # Test raises Runtime error if workspaces have a different number of bins
-        with self.assertRaisesRegex(RuntimeError, "invalid Properties"):
+        with self.assertRaisesRegex(TypeError, "invalid Properties"):
             InterpolateBackground(self.wsGroup, self.interpo)
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcessTest.py
@@ -31,10 +31,10 @@ class SANSILLAutoProcessTest(unittest.TestCase):
         config["datasearch.directories"] = cls._data_search_dirs
 
     def test_noSampleRun(self):
-        self.assertRaises(RuntimeError, SANSILLAutoProcess)
+        self.assertRaises(TypeError, SANSILLAutoProcess)
 
     def test_noOutputWs(self):
-        self.assertRaises(RuntimeError, SANSILLAutoProcess, SampleRuns="010462")
+        self.assertRaises(TypeError, SANSILLAutoProcess, SampleRuns="010462")
 
     def test_wrongAbsorberDim(self):
         self.assertRaisesRegex(

--- a/Testing/SystemTests/tests/framework/LoadVesuvioTest.py
+++ b/Testing/SystemTests/tests/framework/LoadVesuvioTest.py
@@ -17,7 +17,6 @@ DIFF_PLACES = 12
 
 
 class VesuvioTests(unittest.TestCase):
-
     ws_name = "evs_raw"
 
     def tearDown(self):
@@ -379,10 +378,10 @@ class VesuvioTests(unittest.TestCase):
     # ================== Failure cases ================================
 
     def test_run_range_bad_order_raises_error(self):
-        self.assertRaises(RuntimeError, ms.LoadVesuvio, Filename="14188-14187", OutputWorkspace=self.ws_name)
+        self.assertRaises(TypeError, ms.LoadVesuvio, Filename="14188-14187", OutputWorkspace=self.ws_name)
 
     def test_missing_spectra_property_raises_error(self):
-        self.assertRaises(RuntimeError, ms.LoadVesuvio, Filename="14188", OutputWorkspace=self.ws_name)
+        self.assertRaises(TypeError, ms.LoadVesuvio, Filename="14188", OutputWorkspace=self.ws_name)
 
     def test_load_with_invalid_spectra_raises_error(self):
         self.assertRaises(RuntimeError, ms.LoadVesuvio, Filename="14188", OutputWorkspace=self.ws_name, SpectrumList="200")
@@ -444,7 +443,6 @@ class VesuvioTests(unittest.TestCase):
 
 
 class LoadVesuvioTest(systemtesting.MantidSystemTest):
-
     _success = False
 
     def runTest(self):

--- a/docs/source/release/v6.9.0/Framework/Algorithms/New_features/36563.rst
+++ b/docs/source/release/v6.9.0/Framework/Algorithms/New_features/36563.rst
@@ -1,0 +1,1 @@
+- Improve the error messages when calling Algorithms with either missing arguments or invalid arguments. The type of the exceptions is changed from ``RuntimeError`` to ``TypeError`` to be more consistent with python itself.


### PR DESCRIPTION
The goal of this is to improve the error messages in python from invalid parameters being supplied to Algorithms. There main changes are:
1. The type of exception thrown by invalid properties is changed from `RuntimeError` to `TypeError`. The message and exception type is now consistent with invalid argument name (e.g. `print(jimmy="john")`) and missing mandatory argument (e.g. `os.path.exists()`).
2. Properties failing to validate throws a `TypeError` rather than `RuntimeError` similar to the previous item
2. Any generic algorithm issue now includes the name of the failing algorithm in the exception. This should make it significantly easier for users to find issues in parameters when writing scripts.


#### Purpose of work

This PR was created to improve the usability of mantid when algorithms are called with bad kwargs.

*There is no associated issue.*

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

Some examples so you can see the new exception messages

kwarg that doesn't exist
```python
Segfault(jimmy="john")
```
kwarg with wrong type
```python
Segfault(DryRun="john")
```
and an algorithm people should actually use
```python
CompressEvents()
```

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
