### PR TITLE
Add option for number of cylinder slices to SolidAngle

### DIFF
--- a/Framework/Algorithms/src/SolidAngle.cpp
+++ b/Framework/Algorithms/src/SolidAngle.cpp
@@ -104,7 +104,16 @@ protected:
 
 struct GenericShape : public SolidAngleCalculator {
   using SolidAngleCalculator::SolidAngleCalculator;
-  double solidAngle(size_t index) const override { return m_detectorInfo.detector(index).solidAngle(m_samplePos); }
+  GenericShape(const ComponentInfo &componentInfo, const DetectorInfo &detectorInfo, const std::string &method,
+               const double pixelArea, const int numberOfCylinderSlices)
+      : SolidAngleCalculator(componentInfo, detectorInfo, method, pixelArea),
+        m_numberOfCylinderSlices(numberOfCylinderSlices) {}
+  double solidAngle(size_t index) const override {
+    return m_detectorInfo.detector(index).solidAngle(Geometry::SolidAngleParams(m_samplePos, m_numberOfCylinderSlices));
+  }
+
+private:
+  int m_numberOfCylinderSlices;
 };
 
 struct Rectangle : public SolidAngleCalculator {
@@ -176,6 +185,12 @@ void SolidAngle::init() {
                                          HORIZONTAL_TUBE, VERTICAL_WING, HORIZONTAL_WING};
   declareProperty("Method", GENERIC_SHAPE, std::make_shared<StringListValidator>(methods),
                   "Select the method to calculate the Solid Angle.");
+
+  auto greaterThanTwo = std::make_shared<BoundedValidator<int>>();
+  greaterThanTwo->setLower(3);
+  declareProperty("NumberOfCylinderSlices", 11, greaterThanTwo,
+                  "The number of angular slices used when triangulating a cylinder in order to calculate the solid "
+                  "angle of a tube detector.");
 }
 
 /** Executes the algorithm
@@ -230,9 +245,11 @@ void SolidAngle::exec() {
     }
   }
 
+  int numberOfCylinderSlices = getProperty("NumberOfCylinderSlices");
   std::unique_ptr<SolidAngleCalculator> solidAngleCalculator;
   if (method == GENERIC_SHAPE) {
-    solidAngleCalculator = std::make_unique<GenericShape>(componentInfo, detectorInfo, method, pixelArea);
+    solidAngleCalculator =
+        std::make_unique<GenericShape>(componentInfo, detectorInfo, method, pixelArea, numberOfCylinderSlices);
   } else if (method == RECTANGLE) {
     solidAngleCalculator = std::make_unique<Rectangle>(componentInfo, detectorInfo, method, pixelArea);
   } else if (method == VERTICAL_TUBE || method == HORIZONTAL_TUBE) {

--- a/Framework/Algorithms/src/SolidAngle.cpp
+++ b/Framework/Algorithms/src/SolidAngle.cpp
@@ -188,7 +188,7 @@ void SolidAngle::init() {
 
   auto greaterThanTwo = std::make_shared<BoundedValidator<int>>();
   greaterThanTwo->setLower(3);
-  declareProperty("NumberOfCylinderSlices", 11, greaterThanTwo,
+  declareProperty("NumberOfCylinderSlices", 10, greaterThanTwo,
                   "The number of angular slices used when triangulating a cylinder in order to calculate the solid "
                   "angle of a tube detector.");
 }

--- a/Framework/Geometry/CMakeLists.txt
+++ b/Framework/Geometry/CMakeLists.txt
@@ -218,6 +218,7 @@ set(INC_FILES
     inc/MantidGeometry/Instrument/RectangularDetector.h
     inc/MantidGeometry/Instrument/ReferenceFrame.h
     inc/MantidGeometry/Instrument/SampleEnvironment.h
+    inc/MantidGeometry/Instrument/SolidAngleParams.h
     inc/MantidGeometry/Instrument/StructuredDetector.h
     inc/MantidGeometry/Instrument/XMLInstrumentParameter.h
     inc/MantidGeometry/Instrument_fwd.h

--- a/Framework/Geometry/inc/MantidGeometry/IObjComponent.h
+++ b/Framework/Geometry/inc/MantidGeometry/IObjComponent.h
@@ -8,6 +8,7 @@
 
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/IComponent.h"
+#include "MantidGeometry/Instrument/SolidAngleParams.h"
 #include "MantidGeometry/Objects/IObject.h"
 
 namespace Mantid {
@@ -67,7 +68,7 @@ public:
 
   /// Finds the approximate solid angle covered by the component when viewed
   /// from the point given
-  virtual double solidAngle(const Kernel::V3D &observer) const = 0;
+  virtual double solidAngle(const Geometry::SolidAngleParams params) const = 0;
 
   /// Try to find a point that lies within (or on) the object
   virtual int getPointInObject(Kernel::V3D &point) const = 0;

--- a/Framework/Geometry/inc/MantidGeometry/IObjComponent.h
+++ b/Framework/Geometry/inc/MantidGeometry/IObjComponent.h
@@ -68,7 +68,7 @@ public:
 
   /// Finds the approximate solid angle covered by the component when viewed
   /// from the point given
-  virtual double solidAngle(const Geometry::SolidAngleParams params) const = 0;
+  virtual double solidAngle(const Geometry::SolidAngleParams &params) const = 0;
 
   /// Try to find a point that lies within (or on) the object
   virtual int getPointInObject(Kernel::V3D &point) const = 0;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -9,6 +9,7 @@
 #include "MantidBeamline/ComponentType.h"
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/Instrument/ComponentInfoIterator.h"
+#include "MantidGeometry/Instrument/SolidAngleParams.h"
 #include "MantidGeometry/Objects/BoundingBox.h"
 #include "MantidKernel/DateAndTime.h"
 #include <memory>
@@ -121,7 +122,7 @@ public:
 
   const Geometry::IObject &shape(const size_t componentIndex) const;
 
-  double solidAngle(const size_t componentIndex, const Kernel::V3D &observer) const;
+  double solidAngle(const size_t componentIndex, const Geometry::SolidAngleParams params) const;
   BoundingBox boundingBox(const size_t componentIndex, const BoundingBox *reference = nullptr,
                           const bool excludeMonitors = false) const;
   Beamline::ComponentType componentType(const size_t componentIndex) const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -122,7 +122,7 @@ public:
 
   const Geometry::IObject &shape(const size_t componentIndex) const;
 
-  double solidAngle(const size_t componentIndex, const Geometry::SolidAngleParams params) const;
+  double solidAngle(const size_t componentIndex, const Geometry::SolidAngleParams &params) const;
   BoundingBox boundingBox(const size_t componentIndex, const BoundingBox *reference = nullptr,
                           const bool excludeMonitors = false) const;
   Beamline::ComponentType componentType(const size_t componentIndex) const;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
@@ -56,9 +56,9 @@ public:
 
   int interceptSurface(Geometry::Track &t) const override { return m_shape->interceptSurface(t); }
   double distance(const Geometry::Track &t) const override { return m_shape->distance(t); }
-  double solidAngle(const Kernel::V3D &observer) const override { return m_shape->solidAngle(observer); }
-  double solidAngle(const Kernel::V3D &observer, const Kernel::V3D &scaleFactor) const override {
-    return m_shape->solidAngle(observer, scaleFactor);
+  double solidAngle(const SolidAngleParams params) const override { return m_shape->solidAngle(params); }
+  double solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const override {
+    return m_shape->solidAngle(params, scaleFactor);
   }
   double volume() const override { return m_shape->volume(); }
   const BoundingBox &getBoundingBox() const override { return m_shape->getBoundingBox(); }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
@@ -56,8 +56,8 @@ public:
 
   int interceptSurface(Geometry::Track &t) const override { return m_shape->interceptSurface(t); }
   double distance(const Geometry::Track &t) const override { return m_shape->distance(t); }
-  double solidAngle(const SolidAngleParams params) const override { return m_shape->solidAngle(params); }
-  double solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const override {
+  double solidAngle(const SolidAngleParams &params) const override { return m_shape->solidAngle(params); }
+  double solidAngle(const SolidAngleParams &params, const Kernel::V3D &scaleFactor) const override {
     return m_shape->solidAngle(params, scaleFactor);
   }
   double volume() const override { return m_shape->volume(); }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorGroup.h
@@ -44,7 +44,7 @@ public:
                            const Kernel::V3D &instrumentUp) const override;
   double getPhi() const override;
   double getPhiOffset(const double &offset) const override;
-  double solidAngle(const Geometry::SolidAngleParams params) const override;
+  double solidAngle(const Geometry::SolidAngleParams &params) const override;
   bool isParametrized() const override;
   bool isValid(const Kernel::V3D &point) const override;
   bool isOnSide(const Kernel::V3D &point) const override;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorGroup.h
@@ -44,7 +44,7 @@ public:
                            const Kernel::V3D &instrumentUp) const override;
   double getPhi() const override;
   double getPhiOffset(const double &offset) const override;
-  double solidAngle(const Kernel::V3D &observer) const override;
+  double solidAngle(const Geometry::SolidAngleParams params) const override;
   bool isParametrized() const override;
   bool isValid(const Kernel::V3D &point) const override;
   bool isOnSide(const Kernel::V3D &point) const override;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/GridDetector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/GridDetector.h
@@ -112,7 +112,7 @@ public:
 
   /// Finds the approximate solid angle covered by the component when viewed
   /// from the point given
-  double solidAngle(const Geometry::SolidAngleParams params) const override;
+  double solidAngle(const Geometry::SolidAngleParams &params) const override;
   /// Retrieve the cached bounding box
   void getBoundingBox(BoundingBox &assemblyBox) const override;
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/GridDetector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/GridDetector.h
@@ -112,7 +112,7 @@ public:
 
   /// Finds the approximate solid angle covered by the component when viewed
   /// from the point given
-  double solidAngle(const Kernel::V3D &observer) const override;
+  double solidAngle(const Geometry::SolidAngleParams params) const override;
   /// Retrieve the cached bounding box
   void getBoundingBox(BoundingBox &assemblyBox) const override;
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ObjComponent.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ObjComponent.h
@@ -50,7 +50,7 @@ public:
   bool isValid(const Kernel::V3D &point) const override;
   bool isOnSide(const Kernel::V3D &point) const override;
   int interceptSurface(Track &track) const override;
-  double solidAngle(const Kernel::V3D &observer) const override;
+  double solidAngle(const Geometry::SolidAngleParams params) const override;
   ///@todo This should go in favour of just the class related one.
   void boundingBox(double &xmax, double &ymax, double &zmax, double &xmin, double &ymin, double &zmin) const;
   /// get bounding box, which may or may not be axis aligned;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ObjComponent.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ObjComponent.h
@@ -50,7 +50,7 @@ public:
   bool isValid(const Kernel::V3D &point) const override;
   bool isOnSide(const Kernel::V3D &point) const override;
   int interceptSurface(Track &track) const override;
-  double solidAngle(const Geometry::SolidAngleParams params) const override;
+  double solidAngle(const Geometry::SolidAngleParams &params) const override;
   ///@todo This should go in favour of just the class related one.
   void boundingBox(double &xmax, double &ymax, double &zmax, double &xmin, double &ymin, double &zmin) const;
   /// get bounding box, which may or may not be axis aligned;

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/SolidAngleParams.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/SolidAngleParams.h
@@ -18,7 +18,7 @@ public:
   SolidAngleParams(Kernel::V3D observer, int numberOfCylinderSlices = 11)
       : m_observer(std::move(observer)), m_numberOfCylinderSlices(numberOfCylinderSlices) {}
   inline const Kernel::V3D &observer() const { return m_observer; }
-  inline const int cylinderSlices() const { return m_numberOfCylinderSlices; }
+  inline int cylinderSlices() const { return m_numberOfCylinderSlices; }
   inline const SolidAngleParams copyWithNewObserver(Kernel::V3D newObserver) const {
     return SolidAngleParams(std::move(newObserver), m_numberOfCylinderSlices);
   }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/SolidAngleParams.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/SolidAngleParams.h
@@ -1,0 +1,32 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#pragma once
+
+#include "MantidGeometry/DllConfig.h"
+#include "MantidKernel/V3D.h"
+
+namespace Mantid {
+namespace Geometry {
+
+class MANTID_GEOMETRY_DLL SolidAngleParams {
+public:
+  SolidAngleParams(Kernel::V3D observer, int numberOfCylinderSlices = 11)
+      : m_observer(std::move(observer)), m_numberOfCylinderSlices(numberOfCylinderSlices) {}
+  inline const Kernel::V3D observer() const { return m_observer; }
+  inline const int cylinderSlices() const { return m_numberOfCylinderSlices; }
+  inline const SolidAngleParams copyWithNewObserver(Kernel::V3D newObserver) const {
+    return SolidAngleParams(std::move(newObserver), m_numberOfCylinderSlices);
+  }
+
+private:
+  Kernel::V3D m_observer;
+  int m_numberOfCylinderSlices;
+};
+
+} // namespace Geometry
+} // namespace Mantid

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/SolidAngleParams.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/SolidAngleParams.h
@@ -17,7 +17,7 @@ class MANTID_GEOMETRY_DLL SolidAngleParams {
 public:
   SolidAngleParams(Kernel::V3D observer, int numberOfCylinderSlices = 11)
       : m_observer(std::move(observer)), m_numberOfCylinderSlices(numberOfCylinderSlices) {}
-  inline const Kernel::V3D observer() const { return m_observer; }
+  inline const Kernel::V3D &observer() const { return m_observer; }
   inline const int cylinderSlices() const { return m_numberOfCylinderSlices; }
   inline const SolidAngleParams copyWithNewObserver(Kernel::V3D newObserver) const {
     return SolidAngleParams(std::move(newObserver), m_numberOfCylinderSlices);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/SolidAngleParams.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/SolidAngleParams.h
@@ -15,7 +15,7 @@ namespace Geometry {
 
 class MANTID_GEOMETRY_DLL SolidAngleParams {
 public:
-  SolidAngleParams(Kernel::V3D observer, int numberOfCylinderSlices = 11)
+  SolidAngleParams(Kernel::V3D observer, int numberOfCylinderSlices = 10)
       : m_observer(std::move(observer)), m_numberOfCylinderSlices(numberOfCylinderSlices) {}
   inline const Kernel::V3D &observer() const { return m_observer; }
   inline int cylinderSlices() const { return m_numberOfCylinderSlices; }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/StructuredDetector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/StructuredDetector.h
@@ -100,7 +100,7 @@ public:
 
   /// Finds the approximate solid angle covered by the component when viewed
   /// from the point given
-  double solidAngle(const Kernel::V3D &observer) const override;
+  double solidAngle(const Geometry::SolidAngleParams params) const override;
   /// Retrieve the cached bounding box
   void getBoundingBox(BoundingBox &assemblyBox) const override;
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/StructuredDetector.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/StructuredDetector.h
@@ -100,7 +100,7 @@ public:
 
   /// Finds the approximate solid angle covered by the component when viewed
   /// from the point given
-  double solidAngle(const Geometry::SolidAngleParams params) const override;
+  double solidAngle(const Geometry::SolidAngleParams &params) const override;
   /// Retrieve the cached bounding box
   void getBoundingBox(BoundingBox &assemblyBox) const override;
 

--- a/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
@@ -126,13 +126,13 @@ public:
   double distance(const Track &track) const override;
 
   // Solid angle - uses triangleSolidAngle unless many (>30000) triangles
-  double solidAngle(const Kernel::V3D &observer) const override;
+  double solidAngle(const SolidAngleParams params) const override;
   // Solid angle with a scaling of the object
-  double solidAngle(const Kernel::V3D &observer, const Kernel::V3D &scaleFactor) const override;
+  double solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const override;
   // solid angle via triangulation
-  double triangulatedSolidAngle(const Kernel::V3D &observer) const;
+  double triangulatedSolidAngle(const SolidAngleParams params) const;
   // Solid angle via triangulation with scaling factor for object size
-  double triangulatedSolidAngle(const Kernel::V3D &observer, const Kernel::V3D &scaleFactor) const;
+  double triangulatedSolidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const;
   // solid angle via ray tracing
   double rayTraceSolidAngle(const Kernel::V3D &observer) const;
 

--- a/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
@@ -126,13 +126,13 @@ public:
   double distance(const Track &track) const override;
 
   // Solid angle - uses triangleSolidAngle unless many (>30000) triangles
-  double solidAngle(const SolidAngleParams params) const override;
+  double solidAngle(const SolidAngleParams &params) const override;
   // Solid angle with a scaling of the object
-  double solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const override;
+  double solidAngle(const SolidAngleParams &params, const Kernel::V3D &scaleFactor) const override;
   // solid angle via triangulation
-  double triangulatedSolidAngle(const SolidAngleParams params) const;
+  double triangulatedSolidAngle(const SolidAngleParams &params) const;
   // Solid angle via triangulation with scaling factor for object size
-  double triangulatedSolidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const;
+  double triangulatedSolidAngle(const SolidAngleParams &params, const Kernel::V3D &scaleFactor) const;
   // solid angle via ray tracing
   double rayTraceSolidAngle(const Kernel::V3D &observer) const;
 

--- a/Framework/Geometry/inc/MantidGeometry/Objects/IObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/IObject.h
@@ -55,9 +55,9 @@ public:
   virtual int interceptSurface(Geometry::Track &) const = 0;
   virtual double distance(const Geometry::Track &) const = 0;
   // Solid angle
-  virtual double solidAngle(const SolidAngleParams params) const = 0;
+  virtual double solidAngle(const SolidAngleParams &params) const = 0;
   // Solid angle with a scaling of the object
-  virtual double solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const = 0;
+  virtual double solidAngle(const SolidAngleParams &params, const Kernel::V3D &scaleFactor) const = 0;
   /// Return cached value of axis-aligned bounding box
   virtual const BoundingBox &getBoundingBox() const = 0;
   /// Calculate (or return cached value of) Axis Aligned Bounding box

--- a/Framework/Geometry/inc/MantidGeometry/Objects/IObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/IObject.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidGeometry/DllConfig.h"
+#include "MantidGeometry/Instrument/SolidAngleParams.h"
 #include "MantidGeometry/Rendering/ShapeInfo.h"
 #include <boost/optional.hpp>
 #include <map>
@@ -54,9 +55,9 @@ public:
   virtual int interceptSurface(Geometry::Track &) const = 0;
   virtual double distance(const Geometry::Track &) const = 0;
   // Solid angle
-  virtual double solidAngle(const Kernel::V3D &observer) const = 0;
+  virtual double solidAngle(const SolidAngleParams params) const = 0;
   // Solid angle with a scaling of the object
-  virtual double solidAngle(const Kernel::V3D &observer, const Kernel::V3D &scaleFactor) const = 0;
+  virtual double solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const = 0;
   /// Return cached value of axis-aligned bounding box
   virtual const BoundingBox &getBoundingBox() const = 0;
   /// Calculate (or return cached value of) Axis Aligned Bounding box

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
@@ -86,9 +86,9 @@ public:
   double distance(const Track &track) const override;
 
   // Solid angle - uses triangleSolidAngle unless many (>30000) triangles
-  double solidAngle(const SolidAngleParams params) const override;
+  double solidAngle(const SolidAngleParams &params) const override;
   // Solid angle with a scaling of the object
-  double solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const override;
+  double solidAngle(const SolidAngleParams &params, const Kernel::V3D &scaleFactor) const override;
 
   /// Calculates the volume of this object.
   double volume() const override;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
@@ -86,9 +86,9 @@ public:
   double distance(const Track &track) const override;
 
   // Solid angle - uses triangleSolidAngle unless many (>30000) triangles
-  double solidAngle(const Kernel::V3D &observer) const override;
+  double solidAngle(const SolidAngleParams params) const override;
   // Solid angle with a scaling of the object
-  double solidAngle(const Kernel::V3D &observer, const Kernel::V3D &scaleFactor) const override;
+  double solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const override;
 
   /// Calculates the volume of this object.
   double volume() const override;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject2D.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject2D.h
@@ -47,8 +47,8 @@ public:
   MeshObject2D *clone() const override;
   MeshObject2D *cloneWithMaterial(const Kernel::Material &material) const override;
   int getName() const override;
-  double solidAngle(const SolidAngleParams params) const override;
-  double solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const override;
+  double solidAngle(const SolidAngleParams &params) const override;
+  double solidAngle(const SolidAngleParams &params, const Kernel::V3D &scaleFactor) const override;
   bool operator==(const MeshObject2D &other) const;
   const BoundingBox &getBoundingBox() const override;
   const static double MinThickness;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject2D.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject2D.h
@@ -47,8 +47,8 @@ public:
   MeshObject2D *clone() const override;
   MeshObject2D *cloneWithMaterial(const Kernel::Material &material) const override;
   int getName() const override;
-  double solidAngle(const Kernel::V3D &observer) const override;
-  double solidAngle(const Kernel::V3D &observer, const Kernel::V3D &scaleFactor) const override;
+  double solidAngle(const SolidAngleParams params) const override;
+  double solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const override;
   bool operator==(const MeshObject2D &other) const;
   const BoundingBox &getBoundingBox() const override;
   const static double MinThickness;

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -248,7 +248,7 @@ void ComponentInfo::setScaleFactor(const size_t componentIndex, const Kernel::V3
   m_componentInfo->setScaleFactor(componentIndex, Kernel::toVector3d(scaleFactor));
 }
 
-double ComponentInfo::solidAngle(const size_t componentIndex, const Geometry::SolidAngleParams params) const {
+double ComponentInfo::solidAngle(const size_t componentIndex, const Geometry::SolidAngleParams &params) const {
   if (!hasValidShape(componentIndex))
     throw Kernel::Exception::NullPointerException("ComponentInfo::solidAngle", "shape");
   // This is the observer position in the shape's coordinate system.

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -248,18 +248,19 @@ void ComponentInfo::setScaleFactor(const size_t componentIndex, const Kernel::V3
   m_componentInfo->setScaleFactor(componentIndex, Kernel::toVector3d(scaleFactor));
 }
 
-double ComponentInfo::solidAngle(const size_t componentIndex, const Kernel::V3D &observer) const {
+double ComponentInfo::solidAngle(const size_t componentIndex, const Geometry::SolidAngleParams params) const {
   if (!hasValidShape(componentIndex))
     throw Kernel::Exception::NullPointerException("ComponentInfo::solidAngle", "shape");
   // This is the observer position in the shape's coordinate system.
-  const Kernel::V3D relativeObserver = toShapeFrame(observer, *m_componentInfo, componentIndex);
+  const Kernel::V3D relativeObserver = toShapeFrame(params.observer(), *m_componentInfo, componentIndex);
   const Kernel::V3D scaleFactorAtIndex = this->scaleFactor(componentIndex);
+  const auto paramsWithRelativeObserver = params.copyWithNewObserver(relativeObserver);
   if ((scaleFactorAtIndex - Kernel::V3D(1.0, 1.0, 1.0)).norm() < 1e-12)
-    return shape(componentIndex).solidAngle(relativeObserver);
+    return shape(componentIndex).solidAngle(paramsWithRelativeObserver);
   else {
     // This function will scale the object shape when calculating the solid
     // angle.
-    return shape(componentIndex).solidAngle(relativeObserver, scaleFactorAtIndex);
+    return shape(componentIndex).solidAngle(paramsWithRelativeObserver, scaleFactorAtIndex);
   }
 }
 

--- a/Framework/Geometry/src/Instrument/DetectorGroup.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorGroup.cpp
@@ -188,12 +188,12 @@ std::vector<IDetector_const_sptr> DetectorGroup::getDetectors() const {
 
 /** Gives the total solid angle subtended by a group of detectors by summing the
  *  contributions from the individual detectors.
- *  @param observer :: The point from which the detector is being viewed
+ *  @param params :: The point from which the detector is being viewed, and number of cylinder slices
  *  @return The solid angle in steradians
  *  @throw NullPointerException If geometrical form of any detector has not been
  * provided in the instrument definition file
  */
