### PR TITLE
Speed improvements for LoadAscii

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadAscii2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadAscii2.h
@@ -107,6 +107,9 @@ private:
   std::unique_ptr<DataObjects::Histogram1D> m_curSpectra;
   std::vector<double> m_curDx;
   std::vector<double> m_spectrumAxis;
+  std::vector<double> m_curHistoX;
+  std::vector<double> m_curHistoY;
+  std::vector<double> m_curHistoE;
 };
 
 } // namespace DataHandling

--- a/docs/source/release/v6.9.0/Framework/Algorithms/Bugfixes/36541.rst
+++ b/docs/source/release/v6.9.0/Framework/Algorithms/Bugfixes/36541.rst
@@ -1,0 +1,1 @@
+- Sped up the `LoadAscii` algorithm by at least one order of magnitude.


### PR DESCRIPTION
Improves the speed of loading ASCII files by at least one order of magnitude.

Previously after every line of the file was read, the histogram was resized by one, which meant copying everything many times. It will now read all the lines in a spectrum, then update the histogram in one go, with one resize. For comparison, a 6.6 MB file would take minutes to load, but now a 140 MB file can be read in a couple of minutes, while 6.6 MB takes seconds.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
- Store the `x`, `y`, and `e` values from each line in a vector, then when finished call `resize` on the histogram and set all the values.

Fixes #36541. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
- ASCII files load correctly, and load much faster than in 6.8. I was just saving example files as ASCII, then loading them back in.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
