### PR TITLE
Fix error when opening contour plot for multiple workspaces

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -33,6 +33,7 @@ from mantidqt.widgets.plotconfigdialog.presenter import PlotConfigDialogPresente
 from mantidqt.widgets.superplot import Superplot
 from mantidqt.widgets.waterfallplotfillareadialog.presenter import WaterfallPlotFillAreaDialogPresenter
 from mantidqt.widgets.waterfallplotoffsetdialog.presenter import WaterfallPlotOffsetDialogPresenter
+from mantidqt.plotting.figuretype import FigureType, axes_type
 from workbench.config import get_window_config
 from workbench.plotting.globalfiguremanager import GlobalFigureManager
 from workbench.plotting.mantidfigurecanvas import (  # noqa: F401
@@ -572,12 +573,15 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         self.toolbar.set_generate_plot_script_enabled(not is_waterfall)
 
     def change_line_collection_colour(self, colour):
-        line_cols = self.canvas.figure.findobj(LineCollection)
-        for line in line_cols:
-            line.set_color(colour.name())
-        path_cols = self.canvas.figure.findobj(PathCollection)
-        for path in path_cols:
-            path.set_edgecolor(colour.name())
+        if axes_type(self.canvas.figure.get_axes()[0]) == FigureType.Contour:
+            path_cols = self.canvas.figure.findobj(PathCollection)
+            for path in path_cols:
+                path.set_edgecolor(colour.name())
+
+        if axes_type(self.canvas.figure.get_axes()[0]) == FigureType.Wireframe:
+            line_cols = self.canvas.figure.findobj(LineCollection)
+            for line in line_cols:
+                line.set_color(colour.name())
         self.canvas.draw()
 
     @staticmethod

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -17,7 +17,7 @@ from functools import wraps
 import matplotlib
 from matplotlib.axes import Axes
 from matplotlib.backend_bases import FigureManagerBase
-from matplotlib.collections import LineCollection, PathCollection
+from matplotlib.collections import PathCollection
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 from qtpy.QtCore import QObject, Qt
 from qtpy.QtGui import QImage
@@ -33,6 +33,7 @@ from mantidqt.widgets.plotconfigdialog.presenter import PlotConfigDialogPresente
 from mantidqt.widgets.superplot import Superplot
 from mantidqt.widgets.waterfallplotfillareadialog.presenter import WaterfallPlotFillAreaDialogPresenter
 from mantidqt.widgets.waterfallplotoffsetdialog.presenter import WaterfallPlotOffsetDialogPresenter
+from mantidqt.plotting.figuretype import FigureType, axes_type
 from workbench.config import get_window_config
 from workbench.plotting.globalfiguremanager import GlobalFigureManager
 from workbench.plotting.mantidfigurecanvas import (  # noqa: F401
@@ -572,12 +573,15 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         self.toolbar.set_generate_plot_script_enabled(not is_waterfall)
 
     def change_line_collection_colour(self, colour):
-        for col in self.canvas.figure.get_axes()[0].collections:
-            if isinstance(col, LineCollection):
+        axes = self.canvas.figure.get_axes()[0]
+        ax_type = axes_type(axes)
+        if ax_type == FigureType.Wireframe:
+            for col in axes.collections:
                 col.set_color(colour.name())
-            elif isinstance(col, PathCollection):
-                col.set_edgecolor(colour.name())
-
+        elif ax_type == FigureType.Contour:
+            path_cols = self.canvas.figure.findobj(PathCollection)
+            for path in path_cols:
+                path.set_edgecolor(colour.name())
         self.canvas.draw()
 
     @staticmethod

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -33,7 +33,7 @@ from mantidqt.widgets.plotconfigdialog.presenter import PlotConfigDialogPresente
 from mantidqt.widgets.superplot import Superplot
 from mantidqt.widgets.waterfallplotfillareadialog.presenter import WaterfallPlotFillAreaDialogPresenter
 from mantidqt.widgets.waterfallplotoffsetdialog.presenter import WaterfallPlotOffsetDialogPresenter
-from mantidqt.plotting.figuretype import FigureType, axes_type
+from mantidqt.plotting.figuretype import FigureType, figure_type
 from workbench.config import get_window_config
 from workbench.plotting.globalfiguremanager import GlobalFigureManager
 from workbench.plotting.mantidfigurecanvas import (  # noqa: F401
@@ -573,12 +573,12 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         self.toolbar.set_generate_plot_script_enabled(not is_waterfall)
 
     def change_line_collection_colour(self, colour):
-        if axes_type(self.canvas.figure.get_axes()[0]) == FigureType.Contour:
+        if figure_type(self.canvas.figure) == FigureType.Contour:
             path_cols = self.canvas.figure.findobj(PathCollection)
             for path in path_cols:
                 path.set_edgecolor(colour.name())
 
-        if axes_type(self.canvas.figure.get_axes()[0]) == FigureType.Wireframe:
+        if figure_type(self.canvas.figure) == FigureType.Wireframe:
             line_cols = self.canvas.figure.findobj(LineCollection)
             for line in line_cols:
                 line.set_color(colour.name())

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -17,7 +17,7 @@ from functools import wraps
 import matplotlib
 from matplotlib.axes import Axes
 from matplotlib.backend_bases import FigureManagerBase
-from matplotlib.collections import PathCollection
+from matplotlib.collections import PathCollection, LineCollection
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 from qtpy.QtCore import QObject, Qt
 from qtpy.QtGui import QImage
@@ -33,7 +33,6 @@ from mantidqt.widgets.plotconfigdialog.presenter import PlotConfigDialogPresente
 from mantidqt.widgets.superplot import Superplot
 from mantidqt.widgets.waterfallplotfillareadialog.presenter import WaterfallPlotFillAreaDialogPresenter
 from mantidqt.widgets.waterfallplotoffsetdialog.presenter import WaterfallPlotOffsetDialogPresenter
-from mantidqt.plotting.figuretype import FigureType, axes_type
 from workbench.config import get_window_config
 from workbench.plotting.globalfiguremanager import GlobalFigureManager
 from workbench.plotting.mantidfigurecanvas import (  # noqa: F401
@@ -573,15 +572,12 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         self.toolbar.set_generate_plot_script_enabled(not is_waterfall)
 
     def change_line_collection_colour(self, colour):
-        axes = self.canvas.figure.get_axes()[0]
-        ax_type = axes_type(axes)
-        if ax_type == FigureType.Wireframe:
-            for col in axes.collections:
-                col.set_color(colour.name())
-        elif ax_type == FigureType.Contour:
-            path_cols = self.canvas.figure.findobj(PathCollection)
-            for path in path_cols:
-                path.set_edgecolor(colour.name())
+        line_cols = self.canvas.figure.findobj(LineCollection)
+        for line in line_cols:
+            line.set_color(colour.name())
+        path_cols = self.canvas.figure.findobj(PathCollection)
+        for path in path_cols:
+            path.set_edgecolor(colour.name())
         self.canvas.draw()
 
     @staticmethod

--- a/qt/python/mantidqt/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/functions.py
@@ -383,14 +383,13 @@ def plot_wireframe(workspaces, fig=None):
 
 @manage_workspace_names
 def plot_contour(workspaces, fig=None):
-    for ws in workspaces:
-        fig = pcolormesh(workspaces, fig)
-        ax = fig.get_axes()[0]
+    fig = pcolormesh(workspaces, fig)
+    for idx, ws in enumerate(workspaces):
+        ax = fig.get_axes()[idx]
         try:
             ax.contour(ws, levels=DEFAULT_CONTOUR_LEVELS, colors=DEFAULT_CONTOUR_COLOUR, linewidths=DEFAULT_CONTOUR_WIDTH)
         except TypeError as type_error:
             LOGGER.warning(str(type_error))
 
-        fig.show()
-
+    fig.show()
     return fig


### PR DESCRIPTION
### Description of work
This PR fixes an error reported in manual testing #36732 in which there was an error message whenever a contour plot is opened in a group workspace (or selecting multiple workspaces). 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
The function for plotting contour plots is not  very efficient. As it is, it loops through all workspaces and in every iteration calls the `pcolormesh` function. This is not really necessary as `pcolormesh` can be called with one workspace or a group of workspaces, so effectively calling like it was for a 2 workspace group was actually recreating the plot two times, which increases exponentially the time to plot it when more workspaces are selected. This is corrected in this PR. Additionally, there was a bug and only the first workspace of the group was being plot as a contour. Now this is also corrected. 
I haven't been able to exactly trace why this particular issue was not occurring before (in 6.8.0), but it may merit a further investigation, also an issue can be opened regarding the way wireframe plots are being opened, as it may be possible to improve it (I think). 
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36732  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

1. Open MUSR00015189 from the training course data
2. Right click the workspace and select Plot->3D->Contour
3. You'll see the group workspace(containing 2 workspaces) opens a tiled plot, no error is raised in the message center.
Also, no error is raised when you try to resize the plot window.
4. Ungroup the group workspace, and select the two resulting workspaces in the ADS, then right click -> Plot -> 3D -> Contour. It should plot the same as before, with no errors. 
5. In the contour plot window, check that both plotted workspaces are indeed a contour plot (this was not really implemented before) and that changing colour of contour lines tool in the toolbar works as intended.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
