### PR TITLE
Always Return to Default Save Options When Reduction Mode is Switched

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/SaveCanSAS1D.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveCanSAS1D.h
@@ -83,7 +83,9 @@ class MANTID_DATAHANDLING_DLL SaveCanSAS1D : public API::Algorithm {
 public:
   virtual ~SaveCanSAS1D() = default;
   const std::string name() const override { return "SaveCanSAS1D"; }
-  const std::string summary() const override { return "Save a MatrixWorkspace to a file in the canSAS 1-D format"; }
+  const std::string summary() const override {
+    return "Save a MatrixWorkspace to a file in the CanSAS1D XML format for 1D data.";
+  }
   int version() const override { return 1; }
   const std::string category() const override { return "DataHandling\\XML;SANS\\DataHandling"; }
 

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveCanSAS1D.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveCanSAS1D.h
@@ -84,7 +84,7 @@ public:
   virtual ~SaveCanSAS1D() = default;
   const std::string name() const override { return "SaveCanSAS1D"; }
   const std::string summary() const override {
-    return "Save a MatrixWorkspace to a file in the CanSAS1D XML format for 1D data.";
+    return "Save a MatrixWorkspace to a file in the CanSAS1D XML format (for 1D data).";
   }
   int version() const override { return 1; }
   const std::string category() const override { return "DataHandling\\XML;SANS\\DataHandling"; }

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveCanSAS1D2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveCanSAS1D2.h
@@ -64,7 +64,7 @@ stylesheet
 class MANTID_DATAHANDLING_DLL SaveCanSAS1D2 : public SaveCanSAS1D {
 public:
   int version() const override { return 2; }
-  const std::vector<std::string> seeAlso() const override { return {"LoadCanSAS1D"}; }
+  const std::vector<std::string> seeAlso() const override { return {"LoadCanSAS1D", "SaveNXcanSAS"}; }
 
 protected:
   /// Extends the SaveCanSAS1D init method

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSAS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSAS.h
@@ -23,7 +23,9 @@ public:
   ~SaveNXcanSAS() override = default;
   const std::string name() const override { return "SaveNXcanSAS"; }
   /// Summary of algorithms purpose
-  const std::string summary() const override { return "Writes a MatrixWorkspace to a file in the NXcanSAS format."; }
+  const std::string summary() const override {
+    return "Save a MatrixWorkspace to a file in the NXcanSAS format for both 1D and 2D data.";
+  }
 
   /// Algorithm's version
   int version() const override { return (1); }

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSAS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSAS.h
@@ -24,7 +24,7 @@ public:
   const std::string name() const override { return "SaveNXcanSAS"; }
   /// Summary of algorithms purpose
   const std::string summary() const override {
-    return "Save a MatrixWorkspace to a file in the NXcanSAS format for both 1D and 2D data.";
+    return "Save a MatrixWorkspace to a file in the NXcanSAS format (for both 1D and 2D data).";
   }
 
   /// Algorithm's version

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveRKH.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveRKH.h
@@ -33,7 +33,9 @@ public:
   /// Algorithm's name
   const std::string name() const override { return "SaveRKH"; }
   /// Summary of algorithms purpose
-  const std::string summary() const override { return "Save a file in the LOQ RKH/'FISH' format"; }
+  const std::string summary() const override {
+    return "Save a MatrixWorkspace to a file in the ISIS RKH format for 1D or 2D data.";
+  }
 
   /// Algorithm's version
   int version() const override { return (1); }

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveRKH.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveRKH.h
@@ -34,7 +34,7 @@ public:
   const std::string name() const override { return "SaveRKH"; }
   /// Summary of algorithms purpose
   const std::string summary() const override {
-    return "Save a MatrixWorkspace to a file in the ISIS RKH format for 1D or 2D data.";
+    return "Save a MatrixWorkspace to a file in the ISIS RKH format (for 1D or 2D data).";
   }
 
   /// Algorithm's version

--- a/Framework/DataHandling/src/SaveCanSAS1D.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D.cpp
@@ -69,7 +69,7 @@ void SaveCanSAS1D::init() {
   declareProperty(
       std::make_unique<API::WorkspaceProperty<>>("InputWorkspace", "", Kernel::Direction::Input,
                                                  std::make_shared<API::WorkspaceUnitValidator>("MomentumTransfer")),
-      "The input workspace, which must be in units of Q");
+      "The input workspace, which must be in units of Q. Must be a 1D workspace.");
   declareProperty(std::make_unique<API::FileProperty>("Filename", "", API::FileProperty::Save, ".xml"),
                   "The name of the xml file to save");
 

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -731,7 +731,7 @@ void SaveNXcanSAS::init() {
   inputWSValidator->add<API::CommonBinsValidator>();
   declareProperty(std::make_unique<Mantid::API::WorkspaceProperty<>>("InputWorkspace", "", Kernel::Direction::Input,
                                                                      inputWSValidator),
-                  "The input workspace, which must be in units of Q");
+                  "The input workspace, which must be in units of Q. Can be a 1D or a 2D workspace.");
   declareProperty(std::make_unique<Mantid::API::FileProperty>("Filename", "", API::FileProperty::Save, ".h5"),
                   "The name of the .h5 file to save");
 

--- a/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
+++ b/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
@@ -32,10 +32,15 @@ Set up
 
 Automatic Save Selection
 ########################
-#. Switch between 1D and 2D at the bottom of the screen, it should automatically switch
-   between CanSAS and NXcanSAS
-#. Change any of the tick boxes (e.g. tick RKH), and switch between 1D and 2D. It should
-   not change.
+
+#. Switch between ``1D`` and ``2D`` ``Reduction`` modes at the bottom of the screen.
+
+   * When 1D is selected, ``CanSAS (1D)`` and ``NxCanSAS (1D/2D)`` should be checked.
+   * When 2D is selected, only ``NxCanSAS (1D/2D)`` should be checked.
+
+#. Check ``RKH (1D/2D)``.
+#. Change the reduction mode.
+#. The options should revert to the defaults above (with ``RKH (1D/2D)`` unchecked).
 
 Runs table editing
 ##################

--- a/docs/source/algorithms/SaveCanSAS1D-v2.rst
+++ b/docs/source/algorithms/SaveCanSAS1D-v2.rst
@@ -13,15 +13,20 @@
 Description
 -----------
 
-Saves the given :ref:`MatrixWorkspace` to a file in the canSAS 1-D format.
+Saves the given :ref:`MatrixWorkspace` to a file in the CanSAS1D XML format.
+
+This format is only intended to be used for 1D workspaces.
 
 If the workspace contains several spectra, two options are available:
 
-* if OneSpectrumPerFile if false (default value), all spectra will be appended
-  into the same file (into different <SASdata> entries)
-* if OneSpectrumPerFile is true, each spectrum will be written in a separate
-  file. The name of the file will be created as follows: <Filename property>_
-  <spectrum index>_<axis value><axis unit>.<extension>
+* if ``OneSpectrumPerFile`` if ``false`` (default value), all spectra will be appended
+  into the same file (into different ``<SASdata>`` entries)
+* if ``OneSpectrumPerFile`` is ``true``, each spectrum will be written in a separate
+  file. The name of the file will be created as follows:
+
+  ``<Filename property>_<spectrum index>_<axis value><axis unit>.<extension>``
+
+The created file can be loaded back into mantid using the :ref:`algm-LoadCanSAS1D` algorithm.
 
 The canSAS 1-D Format
 #####################

--- a/docs/source/algorithms/SaveCanSAS1D-v2.rst
+++ b/docs/source/algorithms/SaveCanSAS1D-v2.rst
@@ -19,14 +19,14 @@ This format is only intended to be used for 1D workspaces.
 
 If the workspace contains several spectra, two options are available:
 
-* if ``OneSpectrumPerFile`` if ``false`` (default value), all spectra will be appended
+* if ``OneSpectrumPerFile`` is ``false`` (default value), all spectra will be appended
   into the same file (into different ``<SASdata>`` entries)
 * if ``OneSpectrumPerFile`` is ``true``, each spectrum will be written in a separate
   file. The name of the file will be created as follows:
 
   ``<Filename property>_<spectrum index>_<axis value><axis unit>.<extension>``
 
-The created file can be loaded back into mantid using the :ref:`algm-LoadCanSAS1D` algorithm.
+The created file can be loaded back into Mantid using the :ref:`algm-LoadCanSAS1D` algorithm.
 
 The canSAS 1-D Format
 #####################

--- a/docs/source/algorithms/SaveNXcanSAS-v1.rst
+++ b/docs/source/algorithms/SaveNXcanSAS-v1.rst
@@ -9,9 +9,15 @@
 Description
 -----------
 
-Saves a workspace with momentum transfer units into a file adhering to the NXcanSAS format specified by NXcanSAS Data Formats Working Group `schema <http://cansas-org.github.io/NXcanSAS/classes/contributed_definitions/NXcanSAS.html>`__. If the input workspace is 2D then the vertical axis needs to be a numeric axis in momentum transfer units. The created file can be reloaded using the :ref:`algm-LoadNXcanSAS` algorithm.
+Saves a workspace with momentum transfer units into a file adhering to the NXcanSAS format specified by NXcanSAS Data
+Formats Working Group `schema <http://cansas-org.github.io/NXcanSAS/classes/contributed_definitions/NXcanSAS.html>`__.
 
-In addition it is possible to save the transmission workspaces obtain from a reduction.
+1D or 2D workspaces may be saved.
+
+If the input workspace is 2D then the vertical axis needs to be a numeric axis in momentum transfer units. The created
+file can be reloaded using the :ref:`algm-LoadNXcanSAS` algorithm.
+
+In addition, it is possible to save the transmission workspaces obtained from a reduction.
 
 
 Usage

--- a/docs/source/algorithms/SaveRKH-v1.rst
+++ b/docs/source/algorithms/SaveRKH-v1.rst
@@ -9,12 +9,17 @@
 Description
 -----------
 
-Saves the given workspace to a file which will be formatted in one
-of the LOQ data formats.  1D or 2D workspaces may be saved. If a 1D workspace
-is 'horizontal' (a single spectrum) then the first column in the three column
-output will contain the X values of the spectrum (giving the bin centre if histogram
-data). For a 'vertical' (single column) 1D workspace, the first column
-of the file will contain the spectrum number.
+Saves the given workspace to a file which will be formatted in one of the historic ISIS SANS (‘COLETTE’/‘FISH’)
+`data formats <https://www.isis.stfc.ac.uk/Pages/colette-ascii-file-format-descriptions.pdf>`__ devised by Richard K
+Heenan.
+
+1D or 2D workspaces may be saved.
+
+If a 1D workspace is 'horizontal' (a single spectrum) then the first column in the three column output will contain the
+X values of the spectrum (giving the bin centre if histogram data). For a 'vertical' (single column) 1D workspace,
+the first column of the file will contain the spectrum number.
+
+The created file can be reloaded using the :ref:`algm-LoadRKH` algorithm.
 
 Usage
 -----

--- a/docs/source/release/v6.9.0/SANS/Bugfixes/36115.rst
+++ b/docs/source/release/v6.9.0/SANS/Bugfixes/36115.rst
@@ -1,0 +1,1 @@
+- The GUI will now return to its default output options when the reduction mode is switched between 1D and 2D.

--- a/docs/source/release/v6.9.0/SANS/Bugfixes/36115.rst
+++ b/docs/source/release/v6.9.0/SANS/Bugfixes/36115.rst
@@ -1,1 +1,2 @@
-- The GUI will now return to its default output options when the reduction mode is switched between 1D and 2D.
+- The :ref:`ISIS_SANS_Runs_Tab-ref` will now return to its default output options when the reduction mode is switched
+  between 1D and 2D.

--- a/scripts/SANS/sans/gui_logic/models/POD/save_options.py
+++ b/scripts/SANS/sans/gui_logic/models/POD/save_options.py
@@ -13,7 +13,6 @@ class SaveOptions:
     can_sas_1d: bool = False
     nxs_can_sas: bool = False
     rkh: bool = False
-    user_modified: bool = False
 
     def to_all_states(self):
         """

--- a/scripts/SANS/sans/gui_logic/models/run_tab_model.py
+++ b/scripts/SANS/sans/gui_logic/models/run_tab_model.py
@@ -21,7 +21,6 @@ class RunTabModel:
 
     def update_save_types(self, selected_types: SaveOptions):
         self._save_types = selected_types
-        self._save_types.user_modified = True
 
     def get_reduction_mode(self):
         return self._reduction_mode
@@ -33,11 +32,8 @@ class RunTabModel:
     def _set_save_opts_for_reduction_mode(self, val: ReductionDimensionality):
         """
         Sets the save options for the given reduction mode depending on reduction mode
-        *if* the user has not changed their save options at any point
         :param val: New reduction dimensionality
         """
-        if self._save_types.user_modified:
-            return  # Don't mess with what a user might have preset
         if val is ReductionDimensionality.ONE_DIM:
             self._save_types = SaveOptions(can_sas_1d=True)
         elif val is ReductionDimensionality.TWO_DIM:

--- a/scripts/SANS/sans/gui_logic/models/run_tab_model.py
+++ b/scripts/SANS/sans/gui_logic/models/run_tab_model.py
@@ -35,7 +35,7 @@ class RunTabModel:
         :param val: New reduction dimensionality
         """
         if val is ReductionDimensionality.ONE_DIM:
-            self._save_types = SaveOptions(can_sas_1d=True)
+            self._save_types = SaveOptions(can_sas_1d=True, nxs_can_sas=True)
         elif val is ReductionDimensionality.TWO_DIM:
             self._save_types = SaveOptions(nxs_can_sas=True)
         else:

--- a/scripts/test/SANS/gui_logic/models/test_run_tab_model.py
+++ b/scripts/test/SANS/gui_logic/models/test_run_tab_model.py
@@ -20,13 +20,6 @@ class TestRunTabModel(unittest.TestCase):
         # Represents default save opts for 1D
         self.assertEqual(SaveOptions(can_sas_1d=True), self.model.get_save_types())
 
-    def test_setting_save_types_marks_as_user_set(self):
-        default_options = SaveOptions()
-        self.assertFalse(default_options.user_modified)
-        self.model.update_save_types(default_options)
-        save_types = self.model.get_save_types()
-        self.assertTrue(save_types.user_modified)
-
     def test_reduction_mode_stored(self):
         for mode in [ReductionDimensionality.TWO_DIM, ReductionDimensionality.ONE_DIM]:
             self.model.update_reduction_mode(mode)
@@ -37,14 +30,6 @@ class TestRunTabModel(unittest.TestCase):
             (ReductionDimensionality.TWO_DIM, SaveOptions(nxs_can_sas=True)),
             (ReductionDimensionality.ONE_DIM, SaveOptions(can_sas_1d=True)),
         ]:
-            self.model.update_reduction_mode(mode)
-            self.assertEqual(expected, self.model.get_save_types())
-
-    def test_reduction_mode_skips_update_with_custom_save(self):
-        expected = SaveOptions(nxs_can_sas=True, rkh=True, user_modified=True)
-        self.model.update_save_types(expected)
-
-        for mode in [ReductionDimensionality.ONE_DIM, ReductionDimensionality.TWO_DIM]:
             self.model.update_reduction_mode(mode)
             self.assertEqual(expected, self.model.get_save_types())
 

--- a/scripts/test/SANS/gui_logic/models/test_run_tab_model.py
+++ b/scripts/test/SANS/gui_logic/models/test_run_tab_model.py
@@ -18,7 +18,7 @@ class TestRunTabModel(unittest.TestCase):
     def test_constructor_sets_defaults(self):
         self.assertEqual(ReductionDimensionality.ONE_DIM, self.model.get_reduction_mode())
         # Represents default save opts for 1D
-        self.assertEqual(SaveOptions(can_sas_1d=True), self.model.get_save_types())
+        self.assertEqual(SaveOptions(can_sas_1d=True, nxs_can_sas=True), self.model.get_save_types())
 
     def test_reduction_mode_stored(self):
         for mode in [ReductionDimensionality.TWO_DIM, ReductionDimensionality.ONE_DIM]:
@@ -28,7 +28,7 @@ class TestRunTabModel(unittest.TestCase):
     def test_reduction_mode_updates_save_opts(self):
         for mode, expected in [
             (ReductionDimensionality.TWO_DIM, SaveOptions(nxs_can_sas=True)),
-            (ReductionDimensionality.ONE_DIM, SaveOptions(can_sas_1d=True)),
+            (ReductionDimensionality.ONE_DIM, SaveOptions(can_sas_1d=True, nxs_can_sas=True)),
         ]:
             self.model.update_reduction_mode(mode)
             self.assertEqual(expected, self.model.get_save_types())


### PR DESCRIPTION
### Description of work

#### Summary of work
Removes the function where if the save options were changed, then the GUI did not automatically select the most appropriate saving algorithms when changing between 1D and 2D reduction modes. 

Fixes #36115 

#### Further detail of work
In addition, updates the documentation in line with the scientist's requests. Improving the clarity of what each saving algorithm is designed for.

### To test:
1. Build the `dev-docs-html` target.
2. Check the formatting of the changed manual test instructions
3. Follow the instructions in the changed Manual Testing document
4. Ensure the selection behaves as described
5. Build the `docs-html` target.
6. Ensure that the documentation for SaveNXCanSAS, SaveCanSAS1D, and SaveRKH all look correct and all added links work properly. 

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
