### PR TITLE
Estimate the FWHM parameter in ConvFit for Lorentzians

### DIFF
--- a/docs/source/release/v6.9.0/Inelastic/New_features/36346.rst
+++ b/docs/source/release/v6.9.0/Inelastic/New_features/36346.rst
@@ -1,1 +1,1 @@
-- When loading data into the ``ConvFit`` tab of the :ref:`Inelastic Data Analysis interface <interface-inelastic-data-analysis>`, an estimate is provided for the ``Amplitude`` and ``Height`` parameter values. They are estimated to be the maximum value in the corresponding spectrum.
+- When loading data into the ``ConvFit`` tab of the :ref:`Inelastic Data Analysis interface <interface-inelastic-data-analysis>`, an estimate is provided for the ``Amplitude``, ``Height`` and ``FWHM`` parameter values. They are estimated to be the maximum value in the corresponding spectrum.


### PR DESCRIPTION
### Description of work
This PR fixes an issue where fitting a 1L and FlatBackground in the ConvFit tab causes a poor fit with the new estimate for the Amplitude parameter. It appears GSL only manages one fit iteration for the first spectrum and then fails with the error "iteration is not making progress towards solution". I find an optimal solution which involves estimating the FWHM maximum parameter as well as Amplitude. If an estimate for the FWHM cannot be found, then neither of the parameters will be estimated.

The FWHM parameter for Lorentzians in ConvFit are now estimated by:

1. Finding the maximum y value (y_max). Its corresponding x value is assumed to be roughly the peak centre, `x_centre`
2. Finding the first `x_value` in the spectrum where its corresponding y value is > y_max / 2
3. Then estimate the FWHM with the following formula
```
FWHM_estimate = 2.0 * abs(x_centre - x_value)
```

This provides a better FWHM value, typically in the region of 0.03, rather than the default value of 1 (which is way too big). A subsequent fit gives a value of 0.04. 

A similar method is used in the ALF View interface to calculate an estimate for the sigma parameter of a Gaussian. https://github.com/mantidproject/mantid/blob/6e1a1b6f29a95ec62a4762ebac606648072df20e/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp#L48

Fixes #36623 

### To test:
1. Open Inelastic Data Analysis interface
2. Go to the ConvFit tab
3. Load the following data
4. Select 1 Lorentzian and a Flat Background
5. Click Run
6. The fit should be ok:
![image](https://github.com/mantidproject/mantid/assets/40830825/cd25b4dd-3d64-49de-972f-b306e13d8c67)
### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
