### PR TITLE
PyChop bugfixes and feature request implementation

### DIFF
--- a/docs/source/release/v6.9.0/Direct_Geometry/General/Bugfixes/34213.rst
+++ b/docs/source/release/v6.9.0/Direct_Geometry/General/Bugfixes/34213.rst
@@ -1,0 +1,1 @@
+- A bug in PyChop where opening the "Ascii Data Window" resets the internal state so that subsequent calculations become incorrect has been fixed.

--- a/docs/source/release/v6.9.0/Direct_Geometry/General/New_features/36426.rst
+++ b/docs/source/release/v6.9.0/Direct_Geometry/General/New_features/36426.rst
@@ -1,0 +1,1 @@
+- A new feature in PyChop which checks that the user input incident energy is within range for a particular instrument and chopper was added.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
@@ -625,7 +625,7 @@ class PyChopGui(QMainWindow):
             self.repcanvas.draw()
 
     def _gen_text_ei(self, ei, obj_in):
-        obj = Instrument(obj_in)
+        obj = copy.deepcopy(obj_in)
         obj.setEi(ei)
         en = np.linspace(0, 0.95 * ei, 10)
         # ValueErrors here will be caught in showText() or writeText()

--- a/qt/python/mantidqtinterfaces/test/PyChopInstrumentTest.py
+++ b/qt/python/mantidqtinterfaces/test/PyChopInstrumentTest.py
@@ -184,90 +184,114 @@ class MockImports:
             return getattr(self.loaded_from[module_name], module_name)
 
 
