### PR TITLE
Pass through ROIDetectorIDs setting in ISIS Reflectometry GUI live data

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -104,6 +104,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
             "CalibrationFile",
             "OutputWorkspace",
             "PolarizationEfficiencies",
+            "ROIDetectorIDs",
         ]
         self.copyProperties("ReflectometryISISLoadAndProcess", self._child_properties)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -195,7 +195,6 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         child_alg = create_algorithm("ReflectometryISISLoadAndProcess")
         excluded = [
             "InputRunList",
-            "ROIDetectorIDs",
             "ThetaIn",
             "ThetaLogName",
             "HideInputWorkspaces",

--- a/docs/source/release/v6.9.0/Reflectometry/Bugfixes/36570.rst
+++ b/docs/source/release/v6.9.0/Reflectometry/Bugfixes/36570.rst
@@ -1,0 +1,1 @@
+- Fix an error where live data reduction via the :ref:`ISIS Reflectometry Interface <interface-isis-refl>` would not work if ROI Detector IDs had been specified in the interface.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
When the `ROIDetectorIDs` parameter was exposed in `ReflectometryISISLoadAndProcess`, it wasn't exposed in `ReflectometryReductionOneLiveData` as well. This PR exposes the parameter in `ReflectometryReductionOneLiveData` so that the setting is passed through and can be applied as normal in the reduction.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36570. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

**Report to:** Becky at ISIS

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Use the instructions on the linked issue. When the beamline is off it won't be possible to receive live data from the instrument so it's not possible to test the outcome of a successful reduction. ~It is possible to check that we don't get the error that was originally reported, though, and that there is an attempt to start algorithm `ReflectometryReductionOneLiveData` before encountering an error at some point due to the empty dataset.~ It's not possible to test at all once the instrument DAEs have been switched off.

I was able to test the changes in some Conda packages on IDAaaS before the end of cycle and the reduction seemed to me to be working correctly and applying the relevant settings. I checked live data for all instruments supported by the GUI, with and without ROI Detector ID settings applied, and it all seemed to be working OK with the reductions completing successfully.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
