### PR TITLE
Configure special branches to auto-merge on push - ornl-next

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   merge-relase-into-main:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == release-next }}
+    if: ${{ github.ref_name == 'release-next' }}
     steps:
       - uses: actions/checkout@master
 
@@ -24,7 +24,7 @@ jobs:
 
   merge-ornl-into-main:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == ornl-next }}
+    if: ${{ github.ref_name == 'ornl-next' }}
     steps:
       - uses: actions/checkout@master
 
@@ -38,7 +38,7 @@ jobs:
 
   merge-release-into-ornl:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == release-next }}
+    if: ${{ github.ref_name == 'release-next' }}
     steps:
       - uses: actions/checkout@master
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,51 @@
+# this uses the action to merge special branches on push
+# https://github.com/marketplace/actions/merge-branch
+name: Merge protected branches
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ornl-next, release-next]
+
+jobs:
+  merge-relase-into-main:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == release-next }}
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Merge release-next into main
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          target_branch: main
+          message: Merge release-next into main
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  merge-ornl-into-main:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == ornl-next }}
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Merge ornl-next into main
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          target_branch: main
+          message: Merge ornl-next into main
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  merge-release-into-ornl:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == release-next }}
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Merge ornl-next into main
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          target_branch: ornl-next
+          message: Merge release-next into ornl-next
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a version of #36675 into `ornl-next`, but it should automatically get in because the original PR is on `release-next` already.