### PR TITLE
Disable Option to Save to CanSAS1D if 2D reduction Mode is Selected in ISIS SANS GUI

### DIFF
--- a/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
+++ b/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
@@ -33,6 +33,7 @@ Set up
 Automatic Save Selection
 ########################
 
+#. Select ``File`` or ``Both`` from the ``Save Options``.
 #. Switch between ``1D`` and ``2D`` ``Reduction`` modes at the bottom of the screen.
 
    * When 1D is selected, ``CanSAS (1D)`` and ``NxCanSAS (1D/2D)`` should be checked.
@@ -41,6 +42,8 @@ Automatic Save Selection
 #. Check ``RKH (1D/2D)``.
 #. Change the reduction mode.
 #. The options should revert to the defaults above (with ``RKH (1D/2D)`` unchecked).
+#. Select ``Memory``. The ``CanSAS (1D)``, ``NxCanSAS (1D/2D)``, and ``RKH (1D/2D)`` checkboxes should be disabled.
+#. Swap between ``Memory`` and ``File`` with a ``2D`` reduction mode. ``CanSAS (1D)`` should always stay disabled.
 
 Runs table editing
 ##################

--- a/docs/source/release/v6.9.0/SANS/Bugfixes/36398.rst
+++ b/docs/source/release/v6.9.0/SANS/Bugfixes/36398.rst
@@ -1,0 +1,3 @@
+- The option to save an output file using :ref:`algm-SaveCanSAS1D` has now been disabled if the reduction mode is set to
+  2D on the :ref:`ISIS_SANS_Runs_Tab-ref`. While the algorithm is able to handle 2D data without crashing, the output
+  file it produces is not meaningful.

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -682,6 +682,12 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         self.nx_can_sas_checkbox.setEnabled(True)
         self.rkh_checkbox.setEnabled(True)
 
+    def disable_can_sas_1D_button(self):
+        self.can_sas_checkbox.setEnabled(False)
+
+    def enable_can_sas_1D_button(self):
+        self.can_sas_checkbox.setEnabled(True)
+
     def disable_process_buttons(self):
         self.process_selected_button.setEnabled(False)
         self.process_all_button.setEnabled(False)

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -22,11 +22,10 @@ from ui.sans_isis import SANSSaveOtherWindow
 from ui.sans_isis.sans_data_processor_gui import SANSDataProcessorGui
 from ui.sans_isis.sans_gui_observable import SansGuiObservable
 
-from sans.common.enums import ReductionDimensionality
 from mantid.api import FileFinder
 from mantid.kernel import Logger, ConfigService, ConfigPropertyObserver
 from sans.command_interface.batch_csv_parser import BatchCsvParser
