### PR TITLE
Add support for multiple oriented lattices to Sample API

### DIFF
--- a/Framework/API/inc/MantidAPI/Sample.h
+++ b/Framework/API/inc/MantidAPI/Sample.h
@@ -85,6 +85,11 @@ public:
   /// orientation
   void setOrientedLattice(std::unique_ptr<Geometry::OrientedLattice> lattice);
   bool hasOrientedLattice() const;
+
+  void addOrientedLattice(std::unique_ptr<Geometry::OrientedLattice> lattice);
+  void setOrientedLattices(std::unique_ptr<std::vector<Geometry::OrientedLattice>> lattices);
+  std::vector<Geometry::OrientedLattice> &getOrientedLattices();
+  const std::vector<Geometry::OrientedLattice> &getOrientedLattices() const;
   //@}
 
   /** @name Access the sample's crystal structure */
@@ -130,7 +135,7 @@ private:
   /// An owned pointer to the SampleEnvironment object
   std::shared_ptr<Geometry::SampleEnvironment> m_environment;
   /// Pointer to the OrientedLattice of the sample, NULL if not set.
-  std::unique_ptr<Geometry::OrientedLattice> m_lattice;
+  std::unique_ptr<std::vector<Geometry::OrientedLattice>> m_lattices;
 
   /// CrystalStructure of the sample
   std::unique_ptr<Geometry::CrystalStructure> m_crystalStructure;

--- a/Framework/API/inc/MantidAPI/Sample.h
+++ b/Framework/API/inc/MantidAPI/Sample.h
@@ -87,9 +87,9 @@ public:
   bool hasOrientedLattice() const;
 
   void addOrientedLattice(std::unique_ptr<Geometry::OrientedLattice> lattice);
-  void setOrientedLattices(std::unique_ptr<std::vector<Geometry::OrientedLattice>> lattices);
-  std::vector<Geometry::OrientedLattice> &getOrientedLattices();
-  const std::vector<Geometry::OrientedLattice> &getOrientedLattices() const;
+  void setOrientedLattices(std::vector<std::shared_ptr<Geometry::OrientedLattice>> lattices);
+  std::vector<std::shared_ptr<Geometry::OrientedLattice>> &getOrientedLattices();
+  const std::vector<std::shared_ptr<Geometry::OrientedLattice>> &getOrientedLattices() const;
   //@}
 
   /** @name Access the sample's crystal structure */
@@ -134,8 +134,8 @@ private:
   Geometry::IObject_sptr m_shape;
   /// An owned pointer to the SampleEnvironment object
   std::shared_ptr<Geometry::SampleEnvironment> m_environment;
