### PR TITLE
Add a checkbox to decide if a custom output filename should be used in the Sum Runs tab

### DIFF
--- a/docs/source/release/v6.9.0/SANS/New_features/35869.rst
+++ b/docs/source/release/v6.9.0/SANS/New_features/35869.rst
@@ -1,0 +1,2 @@
+- Switching between a custom output file and an automatically-generated one can now be performed using the
+  ``Enter Custom Filename`` checkbox on the ``Sum Runs`` tab.

--- a/docs/source/release/v6.9.0/SANS/New_features/35869.rst
+++ b/docs/source/release/v6.9.0/SANS/New_features/35869.rst
@@ -1,2 +1,3 @@
 - Switching between a custom output file and an automatically-generated one can now be performed using the
-  ``Enter Custom Filename`` checkbox on the ``Sum Runs`` tab.
+  ``Enter Custom Filename`` checkbox on the :ref:`Sum Runs tab <ISIS_SANS_Sum_Runs_Tab-ref>` in the
+  :ref:`ISIS SANS GUI <ISIS_Sans_interface_contents>`

--- a/scripts/Interface/ui/sans_isis/add_runs_page.py
+++ b/scripts/Interface/ui/sans_isis/add_runs_page.py
@@ -66,6 +66,9 @@ class AddRunsPage(QtWidgets.QWidget, Ui_AddRunsPage):
     def disable_output_file_name_edit(self):
         self.fileNameEdit.setEnabled(False)
 
+    def clear_output_file_name_edit(self):
+        self.fileNameEdit.clear()
+
     def display_save_directory_box(self, title, default_path):
         filename = QtWidgets.QFileDialog.getExistingDirectory(self, title, default_path, QtWidgets.QFileDialog.ShowDirsOnly)
         return filename

--- a/scripts/Interface/ui/sans_isis/add_runs_page.py
+++ b/scripts/Interface/ui/sans_isis/add_runs_page.py
@@ -15,7 +15,7 @@ Ui_AddRunsPage, _ = load_ui(__file__, "add_runs_page.ui")
 class AddRunsPage(QtWidgets.QWidget, Ui_AddRunsPage):
     sum = Signal()
     outFileChanged = Signal()
-    customOutFileChanged = Signal()
+    customOutFileChanged = Signal(bool)
     saveDirectoryClicked = Signal()
 
     def __init__(self, parent=None):

--- a/scripts/Interface/ui/sans_isis/add_runs_page.py
+++ b/scripts/Interface/ui/sans_isis/add_runs_page.py
@@ -15,6 +15,7 @@ Ui_AddRunsPage, _ = load_ui(__file__, "add_runs_page.ui")
 class AddRunsPage(QtWidgets.QWidget, Ui_AddRunsPage):
     sum = Signal()
     outFileChanged = Signal()
+    customOutFileChanged = Signal()
     saveDirectoryClicked = Signal()
 
     def __init__(self, parent=None):
@@ -25,7 +26,11 @@ class AddRunsPage(QtWidgets.QWidget, Ui_AddRunsPage):
     def _connect_signals(self):
         self.sumButton.pressed.connect(self.sum)
         self.fileNameEdit.textEdited.connect(self.outFileChanged)
+        self.customFilenameCheckBox.stateChanged.connect(self._handle_custom_filename_checked)
         self.saveDirectoryButton.clicked.connect(self.saveDirectoryClicked)
+
+    def _handle_custom_filename_checked(self, enabled):
+        self.customOutFileChanged.emit(enabled)
 
     def run_selector_view(self):
         return self.run_selector

--- a/scripts/Interface/ui/sans_isis/add_runs_page.py
+++ b/scripts/Interface/ui/sans_isis/add_runs_page.py
@@ -14,7 +14,6 @@ Ui_AddRunsPage, _ = load_ui(__file__, "add_runs_page.ui")
 
 class AddRunsPage(QtWidgets.QWidget, Ui_AddRunsPage):
     sum = Signal()
-    outFileChanged = Signal()
     customOutFileChanged = Signal(bool)
     saveDirectoryClicked = Signal()
 
@@ -25,7 +24,6 @@ class AddRunsPage(QtWidgets.QWidget, Ui_AddRunsPage):
 
     def _connect_signals(self):
         self.sumButton.pressed.connect(self.sum)
-        self.fileNameEdit.textEdited.connect(self.outFileChanged)
         self.customFilenameCheckBox.stateChanged.connect(self._handle_custom_filename_checked)
         self.saveDirectoryButton.clicked.connect(self.saveDirectoryClicked)
 

--- a/scripts/Interface/ui/sans_isis/add_runs_page.py
+++ b/scripts/Interface/ui/sans_isis/add_runs_page.py
@@ -60,6 +60,12 @@ class AddRunsPage(QtWidgets.QWidget, Ui_AddRunsPage):
     def disable_summation_settings(self):
         self.summation_settings_view().setEnabled(False)
 
