### PR TITLE
Move Values Saved to `sasprocessnote` to `sasprocess` in SaveNXCanSAS

### DIFF
--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -404,14 +404,10 @@ void createNote(H5::Group &group) {
  * save
  * @param secondEntryValue: string containing the second value to save
  */
-void addNoteToProcess(H5::Group &group, const std::string &firstEntryName, const std::string &firstEntryValue,
-                      const std::string &secondEntryName, const std::string &secondEntryValue) {
+void addProcessEntry(H5::Group &group, const std::string &entryName, const std::string &entryValue) {
   auto process = group.openGroup(sasProcessGroupName);
-  auto note = process.openGroup(sasNoteGroupName);
-
   // Populate note
-  Mantid::DataHandling::H5Util::write(note, firstEntryName, firstEntryValue);
-  Mantid::DataHandling::H5Util::write(note, secondEntryName, secondEntryValue);
+  Mantid::DataHandling::H5Util::write(process, entryName, entryValue);
 }
 
 WorkspaceDimensionality getWorkspaceDimensionality(const Mantid::API::MatrixWorkspace_sptr &workspace) {
@@ -908,21 +904,19 @@ void SaveNXcanSAS::exec() {
     addProcess(sasEntry, workspace);
   }
 
-  if (transmissionCan || transmissionSample) {
-    createNote(sasEntry);
-    if (transmissionCan)
-      addNoteToProcess(sasEntry, sasProcessTermCanScatter, canScatterRun, sasProcessTermCanDirect, canDirectRun);
-    if (transmissionSample)
-      addNoteToProcess(sasEntry, sasProcessTermSampleTrans, sampleTransmissionRun, sasProcessTermSampleDirect,
-                       sampleDirectRun);
+  if (transmissionCan) {
+    addProcessEntry(sasEntry, sasProcessTermCanScatter, canScatterRun);
+    addProcessEntry(sasEntry, sasProcessTermCanDirect, canDirectRun);
+  }
+  if (transmissionSample) {
+    addProcessEntry(sasEntry, sasProcessTermSampleTrans, sampleTransmissionRun);
+    addProcessEntry(sasEntry, sasProcessTermSampleDirect, sampleDirectRun);
   }
 
   if (!scaledBgSubWorkspace.empty()) {
     progress.report("Adding scaled background subtraction information.");
-    auto process = sasEntry.openGroup(sasProcessGroupName);
-    auto note = process.openGroup(sasNoteGroupName);
-    Mantid::DataHandling::H5Util::write(note, sasProcessTermScaledBgSubWorkspace, scaledBgSubWorkspace);
-    Mantid::DataHandling::H5Util::write(note, sasProcessTermScaledBgSubScaleFactor, scaledBgSubScaleFactor);
+    addProcessEntry(sasEntry, sasProcessTermScaledBgSubWorkspace, scaledBgSubWorkspace);
+    addProcessEntry(sasEntry, sasProcessTermScaledBgSubScaleFactor, scaledBgSubScaleFactor);
   }
 
   // Add the transmissions for sample

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -511,14 +511,9 @@ void addData1D(H5::Group &data, const Mantid::API::MatrixWorkspace_sptr &workspa
 }
 
 bool areAxesNumeric(const Mantid::API::MatrixWorkspace_sptr &workspace) {
-  const unsigned indices[] = {0, 1};
-  for (const auto index : indices) {
-    auto axis = workspace->getAxis(index);
-    if (!axis->isNumeric()) {
-      return false;
-    }
-  }
-  return true;
+  const std::array<int, 2> indices = {0, 1};
+  return std::all_of(indices.cbegin(), indices.cend(),
+                     [workspace](auto const &index) { return workspace->getAxis(index)->isNumeric(); });
 }
 
 class SpectrumAxisValueProvider {

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -385,19 +385,14 @@ void addProcess(H5::Group &group, const Mantid::API::MatrixWorkspace_sptr &works
 }
 
 /**
- * Add a note containing sample or can run numbers to the process group.
- * We can add two sample runs, direct and trans, and two can runs, scatter and
- * direct. Sample Scatter and Can Transmission are added to the data elsewhere
+ * Add an entry to the process group.
  * @param group: the sasEntry
- * @param firstEntryName: string containing the name of the first value to save
- * @param firstEntryValue: string containing the first value to save
- * @param secondEntryName: string contianing the name of the second value to
- * save
- * @param secondEntryValue: string containing the second value to save
+ * @param entryName: string containing the name of the value to save
+ * @param entryValue: string containing the value to save
  */
 void addProcessEntry(H5::Group &group, const std::string &entryName, const std::string &entryValue) {
   auto process = group.openGroup(sasProcessGroupName);
-  // Populate note
+  // Populate process entry
   Mantid::DataHandling::H5Util::write(process, entryName, entryValue);
 }
 

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -385,15 +385,6 @@ void addProcess(H5::Group &group, const Mantid::API::MatrixWorkspace_sptr &works
 }
 
 /**
- * Create a note class within process
- * @param group: the sasEntry
- */
-void createNote(H5::Group &group) {
-  auto process = group.openGroup(sasProcessGroupName);
-  Mantid::DataHandling::H5Util::createGroupCanSAS(process, sasNoteGroupName, nxNoteClassAttr, sasNoteClassAttr);
-}
-
-/**
  * Add a note containing sample or can run numbers to the process group.
  * We can add two sample runs, direct and trans, and two can runs, scatter and
  * direct. Sample Scatter and Can Transmission are added to the data elsewhere

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -624,45 +624,24 @@ private:
     auto userFileValue = Mantid::DataHandling::H5Util::readString(userFileDataSet);
     TSM_ASSERT_EQUALS("Should have the Mantid NXcanSAS process name", userFileValue, userFile);
 
-    // Check note
-    if (hasSampleRuns || hasCanRuns || hasBgSub) {
-      auto note = process.openGroup(sasNoteGroupName);
-      do_assert_process_note(note, hasSampleRuns, hasCanRuns, hasBgSub, sampleDirectRun, canDirectRun,
-                             scaledBgSubWorkspace, scaledBgSubScaleFactor);
-    }
-  }
-
-  void do_assert_process_note(H5::Group &note, const bool &hasSampleRuns, const bool &hasCanRuns, const bool &hasBgSub,
-                              const std::string &sampleDirectRun, const std::string &canDirectRun,
-                              const std::string &scaledBgSubWorkspace, const double &scaledBgSubScaleFactor) {
-    auto numAttributes = note.getNumAttrs();
-    TSM_ASSERT_EQUALS("Should have 2 attributes", 2, numAttributes);
-
-    // canSAS_class and NX_class attribute
-    auto classAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(note, sasclass);
-    TSM_ASSERT_EQUALS("Should be SASnote class", classAttribute, sasNoteClassAttr);
-
-    classAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(note, nxclass);
-    TSM_ASSERT_EQUALS("Should be NXnote class", classAttribute, nxNoteClassAttr);
-
     if (hasSampleRuns) {
-      auto sampleDirectRunDataSet = note.openDataSet(sasProcessTermSampleDirect);
+      auto sampleDirectRunDataSet = process.openDataSet(sasProcessTermSampleDirect);
       auto sampleDirectRunValue = Mantid::DataHandling::H5Util::readString(sampleDirectRunDataSet);
       TSM_ASSERT_EQUALS("Should have correct sample direct run number", sampleDirectRunValue, sampleDirectRun);
     }
 
     if (hasCanRuns) {
-      auto canDirectRunDataSet = note.openDataSet(sasProcessTermCanDirect);
+      auto canDirectRunDataSet = process.openDataSet(sasProcessTermCanDirect);
       auto canDirectRunValue = Mantid::DataHandling::H5Util::readString(canDirectRunDataSet);
       TSM_ASSERT_EQUALS("Should have correct can direct run number", canDirectRunValue, canDirectRun);
     }
 
     if (hasBgSub) {
-      auto scaledBgSubWorkspaceDataSet = note.openDataSet(sasProcessTermScaledBgSubWorkspace);
+      auto scaledBgSubWorkspaceDataSet = process.openDataSet(sasProcessTermScaledBgSubWorkspace);
       auto scaledBgSubWorkspaceValue = Mantid::DataHandling::H5Util::readString(scaledBgSubWorkspaceDataSet);
       TSM_ASSERT_EQUALS("Should have correct scaled background subtraction workspace", scaledBgSubWorkspaceValue,
                         scaledBgSubWorkspace);
-      auto scaledBgSubScaleFactorDataSet = note.openDataSet(sasProcessTermScaledBgSubScaleFactor);
+      auto scaledBgSubScaleFactorDataSet = process.openDataSet(sasProcessTermScaledBgSubScaleFactor);
       auto scaledBgSubScaleFactorValue = Mantid::DataHandling::H5Util::readString(scaledBgSubScaleFactorDataSet);
       TSM_ASSERT_EQUALS("Should have correct scaled background subtraction scale factor",
                         stod(scaledBgSubScaleFactorValue), scaledBgSubScaleFactor);

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -731,7 +731,6 @@ uselessOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandlin
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/SaveNexusESS.h:27
 variableScope:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNXcanSAS.cpp:147
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNXcanSAS.cpp:320
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNXcanSAS.cpp:519
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SavePAR.cpp:78
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SavePAR.cpp:50
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SavePHX.cpp:77

--- a/docs/source/release/v6.9.0/SANS/Bugfixes/36552.rst
+++ b/docs/source/release/v6.9.0/SANS/Bugfixes/36552.rst
@@ -1,0 +1,2 @@
+- Process metadata has been moved from ``sasnote`` to the parent ``sasprocess`` when saving using
+  :ref:`algm-SaveNXcanSAS`. This allows data analysis tools like SASView to read in this information correctly.


### PR DESCRIPTION
### Description of work

#### Summary of work
Adjusts the `SaveNXCanSAS` algorithm so that the metadata saved to `sasprocessnote` is saved to `sasprocess` instead. 

Fixes #36552 

#### Further detail of work
Note: The data that was saved to `sasprocessnote` (now in `sasprocess`) is not loaded back into mantid when the `.h5` file is loaded. Only the User File and Batch File are loaded as sample logs. This is obviously not ideal, but is outside the scope of this PR and should be done all at once with the other values in `sasprocess` if it is desired. 

### To test:
1. Boot the SANS GUI
2. Load the user file and batch file from the `loqdemo` in the training course data
3. Set the save mode to both NXcanSAS and CanSAS1D. 
4. Process All
5. Open the output `.xml` in your text editor of choice
6. Open the `.h5` in [HDFView](https://www.hdfgroup.org/downloads/hdfview/)
7. Compare the values in sasprocess and ensure that both files have the same structure. 

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
