### PR TITLE
Fix Background Subtraction Workspace Deletion When Saving to File

### DIFF
--- a/docs/source/release/v6.9.0/SANS/Bugfixes/36621.rst
+++ b/docs/source/release/v6.9.0/SANS/Bugfixes/36621.rst
@@ -1,0 +1,2 @@
+- Background Subtracted (``_bgsub``) workspaces are now correctly deleted when ``File`` is selected as the save
+  location in the ISIS SANS GUI.

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -1405,7 +1405,8 @@ def delete_reduced_workspaces(reduction_packages, include_non_transmission=True)
             reduced_lab_sample = reduction_package.reduced_lab_sample
             reduced_hab_sample = reduction_package.reduced_hab_sample
 
-            workspaces_to_delete.extend([reduced_lab, reduced_hab, reduced_merged, reduced_bgsub, reduced_lab_sample, reduced_hab_sample])
+            workspaces_to_delete.extend([reduced_lab, reduced_hab, reduced_merged, reduced_lab_sample, reduced_hab_sample])
+            workspaces_to_delete.extend(reduced_bgsub)
 
         _delete_workspaces(delete_alg, workspaces_to_delete)
 

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -1406,7 +1406,8 @@ def delete_reduced_workspaces(reduction_packages, include_non_transmission=True)
             reduced_hab_sample = reduction_package.reduced_hab_sample
 
             workspaces_to_delete.extend([reduced_lab, reduced_hab, reduced_merged, reduced_lab_sample, reduced_hab_sample])
-            workspaces_to_delete.extend(reduced_bgsub)
+            if reduced_bgsub is not None:
+                workspaces_to_delete.extend(reduced_bgsub)
 
         _delete_workspaces(delete_alg, workspaces_to_delete)
 

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -580,6 +580,13 @@ class DeleteMethodsTest(unittest.TestCase):
         ws_group = GroupWorkspaces(InputWorkspaces=ws_ptrs, OutputWorkspace=str(uuid.uuid4()))
         return ws_group
 
+    def _create_ads_bgsub_workspace(self):
+        ws_ptrs = []
+        for i in range(2):
+            self._ads_names.append(str(uuid.uuid4()))
+            ws_ptrs.append(CreateSampleWorkspace(OutputWorkspace=self._ads_names[-1]))
+        return ws_ptrs
+
     @staticmethod
     def _create_non_ads_sample_workspaces():
         ws_group = WorkspaceGroup()
@@ -598,6 +605,15 @@ class DeleteMethodsTest(unittest.TestCase):
 
     def test_delete_reduced_workspace_in_ads(self):
         package = self._pack_reduction_package(self._create_ads_sample_workspaces)
+        current_ads_names = AnalysisDataService.getObjectNames()
+        self.assertTrue(all(name in current_ads_names for name in self._ads_names))
+        delete_reduced_workspaces(reduction_packages=[package], include_non_transmission=False)
+        current_ads_names = AnalysisDataService.getObjectNames()
+        self.assertFalse(all(name in current_ads_names for name in self._ads_names))
+
+    def test_delete_reduced_and_bgsub_workspace_in_ads(self):
+        package = self._pack_reduction_package(self._create_ads_sample_workspaces)
+        package.reduced_bgsub_name = self._create_ads_bgsub_workspace()
         current_ads_names = AnalysisDataService.getObjectNames()
         self.assertTrue(all(name in current_ads_names for name in self._ads_names))
         delete_reduced_workspaces(reduction_packages=[package], include_non_transmission=False)

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -587,6 +587,10 @@ class DeleteMethodsTest(unittest.TestCase):
             ws_ptrs.append(CreateSampleWorkspace(OutputWorkspace=self._ads_names[-1]))
         return ws_ptrs
 
+    def _create_ads_single_workspace(self):
+        self._ads_names.append(str(uuid.uuid4()))
+        return CreateSampleWorkspace(OutputWorkspace=self._ads_names[-1])
+
     @staticmethod
     def _create_non_ads_sample_workspaces():
         ws_group = WorkspaceGroup()
@@ -617,6 +621,20 @@ class DeleteMethodsTest(unittest.TestCase):
         current_ads_names = AnalysisDataService.getObjectNames()
         self.assertTrue(all(name in current_ads_names for name in self._ads_names))
         delete_reduced_workspaces(reduction_packages=[package], include_non_transmission=False)
+        current_ads_names = AnalysisDataService.getObjectNames()
+        self.assertFalse(all(name in current_ads_names for name in self._ads_names))
+
+    def test_delete_reduced_and_no_bgsub_workspace_given(self):
+        package = self._pack_reduction_package(self._create_ads_sample_workspaces)
+        package.reduced_bgsub_name = None
+        package.reduced_lab = self._create_ads_single_workspace()
+        package.reduced_hab = self._create_ads_single_workspace()
+        package.reduced_merged = self._create_ads_single_workspace()
+        package.reduced_lab_sample = self._create_ads_single_workspace()
+        package.reduced_hab_sample = self._create_ads_single_workspace()
+        current_ads_names = AnalysisDataService.getObjectNames()
+        self.assertTrue(all(name in current_ads_names for name in self._ads_names))
+        delete_reduced_workspaces(reduction_packages=[package])
         current_ads_names = AnalysisDataService.getObjectNames()
         self.assertFalse(all(name in current_ads_names for name in self._ads_names))
 


### PR DESCRIPTION
### Description of work

#### Summary of work
Stopped the a list being added to a list of workspace groups, extending that list instead. This allows the delete algorithm to function properly. 

Fixes #36621 

### To test:

1) Open the ISIS SANS interface.
1) Load the LOQ demo user file and batch file from the training data.
1) Tick the `Scaled Background Subtraction` checkbox and in the second row of data in the batch table enter:
    - `Background Workspace`: first_time
    - `Scale Factor`: 0.5
1) Check that the `Save Options` at the bottom of the interface are set to Memory.
1) Select the first row of the batch table and click `Process Selected`.
1) Go to the `Settings` tab and change the `Reduction Mode` to Hab.
1) Back on the Runs tab, select the second row of the batch table and click `Process Selected`. This should succeed (turns green).
1) Now change the `Save Options` at the bottom of the interface to File.
1) Select the second row of the batch table and click `Process Selected`. The row should process properly, the output workspaces for second_time deleted, and the output files appear in your save directory. 

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