+    def enable_output_file_name_edit(self):
+        self.fileNameEdit.setEnabled(True)
+
+    def disable_output_file_name_edit(self):
+        self.fileNameEdit.setEnabled(False)
+
     def display_save_directory_box(self, title, default_path):
         filename = QtWidgets.QFileDialog.getExistingDirectory(self, title, default_path, QtWidgets.QFileDialog.ShowDirsOnly)
         return filename

--- a/scripts/Interface/ui/sans_isis/add_runs_page.ui
+++ b/scripts/Interface/ui/sans_isis/add_runs_page.ui
@@ -31,7 +31,7 @@
         <x>0</x>
         <y>0</y>
         <width>991</width>
-        <height>31</height>
+        <height>32</height>
        </rect>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -122,6 +122,13 @@
       <property name="bottomMargin">
        <number>6</number>
       </property>
+      <item>
+       <widget class="QCheckBox" name="customFilenameCheckBox">
+        <property name="text">
+         <string>Enter Custom Filename</string>
+        </property>
+       </widget>
+      </item>
       <item>
        <widget class="QLineEdit" name="fileNameEdit"/>
       </item>

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -149,6 +149,12 @@ class AddRunsPagePresenter(object):
     def _handle_out_file_changed(self):
         self._use_generated_file_name = False
 
+    def _handle_custom_outfile_check_changed(self, enabled):
+        if enabled:
+            self._use_generated_file_name = False
+            return
+        self._use_generated_file_name = True
+
     @staticmethod
     def _output_directory_is_not_empty(settings):
         return settings.save_directory

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -67,12 +67,12 @@ class AddRunsPagePresenter(object):
         self._parent_view = parent_view
         self._sum_runs_model = sum_runs_model
         self._use_generated_file_name = True
+        self._view.disable_output_file_name_edit()
 
         self._init_sub_presenters(view)
 
         self.save_directory = ""
         self._connect_to_view(view)
-        self._handle_custom_outfile_check_changed(False)
 
         self.gui_properties_handler = SANSGuiPropertiesHandler({"add_runs_output_directory": (self.set_output_directory, str)})
 

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -154,6 +154,7 @@ class AddRunsPagePresenter(object):
             return
         self._use_generated_file_name = True
         self._view.disable_output_file_name_edit()
+        self._handle_selection_changed(self._run_selector_presenter.run_selection())
 
     @staticmethod
     def _output_directory_is_not_empty(settings):

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -109,7 +109,6 @@ class AddRunsPagePresenter(object):
 
     def _connect_to_view(self, view):
         view.sum.connect(self._handle_sum)
-        view.outFileChanged.connect(self._handle_out_file_changed)
         view.customOutFileChanged.connect(self._handle_custom_outfile_check_changed)
         view.saveDirectoryClicked.connect(self._handle_output_directory_changed)
 
@@ -146,9 +145,6 @@ class AddRunsPagePresenter(object):
 
     def _handle_selection_changed(self, run_selection):
         self._refresh_view(run_selection)
-
-    def _handle_out_file_changed(self):
-        self._use_generated_file_name = False
 
     def _handle_custom_outfile_check_changed(self, enabled):
         if enabled:

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -72,6 +72,7 @@ class AddRunsPagePresenter(object):
 
         self.save_directory = ""
         self._connect_to_view(view)
+        self._handle_custom_outfile_check_changed(False)
 
         self.gui_properties_handler = SANSGuiPropertiesHandler({"add_runs_output_directory": (self.set_output_directory, str)})
 

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -149,6 +149,7 @@ class AddRunsPagePresenter(object):
     def _handle_custom_outfile_check_changed(self, enabled):
         if enabled:
             self._use_generated_file_name = False
+            self._view.clear_output_file_name_edit()
             self._view.enable_output_file_name_edit()
             return
         self._use_generated_file_name = True

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -110,6 +110,7 @@ class AddRunsPagePresenter(object):
     def _connect_to_view(self, view):
         view.sum.connect(self._handle_sum)
         view.outFileChanged.connect(self._handle_out_file_changed)
+        view.customOutFileChanged.connect(self._handle_custom_outfile_check_changed)
         view.saveDirectoryClicked.connect(self._handle_output_directory_changed)
 
     def _make_base_file_name_from_selection(self, run_selection):

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -149,8 +149,10 @@ class AddRunsPagePresenter(object):
     def _handle_custom_outfile_check_changed(self, enabled):
         if enabled:
             self._use_generated_file_name = False
+            self._view.enable_output_file_name_edit()
             return
         self._use_generated_file_name = True
