### PR TITLE
36568 avoid cropping in gsas2 min max

### DIFF
--- a/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/36568.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/36568.rst
@@ -1,0 +1,1 @@
+- Avoid cropping the range of data in the GSAS-II tab of :ref:`Engineering Diffraction GUI<Engineering_Diffraction-ref>` from its original range

--- a/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/36568.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/36568.rst
@@ -1,1 +1,2 @@
-- Avoid cropping the range of data in the GSAS-II tab of :ref:`Engineering Diffraction GUI<Engineering_Diffraction-ref>` from its original range
+- Avoid cropping the range of TOF data in the GSAS-II tab of :ref:`Engineering Diffraction GUI<Engineering_Diffraction-ref>` from its original TOF range
+- Updated the dmax value used to generate ``Pawley Refinement`` from ``3 Ang`` into ``4.2 Ang`` since ENGIN-X has wavelength range of upto ``6 Ang``.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -452,7 +452,7 @@ class GSAS2Model(object):
 
                 generator = ReflectionGenerator(structure)
 
-                hkls = generator.getUniqueHKLsUsingFilter(self.dSpacing_min, 3.0, ReflectionConditionFilter.StructureFactor)
+                hkls = generator.getUniqueHKLsUsingFilter(self.dSpacing_min, 4.2, ReflectionConditionFilter.StructureFactor)
                 dValues = generator.getDValues(hkls)
                 pg = structure.getSpaceGroup().getPointGroup()
                 # Make list of tuples and sort by d-values, descending, include point group for multiplicity.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -565,15 +565,7 @@ class GSAS2Model(object):
         else:
             self.x_min = self.data_x_min
             self.x_max = self.data_x_max
-            success = self.determine_x_limits()
-            if not success:
-                return None
-            if not self.x_min:
-                logger.error(
-                    "Could not determine Minimum and Maximum X values from input files. "
-                    "Please set these values in the Plot Widget on the GSAS-II tab."
-                )
-                return None
+
         self.limits = [self.x_min, self.x_max]
         return True
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -506,29 +506,6 @@ class GSAS2Model(object):
     # X Limits
     # =========
 
-    def determine_x_limits(self):
-        tof_min = self.determine_tof_min()
-        if not tof_min:
-            return None
-        for workspace_index in range(len(self.x_min)):
-            if tof_min[workspace_index] > self.x_min[workspace_index]:
-                self.x_min[workspace_index] = tof_min[workspace_index]
-        return True
-
-    def determine_tof_min(self):
-        tof_min = []
-        if self.number_of_regions > 1 and len(self.instrument_files) == 1:
-            tof_min = self.get_crystal_params_from_instrument(self.instrument_files[0])
-            if not tof_min:
-                return None
-        elif self.number_of_regions == len(self.instrument_files):
-            for input_instrument in self.instrument_files:
-                loop_instrument_tof_min = self.get_crystal_params_from_instrument(input_instrument)
-                if not loop_instrument_tof_min:
-                    return None
-                tof_min.append(loop_instrument_tof_min[0])
-        return tof_min
-
     def understand_data_structure(self):
         self.data_x_min = []
         self.data_x_max = []

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/presenter.py
@@ -4,10 +4,10 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+import numpy as np
 
 from mantidqt.utils.observer_pattern import GenericObserverWithArgPassing
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.fitting_ads_observer import FittingADSObserver
-import functools
 
 
 class GSAS2Presenter(object):
@@ -56,16 +56,9 @@ class GSAS2Presenter(object):
             return None
         current_limits = self.view.get_x_limits_from_line_edits()
         if current_limits:
-            # Check current_limits != self.view.initial_x_limits:
-            if not functools.reduce(
-                lambda p, q: p and q,
-                map(
-                    lambda cur_limit, init_limit: round(float(cur_limit[0]), 2) == round(init_limit, 2),
-                    current_limits,
-                    self.view.initial_x_limits,
-                ),
-            ):
-                return current_limits
+            # Check current_limits != self.view.initial_x_limits upto 2 decimal places
+            if not np.allclose(np.sort(np.array(current_limits, dtype=float), axis=None), self.view.initial_x_limits, atol=1e-2):
+                return np.sort(np.array(current_limits, dtype=float), axis=0).tolist()
         return None
 
     # =================

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/presenter.py
@@ -7,6 +7,7 @@
 
 from mantidqt.utils.observer_pattern import GenericObserverWithArgPassing
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.fitting_ads_observer import FittingADSObserver
+import functools
 
 
 class GSAS2Presenter(object):
@@ -55,8 +56,16 @@ class GSAS2Presenter(object):
             return None
         current_limits = self.view.get_x_limits_from_line_edits()
         if current_limits:
