### PR TITLE
Pin updated dependencies to resolve mantidqt env

### DIFF
--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -33,6 +33,21 @@ requirements:
     - libcxx                                 # [osx]
 
   host:
+    # These following were updated on the same day and caused problems when building mantidqt,
+    # so we are pinning them all for now while investigating further.
+    - aom=3.5.0
+    - dav1d=1.2.0
+    - icu=72.1
+    - libxml2=2.10.4
+    - boost-cpp=1.78.0
+    - libhwloc=2.9.1
+    - tbb=2021.9.0
+    - cairo=1.16.0
+    - tbb-devel=2021.9.0
+    - harfbuzz=7.3.0
+    - libass=0.17.1
+    - ffmpeg=5.1.2
+    - vtk=9.2.6
     - boost {{ boost }}
     - eigen
     - gsl {{ gsl }}


### PR DESCRIPTION
### Description of work
Conda packaging for mantidqt stopped working after these packages were updated for the mantid host environment:

```
Packages changed:
aom changed from 3.5.0-h27087fc_0  ->  3.6.1-h59595ed_0
dav1d changed from 1.2.0-hd590300_0  ->  1.2.1-hd590300_0
icu changed from 72.1-hcb278e6_0  ->  73.2-h59595ed_0
libxml2 changed from 2.10.4-hfdac1af_0  ->  2.12.4-h232c23b_1
boost-cpp changed from 1.78.0-h6582d0a_3  ->  1.78.0-h2c5509c_4
libhwloc changed from 2.9.1-hd6dc26d_0  ->  2.9.3-default_h554bfaf_1009
tbb changed from 2021.9.0-hf52228f_0  ->  2021.11.0-h00ab1b0_0
cairo changed from 1.16.0-hbbf8b49_1016  ->  1.18.0-h3faef2a_0
tbb-devel changed from 2021.9.0-hf52228f_0  ->  2021.11.0-h00ab1b0_0
harfbuzz changed from 7.3.0-hdb3a94d_0  ->  8.3.0-h3d44ed6_0
libass changed from 0.17.1-hc9aadba_0  ->  0.17.1-h8fe9dca_1
ffmpeg changed from 5.1.2-gpl_h9866456_109  ->  5.1.2-gpl_hf01f75b_112
vtk changed from 9.2.6-egl_py310h24f58fe_0  ->  9.2.6-osmesa_py310h7ec9714_100
```

I tried pinning individually a few of the obvious candidates, but it didn't solve the issue. For now we should pin them all to enable us to continue development, and in the meantime we can investigate further.

*There is no associated issue.*

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
PR Linux packaging check should pass.


*This does not require release notes* because **it's a change to a recipe file only that wont affect the user.**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
