### PR TITLE
Add silent flag to ADS.clear() 

### DIFF
--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
@@ -117,8 +117,11 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
    * @param self A reference to the calling object
    */
   static void clearItems(SvcType &self) {
-    PyErr_Warn(PyExc_Warning, "Running ADS.clear() also removes all hidden workspaces.\n"
-                              "Mantid interfaces might still need some of these, for instance, MSlice.");
+    if (self.size() > 0) {
+      PyErr_Warn(PyExc_Warning, "Running ADS.clear() also removes all hidden workspaces.\n"
+                                "Mantid interfaces might still need some of these, for instance, MSlice.");
+    }
+
     ReleaseGlobalInterpreterLock releaseGIL;
     self.clear();
   }

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
@@ -116,6 +116,7 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
   /**
    * Remove an item from the service
    * @param self A reference to the calling object
+   * @param silent A flag to silence the warning message
    */
   static void clearItems(SvcType &self, const bool silent) {
     if (self.size() > 0 && !silent) {

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
@@ -64,7 +64,8 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
                  "Retrieve the named object. Raises an exception if the name "
                  "does not exist")
             .def("remove", &DataServiceExporter::removeItem, (arg("self"), arg("name")), "Remove a named object")
-            .def("clear", &DataServiceExporter::clearItems, arg("self"), "Removes all objects managed by the service.")
+            .def("clear", &DataServiceExporter::clearItems, (arg("self"), arg("silent") = false),
+                 "Removes all objects managed by the service.")
             .def("size", &SvcType::size, arg("self"), "Returns the number of objects within the service")
             .def("getObjectNames", &DataServiceExporter::getObjectNamesAsList, (arg("self"), arg("contain") = ""),
                  "Return the list of names currently known to the ADS")
@@ -116,8 +117,8 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
    * Remove an item from the service
    * @param self A reference to the calling object
    */
-  static void clearItems(SvcType &self) {
-    if (self.size() > 0) {
+  static void clearItems(SvcType &self, const bool silent) {
+    if (self.size() > 0 && !silent) {
       PyErr_Warn(PyExc_Warning, "Running ADS.clear() also removes all hidden workspaces.\n"
                                 "Mantid interfaces might still need some of these, for instance, MSlice.");
     }

--- a/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
@@ -38,6 +38,8 @@ AnalysisDataServiceImpl &instance() {
   // start the framework (if necessary)
   auto &ads = AnalysisDataService::Instance();
   std::call_once(INIT_FLAG, []() {
+    // Passing True as an argument suppresses a warning that is normally
+    // displayed when calling AnalysisDataService.clear()
     PyRun_SimpleString("import atexit\n"
                        "from mantid.api import AnalysisDataService\n"
                        "atexit.register(lambda: AnalysisDataService.clear(), True)");

--- a/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
@@ -40,7 +40,7 @@ AnalysisDataServiceImpl &instance() {
   std::call_once(INIT_FLAG, []() {
     PyRun_SimpleString("import atexit\n"
                        "from mantid.api import AnalysisDataService\n"
-                       "atexit.register(lambda: AnalysisDataService.clear())");
+                       "atexit.register(lambda: AnalysisDataService.clear(), True)");
   });
   return ads;
 }

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -887,7 +887,7 @@ unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/kernel/src/Exp
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/IsNone.h:26
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Muon/src/PlotAsymmetryByLogValue.cpp:216
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp:109
-constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:159
+constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:160
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp:23
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp:34
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp:30

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -887,7 +887,7 @@ unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/kernel/src/Exp
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/IsNone.h:26
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Muon/src/PlotAsymmetryByLogValue.cpp:216
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp:109
-constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:155
+constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:158
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp:23
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp:34
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp:30

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -887,7 +887,7 @@ unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/kernel/src/Exp
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/IsNone.h:26
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Muon/src/PlotAsymmetryByLogValue.cpp:216
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp:109
-constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:158
+constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:159
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp:23
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp:34
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp:30


### PR DESCRIPTION
### Description of work

#### Summary of work
Recently a warning was added to ADS.clear() to avoid confusion about the impact on some interfaces like MSlice (https://github.com/mantidproject/mantid/pull/36548). This caused problems with autoreduction, where this warning was perceived as a genuine error.

ADS.clear() can now accept a bool to silence this warning. The default is `False`, but if the flag is set to `True` the warning is not displayed. There is also a check whether the ADS is empty. Here, there is also no warning message.

Fixes #[36690](https://github.com/mantidproject/mantid/issues/36690).

### To test:

Please follow the testing instructions in the original issue.

*This does not require release notes* because **it is an improvement to a new feature.**


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
