### PR TITLE
Reinstate excludeInPullRequests for system tests

### DIFF
--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -5,7 +5,7 @@
 #
 # Expected args:
 #   1. WORKSPACE: path to the workspace/source code that this should run inside
-#   2. CMAKE_PRESET: the CMake preset that should be ran to generate the cmake files for this CI job
+#   2. CMAKE_PRESET: the CMake preset that should be run to generate the cmake files for this CI job
 #   3. ENABLE_DOCS: build the user docs
 #   4. ENABLE_DEV_DOCS: build the user docs
 #   5. ENABLE_BUILD_CODE: whether or not to build the main code target

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -13,16 +13,16 @@
 # Expected args:
 #   1. WORKSPACE: path to the workspace/source code that this should run inside, Windows Caveat: Only use / for
 #                 this argument do not use \\ or \ in the path.
-#   2. CMAKE_PRESET: the CMake preset that should be ran to generate the cmake files for this CI job
+#   2. CMAKE_PRESET: the CMake preset that should be run to generate the cmake files for this CI job
 #
 # Possible flags:
-#   --enable-systemtests: Runs the system tests from being compiled or ran
+#   --enable-systemtests: Build and run the system tests
 #   --enable-package: Runs a package being produced
-#   --enable-docs: Runs the docs from being built
-#   --enable-dev-docs: Runs the developer docs from being built
-#   --enable-doctests: Runs the documentation tests
-#   --enable-coverity: Runs coverity and submits results, ignore all other options and does not run unit tests
-#   --clean-build: Clears the build folder and builds from scratch
+#   --enable-docs: Build the docs
+#   --enable-dev-docs: Build the developer docs
+#   --enable-doctests: Run the documentation tests
+#   --enable-coverity: Run coverity and submit results; ignores all other options and does not run unit tests
+#   --clean-build: Clear the build folder and build from scratch
 #   --clean-external-projects: Clear the external projects from the build folder
 #
 # Possible parameters:

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -17,7 +17,6 @@
 #
 # Possible flags:
 #   --enable-systemtests: Build and run the system tests
-#   --enable-package: Runs a package being produced
 #   --enable-docs: Build the docs
 #   --enable-dev-docs: Build the developer docs
 #   --enable-doctests: Run the documentation tests
@@ -57,7 +56,6 @@ BUILD_DIR=$WORKSPACE/build
 ENABLE_BUILD_CODE=true
 ENABLE_UNIT_TESTS=true
 ENABLE_SYSTEM_TESTS=false
-ENABLE_PACKAGE=false
 ENABLE_DOCS=false
 ENABLE_DOC_TESTS=false
 ENABLE_DEV_DOCS=false
@@ -71,7 +69,6 @@ while [ ! $# -eq 0 ]
 do
     case "$1" in
         --enable-systemtests) ENABLE_SYSTEM_TESTS=true ;;
-        --enable-package) ENABLE_PACKAGE=true ;;
         --enable-docs) ENABLE_DOCS=true ;;
         --enable-doctests)
             ENABLE_DOCS=true

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -5,10 +5,10 @@
 #
 # Expected args:
 #   1. WORKSPACE: path to the workspace/source code that this should run inside
-#   2. ENABLE_SYSTEM_TESTS: whether or not system tests are being ran/built
-#   3. ENABLE_UNIT_TESTS: whether or not unit tests are being ran/built
+#   2. ENABLE_SYSTEM_TESTS: whether or not system tests are being run/built
+#   3. ENABLE_UNIT_TESTS: whether or not unit tests are being run/built
 #   4. ENABLE_DOCS: Whether or not the docs have been built
-#   5. ENABLE_DOC_TESTS: Whether or not the doc tests should be ran
+#   5. ENABLE_DOC_TESTS: Whether or not the doc tests should be run
 #   6. BUILD_THREADS: The number of threads to use during testing
 
 WORKSPACE=$1

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -105,5 +105,11 @@ if [[ $ENABLE_SYSTEM_TESTS == true ]]; then
     echo "usagereports.enabled = 0" >> $userprops
     echo "CheckMantidVersion.OnStartup = 0" >> $userprops
 