-from sans.common.enums import ReductionMode, RangeStepType, RowState, SampleShape, SaveType, SANSInstrument
+from sans.common.enums import ReductionMode, RangeStepType, RowState, SampleShape, SaveType, SANSInstrument, ReductionDimensionality
 from sans.gui_logic.gui_common import (
     add_dir_to_datasearch,
     get_reduction_mode_from_gui_selection,

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -585,7 +585,7 @@ class RunTabPresenter(PresenterCommon):
         # Update save options in case they've updated in the model
         save_opts = self._run_tab_model.get_save_types()
         self._view.save_types = save_opts
-        self._check_if_saveCanSAS1D_is_usable()
+        self._check_if_SaveCanSAS1D_is_usable()
 
     def _validate_output_modes(self):
         """
@@ -619,7 +619,7 @@ class RunTabPresenter(PresenterCommon):
             self._view.disable_file_type_buttons()
         else:
             self._view.enable_file_type_buttons()
-            self._check_if_saveCanSAS1D_is_usable()
+            self._check_if_SaveCanSAS1D_is_usable()
 
     def on_process_all_clicked(self):
         """

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -25,7 +25,16 @@ from ui.sans_isis.sans_gui_observable import SansGuiObservable
 from mantid.api import FileFinder
 from mantid.kernel import Logger, ConfigService, ConfigPropertyObserver
 from sans.command_interface.batch_csv_parser import BatchCsvParser
-from sans.common.enums import ReductionMode, RangeStepType, RowState, SampleShape, SaveType, SANSInstrument, ReductionDimensionality
+from sans.common.enums import (
+    ReductionMode,
+    RangeStepType,
+    RowState,
+    SampleShape,
+    SaveType,
+    SANSInstrument,
+    ReductionDimensionality,
+    OutputMode,
+)
 from sans.gui_logic.gui_common import (
     add_dir_to_datasearch,
     get_reduction_mode_from_gui_selection,
@@ -576,10 +585,7 @@ class RunTabPresenter(PresenterCommon):
         # Update save options in case they've updated in the model
         save_opts = self._run_tab_model.get_save_types()
         self._view.save_types = save_opts
-        if dimensionality is ReductionDimensionality.TWO_DIM:
-            self._view.disable_can_sas_1D_button()
-            return
-        self._view.enable_can_sas_1D_button()
+        self._check_if_saveCanSAS1D_is_usable()
 
     def _validate_output_modes(self):
         """
@@ -592,6 +598,17 @@ class RunTabPresenter(PresenterCommon):
             if self._view.save_types == [SaveType.NO_TYPE]:
                 raise ValueError("You have selected an output mode which saves to file, " "but no file types have been selected.")
 
+    def _check_if_SaveCanSAS1D_is_usable(self):
+        """
+        SaveCanSAS1D is only allowed to be used for 1D data. Check that we're in a file saving mode and in one dimension
+        before enabling the checkbox.
+        """
+        if self._view.output_mode is OutputMode.BOTH or self._view.output_mode is OutputMode.SAVE_TO_FILE:
+            if self._view.reduction_dimensionality is ReductionDimensionality.TWO_DIM:
+                self._view.disable_can_sas_1D_button()
+                return
+            self._view.enable_can_sas_1D_button()
+
     def on_output_mode_changed(self):
         """
         When output mode changes, dis/enable file type buttons
@@ -602,6 +619,7 @@ class RunTabPresenter(PresenterCommon):
             self._view.disable_file_type_buttons()
         else:
             self._view.enable_file_type_buttons()
+            self._check_if_saveCanSAS1D_is_usable()
 
     def on_process_all_clicked(self):
         """

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -22,6 +22,7 @@ from ui.sans_isis import SANSSaveOtherWindow
 from ui.sans_isis.sans_data_processor_gui import SANSDataProcessorGui
 from ui.sans_isis.sans_gui_observable import SansGuiObservable
 
+from sans.common.enums import ReductionDimensionality
 from mantid.api import FileFinder
 from mantid.kernel import Logger, ConfigService, ConfigPropertyObserver
 from sans.command_interface.batch_csv_parser import BatchCsvParser
@@ -571,10 +572,15 @@ class RunTabPresenter(PresenterCommon):
         )
 
     def on_reduction_dimensionality_changed(self):
-        self._run_tab_model.update_reduction_mode(self._view.reduction_dimensionality)
+        dimensionality = self._view.reduction_dimensionality
+        self._run_tab_model.update_reduction_mode(dimensionality)
         # Update save options in case they've updated in the model
         save_opts = self._run_tab_model.get_save_types()
         self._view.save_types = save_opts
+        if dimensionality is ReductionDimensionality.TWO_DIM:
+            self._view.disable_can_sas_1D_button()
+            return
+        self._view.enable_can_sas_1D_button()
 
     def _validate_output_modes(self):
         """

--- a/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
+++ b/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
@@ -10,7 +10,7 @@ from unittest import mock
 from mantid.kernel import PropertyManagerDataService
 from mantid.kernel import config
 from sans.command_interface.batch_csv_parser import BatchCsvParser
-from sans.common.enums import SANSFacility, ReductionDimensionality, SaveType, RowState
+from sans.common.enums import SANSFacility, ReductionDimensionality, SaveType, RowState, OutputMode
 from sans.common.enums import SANSInstrument
 from sans.gui_logic.models.RowEntries import RowEntries
 from sans.gui_logic.models.file_loading import UserFileLoadException
@@ -290,11 +290,13 @@ class RunTabPresenterTest(unittest.TestCase):
         self.mock_run_tab_model.update_save_types.assert_called_once_with(self._mock_view.save_types)
 
     def test_on_reduction_options_changed(self):
+        self._mock_view.output_mode = OutputMode.SAVE_TO_FILE
         self.view_observers.reduction_dim.notify_subscribers()
         self.mock_run_tab_model.update_reduction_mode.assert_called_once_with(self._mock_view.reduction_dimensionality)
         self._mock_view.enable_can_sas_1D_button.assert_called_once()
 
     def test_on_reduction_options_changed_called_2D(self):
+        self._mock_view.output_mode = OutputMode.SAVE_TO_FILE
         self._mock_view.reduction_dimensionality = ReductionDimensionality.TWO_DIM
         self.view_observers.reduction_dim.notify_subscribers()
         self.mock_run_tab_model.update_reduction_mode.assert_called_once_with(self._mock_view.reduction_dimensionality)

--- a/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
+++ b/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
@@ -289,9 +289,16 @@ class RunTabPresenterTest(unittest.TestCase):
         self.view_observers.save_options.notify_subscribers()
         self.mock_run_tab_model.update_save_types.assert_called_once_with(self._mock_view.save_types)
 
-    def test_on_reduction_options_changed_called(self):
+    def test_on_reduction_options_changed(self):
         self.view_observers.reduction_dim.notify_subscribers()
         self.mock_run_tab_model.update_reduction_mode.assert_called_once_with(self._mock_view.reduction_dimensionality)
+        self._mock_view.enable_can_sas_1D_button.assert_called_once()
+
+    def test_on_reduction_options_changed_called_2D(self):
+        self._mock_view.reduction_dimensionality = ReductionDimensionality.TWO_DIM
+        self.view_observers.reduction_dim.notify_subscribers()
+        self.mock_run_tab_model.update_reduction_mode.assert_called_once_with(self._mock_view.reduction_dimensionality)
+        self._mock_view.disable_can_sas_1D_button.assert_called_once()
 
     def test_on_reduction_options_changed_updates_save_opts(self):
         self.view_observers.reduction_dim.notify_subscribers()


### PR DESCRIPTION
### Description of work

#### Summary of work
Disables the checkbox if 2D reduction mode is selected. The SaveCanSAS1D algorithm can theoretically save 2D data without crashing but it is not meaningful. 

Fixes #36398

### To test:
1. Open ISIS SANS
2. Switch between 1D and 2D
3. See the checkbox enable and disable. 

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
