### PR TITLE
Fix for fit property browser fixes being unfixable

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36722.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36722.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where fixed properties in the fitting view could not be un-fixed.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -598,7 +598,7 @@ private:
   virtual void workspaceChange(const QString &wsName);
 
   /// Does a parameter have a tie
-  void hasConstraints(QtProperty *parProp, bool &hasTie, bool &hasBounds) const;
+  void hasConstraints(QtProperty *parProp, bool &hasTie, bool &hasFix, bool &hasBounds) const;
   /// Returns the tie property for a parameter property, or NULL
   QtProperty *getTieProperty(QtProperty *parProp) const;
 


### PR DESCRIPTION
### Description of work

In a past PR I changed fixes to properties in the FitPropertyBrowser so that the property name would be "Fix" rather than "Tie" (amongst other things). I didn't realise the name was being used to build the right click menus, so a fixed property was being treated as a regular one (no way to unfix).
This PR adds in that consideration.

Fixes #36722

### To test:

- Load some data and plot a spectrum
- Enter the fitting view by clicking the `fit` button
- Add a curve and fix one of its properties
- [x] Check that right clicking the property brings up a menu saying "Remove fix"
- [x] Check that clicking "Remove fix" unfixes the property
- Add another curve and tie two properties
- [x] Check you are able to remove the tie
- Any other combinations you can think of

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
