### PR TITLE
Add measurement files metadata to ISIS Reflectometry ORSO file

### DIFF
--- a/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
+++ b/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
@@ -11,7 +11,7 @@ import re
 from orsopy.fileio.data_source import DataSource, Person, Experiment, Sample, Measurement
 from orsopy.fileio import Reduction, Software
 from orsopy.fileio.orso import Orso, OrsoDataset, save_orso
-from orsopy.fileio.base import Column, ErrorColumn
+from orsopy.fileio.base import Column, ErrorColumn, File
 
 from mantid.kernel import version
 from enum import Enum
@@ -69,6 +69,18 @@ class MantidORSODataset:
 
     def set_doi(self, doi: str) -> None:
         self._header.data_source.experiment.doi = doi
+
+    def add_measurement_file(
+        self, is_data_file, filename: str, timestamp: Optional[datetime] = None, comment: Optional[str] = None
+    ) -> None:
+        file = File(filename, timestamp, comment)
+
+        if is_data_file:
+            self._header.data_source.measurement.data_files.append(file)
+        else:
+            if self._header.data_source.measurement.additional_files is None:
+                self._header.data_source.measurement.additional_files = []
+            self._header.data_source.measurement.additional_files.append(file)
 
     def _create_mandatory_header(
         self, ws, dataset_name: str, reduction_timestamp: datetime, creator_name: str, creator_affiliation: str

--- a/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
+++ b/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
@@ -70,17 +70,17 @@ class MantidORSODataset:
     def set_doi(self, doi: str) -> None:
         self._header.data_source.experiment.doi = doi
 
-    def add_measurement_file(
-        self, is_data_file, filename: str, timestamp: Optional[datetime] = None, comment: Optional[str] = None
-    ) -> None:
-        file = File(filename, timestamp, comment)
+    def add_measurement_data_file(self, filename: str, timestamp: Optional[datetime] = None, comment: Optional[str] = None) -> None:
+        self._header.data_source.measurement.data_files.append(self._create_file(filename, timestamp, comment))
 
-        if is_data_file:
-            self._header.data_source.measurement.data_files.append(file)
-        else:
-            if self._header.data_source.measurement.additional_files is None:
-                self._header.data_source.measurement.additional_files = []
-            self._header.data_source.measurement.additional_files.append(file)
+    def add_measurement_additional_file(self, filename: str, timestamp: Optional[datetime] = None, comment: Optional[str] = None) -> None:
+        if self._header.data_source.measurement.additional_files is None:
+            self._header.data_source.measurement.additional_files = []
+        self._header.data_source.measurement.additional_files.append(self._create_file(filename, timestamp, comment))
+
+    @staticmethod
+    def _create_file(filename: str, timestamp: Optional[datetime] = None, comment: Optional[str] = None) -> File:
+        return File(filename, timestamp, comment)
 
     def _create_mandatory_header(
         self, ws, dataset_name: str, reduction_timestamp: datetime, creator_name: str, creator_affiliation: str

--- a/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
@@ -157,14 +157,14 @@ class SaveISISReflectometryORSO(PythonAlgorithm):
         instrument_name = ws.getInstrument().getName()
 
         for file, theta in self._get_individual_angle_files(instrument_name, reduction_workflow_histories):
-            dataset.add_measurement_file(True, file, comment=f"Incident angle {theta}")
+            dataset.add_measurement_data_file(file, comment=f"Incident angle {theta}")
 
         first_trans_files, second_trans_files = self._get_transmission_files(instrument_name, reduction_workflow_histories)
         for file in first_trans_files:
-            dataset.add_measurement_file(False, file, comment="First transmission run")
+            dataset.add_measurement_additional_file(file, comment="First transmission run")
 
         for file in second_trans_files:
-            dataset.add_measurement_file(False, file, comment="Second transmission run")
+            dataset.add_measurement_additional_file(file, comment="Second transmission run")
 
     def _get_rb_number_and_doi(self, run) -> Union[Tuple[str, str], Tuple[None, None]]:
         """

--- a/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
@@ -156,8 +156,8 @@ class SaveISISReflectometryORSO(PythonAlgorithm):
 
         instrument_name = ws.getInstrument().getName()
 
-        for file in self._get_individual_angle_files(instrument_name, reduction_workflow_histories):
-            dataset.add_measurement_file(True, file)
+        for file, theta in self._get_individual_angle_files(instrument_name, reduction_workflow_histories):
+            dataset.add_measurement_file(True, file, comment=f"Incident angle {theta}")
 
         first_trans_files, second_trans_files = self._get_transmission_files(instrument_name, reduction_workflow_histories)
         for file in first_trans_files:
@@ -217,7 +217,7 @@ class SaveISISReflectometryORSO(PythonAlgorithm):
             )
             return None
 
-    def _get_individual_angle_files(self, instrument_name, reduction_workflow_histories) -> List[str]:
+    def _get_individual_angle_files(self, instrument_name, reduction_workflow_histories) -> List[Tuple[str, str]]:
         """
         Find the names of the individual angle files that were used in the reduction
         """
@@ -225,8 +225,9 @@ class SaveISISReflectometryORSO(PythonAlgorithm):
 
         for history in reduction_workflow_histories:
             input_runs = history.getPropertyValue("InputRunList")
+            theta = history.getPropertyValue("ThetaIn")
             try:
-                angle_files.extend(self._get_file_names_from_run_numbers(input_runs, instrument_name))
+                angle_files.extend([(file, theta) for file in self._get_file_names_from_run_numbers(input_runs, instrument_name)])
             except RuntimeError:
                 self.log().warning(
                     f"Could not find all filenames for run(s) {input_runs}. Angle file information will be excluded from the file."

--- a/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
@@ -224,8 +224,92 @@ class MantidORSODatasetTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Cannot parse datetime string"):
             MantidORSODataset.create_local_datetime_from_utc_string("23-10-18T12:30:45")
 
+    def test_add_data_file_to_mantid_orso_dataset(self):
+        dataset = self._create_test_dataset()
+        filename = "test.nxs"
+        timestamp = datetime.now()
+        comment = "A test comment"
+
+        self._check_num_data_files(dataset, 0)
+        self._check_num_additional_files(dataset, 0)
+
+        dataset.add_measurement_file(True, filename, timestamp, comment)
+
+        self._check_files_are_created(dataset, [filename], 1, 0, True)
+        data_file = dataset.dataset.info.data_source.measurement.data_files[0]
+        self.assertEqual(timestamp, data_file.timestamp)
+        self.assertEqual(comment, data_file.comment)
+
+    def test_add_data_file_with_name_only_to_mantid_orso_dataset(self):
+        dataset = self._create_test_dataset()
+        filename = "test.nxs"
+
+        self._check_num_data_files(dataset, 0)
+        self._check_num_additional_files(dataset, 0)
+
+        dataset.add_measurement_file(True, filename)
+
+        self._check_files_are_created(dataset, [filename], 1, 0, True)
+        data_file = dataset.dataset.info.data_source.measurement.data_files[0]
+        self.assertEqual(None, data_file.timestamp)
+        self.assertEqual(None, data_file.comment)
+
+    def test_add_multiple_data_files_to_mantid_orso_dataset(self):
+        dataset = self._create_test_dataset()
+        filenames = ["test1.nxs", "test2.nxs", "test3.nxs"]
+
+        self._check_num_data_files(dataset, 0)
+        self._check_num_additional_files(dataset, 0)
+
+        for filename in filenames:
+            dataset.add_measurement_file(True, filename)
+
+        self._check_files_are_created(dataset, filenames, len(filenames), 0, True)
+
+    def test_add_additional_file_to_mantid_orso_dataset(self):
+        dataset = self._create_test_dataset()
+        filename = "test_additional.nxs"
+        timestamp = datetime.now()
+        comment = "A test comment"
+
+        self._check_num_data_files(dataset, 0)
+        self._check_num_additional_files(dataset, 0)
+
+        dataset.add_measurement_file(False, filename, timestamp, comment)
+
+        self._check_files_are_created(dataset, [filename], 0, 1, False)
+        data_file = dataset.dataset.info.data_source.measurement.additional_files[0]
+        self.assertEqual(timestamp, data_file.timestamp)
+        self.assertEqual(comment, data_file.comment)
+
+    def test_add_additional_file_with_name_only_to_mantid_orso_dataset(self):
+        dataset = self._create_test_dataset()
+        filename = "test_additional.nxs"
+
+        self._check_num_data_files(dataset, 0)
+        self._check_num_additional_files(dataset, 0)
+
+        dataset.add_measurement_file(False, filename)
+
+        self._check_files_are_created(dataset, [filename], 0, 1, False)
+        data_file = dataset.dataset.info.data_source.measurement.additional_files[0]
+        self.assertEqual(None, data_file.timestamp)
+        self.assertEqual(None, data_file.comment)
+
+    def test_add_multiple_additional_files_to_mantid_orso_dataset(self):
+        dataset = self._create_test_dataset()
+        filenames = ["test_additional1.nxs", "test_additional2.nxs", "test_additional3.nxs"]
+
+        self._check_num_data_files(dataset, 0)
+        self._check_num_additional_files(dataset, 0)
+
+        for filename in filenames:
+            dataset.add_measurement_file(False, filename)
+
+        self._check_files_are_created(dataset, filenames, 0, len(filenames), False)
+
     def _create_test_dataset(self):
-        return MantidORSODataset("Test dataset", self._data_columns, self._ws, datetime.now(), None, None)
+        return MantidORSODataset("Test dataset", self._data_columns, self._ws, datetime.now(), "", "")
 
     def _check_mantid_default_header(self, orso_dataset, dataset_name, ws, reduction_timestamp, creator_name, creator_affiliation):
         """Check that the default header contains only the information that can be shared
@@ -262,6 +346,29 @@ class MantidORSODatasetTest(unittest.TestCase):
         )
 
         self.assertEqual(expected_header, orso_dataset.header())
+
+    def _check_num_data_files(self, dataset, expected_number):
+        self.assertTrue(len(dataset.dataset.info.data_source.measurement.data_files) == expected_number)
+
+    def _check_num_additional_files(self, dataset, expected_number):
+        additional_files = dataset.dataset.info.data_source.measurement.additional_files
+        if expected_number == 0:
+            self.assertIsNone(additional_files)
+        else:
+            self.assertTrue(len(additional_files) == expected_number)
+
+    def _check_files_are_created(self, dataset, filenames, num_data_files, num_additional_files, is_data_files):
+        self._check_num_data_files(dataset, num_data_files)
+        self._check_num_additional_files(dataset, num_additional_files)
+
+        created_files = (
+            dataset.dataset.info.data_source.measurement.data_files
+            if is_data_files
+            else dataset.dataset.info.data_source.measurement.additional_files
+        )
+        for i, filename in enumerate(filenames):
+            created_file = created_files[i]
+            self.assertEqual(filename, created_file.file)
 
     def _check_data(self, orso_dataset):
         self.assertTrue(np.array_equal(self._data_columns.data, orso_dataset.data))

--- a/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
@@ -233,7 +233,7 @@ class MantidORSODatasetTest(unittest.TestCase):
         self._check_num_data_files(dataset, 0)
         self._check_num_additional_files(dataset, 0)
 
-        dataset.add_measurement_file(True, filename, timestamp, comment)
+        dataset.add_measurement_data_file(filename, timestamp, comment)
 
         self._check_files_are_created(dataset, [filename], 1, 0, True)
         data_file = dataset.dataset.info.data_source.measurement.data_files[0]
@@ -247,7 +247,7 @@ class MantidORSODatasetTest(unittest.TestCase):
         self._check_num_data_files(dataset, 0)
         self._check_num_additional_files(dataset, 0)
 
-        dataset.add_measurement_file(True, filename)
+        dataset.add_measurement_data_file(filename)
 
         self._check_files_are_created(dataset, [filename], 1, 0, True)
         data_file = dataset.dataset.info.data_source.measurement.data_files[0]
@@ -262,7 +262,7 @@ class MantidORSODatasetTest(unittest.TestCase):
         self._check_num_additional_files(dataset, 0)
 
         for filename in filenames:
-            dataset.add_measurement_file(True, filename)
+            dataset.add_measurement_data_file(filename)
 
         self._check_files_are_created(dataset, filenames, len(filenames), 0, True)
 
@@ -275,7 +275,7 @@ class MantidORSODatasetTest(unittest.TestCase):
         self._check_num_data_files(dataset, 0)
         self._check_num_additional_files(dataset, 0)
 
-        dataset.add_measurement_file(False, filename, timestamp, comment)
+        dataset.add_measurement_additional_file(filename, timestamp, comment)
 
         self._check_files_are_created(dataset, [filename], 0, 1, False)
         data_file = dataset.dataset.info.data_source.measurement.additional_files[0]
@@ -289,7 +289,7 @@ class MantidORSODatasetTest(unittest.TestCase):
         self._check_num_data_files(dataset, 0)
         self._check_num_additional_files(dataset, 0)
 
-        dataset.add_measurement_file(False, filename)
+        dataset.add_measurement_additional_file(filename)
 
         self._check_files_are_created(dataset, [filename], 0, 1, False)
         data_file = dataset.dataset.info.data_source.measurement.additional_files[0]
@@ -304,7 +304,7 @@ class MantidORSODatasetTest(unittest.TestCase):
         self._check_num_additional_files(dataset, 0)
 
         for filename in filenames:
-            dataset.add_measurement_file(False, filename)
+            dataset.add_measurement_additional_file(filename)
 
         self._check_files_are_created(dataset, filenames, 0, len(filenames), False)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
@@ -61,6 +61,11 @@ class SaveISISReflectometryORSOTest(unittest.TestCase):
             "facility: ISIS",
             f"creator:\n#     name: {self._SAVE_ALG}\n#     affiliation: {MantidORSODataset.SOFTWARE_NAME}\n#",
         ]