-double DetectorGroup::solidAngle(const Geometry::SolidAngleParams params) const {
+double DetectorGroup::solidAngle(const Geometry::SolidAngleParams &params) const {
   double result =
       std::accumulate(m_detectors.cbegin(), m_detectors.cend(), 0.0,
                       [&params](double angle, const auto &det) { return angle + det.second->solidAngle(params); });

--- a/Framework/Geometry/src/Instrument/DetectorGroup.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorGroup.cpp
@@ -193,10 +193,10 @@ std::vector<IDetector_const_sptr> DetectorGroup::getDetectors() const {
  *  @throw NullPointerException If geometrical form of any detector has not been
  * provided in the instrument definition file
  */
-double DetectorGroup::solidAngle(const V3D &observer) const {
+double DetectorGroup::solidAngle(const Geometry::SolidAngleParams params) const {
   double result =
       std::accumulate(m_detectors.cbegin(), m_detectors.cend(), 0.0,
-                      [&observer](double angle, const auto &det) { return angle + det.second->solidAngle(observer); });
+                      [&params](double angle, const auto &det) { return angle + det.second->solidAngle(params); });
   return result;
 }
 

--- a/Framework/Geometry/src/Instrument/GridDetector.cpp
+++ b/Framework/Geometry/src/Instrument/GridDetector.cpp
@@ -738,7 +738,7 @@ int GridDetector::interceptSurface(Track & /*track*/) const {
 //-------------------------------------------------------------------------------------------------
 /// Finds the approximate solid angle covered by the component when viewed from
 /// the point given
-double GridDetector::solidAngle(const V3D & /*observer*/) const {
+double GridDetector::solidAngle(const Geometry::SolidAngleParams /*params*/) const {
   throw Kernel::Exception::NotImplementedError("GridDetector::solidAngle() is not implemented.");
 }
 

--- a/Framework/Geometry/src/Instrument/GridDetector.cpp
+++ b/Framework/Geometry/src/Instrument/GridDetector.cpp
@@ -738,7 +738,7 @@ int GridDetector::interceptSurface(Track & /*track*/) const {
 //-------------------------------------------------------------------------------------------------
 /// Finds the approximate solid angle covered by the component when viewed from
 /// the point given
-double GridDetector::solidAngle(const Geometry::SolidAngleParams /*params*/) const {
+double GridDetector::solidAngle(const Geometry::SolidAngleParams & /*params*/) const {
   throw Kernel::Exception::NotImplementedError("GridDetector::solidAngle() is not implemented.");
 }
 

--- a/Framework/Geometry/src/Instrument/ObjComponent.cpp
+++ b/Framework/Geometry/src/Instrument/ObjComponent.cpp
@@ -134,12 +134,12 @@ int ObjComponent::interceptSurface(Track &track) const {
 
 /** Finds the approximate solid angle covered by the component when viewed from
  * the point given
- *  @param observer :: The position from which the component is being viewed
+ *  @param params :: The position from which the component is being viewed, and number of cylinder slices
  *  @returns The solid angle in steradians
  *  @throw NullPointerException if the underlying geometrical Object has not
  * been set
  */
-double ObjComponent::solidAngle(const Geometry::SolidAngleParams params) const {
+double ObjComponent::solidAngle(const Geometry::SolidAngleParams &params) const {
   if (m_map) {
     if (hasComponentInfo()) {
       return m_map->componentInfo().solidAngle(index(), params);

--- a/Framework/Geometry/src/Instrument/ObjComponent.cpp
+++ b/Framework/Geometry/src/Instrument/ObjComponent.cpp
@@ -139,10 +139,10 @@ int ObjComponent::interceptSurface(Track &track) const {
  *  @throw NullPointerException if the underlying geometrical Object has not
  * been set
  */
-double ObjComponent::solidAngle(const V3D &observer) const {
+double ObjComponent::solidAngle(const Geometry::SolidAngleParams params) const {
   if (m_map) {
     if (hasComponentInfo()) {
-      return m_map->componentInfo().solidAngle(index(), observer);
+      return m_map->componentInfo().solidAngle(index(), params);
     }
   }
   // If the form of this component is not defined, throw NullPointerException
@@ -150,14 +150,15 @@ double ObjComponent::solidAngle(const V3D &observer) const {
     throw Kernel::Exception::NullPointerException("ObjComponent::solidAngle", "shape");
   // Otherwise pass through the shifted point to the Object::solidAngle method
   V3D scaleFactor = this->getScaleFactor();
+  // This is the observer position in the shape's coordinate system.
+  const auto paramsWithFactoredOutComponentPosition =
+      params.copyWithNewObserver(factorOutComponentPosition(params.observer()));
   if ((scaleFactor - V3D(1.0, 1.0, 1.0)).norm() < 1e-12)
-    return shape()->solidAngle(factorOutComponentPosition(observer));
+    return shape()->solidAngle(paramsWithFactoredOutComponentPosition);
   else {
-    // This is the observer position in the shape's coordinate system.
-    V3D relativeObserver = factorOutComponentPosition(observer);
     // This function will scale the object shape when calculating the solid
     // angle.
-    return shape()->solidAngle(relativeObserver, scaleFactor);
+    return shape()->solidAngle(paramsWithFactoredOutComponentPosition, scaleFactor);
   }
 }
 

--- a/Framework/Geometry/src/Instrument/StructuredDetector.cpp
+++ b/Framework/Geometry/src/Instrument/StructuredDetector.cpp
@@ -467,7 +467,7 @@ int StructuredDetector::interceptSurface(Track & /*track*/) const {
 
 /// Finds the approximate solid angle covered by the component when viewed from
 /// the point given
-double StructuredDetector::solidAngle(const V3D & /*observer*/) const {
+double StructuredDetector::solidAngle(const Geometry::SolidAngleParams /*params*/) const {
   throw Kernel::Exception::NotImplementedError("StructuredDetector::solidAngle() is not implemented.");
 }
 

--- a/Framework/Geometry/src/Instrument/StructuredDetector.cpp
+++ b/Framework/Geometry/src/Instrument/StructuredDetector.cpp
@@ -467,7 +467,7 @@ int StructuredDetector::interceptSurface(Track & /*track*/) const {
 
 /// Finds the approximate solid angle covered by the component when viewed from
 /// the point given
-double StructuredDetector::solidAngle(const Geometry::SolidAngleParams /*params*/) const {
+double StructuredDetector::solidAngle(const Geometry::SolidAngleParams & /*params*/) const {
   throw Kernel::Exception::NotImplementedError("StructuredDetector::solidAngle() is not implemented.");
 }
 

--- a/Framework/Geometry/src/Objects/CSGObject.cpp
+++ b/Framework/Geometry/src/Objects/CSGObject.cpp
@@ -1212,7 +1212,7 @@ TrackDirection CSGObject::calcValidTypeBy3Points(const Kernel::V3D &prePt, const
  * @return :: estimate of solid angle of object. Accuracy depends on object
  * shape.
  */
-double CSGObject::solidAngle(const SolidAngleParams params) const {
+double CSGObject::solidAngle(const SolidAngleParams &params) const {
   if (this->numberOfTriangles() > 30000)
     return rayTraceSolidAngle(params.observer());
   return triangulatedSolidAngle(params);
@@ -1226,7 +1226,7 @@ double CSGObject::solidAngle(const SolidAngleParams params) const {
  * @return :: estimate of solid angle of object. Accuracy depends on
  * triangulation quality.
  */
-double CSGObject::solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const {
+double CSGObject::solidAngle(const SolidAngleParams &params, const Kernel::V3D &scaleFactor) const {
   return triangulatedSolidAngle(params, scaleFactor);
 }
 
@@ -1353,13 +1353,13 @@ double CSGObject::rayTraceSolidAngle(const Kernel::V3D &observer) const {
  * @param params :: Point from which solid angle is required, and number of cylinder slices
  * @return the solid angle
  */
-double CSGObject::triangulatedSolidAngle(const SolidAngleParams params) const {
+double CSGObject::triangulatedSolidAngle(const SolidAngleParams &params) const {
   //
   // Because the triangles from OC are not consistently ordered wrt their
   // outward normal internal points give incorrect solid angle. Surface
   // points are difficult to get right with the triangle based method.
   // Hence catch these two (unlikely) cases.
-  const auto observer = params.observer();
+  const auto &observer = params.observer();
   const BoundingBox &boundingBox = this->getBoundingBox();
   if (boundingBox.isNonNull() && boundingBox.isPointInside(observer)) {
     if (isValid(observer)) {
@@ -1440,13 +1440,13 @@ double CSGObject::triangulatedSolidAngle(const SolidAngleParams params) const {
  *only (not observer)
  * @return the solid angle
  */
-double CSGObject::triangulatedSolidAngle(const SolidAngleParams params, const V3D &scaleFactor) const {
+double CSGObject::triangulatedSolidAngle(const SolidAngleParams &params, const V3D &scaleFactor) const {
   //
   // Because the triangles from OC are not consistently ordered wrt their
   // outward normal internal points give incorrect solid angle. Surface
   // points are difficult to get right with the triangle based method.
   // Hence catch these two (unlikely) cases.
-  const auto observer = params.observer();
+  const auto &observer = params.observer();
   const BoundingBox &boundingBox = this->getBoundingBox();
   double sx = scaleFactor[0], sy = scaleFactor[1], sz = scaleFactor[2];
   const V3D sObserver = observer;

--- a/Framework/Geometry/src/Objects/CSGObject.cpp
+++ b/Framework/Geometry/src/Objects/CSGObject.cpp
@@ -298,7 +298,7 @@ double cuboidSolidAngle(const V3D &observer, const std::vector<V3D> &vectors) {
  * @returns The solid angle value
  */
 double cylinderSolidAngle(const V3D &observer, const V3D &centre, const V3D &axis, const double radius,
-                          const double height) {
+                          const double height, const int numberOfSlices) {
   // The cylinder is triangulated along its axis EXCLUDING the end caps so that
   // stacked cylinders give the correct value of solid angle (i.e shadowing is
   // loosely taken into account by this method) Any triangle that has a normal
@@ -311,7 +311,7 @@ double cylinderSolidAngle(const V3D &observer, const V3D &centre, const V3D &axi
   const Quat transform(initial_axis, axis);
 
   // Do the base cap which is a point at the centre and nslices points around it
-  constexpr double angle_step = 2 * M_PI / static_cast<double>(Cylinder::g_NSLICES);
+  const double angle_step = 2 * M_PI / static_cast<double>(numberOfSlices);
 
   const double z_step = height / Cylinder::g_NSTACKS;
   double z0(0.0), z1(z_step);
@@ -320,12 +320,12 @@ double cylinderSolidAngle(const V3D &observer, const V3D &centre, const V3D &axi
     if (st == Cylinder::g_NSTACKS)
       z1 = height;
 
-    for (int sl = 0; sl < Cylinder::g_NSLICES; ++sl) {
+    for (int sl = 0; sl < numberOfSlices; ++sl) {
       double x = radius * std::cos(angle_step * sl);
       double y = radius * std::sin(angle_step * sl);
       V3D pt1 = V3D(x, y, z0);
       V3D pt2 = V3D(x, y, z1);
-      int vertex = (sl + 1) % Cylinder::g_NSLICES;
+      int vertex = (sl + 1) % numberOfSlices;
       x = radius * std::cos(angle_step * vertex);
       y = radius * std::sin(angle_step * vertex);
       V3D pt3 = V3D(x, y, z0);
@@ -1208,26 +1208,26 @@ TrackDirection CSGObject::calcValidTypeBy3Points(const Kernel::V3D &prePt, const
  * This interface routine calls either getTriangleSolidAngle or
  * getRayTraceSolidAngle.
  * Choice made on number of triangles in the discrete surface representation.
- * @param observer :: point to measure solid angle from
+ * @param params :: point to measure solid angle from, and number of cylinder slices
  * @return :: estimate of solid angle of object. Accuracy depends on object
  * shape.
  */
-double CSGObject::solidAngle(const Kernel::V3D &observer) const {
+double CSGObject::solidAngle(const SolidAngleParams params) const {
   if (this->numberOfTriangles() > 30000)
-    return rayTraceSolidAngle(observer);
-  return triangulatedSolidAngle(observer);
+    return rayTraceSolidAngle(params.observer());
+  return triangulatedSolidAngle(params);
 }
 
 /**
  * Find solid angle of object wrt the observer with a scaleFactor for the
  * object.
- * @param observer :: point to measure solid angle from
+ * @param params :: point to measure solid angle from, and number of cylinder slices
  * @param scaleFactor :: V3D giving scaling of the object
  * @return :: estimate of solid angle of object. Accuracy depends on
  * triangulation quality.
  */
-double CSGObject::solidAngle(const Kernel::V3D &observer, const Kernel::V3D &scaleFactor) const {
-  return triangulatedSolidAngle(observer, scaleFactor);
+double CSGObject::solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const {
+  return triangulatedSolidAngle(params, scaleFactor);
 }
 
 /**
@@ -1350,15 +1350,16 @@ double CSGObject::rayTraceSolidAngle(const Kernel::V3D &observer) const {
  * Find solid angle of object from point "observer" using the
  * OC triangulation of the object, if it exists
  *
- * @param observer :: Point from which solid angle is required
+ * @param params :: Point from which solid angle is required, and number of cylinder slices
  * @return the solid angle
  */
-double CSGObject::triangulatedSolidAngle(const V3D &observer) const {
+double CSGObject::triangulatedSolidAngle(const SolidAngleParams params) const {
   //
   // Because the triangles from OC are not consistently ordered wrt their
   // outward normal internal points give incorrect solid angle. Surface
   // points are difficult to get right with the triangle based method.
   // Hence catch these two (unlikely) cases.
+  const auto observer = params.observer();
   const BoundingBox &boundingBox = this->getBoundingBox();
   if (boundingBox.isNonNull() && boundingBox.isPointInside(observer)) {
     if (isValid(observer)) {
@@ -1377,6 +1378,7 @@ double CSGObject::triangulatedSolidAngle(const V3D &observer) const {
   geometry_vectors.reserve(4);
   this->GetObjectGeom(type, geometry_vectors, innerRadius, radius, height);
   auto nTri = this->numberOfTriangles();
+
   // Cylinders are by far the most frequently used
   switch (type) {
   case detail::ShapeInfo::GeometryShape::CUBOID:
@@ -1386,7 +1388,8 @@ double CSGObject::triangulatedSolidAngle(const V3D &observer) const {
     return sphereSolidAngle(observer, geometry_vectors, radius);
     break;
   case detail::ShapeInfo::GeometryShape::CYLINDER:
-    return cylinderSolidAngle(observer, geometry_vectors[0], geometry_vectors[1], radius, height);
+    return cylinderSolidAngle(observer, geometry_vectors[0], geometry_vectors[1], radius, height,
+                              params.cylinderSlices());
     break;
   case detail::ShapeInfo::GeometryShape::CONE:
     return coneSolidAngle(observer, geometry_vectors[0], geometry_vectors[1], radius, height);
@@ -1432,17 +1435,18 @@ double CSGObject::triangulatedSolidAngle(const V3D &observer) const {
  * OC triangulation of the object, if it exists. This method expects a
  * scaling vector scaleFactor that scales the three axes.
  *
- * @param observer :: Point from which solid angle is required.
+ * @param params :: Point from which solid angle is required, and number of cylinder slices
  * @param scaleFactor :: V3D each component giving the scaling of the object
  *only (not observer)
  * @return the solid angle
  */
-double CSGObject::triangulatedSolidAngle(const V3D &observer, const V3D &scaleFactor) const {
+double CSGObject::triangulatedSolidAngle(const SolidAngleParams params, const V3D &scaleFactor) const {
   //
   // Because the triangles from OC are not consistently ordered wrt their
   // outward normal internal points give incorrect solid angle. Surface
   // points are difficult to get right with the triangle based method.
   // Hence catch these two (unlikely) cases.
+  const auto observer = params.observer();
   const BoundingBox &boundingBox = this->getBoundingBox();
   double sx = scaleFactor[0], sy = scaleFactor[1], sz = scaleFactor[2];
   const V3D sObserver = observer;

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -267,14 +267,14 @@ void MeshObject::getBoundingBox(double &xmax, double &ymax, double &zmax, double
 
 /**
  * Find solid angle of object wrt the observer.
- * @param observer :: point to measure solid angle from
+ * @param params :: point to measure solid angle from, and number of cylinder slices.
  * @return :: estimate of solid angle of object.
  */
-double MeshObject::solidAngle(const Kernel::V3D &observer) const {
+double MeshObject::solidAngle(const SolidAngleParams params) const {
   double solidAngleSum(0), solidAngleNegativeSum(0);
   Kernel::V3D vertex1, vertex2, vertex3;
   for (size_t i = 0; this->getTriangle(i, vertex1, vertex2, vertex3); ++i) {
-    double sa = MeshObjectCommon::getTriangleSolidAngle(vertex1, vertex2, vertex3, observer);
+    double sa = MeshObjectCommon::getTriangleSolidAngle(vertex1, vertex2, vertex3, params.observer());
     if (sa > 0.0) {
       solidAngleSum += sa;
     } else {
@@ -294,17 +294,17 @@ double MeshObject::solidAngle(const Kernel::V3D &observer) const {
 /**
  * Find solid angle of object wrt the observer with a scaleFactor for the
  * object.
- * @param observer :: point to measure solid angle from
+ * @param params :: point to measure solid angle from, and number of cylinder slices
  * @param scaleFactor :: Kernel::V3D giving scaling of the object
  * @return :: estimate of solid angle of object.
  */
-double MeshObject::solidAngle(const Kernel::V3D &observer, const Kernel::V3D &scaleFactor) const {
+double MeshObject::solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const {
   std::vector<Kernel::V3D> scaledVertices;
   scaledVertices.reserve(m_vertices.size());
   std::transform(m_vertices.cbegin(), m_vertices.cend(), std::back_inserter(scaledVertices),
                  [&scaleFactor](const auto &vertex) { return scaleFactor * vertex; });
   MeshObject meshScaled(m_triangles, scaledVertices, m_material);
-  return meshScaled.solidAngle(observer);
+  return meshScaled.solidAngle(params);
 }
 
 /**

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -270,7 +270,7 @@ void MeshObject::getBoundingBox(double &xmax, double &ymax, double &zmax, double
  * @param params :: point to measure solid angle from, and number of cylinder slices.
  * @return :: estimate of solid angle of object.
  */
-double MeshObject::solidAngle(const SolidAngleParams params) const {
+double MeshObject::solidAngle(const SolidAngleParams &params) const {
   double solidAngleSum(0), solidAngleNegativeSum(0);
   Kernel::V3D vertex1, vertex2, vertex3;
   for (size_t i = 0; this->getTriangle(i, vertex1, vertex2, vertex3); ++i) {
@@ -298,7 +298,7 @@ double MeshObject::solidAngle(const SolidAngleParams params) const {
  * @param scaleFactor :: Kernel::V3D giving scaling of the object
  * @return :: estimate of solid angle of object.
  */
-double MeshObject::solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const {
+double MeshObject::solidAngle(const SolidAngleParams &params, const Kernel::V3D &scaleFactor) const {
   std::vector<Kernel::V3D> scaledVertices;
   scaledVertices.reserve(m_vertices.size());
   std::transform(m_vertices.cbegin(), m_vertices.cend(), std::back_inserter(scaledVertices),

--- a/Framework/Geometry/src/Objects/MeshObject2D.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject2D.cpp
@@ -304,7 +304,7 @@ int MeshObject2D::getName() const {
  * @param params
  * @return
  */
-double MeshObject2D::solidAngle(const SolidAngleParams params) const {
+double MeshObject2D::solidAngle(const SolidAngleParams &params) const {
   double solidAngleSum(0);
   Kernel::V3D vertex1, vertex2, vertex3;
   for (size_t i = 0; getTriangle(i, m_triangles, m_vertices, vertex1, vertex2, vertex3); ++i) {
@@ -316,7 +316,7 @@ double MeshObject2D::solidAngle(const SolidAngleParams params) const {
   return solidAngleSum;
 }
 
-double MeshObject2D::solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const {
+double MeshObject2D::solidAngle(const SolidAngleParams &params, const Kernel::V3D &scaleFactor) const {
   std::vector<Kernel::V3D> scaledVertices;
   scaledVertices.reserve(m_vertices.size());
   std::transform(m_vertices.cbegin(), m_vertices.cend(), std::back_inserter(scaledVertices),

--- a/Framework/Geometry/src/Objects/MeshObject2D.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject2D.cpp
@@ -301,14 +301,14 @@ int MeshObject2D::getName() const {
  * another. In that case there would still be a solid angle contribution as
  * there is no way of detecting the shadowing.
  *
- * @param observer
+ * @param params
  * @return
  */
-double MeshObject2D::solidAngle(const Kernel::V3D &observer) const {
+double MeshObject2D::solidAngle(const SolidAngleParams params) const {
   double solidAngleSum(0);
   Kernel::V3D vertex1, vertex2, vertex3;
   for (size_t i = 0; getTriangle(i, m_triangles, m_vertices, vertex1, vertex2, vertex3); ++i) {
-    double sa = MeshObjectCommon::getTriangleSolidAngle(vertex1, vertex2, vertex3, observer);
+    double sa = MeshObjectCommon::getTriangleSolidAngle(vertex1, vertex2, vertex3, params.observer());
     if (sa > 0) {
       solidAngleSum += sa;
     }
@@ -316,13 +316,13 @@ double MeshObject2D::solidAngle(const Kernel::V3D &observer) const {
   return solidAngleSum;
 }
 
-double MeshObject2D::solidAngle(const Kernel::V3D &observer, const Kernel::V3D &scaleFactor) const {
+double MeshObject2D::solidAngle(const SolidAngleParams params, const Kernel::V3D &scaleFactor) const {
   std::vector<Kernel::V3D> scaledVertices;
   scaledVertices.reserve(m_vertices.size());
   std::transform(m_vertices.cbegin(), m_vertices.cend(), std::back_inserter(scaledVertices),
                  [&scaleFactor](const auto &vertex) { return vertex * scaleFactor; });
   MeshObject2D meshScaled(m_triangles, scaledVertices, m_material);
-  return meshScaled.solidAngle(observer);
+  return meshScaled.solidAngle(params);
 }
 
 bool MeshObject2D::operator==(const MeshObject2D &other) const {

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -1395,27 +1395,71 @@ public:
 
     double satol(1e-8); // tolerance for solid angle
 
+    // First test with the old default (only) number of cylinder slices (10)
+    auto solidAngleParams = SolidAngleParams(V3D(), 10);
+
     // solid angle at point -0.5 from capped cyl -1.0 -0.997 in x, rad 0.005 -
     // approx WISH cylinder
     // We intentionally exclude the cylinder end caps so they this should
     // produce 0
-    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(V3D(-0.5, 0.0, 0.0)), 0.0, satol);
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(-0.5, 0.0, 0.0))), 0.0,
+                    satol);
     // Other end
-    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(V3D(-1.497, 0.0, 0.0)), 0.0, satol);
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(-1.497, 0.0, 0.0))), 0.0,
+                    satol);
 
     // Side values
-    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(V3D(0, 0, 0.1)), 0.00301186, satol);
-    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(V3D(0, 0, -0.1)), 0.00301186, satol);
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(0, 0, 0.1))), 0.00301186,
+                    satol);
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(0, 0, -0.1))), 0.00301186,
+                    satol);
     // Sweep in the axis of the cylinder angle to see if the solid angle
     // decreases (as we are excluding the end caps)
-    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(V3D(0.1, 0.0, 0.1)), 0.00100267, satol);
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(0.1, 0.0, 0.1))),
+                    0.00100267, satol);
 
     // internal point (should be 4pi)
-    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(V3D(-0.999, 0.0, 0.0)), 4 * M_PI, satol);
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(-0.999, 0.0, 0.0))),
+                    4 * M_PI, satol);
 
     // surface points
-    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(V3D(-1.0, 0.0, 0.0)), 2 * M_PI, satol);
-    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(V3D(-0.997, 0.0, 0.0)), 2 * M_PI, satol);
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(-1.0, 0.0, 0.0))),
+                    2 * M_PI, satol);
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(-0.997, 0.0, 0.0))),
+                    2 * M_PI, satol);
+
+    // Now test with the new default number of cylinder slices
+    solidAngleParams = SolidAngleParams(V3D(), 11);
+
+    // solid angle at point -0.5 from capped cyl -1.0 -0.997 in x, rad 0.005 -
+    // approx WISH cylinder
+    // We intentionally exclude the cylinder end caps so they this should
+    // produce 0
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(-0.5, 0.0, 0.0))), 0.0,
+                    satol);
+    // Other end
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(-1.497, 0.0, 0.0))), 0.0,
+                    satol);
+
+    // Side values
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(0, 0, 0.1))), 0.00310589,
+                    satol);
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(0, 0, -0.1))),
+                    0.0030629329, satol);
+    // Sweep in the axis of the cylinder angle to see if the solid angle
+    // decreases (as we are excluding the end caps)
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(0.1, 0.0, 0.1))),
+                    0.0010351385, satol);
+
+    // internal point (should be 4pi)
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(-0.999, 0.0, 0.0))),
+                    4 * M_PI, satol);
+
+    // surface points
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(-1.0, 0.0, 0.0))),
+                    2 * M_PI, satol);
+    TS_ASSERT_DELTA(geom_obj->triangulatedSolidAngle(solidAngleParams.copyWithNewObserver(V3D(-0.997, 0.0, 0.0))),
+                    2 * M_PI, satol);
   }
 
   void testSolidAngleCubeTriangles()

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -866,9 +866,9 @@ constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/vtkGe
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:320
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:473
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:563
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:1672
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:1677
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:1682
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:1676
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:1681
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:1686
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/vtkGeometryCacheWriter.cpp:83
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:702
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:909

--- a/docs/source/algorithms/SolidAngle-v1.rst
+++ b/docs/source/algorithms/SolidAngle-v1.rst
@@ -63,8 +63,8 @@ Output:
 
 .. testoutput:: solidAngle
 
-    Solid angle of Spectra 1 in Bank 1: 6.27e-08
-    Solid angle of Spectra 101 in Bank 2: 1.57e-08
+    Solid angle of Spectra 1 in Bank 1: 6.40e-08
+    Solid angle of Spectra 101 in Bank 2: 1.60e-08
 
 **Example: BIOSANS**
 

--- a/docs/source/algorithms/SolidAngle-v1.rst
+++ b/docs/source/algorithms/SolidAngle-v1.rst
@@ -63,8 +63,8 @@ Output:
 
 .. testoutput:: solidAngle
 
-    Solid angle of Spectra 1 in Bank 1: 6.40e-08
-    Solid angle of Spectra 101 in Bank 2: 1.60e-08
+    Solid angle of Spectra 1 in Bank 1: 6.27e-08
+    Solid angle of Spectra 101 in Bank 2: 1.57e-08
 
 **Example: BIOSANS**
 

--- a/docs/source/release/v6.9.0/Framework/Algorithms/New_features/36581.rst
+++ b/docs/source/release/v6.9.0/Framework/Algorithms/New_features/36581.rst
@@ -1,0 +1,1 @@
+- Added the option to change the number of points used in the `SolidAngle` algorithm when triangulating a cylinder, which is what happens for tube detectors. The new argument is called `NumberOfCylinderSlices` and will default to `10`, which is the current number of slices used.


### PR DESCRIPTION
Add option to specify how many angular slices will be used when triangulating a cylinder in order to calculate solid angle. Do this by passing a new object - ``SolidAngleParams`` - around when calculating solid angle. There is also a new argument defined on the actual ``SolidAngle`` algorithm. The default value will be 10, which is what is used currently, so no results should change. To fix issue #36493 we'll need to change the default value.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Added a new type, `SolidAngleParams` that holds the arguments required for performing the solid angle calculation. Most of the changes in the code are plumbing to pass this object around. The actual calculation happens in `CSGObject.cpp`.

See #36493 for the problem that this relates to. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
No results should change when calling `SolidAngle`, unless you use the new argument called `NumberOfCylinderSlices`. To see results from this you can use the following:
```
ws = LoadEmptyInstrument(InstrumentName = "SANS2D")
sa = SolidAngle(ws, NumberOfCylinderSlices=13)
```
Then look at the instrument view (or the data) for the `sa` workspace.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
