### PR TITLE
Fix LoadNXSPE of buggy files #36639 #36640

### DIFF
--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -287,8 +287,10 @@ void LoadNXSPE::exec() {
 
     Kernel::V3D pos;
     pos.spherical(r, polar.at(i), azimuthal.at(i));
-    // Define the size of the detector using the minimum of the polar or azimuthal width
-    double rr = r * sin(std::min(std::abs(polar_width.at(i)), std::abs(azimuthal_width.at(i))) * deg2rad / 2);
+    // Define the size of the detector using the minimum of the polar or azimuthal width (with maximum of 2 deg)
+    double rr =
+        r * sin(std::min(std::min(std::abs(polar_width.at(i)), std::abs(azimuthal_width.at(i))), 2.0) * deg2rad / 2);
+
     const auto shape = Geometry::ShapeFactory().createSphere(V3D(0, 0, 0), std::max(rr, 0.01));
 
     Geometry::Detector *det = new Geometry::Detector("pixel", static_cast<int>(i + 1), sample);

--- a/Framework/Kernel/src/NexusDescriptor.cpp
+++ b/Framework/Kernel/src/NexusDescriptor.cpp
@@ -257,8 +257,10 @@ void NexusDescriptor::walkFile(::NeXus::File &file, const std::string &rootPath,
     } else {
       if (level == 0)
         m_firstEntryNameType = (*it); // copy first entry name & type
-      file.openGroup(entryName, entryClass);
-      walkFile(file, entryPath, entryClass, pmap, level + 1);
+      if (!entryClass.empty()) {      // handles buggy files
+        file.openGroup(entryName, entryClass);
+        walkFile(file, entryPath, entryClass, pmap, level + 1);
+      }
     }
   }
   file.closeGroup();

--- a/docs/source/release/v6.9.0/Direct_Geometry/General/Bugfixes/36639.rst
+++ b/docs/source/release/v6.9.0/Direct_Geometry/General/Bugfixes/36639.rst
@@ -1,0 +1,1 @@
+- Allow loading of buggy .nxspe files with incorrect fields or detector sizes


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

Add a check in `NexusDescriptor` to ignore incorrect NeXus groups (these are valid HDF groups but do not have a NeXus `NXClass` attribute). This would allow parsing of malformed NeXus (specifically `.nxspe` files as described in issue #36639)

Add a maximum bound to the computed detector size when loading `.nxspe` files of two degrees. Previously some `nxspe` files could give a computed detector size much larger than is physically the case. This is because the `.nxspe` format is limited to having one detector angular width and the `LoadNXSPE` code has to infer from this what the widths in theta and phi are. For some detectors at odd angles, this calculation goes awry. The code changes ensure that the computed widths can be no larger than 2 degrees which is the largest which is a reasonable upper bound.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36639
Fixes #36640

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

In MSlice, load the files attached to the two issues and check that they load ok.

Plot the `MAR27256_121_meV*` files and check that they look similar (unlike the screenshot in the issue).

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
