### PR TITLE
Fix live data slit lookup values for OFFSPEC

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -209,7 +209,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
         return "s2vgap" if self._instrument == "OFFSPEC" else "S2VG"
 
     def _alternative_s2vg_name(self):
-        return "S1VG" if self._instrument == "OFFSPEC" else "s2vg"
+        return "S2VG" if self._instrument == "OFFSPEC" else "s2vg"
 
     def _get_double_or_none(self, propertyName):
         value = self.getProperty(propertyName)

--- a/docs/source/release/v6.9.0/Reflectometry/Bugfixes/36534.rst
+++ b/docs/source/release/v6.9.0/Reflectometry/Bugfixes/36534.rst
@@ -1,0 +1,1 @@
+- Fixes a bug with live data on OFFSPEC where the alternative method for looking up the vertical gap for slit 2 in :ref:`algm-ReflectometryReductionOneLiveData` was incorrectly returning the vertical gap for slit 1.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
In `ReflectometryReductionOneLiveData` we seem to provide support for instruments running either the old or new Controls software. To do this, the algorithm has a set of alternative values for looking up the slit vertical gaps. For most instruments we try the new Controls software values first and then the old ones second, while for OFFSPEC this is done the other way round as they haven't moved over to the new software yet.

During recent testing with the new Controls software on OFFSPEC we noticed that the value being used to look up the vertical gap for the second slit was actually looking up the value for the first slit (looks like a copy and paste error).

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Refs #36534. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
Resolves part one of this issue.
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
At the moment OFFSPEC only seem to be testing with the new Controls software, most of the time they are running with the old software. When they eventually move across, though, it would be better to do a more thorough update of the code.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Unfortunately it's not really possible to test this at the moment as it requires both the beamline at ISIS to be on and for OFFSPEC to be testing with the new Controls software. It's a low risk change as the slit vertical gaps are used in the reduction to calculate the resolution only if a resolution hasn't already been provided. OFFSPEC usually do provide the resolution via the GUI, so this is just to ensure the default would work correctly if it was ever being relied on. It's only the alternative value that has been changed and the change only applies to the OFFSPEC instrument.

I will make a note to test this when next possible - it didn't seem worth delaying it as it seemed a small and obvious fix that would be good to get into the next release. So far I have tested that running live data on OFFSPEC while they're using the old Controls software that they normally use is still working correctly.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