+        self._runs_and_angles = {
+            "INTER00013460.nxs": "0.5",
+            "INTER00013461.nxs": "0.5",
+            "INTER00013462.nxs": "0.5",
+        }
 
     def tearDown(self):
         """
@@ -222,12 +227,12 @@ class SaveISISReflectometryORSOTest(unittest.TestCase):
 
         return expected_header_values
 
-    @staticmethod
-    def _expected_data_file_header_values(expected_files):
+    def _expected_data_file_header_values(self, expected_entries):
         files_entry = [f"#     data_files:\n"]
 
-        for run_file in expected_files:
+        for run_file in expected_entries:
             files_entry.append(f"#     - file: {run_file}\n")
+            files_entry.append(f"#       comment: Incident angle {self._runs_and_angles[run_file]}\n")
 
         return "".join(files_entry)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
@@ -66,9 +66,9 @@ class SaveISISReflectometryORSOTest(unittest.TestCase):
             f"creator:\n#     name: {self._SAVE_ALG}\n#     affiliation: {MantidORSODataset.SOFTWARE_NAME}\n#",
         ]
         self._runs_and_angles = {
-            "INTER00013460.nxs": "0.5",
-            "INTER00013461.nxs": "0.5",
-            "INTER00013462.nxs": "0.5",
+            "INTER00013460": "0.5",
+            "INTER00013469": "0.5",
+            "INTER00013462": "0.5",
         }
 
     def tearDown(self):
@@ -83,16 +83,19 @@ class SaveISISReflectometryORSOTest(unittest.TestCase):
     def test_create_file_from_workspace_with_reduction_history(self):
         # Check that relevant information is extracted from the history produced by the ISIS Reflectometry GUI reduction
         resolution = 0.02
+        # One of the input runs should be an already loaded workspace as this appears differently in the history
+        input_ws_name = "Test_ws"
+        LoadNexus("13469", OutputWorkspace=input_ws_name)
         reduced_ws = self._get_ws_from_reduction(
-            "INTER13460, 13461, 13462.nxs", resolution, "IvsQ_13460+13461+13462", "13463", "13464, 13462"
+            f"0000013460, {input_ws_name}, inter13462.nxs", resolution, f"IvsQ_13460+{input_ws_name}+13462", "13463", "13464, 13462"
         )
         SaveISISReflectometryORSO(InputWorkspace=reduced_ws, Filename=self._output_filename)
 
-        expected_data_files = ["INTER00013460.nxs", "INTER00013461.nxs", "INTER00013462.nxs"]
+        expected_data_files = ["INTER00013460", "INTER00013469", "INTER00013462"]
         expected_additional_file_entries = {
-            "INTER00013463.nxs": self._FIRST_TRANS_COMMENT,
-            "INTER00013464.nxs": self._SECOND_TRANS_COMMENT,
-            "INTER00013462.nxs": self._SECOND_TRANS_COMMENT,
+            "INTER00013463": self._FIRST_TRANS_COMMENT,
+            "INTER00013464": self._SECOND_TRANS_COMMENT,
+            "INTER00013462": self._SECOND_TRANS_COMMENT,
         }
         metadata_to_check = self._get_basic_metadata_expected_from_reduced_ws(reduced_ws)
         metadata_to_check.append(self._get_expected_data_file_metadata(expected_data_files, self._ADDITIONAL_FILES_HEADING))
@@ -104,14 +107,14 @@ class SaveISISReflectometryORSOTest(unittest.TestCase):
         # Testing the stitched reduction output helps to ensure that we're not getting duplicates in the metadata
         # because there will be multiple calls to ReflectometryISISLoadAndProcess in the history
         resolution = 0.02
-        reduced_ws = self._get_ws_from_stitched_reduction(["13460", "13461"], resolution, "13463", "13464, 13462")
+        reduced_ws = self._get_ws_from_stitched_reduction(["13460", "13469"], resolution, "13463", "13464, 13462")
         SaveISISReflectometryORSO(InputWorkspace=reduced_ws, Filename=self._output_filename)
 
-        expected_data_files = ["INTER00013460.nxs", "INTER00013461.nxs"]
+        expected_data_files = ["INTER00013460", "INTER00013469"]
         expected_additional_file_entries = {
-            "INTER00013463.nxs": self._FIRST_TRANS_COMMENT,
-            "INTER00013464.nxs": self._SECOND_TRANS_COMMENT,
-            "INTER00013462.nxs": self._SECOND_TRANS_COMMENT,
+            "INTER00013463": self._FIRST_TRANS_COMMENT,
+            "INTER00013464": self._SECOND_TRANS_COMMENT,
+            "INTER00013462": self._SECOND_TRANS_COMMENT,
         }
         metadata_to_check = self._get_basic_metadata_expected_from_reduced_ws(reduced_ws)
         metadata_to_check.append(self._get_expected_data_file_metadata(expected_data_files, self._ADDITIONAL_FILES_HEADING))

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
@@ -67,8 +67,8 @@ class SaveISISReflectometryORSOTest(unittest.TestCase):
         ]
         self._runs_and_angles = {
             "INTER00013460": "0.5",
-            "INTER00013469": "0.5",
-            "INTER00013462": "0.5",
+            "INTER00038393": "0.5",
+            "INTER00038415": "0.5",
         }
 
     def tearDown(self):
@@ -85,17 +85,17 @@ class SaveISISReflectometryORSOTest(unittest.TestCase):
         resolution = 0.02
         # One of the input runs should be an already loaded workspace as this appears differently in the history
         input_ws_name = "Test_ws"
-        LoadNexus("13469", OutputWorkspace=input_ws_name)
+        LoadNexus("38393", OutputWorkspace=input_ws_name)
         reduced_ws = self._get_ws_from_reduction(
-            f"0000013460, {input_ws_name}, inter13462.nxs", resolution, f"IvsQ_13460+{input_ws_name}+13462", "13463", "13464, 13462"
+            f"0000013460, {input_ws_name}, inter38415.nxs", resolution, f"IvsQ_13460+{input_ws_name}+38415", "13463", "13464, 38415"
         )
         SaveISISReflectometryORSO(InputWorkspace=reduced_ws, Filename=self._output_filename)
 
-        expected_data_files = ["INTER00013460", "INTER00013469", "INTER00013462"]
+        expected_data_files = ["INTER00013460", "INTER00038393", "INTER00038415"]
         expected_additional_file_entries = {
             "INTER00013463": self._FIRST_TRANS_COMMENT,
             "INTER00013464": self._SECOND_TRANS_COMMENT,
-            "INTER00013462": self._SECOND_TRANS_COMMENT,
+            "INTER00038415": self._SECOND_TRANS_COMMENT,
         }
         metadata_to_check = self._get_basic_metadata_expected_from_reduced_ws(reduced_ws)
         metadata_to_check.append(self._get_expected_data_file_metadata(expected_data_files, self._ADDITIONAL_FILES_HEADING))
@@ -107,14 +107,14 @@ class SaveISISReflectometryORSOTest(unittest.TestCase):
         # Testing the stitched reduction output helps to ensure that we're not getting duplicates in the metadata
         # because there will be multiple calls to ReflectometryISISLoadAndProcess in the history
         resolution = 0.02
-        reduced_ws = self._get_ws_from_stitched_reduction(["13460", "13469"], resolution, "13463", "13464, 13462")
+        reduced_ws = self._get_ws_from_stitched_reduction(["13460", "38393"], resolution, "13463", "13464, 38415")
         SaveISISReflectometryORSO(InputWorkspace=reduced_ws, Filename=self._output_filename)
 
-        expected_data_files = ["INTER00013460", "INTER00013469"]
+        expected_data_files = ["INTER00013460", "INTER00038393"]
         expected_additional_file_entries = {
             "INTER00013463": self._FIRST_TRANS_COMMENT,
             "INTER00013464": self._SECOND_TRANS_COMMENT,
-            "INTER00013462": self._SECOND_TRANS_COMMENT,
+            "INTER00038415": self._SECOND_TRANS_COMMENT,
         }
         metadata_to_check = self._get_basic_metadata_expected_from_reduced_ws(reduced_ws)
         metadata_to_check.append(self._get_expected_data_file_metadata(expected_data_files, self._ADDITIONAL_FILES_HEADING))

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
@@ -245,14 +245,6 @@ class SaveISISReflectometryORSOTest(unittest.TestCase):
 
         return None
 
-    def _get_reduction_workflow_histories_for_reduced_ws(self, reduced_ws):
-        workflow_histories = []
-        for history in reduced_ws.getHistory().getAlgorithmHistories():
-            if history.name() == self._REDUCTION_WORKFLOW_ALG:
-                workflow_histories.append(history)
-
-        return workflow_histories
-
     def _check_file_contents(self, header_values_to_check, ws, resolution, excluded_header_values=None):
         self._check_file_header(header_values_to_check, excluded_header_values)
         self._check_data_in_file(ws, resolution, check_file_exists=False)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
@@ -88,19 +88,6 @@ class SaveISISReflectometryORSOTest(unittest.TestCase):
 
         self._check_file_contents(header_values_to_check, reduced_ws, resolution, excluded_values)
 
-    def test_file_metadata_matches_reduced_workspace_instrument_when_save_after_default_instrument_changed(self):
-        self.assertTrue(config["default.instrument"] == "INTER")
-        resolution = 0.02
-        reduced_ws = self._get_ws_from_reduction("13460", resolution, "IvsQ_binned_13460")
-
-        config["default.instrument"] = "OFFSPEC"
-        SaveISISReflectometryORSO(InputWorkspace=reduced_ws, Filename=self._output_filename)
-
-        expected_data_files = ["INTER00013460.nxs"]
-        header_values_to_check = self._get_header_values_expected_from_reduced_ws(reduced_ws, expected_data_files)
-
-        self._check_file_contents(header_values_to_check, reduced_ws, resolution)
-
     def test_create_file_from_workspace_with_reduction_history_and_transmission_runs(self):
         resolution = 0.02
         reduced_ws = self._get_ws_from_reduction("13460", resolution, "IvsQ_binned_13460", "13463", "13464, 13462")

--- a/docs/source/algorithms/SaveISISReflectometryORSO-v1.rst
+++ b/docs/source/algorithms/SaveISISReflectometryORSO-v1.rst
@@ -38,7 +38,9 @@ If a resolution value cannot be found from the workspace history then a warning 
 Header Metadata
 ---------------
 
-Some of the metadata for the ORSO file header is retrieved directly from the input workspace, as described below:
+Some of the metadata for the ORSO file header is retrieved directly from the input workspace, as detailed below.
+For values retrieved from the workspace history, if any information cannot be extracted from the history then
+a warning is logged and the file is saved without this metadata included.
 
 +---------------------+-----------------------------------------------------------------------------------------------+
 | Header value        | Workspace location                                                                            |
@@ -53,6 +55,13 @@ Some of the metadata for the ORSO file header is retrieved directly from the inp
 +---------------------+-----------------------------------------------------------------------------------------------+
 | reduction timestamp | The execution time of the last occurrence of :ref:`algm-ReflectometryReductionOneAuto` in the |
 |                     | workspace history.                                                                            |
++---------------------+-----------------------------------------------------------------------------------------------+
+| measurement         | The individual file names for all of the run numbers passed to the ``InputRunList`` parameter |
+| data_files          | from all calls to :ref:`algm-ReflectometryISISLoadAndProcess` in the workspace history.       |
++---------------------+-----------------------------------------------------------------------------------------------+
+| measurement         | The individual file names for all of the run numbers passed to parameters                     |
+| additional_files    | ``FirstTransmissionRunList`` and ``SecondTransmissionRunList`` from all calls to              |
+|                     | :ref:`algm-ReflectometryISISLoadAndProcess` in the workspace history.                         |
 +---------------------+-----------------------------------------------------------------------------------------------+
 
 Usage

--- a/docs/source/release/v6.10.0/Reflectometry/New_features/36395.rst
+++ b/docs/source/release/v6.10.0/Reflectometry/New_features/36395.rst
@@ -1,0 +1,1 @@
+- Algorithm :ref:`algm-SaveISISReflectometryORSO` now outputs the individual angle and transmission files in the ORSO file metadata.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Adds the incident angle and transmission run metadata to the ISIS ORSO reduced reflectivity data file. This completes part of the first bullet point on issue #36395.

As the comments in the code explain, I haven't used the `FileFinder` to get the filenames here because it runs too slowly for the performance we require from this algorithm. Instead the algorithm will try to construct the run file name based on the run value entered into the history (omitting the file extension, as it is not required). Under normal use scientists will simply enter run numbers into the ISIS Refl GUI and these are not a problem to format correctly. There are some edge cases that may result in incorrect file names being included in the metadata, but I have tried to write the code so that the scientists would have to be doing something very deliberately obscure to encounter these.

I have written tests to cover the new functionality, however I am opening a maintenance issue to take a proper look at a better approach for these (see #36777), as I think there are a number of things we ideally should improve.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Refs #36395. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
1) Ask Rachel for a batch file to test with and save it somewhere on your machine. This batch file populates transmission runs on the Experiment Settings tab of the GUI, which is needed for testing.
1) Go to `Interfaces -> Reflectometry -> ISIS Reflectometry`.
1) Load the batch file by going to `Batch -> Load` and selecting the batch file location.
1) Go to the Save ASCII tab. Set a Save Path for saving the file to.
1) In the File Format section, select `ORSO ASCII (*.ort)` from the drop-down.
1) In the Automatic Save section, tick option `Save as ASCII on completion`.
1) Go back to the Runs tab, click on the first group in the main table to select it and click the `Process` button to process the group.
1) The reduction should complete successfully and there should be a successful call to `SaveISISReflectometryORSO` recorded in the messages pane. If you navigate to the save path you set in the Save ASCII tab, you should see a `.ort` file. Open this in a text editor and check the following:
    - There are entries in the header under `measurement -> data_files` for each individual sample run, with a comment identifying the incident angle.
    - There are entries in the header under  `measurement -> additional_files` for each transmission run, with a comment identifying whether it's a first or second transmission run.
The format of all measurement file entries should be `{instrument name}{zero padding}{run number}`.
1) Check some different ways of entering run numbers to ensure the metadata output to the `.ort` file is sensible. As mentioned in the PR main description, there are edge cases where you can end up with incorrect file names in the `.ort` header, but these shouldn't be encountered under normal use.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
