### PR TITLE
Save and Load OrientedLattice errors in NeXus files

### DIFF
--- a/Framework/Geometry/src/Crystal/OrientedLattice.cpp
+++ b/Framework/Geometry/src/Crystal/OrientedLattice.cpp
@@ -269,6 +269,12 @@ void OrientedLattice::saveNexus(::NeXus::File *file, const std::string &group) c
   file->writeData("unit_cell_alpha", this->alpha());
   file->writeData("unit_cell_beta", this->beta());
   file->writeData("unit_cell_gamma", this->gamma());
+  file->writeData("unit_cell_a_error", this->errora());
+  file->writeData("unit_cell_b_error", this->errorb());
+  file->writeData("unit_cell_c_error", this->errorc());
+  file->writeData("unit_cell_alpha_error", this->erroralpha());
+  file->writeData("unit_cell_beta_error", this->errorbeta());
+  file->writeData("unit_cell_gamma_error", this->errorgamma());
   // Save the UB matrix
   std::vector<double> ub = this->UB.getVector();
   std::vector<int> dims(2, 3); // 3x3 matrix
@@ -277,7 +283,10 @@ void OrientedLattice::saveNexus(::NeXus::File *file, const std::string &group) c
   // Save the modulated UB matrix
   std::vector<double> modUB = this->ModUB.getVector();
   file->writeData("modulated_orientation_matrix", modUB, dims);
+  std::vector<double> errorModHKL = this->errorModHKL.getVector();
+  file->writeData("modulated_hkl_error", errorModHKL, dims);
   file->writeData("maximum_order", this->getMaxOrder());
+  file->writeData("cross_term", int(this->getCrossTerm()));
 
   file->closeGroup();
 }
@@ -296,13 +305,31 @@ void OrientedLattice::loadNexus(::NeXus::File *file, const std::string &group) {
   this->setUB(ubMat);
 
   try {
+    double errora, errorb, errorc, erroralpha, errorbeta, errorgamma;
+    file->readData("unit_cell_a_error", errora);
+    file->readData("unit_cell_b_error", errorb);
+    file->readData("unit_cell_c_error", errorc);
+    file->readData("unit_cell_alpha_error", erroralpha);
+    file->readData("unit_cell_beta_error", errorbeta);
+    file->readData("unit_cell_gamma_error", errorgamma);
+    this->setError(errora, errorb, errorc, erroralpha, errorbeta, errorgamma);
+
     std::vector<double> modUB;
     file->readData("modulated_orientation_matrix", modUB);
     DblMatrix ModUBMat(modUB);
     this->setModUB(ModUBMat);
+
+    std::vector<double> errorModHKL;
+    file->readData("modulated_hkl_error", errorModHKL);
+    DblMatrix ErrorModHKL(errorModHKL);
+    this->setErrorModHKL(ErrorModHKL);
+
     int maxOrder;
     file->readData("maximum_order", maxOrder);
     this->setMaxOrder(maxOrder);
+    int crossTerm;
+    file->readData("cross_term", crossTerm);
+    this->setCrossTerm(crossTerm);
   } catch (::NeXus::Exception &) {
     // Old files don't have these. Ignore
   }

--- a/Framework/Geometry/test/OrientedLatticeTest.h
+++ b/Framework/Geometry/test/OrientedLatticeTest.h
@@ -81,7 +81,9 @@ public:
     th.createFile("OrientedLatticeTest.nxs");
     DblMatrix U(3, 3, true);
     OrientedLattice u(1, 2, 3, 90, 89, 88);
+    u.setError(0.1, 0.2, 0.3, 0.4, 0.5, 0.6);
     u.setMaxOrder(1);
+    u.setCrossTerm(true);
 
     DblMatrix modUB(3, 3);
     modUB[0][0] = 1.;
@@ -94,6 +96,7 @@ public:
     modUB[1][2] = 8.;
     modUB[2][2] = 9.;
     u.setModUB(modUB);
+    u.setErrorModHKL(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9);
 
     u.saveNexus(th.file.get(), "lattice");
     th.reopenFile();
@@ -107,8 +110,24 @@ public:
     TS_ASSERT_DELTA(u2.alpha(), 90.0, 1e-5);
     TS_ASSERT_DELTA(u2.beta(), 89.0, 1e-5);
     TS_ASSERT_DELTA(u2.gamma(), 88.0, 1e-5);
+    TS_ASSERT_DELTA(u2.errora(), 0.1, 1e-5);
+    TS_ASSERT_DELTA(u2.errorb(), 0.2, 1e-5);
+    TS_ASSERT_DELTA(u2.errorc(), 0.3, 1e-5);
+    TS_ASSERT_DELTA(u2.erroralpha(), 0.4, 1e-5);
+    TS_ASSERT_DELTA(u2.errorbeta(), 0.5, 1e-5);
+    TS_ASSERT_DELTA(u2.errorgamma(), 0.6, 1e-5);
     TS_ASSERT_EQUALS(u2.getMaxOrder(), 1);
+    TS_ASSERT_EQUALS(u2.getCrossTerm(), true);
     TS_ASSERT_EQUALS(u2.getModUB(), modUB);
+    TS_ASSERT_DELTA(u2.getdherr(0), 0.1, 1e-5);
+    TS_ASSERT_DELTA(u2.getdkerr(0), 0.2, 1e-5);
+    TS_ASSERT_DELTA(u2.getdlerr(0), 0.3, 1e-5);
+    TS_ASSERT_DELTA(u2.getdherr(1), 0.4, 1e-5);
+    TS_ASSERT_DELTA(u2.getdkerr(1), 0.5, 1e-5);
+    TS_ASSERT_DELTA(u2.getdlerr(1), 0.6, 1e-5);
+    TS_ASSERT_DELTA(u2.getdherr(2), 0.7, 1e-5);
+    TS_ASSERT_DELTA(u2.getdkerr(2), 0.8, 1e-5);
+    TS_ASSERT_DELTA(u2.getdlerr(2), 0.9, 1e-5);
   }
 
   /** @author Alex Buts, fixed by Andrei Savici */

--- a/docs/source/release/v6.9.0/Framework/Data_Handling/Bugfixes/36557.rst
+++ b/docs/source/release/v6.9.0/Framework/Data_Handling/Bugfixes/36557.rst
@@ -1,1 +1,1 @@
-- Fixed modulation information in oriented lattice not being saved and loaded to NeXus files
+- Fixed modulation information and lattice errors in oriented lattice not being saved and loaded to NeXus files


### PR DESCRIPTION
This follows on from #36557 to also include the errors and the cross term.

### Description of work

Currently the lattice errors, modulation vectors errors and the cross term is not save or loaded in NeXus files.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [EWM3331](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=3331)

<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

The easiest was to test everything is to save a Isaw UB file.

Using [UB.txt](https://github.com/mantidproject/mantid/files/13722774/UB.txt)


```python
ws = CreateSampleWorkspace()
LoadIsawUB(ws, Filename='UB.txt')

SaveNexus(ws, "ws.nxs")
loaded = LoadNexus("ws.nxs")
SaveIsawUB(loaded, "newUB.txt")
```

Then compare `UB.txt` to `newUB.txt` and it should be identical, previously the newUB would be missing the errors for the lattice parameter, the mod vector errors and the cross terms.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Release notes are already covered by #36557

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
