### PR TITLE
TransformtoIqt - Integration Bug

### DIFF
--- a/Framework/Algorithms/src/Integration.cpp
+++ b/Framework/Algorithms/src/Integration.cpp
@@ -270,7 +270,7 @@ void Integration::integrateSpectrum(const API::ISpectrum &inSpec, API::ISpectrum
   } else {
     if (Fin) {
       // Workspace has fractional area information, need to take into account
-      sumF = std::accumulate(Fin->begin() + distmin, Fin->begin() + distmax, 0.0);
+      sumF = std::accumulate(Fin->cbegin() + distmin, Fin->cbegin() + distmax, 0.0);
       // Need to normalise by the number of non-NaN bins - see issue #33407 for details
       Fnor = static_cast<double>(
           std::count_if(Fin->begin() + distmin, Fin->begin() + distmax, [](double f) { return f != 0.; }));
@@ -281,8 +281,8 @@ void Integration::integrateSpectrum(const API::ISpectrum &inSpec, API::ISpectrum
     if (!is_distrib) {
       // Sum the Y, and sum the E in quadrature
       {
-        sumY = std::accumulate(Y.begin() + distmin, Y.begin() + distmax, 0.0);
-        sumE = std::accumulate(E.begin() + distmin, E.begin() + distmax, 0.0, VectorHelper::SumSquares<double>());
+        sumY = std::accumulate(Y.cbegin() + distmin, Y.cbegin() + distmax, 0.0);
+        sumE = std::accumulate(E.cbegin() + distmin, E.cbegin() + distmax, 0.0, VectorHelper::SumSquares<double>());
       }
     } else {
       // Sum Y*binwidth and Sum the (E*binwidth)^2.
@@ -356,8 +356,13 @@ void Integration::integrateSpectrum(const API::ISpectrum &inSpec, API::ISpectrum
 
   outSpec.mutableY()[0] = sumY;
   outSpec.mutableE()[0] = sqrt(sumE); // Propagate Gaussian error
+
+  std::cout << "sumY: " << sumY << std::endl;
+  std::cout << "sumE: " << sumE << std::endl;
+
   if (Fout) {
     (*Fout)[0] = sumF;
+    std::cout << "sumF" << sumF << std::endl;
     if (Fnor != 0)
       (*Fout)[0] /= Fnor;
   }

--- a/Framework/Algorithms/src/Integration.cpp
+++ b/Framework/Algorithms/src/Integration.cpp
@@ -357,7 +357,9 @@ void Integration::integrateSpectrum(const API::ISpectrum &inSpec, API::ISpectrum
   outSpec.mutableY()[0] = sumY;
   outSpec.mutableE()[0] = sqrt(sumE); // Propagate Gaussian error
   if (Fout) {
-    (*Fout)[0] = sumF / Fnor;
+    (*Fout)[0] = sumF;
+    if (Fnor != 0)
+      (*Fout)[0] /= Fnor;
   }
 }
 

--- a/Framework/Algorithms/src/Integration.cpp
+++ b/Framework/Algorithms/src/Integration.cpp
@@ -357,12 +357,8 @@ void Integration::integrateSpectrum(const API::ISpectrum &inSpec, API::ISpectrum
   outSpec.mutableY()[0] = sumY;
   outSpec.mutableE()[0] = sqrt(sumE); // Propagate Gaussian error
 
-  std::cout << "sumY: " << sumY << std::endl;
-  std::cout << "sumE: " << sumE << std::endl;
-
   if (Fout) {
     (*Fout)[0] = sumF;
-    std::cout << "sumF" << sumF << std::endl;
     if (Fnor != 0)
       (*Fout)[0] /= Fnor;
   }

--- a/Framework/Algorithms/test/IntegrationTest.h
+++ b/Framework/Algorithms/test/IntegrationTest.h
@@ -285,6 +285,13 @@ public:
     doTestRebinned("-1.5", "1.75", 0, 3, true, 4, truth);
   }
 
+  void testRebinnedOutput_FnorEquals0() {
+    // Validate a bug fix that caused a divide by 0 error for some cases
+
+    const double truth[] = {0, 0};
+    doTestRebinned("-0.12", "0.12", 0, 3, false, 4, truth);
+  }
+
   void makeRealBinBoundariesWorkspace(const std::string &inWsName) {
     const unsigned int lenX = 11, lenY = 10, lenE = lenY;
 


### PR DESCRIPTION
### Description of work
This fixes a test case where Integration and TransformtoIqt return NaN and 0 values for E and Y values respectively.

#### Summary of work
The Integration algorithm has a normalization process when calculating the values. In a test case (fileset) provided by scientists, the algorithm produces NaN values during this step, because of 0 division. We included a line to check whether the value is 0 and allow the division to happen.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
Bug fix

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
Fix related to this line:
(*Fout)[0] = sumF / **Fnor**;

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]


#### Further detail of work


### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
