### PR TITLE
Fixed unhandled exception when plotting a live event histogram

### DIFF
--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -383,7 +383,13 @@ class WorkspaceWidget(PluginWidget):
                     plot_kwargs = {"axis": MantidAxType.BIN}
                     plot([ws], errors=False, overplot=False, wksp_indices=[0], plot_kwargs=plot_kwargs)
             else:
-                plot_from_names([name], errors=False, overplot=False, show_colorfill_btn=True)
+                try:
+                    plot_from_names([name], errors=False, overplot=False, show_colorfill_btn=True)
+                except RuntimeError as err:
+                    if "Variable invalidated" in str(err):
+                        logger.error(str(err))
+                    else:
+                        raise err
 
     def refresh_workspaces(self):
         self.workspacewidget.refreshWorkspaces()


### PR DESCRIPTION
### Description of work
Fixed unhandled exception found in manual testing, as detailed in #36726 

#### Summary of work
Caught `RunTime` error exception and replaced it by logging an error to the console.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->
Avoids an uncaught exception. This behaviour was already present in previous versions of mantid.

Fixes #36726 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
This error only happens at a high updating fequency. When we select the live data interface to update every 1 second, the workspace in the ADS gets rewritten every 1 second. When the plotting is still loading the data will change, which causes a RunTime error: `Variable invalidated, data has been deleted.`. If you select this update to 5 seconds, the plot will usually happen with no issues.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Here is a summary:

1. Change facility and test instrument to `TEST_LIVE` and `ISIS_HISTOGRAM`
2. Execute `FakeISISEventDAE` (use defaults)
3. Execute `FakeISISHistoDAE` (use defaults)
4. Click Load > Live Data
5. Set parameters:
    Instrument: ISIS_Histogram
    Connection: Histo
    Starting time: Now
    Update every: 1 second
    No processing
    Accumulation method: Replace
    No processing
    Output workspace: live_histo_ws
6. Click run
7. Double click on workspace that shows up on ADS and plot all spectra

An error should be logged saying that data has been deleted.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
