### PR TITLE
Debugging RectangleSelection after matplotlib API upgrade

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/simplescanviewer/rectangle_selection.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/simplescanviewer/rectangle_selection.py
@@ -50,7 +50,7 @@ class RectangleSelection(RectangleSelector):
 
         # check if drawn distance (if it exists) is not too small in
         # either x or y-direction
-        if self._drawtype != "none" and (
+        if self.get_visible() and (
             self.minspanx is not None and spanx < self.minspanx or self.minspany is not None and spany < self.minspany
         ):
             for artist in self.artists:


### PR DESCRIPTION
### Description of work

#### Summary of work
Fixes issue #36758

### To test:

1. Click Interfaces > ILL > SimpleScanViewer
2. Click "Browse" and select the file `Testing/Data/UnitTest/ILL/D16/025786.nxs`
3. Draw a rectangle in the plot, try to move it. No error should happen

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
