### PR TITLE
Fail Windows packaging if no package was generated.

### DIFF
--- a/installers/conda/win/create_package.sh
+++ b/installers/conda/win/create_package.sh
@@ -2,7 +2,7 @@
 
 # Constructs a standalone windows MantidWorkbench installer using NSIS.
 # The package is created from a pre-packaged version of Mantid from conda
-# and removes any excess that is not necessary in a standalone
+# and removes some excess that is not necessary in a standalone
 # package
 
 # Print usage and exit
@@ -217,6 +217,12 @@ OUTFILE_NAME="$SCRIPT_DRIVE_LETTER:${OUTFILE_NAME:2}"
 # Run the makensis command from our nsis Conda environment
 echo makensis /V4 /O\"$NSIS_OUTPUT_LOG\" /DVERSION=$VERSION /DPACKAGE_DIR=\"$COPY_DIR\" /DPACKAGE_SUFFIX=$SUFFIX /DOUTFILE_NAME=$OUTFILE_NAME /DMANTID_ICON=$MANTID_ICON /DMUI_PAGE_LICENSE_PATH=$LICENSE_PATH \"$NSIS_SCRIPT\"
 cmd.exe //C "START /wait "" $MAKENSIS_COMMAND /V4 /DVERSION=$VERSION /O"$NSIS_OUTPUT_LOG" /DPACKAGE_DIR="$COPY_DIR" /DPACKAGE_SUFFIX=$SUFFIX /DOUTFILE_NAME=$OUTFILE_NAME /DMANTID_ICON=$MANTID_ICON /DMUI_PAGE_LICENSE_PATH=$LICENSE_PATH "$NSIS_SCRIPT""
+
+if [ ! -f "$OUTFILE_NAME" ]; then
+  echo "Error creating package, no file found at $OUTFILE_NAME"
+  exit 1
+fi
+
 echo "Package packaged, find it here: $OUTFILE_NAME"
 
 echo "Done"


### PR DESCRIPTION
### Description of work
Exit the Windows standalone installer packaging script with failure if the NSIS command fails.

#### Purpose of work
Previously, if the NSIS step failed (e.g. it failed due to a syntax error when our Windows VMs were upgraded), it would still execute this line, which was misleading:
`echo "Package packaged, find it here: $OUTFILE_NAME"`
Here I commented out the NSIS step to recreate the problem:
https://builds.mantidproject.org/job/build_packages_from_branch/726/
specifically, the end of this log file, which suggests the package was created:
https://builds.mantidproject.org/job/build_packages_from_branch/726/execution/node/236/log/


*There is no associated issue.*


### To test:
1. Check that the package build still succeeds under normal conditions with these changes:
https://builds.mantidproject.org/job/build_packages_from_branch/727/
2. Check that the pipeline fails and gives useful error output when the NSIS step fails (I simply commented it out)
https://builds.mantidproject.org/job/build_packages_from_branch/728/
(log file is [here](https://builds.mantidproject.org/job/build_packages_from_branch/728/execution/node/302/log/))

*This does not require release notes* because **it's a change to a build script to help with debugging**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