-    run_with_xvfb $SYSTEM_TEST_EXECUTABLE $WINDOWS_TEST_OPTIONS -j$BUILD_THREADS_SYSTEM_TESTS -l information --quiet --output-on-failure
+    SYSTEM_TEST_OPTIONS="-j${BUILD_THREADS_SYSTEM_TESTS} -l information --quiet --output-on-failure"
+
+    if [[ ${JOB_NAME} == *pull_requests* ]]; then
+        SYSTEM_TEST_OPTIONS+=" --exclude-in-pull-requests"
+    fi
+
+    run_with_xvfb $SYSTEM_TEST_EXECUTABLE $WINDOWS_TEST_OPTIONS $SYSTEM_TEST_OPTIONS
 fi

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -426,9 +426,9 @@ fi
 ###############################################################################
 # Uncomment this when the dev-docs are ready to build without warnings
 if [[ ${DO_BUILD_DEVDOCS} == true ]]; then
-  rm -fr $BUILD_DIR/dev-docs/doctree/*
-  rm -f $BUILD_DIR/dev-docs/dev_docs_warnings.txt
-  ${CMAKE_EXE} --build . --target dev-docs-html
+    rm -fr $BUILD_DIR/dev-docs/doctree/*
+    rm -f $BUILD_DIR/dev-docs/dev_docs_warnings.txt
+    ${CMAKE_EXE} --build . --target dev-docs-html
 fi
 
 ###############################################################################
@@ -458,11 +458,11 @@ fi
 if [[ ${DO_SYSTEMTESTS} == true ]]; then
     if [[ ${PRBUILD} == true ]]; then
         # Don't run installer tests if package isn't built.
-		if [[ ${DO_BUILD_PKG} == false ]]; then
-		    RUN_INSTALLER_TESTS=false BUILD_CONFIG=$BUILD_CONFIG EXTRA_ARGS="--exclude-in-pull-requests" $SCRIPT_DIR/systemtests
-		else
+		    if [[ ${DO_BUILD_PKG} == false ]]; then
+		        RUN_INSTALLER_TESTS=false BUILD_CONFIG=$BUILD_CONFIG EXTRA_ARGS="--exclude-in-pull-requests" $SCRIPT_DIR/systemtests
+		    else
             EXTRA_ARGS="--exclude-in-pull-requests" $SCRIPT_DIR/systemtests
-		fi
+		    fi
     else
         $SCRIPT_DIR/systemtests
     fi

--- a/dev-docs/source/SystemTests.rst
+++ b/dev-docs/source/SystemTests.rst
@@ -217,7 +217,7 @@ fixed when running CMake, e.g.
 Selecting Tests to Run From IDE
 -------------------------------
 
-System tests can be ran from the MSVC IDE using the ``SystemTests`` target,
+System tests can be run from the MSVC IDE using the ``SystemTests`` target,
 which behaves in a similar way to unit test targets. One key advantage is
 that it allows you to start Mantid in a debug environment rather than attach
 to one midway through.


### PR DESCRIPTION
### Description of work
Some system tests override `excludeInPullRequests()` to return `true` because they are not intended to be run for every pull request, but only on the nightly build. This functionality was lost when we moved over to using conda environments for our pull request builds. Here it is reinstated.

#### Summary of work
Only the final commit serves the purpose. Previous commits are code tidying.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #33750 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
- Ensure that the `LoadLotsOfFiles` system test is not run in the pull request build.
- Ensure that it IS run in the following _non-pull request_ builds for all OS:
https://builds.mantidproject.org/job/build_packages_from_branch/720/


*This does not require release notes* because **it only affects how tests are run for pull request builds**


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
