### PR TITLE
Fix string format for multiple files input in Elwin tab.

### DIFF
--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
@@ -123,7 +123,6 @@ void InelasticDataManipulationElwinTab::runFileInput() {
 
   QFileInfo firstFileInfo(inputFilenames[0]);
   const auto filename = firstFileInfo.baseName().toStdString();
-
   auto workspaceBaseName = filename.substr(0, filename.find_last_of("_"));
 
   if (inputFilenames.size() > 1) {
@@ -141,8 +140,8 @@ void InelasticDataManipulationElwinTab::runFileInput() {
     // reassemble workspace base name with additional run number
     runNumber = runNumber.substr(runNumberStart, strLength);
     auto baseName = firstFileInfo.baseName().toStdString();
-    const auto prefix = baseName.substr(baseName.find_last_of("_"));
-    const auto suffix = baseName.substr(baseName.length() - baseName.find_last_of("_"));
+    const auto prefix = baseName.substr(0, baseName.find_first_of("_"));
+    const auto suffix = baseName.substr(baseName.find_first_of("_"));
     workspaceBaseName = prefix + "-" + runNumber + suffix;
   }
 
@@ -155,7 +154,6 @@ void InelasticDataManipulationElwinTab::runFileInput() {
     m_model->setupLoadAlgorithm(m_batchAlgoRunner, inputFilename.toStdString(), workspaceName);
     inputWorkspacesString += workspaceName + ",";
   }
-
   m_model->setupGroupAlgorithm(m_batchAlgoRunner, inputWorkspacesString, inputGroupWsName);
   m_model->setupElasticWindowMultiple(m_batchAlgoRunner, workspaceBaseName, inputGroupWsName, m_view->getLogName(),
                                       m_view->getLogValue());


### PR DESCRIPTION
### Description of work
This PR fixes a bug in the formatting of multiple files as input for the Elwin tab in the Data Manipulation interface. 
On this release cycle, there's been a lot of maintenance task in indirect/inelastic tabs. One of these changed some of the `QString` types used in presenters to `std::string` types. The string manipulation for both formats is slightly different, there were two lines in the string formatting function that we didn't correct during development when we modified the type. Now is it fixed.



Fixes #36725 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

1. Open `Data Manipulation -> Elwin tab` interface. 
2. On file input, click on Browse and multi-select files: `irs26173_graphite002_red.nxs` and `irs2617_graphite002_red.nxs`.
3. Click on `Run`. 
4. Check the ADS, the Output workspace names should look like this: 

![image](https://github.com/mantidproject/mantid/assets/146007827/131c2011-2f1f-427e-80ca-bc42fd23ba85)

Instead of this:

![image](https://github.com/mantidproject/mantid/assets/146007827/d0c00e59-eaab-4e44-80b3-ad68e92c087f)



---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