+        self._view.disable_output_file_name_edit()
 
     @staticmethod
     def _output_directory_is_not_empty(settings):

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -37,7 +37,6 @@ class AddRunsPagePresenterTestCase(unittest.TestCase):
     def _make_mock_view(self):
         mock_view = mock.create_autospec(AddRunsPage, spec_set=True)
         mock_view.sum = FakeSignal()
-        mock_view.outFileChanged = FakeSignal()
         mock_view.customOutFileChanged = FakeSignal()
         mock_view.saveDirectoryClicked = FakeSignal()
         return mock_view
@@ -225,7 +224,7 @@ class BaseFileNameTest(AddRunsPagePresenterTestCase):
 
         self.assertEqual("LOQ00005-add", returned)
 
-    def test_correct_base_name_after_set_by_user(self):
+    def test_correct_base_name_after_set_by_user_and_custom_selected(self):
         user_out_file_name = "Output"
         run_summation = mock.MagicMock()
         presenter = self._make_presenter(run_summation)
@@ -236,13 +235,13 @@ class BaseFileNameTest(AddRunsPagePresenterTestCase):
         run_summation.__iter__.return_value = run_selection
 
         self.view.out_file_name.return_value = user_out_file_name
-        self.view.outFileChanged.emit()
+        self.view.customOutFileChanged.emit(True)
 
         returned = presenter._sum_base_file_name(run_selection=run_selection)
 
         self.assertEqual(returned, user_out_file_name)
 
-    def test_base_name_not_reset_after_set_by_user(self):
+    def test_base_name_not_reset_when_custom_selected(self):
         run_summation = mock.MagicMock()
         presenter = self._make_presenter(run_summation)
         # Runs 4 / 5 / 6
@@ -250,7 +249,7 @@ class BaseFileNameTest(AddRunsPagePresenterTestCase):
 
         user_out_file_name = "Output"
         self.view.out_file_name.return_value = user_out_file_name
-        self.view.outFileChanged.emit()
+        self.view.customOutFileChanged.emit(True)
 
         run_summation.__iter__.return_value = run_selection
         returned = presenter._sum_base_file_name(run_selection=run_selection)

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -273,6 +273,20 @@ class BaseFileNameTest(AddRunsPagePresenterTestCase):
 
         self.view.set_out_file_name.assert_called_with("LOQ00006-add")
 
+    def test_custom_filename_box_disabled_when_custom_filename_unchecked(self):
+        run_summation = mock.MagicMock()
+        _ = self._make_presenter(run_summation)
+        self.view.customOutFileChanged.emit(False)
+
+        self.view.disable_output_file_name_edit.assert_called_once()
+
+    def test_custom_filename_box_enabled_when_custom_filename_checked(self):
+        run_summation = mock.MagicMock()
+        _ = self._make_presenter(run_summation)
+        self.view.customOutFileChanged.emit(True)
+
+        self.view.enable_output_file_name_edit.assert_called_once()
+
 
 class SumButtonTest(AddRunsPagePresenterTestCase):
     def setUp(self):

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -38,6 +38,7 @@ class AddRunsPagePresenterTestCase(unittest.TestCase):
         mock_view = mock.create_autospec(AddRunsPage, spec_set=True)
         mock_view.sum = FakeSignal()
         mock_view.outFileChanged = FakeSignal()
+        mock_view.customOutFileChanged = FakeSignal()
         mock_view.saveDirectoryClicked = FakeSignal()
         return mock_view
 

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -286,6 +286,7 @@ class BaseFileNameTest(AddRunsPagePresenterTestCase):
         self.view.customOutFileChanged.emit(True)
 
         self.view.enable_output_file_name_edit.assert_called_once()
+        self.view.clear_output_file_name_edit.assert_called_once()
 
 
 class SumButtonTest(AddRunsPagePresenterTestCase):

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -273,12 +273,22 @@ class BaseFileNameTest(AddRunsPagePresenterTestCase):
 
         self.view.set_out_file_name.assert_called_with("LOQ00006-add")
 
-    def test_custom_filename_box_disabled_when_custom_filename_unchecked(self):
+    def test_custom_filename_box_disabled_and_repopulated_when_custom_filename_unchecked(self):
         run_summation = mock.MagicMock()
-        _ = self._make_presenter(run_summation)
-        self.view.customOutFileChanged.emit(False)
+        presenter = self._make_presenter(run_summation)
+
+        run_summation.has_any_runs.return_value = True
+
+        # Runs 4 / 5 / 6
+        run_selection = create_mocked_runs(start=4, len=3)
+
+        run_summation.__iter__.return_value = run_selection
+        presenter._run_selector_presenter.run_selection = mock.MagicMock()
+        presenter._run_selector_presenter.run_selection.return_value = run_summation
+        presenter._handle_custom_outfile_check_changed(False)
 
         self.view.disable_output_file_name_edit.assert_called_once()
