### PR TITLE
36747 avoid crash on GSAS-II

### DIFF
--- a/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/36747.rst
+++ b/docs/source/release/v6.9.0/Diffraction/Engineering/Bugfixes/36747.rst
@@ -1,0 +1,1 @@
+- Avoid crashing the engineering diffraction GUI :ref:`Engineering Diffraction GUI<Engineering_Diffraction-ref>` when errors are raised from GSASIIscriptable module in the GSAS-II tab.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -272,7 +272,13 @@ class GSAS2Model(object):
                 universal_newlines=True,
                 env=env,
             )
+
             shell_output = shell_process.communicate(timeout=self.timeout)
+
+            if shell_process.returncode != 0:
+                logger.error(f"GSAS-II call failed with error: {shell_output[-1]}")
+                return None
+
             return shell_output
         except subprocess.TimeoutExpired:
             shell_process.terminate()


### PR DESCRIPTION
#### Summary of work
GSAS-II tab crashed on IDAaaS environment because of the unavailability of files expected to be generated from GSASIIscriptable interface. The invocation of the interface happens in a subprocess and the code has not checked the return codes of the call which contained errors with the reasons. By handling the error codes it can be decided whether to proceed further and avoid the crash.

Note: Although the crash is avioded with the fix, it needs to further investigate why GSASIIscriptable is not generating the expected output files(the reflections files) for the provided TOF limits.

Fixes #36747. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

### To test:

Follow the instructions on an IDAaaS environment as listed in #36747 and the mantid workbench should not crash and instead raise the errors in the log.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
