### PR TITLE
36591 added nexus file support in PEARLTransfit algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
@@ -22,7 +22,7 @@
 from mantid.kernel import Direction, StringListValidator, EnabledWhenProperty, PropertyCriterion
 from mantid.api import PythonAlgorithm, MultipleFileProperty, AlgorithmFactory, mtd
 from mantid.simpleapi import (
-    LoadRaw,
+    Load,
     DeleteWorkspace,
     CropWorkspace,
     NormaliseByCurrent,
@@ -127,7 +127,8 @@ class PEARLTransfit(PythonAlgorithm):
 
     def PyInit(self):
         self.declareProperty(
-            MultipleFileProperty("Files", extensions=[".raw", ".s0x"]), doc="Files of calibration runs (numors). Must be detector scans."
+            MultipleFileProperty("Files", extensions=[".raw", ".s0x", ".nxs"]),
+            doc="Files of calibration runs (numors). Must be detector scans.",
         )
         self.declareProperty(
             name="FoilType",
@@ -375,13 +376,13 @@ class PEARLTransfit(PythonAlgorithm):
             fnNoExt = path.splitext(fileName)[0]
             if isFirstFile:
                 firstFileName = fnNoExt
-            fileName_Raw = fnNoExt + "_raw"
+            fileName_format = fnNoExt + "_" + fileName.split(".")[-1]
             fileName_3 = fnNoExt + "_3"
-            LoadRaw(Filename=file, OutputWorkspace=fileName_Raw)
-            CropWorkspace(InputWorkspace=fileName_Raw, OutputWorkspace=fileName_Raw, XMin=100, XMax=19990)
-            NormaliseByCurrent(InputWorkspace=fileName_Raw, OutputWorkspace=fileName_Raw)
-            ExtractSingleSpectrum(InputWorkspace=fileName_Raw, OutputWorkspace=fileName_3, WorkspaceIndex=3)
-            DeleteWorkspace(fileName_Raw)
+            Load(Filename=file, OutputWorkspace=fileName_format)
+            CropWorkspace(InputWorkspace=fileName_format, OutputWorkspace=fileName_format, XMin=100, XMax=19990)
+            NormaliseByCurrent(InputWorkspace=fileName_format, OutputWorkspace=fileName_format)
+            ExtractSingleSpectrum(InputWorkspace=fileName_format, OutputWorkspace=fileName_3, WorkspaceIndex=3)
+            DeleteWorkspace(fileName_format)
             ConvertUnits(InputWorkspace=fileName_3, Target="Energy", OutputWorkspace=fileName_3)
             self.TransfitRebin(fileName_3, fileName_3, foilType, divE)
             if not isFirstFile:

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
@@ -56,6 +56,12 @@ class PEARLTransfitTest(unittest.TestCase):
         self.assertNotIn("S_fit_Parameters", mtd)
         self.assertNotIn("S_fit_Workspace", mtd)
 
+    def test_calibration_run_single_run_with_nexus_file(self):
+        # Test that the calibration run produces the correct workspaces for a single run
+        PEARLTransfit(Files="PEARL00112777.nxs", Calibration=True)
+        self.assertIn("S_fit_Parameters", mtd)
+        self.assertIn("S_fit_Workspace", mtd)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Testing/Data/UnitTest/PEARL00112777.nxs.md5
+++ b/Testing/Data/UnitTest/PEARL00112777.nxs.md5
@@ -1,0 +1,1 @@
+dec1d707f7e4fe9c0dae5670565e0ca1

--- a/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36591.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Powder/New_features/36591.rst
@@ -1,0 +1,1 @@
+- Added nexus file support in :ref:`PEARLTransfit <algm-PEARLTransfit>`


### PR DESCRIPTION
### Description of work
Added nexus file support in PEARLTransfit algorithm so that now it can load .nexus files in addition to the existing file types already supported.

Fixes #36591.
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
(1) Open the PEARLTransfit algorithm GUI
(2) Set Files to PEARL00112777.nxs
(3) Check Calibration=True
(4) It should generate `S_fit_Parameters` and `S_fit_Workspace` workspaces and `S_fit_Workspace` should look like the below when plot all is selected

![image](https://github.com/mantidproject/mantid/assets/142818102/90f14501-6333-46d2-8dfc-b567679894b2)


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