+class fake_QMainWindow:
+    def __init__(self, *args, **kwargs):
+        self.menuBar = mock.MagicMock()
+        self.setCentralWidget = mock.MagicMock()
+        self.setWindowTitle = mock.MagicMock()
+
+    def setWindowFlags(self, *args, **kwargs):
+        pass
+
+    def show(self):
+        pass
+
+
+class fake_QCombo(mock.MagicMock):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.clear()
+
+    def clear(self):
+        self.items = []
+        self.currentIndex = 0
+
+    def addItem(self, item):
+        self.items.append(item)
+
+    def currentText(self):
+        return self.items[self.currentIndex]
+
+    def count(self):
+        return len(self.items)
+
+    def itemText(self, idx):
+        return self.items[idx]
+
+    def setCurrentIndex(self, idx):
+        self.currentIndex = idx
+
+    def __getattr__(self, attribute):
+        if attribute not in self.__dict__:
+            self.__dict__[attribute] = mock.MagicMock()
+        return self.__dict__[attribute]
+
+
+class fake_QLineEdit(mock.MagicMock):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.value = "1.0"
+
+    def setText(self, value):
+        self.value = value
+
+    def text(self):
+        return self.value
+
+    def __getattr__(self, attribute):
+        if attribute not in self.__dict__:
+            self.__dict__[attribute] = mock.MagicMock()
+        return self.__dict__[attribute]
+
+
+class fake_Line(mock.MagicMock):
+    def __init__(self, parent, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.parent = parent
+
+    def set_label(self, label):
+        self.parent.legends[self] = label
+
+
+class fake_Axes(mock.MagicMock):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.legends = {}
+
+    def plot(self, *args, **kwargs):
+        self.lines.append(fake_Line(self))
+        return (self.lines[-1],)
+
+    def get_legend_handles_labels(self):
+        labels = [self.legends[line] for line in self.lines]
+        return self.lines, labels
+
+
+class fake_Figure(mock.MagicMock):
+    def add_subplot(self, *args, **kwargs):
+        return fake_Axes()
+
+
+class fake_Slider(mock.MagicMock):
+    def __init__(self, parent, label, valmin, valmax, **kwargs):
+        super().__init__(parent, label, valmin, valmax, **kwargs)
+        self.parent, self.label, self.valmin, self.valmax = parent, label, valmin, valmax
+        self.val = kwargs.pop("valinit", 0.5)
+        self.valtext = mock.MagicMock()
+        self.on_changed = mock.MagicMock()
+
+
 class PyChopGuiTests(unittest.TestCase):
     # Tests GUI routines
 
     @classmethod
     def setUpClass(cls):
-        class fake_QMainWindow:
-            def __init__(self, *args, **kwargs):
-                self.menuBar = mock.MagicMock()
-                self.setCentralWidget = mock.MagicMock()
-                self.setWindowTitle = mock.MagicMock()
-
-            def setWindowFlags(self, *args, **kwargs):
-                pass
-
-            def show(self):
-                pass
-
-        class fake_QCombo(mock.MagicMock):
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-                self.clear()
-
-            def clear(self):
-                self.items = []
-                self.currentIndex = 0
-
-            def addItem(self, item):
-                self.items.append(item)
-
-            def currentText(self):
-                return self.items[self.currentIndex]
-
-            def count(self):
-                return len(self.items)
-
-            def itemText(self, idx):
-                return self.items[idx]
-
-            def setCurrentIndex(self, idx):
-                self.currentIndex = idx
-
-            def __getattr__(self, attribute):
-                if attribute not in self.__dict__:
-                    self.__dict__[attribute] = mock.MagicMock()
-                return self.__dict__[attribute]
-
-        class fake_Line(mock.MagicMock):
-            def __init__(self, parent, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-                self.parent = parent
-
-            def set_label(self, label):
-                self.parent.legends[self] = label
-
-        class fake_Axes(mock.MagicMock):
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-                self.legends = {}
-
-            def plot(self, *args, **kwargs):
-                self.lines.append(fake_Line(self))
-                return (self.lines[-1],)
-
-            def get_legend_handles_labels(self):
-                labels = [self.legends[line] for line in self.lines]
-                return self.lines, labels
-
-        class fake_Figure(mock.MagicMock):
-            def add_subplot(self, *args, **kwargs):
-                return fake_Axes()
-
-        class fake_Slider(mock.MagicMock):
-            def __init__(self, parent, label, valmin, valmax, **kwargs):
-                super().__init__(parent, label, valmin, valmax, **kwargs)
-                self.parent, self.label, self.valmin, self.valmax = parent, label, valmin, valmax
-                self.val = kwargs.pop("valinit", 0.5)
-                self.valtext = mock.MagicMock()
-                self.on_changed = mock.MagicMock()
-
         cls.mock_modules = MockImports(
             include=["qtpy", "matplotlib", "mantidqt", "mantid.plots"],
             replace={
                 "QMainWindow": fake_QMainWindow,
                 "QComboBox": MockedModule(mock_class=fake_QCombo),
+                "QLineEdit": MockedModule(mock_class=fake_QLineEdit),
                 "Figure": MockedModule(mock_class=fake_Figure),
                 "Slider": MockedModule(mock_class=fake_Slider),
             },
@@ -287,6 +311,8 @@ class PyChopGuiTests(unittest.TestCase):
             self.window.calc_callback()
             setS2.assert_not_called()
             self.window.setInstrument("HYSPEC")
+            self.window.widgets["EiEdit"]["Edit"].setText("50")
+            self.window.setEi()
             self.window.calc_callback()
             setS2.assert_called()
         # Test that the value of S2 is set correctly
@@ -356,6 +382,46 @@ class PyChopGuiTests(unittest.TestCase):
         self.window.instSciAct.isChecked = mock.MagicMock(return_value=True)
         self.window.setChopper("G")
         self.window.widgets["Chopper0Phase"]["Edit"].show.assert_called()
+
+    def test_pychop_numerics(self):
+        # Tests all instruments resolution and flux values against reference
+        instruments = ["ARCS", "CNCS", "HYSPEC", "LET", "MAPS", "MARI", "MERLIN", "SEQUOIA"]
+        choppers = ["ARCS-100-1.5-AST", "High Flux", "OnlyOne", "High Flux", "S", "S", "G", "SEQ-100-2.0-AST"]
+        freqs = [[300], [300, 60], [180], [240, 120], [400, 50], [400], [400], [300]]
+        eis = [120, 3.7, 45, 3.7, 120, 80, 120, 120]
+        ref_res = [
+            10.278744237772832,
+            0.13188102618129077,
+            3.6751279831313703,
+            0.08079912729715726,
+            4.9611687063450995,
+            2.6049587487601764,
+            6.8755979524827255,
+            5.396705255853653,
+        ]
+        ref_flux = [
+            2055.562054927915,
+            128986.24972543867,
+            0.014779264739956933,
+            45438.33797146135,
+            24196.496233770937,
+            5747.118187298609,
+            22287.647098883135,
+            4063.3113893387676,
+        ]
+        for inst, ch, frq, ei, res0, flux0 in zip(instruments, choppers, freqs, eis, ref_res, ref_flux):
+            res, flux = Instrument.calculate(inst, ch, frq, ei, 0)
+            np.testing.assert_allclose(res[0], res0, rtol=1e-4, atol=0)
+            np.testing.assert_allclose(flux[0], flux0, rtol=1e-4, atol=0)
+
+    def test_erange(self):
+        # Tests MARI raises if Ei outside range [0, 180meV] with G chopper only ('S' chopper ok up to 1000meV)
+        obj = Instrument("MARI", "S", 400)
+        obj.setEi(500)
+        obj.setChopper("G", 400)
+        with self.assertRaises(ValueError):
+            obj.setEi(500)
+        obj.setEi(180)
 
 
 if __name__ == "__main__":

--- a/scripts/pychop/mari.yaml
+++ b/scripts/pychop/mari.yaml
@@ -65,6 +65,7 @@ chopper_system:
           tjit: 0.0             # Jitter time (us)
           fluxcorr: 3.2         # (Empirical/Fudge) factor to scale calculated flux by
           isPi: True            # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+          ei_limits: [0, 181]   # Limits on ei for this chopper (setting Ei outside this will give error)
         R:
           name: MARI R (500meV)
           pslit: 1.143          # Neutron transparent slit width (mm)

--- a/scripts/pychop/merlin.yaml
+++ b/scripts/pychop/merlin.yaml
@@ -37,6 +37,7 @@ chopper_system:
           tjit: 0.0             # Jitter time (us)
           fluxcorr: 3.          # (Empirical/Fudge) factor to scale calculated flux by
           isPi: True            # Should the PI pulse (at 180 deg rotation) be transmitted by this package?
+          ei_limits: [0, 181]   # Limits on ei for this chopper (setting Ei outside this will give error)
         S:
           name: MERLIN S (Sloppy)
           pslit: 2.280          # Neutron transparent slit width (mm)


### PR DESCRIPTION
### Description of work

Fixes bug #34213 and add feature request #36462 - see individual commits for details.

Although these two issues are quite different, they both relate to PyChop and both require relatively small changes (1 line in one case, 13 in the other), so I thought it reasonable to put them into one PR.

#### Summary of work

The biggest change is actually to add a unit test for the energy range feature request (#36462). This feature meant that an existing test (`test_hyspec`) would fail because it did not set the incident energy (`Ei`) the default (`1` meV) is outside the default HYSPEC range (from `3.6` to `61` meV). This meant creating a new mock for a `QLineEdit` to be able to set the energy in the test. This then meant the `setUpClass` method was too complex for `ruff` so the GUI tests had to be refactored.

I also added a numerics test of the resolution and flux output of the calculations for the default settings for all instruments. This is mainly to check that using `np.interp` instead of `scipy.interpolate.interp1d` would not cause large numerical differences in the interpolation of measured flux / energy widths data. (The results agree to within 1%). The test is also quite tolerant (0.1% relative) so would be good as a guard against accidental changes to the instrument `yaml` files or computing code. (Large changes would require changing the reference values).

<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.

Fixes #34213 and #36462
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
N/A

### To test:

1. Run the PyChop GUI (in `Interfaces` -> `Direct`) and select `MARI` with the `G` chopper. 
2. Set the energy to `500` meV and press `Enter`. A pop-up saying that the energy is out of range should appear. 
3. Change the energy to `180` meV and press `Enter` and it should work (Click `Calculate` to check).

----

1. In the `Options` menu, click `Instrument Scientist Mode`, then select `ARCS` and set: Chopper: `ARCS-100-1.5-AST`, Frequency: `600`, Ei: `150`. 
2. Click `Calculate` and check in the `Script Output` tab that the resolution is calculated to be `7216.85 ueV`. 
3. Click `Show data ascii window` and check the `Elastic resolution` says `7.22` meV.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
