### PR TITLE
New algorithm LoadEventAsWorkspace2D

### DIFF
--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SRC_FILES
     src/LoadDspacemap.cpp
     src/LoadEMU.cpp
     src/LoadEmptyInstrument.cpp
+    src/LoadEventAsWorkspace2D.cpp
     src/LoadEventNexus.cpp
     src/LoadEventNexusIndexSetup.cpp
     src/LoadEventPreNexus2.cpp
@@ -271,6 +272,7 @@ set(INC_FILES
     inc/MantidDataHandling/LoadDspacemap.h
     inc/MantidDataHandling/LoadEMU.h
     inc/MantidDataHandling/LoadEmptyInstrument.h
+    inc/MantidDataHandling/LoadEventAsWorkspace2D.h
     inc/MantidDataHandling/LoadEventNexus.h
     inc/MantidDataHandling/LoadEventNexusIndexSetup.h
     inc/MantidDataHandling/LoadEventPreNexus2.h
@@ -483,6 +485,7 @@ set(TEST_FILES
     LoadDspacemapTest.h
     LoadEMUauTest.h
     LoadEmptyInstrumentTest.h
+    LoadEventAsWorkspace2DTest.h
     LoadEventNexusIndexSetupTest.h
     LoadEventNexusTest.h
     LoadEventPreNexus2Test.h

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventAsWorkspace2D.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventAsWorkspace2D.h
@@ -1,0 +1,31 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/SpectraDetectorTypes.h"
+#include "MantidDataHandling/DllConfig.h"
+
+namespace Mantid {
+namespace DataHandling {
+
+/** LoadEventAsWorkspace2D : TODO: DESCRIPTION
+ */
+class MANTID_DATAHANDLING_DLL LoadEventAsWorkspace2D : public API::Algorithm {
+public:
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
+
+private:
+  void init() override;
+  void exec() override;
+};
+
+} // namespace DataHandling
+} // namespace Mantid

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventAsWorkspace2D.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventAsWorkspace2D.h
@@ -13,7 +13,7 @@
 namespace Mantid {
 namespace DataHandling {
 
-/** LoadEventAsWorkspace2D : TODO: DESCRIPTION
+/** LoadEventAsWorkspace2D : Load event data, integrating the events during loading
  */
 class MANTID_DATAHANDLING_DLL LoadEventAsWorkspace2D : public API::Algorithm {
 public:
@@ -21,6 +21,7 @@ public:
   int version() const override;
   const std::string category() const override;
   const std::string summary() const override;
+  const std::vector<std::string> seeAlso() const override { return {"LoadEventNexus", "HFIRSANS2Wavelength"}; }
 
 private:
   void init() override;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventAsWorkspace2D.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventAsWorkspace2D.h
@@ -25,6 +25,7 @@ public:
 private:
   void init() override;
   void exec() override;
+  std::map<std::string, std::string> validateInputs() override;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/LoadEventAsWorkspace2D.cpp
+++ b/Framework/DataHandling/src/LoadEventAsWorkspace2D.cpp
@@ -139,6 +139,16 @@ void LoadEventAsWorkspace2D::exec() {
   if (nPeriods != 1)
     g_log.warning("This algorithm does not correctly handle period data");
 
+  // set center and width parameters, do it before we try to load the data so if the log doesn't exist we fail fast
+  double center = getProperty("XCenter");
+  if (center == EMPTY_DBL())
+    center = WS->run().getStatistics(getPropertyValue("XCenterLog")).mean;
+
+  double width = getProperty("XWidth");
+  if (width == EMPTY_DBL())
+    width = WS->run().getStatistics(getPropertyValue("XWidthLog")).mean;
+  width *= center;
+
   const Kernel::NexusHDF5Descriptor descriptor(filename);
 
   // Load the instrument
@@ -243,15 +253,6 @@ void LoadEventAsWorkspace2D::exec() {
   h5file.close();
 
   // determine x values
-  double center = getProperty("XCenter");
-  if (center == EMPTY_DBL())
-    center = outWS->run().getStatistics(getPropertyValue("XCenterLog")).mean;
-
-  double width = getProperty("XWidth");
-  if (width == EMPTY_DBL())
-    width = outWS->run().getStatistics(getPropertyValue("XWidthLog")).mean;
-  width *= center;
-
   const auto xBins = {center - width / 2, center + width / 2};
 
   // set the data on the workspace

--- a/Framework/DataHandling/src/LoadEventAsWorkspace2D.cpp
+++ b/Framework/DataHandling/src/LoadEventAsWorkspace2D.cpp
@@ -1,0 +1,176 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidDataHandling/LoadEventAsWorkspace2D.h"
+#include "MantidAPI/Axis.h"
+#include "MantidAPI/FileProperty.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Run.h"
+#include "MantidAPI/Sample.h"
+#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidDataHandling/LoadEventNexus.h"
+#include "MantidDataHandling/LoadEventNexusIndexSetup.h"
+#include "MantidKernel/TimeSeriesProperty.h"
+#include "MantidNexus/NexusIOHelper.h"
+
+#include <regex>
+
+namespace Mantid {
+namespace DataHandling {
+using namespace API;
+using Mantid::HistogramData::HistogramX;
+using Mantid::Kernel::Direction;
+using Mantid::Kernel::TimeSeriesProperty;
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(LoadEventAsWorkspace2D)
+
+//----------------------------------------------------------------------------------------------
+
+/// Algorithms name for identification. @see Algorithm::name
+const std::string LoadEventAsWorkspace2D::name() const { return "LoadEventAsWorkspace2D"; }
+
+/// Algorithm's version for identification. @see Algorithm::version
+int LoadEventAsWorkspace2D::version() const { return 1; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string LoadEventAsWorkspace2D::category() const { return "TODO: FILL IN A CATEGORY"; }
+
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string LoadEventAsWorkspace2D::summary() const { return "TODO: FILL IN A SUMMARY"; }
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithms properties.
+ */
+void LoadEventAsWorkspace2D::init() {
+  const std::vector<std::string> exts{".nxs.h5", ".nxs", "_event.nxs"};
+  this->declareProperty(std::make_unique<FileProperty>("Filename", "", FileProperty::Load, exts),
+                        "The name of the Event NeXus file to read, including its full or "
+                        "relative path. ");
+  declareProperty(std::make_unique<WorkspaceProperty<API::Workspace>>("OutputWorkspace", "", Direction::Output),
+                  "An output workspace.");
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void LoadEventAsWorkspace2D::exec() {
+  std::string filename = getPropertyValue("Filename");
+
+  // temporary workspace to load instrument and metadata
+  MatrixWorkspace_sptr WS = WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+
+  // Load the logs
+  int nPeriods = 1;                                                               // Unused
+  auto periodLog = std::make_unique<const TimeSeriesProperty<int>>("period_log"); // Unused
+  LoadEventNexus::runLoadNexusLogs<MatrixWorkspace_sptr>(filename, WS, *this, false, nPeriods, periodLog);
+
+  if (nPeriods != 1)
+    g_log.warning("This algorithm does not correctly handle period data");
+
+  const Kernel::NexusHDF5Descriptor descriptor(filename);
+
+  // Load the instrument
+  LoadEventNexus::loadInstrument<MatrixWorkspace_sptr>(filename, WS, "entry", this, &descriptor);
+
+  // load run metadata
+  try {
+    LoadEventNexus::loadEntryMetadata(filename, WS, "entry", descriptor);
+  } catch (std::exception &e) {
+    g_log.warning() << "Error while loading meta data: " << e.what() << '\n';
+  }
+
+  // create IndexInfo
+  const std::vector<int32_t> range;
+  LoadEventNexusIndexSetup indexSetup(WS, EMPTY_INT(), EMPTY_INT(), range);
+  auto indexInfo = indexSetup.makeIndexInfo();
+  const size_t numHist = indexInfo.size();
+  g_log.warning() << "found " << indexInfo.size() << " histograms\n";
+
+  // make output workspace with correct number of histograms
+  MatrixWorkspace_sptr outWS = WorkspaceFactory::Instance().create(WS, numHist, 2, 1);
+  // set spectrum index information
+  outWS->setIndexInfo(indexInfo);
+
+  // now load the data
+  const auto id_to_wi = outWS->getDetectorIDToWorkspaceIndexMap();
+
+  std::vector<uint32_t> Y(numHist, 0);
+
+  ::NeXus::File h5file(filename);
+
+  h5file.openPath("/");
+  h5file.openGroup("entry", "NXentry");
+
+  // Now we want to go through all the bankN_event entries
+  const std::map<std::string, std::set<std::string>> &allEntries = descriptor.getAllEntries();
+
+  auto itClassEntries = allEntries.find("NXevent_data");
+
+  if (itClassEntries != allEntries.end()) {
+
+    const std::set<std::string> &classEntries = itClassEntries->second;
+    const std::regex classRegex("(/entry/)([^/]*)");
+    std::smatch groups;
+
+    for (const std::string &classEntry : classEntries) {
+
+      if (std::regex_match(classEntry, groups, classRegex)) {
+        const std::string entry_name(groups[2].str());
+
+        // skip entries with junk data
+        if (entry_name == "bank_error_events" || entry_name == "bank_unmapped_events")
+          continue;
+        h5file.openGroup(entry_name, "NXevent_data");
+
+        const auto event_ids = Mantid::NeXus::NeXusIOHelper::readNexusVector<uint32_t>(h5file, "event_id");
+        const auto event_times = Mantid::NeXus::NeXusIOHelper::readNexusVector<float>(h5file, "event_time_offset");
+
+        for (size_t i = 0; i < event_ids.size(); i++) {
+          auto det_id = event_ids[i];
+          auto wi = id_to_wi.find(det_id);
+          if (wi == id_to_wi.end())
+            continue;
+
+          auto tof = event_times[i];
+          if (tof > 20000. || tof < -20000.)
+            continue;
+
+          Y[wi->second]++;
+        }
+
+        h5file.closeGroup();
+      }
+    }
+  }
+
+  h5file.closeGroup();
+  h5file.close();
+
+  // determine x values
+  const auto center = outWS->run().getStatistics("wavelength").mean;
+  const auto width = outWS->run().getStatistics("wavelength_spread").mean * center;
+  const auto xBins = {center - width / 2, center + width / 2};
+
+  // set the data on the workspace
+  auto histX = Mantid::Kernel::make_cow<HistogramX>(xBins);
+  for (size_t idx = 0; idx < numHist; idx++) {
+    outWS->mutableY(idx) = Y[idx];
+    outWS->mutableE(idx) = sqrt(Y[idx]);
+    outWS->setSharedX(idx, histX);
+  }
+
+  // set units
+  outWS->getAxis(0)->setUnit("wavelength");
+  outWS->setYUnit("Counts");
+
+  // add filename
+  outWS->mutableRun().addProperty("Filename", filename);
+  setProperty("OutputWorkspace", outWS);
+}
+
+} // namespace DataHandling
+} // namespace Mantid

--- a/Framework/DataHandling/src/LoadEventAsWorkspace2D.cpp
+++ b/Framework/DataHandling/src/LoadEventAsWorkspace2D.cpp
@@ -14,6 +14,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataHandling/LoadEventNexus.h"
 #include "MantidDataHandling/LoadEventNexusIndexSetup.h"
+#include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/UnitFactory.h"
@@ -24,6 +25,7 @@
 namespace Mantid {
 namespace DataHandling {
 using namespace API;
+using Mantid::DataObjects::Workspace2D;
 using Mantid::HistogramData::HistogramX;
 using Mantid::Kernel::Direction;
 using Mantid::Kernel::PropertyWithValue;
@@ -88,7 +90,7 @@ void LoadEventAsWorkspace2D::init() {
                   "The name of the units to convert to (must be one of those "
                   "registered in\n"
                   "the Unit Factory)");
-  declareProperty(std::make_unique<WorkspaceProperty<API::Workspace>>("OutputWorkspace", "", Direction::Output),
+  declareProperty(std::make_unique<WorkspaceProperty<Workspace2D>>("OutputWorkspace", "", Direction::Output),
                   "An output workspace.");
 }
 

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -969,7 +969,6 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
   vector<string> bankNames;
   vector<std::size_t> bankNumEvents;
   std::string classType = monitors ? "NXmonitor" : "NXevent_data";
-  ::NeXus::Info info;
   bool oldNeXusFileNames(false);
   bool haveWeights = false;
   auto firstPulseT = DateAndTime::maximum();

--- a/Framework/DataHandling/test/LoadEventAsWorkspace2DTest.h
+++ b/Framework/DataHandling/test/LoadEventAsWorkspace2DTest.h
@@ -8,8 +8,13 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/Axis.h"
 #include "MantidDataHandling/LoadEventAsWorkspace2D.h"
+#include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
 
+using Mantid::API::AlgorithmManager;
 using Mantid::DataHandling::LoadEventAsWorkspace2D;
 
 class LoadEventAsWorkspace2DTest : public CxxTest::TestSuite {
@@ -19,34 +24,172 @@ public:
   static LoadEventAsWorkspace2DTest *createSuite() { return new LoadEventAsWorkspace2DTest(); }
   static void destroySuite(LoadEventAsWorkspace2DTest *suite) { delete suite; }
 
-  void test_Init() {
+  void test_EQSANS() {
     LoadEventAsWorkspace2D alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
-  }
-
-  void test_exec() {
-    // Create test input if necessary
-    MatrixWorkspace_sptr
-        inputWS = //-- Fill in appropriate code. Consider using MantidFrameworkTestHelpers/WorkspaceCreationHelper.h --
-
-        LoadEventAsWorkspace2D alg;
-    // Don't put output in ADS by default
     alg.setChild(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
-    TS_ASSERT_THROWS_NOTHING(alg.execute(););
-    TS_ASSERT(alg.isExecuted());
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "unused"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "EQSANS_89157.nxs.h5"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("XWidth", "0.1"))
+    TS_ASSERT(alg.execute());
 
-    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
-    // be the type using in declareProperty for the "OutputWorkspace" type.
-    // We can't use auto as it's an implicit conversion.
-    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    Mantid::DataObjects::Workspace2D_sptr outputWS = alg.getProperty("OutputWorkspace");
     TS_ASSERT(outputWS);
-    TS_FAIL("TODO: Check the results and remove this line");
+
+    TS_ASSERT_EQUALS(outputWS->blocksize(), 1)
+    TS_ASSERT_EQUALS(outputWS->getAxis(0)->unit()->unitID(), "Wavelength")
+    TS_ASSERT_EQUALS(outputWS->readY(18)[0], 2)
+    TS_ASSERT_DELTA(outputWS->readE(18)[0], 1.4142135625, 1e-8)
+    TS_ASSERT_EQUALS(outputWS->readX(18)[0], 2.375)
+    TS_ASSERT_EQUALS(outputWS->readX(18)[1], 2.625)
   }
 
-  void test_Something() { TS_FAIL("You forgot to write a test!"); }
+  void test_CNCS() {
+    LoadEventAsWorkspace2D alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "unused"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "CNCS_7860_event.nxs"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("XCenterLog", "EnergyRequest"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("XWidth", "0.1"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Units", "Energy"))
+    TS_ASSERT(alg.execute());
+
+    Mantid::DataObjects::Workspace2D_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);
+
+    TS_ASSERT_EQUALS(outputWS->blocksize(), 1)
+    TS_ASSERT_EQUALS(outputWS->getAxis(0)->unit()->unitID(), "Energy")
+    TS_ASSERT_EQUALS(outputWS->readY(0)[0], 1)
+    TS_ASSERT_EQUALS(outputWS->readE(0)[0], 1)
+    TS_ASSERT_EQUALS(outputWS->readX(0)[0], 2.85)
+    TS_ASSERT_EQUALS(outputWS->readX(0)[1], 3.15)
+  }
+
+  void test_CG3() {
+    // compare loading with LoadEventAsWorkspace2D to LoadEventNexus+HFIRSANS2Wavelength
+
+    const double wavelength = 6;
+    const double wavelength_spread = 0.13235;
+
+    // load with LoadEventAsWorkspace2D
+    LoadEventAsWorkspace2D alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "unused"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "CG3_13118.nxs.h5"))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XCenter", wavelength))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("XWidth", wavelength_spread))
+    TS_ASSERT(alg.execute());
+
+    Mantid::DataObjects::Workspace2D_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);
+
+    // load with LoadEventNexus then do the same as what HFIRSANS2Wavelength does.
+    // HFIRSANS2Wavelength is a python algorithm so do Rebin+ScaleX instead
+    auto load = AlgorithmManager::Instance().createUnmanaged("LoadEventNexus");
+    load->initialize();
+    load->setChild(true);
+    load->setProperty("Filename", "CG3_13118.nxs.h5");
+    load->execute();
+    Mantid::API::Workspace_sptr outputWS2 = load->getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS2);
+
+    auto rebin = AlgorithmManager::Instance().createUnmanaged("Rebin");
+    rebin->initialize();
+    rebin->setChild(true);
+    rebin->setProperty("InputWorkspace", outputWS2);
+    rebin->setProperty("Params", "-20000,40000,20000");
+    rebin->setProperty("PreserveEvents", false);
+    rebin->execute();
+
+    Mantid::API::MatrixWorkspace_sptr outputWS3 = rebin->getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS3);
+
+    auto scale1 = AlgorithmManager::Instance().createUnmanaged("ScaleX");
+    scale1->initialize();
+    scale1->setChild(true);
+    scale1->setProperty("InputWorkspace", outputWS3);
+    scale1->setProperty("Factor", wavelength * wavelength_spread / 40000);
+    scale1->execute();
+    outputWS3 = scale1->getProperty("OutputWorkspace");
+
+    auto scale2 = AlgorithmManager::Instance().createUnmanaged("ScaleX");
+    scale2->initialize();
+    scale2->setChild(true);
+    scale2->setProperty("InputWorkspace", outputWS3);
+    scale2->setProperty("Factor", wavelength);
+    scale2->setProperty("Operation", "Add");
+    scale2->execute();
+    outputWS3 = scale2->getProperty("OutputWorkspace");
+
+    // set the expected X-axis
+    outputWS3->getAxis(0)->setUnit("Wavelength");
+
+    // compare workspaces
+    auto compare = AlgorithmManager::Instance().createUnmanaged("CompareWorkspaces");
+    compare->initialize();
+    compare->setChild(true);
+    compare->setProperty("Workspace1", outputWS);
+    compare->setProperty("Workspace2", outputWS3);
+    compare->execute();
+    TS_ASSERT(compare->getProperty("Result"));
+  }
+
+  void test_HB2C() {
+    // compare loading with LoadEventAsWorkspace2D to LoadEventNexus+Integration
+
+    // load with LoadEventAsWorkspace2D
+    LoadEventAsWorkspace2D alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "unused"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "HB2C_475936.nxs.h5"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("XCenter", "1.54"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("XWidth", "0.1"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FilterByTOFMin", "0"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FilterByTOFMax", "1000000"))
+    TS_ASSERT(alg.execute());
+
+    Mantid::DataObjects::Workspace2D_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);
+
+    // load with LoadEventNexus then do Integration
+    auto load = AlgorithmManager::Instance().createUnmanaged("LoadEventNexus");
+    load->initialize();
+    load->setChild(true);
+    load->setProperty("Filename", "HB2C_475936.nxs.h5");
+    load->execute();
+    Mantid::API::Workspace_sptr outputWS2 = load->getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS2);
+
+    auto integrate = AlgorithmManager::Instance().createUnmanaged("Integration");
+    integrate->initialize();
+    integrate->setChild(true);
+    integrate->setProperty("InputWorkspace", outputWS2);
+    integrate->execute();
+
+    Mantid::API::MatrixWorkspace_sptr outputWS3 = integrate->getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS3);
+
+    // set the expected X-axis
+    outputWS3->getAxis(0)->setUnit("Wavelength");
+    const auto xBins = {1.463, 1.617};
+    const auto histX = Mantid::Kernel::make_cow<Mantid::HistogramData::HistogramX>(xBins);
+    for (size_t i = 0; i < outputWS3->getNumberHistograms(); i++)
+      outputWS3->setSharedX(i, histX);
+
+    // compare workspaces
+    auto compare = AlgorithmManager::Instance().createUnmanaged("CompareWorkspaces");
+    compare->initialize();
+    compare->setChild(true);
+    compare->setProperty("Workspace1", outputWS);
+    compare->setProperty("Workspace2", outputWS3);
+    compare->execute();
+    TS_ASSERT(compare->getProperty("Result"));
+  }
 };

--- a/Framework/DataHandling/test/LoadEventAsWorkspace2DTest.h
+++ b/Framework/DataHandling/test/LoadEventAsWorkspace2DTest.h
@@ -83,6 +83,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "CG3_13118.nxs.h5"))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("XCenter", wavelength))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("XWidth", wavelength_spread))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FilterByTOFMin", "-20000"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FilterByTOFMax", "20000"))
     TS_ASSERT(alg.execute());
 
     Mantid::DataObjects::Workspace2D_sptr outputWS = alg.getProperty("OutputWorkspace");
