### PR TITLE
LoadNexusMonitors Set tof range for empty monitors to be 0 to 1

### DIFF
--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -123,10 +123,10 @@ bool isEventMonitor(::NeXus::File &file) {
 //------------------------------------------------------------------------------
 /// Initialization method.
 void LoadNexusMonitors2::init() {
-  const std::vector<std::string> exts{".nxs.h5", ".nxs", "_event.nxs"};
+  const std::vector<std::string> exts{".nxs.h5", ".nxs"};
   declareProperty(std::make_unique<API::FileProperty>("Filename", "", API::FileProperty::Load, exts),
                   "The name (including its full or relative path) of the NeXus file to "
-                  "attempt to load. The file extension must either be .nxs or .NXS");
+                  "attempt to load. The file extension must either be .nxs, .NXS, or .nxs.h5");
 
   declareProperty(
       std::make_unique<API::WorkspaceProperty<API::Workspace>>("OutputWorkspace", "", Kernel::Direction::Output),
@@ -712,7 +712,7 @@ void LoadNexusMonitors2::readEventMonitorEntry(::NeXus::File &file, size_t ws_in
   // load up the event list
   DataObjects::EventList &event_list = eventWS->getSpectrum(ws_index);
 
-  Mantid::Types::Core::DateAndTime pulsetime(0);
+  Mantid::Types::Core::DateAndTime pulsetime;
   Mantid::Types::Core::DateAndTime lastpulsetime(0);
   std::size_t numEvents = time_of_flight.size();
   bool pulsetimesincreasing = true;

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -1082,6 +1082,46 @@ public:
     AnalysisDataService::Instance().remove(wsName);
   }
 
+  void test_no_events() {
+    // this test was created for the strange case of an event file having no events anywhere
+    // originally it was only an empty monitor but the test file was expanded
+
+    const std::string filename = "CG3_22446_empty.nxs.h5";
+    const std::string wsname = "CG3_empty";
+
+    // run the algorithm
+    LoadEventNexus loader;
+    loader.initialize();
+    loader.setPropertyValue("Filename", filename);
+    loader.setPropertyValue("OutputWorkspace", wsname);
+    //    loader.setProperty("LoadAllLogs", false);
+    loader.setProperty("LoadMonitors", true);
+    TS_ASSERT_THROWS_NOTHING(loader.execute());
+
+    auto &ads = AnalysisDataService::Instance();
+
+    // validate the event workspace
+    {
+      MatrixWorkspace_sptr wksp = ads.retrieveWS<MatrixWorkspace>(wsname);
+      TS_ASSERT(wksp);
+      auto event_wksp = std::dynamic_pointer_cast<EventWorkspace>(wksp);
+      TS_ASSERT(event_wksp);
+      TS_ASSERT_EQUALS(event_wksp->getNumberEvents(), 0.);
+    }
+
+    // validate the monitor workspace
+    {
+      MatrixWorkspace_sptr wksp_mon = ads.retrieveWS<MatrixWorkspace>(wsname + "_monitors");
+      TS_ASSERT(wksp_mon);
+      auto event_wksp = std::dynamic_pointer_cast<EventWorkspace>(wksp_mon);
+      TS_ASSERT(event_wksp);
+      TS_ASSERT_EQUALS(event_wksp->getNumberEvents(), 0.);
+    }
+
+    // cleanup
+    AnalysisDataService::Instance().remove(wsname);
+  }
+
 private:
   std::string wsSpecFilterAndEventMonitors;
 };

--- a/Testing/Data/UnitTest/CG3_22446_empty.nxs.h5.md5
+++ b/Testing/Data/UnitTest/CG3_22446_empty.nxs.h5.md5
@@ -1,0 +1,1 @@
+422f8f45dbe4ed61ebb15e7bdcf17abc

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -782,9 +782,8 @@ shadowFunction:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNexus.cpp:248
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h:92
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNexusLogs.cpp:587
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed2.h:38
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNexusMonitors2.cpp:434
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNexusMonitors2.cpp:183
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNexusMonitors2.cpp:690
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNexusMonitors2.cpp:453
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNexusMonitors2.cpp:184
 integerOverflowCond:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/byte_rel_comp.cpp:59
 uninitdata:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/isisraw.cpp:518
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/vms_convert.cpp:366

--- a/docs/source/release/v6.9.0/Framework/Data_Handling/Bugfixes/36629.rst
+++ b/docs/source/release/v6.9.0/Framework/Data_Handling/Bugfixes/36629.rst
@@ -1,0 +1,1 @@
+- :ref:`LoadNexusMonitors <algm-LoadNexusMonitors>` can now load empty event based monitors. It will log messages to the user and set the time-of-flight range to 0-1 similar to :ref:`LoadEventNexus <algm-LoadEventNexus>`


### PR DESCRIPTION
This is consistent with `LoadEventNexus`. There is an additional warning logged for each monitor that contains zero events to better inform the user about what is going on. The new test is for an event nexus file that has no events in the detectors or monitors.

### Description of work

A commissioning file for BIOSANS, `CG3_22446.nxs.h5` was measured with the "bucket of neutrons" and the monitor collected no events. `LoadNexusMonitors` did not have in place similar logic to `LoadEventNexus` and threw very unhelpful errors. This PR changes the behavior to return an empty EventWorkspace and log warnings/errors informing the user what is going on.

*There is no associated issue,* but this is associated with defect [EWM3561](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=3561)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

The main test is to load the offending file,  `CG3_22446.nxs.h5`. The new unit test used [shrinkeventfile](https://github.com/neutrons/shrinkeventfile) to convert it to a very small file that has no events whatsoever. 

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
