### PR TITLE
Make `FunctionModel::checkIndex` safer by removing the unguarded throw

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1144,7 +1144,6 @@ constParameterPointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/ConvolutionFunct
 constVariablePointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitScriptOptionsBrowser.cpp:189
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/FlowLayout.h:68
 cppcheckError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/TransformMD.cpp:0
-knownPointerToBool:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FunctionModel.cpp:591
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/InstrumentSelector.cpp:38
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/ListPropertyWidget.cpp:46
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h:107

--- a/qt/python/mantidqt/mantidqt/_common.sip
+++ b/qt/python/mantidqt/mantidqt/_common.sip
@@ -909,7 +909,7 @@ public:
     double getParameter(const QString &funStr);
     int getNumberOfDatasets() const;
     void setNumberOfDatasets(int n);
-    void setCurrentDataset(int i);
+    void setCurrentDataset(int i) throw(std::exception);
     int getCurrentDataset() const;
     void setDatasets(const QStringList &datasetNames);
     void addDatasets(const QStringList &names);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionModel.h
@@ -85,7 +85,7 @@ private:
   void checkDatasets();
   void checkNumberOfDomains(const QList<FunctionModelDataset> &datasets) const;
   int numberOfDomains(const QList<FunctionModelDataset> &datasets) const;
-  void checkIndex(int) const;
+  [[nodiscard]] bool checkIndex(int const index) const;
   void updateGlobals();
   void setResolutionFromWorkspace(const IFunction_sptr &fun);
   void setResolutionFromWorkspace(const IFunction_sptr &fun, const MatrixWorkspace_sptr &workspace);

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -230,8 +230,7 @@ QStringList FunctionModel::getAttributeNames() const {
 }
 
 IFunction_sptr FunctionModel::getSingleFunction(int index) const {
-  checkIndex(index);
-  if (!hasFunction()) {
+  if (!checkIndex(index) || !hasFunction()) {
     return IFunction_sptr();
   }
   return m_function->getFunction(index);
@@ -357,8 +356,9 @@ int FunctionModel::getNumberDomains() const { return static_cast<int>(m_numberDo
 int FunctionModel::currentDomainIndex() const { return static_cast<int>(m_currentDomainIndex); }
 
 void FunctionModel::setCurrentDomainIndex(int index) {
-  checkIndex(index);
-  m_currentDomainIndex = static_cast<size_t>(index);
+  if (checkIndex(index)) {
+    m_currentDomainIndex = static_cast<size_t>(index);
+  }
 }
 
 double FunctionModel::getLocalParameterValue(const QString &parName, int i) const {
@@ -509,14 +509,13 @@ int FunctionModel::numberOfDomains(const QList<FunctionModelDataset> &datasets) 
   });
 }
 
-/// Check a domain/function index to be in range.
-void FunctionModel::checkIndex(int index) const {
-  if (index == 0)
-    return;
-  if (index < 0 || index >= getNumberDomains()) {
-    throw std::runtime_error("Domain index is out of range: " + std::to_string(index) + " out of " +
-                             std::to_string(getNumberDomains()));
-  }
+bool FunctionModel::checkIndex(int const index) const {
+  auto const indexInRange = index == 0 || (index > 0 && index < getNumberDomains());
+  // If the domain index is out of range, this indicates a problem in the logic of our code.
+  // We want the index to be ignored in Release mode (i.e. for a user), but we want an exception
+  // when in Debug mode (i.e. to alert a dev of the logic issue).
+  assert(indexInRange);
+  return indexInRange;
 }
 
 void FunctionModel::updateMultiDatasetParameters(const IFunction &fun) {


### PR DESCRIPTION
### Description of work
A user reported the following exception via the ErrorReporter:
```
        Additional text:
        Not provided
        Stack Trace:
        Traceback (most recent call last):
  File "C:\MantidInstall\bin\lib\site-packages\mantidqtinterfaces\Muon\GUI\Common\fitting_widgets\tf_asymmetry_fitting\tf_asymmetry_fitting_presenter.py", line 54, in handle_function_structure_changed
    super().handle_function_structure_changed()
  File "C:\MantidInstall\bin\lib\site-packages\mantidqtinterfaces\Muon\GUI\Common\fitting_widgets\basic_fitting\basic_fitting_presenter.py", line 294, in handle_function_structure_changed
    self.view.set_current_dataset_index(self.model.current_dataset_index)
  File "C:\MantidInstall\bin\lib\site-packages\mantidqtinterfaces\Muon\GUI\Common\fitting_widgets\basic_fitting\basic_fitting_view.py", line 143, in set_current_dataset_index
    self.fit_function_options.set_current_dataset_index(dataset_index)
  File "C:\MantidInstall\bin\lib\site-packages\mantidqtinterfaces\Muon\GUI\Common\fitting_widgets\basic_fitting\fit_function_options_view.py", line 173, in set_current_dataset_index
    self.function_browser.setCurrentDataset(dataset_index)
Exception: unknown
```

The problem could not be replicated, however we discovered an unguarded throw statement in the FunctionModel which is likely to have caused the crash. Ideally, we do not want to crash Mantid in any situation, so it was decided to try make this code safer. The solution I went for was to remove the unguarded throw and to add an assertion which will give an exception only in Debug mode. This will mean no crashes for users who get their GUIs into a state, but developers will still be able to find logic errors in their code. 

The other change I made was to make sure C++ exceptions for the `setCurrentDataset` method get propagated through the sip layer to python. So in future we should get more information than just `Exception: unknown`.

*There is no associated issue.*

### To test:
Follow the testing instructions in https://mantidproject.github.io/developer/Testing/MuonAnalysis_test_guides/Muon_EMU.html

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