@@ -139,7 +141,7 @@ public:
     TS_ASSERT(compare->getProperty("Result"));
   }
 
-  void test_HB2C() {
+  void test_BSS() {
     // compare loading with LoadEventAsWorkspace2D to LoadEventNexus+Integration
 
     // load with LoadEventAsWorkspace2D
@@ -148,11 +150,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "unused"))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "HB2C_475936.nxs.h5"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "BSS_11841_event.nxs"))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("XCenter", "1.54"))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("XWidth", "0.1"))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FilterByTOFMin", "0"))
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FilterByTOFMax", "1000000"))
     TS_ASSERT(alg.execute());
 
     Mantid::DataObjects::Workspace2D_sptr outputWS = alg.getProperty("OutputWorkspace");
@@ -162,7 +162,7 @@ public:
     auto load = AlgorithmManager::Instance().createUnmanaged("LoadEventNexus");
     load->initialize();
     load->setChild(true);
-    load->setProperty("Filename", "HB2C_475936.nxs.h5");
+    load->setProperty("Filename", "BSS_11841_event.nxs");
     load->execute();
     Mantid::API::Workspace_sptr outputWS2 = load->getProperty("OutputWorkspace");
     TS_ASSERT(outputWS2);
@@ -171,6 +171,7 @@ public:
     integrate->initialize();
     integrate->setChild(true);
     integrate->setProperty("InputWorkspace", outputWS2);
