### PR TITLE
Fit function available in FqFit depend on type of input data. 

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1439,6 +1439,4 @@ postfixOperator:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/
 postfixOperator:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/IndirectFittingModel.cpp:187
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp:45
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp:66
-constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp:158
-constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp:191
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1425,7 +1425,7 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectome
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp:786
 passedByValue:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferValidator.cpp:100
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModelUtils.h:99
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp:22
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp:23
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h:41
 returnTempReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitData.cpp:127
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitData.cpp:93

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1439,3 +1439,6 @@ postfixOperator:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/
 postfixOperator:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/IndirectFittingModel.cpp:187
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp:45
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp:66
+constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp:158
+constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp:191
+

--- a/docs/source/release/v6.9.0/Inelastic/Bugfixes/36348.rst
+++ b/docs/source/release/v6.9.0/Inelastic/Bugfixes/36348.rst
@@ -1,0 +1,1 @@
+- The available fit functions in FqFit tab of :ref:`Inelastic Data Analysis <interface-inelastic-data-analysis>` change in relation to the type of the analysis parameter selected when adding a workspace, in this case either WIDTH or EISF.

--- a/qt/scientific_interfaces/Inelastic/Analysis/DataAnalysisTabFactory.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/DataAnalysisTabFactory.cpp
@@ -65,6 +65,7 @@ IndirectDataAnalysisTab *DataAnalysisTabFactory::makeFqFitTab(int const index) c
   tab->setupFitDataView<FqFitDataView>();
   tab->setupOutputOptionsPresenter();
   tab->setUpFitDataPresenter<FqFitDataPresenter>();
