### PR TITLE
Updated SHA for MSlice and added release notes

### DIFF
--- a/docs/source/release/v6.9.0/Direct_Geometry/MSlice/Bugfixes/36659.rst
+++ b/docs/source/release/v6.9.0/Direct_Geometry/MSlice/Bugfixes/36659.rst
@@ -1,0 +1,3 @@
+- Fixed bug where data gets distorted from setting log scale to x axis and then setting it to linear again
+- Deleted hidden workspaces are now also removed from the ADS to avoid memory issues
+- Added import for Mantid algorithm wrappers back into the command line interface

--- a/docs/source/release/v6.9.0/Direct_Geometry/MSlice/New_features/36659.rst
+++ b/docs/source/release/v6.9.0/Direct_Geometry/MSlice/New_features/36659.rst
@@ -1,0 +1,2 @@
+- When closing the MSlice interface in Mantid the Jupyter QtConsole is now cleaned up
+- Upgrade from matplotlib 3.6 to 3.7

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -7,7 +7,7 @@ externalproject_add(
   mslice
   PREFIX ${_mslice_external_root}
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
-  GIT_TAG 98719f93467237ed9199c5940c78c632649eb3ca
+  GIT_TAG 5975927847b02da9ece3224912e24d6fee1f042b
   EXCLUDE_FROM_ALL 1
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""


### PR DESCRIPTION
### Description of work

Replaced MSlice SHA for Mantid with SHA of current MSlice main branch.

Added release notes for all changes since the last SHA update.

### To test:

Double-check SHA with SHA of current MSlice main branch.

*There is no associated issue.*

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