+    integrate->setProperty("RangeLower", 0.0);
     integrate->execute();
 
     Mantid::API::MatrixWorkspace_sptr outputWS3 = integrate->getProperty("OutputWorkspace");

--- a/Framework/DataHandling/test/LoadEventAsWorkspace2DTest.h
+++ b/Framework/DataHandling/test/LoadEventAsWorkspace2DTest.h
@@ -1,0 +1,52 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidDataHandling/LoadEventAsWorkspace2D.h"
+
+using Mantid::DataHandling::LoadEventAsWorkspace2D;
+
+class LoadEventAsWorkspace2DTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static LoadEventAsWorkspace2DTest *createSuite() { return new LoadEventAsWorkspace2DTest(); }
+  static void destroySuite(LoadEventAsWorkspace2DTest *suite) { delete suite; }
+
+  void test_Init() {
+    LoadEventAsWorkspace2D alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
+
+  void test_exec() {
+    // Create test input if necessary
+    MatrixWorkspace_sptr
+        inputWS = //-- Fill in appropriate code. Consider using MantidFrameworkTestHelpers/WorkspaceCreationHelper.h --
+
+        LoadEventAsWorkspace2D alg;
+    // Don't put output in ADS by default
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
+    // be the type using in declareProperty for the "OutputWorkspace" type.
+    // We can't use auto as it's an implicit conversion.
+    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);
+    TS_FAIL("TODO: Check the results and remove this line");
+  }
+
+  void test_Something() { TS_FAIL("You forgot to write a test!"); }
+};

