### PR TITLE
Fix ISIS SANS GUI Mask tab unhandled exception

### DIFF
--- a/docs/source/release/v6.9.0/SANS/Bugfixes/36666.rst
+++ b/docs/source/release/v6.9.0/SANS/Bugfixes/36666.rst
@@ -1,0 +1,1 @@
+- Fixes a crash when a sample run cannot be found in the Mask tab of the :ref:`ISIS_SANS_Settings_Tab-ref`.

--- a/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
@@ -52,7 +52,7 @@ class MaskingTablePresenter(object):
             state = self.get_state(row_index)
         except Exception as e:
             self.on_processing_error_masking_display(e)
-            raise e  # propagate errors for run_tab_presenter to deal with
+            return
 
         if not state:
             self._logger.error(
@@ -76,7 +76,7 @@ class MaskingTablePresenter(object):
         self._view.set_display_mask_button_to_normal()
 
     def on_processing_error_masking_display(self, error):
-        self._logger.warning("There has been an error. See more: {}".format(error))
+        self._logger.error("There has been an error. See more: {}".format(error))
         # Enable button
         self._view.set_display_mask_button_to_normal()
 

--- a/scripts/test/SANS/gui_logic/masking_table_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/masking_table_presenter_test.py
@@ -51,7 +51,7 @@ class MaskingTablePresenterTest(unittest.TestCase):
         presenter._view.set_display_mask_button_to_processing = mock.MagicMock()
         presenter._view.get_current_row.side_effect = RuntimeError("Mock get_current_row failure")
 
-        self.assertRaises(Exception, presenter.on_display)
+        presenter.on_display()
 
         # Confirm that on_processing_error_masking_display was called
         self.assertEqual(


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Fixes the crash described on the issue. The crash was being caused because, although we were catching the exception and taking appropriate action in the masking table presenter, we were then rethrowing it to (according to the comment) be handled by the run tab presenter. The code may have been refactored since this was originally done, as I can't see from the structure of the code now why this would make sense. As a result, I have replaced the rethrow with a simple return after the exception has been dealt with by the masking table presenter. This seems to resolve the issue and doesn't appear to cause any odd behaviour.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36666. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
See instructions on linked issue and ensure crash no longer occurs.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
