### PR TITLE
Add plugin dll directory to windows path

### DIFF
--- a/installers/conda/win/sitecustomize.py
+++ b/installers/conda/win/sitecustomize.py
@@ -9,13 +9,17 @@
 
 def _add_executable_path_to_path():
     """
-    Adds the sys.executable directory to the DLL load list of allowed directories
+    Adds the sys.executable and plugin directory to the DLL load list of allowed directories
     """
     import os
     import sys
 
-    os.environ["PATH"] = f'{os.path.dirname(sys.executable)};{os.environ["PATH"]}'
-    os.add_dll_directory(os.path.dirname(sys.executable))
+    executable_dir = os.path.dirname(sys.executable)
+    plugin_dir = os.path.join(executable_dir, os.pardir, "plugins", "qt5")
+
+    os.environ["PATH"] = f'{executable_dir};{plugin_dir};{os.environ["PATH"]}'
+    os.add_dll_directory(executable_dir)
+    os.add_dll_directory(plugin_dir)
 
 
 _add_executable_path_to_path()

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -244,7 +244,7 @@ mtd_add_qt_library(
             Qt5::Concurrent
             Qt5::Xml
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsPlotting MantidQtWidgetsMplCpp MantidQtIcons
-  INSTALL_DIR ${WORKBENCH_LIB_DIR}
+  INSTALL_DIR_BASE ${WORKBENCH_PLUGINS_DIR}
   OSX_INSTALL_RPATH @loader_path/../../MacOS @loader_path/../../Frameworks @loader_path/../../plugins/qt5
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../plugins/qt5/"
 )


### PR DESCRIPTION
### Description of work
This PR ensures the plugin directory `plugins/qt5` is added to the PATH environment variable as a path where you might find DLL files. It means that it is possible to have other plugin Libraries that depend on one of our plugin libraries. This was previously not possible on Windows. A workaround to temporarily move one of our plugin DLL's to the `Library/bin` location was added in this PR #36645 but has now been reverted now that we have this better solution.

*There is no associated issue.*

### To test:
1. Download the Windows package from this build https://builds.mantidproject.org/job/build_packages_from_branch/745/
2. Check that the Indirect interface category exists

*This does not require release notes* because **the change is not user-facing**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
