### PR TITLE
Improving the performance of CrystalStructure creation.

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Crystal/CompositeBraggScatterer.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/CompositeBraggScatterer.h
@@ -57,6 +57,7 @@ public:
   BraggScatterer_sptr clone() const override;
 
   virtual void addScatterer(const BraggScatterer_sptr &scatterer);
+  virtual void addScatterers(const BraggScatterer_sptr &scatterer);
   void setScatterers(const std::vector<BraggScatterer_sptr> &scatterers);
   size_t nScatterers() const;
   BraggScatterer_sptr getScatterer(size_t i) const;

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/CompositeBraggScatterer.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/CompositeBraggScatterer.h
@@ -60,6 +60,7 @@ public:
   void setScatterers(const std::vector<BraggScatterer_sptr> &scatterers);
   size_t nScatterers() const;
   BraggScatterer_sptr getScatterer(size_t i) const;
+  std::vector<BraggScatterer_sptr> getScatterers() const;
   void removeScatterer(size_t i);
   void removeAllScatterers();
 

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/CompositeBraggScatterer.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/CompositeBraggScatterer.h
@@ -57,7 +57,7 @@ public:
   BraggScatterer_sptr clone() const override;
 
   virtual void addScatterer(const BraggScatterer_sptr &scatterer);
-  virtual void addScatterers(const BraggScatterer_sptr &scatterer);
+  void addScatterers(const std::vector<BraggScatterer_sptr> &scatterer);
   void setScatterers(const std::vector<BraggScatterer_sptr> &scatterers);
   size_t nScatterers() const;
   BraggScatterer_sptr getScatterer(size_t i) const;

--- a/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp
+++ b/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp
@@ -78,10 +78,7 @@ BraggScatterer_sptr CompositeBraggScatterer::getScatterer(size_t i) const {
 }
 
 /// Returns the scatterers.
-std::vector<BraggScatterer_sptr> CompositeBraggScatterer::getScatterers() const {
-
-  return m_scatterers;
-}
+std::vector<BraggScatterer_sptr> CompositeBraggScatterer::getScatterers() const { return m_scatterers; }
 
 /// Removes the i-th scatterer from the composite or throws an std::out_of_range
 /// exception.

--- a/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp
+++ b/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp
@@ -77,6 +77,12 @@ BraggScatterer_sptr CompositeBraggScatterer::getScatterer(size_t i) const {
   return m_scatterers[i];
 }
 
+/// Returns the scatterers.
+std::vector<BraggScatterer_sptr> CompositeBraggScatterer::getScatterers() const {
+
+  return m_scatterers;
+}
+
 /// Removes the i-th scatterer from the composite or throws an std::out_of_range
 /// exception.
 void CompositeBraggScatterer::removeScatterer(size_t i) {

--- a/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp
+++ b/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp
@@ -54,15 +54,18 @@ void CompositeBraggScatterer::addScatterer(const BraggScatterer_sptr &scatterer)
   redeclareProperties();
 }
 