--- a/Framework/PythonInterface/plugins/algorithms/HFIRSANS2Wavelength.py
+++ b/Framework/PythonInterface/plugins/algorithms/HFIRSANS2Wavelength.py
@@ -12,6 +12,9 @@ class HFIRSANS2Wavelength(PythonAlgorithm):
     def category(self):
         return "SANS\\Wavelength"
 
+    def seeAlso(self):
+        return ["LoadEventAsWorkspace2D"]
+
     def summary(self):
         return "Convert the fake time of flight event workspace into a Workspace2D with units of wavelength"
 

--- a/docs/source/algorithms/LoadEventAsWorkspace2D-v1.rst
+++ b/docs/source/algorithms/LoadEventAsWorkspace2D-v1.rst
@@ -10,7 +10,12 @@
 Description
 -----------
 
-TODO: Enter a full rst-markup description of your algorithm here.
+
+This algorithm loads event data, integrating the events during loading. It will also set the X-axis based on log data. This will be mostly used by contant wavelength instruments that collect event data but are not performing event filtering. It will be faster than running :ref:`LoadEventNexus <algm-LoadEventNexus>` then doing :ref:`Integration <algm-Integration>`.
+
+An example usage is instead of running :ref:`LoadEventNexus <algm-LoadEventNexus>` then :ref:`HFIRSANS2Wavelength <algm-HFIRSANS2Wavelength>`, you can just use ``LoadEventAsWorkspace2D``.
+
+The X-axis is set based on the either the provided parameters ``XCenter`` and ``XWidth`` of the mean of the log values defined by ``XCenterLog`` and ``XWidthLog``. The X-axis bin will be centered on ``XCenter`` with a width of ``XCenter*XWidth``.
 
 
 Usage