-  /// Pointer to the OrientedLattice of the sample, NULL if not set.
-  std::unique_ptr<std::vector<Geometry::OrientedLattice>> m_lattices;
+  /// Vector of oriented lattices
+  std::vector<std::shared_ptr<Geometry::OrientedLattice>> m_lattices;
 
   /// CrystalStructure of the sample
   std::unique_ptr<Geometry::CrystalStructure> m_crystalStructure;

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -415,7 +415,7 @@ int Sample::loadNexus(::NeXus::File *file, const std::string &group) {
     if (num_oriented_lattice > 0) {
       std::unique_ptr<Geometry::OrientedLattice> lattice = std::make_unique<Geometry::OrientedLattice>();
       lattice->loadNexus(file, "oriented_lattice");
-      setOrientedLattice(move(lattice));
+      setOrientedLattice(std::move(lattice));
     }
   }
 

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -168,11 +168,9 @@ OrientedLattice &Sample::getOrientedLattice() {
  * @param lattice :: A pointer to a OrientedLattice.
  */
 void Sample::setOrientedLattice(std::unique_ptr<Geometry::OrientedLattice> lattice) {
-  if (!lattice) {
-    throw std::runtime_error("Sample::setOrientedLattice - The provided lattice pointer is nullptr.");
+  if (lattice) {
+    m_lattices.push_back(std::move(lattice));
   }
-
-  m_lattices = std::vector<std::shared_ptr<Geometry::OrientedLattice>>{std::move(lattice)};
 }
 
 /** @return true if the sample has an OrientedLattice  */

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -39,10 +39,11 @@ Sample::Sample(const Sample &copy)
     : m_name(copy.m_name), m_shape(copy.m_shape), m_environment(copy.m_environment), m_lattices(), m_crystalStructure(),
       m_samples(copy.m_samples), m_geom_id(copy.m_geom_id), m_thick(copy.m_thick), m_height(copy.m_height),
       m_width(copy.m_width) {
+  m_lattices = std::vector<std::shared_ptr<Geometry::OrientedLattice>>();
+  std::transform(copy.m_lattices.begin(), copy.m_lattices.end(), std::back_inserter(m_lattices),
+                 [](const auto &lattice) { return std::make_shared<Geometry::OrientedLattice>(*lattice); });
+
   if (copy.hasCrystalStructure()) {
-    m_lattices = std::vector<std::shared_ptr<Geometry::OrientedLattice>>();
-    std::transform(copy.m_lattices.begin(), copy.m_lattices.end(), std::back_inserter(m_lattices),
-                   [](const auto &lattice) { return std::make_shared<Geometry::OrientedLattice>(*lattice); });
     m_crystalStructure = std::make_unique<Geometry::CrystalStructure>(copy.getCrystalStructure());
   }
 }

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -179,11 +179,9 @@ void Sample::setOrientedLattice(std::unique_ptr<Geometry::OrientedLattice> latti
 bool Sample::hasOrientedLattice() const { return !(m_lattices.empty()); }
 
 void Sample::addOrientedLattice(std::unique_ptr<Geometry::OrientedLattice> lattice) {
-  if (!lattice) {
-    throw std::runtime_error("Sample::addOrientedLattice - The provided lattice pointer is nullptr.");
+  if (lattice) {
+    m_lattices.push_back(std::move(lattice));
   }
-
-  m_lattices.push_back(std::move(lattice));
 }
 
 void Sample::setOrientedLattices(std::vector<std::shared_ptr<Geometry::OrientedLattice>> lattices) {

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -174,12 +174,16 @@ OrientedLattice &Sample::getOrientedLattice() {
  * @param lattice :: A pointer to a OrientedLattice.
  */
 void Sample::setOrientedLattice(std::unique_ptr<Geometry::OrientedLattice> lattice) {
-  std::vector<Geometry::OrientedLattice> lattices = {*(lattice.release())};
+  if (!lattice) {
+    throw std::runtime_error("Sample::setOrientedLattice - The provided lattice pointer is nullptr.");
+  }
+
+  std::vector<Geometry::OrientedLattice> lattices = {*lattice};
 
   if (m_lattices == nullptr) {
-    m_lattices = std::make_unique<std::vector<Geometry::OrientedLattice>>(lattices);
+    m_lattices = std::make_unique<std::vector<Geometry::OrientedLattice>>(std::move(lattices));
   } else {
-    m_lattices.reset(&lattices);
+    *m_lattices = std::move(lattices);
   }
 }
 
@@ -187,11 +191,15 @@ void Sample::setOrientedLattice(std::unique_ptr<Geometry::OrientedLattice> latti
 bool Sample::hasOrientedLattice() const { return (m_lattices != nullptr); }
 
 void Sample::addOrientedLattice(std::unique_ptr<Geometry::OrientedLattice> lattice) {
+  if (!lattice) {
+    throw std::runtime_error("Sample::addOrientedLattice - The provided lattice pointer is nullptr.");
+  }
+
   if (!m_lattices) {
-    std::vector<Geometry::OrientedLattice> lattices = {*(lattice.release())};
+    std::vector<Geometry::OrientedLattice> lattices = {*lattice};
     m_lattices = std::make_unique<std::vector<Geometry::OrientedLattice>>(lattices);
   } else {
-    m_lattices->push_back(*(lattice.release()));
+    m_lattices->push_back(*lattice);
   }
 }
 

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -41,9 +41,8 @@ Sample::Sample(const Sample &copy)
       m_width(copy.m_width) {
   if (copy.hasCrystalStructure()) {
     m_lattices = std::vector<std::shared_ptr<Geometry::OrientedLattice>>();
-    for (const auto &lattice : copy.m_lattices) {
-      m_lattices.push_back(std::make_shared<Geometry::OrientedLattice>(*lattice));
-    }
+    std::transform(copy.m_lattices.begin(), copy.m_lattices.end(), std::back_inserter(m_lattices),
+                   [](const auto &lattice) { return std::make_shared<Geometry::OrientedLattice>(*lattice); });
     m_crystalStructure = std::make_unique<Geometry::CrystalStructure>(copy.getCrystalStructure());
   }
 }
@@ -68,9 +67,8 @@ Sample &Sample::operator=(const Sample &rhs) {
   m_height = rhs.m_height;
   m_width = rhs.m_width;
   m_lattices = std::vector<std::shared_ptr<Geometry::OrientedLattice>>();
-  for (const auto &lattice : rhs.m_lattices) {
-    m_lattices.push_back(std::make_shared<Geometry::OrientedLattice>(*lattice));
-  }
+  std::transform(rhs.m_lattices.begin(), rhs.m_lattices.end(), std::back_inserter(m_lattices),
+                 [](const auto &lattice) { return std::make_shared<Geometry::OrientedLattice>(*lattice); });
 
   m_crystalStructure.reset();
   if (rhs.hasCrystalStructure()) {

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -39,7 +39,6 @@ Sample::Sample(const Sample &copy)
     : m_name(copy.m_name), m_shape(copy.m_shape), m_environment(copy.m_environment), m_lattices(), m_crystalStructure(),
       m_samples(copy.m_samples), m_geom_id(copy.m_geom_id), m_thick(copy.m_thick), m_height(copy.m_height),
       m_width(copy.m_width) {
-  m_lattices = std::vector<std::shared_ptr<Geometry::OrientedLattice>>();
   std::transform(copy.m_lattices.begin(), copy.m_lattices.end(), std::back_inserter(m_lattices),
                  [](const auto &lattice) { return std::make_shared<Geometry::OrientedLattice>(*lattice); });
 

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -36,10 +36,14 @@ Sample::Sample()
  *  @param copy :: const reference to the sample object
  */
 Sample::Sample(const Sample &copy)
-    : m_name(copy.m_name), m_shape(copy.m_shape), m_environment(copy.m_environment), m_lattices(copy.m_lattices),
-      m_crystalStructure(), m_samples(copy.m_samples), m_geom_id(copy.m_geom_id), m_thick(copy.m_thick),
-      m_height(copy.m_height), m_width(copy.m_width) {
+    : m_name(copy.m_name), m_shape(copy.m_shape), m_environment(copy.m_environment), m_lattices(), m_crystalStructure(),
+      m_samples(copy.m_samples), m_geom_id(copy.m_geom_id), m_thick(copy.m_thick), m_height(copy.m_height),
+      m_width(copy.m_width) {
   if (copy.hasCrystalStructure()) {
+    m_lattices = std::vector<std::shared_ptr<Geometry::OrientedLattice>>();
+    for (const auto &lattice : copy.m_lattices) {
+      m_lattices.push_back(std::make_shared<Geometry::OrientedLattice>(*lattice));
+    }
     m_crystalStructure = std::make_unique<Geometry::CrystalStructure>(copy.getCrystalStructure());
   }
 }
@@ -63,7 +67,10 @@ Sample &Sample::operator=(const Sample &rhs) {
   m_thick = rhs.m_thick;
   m_height = rhs.m_height;
   m_width = rhs.m_width;
-  m_lattices = std::vector<std::shared_ptr<Geometry::OrientedLattice>>(rhs.m_lattices);
+  m_lattices = std::vector<std::shared_ptr<Geometry::OrientedLattice>>();
+  for (const auto &lattice : rhs.m_lattices) {
+    m_lattices.push_back(std::make_shared<Geometry::OrientedLattice>(*lattice));
+  }
 
   m_crystalStructure.reset();
   if (rhs.hasCrystalStructure()) {
@@ -168,6 +175,7 @@ OrientedLattice &Sample::getOrientedLattice() {
  * @param lattice :: A pointer to a OrientedLattice.
  */
 void Sample::setOrientedLattice(std::unique_ptr<Geometry::OrientedLattice> lattice) {
+  m_lattices.clear();
   if (lattice) {
     m_lattices.push_back(std::move(lattice));
   }

--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -35,7 +35,10 @@ void export_Sample() {
       .def("getName", &Sample::getName, return_value_policy<copy_const_reference>(), arg("self"),
            "Returns the string name of the sample")
       .def("getOrientedLattice", (const OrientedLattice &(Sample::*)() const) & Sample::getOrientedLattice, arg("self"),
-           return_value_policy<reference_existing_object>(), "Get the oriented lattice for this sample")
+           return_value_policy<reference_existing_object>(), "Get the first oriented lattice for this sample")
+      .def("getOrientedLattices",
+           (const std::vector<OrientedLattice> &(Sample::*)() const) & Sample::getOrientedLattices,
+           return_value_policy<reference_existing_object>(), "Get the oriented lattices for this sample")
       .def("hasOrientedLattice", &Sample::hasOrientedLattice, arg("self"),
            "Returns True if this sample has an oriented lattice, false "
            "otherwise")

--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -37,7 +37,7 @@ void export_Sample() {
       .def("getOrientedLattice", (const OrientedLattice &(Sample::*)() const) & Sample::getOrientedLattice, arg("self"),
            return_value_policy<reference_existing_object>(), "Get the first oriented lattice for this sample")
       .def("getOrientedLattices",
-           (const std::vector<OrientedLattice> &(Sample::*)() const) & Sample::getOrientedLattices,
+           (const std::vector<std::shared_ptr<OrientedLattice>> &(Sample::*)() const) & Sample::getOrientedLattices,
            return_value_policy<reference_existing_object>(), "Get the oriented lattices for this sample")
       .def("hasOrientedLattice", &Sample::hasOrientedLattice, arg("self"),
            "Returns True if this sample has an oriented lattice, false "

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -362,8 +362,8 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:302
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:668
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:701
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/BraggScatterer.h:71
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:338
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:347
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:375
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:384
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/ScriptBuilder.cpp:209
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:91
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:151
@@ -919,7 +919,7 @@ passedByValue:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Expor
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp:36
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp:41
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp:46
-syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp:81
+syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp:84
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp:251
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp:58
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp:90

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -362,8 +362,8 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:302
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:668
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:701
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/BraggScatterer.h:71
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:364
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:373
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:362
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:371
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/ScriptBuilder.cpp:209
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:91
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:151

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -362,8 +362,8 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:302
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:668
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:701
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/BraggScatterer.h:71
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:369
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:379
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:368
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:377
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/ScriptBuilder.cpp:209
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:91
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:151

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -362,8 +362,8 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:302
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:668
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:701
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/BraggScatterer.h:71
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:368
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:377
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:369
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:379
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/ScriptBuilder.cpp:209
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:91
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:151

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -362,8 +362,8 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:302
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:668
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:701
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/BraggScatterer.h:71
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:366
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:375
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:364
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:373
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/ScriptBuilder.cpp:209
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:91
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:151

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -362,8 +362,8 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:302
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:668
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:701
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/BraggScatterer.h:71
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:383
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:392
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:366
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:375
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/ScriptBuilder.cpp:209
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:91
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:151

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -362,8 +362,8 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:302
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:668
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:701
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/BraggScatterer.h:71
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:362
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:371
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:370
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:379
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/ScriptBuilder.cpp:209
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:91
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:151

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -362,8 +362,8 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:302
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:668
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:701
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/BraggScatterer.h:71
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:375
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:384
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:383
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:392
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/ScriptBuilder.cpp:209
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:91
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:151

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -362,8 +362,8 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:302
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:668
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:701
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/BraggScatterer.h:71
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:370
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:379
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:368
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/Sample.cpp:377
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/ScriptBuilder.cpp:209
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:91
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:151


### PR DESCRIPTION
### Description of work
This pull request modifies the Sample class by adding APIs to manage multiple oriented lattices for a single sample. The purpose of this addition is to enable a sample to store multiple UB matrices, which would allow different peak algorithms to use them. This PR will resolve part of #36592.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
TBA
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
