### PR TITLE
Fix Crash When Saving to Invalid Locations in ISIS Refl GUI

### DIFF
--- a/docs/source/release/v6.9.0/Reflectometry/Bugfixes/35223.rst
+++ b/docs/source/release/v6.9.0/Reflectometry/Bugfixes/35223.rst
@@ -1,0 +1,1 @@
+- Workbench will no longer crash if an attempt is made to save a batch to an invalid location.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -297,10 +297,14 @@ void MainWindowPresenter::notifySaveBatchRequested(int tabIndex) {
   try {
     m_fileHandler->saveJSONToFile(filename, map);
   } catch (std::invalid_argument const &e) {
-    m_messageHandler->giveUserCritical("Invalid filename provided: " + std::string(e.what()), "Save Batch");
+    m_messageHandler->giveUserCritical(
+        "Invalid path provided. Check you have the correct permissions for this save location. \n" +
+            std::string(e.what()),
+        "Save Batch");
     return;
   } catch (std::runtime_error const &e) {
-    m_messageHandler->giveUserCritical("Save failed: " + std::string(e.what()), "Save Batch");
+    m_messageHandler->giveUserCritical("An error occurred while saving. Please try again. \n" + std::string(e.what()),
+                                       "Save Batch");
     return;
   }
   m_batchPresenters[tabIndex].get()->notifyChangesSaved();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -360,13 +360,13 @@ void MainWindowPresenter::setDefaultInstrument(const std::string &requiredInstru
   auto requiredFacility = "ISIS";
   if (currentFacility != requiredFacility) {
     config.setString("default.facility", requiredFacility);
-    g_log.notice() << "Facility changed to " << requiredFacility;
+    g_log.notice() << "Facility changed to " << requiredFacility << "\n";
   }
 
   auto currentInstrument = config.getString("default.instrument");
   if (currentInstrument != requiredInstrument) {
     config.setString("default.instrument", requiredInstrument);
-    g_log.notice() << "Instrument changed to " << requiredInstrument;
+    g_log.notice() << "Instrument changed to " << requiredInstrument << "\n";
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -297,10 +297,10 @@ void MainWindowPresenter::notifySaveBatchRequested(int tabIndex) {
   try {
     m_fileHandler->saveJSONToFile(filename, map);
   } catch (std::invalid_argument const &e) {
-    g_log.error() << "Invalid filename provided: " << e.what() << "\n";
+    m_messageHandler->giveUserCritical("Invalid filename provided: " + std::string(e.what()), "Save Batch");
     return;
   } catch (std::runtime_error const &e) {
-    g_log.error() << "Save failed: " << e.what() << "\n";
+    m_messageHandler->giveUserCritical("Save failed: " + std::string(e.what()), "Save Batch");
     return;
   }
   m_batchPresenters[tabIndex].get()->notifyChangesSaved();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -294,7 +294,12 @@ void MainWindowPresenter::notifySaveBatchRequested(int tabIndex) {
   if (filename == "")
     return;
   auto map = m_encoder->encodeBatch(m_view, tabIndex, false);
-  m_fileHandler->saveJSONToFile(filename, map);
+  try {
+    m_fileHandler->saveJSONToFile(filename, map);
+  } catch (std::invalid_argument const &e) {
+    g_log.error() << "Invalid filename provided: " << e.what() << "\n";
+    return;
+  }
   m_batchPresenters[tabIndex].get()->notifyChangesSaved();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -299,6 +299,9 @@ void MainWindowPresenter::notifySaveBatchRequested(int tabIndex) {
   } catch (std::invalid_argument const &e) {
     g_log.error() << "Invalid filename provided: " << e.what() << "\n";
     return;
+  } catch (std::runtime_error const &e) {
+    g_log.error() << "Save failed: " << e.what() << "\n";
+    return;
   }
   m_batchPresenters[tabIndex].get()->notifyChangesSaved();
 }

--- a/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MainWindowPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MainWindowPresenterTest.h
@@ -685,6 +685,7 @@ private:
     EXPECT_CALL(m_fileHandler, saveJSONToFile(filename, map))
         .Times(1)
         .WillOnce(Throw(std::invalid_argument("Test error")));
+    EXPECT_CALL(m_messageHandler, giveUserCritical("Invalid filename provided: Test error", "Save Batch")).Times(1);
   }
 
   void expectBatchIsNotSavedWhenSaveFails(int batchIndex) {
@@ -695,6 +696,7 @@ private:
     EXPECT_CALL(m_fileHandler, saveJSONToFile(filename, map))
         .Times(1)
         .WillOnce(Throw(std::runtime_error("Test error, save failed.")));
+    EXPECT_CALL(m_messageHandler, giveUserCritical("Save failed: Test error, save failed.", "Save Batch")).Times(1);
   }
 
   void expectBatchIsLoadedFromFile(int batchIndex) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MainWindowPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MainWindowPresenterTest.h
@@ -32,6 +32,7 @@ using testing::Mock;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
+using testing::Throw;
 
 class MainWindowPresenterTest : public CxxTest::TestSuite {
 public:
@@ -427,6 +428,22 @@ public:
     verifyAndClear();
   }
 
+  void testSaveBatchToInvalidPath() {
+    auto presenter = makePresenter();
+    auto const batchIndex = 1;
+    expectBatchIsNotSavedToInvalidFile(batchIndex);
+    presenter.notifySaveBatchRequested(batchIndex);
+    verifyAndClear();
+  }
+
+  void testSaveBatchHandlesFailedSave() {
+    auto presenter = makePresenter();
+    auto const batchIndex = 1;
+    expectBatchIsNotSavedWhenSaveFails(batchIndex);
+    presenter.notifySaveBatchRequested(batchIndex);
+    verifyAndClear();
+  }
+
   void testLoadBatch() {
     auto presenter = makePresenter();
     auto const batchIndex = 1;
@@ -658,6 +675,26 @@ private:
     EXPECT_CALL(m_messageHandler, askUserForSaveFileName("JSON (*.json)")).Times(1).WillOnce(Return(filename));
     EXPECT_CALL(*m_encoder, encodeBatch(&m_view, batchIndex, false)).Times(1).WillOnce(Return(map));
     EXPECT_CALL(m_fileHandler, saveJSONToFile(filename, map)).Times(1);
+  }
+
+  void expectBatchIsNotSavedToInvalidFile(int batchIndex) {
+    auto const filename = std::string("/test.json");
+    auto const map = QMap<QString, QVariant>();
+    EXPECT_CALL(m_messageHandler, askUserForSaveFileName("JSON (*.json)")).Times(1).WillOnce(Return(filename));
+    EXPECT_CALL(*m_encoder, encodeBatch(&m_view, batchIndex, false)).Times(1).WillOnce(Return(map));
+    EXPECT_CALL(m_fileHandler, saveJSONToFile(filename, map))
+        .Times(1)
+        .WillOnce(Throw(std::invalid_argument("Test error")));
+  }
+
+  void expectBatchIsNotSavedWhenSaveFails(int batchIndex) {
+    auto const filename = std::string("/test.json");
+    auto const map = QMap<QString, QVariant>();
+    EXPECT_CALL(m_messageHandler, askUserForSaveFileName("JSON (*.json)")).Times(1).WillOnce(Return(filename));
+    EXPECT_CALL(*m_encoder, encodeBatch(&m_view, batchIndex, false)).Times(1).WillOnce(Return(map));
+    EXPECT_CALL(m_fileHandler, saveJSONToFile(filename, map))
+        .Times(1)
+        .WillOnce(Throw(std::runtime_error("Test error, save failed.")));
   }
 
   void expectBatchIsLoadedFromFile(int batchIndex) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MainWindowPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MainWindowPresenterTest.h
@@ -685,7 +685,12 @@ private:
     EXPECT_CALL(m_fileHandler, saveJSONToFile(filename, map))
         .Times(1)
         .WillOnce(Throw(std::invalid_argument("Test error")));
-    EXPECT_CALL(m_messageHandler, giveUserCritical("Invalid filename provided: Test error", "Save Batch")).Times(1);
+    EXPECT_CALL(
+        m_messageHandler,
+        giveUserCritical(
+            "Invalid path provided. Check you have the correct permissions for this save location. \nTest error",
+            "Save Batch"))
+        .Times(1);
   }
 
   void expectBatchIsNotSavedWhenSaveFails(int batchIndex) {
@@ -696,7 +701,10 @@ private:
     EXPECT_CALL(m_fileHandler, saveJSONToFile(filename, map))
         .Times(1)
         .WillOnce(Throw(std::runtime_error("Test error, save failed.")));
-    EXPECT_CALL(m_messageHandler, giveUserCritical("Save failed: Test error, save failed.", "Save Batch")).Times(1);
+    EXPECT_CALL(
+        m_messageHandler,
+        giveUserCritical("An error occurred while saving. Please try again. \nTest error, save failed.", "Save Batch"))
+        .Times(1);
   }
 
   void expectBatchIsLoadedFromFile(int batchIndex) {


### PR DESCRIPTION
Note: Doesn't exist on windows, so needs testing on Linux OR macOS

### Description of work

#### Summary of work
Catches the errors from the JSON saver and instead displays an error message to the user describing the issue that may have occurred during saving. 

Fixes #35223 

#### Further detail of work
- Uses the Refl GUI's built in message handler to display the errors from the JSON saver to the user in the form of `QtMessageBox` dialog boxes. 
- Also fixes an issue where changing the instrument wasn't flushing the log, and so the messages weren't getting sent at the right level. 

### To test:
1) Open the ISIS Reflectometry GUI.
1) Open the Batch menu and click Save.
1) In the Save As dialog, navigate to a folder that you do not have permissions to save to (try to save to an RB number folder when testing on IDAaaS, or `C:\`, or `/` for example).
1) Enter a name for the batch file and click Save. An error message box should appear. 

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
