### PR TITLE
Better Colorbar range when opening Slice Viewer from the 'IndirectPlotOptions' widget.

### DIFF
--- a/qt/widgets/mplcpp/src/Plot.cpp
+++ b/qt/widgets/mplcpp/src/Plot.cpp
@@ -15,6 +15,7 @@
 #include "MantidQtWidgets/Common/Python/QHashToDict.h"
 #include "MantidQtWidgets/Common/Python/Sip.h"
 #include "MantidQtWidgets/MplCpp/Plot.h"
+#include <iostream>
 #include <utility>
 
 using Mantid::API::MatrixWorkspace_sptr;
@@ -34,6 +35,8 @@ Python::Object functionsModule() { return Python::NewRef(PyImport_ImportModule("
 Python::Object sviewerModule() {
   return Python::NewRef(PyImport_ImportModule("mantidqt.widgets.sliceviewer.presenters.presenter"));
 }
+
+Python::Object userConfModule() { return Python::NewRef(PyImport_ImportModule("workbench.config")); }
 
 /**
  * Construct a Python list from a vector of strings
@@ -169,7 +172,12 @@ Python::Object sliceviewer(const Workspace_sptr &workspace) {
   try {
     const Python::Object py_workspace = Python::NewRef(Python::ToPythonValue<Workspace_sptr>()(workspace));
     const Python::Object args = Python::NewRef(Py_BuildValue("(O)", py_workspace.ptr()));
-    auto sw = sviewerModule().attr("SliceViewer")(*args);
+    // Get a ref to the CONF singleton
+    const auto conf = userConfModule().attr("CONF");
+    Python::Dict kwargs;
+    kwargs["conf"] = conf;
+
+    auto sw = sviewerModule().attr("SliceViewer")(*args, **kwargs);
     return sw.attr("show_view")();
   } catch (Python::ErrorAlreadySet &) {
     throw PythonException();

--- a/qt/widgets/mplcpp/src/Plot.cpp
+++ b/qt/widgets/mplcpp/src/Plot.cpp
@@ -15,7 +15,7 @@
 #include "MantidQtWidgets/Common/Python/QHashToDict.h"
 #include "MantidQtWidgets/Common/Python/Sip.h"
 #include "MantidQtWidgets/MplCpp/Plot.h"
-#include <iostream>
+
 #include <utility>
 
 using Mantid::API::MatrixWorkspace_sptr;


### PR DESCRIPTION
### Description of work
As described in #36459, when opening the Slice Viewer from the Indirect/Inelastic interfaces, the colorbar range is not always suitable. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
The reason why colorbar range was not the same as when slice viewer is called from the ADS is that when opening slice viewer from the widget, there was a missing keyword argument to the sliceviewer (the singleton `UserConfig` (CONF)) which takes care of the local user configuration available when using Mantid. In the context of the slice viewer, it is setting the scales of the slice viewer plots to 'SymmetricLog10' instead of the default 'Linear' which is called when Slice Viewer is opened without keyword arguments. 
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36459 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
1. Open Data Reduction
2. Select TOSCA
3. Load 26176
4. Click Run
5. Click the Down arrow in the plot options and select `Open Slice Viewer`
6. Without closing Slice Viewer Window, click on the ADS and open the resulting file from running the algorithm `26176_graphite002_red`,  and show the slice viewer from the ADS. Compare that both instances of slice viewer show same colorbar range and scale.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
