### PR TITLE
Fix for crash on deleting workspaces while project save is running

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/32361.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/32361.rst
@@ -1,0 +1,1 @@
+- Fix for crash which could happen if workspaces are deleted while the project saves. Save now fails in a controlled way.

--- a/qt/python/mantidqt/mantidqt/project/workspacesaver.py
+++ b/qt/python/mantidqt/mantidqt/project/workspacesaver.py
@@ -34,9 +34,10 @@ class WorkspaceSaver(object):
         if workspaces_to_save is None:
             return
 
-        for workspace_name in workspaces_to_save:
+        workspaces = ADS.retrieveWorkspaces(workspaces_to_save)
+
+        for workspace, workspace_name in zip(workspaces, workspaces_to_save):
             # Get the workspace from the ADS
-            workspace = ADS.retrieve(workspace_name)
             place_to_save_workspace = os.path.join(self.directory, workspace_name)
 
             from mantid.simpleapi import SaveMD, SaveNexusProcessed
@@ -44,14 +45,14 @@ class WorkspaceSaver(object):
             try:
                 if isinstance(workspace, MDHistoWorkspace) or isinstance(workspace, IMDEventWorkspace):
                     # Save normally using SaveMD
-                    SaveMD(InputWorkspace=workspace_name, Filename=place_to_save_workspace + ".nxs")
+                    SaveMD(InputWorkspace=workspace, Filename=place_to_save_workspace + ".nxs")
                 elif isinstance(workspace, GroupingWorkspace):
                     # catch this rather than leave SaveNexusProcessed to raise error to avoid message of type error
                     # being logged
                     raise RuntimeError("Grouping Workspaces not supported by SaveNexusProcessed")
                 else:
                     # Save normally using SaveNexusProcessed
-                    SaveNexusProcessed(InputWorkspace=workspace_name, Filename=place_to_save_workspace + ".nxs")
+                    SaveNexusProcessed(InputWorkspace=workspace, Filename=place_to_save_workspace + ".nxs")
                 self.output_list.append(workspace_name)
             except Exception as exc:
                 logger.warning("Couldn't save workspace in project: \"" + workspace_name + '" because ' + str(exc))


### PR DESCRIPTION
#### Summary of work
The save method first gets a list of workspaces from the ADS. This gets filtered and passed to the `WorkspaceSaver.save_workspaces` method, which loops over the list, retrieving the workspace from the ADS and then running an appropriate save algorithm.
Since each workspace is retrieved at the start of each iteration, and there could be many workspaces to get through, this leaves a gap long enough for the user to perform an action which deletes a workspace and cause an exception when calling `ADS.retrieve`.

I have just moved the retrieve call so that all workspaces are retrieved before the loop runs. The error now is handled by the save algorithm property validation, which notices there is no longer data attached to the workspace handle passed to the algorithm.

I have had a look into the (probably better) approach that the project save would block deletions from the ADS. This got complicated quickly, mainly because all code which calls `ADS.remove` would need to handle the case where the call was rejected.

Fixes #32361

### To test:

Follow instructions from issue #32361 and ensure that there is no crash and that the output is sensible.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