+  tab->subscribeFitBrowserToDataPresenter();
   tab->setupPlotView(FqFit::X_BOUNDS);
   return tab;
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
@@ -198,8 +198,12 @@ boost::optional<std::vector<std::size_t>> getParameterSpectrum(const FqFitParame
 
 namespace MantidQt::CustomInterfaces::IDA {
 
+FqFitDataPresenter::FqFitDataPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitDataModel *model,
+                                       IIndirectFitDataView *view)
+    : IndirectFitDataPresenter(tab, model, view), m_activeParameterType("Width"), m_activeWorkspaceID(WorkspaceID{0}),
+      m_adsInstance(Mantid::API::AnalysisDataService::Instance()), m_fitPropertyBrowser() {}
 
-void FqFitDataPresenter::subscribeFitPropertyBrowser(IndirectFitPropertyBrowser *browser) {
+void FqFitDataPresenter::subscribeFitPropertyBrowser(IIndirectFitPropertyBrowser *browser) {
   m_fitPropertyBrowser = browser;
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
@@ -253,12 +253,12 @@ void FqFitDataPresenter::addWorkspace(const std::string &workspaceName, const st
   }
 }
 
-std::map<std::string, std::string> FqFitDataPresenter::chooseFqFitFunctions(bool paramWidth) {
+std::map<std::string, std::string> FqFitDataPresenter::chooseFqFitFunctions(bool paramWidth) const {
   if (m_view->isTableEmpty()) { // when first data is added to table, it can only be either WIDTH or EISF
     return paramWidth ? FqFit::WIDTH_FITS : FqFit::EISF_FITS;
-  } else {
-    bool widthFuncs = paramWidth || m_view->DataColumnContainsText("FWHM");
-    bool eisfFuncs = !paramWidth || m_view->DataColumnContainsText("EISF");
+
+    bool widthFuncs = paramWidth || m_view->dataColumnContainsText("FWHM");
+    bool eisfFuncs = !paramWidth || m_view->dataColumnContainsText("EISF");
     if (widthFuncs && eisfFuncs)
       return FqFit::ALL_FITS;
     else if (widthFuncs)

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "FqFitDataPresenter.h"
+#include "FitTabConstants.h"
 #include "IDAFunctionParameterEstimation.h"
 #include "MantidAPI/TextAxis.h"
 
@@ -197,10 +198,16 @@ boost::optional<std::vector<std::size_t>> getParameterSpectrum(const FqFitParame
 
 namespace MantidQt::CustomInterfaces::IDA {
 
+
 FqFitDataPresenter::FqFitDataPresenter(IIndirectDataAnalysisTab *tab, IIndirectFitDataModel *model,
                                        IIndirectFitDataView *view)
     : IndirectFitDataPresenter(tab, model, view), m_activeParameterType("Width"), m_activeWorkspaceID(WorkspaceID{0}),
-      m_adsInstance(Mantid::API::AnalysisDataService::Instance()) {}
+      m_adsInstance(Mantid::API::AnalysisDataService::Instance(), m_fitPropertyBrowser() {}
+
+
+void FqFitDataPresenter::subscribeFitPropertyBrowser(IIndirectFitPropertyBrowser *browser) {
+  m_fitPropertyBrowser = browser;
+}
 
 bool FqFitDataPresenter::addWorkspaceFromDialog(IAddWorkspaceDialog const *dialog) {
   if (const auto fqFitDialog = dynamic_cast<FqFitAddWorkspaceDialog const *>(dialog)) {
@@ -236,9 +243,11 @@ void FqFitDataPresenter::addWorkspace(const std::string &workspaceName, const st
   const auto hwhmWorkspace = createHWHMWorkspace(workspace, name, parameters.widthSpectra);
 
   if (paramType == "Width") {
+    m_fitPropertyBrowser->updateFunctionListInBrowser(FqFit::WIDTH_FITS);
     const auto single_spectra = FunctionModelSpectra(std::to_string(parameters.widthSpectra[spectrum_index]));
     m_model->addWorkspace(hwhmWorkspace->getName(), single_spectra);
   } else if (paramType == "EISF") {
+    m_fitPropertyBrowser->updateFunctionListInBrowser(FqFit::EISF_FITS);
     const auto single_spectra = FunctionModelSpectra(std::to_string(parameters.eisfSpectra[spectrum_index]));
     m_model->addWorkspace(hwhmWorkspace->getName(), single_spectra);
   } else {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
@@ -265,6 +265,8 @@ std::map<std::string, std::string> FqFitDataPresenter::chooseFqFitFunctions(bool
       return FqFit::WIDTH_FITS;
     else
       return FqFit::EISF_FITS;
+
+    return FqFit::ALL_FITS; // default
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp
@@ -254,20 +254,17 @@ void FqFitDataPresenter::addWorkspace(const std::string &workspaceName, const st
 }
 
 std::map<std::string, std::string> FqFitDataPresenter::chooseFqFitFunctions(bool paramWidth) const {
-  if (m_view->isTableEmpty()) { // when first data is added to table, it can only be either WIDTH or EISF
+  if (m_view->isTableEmpty()) // when first data is added to table, it can only be either WIDTH or EISF
     return paramWidth ? FqFit::WIDTH_FITS : FqFit::EISF_FITS;
 
-    bool widthFuncs = paramWidth || m_view->dataColumnContainsText("FWHM");
-    bool eisfFuncs = !paramWidth || m_view->dataColumnContainsText("EISF");
-    if (widthFuncs && eisfFuncs)
-      return FqFit::ALL_FITS;
-    else if (widthFuncs)
-      return FqFit::WIDTH_FITS;
-    else
-      return FqFit::EISF_FITS;
-
-    return FqFit::ALL_FITS; // default
-  }
+  bool widthFuncs = paramWidth || m_view->dataColumnContainsText("FWHM");
+  bool eisfFuncs = !paramWidth || m_view->dataColumnContainsText("EISF");
+  if (widthFuncs && eisfFuncs)
+    return FqFit::ALL_FITS;
+  else if (widthFuncs)
+    return FqFit::WIDTH_FITS;
+  else
+    return FqFit::EISF_FITS;
 }
 
 void FqFitDataPresenter::setActiveParameterType(const std::string &type) { m_activeParameterType = type; }

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
@@ -55,7 +55,7 @@ private:
   void updateParameterOptions(FqFitAddWorkspaceDialog *dialog, const FqFitParameters &parameters);
   void updateParameterTypes(FqFitAddWorkspaceDialog *dialog, FqFitParameters &parameters);
   std::vector<std::string> getParameterTypes(FqFitParameters &parameters) const;
-  std::map<std::string, std::string> chooseFqFitFunctions(bool paramWidth);
+  std::map<std::string, std::string> chooseFqFitFunctions(bool paramWidth) const;
   void setActiveWorkspaceIDToCurrentWorkspace(IAddWorkspaceDialog const *dialog);
 
   std::string m_activeParameterType;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
@@ -10,6 +10,7 @@
 #include "FqFitDataView.h"
 #include "FunctionBrowser/SingleFunctionTemplateBrowser.h"
 #include "IndirectFitDataPresenter.h"
+#include "IndirectFitPropertyBrowser.h"
 
 namespace {
 struct FqFitParameters {
@@ -39,6 +40,7 @@ public:
   void addWorkspace(const std::string &workspaceName, const std::string &paramType, const int &spectrum_index) override;
   void setActiveWidth(std::size_t widthIndex, WorkspaceID dataIndex, bool single = true) override;
   void setActiveEISF(std::size_t eisfIndex, WorkspaceID dataIndex, bool single = true) override;
+  void subscribeFitPropertyBrowser(IIndirectFitPropertyBrowser *browser) override;
 
   void handleAddClicked() override;
   void handleWorkspaceChanged(FqFitAddWorkspaceDialog *dialog, const std::string &workspace) override;
@@ -59,6 +61,7 @@ private:
   WorkspaceID m_activeWorkspaceID;
 
   Mantid::API::AnalysisDataServiceImpl &m_adsInstance;
+  IIndirectFitPropertyBrowser *m_fitPropertyBrowser;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.h
@@ -55,6 +55,7 @@ private:
   void updateParameterOptions(FqFitAddWorkspaceDialog *dialog, const FqFitParameters &parameters);
   void updateParameterTypes(FqFitAddWorkspaceDialog *dialog, FqFitParameters &parameters);
   std::vector<std::string> getParameterTypes(FqFitParameters &parameters) const;
+  std::map<std::string, std::string> chooseFqFitFunctions(bool paramWidth);
   void setActiveWorkspaceIDToCurrentWorkspace(IAddWorkspaceDialog const *dialog);
 
   std::string m_activeParameterType;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
@@ -157,6 +157,11 @@ void SingleFunctionTemplateBrowser::updateParameterNames(const QMap<int, std::st
 
 void SingleFunctionTemplateBrowser::updateParameterDescriptions(const QMap<int, std::string> &) {}
 
+void SingleFunctionTemplateBrowser::updateAvailableFunctions(
+    const std::map<std::string, std::string> &functionInitialisationStrings) {
+  m_presenter.updateAvailableFunctions(functionInitialisationStrings);
+}
+
 void SingleFunctionTemplateBrowser::setErrorsEnabled(bool enabled) {
   ScopedFalse _false(m_emitParameterValueChange);
   m_parameterManager->setErrorsEnabled(enabled);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h
@@ -60,6 +60,7 @@ public:
   void setParameterValueQuietly(std::string const &parameterName, double parameterValue, double parameterError);
   void setDataType(std::vector<std::string> const &allowedFunctionsList);
   void setEnumValue(int enumIndex);
+  void updateAvailableFunctions(const std::map<std::string, std::string> &functionInitialisationStrings);
 
 protected slots:
   void enumChanged(QtProperty *) override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
@@ -43,7 +43,7 @@ public:
   virtual void clearTable() = 0;
   virtual QString getText(int row, int column) const = 0;
   virtual QModelIndexList getSelectedIndexes() const = 0;
-  virtual bool DataColumnContainsText(QString text) const = 0;
+  virtual bool dataColumnContainsText(std::string const &columnText) const = 0;
 
   virtual void setSampleWSSuffices(const QStringList &suffices) = 0;
   virtual void setSampleFBSuffices(const QStringList &suffices) = 0;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IIndirectFitDataView.h
@@ -34,6 +34,7 @@ public:
   virtual void subscribePresenter(IIndirectFitDataPresenter *presenter) = 0;
 
   virtual QTableWidget *getDataTable() const = 0;
+  virtual bool isTableEmpty() const = 0;
 
   virtual UserInputValidator &validate(UserInputValidator &validator) = 0;
   virtual void addTableEntry(size_t row, FitDataRow newRow) = 0;
@@ -42,6 +43,7 @@ public:
   virtual void clearTable() = 0;
   virtual QString getText(int row, int column) const = 0;
   virtual QModelIndexList getSelectedIndexes() const = 0;
+  virtual bool DataColumnContainsText(QString text) const = 0;
 
   virtual void setSampleWSSuffices(const QStringList &suffices) = 0;
   virtual void setSampleFBSuffices(const QStringList &suffices) = 0;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.cpp
@@ -85,6 +85,10 @@ void IndirectDataAnalysisTab::connectFitPropertyBrowser() {
   connect(m_fitPropertyBrowser, SIGNAL(functionChanged()), this, SLOT(respondToFunctionChanged()));
 }
 
+void IndirectDataAnalysisTab::subscribeFitBrowserToDataPresenter() {
+  m_dataPresenter->subscribeFitPropertyBrowser(m_fitPropertyBrowser);
+}
+
 void IndirectDataAnalysisTab::setupOutputOptionsPresenter(bool const editResults) {
   auto model = std::make_unique<IndirectFitOutputOptionsModel>();
   m_outOptionsPresenter =

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
@@ -84,6 +84,7 @@ public:
 
   void setupOutputOptionsPresenter(bool const editResults = false);
   void setupPlotView(std::optional<std::pair<double, double>> const &xPlotBounds = std::nullopt);
+  void subscribeFitBrowserToDataPresenter();
 
   WorkspaceID getSelectedDataIndex() const;
   WorkspaceIndex getSelectedSpectrum() const;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -85,7 +85,6 @@ public:
   void handleUnifyClicked() override;
   void handleCellChanged(int row, int column) override;
 
-
 protected:
   IIndirectFitDataView const *getView() const;
   void displayWarning(const std::string &warning);

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -12,6 +12,7 @@
 #include "ParameterEstimation.h"
 
 #include "DllConfig.h"
+#include "IndirectFitPropertyBrowser.h"
 #include "MantidAPI/AnalysisDataServiceObserver.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
@@ -77,10 +78,13 @@ public:
     UNUSED_ARG(single);
   };
 
+  virtual void subscribeFitPropertyBrowser(IndirectFitPropertyBrowser *browser) { UNUSED_ARG(browser); };
+
   void handleAddData(IAddWorkspaceDialog const *dialog) override;
   void handleRemoveClicked() override;
   void handleUnifyClicked() override;
   void handleCellChanged(int row, int column) override;
+
 
 protected:
   IIndirectFitDataView const *getView() const;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataPresenter.h
@@ -78,7 +78,7 @@ public:
     UNUSED_ARG(single);
   };
 
-  virtual void subscribeFitPropertyBrowser(IndirectFitPropertyBrowser *browser) { UNUSED_ARG(browser); };
+  virtual void subscribeFitPropertyBrowser(IIndirectFitPropertyBrowser *browser) { UNUSED_ARG(browser); };
 
   void handleAddData(IAddWorkspaceDialog const *dialog) override;
   void handleRemoveClicked() override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -179,12 +179,8 @@ void IndirectFitDataView::setCell(std::unique_ptr<QTableWidgetItem> cell, size_t
   m_uiForm->tbFitData->setItem(static_cast<int>(row), static_cast<int>(column), cell.release());
 }
 
-bool IndirectFitDataView::DataColumnContainsText(QString columnText) const {
-  if (!m_uiForm->tbFitData->findItems(columnText, Qt::MatchContains).isEmpty()) {
-    return true;
-  } else {
-    return false;
-  };
+bool IndirectFitDataView::dataColumnContainsText(std::string const &columnText) const {
+  return !m_uiForm->tbFitData->findItems(QString::fromStdString(columnText), Qt::MatchContains).isEmpty();
 }
 
 QString IndirectFitDataView::getText(int row, int column) const {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.cpp
@@ -179,6 +179,14 @@ void IndirectFitDataView::setCell(std::unique_ptr<QTableWidgetItem> cell, size_t
   m_uiForm->tbFitData->setItem(static_cast<int>(row), static_cast<int>(column), cell.release());
 }
 
+bool IndirectFitDataView::DataColumnContainsText(QString columnText) const {
+  if (!m_uiForm->tbFitData->findItems(columnText, Qt::MatchContains).isEmpty()) {
+    return true;
+  } else {
+    return false;
+  };
+}
+
 QString IndirectFitDataView::getText(int row, int column) const {
   return m_uiForm->tbFitData->item(static_cast<int>(row), column)->text();
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
@@ -42,7 +42,7 @@ public:
   void clearTable() override;
   QString getText(int row, int column) const override;
   QModelIndexList getSelectedIndexes() const override;
-  bool DataColumnContainsText(QString text) const override;
+  bool dataColumnContainsText(std::string const &columnText) const override;
 
   void setSampleWSSuffices(const QStringList &suffices) override;
   void setSampleFBSuffices(const QStringList &suffices) override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitDataView.h
@@ -33,7 +33,7 @@ public:
   void subscribePresenter(IIndirectFitDataPresenter *presenter) override;
 
   QTableWidget *getDataTable() const override;
-  bool isTableEmpty() const;
+  bool isTableEmpty() const override;
 
   UserInputValidator &validate(UserInputValidator &validator) override;
   virtual void addTableEntry(size_t row, FitDataRow newRow) override;
@@ -42,6 +42,7 @@ public:
   void clearTable() override;
   QString getText(int row, int column) const override;
   QModelIndexList getSelectedIndexes() const override;
+  bool DataColumnContainsText(QString text) const override;
 
   void setSampleWSSuffices(const QStringList &suffices) override;
   void setSampleFBSuffices(const QStringList &suffices) override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectFitPropertyBrowser.h"
 #include "FitStatusWidget.h"
+#include "FunctionBrowser/SingleFunctionTemplateBrowser.h"
 #include "FunctionTemplateBrowser.h"
 
 #include "MantidAPI/AlgorithmManager.h"
@@ -255,6 +256,14 @@ void IndirectFitPropertyBrowser::updateParameters(const IFunction &fun) {
     m_functionBrowser->updateParameters(fun);
   else
     m_templateBrowser->updateParameters(fun);
+}
+
+void IndirectFitPropertyBrowser::updateFunctionListInBrowser(
+    const std::map<std::string, std::string> &functionStrings) {
+  auto singleFuncTemplate = dynamic_cast<SingleFunctionTemplateBrowser *>(m_templateBrowser);
+  if (singleFuncTemplate) {
+    singleFuncTemplate->updateAvailableFunctions(functionStrings);
+  }
 }
 
 void IndirectFitPropertyBrowser::updateMultiDatasetParameters(const IFunction &fun) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.h
@@ -84,6 +84,7 @@ public:
   void estimateFunctionParameters();
   void setBackgroundA0(double value);
   void setHiddenProperties(const std::vector<std::string> &);
+  void updateFunctionListInBrowser(const std::map<std::string, std::string> &functionStrings);
 
 public slots:
   void fit();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.h
@@ -40,6 +40,7 @@ using namespace MantidWidgets;
 
 class FunctionTemplateBrowser;
 class FitStatusWidget;
+
 class MANTIDQT_INELASTIC_DLL IIndirectFitPropertyBrowser {
 public:
   virtual ~IIndirectFitPropertyBrowser() = default;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.h
@@ -40,8 +40,12 @@ using namespace MantidWidgets;
 
 class FunctionTemplateBrowser;
 class FitStatusWidget;
-
-class MANTIDQT_INELASTIC_DLL IndirectFitPropertyBrowser : public QDockWidget {
+class MANTIDQT_INELASTIC_DLL IIndirectFitPropertyBrowser {
+public:
+  virtual ~IIndirectFitPropertyBrowser() = default;
+  virtual void updateFunctionListInBrowser(const std::map<std::string, std::string> &functionStrings);
+};
+class MANTIDQT_INELASTIC_DLL IndirectFitPropertyBrowser : public QDockWidget, public IIndirectFitPropertyBrowser {
   Q_OBJECT
 
 public:
@@ -84,7 +88,7 @@ public:
   void estimateFunctionParameters();
   void setBackgroundA0(double value);
   void setHiddenProperties(const std::vector<std::string> &);
-  void updateFunctionListInBrowser(const std::map<std::string, std::string> &functionStrings);
+  void updateFunctionListInBrowser(const std::map<std::string, std::string> &functionStrings) override;
 
 public slots:
   void fit();

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.h
@@ -44,7 +44,7 @@ class FitStatusWidget;
 class MANTIDQT_INELASTIC_DLL IIndirectFitPropertyBrowser {
 public:
   virtual ~IIndirectFitPropertyBrowser() = default;
-  virtual void updateFunctionListInBrowser(const std::map<std::string, std::string> &functionStrings);
+  virtual void updateFunctionListInBrowser(const std::map<std::string, std::string> &functionStrings) = 0;
 };
 class MANTIDQT_INELASTIC_DLL IndirectFitPropertyBrowser : public QDockWidget, public IIndirectFitPropertyBrowser {
   Q_OBJECT

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/FqFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/FqFitDataPresenterTest.h
@@ -14,6 +14,7 @@
 #include "Analysis/FqFitModel.h"
 #include "Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h"
 #include "Analysis/IndirectFitDataView.h"
+#include "Analysis/IndirectFitPropertyBrowser.h"
 #include "Common/IndirectAddWorkspaceDialog.h"
 #include "MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h"
 #include "MockObjects.h"
@@ -63,6 +64,8 @@ public:
     m_presenter = std::make_unique<FqFitDataPresenter>(m_tab.get(), m_model.get(), m_view.get());
     m_workspace = createWorkspaceWithTextAxis(6, getTextAxisLabels());
     m_ads = std::make_unique<SetUpADSWithWorkspace>("WorkspaceName", m_workspace);
+    m_fitPropertyBrowser = std::make_unique<IndirectFitPropertyBrowser>();
+    m_presenter->subscribeFitPropertyBrowser(std::move(m_fitPropertyBrowser.get()));
   }
 
   void tearDown() override {
@@ -70,18 +73,21 @@ public:
 
     TS_ASSERT(Mock::VerifyAndClearExpectations(m_view.get()));
     TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_fitPropertyBrowser.get()))
 
     m_presenter.reset();
     m_model.reset();
     m_view.reset();
 
     m_dataTable.reset();
+    m_fitPropertyBrowser.reset();
   }
 
   void test_that_the_presenter_and_mock_objects_have_been_created() {
     TS_ASSERT(m_presenter);
     TS_ASSERT(m_model);
     TS_ASSERT(m_view);
+    TS_ASSERT(m_fitPropertyBrowser);
   }
 
   void test_addWorkspaceFromDialog_returns_false_if_the_dialog_is_not_fqfit() {
@@ -130,4 +136,5 @@ private:
 
   MatrixWorkspace_sptr m_workspace;
   std::unique_ptr<SetUpADSWithWorkspace> m_ads;
+  std::unique_ptr<IndirectFitPropertyBrowser> m_fitPropertyBrowser;
 };

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/FqFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/FqFitDataPresenterTest.h
@@ -83,7 +83,6 @@ public:
 
     m_dataTable.reset();
     m_fitPropertyBrowser.reset();
-    // delete m_fitPropertyBrowser;
   }
 
   void test_that_the_presenter_and_mock_objects_have_been_created() {

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/FqFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/FqFitDataPresenterTest.h
@@ -9,6 +9,7 @@
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 
+#include "Analysis/FitTabConstants.h"
 #include "Analysis/FqFitAddWorkspaceDialog.h"
 #include "Analysis/FqFitDataPresenter.h"
 #include "Analysis/FqFitModel.h"
@@ -64,8 +65,9 @@ public:
     m_presenter = std::make_unique<FqFitDataPresenter>(m_tab.get(), m_model.get(), m_view.get());
     m_workspace = createWorkspaceWithTextAxis(6, getTextAxisLabels());
     m_ads = std::make_unique<SetUpADSWithWorkspace>("WorkspaceName", m_workspace);
-    m_fitPropertyBrowser = std::make_unique<NiceMock<MockFitPropertyBrowser>>();
-    m_presenter->subscribeFitPropertyBrowser(std::move(m_fitPropertyBrowser.get()));
+
+    m_fitPropertyBrowser = new NiceMock<MockFitPropertyBrowser>();
+    m_presenter->subscribeFitPropertyBrowser(m_fitPropertyBrowser);
   }
 
   void tearDown() override {
@@ -73,14 +75,14 @@ public:
 
     TS_ASSERT(Mock::VerifyAndClearExpectations(m_view.get()));
     TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
-    TS_ASSERT(Mock::VerifyAndClearExpectations(m_fitPropertyBrowser.get()))
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_fitPropertyBrowser));
 
     m_presenter.reset();
     m_model.reset();
     m_view.reset();
 
     m_dataTable.reset();
-    m_fitPropertyBrowser.reset();
+    delete m_fitPropertyBrowser;
   }
 
   void test_that_the_presenter_and_mock_objects_have_been_created() {
@@ -136,5 +138,5 @@ private:
 
   MatrixWorkspace_sptr m_workspace;
   std::unique_ptr<SetUpADSWithWorkspace> m_ads;
-  std::unique_ptr<NiceMock<MockFitPropertyBrowser>> m_fitPropertyBrowser;
+  MockFitPropertyBrowser *m_fitPropertyBrowser;
 };

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/FqFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/FqFitDataPresenterTest.h
@@ -64,7 +64,7 @@ public:
     m_presenter = std::make_unique<FqFitDataPresenter>(m_tab.get(), m_model.get(), m_view.get());
     m_workspace = createWorkspaceWithTextAxis(6, getTextAxisLabels());
     m_ads = std::make_unique<SetUpADSWithWorkspace>("WorkspaceName", m_workspace);
-    m_fitPropertyBrowser = std::make_unique<IndirectFitPropertyBrowser>();
+    m_fitPropertyBrowser = std::make_unique<NiceMock<MockFitPropertyBrowser>>();
     m_presenter->subscribeFitPropertyBrowser(std::move(m_fitPropertyBrowser.get()));
   }
 
@@ -136,5 +136,5 @@ private:
 
   MatrixWorkspace_sptr m_workspace;
   std::unique_ptr<SetUpADSWithWorkspace> m_ads;
-  std::unique_ptr<IndirectFitPropertyBrowser> m_fitPropertyBrowser;
+  std::unique_ptr<NiceMock<MockFitPropertyBrowser>> m_fitPropertyBrowser;
 };

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/FqFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/FqFitDataPresenterTest.h
@@ -66,8 +66,8 @@ public:
     m_workspace = createWorkspaceWithTextAxis(6, getTextAxisLabels());
     m_ads = std::make_unique<SetUpADSWithWorkspace>("WorkspaceName", m_workspace);
 
-    m_fitPropertyBrowser = new NiceMock<MockFitPropertyBrowser>();
-    m_presenter->subscribeFitPropertyBrowser(m_fitPropertyBrowser);
+    m_fitPropertyBrowser = std::make_unique<NiceMock<MockFitPropertyBrowser>>();
+    m_presenter->subscribeFitPropertyBrowser(m_fitPropertyBrowser.get());
   }
 
   void tearDown() override {
@@ -75,14 +75,15 @@ public:
 
     TS_ASSERT(Mock::VerifyAndClearExpectations(m_view.get()));
     TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
-    TS_ASSERT(Mock::VerifyAndClearExpectations(m_fitPropertyBrowser));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_fitPropertyBrowser.get()));
 
     m_presenter.reset();
     m_model.reset();
     m_view.reset();
 
     m_dataTable.reset();
-    delete m_fitPropertyBrowser;
+    m_fitPropertyBrowser.reset();
+    // delete m_fitPropertyBrowser;
   }
 
   void test_that_the_presenter_and_mock_objects_have_been_created() {
@@ -138,5 +139,5 @@ private:
 
   MatrixWorkspace_sptr m_workspace;
   std::unique_ptr<SetUpADSWithWorkspace> m_ads;
-  MockFitPropertyBrowser *m_fitPropertyBrowser;
+  std::unique_ptr<NiceMock<MockFitPropertyBrowser>> m_fitPropertyBrowser;
 };

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
@@ -17,9 +17,8 @@
 #include "Analysis/IIndirectFitOutputOptionsView.h"
 #include "Analysis/IIndirectFitPlotView.h"
 #include "Analysis/IndirectDataAnalysisTab.h"
-#include "Common/IAddWorkspaceDialog.h"
 #include "Analysis/IndirectFitPropertyBrowser.h"
-
+#include "Common/IAddWorkspaceDialog.h"
 
 #include <string>
 #include <utility>

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
@@ -18,6 +18,8 @@
 #include "Analysis/IIndirectFitPlotView.h"
 #include "Analysis/IndirectDataAnalysisTab.h"
 #include "Common/IAddWorkspaceDialog.h"
+#include "Analysis/IndirectFitPropertyBrowser.h"
+
 
 #include <string>
 #include <utility>
@@ -237,6 +239,7 @@ public:
   MOCK_METHOD1(subscribePresenter, void(IIndirectFitDataPresenter *presenter));
 
   MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
+  MOCK_CONST_METHOD0(isTableEmpty, bool());
   MOCK_METHOD1(validate, MantidQt::CustomInterfaces::UserInputValidator &(
                              MantidQt::CustomInterfaces::UserInputValidator &validator));
   MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
@@ -245,6 +248,7 @@ public:
   MOCK_METHOD0(clearTable, void());
   MOCK_CONST_METHOD2(getText, QString(int row, int column));
   MOCK_CONST_METHOD0(getSelectedIndexes, QModelIndexList());
+  MOCK_CONST_METHOD1(DataColumnContainsText, bool(QString));
 
   MOCK_METHOD1(setSampleWSSuffices, void(const QStringList &suffices));
   MOCK_METHOD1(setSampleFBSuffices, void(const QStringList &suffices));
@@ -254,4 +258,11 @@ public:
   MOCK_METHOD1(displayWarning, void(std::string const &warning));
 };
 
-GNU_DIAG_ON_SUGGEST_OVERRIDE
+class MockFitPropertyBrowser : public IIndirectFitPropertyBrowser {
+public:
+  virtual ~MockFitPropertyBrowser() = default;
+
+  MOCK_METHOD1(updateFunctionListInBrowser, void(const std::map<std::string, std::string> &functionStrings));
+};
+
+GNU_DIAG_ON_SUGGEST_OVERRIDE;

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
@@ -247,7 +247,7 @@ public:
   MOCK_METHOD0(clearTable, void());
   MOCK_CONST_METHOD2(getText, QString(int row, int column));
   MOCK_CONST_METHOD0(getSelectedIndexes, QModelIndexList());
-  MOCK_CONST_METHOD1(DataColumnContainsText, bool(QString));
+  MOCK_CONST_METHOD1(dataColumnContainsText, bool(const std::string &columnText));
 
   MOCK_METHOD1(setSampleWSSuffices, void(const QStringList &suffices));
   MOCK_METHOD1(setSampleFBSuffices, void(const QStringList &suffices));
@@ -264,4 +264,4 @@ public:
   MOCK_METHOD1(updateFunctionListInBrowser, void(const std::map<std::string, std::string> &functionStrings));
 };
 
-GNU_DIAG_ON_SUGGEST_OVERRIDE;
+GNU_DIAG_ON_SUGGEST_OVERRIDE


### PR DESCRIPTION
### Description of work
 The selectable fit functions on the drop-down list of the function browser on the FqFit tab on the Data Analysis interface are made to be dependent on the type of data which is loaded. If EISF data is loaded, then the fit functions beginning with EISF are the only functions made available. If FWHM  data is loaded, then the fit functions not beginning with EISF are the only functions made available.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
The functions are updated in the fit property browser widget of the tab, which is in no direct communication with the data presenter, where new data is added. To avoid using QSignals, I have tried the following approach, not sure if is the more elegant way, or there are better ways to handle this: 
- The fit property browser widget class contains the function template browser, which handles the fit functions. I have added a function in the class to update the function list which are made available when the tab is created.
- Subscribe a pointer of the fit property browser to the presenter.
- Update the function list whenever a type of data (WIDTH or EISF) is added to the tab, to the appropiate subfunction list. These subfunctions are already defined in the `FitTabConstants` header.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36348 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
On the ConvFit tab
1. Load a sample and resolution from the sample dataset:`irs26173_graphite002`.
2. Load in 0-5 spectra.
3. Select 2 lorentzians.
4. Click Run and wait
5. There should be a `_results` workspace in the ADS.

Then on FqFit:
1. Load the results workspace
2. Only FWHM functions are available (without EISF prefix)

Again on ConvFit tab
1. Load a sample and resolution from the sample dataset:`irs26173_graphite002`.
2. Load in 0-5 spectra.
3. Select 2 lorentzians.
4. Tick `Delta Function` checkbox as `True` in the Function Property list. 
5. Run and wait
6. There should be a `Delta_..._results` workspace in the ADS.

Back on FqFit:
1. Load the `Delta_..._results` workspace selecting `EISF` as a parameter type in the add workspace dialog window.
2. Only EISF functions are available.


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