@@ -20,25 +25,16 @@ Usage
     autotestdata\UsageData and the following tag unindented
     .. include:: ../usagedata-note.txt
 
-**Example - LoadEventAsWorkspace2D**
+**Example - LoadEventAsWorkspace2D compared to LoadEventNexus+HFIRSANS2Wavelength**
 
-.. testcode:: LoadEventAsWorkspace2DExample
+.. code-block:: python
 
-   # Create a host workspace
-   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
-   or
-   ws = CreateSampleWorkspace()
+   ws = LoadEventAsWorkspace2D("CG3_16931")
 
-   wsOut = LoadEventAsWorkspace2D()
+   ws2 = LoadEventNexus("CG3_16931")
+   ws2 = HFIRSANS2Wavelength(ws2)
 
-   # Print the result
-   print "The output workspace has %%i spectra" %% wsOut.getNumberHistograms()
-
-Output:
-
-.. testoutput:: LoadEventAsWorkspace2DExample
-
-  The output workspace has ?? spectra
+   CompareWorkspaces(Workspace1=ws, Workspace2=ws2)
 
 .. categories::
 

--- a/docs/source/algorithms/LoadEventAsWorkspace2D-v1.rst
+++ b/docs/source/algorithms/LoadEventAsWorkspace2D-v1.rst
@@ -1,0 +1,46 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+TODO: Enter a full rst-markup description of your algorithm here.
+
+
+Usage
+-----
+..  Try not to use files in your examples,
+    but if you cannot avoid it then the (small) files must be added to
+    autotestdata\UsageData and the following tag unindented
+    .. include:: ../usagedata-note.txt
+
+**Example - LoadEventAsWorkspace2D**
+
+.. testcode:: LoadEventAsWorkspace2DExample
+
+   # Create a host workspace
+   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
+   or
+   ws = CreateSampleWorkspace()
+
+   wsOut = LoadEventAsWorkspace2D()
+
+   # Print the result
+   print "The output workspace has %%i spectra" %% wsOut.getNumberHistograms()
+
+Output:
+
+.. testoutput:: LoadEventAsWorkspace2DExample
+
+  The output workspace has ?? spectra
+
+.. categories::
+
+.. sourcelink::
+