-/// Clears all scatterers and assigns clones of the supplied ones.
-void CompositeBraggScatterer::setScatterers(const std::vector<BraggScatterer_sptr> &scatterers) {
-  removeAllScatterers();
-
+/// Adds scatterers and assigns clones of the supplied ones.
+void CompositeBraggScatterer::addScatterers(const std::vector<BraggScatterer_sptr> &scatterers) {
   for (const auto &scatterer : scatterers) {
     addScattererImplementation(scatterer);
   }
-
   redeclareProperties();
+}
+
+/// Clears all scatterers and assigns clones of the supplied ones.
+void CompositeBraggScatterer::setScatterers(const std::vector<BraggScatterer_sptr> &scatterers) {
+  removeAllScatterers();
+  addScatterers(scatterers);
 }
 
 /// Returns the number of scatterers contained in the composite.

--- a/Framework/Geometry/src/Crystal/CrystalStructure.cpp
+++ b/Framework/Geometry/src/Crystal/CrystalStructure.cpp
@@ -7,6 +7,7 @@
 #include "MantidGeometry/Crystal/CrystalStructure.h"
 #include <algorithm>
 #include <stdexcept>
+#include <iostream>
 
 #include "MantidGeometry/Crystal/BasicHKLFilters.h"
 #include "MantidGeometry/Crystal/HKLGenerator.h"
@@ -82,11 +83,7 @@ void CrystalStructure::setScatterers(const CompositeBraggScatterer_sptr &scatter
 /// Adds all scatterers in the supplied collection into the internal one
 /// (scatterers are copied).
 void CrystalStructure::addScatterers(const CompositeBraggScatterer_sptr &scatterers) {
-  size_t count = scatterers->nScatterers();
-
-  for (size_t i = 0; i < count; ++i) {
-    m_scatterers->addScatterer(scatterers->getScatterer(i));
-  }
+  m_scatterers->setScatterers(scatterers->getScatterers());
 
   assignUnitCellToScatterers(m_cell);
 }

--- a/Framework/Geometry/src/Crystal/CrystalStructure.cpp
+++ b/Framework/Geometry/src/Crystal/CrystalStructure.cpp
@@ -82,7 +82,7 @@ void CrystalStructure::setScatterers(const CompositeBraggScatterer_sptr &scatter
 /// Adds all scatterers in the supplied collection into the internal one
 /// (scatterers are copied).
 void CrystalStructure::addScatterers(const CompositeBraggScatterer_sptr &scatterers) {
-  m_scatterers->setScatterers(scatterers->getScatterers());
+  m_scatterers->addScatterers(scatterers->getScatterers());
 
   assignUnitCellToScatterers(m_cell);
 }

--- a/Framework/Geometry/src/Crystal/CrystalStructure.cpp
+++ b/Framework/Geometry/src/Crystal/CrystalStructure.cpp
@@ -7,7 +7,6 @@
 #include "MantidGeometry/Crystal/CrystalStructure.h"
 #include <algorithm>
 #include <stdexcept>
-#include <iostream>
 
 #include "MantidGeometry/Crystal/BasicHKLFilters.h"
 #include "MantidGeometry/Crystal/HKLGenerator.h"

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -793,7 +793,7 @@ useInitializationList:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TimeSplitter
 variableScope:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TimeSplitter.cpp:354
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/Workspace2D.cpp:373
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TimeSplitter.cpp:354
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp:186
+constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp:194
 cppcheckError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/ReflectometryTransform.cpp:0
 cppcheckError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/FakeMD.cpp:0
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/WorkspaceSingleValue.cpp:93

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -793,7 +793,7 @@ useInitializationList:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TimeSplitter
 variableScope:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TimeSplitter.cpp:354
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/Workspace2D.cpp:373
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TimeSplitter.cpp:354
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp:183
+constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp:186
 cppcheckError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/ReflectometryTransform.cpp:0
 cppcheckError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/FakeMD.cpp:0
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/WorkspaceSingleValue.cpp:93

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -793,7 +793,7 @@ useInitializationList:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TimeSplitter
 variableScope:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TimeSplitter.cpp:354
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/Workspace2D.cpp:373
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TimeSplitter.cpp:354
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp:194
+constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp:189
 cppcheckError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/ReflectometryTransform.cpp:0
 cppcheckError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/FakeMD.cpp:0
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/WorkspaceSingleValue.cpp:93

--- a/docs/source/release/v6.9.0/Diffraction/Single_Crystal/Bugfixes/36613.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Single_Crystal/Bugfixes/36613.rst
@@ -1,0 +1,1 @@
+- Fix slow creation of ``CrystalStructure`` object when loading a CIF file with many atoms. A new method to add many scatterers at a time is added from ``CompositeBraggScatterer`` to ``CrystalStructure`` rather than one atom at a time.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

LoadCIF appeared to be taking a long time for some large unit cells. Turns out, it was related to the initialization of the CrystalStructure.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.

-->


The original method for `addScatterers` added them one at a time. The problem with this is each time `redeclareProperties()` is called over and over again and only needs to be done at the end. Thus, a new method is added so they can be set first before  `redeclareProperties()`. 

No chanced to functionality is expected.

### To test:

Run this test
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from mantid.geometry import (CrystalStructure,
                             ReflectionGenerator,
                             ReflectionConditionFilter)

CreatePeaksWorkspace(NumberOfPeaks=0,
                     OutputType='LeanElasticPeak',
                     OutputWorkspace='struct_fact_ws')

LoadCIF(Workspace='struct_fact_ws', 
        InputFile='/HFIR/CG4D/shared/instrument/data/5vnq.cif')
```

Previously took 3 minutes, now it takes 3 seconds.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
