### PR TITLE
Fix error on cancelling save

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -389,6 +389,8 @@ class MultiPythonFileInterpreter(QWidget):
     def save_current_file(self):
         self.current_editor().save(force_save=True)
         filename = self.current_editor().filename
+        if not filename:
+            return
         self.add_file_to_watcher(filename)
         self.files_that_we_have_changed[filename] = osp.getmtime(filename)
 

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -134,6 +134,14 @@ class MultiPythonFileInterpreterTest(unittest.TestCase, QtWidgetFinder):
             QApplication.instance().processEvents()
             self.assertEqual(0, len(widget.files_changed_unhandled), "Saving the file should not generate events")
 
+    def test_cancelled_save_does_not_add_file_to_watcher(self):
+        widget = MultiPythonFileInterpreter()
+        widget.current_editor = mock.MagicMock(autospec=True)
+        widget.current_editor().filename = ""
+        widget.save_current_file()
+        self.assertEqual(0, len(widget.file_watcher.files()), "File watcher should be empty")
+        self.assertEqual(0, len(widget.files_that_we_have_changed), "We haven't changed any files so this should be empty")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
If the save is cancelled, then the returned filename will be empty, in which case we don't want to continue any further.

Fixes #36642. 

### To test:
See #36642 for how to reproduce.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **this problem is not in any released version.**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
