### PR TITLE
Allow Negative Values for dQ/Q in the Refl GUI

### DIFF
--- a/docs/source/release/v6.9.0/Reflectometry/Bugfixes/35876.rst
+++ b/docs/source/release/v6.9.0/Reflectometry/Bugfixes/35876.rst
@@ -1,0 +1,2 @@
+- It is now once again possible to provide a negative ``dQ/Q`` value on the Experiment Settings and Runs tab of the
+  :ref:`ISIS Reflectometry Interface <interface-isis-refl>` to indicate that linear binning should be performed.

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
@@ -146,7 +146,7 @@ boost::variant<RangeInQ, std::vector<int>> parseQRange(std::string const &min, s
   }
 
   if (!isEntirelyWhitespace(step)) {
-    stepValue = parseNonNegativeDouble(step);
+    stepValue = parseDouble(step);
     if (!stepValue.is_initialized())
       invalidParams.emplace_back(2);
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ParseReflectometryStringsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ParseReflectometryStringsTest.h
@@ -173,6 +173,12 @@ public:
     TS_ASSERT_EQUALS(boost::get<RangeInQ>(result), RangeInQ(0.05, 0.02, 0.16));
   }
 
+  void testParseQRangeNegativeQStep() {
+    auto result = parseQRange("0.05", "0.16", "-1");
+    TS_ASSERT_EQUALS(result.which(), asInt(Result::Value));
+    TS_ASSERT_EQUALS(boost::get<RangeInQ>(result), RangeInQ(0.05, -1, 0.16));
+  }
+
   void testParseQRangeInvalidQMin() {
     auto result = parseQRange("bad", "0.16", "0.02");
     std::vector<int> expected = {0};

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ValidateLookupRowTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ValidateLookupRowTest.h
@@ -133,6 +133,13 @@ public:
     TS_ASSERT_EQUALS(result.assertValid().qRange(), RangeInQ(0.05, 0.02, 1.3));
   }
 
+  void testParseQRangeNegativeStep() {
+    LookupRowValidator validator;
+    auto result = validator({"", "", "", "", "", "0.05", "1.3", "-1"});
+    TS_ASSERT(result.isValid());
+    TS_ASSERT_EQUALS(result.assertValid().qRange(), RangeInQ(0.05, -1, 1.3));
+  }
+
   void testParseQRangeError() {
     LookupRowValidator validator;
     auto result = validator({"", "", "", "", "", "bad", "bad", "bad"});


### PR DESCRIPTION
### Description of work

#### Summary of work
Adjusts the string parser so that negative values can be provided for dQ/Q (QStep) to indicate that linear binning should be used.

Fixes #35876 


#### Further detail of work
Adjusts the string parsing so that negative doubles are allowed. Also adds tests to the validator and the parser for negative values. 

### To test:
1) Open the ISIS Reflectometry interface.
2) Change the instrument to OFFSPEC
2) On the Experiment Settings tab, enter a negative number into the dQ/Q cell in the lookup table. From the AnalysisMode drop-down, select `MultiDetectorAnalysis`.
3) On the Runs tab, enter `61135` and angle `2.3` into the processing table on the right hand side. Click to run the reduction.
4) Ensure that the entered value can also be entered in the dQ/Q cell of the runs table. 

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
