### PR TITLE
Install Inelastic library in `Library/bin`

### DIFF
--- a/installers/conda/win/create_package.sh
+++ b/installers/conda/win/create_package.sh
@@ -132,7 +132,7 @@ mv $CONDA_ENV_PATH/Library/plugins/imageformats $COPY_DIR/plugins/qt5/
 mv $CONDA_ENV_PATH/Library/plugins/printsupport $COPY_DIR/plugins/qt5/
 mv $CONDA_ENV_PATH/Library/plugins/sqldrivers $COPY_DIR/plugins/qt5/
 mv $CONDA_ENV_PATH/Library/plugins/styles $COPY_DIR/plugins/qt5/
-mv $CONDA_ENV_PATH/Library/plugins/qt5/*.dll $COPY_DIR/plugins/qt5
+mv $CONDA_ENV_PATH/Library/plugins/qt5/*.dll $COPY_DIR/plugins/qt5/
 mv $CONDA_ENV_PATH/Library/plugins/*.dll $COPY_DIR/plugins/
 mv $CONDA_ENV_PATH/Library/plugins/python $COPY_DIR/plugins/
 

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -244,7 +244,7 @@ mtd_add_qt_library(
             Qt5::Concurrent
             Qt5::Xml
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsPlotting MantidQtWidgetsMplCpp MantidQtIcons
-  INSTALL_DIR_BASE ${WORKBENCH_PLUGINS_DIR}
+  INSTALL_DIR ${WORKBENCH_LIB_DIR}
   OSX_INSTALL_RPATH @loader_path/../../MacOS @loader_path/../../Frameworks @loader_path/../../plugins/qt5
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../plugins/qt5/"
 )


### PR DESCRIPTION
### Description of work
The Indirect interface category went missing because it now depends on the Inelastic library, and it appears the linker could not find this Inelastic library according to this warning message when building the package:
```
00:46:32  WARNING (mantidqt,Library/plugins/qt5/MantidScientificInterfacesIndirectQt5.dll): $RPATH/MantidScientificInterfacesInelasticQt5.dll not found in packages, sysroot(s) nor the missing_dso_whitelist.
00:46:32  .. is this binary repackaging?
```
This meant that the Indirect interfaces were not being subscribed to the InterfaceManager.

I found that the locations in which conda build searches for dlls to link to other dlls is hard coded here
https://github.com/conda/conda-build/blob/c79640164a58317ff63c1c3ff78896d580df2303/conda_build/os_utils/liefldd.py#L372

Hence it could find the dlls stored in `Library/bin`, but not the dlls stored in `Library/plugins/qt5`. To fix this, I need to install the indirect library into `Library/bin` so it can be found.

*There is no associated issue.*

Ideally we probably want plugins to be independent of each other. This will be something to work on in the future.

### To test:
1. Download the Windows package from this build https://builds.mantidproject.org/job/build_packages_from_branch/735/
2. Check that the Indirect interface category exists

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
