### PR TITLE
Fix hang from quickly overplotting with plotSpectrum

### DIFF
--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -288,7 +288,7 @@ def _update_show_figure(fig):
     except AttributeError:
         pass
 
-    fig.canvas.draw()
+    fig.canvas.draw_idle()
     # This displays the figure, but only works if a manager is attached to the figure.
     # The try catch is in case a figure manager is not present
     try:

--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36727.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36727.rst
@@ -1,0 +1,1 @@
+- Fix bug with ``plotSpectrum`` where quickly over-plotting could cause Workbench to hang.


### PR DESCRIPTION
### Description of work
```
RawData = Load("MAR11015")

# Assign original plot to a window called graph_spce
graph_spec = plotSpectrum(RawData, 0)

# Overplot on that window, without clearing it
plotSpectrum(RawData, 1, window=graph_spec, clearWindow=False)
```
This script was hanging workbench. I found that the second `plotSpectrum` call caused the problem. If you put `time.sleep(5)` in-between calls then the problem also goes away.

#### Summary of work
At the end of the `plot()` function, `_update_show_figure()` is called which contains `fig.canvas.draw()`. I've changed this call to `draw_idle()` since it is more thread safe than `draw()`.
This seems to have fixed the problem. 

Fixes #36727 


### To test:

- Test original script works as expected
- Test script B from this page - https://docs.mantidproject.org/nightly/tutorials/python_in_mantid/solutions/03_pim_sol.html#pim-sol
- Test a variety of other plotting techniques 

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
