### PR TITLE
Use full fit function names for Inelastic Data Analysis ConvFit tab

### DIFF
--- a/dev-docs/source/IndirectDataAnalysisAddingFitType.rst
+++ b/dev-docs/source/IndirectDataAnalysisAddingFitType.rst
@@ -9,7 +9,7 @@ list of available ones can seem daunting at first but it can be done by followin
 FqFit
 -----
 
-In the `FQFitConstants.h` file, there are sets of maps of {"Fit function class name", "Fit function class initialization string"}, e.g.
+In the `FitTabConstants.h` file, there are sets of maps of {"Fit function class name", "Fit function class initialization string"}, e.g.
 `{std::string("TeixeiraWater"), std::string("name=TeixeiraWater, Tau=1, L=1.5, constraints=(Tau>0, L>0)")}`. To add
 a new fit function to FqFit you simply need to add it to this list of available functions. Currently, we divide up the
 functions into Width, EISF, and All with the intent that the list of functions would change depending on what data is
@@ -18,15 +18,13 @@ loaded into the tab, however as it is not yet implemented for the workspace inpu
 MSDFit
 ------
 
-The fit function strings in MSDFit are stored in the `IndirectDataAnalysisMSDFitTab.cpp` file in `msdFunctionStrings`,
-To add a function you just need to add it to this map and add the function to the others in `createParameterEstimation`
-e.e. `parameterEstimation.addParameterEstimationFunction(MSDGAUSSFUNC, estimateMsd);`
+The fit function strings for MSDFit are also stored in the `FitTabConstants.h` file.
 
 IqtFit
 ------
 
-The fitting functions in IqtFit are hard coded into the template browser because it is not expected for other functions to be
-added to it.
+The fitting functions in IqtFit are hard coded into the template browser. These should be moved into the `FitTabConstants.h` file to
+allow us to add more functions easily in the future.
 
 ConvFit
 -------
@@ -72,14 +70,11 @@ LorentzianType, and BackgroundType. ConvFit can run fits with one of each Fit, L
 
 .. code-block:: cpp
 
-    {FitType::TeixeiraWater, {"Teixeira Water", "TeixeiraWaterSQE", {ParamID::TW_HEIGHT, ParamID::TW_CENTRE}}},
+    {FitType::TeixeiraWater, {"Teixeira Water SQE", "TeixeiraWaterSQE", {ParamID::TW_HEIGHT, ParamID::TW_CENTRE}}},
 
 
-Finally, in IndirectDataAnalysisConvFitTab in setupFitTab add to m_fitStrings with the fit function name and shortened key, this key will be used in the output workspace from the fit.
-
-.. code-block:: cpp
-
-   m_fitStrings["TeixeiraWaterSQE"] = "TxWater";
+Finally, in `FitTabConstants.h` add the fit function name and shortened key to the `FUNCTION_STRINGS` variable. This key will be used in the output
+workspace from the fit.
 
 In ConvFunctionModel add the build function string function
 

--- a/docs/source/release/v6.9.0/Inelastic/Bugfixes/36576.rst
+++ b/docs/source/release/v6.9.0/Inelastic/Bugfixes/36576.rst
@@ -1,0 +1,1 @@
+- The full fit function names are now used on the ConvFit tab of :ref:`Inelastic Data Analysis <interface-inelastic-data-analysis>` to avoid confusion with similarly named functions.

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTypes.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTypes.cpp
@@ -132,10 +132,10 @@ std::map<ParamID, QString> g_paramName{
 template <>
 std::map<FitType, TemplateSubTypeDescriptor> TemplateSubTypeImpl<FitType>::g_typeMap{
     {FitType::None, {"None", "", {ParamID::NONE, ParamID::NONE}}},
-    {FitType::TeixeiraWater, {"Teixeira Water", "TeixeiraWaterSQE", {ParamID::TW_HEIGHT, ParamID::TW_CENTRE}}},
-    {FitType::FickDiffusion, {"Fick Diffusion", "FickDiffusionSQE", {ParamID::FD_HEIGHT, ParamID::FD_CENTRE}}},
-    {FitType::ChudleyElliot, {"Chudley-Elliot", "ChudleyElliotSQE", {ParamID::CE_HEIGHT, ParamID::CE_CENTRE}}},
-    {FitType::HallRoss, {"Hall-Ross", "HallRossSQE", {ParamID::HR_HEIGHT, ParamID::HR_CENTRE}}},
+    {FitType::TeixeiraWater, {"Teixeira Water SQE", "TeixeiraWaterSQE", {ParamID::TW_HEIGHT, ParamID::TW_CENTRE}}},
+    {FitType::FickDiffusion, {"Fick Diffusion SQE", "FickDiffusionSQE", {ParamID::FD_HEIGHT, ParamID::FD_CENTRE}}},
+    {FitType::ChudleyElliot, {"Chudley-Elliot SQE", "ChudleyElliotSQE", {ParamID::CE_HEIGHT, ParamID::CE_CENTRE}}},
+    {FitType::HallRoss, {"Hall-Ross SQE", "HallRossSQE", {ParamID::HR_HEIGHT, ParamID::HR_CENTRE}}},
     {FitType::StretchedExpFT, {"StretchedExpFT", "StretchedExpFT", {ParamID::SE_HEIGHT, ParamID::SE_CENTRE}}},
     {FitType::DiffSphere, {"DiffSphere", "DiffSphere", {ParamID::DP_INTENSITY, ParamID::DP_SHIFT}}},
     {FitType::ElasticDiffSphere,


### PR DESCRIPTION
### Description of work
This PR ensures that the full fit function names are used in the ConvFit tab of the Inelastic Data Analysis interface. This is to avoid confusion because we have a bunch of functions with names `TW`, `CE`, `FD` and `HR` ; and we also have SQE versions of these fit functions. So it is misleading to call use `TeixeiraWater` on the ConvFit tab when the actually function being used is the `TeixeiraWaterSQE` function.

Fixes #36576 

### To test:
1. Open Inelastic -> Data Analysis interface
2. Go to ConvFit tab
3. Look at the Fit Types combo box.
4. See that the `TW`, `CE`, `FD` and `HR` functions have SQE after their name

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
