### PR TITLE
Fix Workbench Crashing if Invalid Options are Given in the Options Column of the Refl GUI

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1480,7 +1480,6 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/sr
 constVariablePointer:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp:413
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.cpp:80
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.cpp:177
-constVariablePointer:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp:301
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h:33
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h:30
 constParameterReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp:243

--- a/docs/source/release/v6.9.0/Reflectometry/Bugfixes/34925.rst
+++ b/docs/source/release/v6.9.0/Reflectometry/Bugfixes/34925.rst
@@ -1,0 +1,2 @@
+- Workbench will no longer crash if invalid inputs are given in the options column of the Runs Table in the
+  :ref:`ISIS Reflectometry Interface <interface-isis-refl>`.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp
@@ -223,6 +223,10 @@ void BatchJobManager::addAlgorithmForProcessingRow(Row &row, std::deque<IConfigu
     // reductions.
     row.setSkipped(true);
     return;
+  } catch (std::invalid_argument const &e) {
+    row.setError("Error while setting algorithm properties: " + std::string(e.what()));
+    row.setSkipped(true);
+    return;
   }
   algorithms.emplace_back(std::move(algorithm));
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp
@@ -302,7 +302,7 @@ std::vector<std::string> BatchJobManager::getWorkspacesToSave(Row const &row) co
   // workspaces for the row if the group does not have postprocessing, because
   // in that case users just want to see the postprocessed output instead.
   auto workspaces = std::vector<std::string>();
-  auto *const group = row.getParent();
+  auto const *group = row.getParent();
   if (group && group->hasPostprocessing())
     return workspaces;
 


### PR DESCRIPTION
### Description of work

#### Summary of work
Catch an unhandled exception that can occur when an invalid value (often type) is given in the Options column. These values are passed as properties directly, so catching the `std::invalid_argument` thrown by the algorithm object is necessary. 

Fixes #34925 

### To test:
1. Open the Refl GUI
2. Enter 13460 into the Run(s) cell (second one down)
3. Enter 1 into the Angle cell
4. Enter `IncludePartialBins='crash'` into the Options Cell.
5. Click Process
6. Rather than crashing, the row should turn blue to indicate an error with an appropriate error message in the tooltip. 

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