--- a/docs/source/release/v6.9.0/Framework/Data_Handling/New_features/36671.rst
+++ b/docs/source/release/v6.9.0/Framework/Data_Handling/New_features/36671.rst
@@ -1,0 +1,1 @@
+- New algorithm :ref:`LoadEventAsWorkspace2D <algm-LoadEventAsWorkspace2D>` for monochromatic instruments which integrates events while loading and sets the X-axis based on log data.


### PR DESCRIPTION
### Description of work

This implements the new algorithm as described in #36595 

One of the main usages is to replace using `LoadEventNexus` + `HFIRSANS2Wavelength` as this should be faster. This algorithm is a lot faster if you don't fillter on TOF min/max as you can avoid loading the TOF data and only load the event_ids.


#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

Fixes #36595 [EWM3413](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=3413)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

In terms of performance improvement when compared to LoadEventNexus+HFIRSANS2Wavelength, I tested it will 3 different files, run on analysis-node01.

* CG3_13118 # 663Mb
* CG3_16931 # 2.5Gb
* CG3_14962 # 12Gb

```python
ws = LoadEventAsWorkspace2D(filename, FilterByTofMin=-20000, FilterByTofMax=20000)
ws2 = LoadEventNexus(filename)
ws2 = HFIRSANS2Wavelength(ws2)
ws3 = LoadEventAsWorkspace2D(filename)
```

File | LoadEventAsWorkspace2D | LoadEventNexus + HFIRSANS2Wavelength | LoadEventAsWorkspace2D (without TOF filter)
-|-|-|-
CG3_13118 | 1.7 | 2.1 | 1.5
CG3_16931|5.9|7.9|5.1
CG3_14962|53.81|84.1|31.8

### To test:

```python
filename = "/HFIR/CG3/IPTS-27598/nexus/CG3_16931.nxs.h5"

ws = LoadEventAsWorkspace2D(filename, FilterByTofMin=-20000, FilterByTofMax=20000)

ws2 = LoadEventNexus(filename)
ws2 = HFIRSANS2Wavelength(ws2)

CompareWorkspaces(Workspace1=ws, Workspace2=ws2)

```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