-            if current_limits != self.view.initial_x_limits:
-                return sorted(current_limits)
+            # Check current_limits != self.view.initial_x_limits:
+            if not functools.reduce(
+                lambda p, q: p and q,
+                map(
+                    lambda cur_limit, init_limit: round(float(cur_limit[0]), 2) == round(init_limit, 2),
+                    current_limits,
+                    self.view.initial_x_limits,
+                ),
+            ):
+                return current_limits
         return None
 
     # =================

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_model.py
@@ -199,16 +199,8 @@ class TestGSAS2Model(unittest.TestCase):
         self.model.number_of_regions = 2
         self.assertEqual(self.model.get_crystal_params_from_instrument("mock_instrument"), [18017.0, 18017.0])
 
-    @patch(model_path + ".GSAS2Model.determine_tof_min")
-    def test_determine_x_limits(self, mock_tof_min):
-        mock_tof_min.return_value = [17000, 19000]
-        self.model.x_min = [18000, 18000]
-        self.model.determine_x_limits()
-        self.assertEqual(self.model.x_min, [18000, 19000])
-
-    @patch(model_path + ".GSAS2Model.determine_tof_min")
     @patch(model_path + ".GSAS2Model.understand_data_structure")
-    def test_validate_x_limits(self, mock_understand_data, mock_tof_min):
+    def test_validate_x_limits(self, mock_understand_data):
         self.model.number_of_regions = 1
         self.model.instrument_files = ["inst1", "inst2"]
         self.model.data_files = ["data1", "data2", "data3"]
@@ -228,14 +220,13 @@ class TestGSAS2Model(unittest.TestCase):
         self.assertEqual(one_inst_one_hist_two_regions, True)
         self.assertEqual(self.model.limits, [[18000.0, 18000.0], [50000.0, 50000.0]])
 
-        mock_tof_min.return_value = [19000]
         self.model.data_x_min = [18000]
         self.model.data_x_max = [40000]
         self.model.instrument_files = ["inst1"]
         self.model.data_files = ["data1"]
         no_user_limits = self.model.validate_x_limits(None)
         self.assertEqual(no_user_limits, True)
-        self.assertEqual(self.model.limits, [[19000], [40000]])
+        self.assertEqual(self.model.limits, [[18000], [40000]])
 
     def test_read_gsas_lst(self):
         logged_lst_result = self.model.read_gsas_lst_and_print_wR(

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_presenter.py
@@ -8,6 +8,8 @@ import unittest
 
 from unittest import mock
 from unittest.mock import patch
+
+
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.gsas2 import model, view, presenter
 
 # from testhelpers import assertRaisesNothing
@@ -98,11 +100,11 @@ class TestGSAS2Presenter(unittest.TestCase):
         # Success
         self.view.get_x_limits_from_line_edits.return_value = [["18000"], ["50000"]]
         self.view.get_load_parameters.return_value = ["inst", "phase", "data"]
-        self.assertEqual(self.presenter.get_limits_if_same_load_parameters(), [["18000"], ["50000"]])
+        self.assertEqual(self.presenter.get_limits_if_same_load_parameters(), [[18000.0], [50000.0]])
         # Success with limits reversed
-        self.view.get_x_limits_from_line_edits.return_value = [["5000"], ["80000"]]
+        self.view.get_x_limits_from_line_edits.return_value = [["50000"], ["8000"]]
         self.view.get_load_parameters.return_value = ["inst", "phase", "data"]
-        self.assertEqual(self.presenter.get_limits_if_same_load_parameters(), [["5000"], ["80000"]])
+        self.assertEqual(self.presenter.get_limits_if_same_load_parameters(), [[8000.0], [50000.0]])
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_presenter.py
@@ -96,13 +96,13 @@ class TestGSAS2Presenter(unittest.TestCase):
         self.view.get_load_parameters.return_value = ["inst", "phase", "data"]
         self.assertEqual(self.presenter.get_limits_if_same_load_parameters(), None)
         # Success
-        self.view.get_x_limits_from_line_edits.return_value = [18000, 50000]
+        self.view.get_x_limits_from_line_edits.return_value = [["18000"], ["50000"]]
         self.view.get_load_parameters.return_value = ["inst", "phase", "data"]
-        self.assertEqual(self.presenter.get_limits_if_same_load_parameters(), [18000, 50000])
+        self.assertEqual(self.presenter.get_limits_if_same_load_parameters(), [["18000"], ["50000"]])
         # Success with limits reversed
-        self.view.get_x_limits_from_line_edits.return_value = [50000, 18000]
+        self.view.get_x_limits_from_line_edits.return_value = [["5000"], ["80000"]]
         self.view.get_load_parameters.return_value = ["inst", "phase", "data"]
-        self.assertEqual(self.presenter.get_limits_if_same_load_parameters(), [18000, 50000])
+        self.assertEqual(self.presenter.get_limits_if_same_load_parameters(), [["5000"], ["80000"]])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of work
The range of data plotted in GSAS-II tab was different to the original range and was truncated. With this work, TOF range is preserved to the original min and max values.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36568. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

### To test:
1. Follow the instructions of Test 11 https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html#test-11
2. After clicking `Refine in GSAS II` at instruction 7, check the Min and Max TOF values which should resemble the original TOF range for that data which can be cross-checked with the Fitting tab.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
