### PR TITLE
IndirectFitDataPresenter is no longer a QObject

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1523,10 +1523,8 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectome
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp:786
 passedByValue:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferValidator.cpp:100
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModelUtils.h:99
-constParameterPointer:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp:34
-constVariablePointer:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp:374
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp:22
-virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h:35
+virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h:41
 returnTempReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitData.cpp:127
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitData.cpp:93
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/IqtFitModel.cpp:47

--- a/qt/scientific_interfaces/Inelastic/Analysis/ConvFitAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/ConvFitAddWorkspaceDialog.cpp
@@ -74,7 +74,7 @@ ConvFitAddWorkspaceDialog::ConvFitAddWorkspaceDialog(QWidget *parent) : IAddWork
   connect(m_uiForm.dsWorkspace, SIGNAL(dataReady(const QString &)), this, SLOT(workspaceChanged(const QString &)));
   connect(m_uiForm.ckAllSpectra, SIGNAL(stateChanged(int)), this, SLOT(selectAllSpectra(int)));
   connect(m_uiForm.pbAdd, SIGNAL(clicked()), this, SIGNAL(addData()));
-  connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SIGNAL(closeDialog()));
+  connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SLOT(close()));
 }
 
 std::string ConvFitAddWorkspaceDialog::workspaceName() const {

--- a/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataPresenter.cpp
@@ -11,8 +11,9 @@
 
 namespace MantidQt::CustomInterfaces::IDA {
 
-ConvFitDataPresenter::ConvFitDataPresenter(IIndirectFitDataModel *model, IIndirectFitDataView *view)
-    : IndirectFitDataPresenter(model, view) {}
+ConvFitDataPresenter::ConvFitDataPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitDataModel *model,
+                                           IIndirectFitDataView *view)
+    : IndirectFitDataPresenter(tab, model, view) {}
 
 bool ConvFitDataPresenter::addWorkspaceFromDialog(IAddWorkspaceDialog const *dialog) {
   if (const auto convDialog = dynamic_cast<ConvFitAddWorkspaceDialog const *>(dialog)) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataPresenter.cpp
@@ -23,13 +23,6 @@ bool ConvFitDataPresenter::addWorkspaceFromDialog(IAddWorkspaceDialog const *dia
   return false;
 }
 
-std::unique_ptr<IAddWorkspaceDialog> ConvFitDataPresenter::getAddWorkspaceDialog(QWidget *parent) const {
-  auto dialog = std::make_unique<ConvFitAddWorkspaceDialog>(parent);
-  dialog->setResolutionWSSuffices(getResolutionWSSuffices());
-  dialog->setResolutionFBSuffices(getResolutionFBSuffices());
-  return dialog;
-}
-
 void ConvFitDataPresenter::addTableEntry(FitDomainIndex row) {
   const auto &name = m_model->getWorkspace(row)->getName();
   auto resolutionVector = m_model->getResolutionsForFit();

--- a/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataPresenter.h
@@ -17,7 +17,7 @@ namespace IDA {
 class ConvFitAddWorkspaceDialog;
 class MANTIDQT_INELASTIC_DLL ConvFitDataPresenter : public IndirectFitDataPresenter {
 public:
-  ConvFitDataPresenter(IIndirectFitDataModel *model, IIndirectFitDataView *view);
+  ConvFitDataPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitDataModel *model, IIndirectFitDataView *view);
 
   bool addWorkspaceFromDialog(IAddWorkspaceDialog const *dialog) override;
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataPresenter.h
@@ -23,9 +23,6 @@ public:
 
 protected:
   void addTableEntry(FitDomainIndex row) override;
-
-private:
-  std::unique_ptr<IAddWorkspaceDialog> getAddWorkspaceDialog(QWidget *parent) const override;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataPresenter.h
@@ -16,14 +16,10 @@ namespace IDA {
 
 class ConvFitAddWorkspaceDialog;
 class MANTIDQT_INELASTIC_DLL ConvFitDataPresenter : public IndirectFitDataPresenter {
-  Q_OBJECT
 public:
   ConvFitDataPresenter(IIndirectFitDataModel *model, IIndirectFitDataView *view);
 
   bool addWorkspaceFromDialog(IAddWorkspaceDialog const *dialog) override;
-
-signals:
-  void modelResolutionAdded(std::string const &name, WorkspaceID const &workspaceID);
 
 protected:
   void addTableEntry(FitDomainIndex row) override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataView.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "ConvFitDataView.h"
+#include "ConvFitAddWorkspaceDialog.h"
 
 #include <QComboBox>
 #include <QHeaderView>
@@ -30,6 +31,16 @@ ConvFitDataView::ConvFitDataView(QWidget *parent) : ConvFitDataView(convFitHeade
 ConvFitDataView::ConvFitDataView(const QStringList &headers, QWidget *parent) : IndirectFitDataView(headers, parent) {
   auto header = m_uiForm->tbFitData->horizontalHeader();
   header->setSectionResizeMode(1, QHeaderView::Stretch);
+}
+
+IAddWorkspaceDialog *ConvFitDataView::getAddWorkspaceDialog() {
+  m_addWorkspaceDialog = new ConvFitAddWorkspaceDialog(parentWidget());
+  m_addWorkspaceDialog->setResolutionWSSuffices(m_wsResolutionSuffixes);
+  m_addWorkspaceDialog->setResolutionFBSuffices(m_fbResolutionSuffixes);
+
+  connect(m_addWorkspaceDialog, SIGNAL(addData()), this, SLOT(notifyAddData()));
+
+  return m_addWorkspaceDialog;
 }
 
 void ConvFitDataView::addTableEntry(size_t row, FitDataRow newRow) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataView.cpp
@@ -35,9 +35,10 @@ ConvFitDataView::ConvFitDataView(const QStringList &headers, QWidget *parent) : 
 
 IAddWorkspaceDialog *ConvFitDataView::getAddWorkspaceDialog() {
   m_addWorkspaceDialog = new ConvFitAddWorkspaceDialog(parentWidget());
-  m_addWorkspaceDialog->setResolutionWSSuffices(m_wsResolutionSuffixes);
-  m_addWorkspaceDialog->setResolutionFBSuffices(m_fbResolutionSuffixes);
-
+  if (auto dialog = dynamic_cast<ConvFitAddWorkspaceDialog *>(m_addWorkspaceDialog)) {
+    dialog->setResolutionWSSuffices(m_wsResolutionSuffixes);
+    dialog->setResolutionFBSuffices(m_fbResolutionSuffixes);
+  }
   connect(m_addWorkspaceDialog, SIGNAL(addData()), this, SLOT(notifyAddData()));
 
   return m_addWorkspaceDialog;

--- a/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataView.h
@@ -31,9 +31,6 @@ public:
 protected:
   ConvFitDataView(const QStringList &headers, QWidget *parent = nullptr);
   IAddWorkspaceDialog *getAddWorkspaceDialog() override;
-
-private:
-  ConvFitAddWorkspaceDialog *m_addWorkspaceDialog;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/ConvFitDataView.h
@@ -15,6 +15,10 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
+
+class IAddWorkspaceDialog;
+class ConvFitAddWorkspaceDialog;
+
 /**
 Presenter for a table of convolution fitting data.
 */
@@ -26,6 +30,10 @@ public:
 
 protected:
   ConvFitDataView(const QStringList &headers, QWidget *parent = nullptr);
+  IAddWorkspaceDialog *getAddWorkspaceDialog() override;
+
+private:
+  ConvFitAddWorkspaceDialog *m_addWorkspaceDialog;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitAddWorkspaceDialog.cpp
@@ -19,7 +19,7 @@ FqFitAddWorkspaceDialog::FqFitAddWorkspaceDialog(QWidget *parent) : IAddWorkspac
   connect(m_uiForm.cbParameterType, SIGNAL(currentIndexChanged(const QString &)), this,
           SLOT(emitParameterTypeChanged(const QString &)));
   connect(m_uiForm.pbAdd, SIGNAL(clicked()), this, SIGNAL(addData()));
-  connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SIGNAL(closeDialog()));
+  connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SLOT(close()));
 }
 
 std::string FqFitAddWorkspaceDialog::workspaceName() const {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitAddWorkspaceDialog.ui
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitAddWorkspaceDialog.ui
@@ -146,40 +146,7 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>pbAdd</sender>
-   <signal>clicked()</signal>
-   <receiver>FqFitAddWorkspaceDialog</receiver>
-   <slot>addData()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>273</x>
-     <y>166</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>270</x>
-     <y>221</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>pbClose</sender>
-   <signal>clicked()</signal>
-   <receiver>FqFitAddWorkspaceDialog</receiver>
-   <slot>closeDialog()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>369</x>
-     <y>164</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>361</x>
-     <y>212</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
  <slots>
   <slot>addData()</slot>
   <slot>closeDialog()</slot>

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
@@ -31,7 +31,7 @@ private:
 };
 
 template <typename Predicate>
-std::pair<std::vector<std::string>, std::vector<std::size_t>> findAxisLabels(TextAxis *axis,
+std::pair<std::vector<std::string>, std::vector<std::size_t>> findAxisLabels(TextAxis const *axis,
                                                                              Predicate const &predicate) {
   std::vector<std::string> labels;
   std::vector<std::size_t> spectra;
@@ -361,7 +361,7 @@ void FqFitDataPresenter::addTableEntry(FitDomainIndex row) {
 
   auto subIndices = m_model->getSubIndices(row);
   const auto workspace = m_model->getWorkspace(subIndices.first);
-  const auto axis = dynamic_cast<Mantid::API::TextAxis *>(workspace->getAxis(1));
+  const auto axis = dynamic_cast<Mantid::API::TextAxis const *>(workspace->getAxis(1));
   const auto parameter = axis->label(subIndices.second.value);
 
   const auto workspaceIndex = m_model->getSpectrum(row);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
@@ -254,7 +254,7 @@ void FqFitDataPresenter::updateActiveWorkspaceID() { m_activeWorkspaceID = m_mod
 
 void FqFitDataPresenter::updateActiveWorkspaceID(WorkspaceID index) { m_activeWorkspaceID = index; }
 
-void FqFitDataPresenter::setDialogParameterNames(FqFitAddWorkspaceDialog *dialog, const std::string &workspaceName) {
+void FqFitDataPresenter::handleWorkspaceChanged(FqFitAddWorkspaceDialog *dialog, const std::string &workspaceName) {
   FqFitParameters parameters;
   try {
     auto workspace = m_adsInstance.retrieveWS<MatrixWorkspace>(workspaceName);
@@ -267,7 +267,7 @@ void FqFitDataPresenter::setDialogParameterNames(FqFitAddWorkspaceDialog *dialog
   updateParameterOptions(dialog, parameters);
 }
 
-void FqFitDataPresenter::dialogParameterTypeUpdated(FqFitAddWorkspaceDialog *dialog, const std::string &type) {
+void FqFitDataPresenter::handleParameterTypeChanged(FqFitAddWorkspaceDialog *dialog, const std::string &type) {
   const auto workspaceName = dialog->workspaceName();
   if (!workspaceName.empty() && m_adsInstance.doesExist(workspaceName)) {
     auto workspace = m_adsInstance.retrieveWS<MatrixWorkspace>(workspaceName);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
@@ -200,9 +200,7 @@ namespace MantidQt::CustomInterfaces::IDA {
 FqFitDataPresenter::FqFitDataPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitDataModel *model,
                                        IIndirectFitDataView *view)
     : IndirectFitDataPresenter(tab, model, view), m_activeParameterType("Width"), m_activeWorkspaceID(WorkspaceID{0}),
-      m_adsInstance(Mantid::API::AnalysisDataService::Instance()) {
-  connect(this, SIGNAL(requestedAddWorkspaceDialog()), this, SLOT(updateActiveWorkspaceID()));
-}
+      m_adsInstance(Mantid::API::AnalysisDataService::Instance()) {}
 
 bool FqFitDataPresenter::addWorkspaceFromDialog(IAddWorkspaceDialog const *dialog) {
   if (const auto fqFitDialog = dynamic_cast<FqFitAddWorkspaceDialog const *>(dialog)) {
@@ -250,9 +248,9 @@ void FqFitDataPresenter::addWorkspace(const std::string &workspaceName, const st
 
 void FqFitDataPresenter::setActiveParameterType(const std::string &type) { m_activeParameterType = type; }
 
-void FqFitDataPresenter::updateActiveWorkspaceID() { m_activeWorkspaceID = m_model->getNumberOfWorkspaces(); }
-
 void FqFitDataPresenter::updateActiveWorkspaceID(WorkspaceID index) { m_activeWorkspaceID = index; }
+
+void FqFitDataPresenter::handleAddClicked() { updateActiveWorkspaceID(m_model->getNumberOfWorkspaces()); }
 
 void FqFitDataPresenter::handleWorkspaceChanged(FqFitAddWorkspaceDialog *dialog, const std::string &workspaceName) {
   FqFitParameters parameters;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
@@ -357,15 +357,6 @@ void FqFitDataPresenter::setActiveEISF(std::size_t eisfIndex, WorkspaceID worksp
     logger.warning("Invalid EISF index specified.");
 }
 
-std::unique_ptr<IAddWorkspaceDialog> FqFitDataPresenter::getAddWorkspaceDialog(QWidget *parent) const {
-  auto dialog = std::make_unique<FqFitAddWorkspaceDialog>(parent);
-  connect(dialog.get(), SIGNAL(workspaceChanged(FqFitAddWorkspaceDialog *, const std::string &)), this,
-          SLOT(setDialogParameterNames(FqFitAddWorkspaceDialog *, const std::string &)));
-  connect(dialog.get(), SIGNAL(parameterTypeChanged(FqFitAddWorkspaceDialog *, const std::string &)), this,
-          SLOT(dialogParameterTypeUpdated(FqFitAddWorkspaceDialog *, const std::string &)));
-  return dialog;
-}
-
 void FqFitDataPresenter::addTableEntry(FitDomainIndex row) {
   const auto &name = m_model->getWorkspace(row)->getName();
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
@@ -197,8 +197,9 @@ boost::optional<std::vector<std::size_t>> getParameterSpectrum(const FqFitParame
 
 namespace MantidQt::CustomInterfaces::IDA {
 
-FqFitDataPresenter::FqFitDataPresenter(IIndirectFitDataModel *model, IIndirectFitDataView *view)
-    : IndirectFitDataPresenter(model, view), m_activeParameterType("Width"), m_activeWorkspaceID(WorkspaceID{0}),
+FqFitDataPresenter::FqFitDataPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitDataModel *model,
+                                       IIndirectFitDataView *view)
+    : IndirectFitDataPresenter(tab, model, view), m_activeParameterType("Width"), m_activeWorkspaceID(WorkspaceID{0}),
       m_adsInstance(Mantid::API::AnalysisDataService::Instance()) {
   connect(this, SIGNAL(requestedAddWorkspaceDialog()), this, SLOT(updateActiveWorkspaceID()));
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
@@ -50,7 +50,6 @@ protected:
   void addTableEntry(FitDomainIndex row) override;
 
 private:
-  std::unique_ptr<IAddWorkspaceDialog> getAddWorkspaceDialog(QWidget *parent) const override;
   void updateParameterOptions(FqFitAddWorkspaceDialog *dialog, const FqFitParameters &parameters);
   void updateParameterTypes(FqFitAddWorkspaceDialog *dialog, FqFitParameters &parameters);
   std::vector<std::string> getParameterTypes(FqFitParameters &parameters) const;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
@@ -27,7 +27,13 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-class MANTIDQT_INELASTIC_DLL FqFitDataPresenter : public IndirectFitDataPresenter {
+class MANTIDQT_INELASTIC_DLL IFqFitDataPresenter {
+public:
+  virtual void handleWorkspaceChanged(FqFitAddWorkspaceDialog *dialog, const std::string &workspace) = 0;
+  virtual void handleParameterTypeChanged(FqFitAddWorkspaceDialog *dialog, const std::string &type) = 0;
+};
+
+class MANTIDQT_INELASTIC_DLL FqFitDataPresenter : public IndirectFitDataPresenter, public IFqFitDataPresenter {
   Q_OBJECT
 public:
   FqFitDataPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitDataModel *model, IIndirectFitDataView *view);
@@ -36,9 +42,10 @@ public:
   void setActiveWidth(std::size_t widthIndex, WorkspaceID dataIndex, bool single = true) override;
   void setActiveEISF(std::size_t eisfIndex, WorkspaceID dataIndex, bool single = true) override;
 
+  void handleWorkspaceChanged(FqFitAddWorkspaceDialog *dialog, const std::string &workspace) override;
+  void handleParameterTypeChanged(FqFitAddWorkspaceDialog *dialog, const std::string &type) override;
+
 private slots:
-  void dialogParameterTypeUpdated(FqFitAddWorkspaceDialog *dialog, const std::string &type);
-  void setDialogParameterNames(FqFitAddWorkspaceDialog *dialog, const std::string &workspace);
   void setActiveParameterType(const std::string &type);
   void updateActiveWorkspaceID();
   void updateActiveWorkspaceID(WorkspaceID index);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
@@ -11,9 +11,6 @@
 #include "FunctionBrowser/SingleFunctionTemplateBrowser.h"
 #include "IndirectFitDataPresenter.h"
 
-#include <QComboBox>
-#include <QSpacerItem>
-
 namespace {
 struct FqFitParameters {
   std::vector<std::string> widths;
@@ -35,7 +32,7 @@ public:
 };
 
 class MANTIDQT_INELASTIC_DLL FqFitDataPresenter : public IndirectFitDataPresenter, public IFqFitDataPresenter {
-  Q_OBJECT
+
 public:
   FqFitDataPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitDataModel *model, IIndirectFitDataView *view);
   bool addWorkspaceFromDialog(IAddWorkspaceDialog const *dialog) override;
@@ -47,17 +44,12 @@ public:
   void handleWorkspaceChanged(FqFitAddWorkspaceDialog *dialog, const std::string &workspace) override;
   void handleParameterTypeChanged(FqFitAddWorkspaceDialog *dialog, const std::string &type) override;
 
-private slots:
-  void setActiveParameterType(const std::string &type);
-  void updateActiveWorkspaceID(WorkspaceID index);
-
-signals:
-  void spectrumChanged(WorkspaceIndex);
-
 protected:
   void addTableEntry(FitDomainIndex row) override;
 
 private:
+  void setActiveParameterType(const std::string &type);
+  void updateActiveWorkspaceID(WorkspaceID index);
   void updateParameterOptions(FqFitAddWorkspaceDialog *dialog, const FqFitParameters &parameters);
   void updateParameterTypes(FqFitAddWorkspaceDialog *dialog, FqFitParameters &parameters);
   std::vector<std::string> getParameterTypes(FqFitParameters &parameters) const;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
@@ -30,7 +30,7 @@ namespace IDA {
 class MANTIDQT_INELASTIC_DLL FqFitDataPresenter : public IndirectFitDataPresenter {
   Q_OBJECT
 public:
-  FqFitDataPresenter(IIndirectFitDataModel *model, IIndirectFitDataView *view);
+  FqFitDataPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitDataModel *model, IIndirectFitDataView *view);
   bool addWorkspaceFromDialog(IAddWorkspaceDialog const *dialog) override;
   void addWorkspace(const std::string &workspaceName, const std::string &paramType, const int &spectrum_index) override;
   void setActiveWidth(std::size_t widthIndex, WorkspaceID dataIndex, bool single = true) override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
@@ -29,6 +29,7 @@ namespace IDA {
 
 class MANTIDQT_INELASTIC_DLL IFqFitDataPresenter {
 public:
+  virtual void handleAddClicked() = 0;
   virtual void handleWorkspaceChanged(FqFitAddWorkspaceDialog *dialog, const std::string &workspace) = 0;
   virtual void handleParameterTypeChanged(FqFitAddWorkspaceDialog *dialog, const std::string &type) = 0;
 };
@@ -42,12 +43,12 @@ public:
   void setActiveWidth(std::size_t widthIndex, WorkspaceID dataIndex, bool single = true) override;
   void setActiveEISF(std::size_t eisfIndex, WorkspaceID dataIndex, bool single = true) override;
 
+  void handleAddClicked() override;
   void handleWorkspaceChanged(FqFitAddWorkspaceDialog *dialog, const std::string &workspace) override;
   void handleParameterTypeChanged(FqFitAddWorkspaceDialog *dialog, const std::string &type) override;
 
 private slots:
   void setActiveParameterType(const std::string &type);
-  void updateActiveWorkspaceID();
   void updateActiveWorkspaceID(WorkspaceID index);
 
 signals:

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "FqFitDataView.h"
+#include "FqFitAddWorkspaceDialog.h"
 
 #include <QComboBox>
 #include <QHeaderView>
@@ -30,6 +31,18 @@ FqFitDataView::FqFitDataView(QWidget *parent) : FqFitDataView(FqFitHeaders(), pa
 FqFitDataView::FqFitDataView(const QStringList &headers, QWidget *parent) : IndirectFitDataView(headers, parent) {
   auto header = m_uiForm->tbFitData->horizontalHeader();
   header->setSectionResizeMode(1, QHeaderView::Stretch);
+}
+
+IAddWorkspaceDialog *FqFitDataView::getAddWorkspaceDialog() {
+  m_addWorkspaceDialog = new FqFitAddWorkspaceDialog(parentWidget());
+
+  connect(m_addWorkspaceDialog, SIGNAL(addData()), this, SLOT(notifyAddData()));
+  connect(m_addWorkspaceDialog, SIGNAL(workspaceChanged(FqFitAddWorkspaceDialog *, const std::string &)), this,
+          SLOT(setDialogParameterNames(FqFitAddWorkspaceDialog *, const std::string &)));
+  connect(m_addWorkspaceDialog, SIGNAL(parameterTypeChanged(FqFitAddWorkspaceDialog *, const std::string &)), this,
+          SLOT(dialogParameterTypeUpdated(FqFitAddWorkspaceDialog *, const std::string &)));
+
+  return m_addWorkspaceDialog;
 }
 
 void FqFitDataView::addTableEntry(size_t row, FitDataRow newRow) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "FqFitDataView.h"
 #include "FqFitAddWorkspaceDialog.h"
+#include "FqFitDataPresenter.h"
 
 #include <QComboBox>
 #include <QHeaderView>
@@ -38,11 +39,23 @@ IAddWorkspaceDialog *FqFitDataView::getAddWorkspaceDialog() {
 
   connect(m_addWorkspaceDialog, SIGNAL(addData()), this, SLOT(notifyAddData()));
   connect(m_addWorkspaceDialog, SIGNAL(workspaceChanged(FqFitAddWorkspaceDialog *, const std::string &)), this,
-          SLOT(setDialogParameterNames(FqFitAddWorkspaceDialog *, const std::string &)));
+          SLOT(notifyWorkspaceChanged(FqFitAddWorkspaceDialog *, const std::string &)));
   connect(m_addWorkspaceDialog, SIGNAL(parameterTypeChanged(FqFitAddWorkspaceDialog *, const std::string &)), this,
-          SLOT(dialogParameterTypeUpdated(FqFitAddWorkspaceDialog *, const std::string &)));
+          SLOT(notifyParameterTypeChanged(FqFitAddWorkspaceDialog *, const std::string &)));
 
   return m_addWorkspaceDialog;
+}
+
+void FqFitDataView::notifyWorkspaceChanged(FqFitAddWorkspaceDialog *dialog, const std::string &workspaceName) {
+  if (auto presenter = dynamic_cast<FqFitDataPresenter *>(m_presenter)) {
+    presenter->handleWorkspaceChanged(dialog, workspaceName);
+  }
+}
+
+void FqFitDataView::notifyParameterTypeChanged(FqFitAddWorkspaceDialog *dialog, const std::string &type) {
+  if (auto presenter = dynamic_cast<FqFitDataPresenter *>(m_presenter)) {
+    presenter->handleParameterTypeChanged(dynamic_cast<FqFitAddWorkspaceDialog *>(m_addWorkspaceDialog), type);
+  }
 }
 
 void FqFitDataView::addTableEntry(size_t row, FitDataRow newRow) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.cpp
@@ -27,7 +27,9 @@ QStringList FqFitHeaders() {
 
 namespace MantidQt::CustomInterfaces::IDA {
 
-FqFitDataView::FqFitDataView(QWidget *parent) : FqFitDataView(FqFitHeaders(), parent) {}
+FqFitDataView::FqFitDataView(QWidget *parent) : FqFitDataView(FqFitHeaders(), parent) {
+  connect(m_uiForm->pbAdd, SIGNAL(clicked()), this, SLOT(notifyAddClicked()));
+}
 
 FqFitDataView::FqFitDataView(const QStringList &headers, QWidget *parent) : IndirectFitDataView(headers, parent) {
   auto header = m_uiForm->tbFitData->horizontalHeader();
@@ -44,6 +46,12 @@ IAddWorkspaceDialog *FqFitDataView::getAddWorkspaceDialog() {
           SLOT(notifyParameterTypeChanged(FqFitAddWorkspaceDialog *, const std::string &)));
 
   return m_addWorkspaceDialog;
+}
+
+void FqFitDataView::notifyAddClicked() {
+  if (auto presenter = dynamic_cast<FqFitDataPresenter *>(m_presenter)) {
+    presenter->handleAddClicked();
+  }
 }
 
 void FqFitDataView::notifyWorkspaceChanged(FqFitAddWorkspaceDialog *dialog, const std::string &workspaceName) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.cpp
@@ -62,7 +62,7 @@ void FqFitDataView::notifyWorkspaceChanged(FqFitAddWorkspaceDialog *dialog, cons
 
 void FqFitDataView::notifyParameterTypeChanged(FqFitAddWorkspaceDialog *dialog, const std::string &type) {
   if (auto presenter = dynamic_cast<FqFitDataPresenter *>(m_presenter)) {
-    presenter->handleParameterTypeChanged(dynamic_cast<FqFitAddWorkspaceDialog *>(m_addWorkspaceDialog), type);
+    presenter->handleParameterTypeChanged(dialog, type);
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.h
@@ -15,6 +15,9 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
+class IAddWorkspaceDialog;
+class FqFitAddWorkspaceDialog;
+
 /**
 Presenter for a table of convolution fitting data.
 */
@@ -26,6 +29,10 @@ public:
 
 protected:
   FqFitDataView(const QStringList &headers, QWidget *parent = nullptr);
+  IAddWorkspaceDialog *getAddWorkspaceDialog() override;
+
+private:
+  FqFitAddWorkspaceDialog *m_addWorkspaceDialog;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.h
@@ -32,6 +32,7 @@ protected:
   IAddWorkspaceDialog *getAddWorkspaceDialog() override;
 
 private slots:
+  void notifyAddClicked();
   void notifyWorkspaceChanged(FqFitAddWorkspaceDialog *dialog, const std::string &workspaceName);
   void notifyParameterTypeChanged(FqFitAddWorkspaceDialog *dialog, const std::string &type);
 };

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.h
@@ -30,9 +30,6 @@ public:
 protected:
   FqFitDataView(const QStringList &headers, QWidget *parent = nullptr);
   IAddWorkspaceDialog *getAddWorkspaceDialog() override;
-
-private:
-  FqFitAddWorkspaceDialog *m_addWorkspaceDialog;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataView.h
@@ -30,6 +30,10 @@ public:
 protected:
   FqFitDataView(const QStringList &headers, QWidget *parent = nullptr);
   IAddWorkspaceDialog *getAddWorkspaceDialog() override;
+
+private slots:
+  void notifyWorkspaceChanged(FqFitAddWorkspaceDialog *dialog, const std::string &workspaceName);
+  void notifyParameterTypeChanged(FqFitAddWorkspaceDialog *dialog, const std::string &type);
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
@@ -54,8 +54,6 @@ public:
   virtual void setResolutionWSSuffices(const QStringList &suffices) = 0;
   virtual void setResolutionFBSuffices(const QStringList &suffices) = 0;
 
-  virtual void showAddWorkspaceDialog() = 0;
-
 public slots:
   virtual void displayWarning(std::string const &warning) = 0;
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
@@ -38,7 +38,7 @@ public:
   virtual UserInputValidator &validate(UserInputValidator &validator) = 0;
   virtual void addTableEntry(size_t row, FitDataRow newRow) = 0;
   virtual void updateNumCellEntry(double numEntry, size_t row, size_t column) = 0;
-  virtual int getColumnIndexFromName(QString ColName) = 0;
+  virtual int getColumnIndexFromName(std::string const &ColName) = 0;
   virtual void clearTable() = 0;
   virtual QString getText(int row, int column) const = 0;
   virtual QModelIndexList getSelectedIndexes() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
@@ -10,8 +10,6 @@
 #include "MantidQtWidgets/Common/IndexTypes.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 
-#include <QObject>
-#include <QTabWidget>
 #include <QTableWidget>
 
 namespace MantidQt {
@@ -30,13 +28,9 @@ struct FitDataRow {
   std::string parameter;
 };
 
-class MANTIDQT_INELASTIC_DLL IIndirectFitDataView : public QTabWidget {
-  Q_OBJECT
+class MANTIDQT_INELASTIC_DLL IIndirectFitDataView {
 
 public:
-  IIndirectFitDataView(QWidget *parent = nullptr) : QTabWidget(parent){};
-  virtual ~IIndirectFitDataView() = default;
-
   virtual void subscribePresenter(IIndirectFitDataPresenter *presenter) = 0;
 
   virtual QTableWidget *getDataTable() const = 0;
@@ -54,11 +48,7 @@ public:
   virtual void setResolutionWSSuffices(const QStringList &suffices) = 0;
   virtual void setResolutionFBSuffices(const QStringList &suffices) = 0;
 
-public slots:
   virtual void displayWarning(std::string const &warning) = 0;
-
-signals:
-  void addClicked();
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
@@ -18,6 +18,8 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
+class IIndirectFitDataPresenter;
+
 struct FitDataRow {
   std::string name;
   std::string exclude;
@@ -35,6 +37,8 @@ public:
   IIndirectFitDataView(QWidget *parent = nullptr) : QTabWidget(parent){};
   virtual ~IIndirectFitDataView() = default;
 
+  virtual void subscribePresenter(IIndirectFitDataPresenter *presenter) = 0;
+
   virtual QTableWidget *getDataTable() const = 0;
 
   virtual UserInputValidator &validate(UserInputValidator &validator) = 0;
@@ -44,6 +48,13 @@ public:
   virtual void clearTable() = 0;
   virtual QString getText(int row, int column) const = 0;
   virtual QModelIndexList getSelectedIndexes() const = 0;
+
+  virtual void setSampleWSSuffices(const QStringList &suffices) = 0;
+  virtual void setSampleFBSuffices(const QStringList &suffices) = 0;
+  virtual void setResolutionWSSuffices(const QStringList &suffices) = 0;
+  virtual void setResolutionFBSuffices(const QStringList &suffices) = 0;
+
+  virtual void showAddWorkspaceDialog() = 0;
 
 public slots:
   virtual void displayWarning(std::string const &warning) = 0;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
@@ -65,8 +65,6 @@ signals:
   void addClicked();
   void removeClicked();
   void unifyClicked();
-  void startXChanged(double);
-  void endXChanged(double);
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
@@ -58,11 +58,7 @@ public slots:
   virtual void displayWarning(std::string const &warning) = 0;
 
 signals:
-  void resolutionLoaded(QString const & /*_t1*/);
-  void cellChanged(int, int);
   void addClicked();
-  void removeClicked();
-  void unifyClicked();
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
@@ -7,8 +7,8 @@
 #include "IndirectDataAnalysisTab.h"
 
 #include "Common/SettingsHelper.h"
-#include "IndirectFitPlotView.h"
 #include "FitTabConstants.h"
+#include "IndirectFitPlotView.h"
 
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/MultiDomainFunction.h"

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
@@ -85,10 +85,7 @@ void IndirectDataAnalysisTab::connectDataPresenter() {
           SLOT(tableStartXChanged(double, WorkspaceID, WorkspaceIndex)));
   connect(m_dataPresenter.get(), SIGNAL(endXChanged(double, WorkspaceID, WorkspaceIndex)), this,
           SLOT(tableEndXChanged(double, WorkspaceID, WorkspaceIndex)));
-  connect(m_dataPresenter.get(), SIGNAL(startXChanged(double)), this, SLOT(handleStartXChanged(double)));
-  connect(m_dataPresenter.get(), SIGNAL(endXChanged(double)), this, SLOT(handleEndXChanged(double)));
 
-  connect(m_dataPresenter.get(), SIGNAL(singleResolutionLoaded()), this, SLOT(respondToSingleResolutionLoaded()));
   connect(m_dataPresenter.get(), SIGNAL(dataChanged()), this, SLOT(respondToDataChanged()));
   connect(m_dataPresenter.get(), SIGNAL(dataRemoved()), this, SLOT(respondToDataRemoved()));
 }
@@ -600,12 +597,6 @@ void IndirectDataAnalysisTab::updateResultOptions() {
   m_outOptionsPresenter->setPlotEnabled(isFit);
   m_outOptionsPresenter->setEditResultEnabled(isFit);
   m_outOptionsPresenter->setSaveEnabled(isFit);
-}
-
-void IndirectDataAnalysisTab::respondToSingleResolutionLoaded() {
-  setModelFitFunction();
-  m_plotPresenter->updatePlots();
-  m_plotPresenter->updateGuessAvailability();
 }
 
 void IndirectDataAnalysisTab::respondToDataChanged() {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
@@ -5,9 +5,11 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectDataAnalysisTab.h"
-#include "Common/SettingsHelper.h"
 
+#include "Common/SettingsHelper.h"
+#include "IndirectFitPlotView.h"
 #include "FitTabConstants.h"
+
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/MultiDomainFunction.h"
 #include "MantidAPI/TextAxis.h"

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
@@ -85,9 +85,6 @@ void IndirectDataAnalysisTab::connectDataPresenter() {
           SLOT(tableStartXChanged(double, WorkspaceID, WorkspaceIndex)));
   connect(m_dataPresenter.get(), SIGNAL(endXChanged(double, WorkspaceID, WorkspaceIndex)), this,
           SLOT(tableEndXChanged(double, WorkspaceID, WorkspaceIndex)));
-
-  connect(m_dataPresenter.get(), SIGNAL(dataChanged()), this, SLOT(respondToDataChanged()));
-  connect(m_dataPresenter.get(), SIGNAL(dataRemoved()), this, SLOT(respondToDataRemoved()));
 }
 
 void IndirectDataAnalysisTab::connectFitPropertyBrowser() {
@@ -599,7 +596,7 @@ void IndirectDataAnalysisTab::updateResultOptions() {
   m_outOptionsPresenter->setSaveEnabled(isFit);
 }
 
-void IndirectDataAnalysisTab::respondToDataChanged() {
+void IndirectDataAnalysisTab::handleDataChanged() {
   updateDataReferences();
   m_fittingModel->removeFittingData();
   m_plotPresenter->updateAvailableSpectra();
@@ -619,7 +616,7 @@ void IndirectDataAnalysisTab::handleDataAdded(IAddWorkspaceDialog const *dialog)
   updateParameterEstimationData();
 }
 
-void IndirectDataAnalysisTab::respondToDataRemoved() {
+void IndirectDataAnalysisTab::handleDataRemoved() {
   m_fittingModel->removeDefaultParameters();
   updateDataReferences();
   auto displayNames = m_dataPresenter->createDisplayNames();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
@@ -90,8 +90,6 @@ void IndirectDataAnalysisTab::connectDataPresenter() {
 
   connect(m_dataPresenter.get(), SIGNAL(singleResolutionLoaded()), this, SLOT(respondToSingleResolutionLoaded()));
   connect(m_dataPresenter.get(), SIGNAL(dataChanged()), this, SLOT(respondToDataChanged()));
-  connect(m_dataPresenter.get(), SIGNAL(dataAdded(IAddWorkspaceDialog const *)), this,
-          SLOT(respondToDataAdded(IAddWorkspaceDialog const *)));
   connect(m_dataPresenter.get(), SIGNAL(dataRemoved()), this, SLOT(respondToDataRemoved()));
 }
 
@@ -620,7 +618,7 @@ void IndirectDataAnalysisTab::respondToDataChanged() {
   updateResultOptions();
 }
 
-void IndirectDataAnalysisTab::respondToDataAdded(IAddWorkspaceDialog const *dialog) {
+void IndirectDataAnalysisTab::handleDataAdded(IAddWorkspaceDialog const *dialog) {
   if (m_dataPresenter->addWorkspaceFromDialog(dialog)) {
     m_fittingModel->addDefaultParameters();
   }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
@@ -76,15 +76,7 @@ void IndirectDataAnalysisTab::setup() {
   connect(m_uiForm->pbRun, SIGNAL(clicked()), this, SLOT(runTab()));
   updateResultOptions();
 
-  connectDataPresenter();
   connectFitPropertyBrowser();
-}
-
-void IndirectDataAnalysisTab::connectDataPresenter() {
-  connect(m_dataPresenter.get(), SIGNAL(startXChanged(double, WorkspaceID, WorkspaceIndex)), this,
-          SLOT(tableStartXChanged(double, WorkspaceID, WorkspaceIndex)));
-  connect(m_dataPresenter.get(), SIGNAL(endXChanged(double, WorkspaceID, WorkspaceIndex)), this,
-          SLOT(tableEndXChanged(double, WorkspaceID, WorkspaceIndex)));
 }
 
 void IndirectDataAnalysisTab::connectFitPropertyBrowser() {
@@ -192,14 +184,15 @@ void IndirectDataAnalysisTab::setModelEndX(double endX) {
   m_dataPresenter->setStartX(endX, dataIndex, getSelectedSpectrum());
 }
 
-void IndirectDataAnalysisTab::tableStartXChanged(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum) {
+void IndirectDataAnalysisTab::handleTableStartXChanged(double startX, WorkspaceID workspaceID,
+                                                       WorkspaceIndex spectrum) {
   if (isRangeCurrentlySelected(workspaceID, spectrum)) {
     m_plotPresenter->setStartX(startX);
     m_plotPresenter->updateGuess();
   }
 }
 
-void IndirectDataAnalysisTab::tableEndXChanged(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum) {
+void IndirectDataAnalysisTab::handleTableEndXChanged(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum) {
   if (isRangeCurrentlySelected(workspaceID, spectrum)) {
     m_plotPresenter->setEndX(endX);
     m_plotPresenter->updateGuess();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
@@ -72,7 +72,7 @@ public:
 
   template <typename FitDataPresenter> void setUpFitDataPresenter() {
     m_dataPresenter =
-        std::make_unique<FitDataPresenter>(m_fittingModel->getFitDataModel(), m_uiForm->dockArea->m_fitDataView);
+        std::make_unique<FitDataPresenter>(this, m_fittingModel->getFitDataModel(), m_uiForm->dockArea->m_fitDataView);
   }
 
   void setupOutputOptionsPresenter(bool const editResults = false);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
@@ -39,6 +39,8 @@ public:
   virtual void handleDataAdded(IAddWorkspaceDialog const *dialog) = 0;
   virtual void handleDataChanged() = 0;
   virtual void handleDataRemoved() = 0;
+  virtual void handleTableStartXChanged(double startX, WorkspaceID workspaceID, WorkspaceIndex workspaceIndex) = 0;
+  virtual void handleTableEndXChanged(double endX, WorkspaceID workspaceID, WorkspaceIndex workspaceIndex) = 0;
 
   // Used by FitPlotPresenter
   virtual void handleSingleFitClicked(WorkspaceID workspaceID, WorkspaceIndex workspaceIndex) = 0;
@@ -99,6 +101,8 @@ public:
   void handleDataAdded(IAddWorkspaceDialog const *dialog) override;
   void handleDataChanged() override;
   void handleDataRemoved() override;
+  void handleTableStartXChanged(double startX, WorkspaceID workspaceID, WorkspaceIndex workspaceIndex) override;
+  void handleTableEndXChanged(double endX, WorkspaceID workspaceID, WorkspaceIndex workspaceIndex) override;
 
   void handleSingleFitClicked(WorkspaceID workspaceID, WorkspaceIndex workspaceIndex) override;
   void handlePlotSpectrumChanged() override;
@@ -142,7 +146,6 @@ private:
   void setup() override;
   bool validate() override;
   void connectFitPropertyBrowser();
-  void connectDataPresenter();
   void plotSelectedSpectra(std::vector<SpectrumToPlot> const &spectra);
   void plotSpectrum(std::string const &workspaceName, std::size_t const &index);
   std::string getOutputBasename() const;
@@ -165,8 +168,6 @@ protected slots:
   void setModelFitFunction();
   void setModelStartX(double startX);
   void setModelEndX(double endX);
-  void tableStartXChanged(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum);
-  void tableEndXChanged(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum);
   void updateFitOutput(bool error);
   void updateSingleFitOutput(bool error);
   void fitAlgorithmComplete(bool error);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
@@ -37,6 +37,8 @@ class MANTIDQT_INELASTIC_DLL IIndirectDataAnalysisTab {
 public:
   // Used by FitDataPresenter
   virtual void handleDataAdded(IAddWorkspaceDialog const *dialog) = 0;
+  virtual void handleDataChanged() = 0;
+  virtual void handleDataRemoved() = 0;
 
   // Used by FitPlotPresenter
   virtual void handleSingleFitClicked(WorkspaceID workspaceID, WorkspaceIndex workspaceIndex) = 0;
@@ -95,6 +97,8 @@ public:
   void setFileExtensionsByName(bool filter);
 
   void handleDataAdded(IAddWorkspaceDialog const *dialog) override;
+  void handleDataChanged() override;
+  void handleDataRemoved() override;
 
   void handleSingleFitClicked(WorkspaceID workspaceID, WorkspaceIndex workspaceIndex) override;
   void handlePlotSpectrumChanged() override;
@@ -177,10 +181,6 @@ protected slots:
   void updateDataReferences();
   void updateResultOptions();
   void respondToFunctionChanged();
-
-private slots:
-  void respondToDataChanged();
-  void respondToDataRemoved();
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
@@ -35,6 +35,9 @@ namespace IDA {
 
 class MANTIDQT_INELASTIC_DLL IIndirectDataAnalysisTab {
 public:
+  // Used by FitDataPresenter
+  virtual void handleDataAdded(IAddWorkspaceDialog const *dialog) = 0;
+
   // Used by FitPlotPresenter
   virtual void handleSingleFitClicked(WorkspaceID workspaceID, WorkspaceIndex workspaceIndex) = 0;
   virtual void handleStartXChanged(double startX) = 0;
@@ -90,6 +93,8 @@ public:
   std::string getTabName() const noexcept { return m_tabName; }
   bool hasResolution() const noexcept { return m_hasResolution; }
   void setFileExtensionsByName(bool filter);
+
+  void handleDataAdded(IAddWorkspaceDialog const *dialog) override;
 
   void handleSingleFitClicked(WorkspaceID workspaceID, WorkspaceIndex workspaceIndex) override;
   void handlePlotSpectrumChanged() override;
@@ -176,7 +181,6 @@ protected slots:
 private slots:
   void respondToSingleResolutionLoaded();
   void respondToDataChanged();
-  void respondToDataAdded(IAddWorkspaceDialog const *dialog);
   void respondToDataRemoved();
 };
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
@@ -179,7 +179,6 @@ protected slots:
   void respondToFunctionChanged();
 
 private slots:
-  void respondToSingleResolutionLoaded();
   void respondToDataChanged();
   void respondToDataRemoved();
 };

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDockWidgetArea.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDockWidgetArea.cpp
@@ -5,6 +5,8 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectDockWidgetArea.h"
+#include "IndirectFitDataView.h"
+#include "IndirectFitPlotView.h"
 
 namespace MantidQt::CustomInterfaces::IDA {
 
@@ -33,7 +35,7 @@ IndirectDockWidgetArea::IndirectDockWidgetArea(QWidget *parent) : QMainWindow(pa
   resizeDocks({m_fitPropertyBrowser, plotViewArea}, {20, 20}, Qt::Horizontal);
 }
 
-void IndirectDockWidgetArea::setFitDataView(IIndirectFitDataView *fitDataView) {
+void IndirectDockWidgetArea::setFitDataView(IndirectFitDataView *fitDataView) {
   QDockWidget *dataViewArea = new QDockWidget();
   dataViewArea->setWindowTitle("Data Input");
   m_fitDataView = fitDataView;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDockWidgetArea.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDockWidgetArea.h
@@ -5,8 +5,6 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
-#include "IIndirectFitDataView.h"
-#include "IndirectFitPlotView.h"
 #include "IndirectFitPropertyBrowser.h"
 
 #include <QMainWindow>
@@ -16,15 +14,19 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
+
+class IndirectFitDataView;
+class IndirectFitPlotView;
+
 class MANTIDQT_INELASTIC_DLL IndirectDockWidgetArea : public QMainWindow {
   Q_OBJECT
 
 public:
   IndirectDockWidgetArea(QWidget *parent = nullptr);
   virtual ~IndirectDockWidgetArea(){};
-  void setFitDataView(IIndirectFitDataView *fitDataView);
+  void setFitDataView(IndirectFitDataView *fitDataView);
   IndirectFitPropertyBrowser *m_fitPropertyBrowser;
-  IIndirectFitDataView *m_fitDataView;
+  IndirectFitDataView *m_fitDataView;
   IndirectFitPlotView *m_fitPlotView;
 };
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
@@ -35,12 +35,6 @@ IndirectFitDataPresenter::IndirectFitDataPresenter(IIndirectDataAnalysisTab *tab
   observeReplace(true);
 
   connect(m_view, SIGNAL(addClicked()), this, SIGNAL(requestedAddWorkspaceDialog()));
-
-  connect(m_view, SIGNAL(removeClicked()), this, SLOT(removeSelectedData()));
-
-  connect(m_view, SIGNAL(unifyClicked()), this, SLOT(unifyRangeToSelectedData()));
-
-  connect(m_view, SIGNAL(cellChanged(int, int)), this, SLOT(handleCellChanged(int, int)));
 }
 
 IndirectFitDataPresenter::~IndirectFitDataPresenter() { observeReplace(false); }
@@ -243,7 +237,7 @@ std::map<int, QModelIndex> IndirectFitDataPresenter::getUniqueIndices(const QMod
 /**
  * Removes selected rows, with no repeats
  */
-void IndirectFitDataPresenter::removeSelectedData() {
+void IndirectFitDataPresenter::handleRemoveClicked() {
   auto selectedIndices = m_view->getSelectedIndexes();
   if (selectedIndices.size() == 0) {
     // check that there are selected indexes.
@@ -258,7 +252,7 @@ void IndirectFitDataPresenter::removeSelectedData() {
   m_tab->handleDataChanged();
 }
 
-void IndirectFitDataPresenter::unifyRangeToSelectedData() {
+void IndirectFitDataPresenter::handleUnifyClicked() {
   auto selectedIndices = m_view->getSelectedIndexes();
   if (selectedIndices.size() == 0) {
     // check that there are selected indexes.

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
@@ -42,8 +42,6 @@ IndirectFitDataPresenter::IndirectFitDataPresenter(IIndirectDataAnalysisTab *tab
   connect(m_view, SIGNAL(unifyClicked()), this, SLOT(unifyRangeToSelectedData()));
 
   connect(m_view, SIGNAL(cellChanged(int, int)), this, SLOT(handleCellChanged(int, int)));
-  connect(m_view, SIGNAL(startXChanged(double)), this, SIGNAL(startXChanged(double)));
-  connect(m_view, SIGNAL(endXChanged(double)), this, SIGNAL(endXChanged(double)));
 }
 
 IndirectFitDataPresenter::~IndirectFitDataPresenter() { observeReplace(false); }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectFitDataPresenter.h"
+#include "IndirectDataAnalysisTab.h"
 
 #include <map>
 #include <utility>
@@ -122,7 +123,7 @@ void IndirectFitDataPresenter::showAddWorkspaceDialog() { m_view->showAddWorkspa
 
 void IndirectFitDataPresenter::handleAddData(IAddWorkspaceDialog const *dialog) {
   try {
-    emit dataAdded(dialog);
+    m_tab->handleDataAdded(dialog);
     updateTableFromModel();
     emit dataChanged();
   } catch (const std::runtime_error &ex) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
@@ -12,20 +12,6 @@
 
 #include "Common/IndirectAddWorkspaceDialog.h"
 
-namespace {
-
-class ScopedFalse {
-  bool &m_ref;
-  bool m_oldValue;
-
-public:
-  // this sets the input bool to false whilst this object is in scope and then
-  // resets it to its old value when this object drops out of scope.
-  explicit ScopedFalse(bool &variable) : m_ref(variable), m_oldValue(variable) { m_ref = false; }
-  ~ScopedFalse() { m_ref = m_oldValue; }
-};
-} // namespace
-
 namespace MantidQt::CustomInterfaces::IDA {
 
 IndirectFitDataPresenter::IndirectFitDataPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitDataModel *model,
@@ -121,7 +107,6 @@ void IndirectFitDataPresenter::handleAddData(IAddWorkspaceDialog const *dialog) 
 }
 
 void IndirectFitDataPresenter::updateTableFromModel() {
-  ScopedFalse _signalBlock(m_emitCellChanged);
   m_view->clearTable();
   for (auto domainIndex = FitDomainIndex{0}; domainIndex < getNumberOfDomains(); domainIndex++) {
     addTableEntry(domainIndex);
@@ -172,10 +157,6 @@ void IndirectFitDataPresenter::addTableEntry(FitDomainIndex row) {
 }
 
 void IndirectFitDataPresenter::handleCellChanged(int row, int column) {
-  if (!m_emitCellChanged) {
-    return;
-  }
-
   if (m_view->getColumnIndexFromName("StartX") == column) {
     setTableStartXAndEmit(m_view->getText(row, column).toDouble(), row, column);
   } else if (m_view->getColumnIndexFromName("EndX") == column) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
@@ -199,7 +199,7 @@ void IndirectFitDataPresenter::setTableStartXAndEmit(double X, int row, int colu
 
   m_model->setStartX(X, subIndices.first, subIndices.second);
   m_view->updateNumCellEntry(m_model->getFittingRange(row).first, row, column);
-  emit startXChanged(m_model->getFittingRange(row).first, subIndices.first, subIndices.second);
+  m_tab->handleTableStartXChanged(m_model->getFittingRange(row).first, subIndices.first, subIndices.second);
 }
 
 void IndirectFitDataPresenter::setTableEndXAndEmit(double X, int row, int column) {
@@ -207,21 +207,21 @@ void IndirectFitDataPresenter::setTableEndXAndEmit(double X, int row, int column
 
   m_model->setEndX(X, subIndices.first, subIndices.second);
   m_view->updateNumCellEntry(m_model->getFittingRange(row).second, row, column);
-  emit endXChanged(m_model->getFittingRange(row).second, subIndices.first, subIndices.second);
+  m_tab->handleTableEndXChanged(m_model->getFittingRange(row).second, subIndices.first, subIndices.second);
 }
 
 void IndirectFitDataPresenter::setModelStartXAndEmit(double startX, FitDomainIndex row) {
   auto subIndices = m_model->getSubIndices(row);
 
   m_model->setStartX(startX, subIndices.first, subIndices.second);
-  emit startXChanged(startX, subIndices.first, subIndices.second);
+  m_tab->handleTableStartXChanged(startX, subIndices.first, subIndices.second);
 }
 
 void IndirectFitDataPresenter::setModelEndXAndEmit(double endX, FitDomainIndex row) {
   auto subIndices = m_model->getSubIndices(row);
 
   m_model->setEndX(endX, subIndices.first, subIndices.second);
-  emit endXChanged(endX, subIndices.first, subIndices.second);
+  m_tab->handleTableEndXChanged(endX, subIndices.first, subIndices.second);
 }
 
 void IndirectFitDataPresenter::setModelExcludeAndEmit(const std::string &exclude, FitDomainIndex row) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
@@ -123,7 +123,7 @@ void IndirectFitDataPresenter::handleAddData(IAddWorkspaceDialog const *dialog) 
   try {
     m_tab->handleDataAdded(dialog);
     updateTableFromModel();
-    emit dataChanged();
+    m_tab->handleDataChanged();
   } catch (const std::runtime_error &ex) {
     displayWarning(ex.what());
   }
@@ -257,8 +257,8 @@ void IndirectFitDataPresenter::removeSelectedData() {
     m_model->removeDataByIndex(FitDomainIndex(item->second.row()));
   }
   updateTableFromModel();
-  emit dataRemoved();
-  emit dataChanged();
+  m_tab->handleDataRemoved();
+  m_tab->handleDataChanged();
 }
 
 void IndirectFitDataPresenter::unifyRangeToSelectedData() {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
@@ -35,7 +35,6 @@ IndirectFitDataPresenter::IndirectFitDataPresenter(IIndirectDataAnalysisTab *tab
   observeReplace(true);
 
   connect(m_view, SIGNAL(addClicked()), this, SIGNAL(requestedAddWorkspaceDialog()));
-  connect(m_view, SIGNAL(addClicked()), this, SLOT(showAddWorkspaceDialog()));
 
   connect(m_view, SIGNAL(removeClicked()), this, SLOT(removeSelectedData()));
 
@@ -116,8 +115,6 @@ std::vector<std::pair<std::string, size_t>> IndirectFitDataPresenter::getResolut
 UserInputValidator &IndirectFitDataPresenter::validate(UserInputValidator &validator) {
   return m_view->validate(validator);
 }
-
-void IndirectFitDataPresenter::showAddWorkspaceDialog() { m_view->showAddWorkspaceDialog(); }
 
 void IndirectFitDataPresenter::handleAddData(IAddWorkspaceDialog const *dialog) {
   try {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
@@ -19,8 +19,6 @@ IndirectFitDataPresenter::IndirectFitDataPresenter(IIndirectDataAnalysisTab *tab
     : m_tab(tab), m_model(model), m_view(view) {
   m_view->subscribePresenter(this);
   observeReplace(true);
-
-  connect(m_view, SIGNAL(addClicked()), this, SIGNAL(requestedAddWorkspaceDialog()));
 }
 
 IndirectFitDataPresenter::~IndirectFitDataPresenter() { observeReplace(false); }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.cpp
@@ -27,8 +27,9 @@ public:
 
 namespace MantidQt::CustomInterfaces::IDA {
 
-IndirectFitDataPresenter::IndirectFitDataPresenter(IIndirectFitDataModel *model, IIndirectFitDataView *view)
-    : m_model(model), m_view(view) {
+IndirectFitDataPresenter::IndirectFitDataPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitDataModel *model,
+                                                   IIndirectFitDataView *view)
+    : m_tab(tab), m_model(model), m_view(view) {
   m_view->subscribePresenter(this);
   observeReplace(true);
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -28,6 +28,9 @@ class IIndirectDataAnalysisTab;
 class MANTIDQT_INELASTIC_DLL IIndirectFitDataPresenter {
 public:
   virtual void handleAddData(IAddWorkspaceDialog const *dialog) = 0;
+  virtual void handleRemoveClicked() = 0;
+  virtual void handleUnifyClicked() = 0;
+  virtual void handleCellChanged(int row, int column) = 0;
 };
 
 class MANTIDQT_INELASTIC_DLL IndirectFitDataPresenter : public QObject,
@@ -79,6 +82,9 @@ public:
   };
 
   void handleAddData(IAddWorkspaceDialog const *dialog) override;
+  void handleRemoveClicked() override;
+  void handleUnifyClicked() override;
+  void handleCellChanged(int row, int column) override;
 
 signals:
   void requestedAddWorkspaceDialog();
@@ -91,11 +97,6 @@ protected:
   IIndirectDataAnalysisTab *m_tab;
   IIndirectFitDataModel *m_model;
   IIndirectFitDataView *m_view;
-
-private slots:
-  void handleCellChanged(int row, int column);
-  void removeSelectedData();
-  void unifyRangeToSelectedData();
 
 private:
   void setModelStartXAndEmit(double startX, FitDomainIndex row);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -85,7 +85,6 @@ protected slots:
 
 signals:
   void singleResolutionLoaded();
-  void dataAdded(IAddWorkspaceDialog const *);
   void dataRemoved();
   void dataChanged();
   void startXChanged(double, WorkspaceID, WorkspaceIndex);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -105,7 +105,6 @@ private:
   void setTableEndXAndEmit(double X, int row, int column);
   void setModelExcludeAndEmit(const std::string &exclude, FitDomainIndex row);
   std::map<int, QModelIndex> getUniqueIndices(const QModelIndexList &selectedIndices);
-  bool m_emitCellChanged = true;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -23,6 +23,8 @@ namespace IDA {
 
 using namespace MantidWidgets;
 
+class IIndirectDataAnalysisTab;
+
 class MANTIDQT_INELASTIC_DLL IIndirectFitDataPresenter {
 public:
   virtual void handleAddData(IAddWorkspaceDialog const *dialog) = 0;
@@ -33,7 +35,7 @@ class MANTIDQT_INELASTIC_DLL IndirectFitDataPresenter : public QObject,
                                                         public IIndirectFitDataPresenter {
   Q_OBJECT
 public:
-  IndirectFitDataPresenter(IIndirectFitDataModel *model, IIndirectFitDataView *view);
+  IndirectFitDataPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitDataModel *model, IIndirectFitDataView *view);
   ~IndirectFitDataPresenter();
   std::vector<IndirectFitData> *getFittingData();
   virtual bool addWorkspaceFromDialog(IAddWorkspaceDialog const *dialog);
@@ -97,6 +99,7 @@ protected:
   void displayWarning(const std::string &warning);
   virtual void addTableEntry(FitDomainIndex row);
 
+  IIndirectDataAnalysisTab *m_tab;
   IIndirectFitDataModel *m_model;
   IIndirectFitDataView *m_view;
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -80,9 +80,6 @@ public:
 
   void handleAddData(IAddWorkspaceDialog const *dialog) override;
 
-protected slots:
-  void showAddWorkspaceDialog();
-
 signals:
   void requestedAddWorkspaceDialog();
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -23,7 +23,14 @@ namespace IDA {
 
 using namespace MantidWidgets;
 
-class MANTIDQT_INELASTIC_DLL IndirectFitDataPresenter : public QObject, public AnalysisDataServiceObserver {
+class MANTIDQT_INELASTIC_DLL IIndirectFitDataPresenter {
+public:
+  virtual void handleAddData(IAddWorkspaceDialog const *dialog) = 0;
+};
+
+class MANTIDQT_INELASTIC_DLL IndirectFitDataPresenter : public QObject,
+                                                        public AnalysisDataServiceObserver,
+                                                        public IIndirectFitDataPresenter {
   Q_OBJECT
 public:
   IndirectFitDataPresenter(IIndirectFitDataModel *model, IIndirectFitDataView *view);
@@ -42,10 +49,7 @@ public:
   void setEndX(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum);
 
   std::vector<std::pair<std::string, size_t>> getResolutionsForFit() const;
-  QStringList getSampleWSSuffices() const;
-  QStringList getSampleFBSuffices() const;
-  QStringList getResolutionWSSuffices() const;
-  QStringList getResolutionFBSuffices() const;
+
   void updateTableFromModel();
   WorkspaceID getNumberOfWorkspaces() const;
   size_t getNumberOfDomains() const;
@@ -72,10 +76,10 @@ public:
     UNUSED_ARG(single);
   };
 
+  void handleAddData(IAddWorkspaceDialog const *dialog) override;
+
 protected slots:
   void showAddWorkspaceDialog();
-
-  virtual void closeDialog();
 
 signals:
   void singleResolutionLoaded();
@@ -90,30 +94,23 @@ signals:
 
 protected:
   IIndirectFitDataView const *getView() const;
-  void addData(IAddWorkspaceDialog const *dialog);
   void displayWarning(const std::string &warning);
   virtual void addTableEntry(FitDomainIndex row);
-  QStringList m_wsSampleSuffixes;
-  QStringList m_fbSampleSuffixes;
-  QStringList m_wsResolutionSuffixes;
-  QStringList m_fbResolutionSuffixes;
+
   IIndirectFitDataModel *m_model;
   IIndirectFitDataView *m_view;
 
 private slots:
-  void addData();
   void handleCellChanged(int row, int column);
   void removeSelectedData();
   void unifyRangeToSelectedData();
 
 private:
-  virtual std::unique_ptr<IAddWorkspaceDialog> getAddWorkspaceDialog(QWidget *parent) const;
   void setModelStartXAndEmit(double startX, FitDomainIndex row);
   void setModelEndXAndEmit(double endX, FitDomainIndex row);
   void setTableStartXAndEmit(double X, int row, int column);
   void setTableEndXAndEmit(double X, int row, int column);
   void setModelExcludeAndEmit(const std::string &exclude, FitDomainIndex row);
-  std::unique_ptr<IAddWorkspaceDialog> m_addWorkspaceDialog;
   std::map<int, QModelIndex> getUniqueIndices(const QModelIndexList &selectedIndices);
   bool m_emitCellChanged = true;
 };

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -84,13 +84,10 @@ protected slots:
   void showAddWorkspaceDialog();
 
 signals:
-  void singleResolutionLoaded();
   void dataRemoved();
   void dataChanged();
   void startXChanged(double, WorkspaceID, WorkspaceIndex);
-  void startXChanged(double);
   void endXChanged(double, WorkspaceID, WorkspaceIndex);
-  void endXChanged(double);
   void requestedAddWorkspaceDialog();
 
 protected:

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -84,8 +84,6 @@ protected slots:
   void showAddWorkspaceDialog();
 
 signals:
-  void startXChanged(double, WorkspaceID, WorkspaceIndex);
-  void endXChanged(double, WorkspaceID, WorkspaceIndex);
   void requestedAddWorkspaceDialog();
 
 protected:

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -86,9 +86,6 @@ public:
   void handleUnifyClicked() override;
   void handleCellChanged(int row, int column) override;
 
-signals:
-  void requestedAddWorkspaceDialog();
-
 protected:
   IIndirectFitDataView const *getView() const;
   void displayWarning(const std::string &warning);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -84,8 +84,6 @@ protected slots:
   void showAddWorkspaceDialog();
 
 signals:
-  void dataRemoved();
-  void dataChanged();
   void startXChanged(double, WorkspaceID, WorkspaceIndex);
   void endXChanged(double, WorkspaceID, WorkspaceIndex);
   void requestedAddWorkspaceDialog();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -15,8 +15,6 @@
 #include "MantidAPI/AnalysisDataServiceObserver.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
-#include <QObject>
-
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
@@ -33,10 +31,8 @@ public:
   virtual void handleCellChanged(int row, int column) = 0;
 };
 
-class MANTIDQT_INELASTIC_DLL IndirectFitDataPresenter : public QObject,
-                                                        public AnalysisDataServiceObserver,
-                                                        public IIndirectFitDataPresenter {
-  Q_OBJECT
+class MANTIDQT_INELASTIC_DLL IndirectFitDataPresenter : public IIndirectFitDataPresenter,
+                                                        public AnalysisDataServiceObserver {
 public:
   IndirectFitDataPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitDataModel *model, IIndirectFitDataView *view);
   ~IndirectFitDataPresenter();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -97,7 +97,7 @@ namespace IDA {
 IndirectFitDataView::IndirectFitDataView(QWidget *parent) : IndirectFitDataView(defaultHeaders(), parent) {}
 
 IndirectFitDataView::IndirectFitDataView(const QStringList &headers, QWidget *parent)
-    : IIndirectFitDataView(parent), m_uiForm(new Ui::IndirectFitDataView) {
+    : QTabWidget(parent), m_uiForm(new Ui::IndirectFitDataView) {
   m_uiForm->setupUi(this);
 
   setHorizontalHeaders(headers);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -104,6 +104,7 @@ IndirectFitDataView::IndirectFitDataView(const QStringList &headers, QWidget *pa
 
   connect(m_uiForm->tbFitData, SIGNAL(cellChanged(int, int)), this, SIGNAL(cellChanged(int, int)));
   connect(m_uiForm->pbAdd, SIGNAL(clicked()), this, SIGNAL(addClicked()));
+  connect(m_uiForm->pbAdd, SIGNAL(clicked()), this, SLOT(showAddWorkspaceDialog()));
   connect(m_uiForm->pbRemove, SIGNAL(clicked()), this, SIGNAL(removeClicked()));
   connect(m_uiForm->pbUnify, SIGNAL(clicked()), this, SIGNAL(unifyClicked()));
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -102,11 +102,11 @@ IndirectFitDataView::IndirectFitDataView(const QStringList &headers, QWidget *pa
 
   setHorizontalHeaders(headers);
 
-  connect(m_uiForm->tbFitData, SIGNAL(cellChanged(int, int)), this, SIGNAL(cellChanged(int, int)));
-  connect(m_uiForm->pbAdd, SIGNAL(clicked()), this, SIGNAL(addClicked()));
   connect(m_uiForm->pbAdd, SIGNAL(clicked()), this, SLOT(showAddWorkspaceDialog()));
-  connect(m_uiForm->pbRemove, SIGNAL(clicked()), this, SIGNAL(removeClicked()));
-  connect(m_uiForm->pbUnify, SIGNAL(clicked()), this, SIGNAL(unifyClicked()));
+  connect(m_uiForm->pbAdd, SIGNAL(clicked()), this, SIGNAL(addClicked()));
+  connect(m_uiForm->pbRemove, SIGNAL(clicked()), this, SLOT(notifyRemoveClicked()));
+  connect(m_uiForm->pbUnify, SIGNAL(clicked()), this, SLOT(notifyUnifyClicked()));
+  connect(m_uiForm->tbFitData, SIGNAL(cellChanged(int, int)), this, SLOT(notifyCellChanged(int, int)));
 }
 
 void IndirectFitDataView::subscribePresenter(IIndirectFitDataPresenter *presenter) { m_presenter = presenter; }
@@ -211,6 +211,12 @@ IAddWorkspaceDialog *IndirectFitDataView::getAddWorkspaceDialog() {
 }
 
 void IndirectFitDataView::notifyAddData() { m_presenter->handleAddData(m_addWorkspaceDialog); }
+
+void IndirectFitDataView::notifyRemoveClicked() { m_presenter->handleRemoveClicked(); }
+
+void IndirectFitDataView::notifyUnifyClicked() { m_presenter->handleUnifyClicked(); }
+
+void IndirectFitDataView::notifyCellChanged(int row, int column) { m_presenter->handleCellChanged(row, column); }
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -7,7 +7,7 @@
 #include "IndirectFitDataView.h"
 #include "IndirectFitDataPresenter.h"
 
-#include "IndirectAddWorkspaceDialog.h"
+#include "Common/IndirectAddWorkspaceDialog.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 #include <QDoubleValidator>
 #include <QItemDelegate>

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -169,7 +169,9 @@ void IndirectFitDataView::updateNumCellEntry(double numEntry, size_t row, size_t
 
 bool IndirectFitDataView::isTableEmpty() const { return m_uiForm->tbFitData->rowCount() == 0; }
 
-int IndirectFitDataView::getColumnIndexFromName(QString ColName) { return m_HeaderLabels.indexOf(ColName); }
+int IndirectFitDataView::getColumnIndexFromName(std::string const &ColName) {
+  return m_HeaderLabels.indexOf(QString::fromStdString(ColName));
+}
 
 void IndirectFitDataView::clearTable() { m_uiForm->tbFitData->setRowCount(0); }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -5,6 +5,9 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectFitDataView.h"
+#include "IndirectFitDataPresenter.h"
+
+#include "IndirectAddWorkspaceDialog.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 #include <QDoubleValidator>
 #include <QItemDelegate>
@@ -105,6 +108,8 @@ IndirectFitDataView::IndirectFitDataView(const QStringList &headers, QWidget *pa
   connect(m_uiForm->pbUnify, SIGNAL(clicked()), this, SIGNAL(unifyClicked()));
 }
 
+void IndirectFitDataView::subscribePresenter(IIndirectFitDataPresenter *presenter) { m_presenter = presenter; }
+
 QTableWidget *IndirectFitDataView::getDataTable() const { return m_uiForm->tbFitData; }
 
 void IndirectFitDataView::setHorizontalHeaders(const QStringList &headers) {
@@ -178,6 +183,33 @@ QString IndirectFitDataView::getText(int row, int column) const {
 QModelIndexList IndirectFitDataView::getSelectedIndexes() const {
   return m_uiForm->tbFitData->selectionModel()->selectedIndexes();
 }
+
+void IndirectFitDataView::setSampleWSSuffices(const QStringList &suffixes) { m_wsSampleSuffixes = suffixes; }
+
+void IndirectFitDataView::setSampleFBSuffices(const QStringList &suffixes) { m_fbSampleSuffixes = suffixes; }
+
+void IndirectFitDataView::setResolutionWSSuffices(const QStringList &suffixes) { m_wsResolutionSuffixes = suffixes; }
+
+void IndirectFitDataView::setResolutionFBSuffices(const QStringList &suffixes) { m_fbResolutionSuffixes = suffixes; }
+
+void IndirectFitDataView::showAddWorkspaceDialog() {
+  auto dialog = getAddWorkspaceDialog();
+  dialog->setAttribute(Qt::WA_DeleteOnClose);
+  dialog->setWSSuffices(m_wsSampleSuffixes);
+  dialog->setFBSuffices(m_fbSampleSuffixes);
+  dialog->updateSelectedSpectra();
+  dialog->show();
+}
+
+IAddWorkspaceDialog *IndirectFitDataView::getAddWorkspaceDialog() {
+  m_addWorkspaceDialog = new IndirectAddWorkspaceDialog(parentWidget());
+
+  connect(m_addWorkspaceDialog, SIGNAL(addData()), this, SLOT(notifyAddData()));
+
+  return m_addWorkspaceDialog;
+}
+
+void IndirectFitDataView::notifyAddData() { m_presenter->handleAddData(m_addWorkspaceDialog); }
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
@@ -38,7 +38,7 @@ public:
   UserInputValidator &validate(UserInputValidator &validator) override;
   virtual void addTableEntry(size_t row, FitDataRow newRow) override;
   virtual void updateNumCellEntry(double numEntry, size_t row, size_t column) override;
-  virtual int getColumnIndexFromName(QString ColName) override;
+  int getColumnIndexFromName(std::string const &ColName) override;
   void clearTable() override;
   QString getText(int row, int column) const override;
   QModelIndexList getSelectedIndexes() const override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
@@ -69,12 +69,11 @@ protected:
   QStringList m_fbResolutionSuffixes;
 
   IAddWorkspaceDialog *m_addWorkspaceDialog;
+  IIndirectFitDataPresenter *m_presenter;
 
 private:
   QStringList m_HeaderLabels;
   void setHorizontalHeaders(const QStringList &headers);
-
-  IIndirectFitDataPresenter *m_presenter;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
@@ -68,11 +68,12 @@ protected:
   QStringList m_wsResolutionSuffixes;
   QStringList m_fbResolutionSuffixes;
 
+  IAddWorkspaceDialog *m_addWorkspaceDialog;
+
 private:
   QStringList m_HeaderLabels;
   void setHorizontalHeaders(const QStringList &headers);
 
-  IndirectAddWorkspaceDialog *m_addWorkspaceDialog;
   IIndirectFitDataPresenter *m_presenter;
 };
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
@@ -48,9 +48,8 @@ public:
   void setResolutionWSSuffices(const QStringList &suffices) override;
   void setResolutionFBSuffices(const QStringList &suffices) override;
 
-  void showAddWorkspaceDialog() override;
-
 public slots:
+  void showAddWorkspaceDialog();
   void displayWarning(const std::string &warning) override;
 
 protected slots:

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
@@ -20,11 +20,17 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
+class IAddWorkspaceDialog;
+class IndirectAddWorkspaceDialog;
+class IIndirectFitDataPresenter;
+
 class MANTIDQT_INELASTIC_DLL IndirectFitDataView : public IIndirectFitDataView {
   Q_OBJECT
 public:
   IndirectFitDataView(QWidget *parent = nullptr);
   ~IndirectFitDataView() override = default;
+
+  void subscribePresenter(IIndirectFitDataPresenter *presenter) override;
 
   QTableWidget *getDataTable() const override;
   bool isTableEmpty() const;
@@ -37,17 +43,37 @@ public:
   QString getText(int row, int column) const override;
   QModelIndexList getSelectedIndexes() const override;
 
+  void setSampleWSSuffices(const QStringList &suffices) override;
+  void setSampleFBSuffices(const QStringList &suffices) override;
+  void setResolutionWSSuffices(const QStringList &suffices) override;
+  void setResolutionFBSuffices(const QStringList &suffices) override;
+
+  void showAddWorkspaceDialog() override;
+
 public slots:
   void displayWarning(const std::string &warning) override;
 
+protected slots:
+  void notifyAddData();
+
 protected:
   IndirectFitDataView(const QStringList &headers, QWidget *parent = nullptr);
+  virtual IAddWorkspaceDialog *getAddWorkspaceDialog();
+
   std::unique_ptr<Ui::IndirectFitDataView> m_uiForm;
   void setCell(std::unique_ptr<QTableWidgetItem> cell, size_t row, size_t column);
+
+  QStringList m_wsSampleSuffixes;
+  QStringList m_fbSampleSuffixes;
+  QStringList m_wsResolutionSuffixes;
+  QStringList m_fbResolutionSuffixes;
 
 private:
   QStringList m_HeaderLabels;
   void setHorizontalHeaders(const QStringList &headers);
+
+  IndirectAddWorkspaceDialog *m_addWorkspaceDialog;
+  IIndirectFitDataPresenter *m_presenter;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
@@ -24,10 +24,10 @@ class IAddWorkspaceDialog;
 class IndirectAddWorkspaceDialog;
 class IIndirectFitDataPresenter;
 
-class MANTIDQT_INELASTIC_DLL IndirectFitDataView : public IIndirectFitDataView {
+class MANTIDQT_INELASTIC_DLL IndirectFitDataView : public QTabWidget, public IIndirectFitDataView {
   Q_OBJECT
 public:
-  IndirectFitDataView(QWidget *parent = nullptr);
+  IndirectFitDataView(QWidget *parent);
   ~IndirectFitDataView() override = default;
 
   void subscribePresenter(IIndirectFitDataPresenter *presenter) override;
@@ -48,15 +48,13 @@ public:
   void setResolutionWSSuffices(const QStringList &suffices) override;
   void setResolutionFBSuffices(const QStringList &suffices) override;
 
-public slots:
-  void showAddWorkspaceDialog();
   void displayWarning(const std::string &warning) override;
 
 protected slots:
   void notifyAddData();
 
 protected:
-  IndirectFitDataView(const QStringList &headers, QWidget *parent = nullptr);
+  IndirectFitDataView(const QStringList &headers, QWidget *parent);
   virtual IAddWorkspaceDialog *getAddWorkspaceDialog();
 
   std::unique_ptr<Ui::IndirectFitDataView> m_uiForm;
@@ -71,6 +69,7 @@ protected:
   IIndirectFitDataPresenter *m_presenter;
 
 private slots:
+  void showAddWorkspaceDialog();
   void notifyRemoveClicked();
   void notifyUnifyClicked();
   void notifyCellChanged(int row, int column);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
@@ -70,6 +70,11 @@ protected:
   IAddWorkspaceDialog *m_addWorkspaceDialog;
   IIndirectFitDataPresenter *m_presenter;
 
+private slots:
+  void notifyRemoveClicked();
+  void notifyUnifyClicked();
+  void notifyCellChanged(int row, int column);
+
 private:
   QStringList m_HeaderLabels;
   void setHorizontalHeaders(const QStringList &headers);

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -87,7 +87,6 @@ set(SRC_FILES
 set(MOC_FILES
     Analysis/ConvFitAddWorkspaceDialog.h
     Analysis/ConvFitDataView.h
-    Analysis/ConvFitDataPresenter.h
     Analysis/IndirectDataAnalysis.h
     Analysis/IndirectDataAnalysisTab.h
     Analysis/FqFitAddWorkspaceDialog.h
@@ -146,6 +145,7 @@ set(MOC_FILES
 set(INC_FILES
     DllConfig.h
     PrecompiledHeader.h
+    Analysis/ConvFitDataPresenter.h
     Analysis/DataAnalysisTabFactory.h
     Analysis/IDAFunctionParameterEstimation.h
     Analysis/FqFitModel.h

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -93,7 +93,6 @@ set(MOC_FILES
     Analysis/FqFitDataView.h
     Analysis/FitStatusWidget.h
     Analysis/FunctionTemplateBrowser.h
-    Analysis/IIndirectFitDataView.h
     Analysis/IIndirectFitOutputOptionsView.h
     Analysis/IndirectDockWidgetArea.h
     Analysis/IndirectEditResultsDialog.h
@@ -153,13 +152,14 @@ set(INC_FILES
     Analysis/ConvFitModel.h
     Analysis/FitTabConstants.h
     Analysis/IIndirectFitDataModel.h
-    Analysis/IndirectFitDataModel.h
-    Analysis/IndirectFitDataPresenter.h
+    Analysis/IIndirectFitDataView.h
     Analysis/IIndirectFitOutput.h
     Analysis/IIndirectFitOutputOptionsModel.h
     Analysis/IIndirectFitPlotView.h
     Analysis/IIndirectFittingModel.h
     Analysis/IndirectFitData.h
+    Analysis/IndirectFitDataModel.h
+    Analysis/IndirectFitDataPresenter.h
     Analysis/IndirectFitOutput.h
     Analysis/IndirectFitOutputOptionsModel.h
     Analysis/IndirectFitOutputOptionsPresenter.h

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -90,7 +90,6 @@ set(MOC_FILES
     Analysis/IndirectDataAnalysis.h
     Analysis/IndirectDataAnalysisTab.h
     Analysis/FqFitAddWorkspaceDialog.h
-    Analysis/FqFitDataPresenter.h
     Analysis/FqFitDataView.h
     Analysis/FitStatusWidget.h
     Analysis/FunctionTemplateBrowser.h
@@ -98,7 +97,6 @@ set(MOC_FILES
     Analysis/IIndirectFitOutputOptionsView.h
     Analysis/IndirectDockWidgetArea.h
     Analysis/IndirectEditResultsDialog.h
-    Analysis/IndirectFitDataPresenter.h
     Analysis/IndirectFitDataView.h
     Analysis/IndirectFitOutputOptionsView.h
     Analysis/IndirectFitPlotView.h
@@ -147,6 +145,7 @@ set(INC_FILES
     PrecompiledHeader.h
     Analysis/ConvFitDataPresenter.h
     Analysis/DataAnalysisTabFactory.h
+    Analysis/FqFitDataPresenter.h
     Analysis/IDAFunctionParameterEstimation.h
     Analysis/FqFitModel.h
     Analysis/IqtFitModel.h
@@ -155,6 +154,7 @@ set(INC_FILES
     Analysis/FitTabConstants.h
     Analysis/IIndirectFitDataModel.h
     Analysis/IndirectFitDataModel.h
+    Analysis/IndirectFitDataPresenter.h
     Analysis/IIndirectFitOutput.h
     Analysis/IIndirectFitOutputOptionsModel.h
     Analysis/IIndirectFitPlotView.h

--- a/qt/scientific_interfaces/Inelastic/Common/IndirectAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/IndirectAddWorkspaceDialog.cpp
@@ -75,7 +75,7 @@ IndirectAddWorkspaceDialog::IndirectAddWorkspaceDialog(QWidget *parent) : IAddWo
   connect(m_uiForm.dsWorkspace, SIGNAL(dataReady(const QString &)), this, SLOT(workspaceChanged(const QString &)));
   connect(m_uiForm.ckAllSpectra, SIGNAL(stateChanged(int)), this, SLOT(selectAllSpectra(int)));
   connect(m_uiForm.pbAdd, SIGNAL(clicked()), this, SIGNAL(addData()));
-  connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SIGNAL(closeDialog()));
+  connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SLOT(close()));
 }
 
 std::string IndirectAddWorkspaceDialog::workspaceName() const {

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/ConvFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/ConvFitDataPresenterTest.h
@@ -41,12 +41,13 @@ public:
   static void destroySuite(ConvFitDataPresenterTest *suite) { delete suite; }
 
   void setUp() override {
+    m_tab = std::make_unique<NiceMock<MockIndirectDataAnalysisTab>>();
     m_view = std::make_unique<NiceMock<MockFitDataView>>();
     m_model = std::make_unique<NiceMock<MockIndirectFitDataModel>>();
 
     m_dataTable = createEmptyTableWidget(6, 6);
     ON_CALL(*m_view, getDataTable()).WillByDefault(Return(m_dataTable.get()));
-    m_presenter = std::make_unique<ConvFitDataPresenter>(std::move(m_model.get()), std::move(m_view.get()));
+    m_presenter = std::make_unique<ConvFitDataPresenter>(m_tab.get(), m_model.get(), m_view.get());
 
     m_workspace = createWorkspace(6);
     m_ads = std::make_unique<SetUpADSWithWorkspace>("WorkspaceName", m_workspace);
@@ -114,6 +115,7 @@ public:
 private:
   std::unique_ptr<QTableWidget> m_dataTable;
 
+  std::unique_ptr<NiceMock<MockIndirectDataAnalysisTab>> m_tab;
   std::unique_ptr<NiceMock<MockFitDataView>> m_view;
   std::unique_ptr<NiceMock<MockIndirectFitDataModel>> m_model;
   std::unique_ptr<ConvFitDataPresenter> m_presenter;

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/FqFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/FqFitDataPresenterTest.h
@@ -52,6 +52,7 @@ public:
   static void destroySuite(FqFitDataPresenterTest *suite) { delete suite; }
 
   void setUp() override {
+    m_tab = std::make_unique<NiceMock<MockIndirectDataAnalysisTab>>();
     m_view = std::make_unique<NiceMock<MockFitDataView>>();
     m_model = std::make_unique<NiceMock<MockIndirectFitDataModel>>();
 
@@ -59,7 +60,7 @@ public:
 
     ON_CALL(*m_view, getDataTable()).WillByDefault(Return(m_dataTable.get()));
 
-    m_presenter = std::make_unique<FqFitDataPresenter>(std::move(m_model.get()), std::move(m_view.get()));
+    m_presenter = std::make_unique<FqFitDataPresenter>(m_tab.get(), m_model.get(), m_view.get());
     m_workspace = createWorkspaceWithTextAxis(6, getTextAxisLabels());
     m_ads = std::make_unique<SetUpADSWithWorkspace>("WorkspaceName", m_workspace);
   }
@@ -122,6 +123,7 @@ public:
 private:
   std::unique_ptr<QTableWidget> m_dataTable;
 
+  std::unique_ptr<NiceMock<MockIndirectDataAnalysisTab>> m_tab;
   std::unique_ptr<NiceMock<MockFitDataView>> m_view;
   std::unique_ptr<NiceMock<MockIndirectFitDataModel>> m_model;
   std::unique_ptr<FqFitDataPresenter> m_presenter;

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/IndirectFitDataPresenterTest.h
@@ -105,11 +105,12 @@ public:
   static void destroySuite(IndirectFitDataPresenterTest *suite) { delete suite; }
 
   void setUp() override {
+    m_tab = std::make_unique<NiceMock<MockIndirectDataAnalysisTab>>();
     m_view = std::make_unique<NiceMock<MockFitDataView>>();
     m_model = std::make_unique<NiceMock<MockIndirectFitDataModel>>();
     m_table = createEmptyTableWidget(5, 5);
     ON_CALL(*m_view, getDataTable()).WillByDefault(Return(m_table.get()));
-    m_presenter = std::make_unique<IndirectFitDataPresenter>(std::move(m_model.get()), std::move(m_view.get()));
+    m_presenter = std::make_unique<IndirectFitDataPresenter>(m_tab.get(), m_model.get(), m_view.get());
     m_workspace = createWorkspace(5);
     m_ads = std::make_unique<SetUpADSWithWorkspace>("WorkspaceName", m_workspace);
   }
@@ -163,26 +164,34 @@ public:
 
   void test_that_setSampleWSSuffices_will_set_the_sample_workspace_suffices_in_the_view() {
     QStringList const suffices{"suffix1", "suffix2"};
+
+    EXPECT_CALL(*m_view, setSampleWSSuffices(suffices)).Times(Exactly(1));
+
     m_presenter->setSampleWSSuffices(suffices);
-    TS_ASSERT_EQUALS(m_presenter->getSampleWSSuffices(), suffices);
   }
 
   void test_that_setSampleFBSuffices_will_set_the_sample_file_suffices_in_the_view() {
     QStringList const suffices{"suffix1", "suffix2"};
+
+    EXPECT_CALL(*m_view, setSampleFBSuffices(suffices)).Times(Exactly(1));
+
     m_presenter->setSampleFBSuffices(suffices);
-    TS_ASSERT_EQUALS(m_presenter->getSampleFBSuffices(), suffices);
   }
 
   void test_that_setResolutionWSSuffices_will_set_the_Resolution_workspace_suffices_in_the_view() {
     QStringList const suffices{"suffix1", "suffix2"};
+
+    EXPECT_CALL(*m_view, setResolutionWSSuffices(suffices)).Times(Exactly(1));
+
     m_presenter->setResolutionWSSuffices(suffices);
-    TS_ASSERT_EQUALS(m_presenter->getResolutionWSSuffices(), suffices);
   }
 
   void test_that_setResolutionFBSuffices_will_set_the_Resolution_file_suffices_in_the_view() {
     QStringList const suffices{"suffix1", "suffix2"};
+
+    EXPECT_CALL(*m_view, setResolutionFBSuffices(suffices)).Times(Exactly(1));
+
     m_presenter->setResolutionFBSuffices(suffices);
-    TS_ASSERT_EQUALS(m_presenter->getResolutionFBSuffices(), suffices);
   }
 
   void test_getResolutionsForFit_calls_from_model() {
@@ -235,6 +244,7 @@ private:
 
   std::unique_ptr<QTableWidget> m_table;
 
+  std::unique_ptr<NiceMock<MockIndirectDataAnalysisTab>> m_tab;
   std::unique_ptr<NiceMock<MockFitDataView>> m_view;
   std::unique_ptr<NiceMock<MockIndirectFitDataModel>> m_model;
   std::unique_ptr<IndirectFitDataPresenter> m_presenter;

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
@@ -17,7 +17,7 @@
 #include "Analysis/IIndirectFitOutputOptionsView.h"
 #include "Analysis/IIndirectFitPlotView.h"
 #include "Analysis/IndirectDataAnalysisTab.h"
-#include "IAddWorkspaceDialog.h"
+#include "Common/IAddWorkspaceDialog.h"
 
 #include <string>
 #include <utility>

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
@@ -241,7 +241,7 @@ public:
                              MantidQt::CustomInterfaces::UserInputValidator &validator));
   MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
   MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
-  MOCK_METHOD1(getColumnIndexFromName, int(QString ColName));
+  MOCK_METHOD1(getColumnIndexFromName, int(std::string const &ColName));
   MOCK_METHOD0(clearTable, void());
   MOCK_CONST_METHOD2(getText, QString(int row, int column));
   MOCK_CONST_METHOD0(getSelectedIndexes, QModelIndexList());

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
@@ -15,7 +15,9 @@
 #include "Analysis/IIndirectFitDataView.h"
 #include "Analysis/IIndirectFitOutputOptionsModel.h"
 #include "Analysis/IIndirectFitOutputOptionsView.h"
+#include "Analysis/IIndirectFitPlotView.h"
 #include "Analysis/IndirectDataAnalysisTab.h"
+#include "IAddWorkspaceDialog.h"
 
 #include <string>
 #include <utility>
@@ -28,6 +30,12 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 class MockIndirectDataAnalysisTab : public IIndirectDataAnalysisTab {
 public:
   virtual ~MockIndirectDataAnalysisTab() = default;
+
+  MOCK_METHOD1(handleDataAdded, void(MantidQt::CustomInterfaces::IDA::IAddWorkspaceDialog const *dialog));
+  MOCK_METHOD0(handleDataChanged, void());
+  MOCK_METHOD0(handleDataRemoved, void());
+  MOCK_METHOD3(handleTableStartXChanged, void(double startX, WorkspaceID workspaceID, WorkspaceIndex workspaceIndex));
+  MOCK_METHOD3(handleTableEndXChanged, void(double endX, WorkspaceID workspaceID, WorkspaceIndex workspaceIndex));
 
   MOCK_METHOD2(handleSingleFitClicked, void(WorkspaceID workspaceID, WorkspaceIndex workspaceIndex));
   MOCK_METHOD1(handleStartXChanged, void(double startX));
@@ -226,6 +234,8 @@ class MockFitDataView : public IIndirectFitDataView {
 public:
   virtual ~MockFitDataView() = default;
 
+  MOCK_METHOD1(subscribePresenter, void(IIndirectFitDataPresenter *presenter));
+
   MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
   MOCK_METHOD1(validate, MantidQt::CustomInterfaces::UserInputValidator &(
                              MantidQt::CustomInterfaces::UserInputValidator &validator));
@@ -235,6 +245,11 @@ public:
   MOCK_METHOD0(clearTable, void());
   MOCK_CONST_METHOD2(getText, QString(int row, int column));
   MOCK_CONST_METHOD0(getSelectedIndexes, QModelIndexList());
+
+  MOCK_METHOD1(setSampleWSSuffices, void(const QStringList &suffices));
+  MOCK_METHOD1(setSampleFBSuffices, void(const QStringList &suffices));
+  MOCK_METHOD1(setResolutionWSSuffices, void(const QStringList &suffices));
+  MOCK_METHOD1(setResolutionFBSuffices, void(const QStringList &suffices));
 
   MOCK_METHOD1(displayWarning, void(std::string const &warning));
 };


### PR DESCRIPTION
### Description of work
This PR refactors the IndirectFitDataPresenter, ConvFitDataPresenter and FqFitDataPresenter  so that it no longer has a QObject dependency. This makes it easier to test the presenter, and also makes it possible to replace the presenter in the future if necessary.  This also means it is easier to write a new model that conforms to a particular interface and replace the old one in the future, easily, if necessary.

Part of #36325

### To test:
1. Load the following data into the Data Analysis IqtFit tab using `Add workspace`

Input file: [irs26176_graphite002_iqt.zip](https://github.com/mantidproject/mantid/files/2361062/irs26176_graphite002_iqt.zip)
2. `Stretched Exponential`
3. `Flat background`
4. Drag the EndX on the graph to the left a bit to miss the noise (`0.15` I think)
5. Click Run and wait
6. Remove a spectrum in the top table
7. Change the EndX in the top table, and make sure the plot updates for the given spectrum
8. Attempt to unify the range across multiple spectra.

Also do a similar thing for the following tabs:

**ConvFit Tab**
Input files: [irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2361070/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2361071/irs26173_graphite002_res.zip)
Fit Type: `Two Lorenztian`
`Flat Background`

**F(Q) Tab**
Input file: [IN16B_125878_QLd_Result.zip](https://github.com/mantidproject/mantid/files/2361073/IN16B_125878_QLd_Result.zip)
Fit Type: `Chudley Elliott`

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