+        self.view.set_out_file_name.assert_called_with("LOQ00006-add")
 
     def test_custom_filename_box_enabled_when_custom_filename_checked(self):
         run_summation = mock.MagicMock()

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -109,8 +109,9 @@ class SummationSettingsViewEnablednessTest(AddRunsPagePresenterTestCase):
         presenter._get_filename_manager = mock.Mock(return_value=MockedOutAddRunsFilenameManager())
         return presenter
 
+    @mock.patch("sans.gui_logic.presenter.add_runs_presenter.AddRunsPagePresenter._handle_custom_outfile_check_changed")
     @mock.patch("sans.gui_logic.presenter.add_runs_presenter.RunSelectionModel", autospec=True)
-    def test_enables_summation_settings_when_event_data(self, patched_init_run_selector):
+    def test_enables_summation_settings_when_event_data(self, _patched_init_run_selector, _):
         histogram_run = self._make_fake_histogram_run()
         runs = mock.MagicMock()
         runs.has_any_runs.return_value = True
@@ -120,8 +121,9 @@ class SummationSettingsViewEnablednessTest(AddRunsPagePresenterTestCase):
         presenter._handle_selection_changed(run_selection=runs)
         self.view.enable_summation_settings.assert_called_once()
 
+    @mock.patch("sans.gui_logic.presenter.add_runs_presenter.AddRunsPagePresenter._handle_custom_outfile_check_changed")
     @mock.patch("sans.gui_logic.presenter.add_runs_presenter.RunSelectionModel", autospec=True)
-    def test_enables_summation_settings_when_event_and_histogram_data(self, _):
+    def test_enables_summation_settings_when_event_and_histogram_data(self, _, _handle_check):
         histogram_run = self._make_fake_histogram_run()
         event_run = self._make_fake_event_run()
 
@@ -139,8 +141,9 @@ class SummationConfigurationTest(AddRunsPagePresenterTestCase):
         self.view = self._make_mock_view()
         self.parent_view = self._make_mock_parent_view()
 
+    @mock.patch("sans.gui_logic.presenter.add_runs_presenter.AddRunsPagePresenter._handle_custom_outfile_check_changed")
     @mock.patch("sans.gui_logic.presenter.add_runs_presenter.RunSelectorPresenter", autospec=True)
-    def test_passes_correct_config_when_summation_requested(self, patched_run_selector):
+    def test_passes_correct_config_when_summation_requested(self, patched_run_selector, _):
         # Ensure we know the type that was returned by the constructor
         run_selector_mock = mock.Mock()
         patched_run_selector.return_value = run_selector_mock
@@ -161,8 +164,9 @@ class SummationConfigurationTest(AddRunsPagePresenterTestCase):
         self.view.sum.emit()
         run_summation.assert_called_with(mock.ANY, mock.ANY, "LOQ00003-add")
 
+    @mock.patch("sans.gui_logic.presenter.add_runs_presenter.AddRunsPagePresenter._handle_custom_outfile_check_changed")
     @mock.patch("sans.gui_logic.presenter.add_runs_presenter.RunSelectionModel", autospec=True)
-    def test_shows_error_when_empty_default_directory(self, _):
+    def test_shows_error_when_empty_default_directory(self, _, _handle_check):
         view = self._make_mock_view()
         presenter = AddRunsPagePresenter(mock.MagicMock(), view, mock.Mock())
         presenter.save_directory = ""
@@ -287,7 +291,8 @@ class BaseFileNameTest(AddRunsPagePresenterTestCase):
         presenter._run_selector_presenter.run_selection.return_value = run_summation
         presenter._handle_custom_outfile_check_changed(False)
 
-        self.view.disable_output_file_name_edit.assert_called_once()
+        self.view.disable_output_file_name_edit.assert_called()
+        self.assertEqual(self.view.disable_output_file_name_edit.call_count, 2)
         self.view.set_out_file_name.assert_called_with("LOQ00006-add")
 
     def test_custom_filename_box_enabled_when_custom_filename_checked(self):


### PR DESCRIPTION
### Description of work

#### Summary of work
Added a checkbox that allows the user to indicate that they want to define their own output filename rather than the automatically generated one. 

Fixes #35869

#### Further detail of work
- A corollary to this is that it also allows a user to go back to the autopopulated name, a feature that originally wasn't possible if the value in the Line Edit box was ever changed. 
- The line edit is disabled when the custom file name checkbox is not selected, this is to make it clear that the auto generated filename is not a user defined value. 

### To test:

1. Boot up the ISIS SANS GUI
2. Switch to the Sum Runs tab
3. Add (assuming you have the training course data somewhere) 74044 and 74024 to the list
4. The output name should be `LOQ74044-add`
5. Check Enter Custom Filename
6. The box should clear and allow entry
7. Uncheck Enter Custom Filename
8. The output name should revert to `LOQ74044-add`

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
