### PR TITLE
Add optional argument to set event type in EventList constructor

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -55,7 +55,7 @@ enum EventSortType {
 
 class MANTID_DATAOBJECTS_DLL EventList : public Mantid::API::IEventList {
 public:
-  EventList();
+  EventList(const Mantid::API::EventType event_type = Mantid::API::EventType::TOF);
 
   EventList(EventWorkspaceMRU *mru, specnum_t specNo);
 

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -137,9 +137,9 @@ struct comparePulseTimeTOFDelta {
 
 /// Constructor (empty)
 // EventWorkspace is always histogram data and so is thus EventList
-EventList::EventList()
-    : m_histogram(HistogramData::Histogram::XMode::BinEdges, HistogramData::Histogram::YMode::Counts), eventType(TOF),
-      order(UNSORTED), mru(nullptr) {}
+EventList::EventList(const EventType event_type)
+    : m_histogram(HistogramData::Histogram::XMode::BinEdges, HistogramData::Histogram::YMode::Counts),
+      eventType(event_type), order(UNSORTED), mru(nullptr) {}
 
 /** Constructor with a MRU list
  * @param mru :: pointer to the MRU of the parent EventWorkspace

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -169,6 +169,17 @@ public:
     TS_ASSERT_EQUALS(target.getWeightedEventsNoTime(), eventList.getWeightedEventsNoTime());
   }
 
+  void test_EventTypeConstructor() {
+    EventList tof;
+    TS_ASSERT_EQUALS(tof.getEventType(), TOF);
+
+    EventList weighted(WEIGHTED);
+    TS_ASSERT_EQUALS(weighted.getEventType(), WEIGHTED);
+
+    EventList weightedNoTime(WEIGHTED_NOTIME);
+    TS_ASSERT_EQUALS(weightedNoTime.getEventType(), WEIGHTED_NOTIME);
+  }
+
   //==================================================================================
   //--- Basics  ----
   //==================================================================================


### PR DESCRIPTION
### Description of work

In support of changes for #36594 and to keep PRs small, this adds an optional argument to the `EventList` constructor to select between `TOF`, `WEIGHTED`, and `WEIGHTED_NOTIME` events. This is slightly faster than creating and `EventList` and calling `EventList::switchTo()`. 

*There is no associated issue,* but this is part of the larger work in [EWM3412](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3412) to rewrite `LoadEventNexus` with compression.

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

The additional unit tests passing should be sufficient to tell that this work was done correctly.

*This does not require release notes* because it adds an optional constructor argument and no other code uses it...yet.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
