### PR TITLE
Fix for error on opening files utf-8 only characters

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36663.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36663.rst
@@ -1,0 +1,1 @@
+- Fix for crash which could occur when opening file with unicode characters

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -338,7 +338,7 @@ class MultiPythonFileInterpreter(QWidget):
         :param filepath: A path to an existing file
         :param startup: Flag for if function is being called on startup
         """
-        with open(filepath, "r") as code_file:
+        with open(filepath, "r", encoding="utf_8") as code_file:
             content = code_file.read()
 
         matching_index = self.find_matching_tab(filepath)
@@ -368,7 +368,7 @@ class MultiPythonFileInterpreter(QWidget):
             self.open_file_in_new_tab(file)
             return
 
-        with open(file, "r") as code_file:
+        with open(file, "r", encoding="utf_8") as code_file:
             content = code_file.read()
 
         editor = self.editor_at(matching_tab_index)

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -134,6 +134,17 @@ class MultiPythonFileInterpreterTest(unittest.TestCase, QtWidgetFinder):
             QApplication.instance().processEvents()
             self.assertEqual(0, len(widget.files_changed_unhandled), "Saving the file should not generate events")
 
+    def test_open_file_in_new_tab_with_utf8_content(self):
+        widget = MultiPythonFileInterpreter()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            filename = os.path.join(temp_dir, "utf8_characters")
+            with open(filename, "w", encoding="utf_8") as f:
+                f.write("输出坐标系")
+            with mock.patch("mantidqt.widgets.codeeditor.interpreter.EditorIO.ask_for_filename", lambda s: filename):
+                # Test that we can open a utf-8 file with no exceptions
+                widget.open_file_in_new_tab(filename)
+            self.assertEqual(2, widget.editor_count, msg="Should be the original tab, plus one (not two) tabs for the file")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -143,7 +143,7 @@ class MultiPythonFileInterpreterTest(unittest.TestCase, QtWidgetFinder):
             with mock.patch("mantidqt.widgets.codeeditor.interpreter.EditorIO.ask_for_filename", lambda s: filename):
                 # Test that we can open a utf-8 file with no exceptions
                 widget.open_file_in_new_tab(filename)
-            self.assertEqual(2, widget.editor_count, msg="Should be the original tab, plus one (not two) tabs for the file"
+            self.assertEqual(2, widget.editor_count, msg="Should be the original tab, plus one (not two) tabs for the file")
 
     def test_cancelled_save_does_not_add_file_to_watcher(self):
         widget = MultiPythonFileInterpreter()


### PR DESCRIPTION
### Description of work

Response to the following error report stack trace
```
File "C:\MantidInstall\bin\lib\site-packages\workbench\plugins\editor.py", line 111, in dropEvent
    self.open_file_in_new_tab(filepath)
  File "C:\MantidInstall\bin\lib\site-packages\workbench\plugins\editor.py", line 140, in open_file_in_new_tab
    return self.editors.open_file_in_new_tab(filepath, startup)
  File "C:\MantidInstall\bin\lib\site-packages\mantidqt\widgets\codeeditor\multifileinterpreter.py", line 315, in open_file_in_new_tab
    content = code_file.read()
UnicodeDecodeError: 'gbk' codec can't decode byte 0x9d in position 2733: illegal multibyte sequence
        Using: workbench 6.8.0 on Microsoft Windows 11 Home China
```

#### Summary of work
Have specified a utf-8 encoding when opening files in the editor. Without specifying an encoding Python will use an os specific default, on Windows especially this means files with unique utf-8 characters were causing a problem.

*There is no associated issue.*

### To test:

- Create a python file and paste in / enter some unicode text.
- (I am using some Chinese characters in the unit test (输出坐标系) since it seems that was the origin of the error report)
- Check that you can open, edit, save, and reopen the file without any problems.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
