### PR TITLE
Fix Rebin dialog crash with group workspace

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/Rebin.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Rebin.h
@@ -61,7 +61,7 @@ public:
 
   static std::vector<double> rebinParamsFromInput(const std::vector<double> &inParams,
                                                   const API::MatrixWorkspace &inputWS, Kernel::Logger &logger,
-                                                  std::string binModeName = "Default");
+                                                  const std::string &binModeName = "Default");
 
 protected:
   const std::string workspaceMethodName() const override { return "rebin"; }

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -8,6 +8,7 @@
 #include "MantidHistogramData/Exception.h"
 #include "MantidHistogramData/Rebin.h"
 
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/HistoWorkspace.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
@@ -135,15 +136,25 @@ std::map<std::string, std::string> Rebin::validateInputs() {
   // validate the rebin params, and outside default mode, reset them
   MatrixWorkspace_sptr inputWS = getProperty(PropertyNames::INPUT_WKSP);
   std::vector<double> rbParams = getProperty(PropertyNames::PARAMS);
-  try {
-    std::vector<double> validParams = rebinParamsFromInput(rbParams, *inputWS, g_log, binMode);
-    // if the binmode has been set, force the rebin params to be consistent
-    if (binMode != BinningMode::DEFAULT) {
-      setProperty(PropertyNames::PARAMS, validParams);
-      rbParams = validParams;
+  if (inputWS == nullptr) {
+    // The workspace could exist, but not be a MatrixWorkspace, e.g. it might be
+    // a group workspace. In that case we don't want a validation error for the
+    // Rebin parameters.
+    std::string inputWsName = getProperty(PropertyNames::INPUT_WKSP);
+    auto &ws = AnalysisDataService::Instance().retrieve(inputWsName);
+    if (ws == nullptr)
+      helpMessages[PropertyNames::INPUT_WKSP] = "Input workspace not in ADS.";
+  } else {
+    try {
+      std::vector<double> validParams = rebinParamsFromInput(rbParams, *inputWS, g_log, binMode);
+      // if the binmode has been set, force the rebin params to be consistent
+      if (binMode != BinningMode::DEFAULT) {
+        setProperty(PropertyNames::PARAMS, validParams);
+        rbParams = validParams;
+      }
+    } catch (std::exception &err) {
+      helpMessages[PropertyNames::PARAMS] = err.what();
     }
-  } catch (std::exception &err) {
-    helpMessages[PropertyNames::PARAMS] = err.what();
   }
 
   // if user specifies a binning mode, set this flag for them

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -74,7 +74,7 @@ using HistogramData::Exception::InvalidBinEdgesError;
  */
 std::vector<double> Rebin::rebinParamsFromInput(const std::vector<double> &inParams,
                                                 const API::MatrixWorkspace &inputWS, Kernel::Logger &logger,
-                                                std::string binModeName) {
+                                                const std::string &binModeName) {
   // EnumeratedString<Rebin::BinningMode, binningModeNames> binMode = binModeName;
   std::vector<double> rbParams;
   // The validator only passes parameters with size 2n+1. No need to check again here
@@ -141,7 +141,7 @@ std::map<std::string, std::string> Rebin::validateInputs() {
     // a group workspace. In that case we don't want a validation error for the
     // Rebin parameters.
     std::string inputWsName = getProperty(PropertyNames::INPUT_WKSP);
-    auto &ws = AnalysisDataService::Instance().retrieve(inputWsName);
+    const auto &ws = AnalysisDataService::Instance().retrieve(inputWsName);
     if (ws == nullptr)
       helpMessages[PropertyNames::INPUT_WKSP] = "Input workspace not in ADS.";
   } else {

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -140,7 +140,7 @@ std::map<std::string, std::string> Rebin::validateInputs() {
     // The workspace could exist, but not be a MatrixWorkspace, e.g. it might be
     // a group workspace. In that case we don't want a validation error for the
     // Rebin parameters.
-    std::string inputWsName = getProperty(PropertyNames::INPUT_WKSP);
+    const std::string &inputWsName = getProperty(PropertyNames::INPUT_WKSP);
     if (!AnalysisDataService::Instance().doesExist(inputWsName)) {
       helpMessages[PropertyNames::INPUT_WKSP] = "Input workspace not in ADS.";
     }

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -141,9 +141,9 @@ std::map<std::string, std::string> Rebin::validateInputs() {
     // a group workspace. In that case we don't want a validation error for the
     // Rebin parameters.
     std::string inputWsName = getProperty(PropertyNames::INPUT_WKSP);
-    const bool wsExists = AnalysisDataService::Instance().doesExist(inputWsName);
-    if (!wsExists)
+    if (!AnalysisDataService::Instance().doesExist(inputWsName)) {
       helpMessages[PropertyNames::INPUT_WKSP] = "Input workspace not in ADS.";
+    }
   } else {
     try {
       std::vector<double> validParams = rebinParamsFromInput(rbParams, *inputWS, g_log, binMode);

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -141,8 +141,8 @@ std::map<std::string, std::string> Rebin::validateInputs() {
     // a group workspace. In that case we don't want a validation error for the
     // Rebin parameters.
     std::string inputWsName = getProperty(PropertyNames::INPUT_WKSP);
-    const auto &ws = AnalysisDataService::Instance().retrieve(inputWsName);
-    if (ws == nullptr)
+    const bool wsExists = AnalysisDataService::Instance().doesExist(inputWsName);
+    if (!wsExists)
       helpMessages[PropertyNames::INPUT_WKSP] = "Input workspace not in ADS.";
   } else {
     try {

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -240,7 +240,6 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/RadiusSum.cpp:
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/Qxy.cpp:325
 duplicateConditionalAssign:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ReadGroupsFromFile.cpp:134
 stlFindInsert:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ReadGroupsFromFile.cpp:229
-passedByValue:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/Rebin.cpp:76
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/RecordPythonScript.cpp:83
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/RemoveBackground.cpp:235
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/RemoveBackground.cpp:236

--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36689.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36689.rst
@@ -1,0 +1,1 @@
+- Fixed crash when opening the `Rebin` algorithm dialog when a group workspace is selected as the input workspace.

--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/36689.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/36689.rst
@@ -1,1 +1,1 @@
-- Fixed crash when opening the `Rebin` algorithm dialog when a group workspace is selected as the input workspace.
+- Fixed crash when opening the :ref:`algm-Rebin` algorithm dialog when a group workspace is selected as the input workspace.


### PR DESCRIPTION
If the workspace selected in the dialog is a group workspace, then calling `getProperty()` with `MatrixWorkspace` as the return type will return null. In that case we can check if the specified workspace name exists in the ADS and skip the `Rebin` parameters validation (which requires a `MatrixWorkspace`). When `Rebin` is actually called, it will be called on each of the members of the group workspace individually, and the parameters will be validated for each one.

#### Summary of work
- When validating parameter for `Rebin`, if the specified input workspace is not a `MatrixWorkspace`, then check if it at least exists in the ADS before adding an error if it doesn't.
- Added a test to check validation of group workspaces.
- Fixed another test that was trying to check bin parameter validation (e.g. `1,1,20`), but it wasn't setting an input workspace, so the validation would now fail before getting to the bin parameter validation.
- Fixed a cppcheck error instead of changing the line number in the suppression file.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36689. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

See #36689 for how to reproduce.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
