### PR TITLE
Fix Muon Analysis fitting error

### DIFF
--- a/docs/source/release/v6.9.0/Muon/Muon_Analysis/Bugfixes/36742.rst
+++ b/docs/source/release/v6.9.0/Muon/Muon_Analysis/Bugfixes/36742.rst
@@ -1,0 +1,1 @@
+- Fixed intermittent crash in the `Muon Analysis` window when performing simultaneous fitting on certain files

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid import AlgorithmManager, logger
 from mantid.api import IFunction
-from mantid.simpleapi import CopyLogs, ConvertFitFunctionForMuonTFAsymmetry
+from mantid.simpleapi import CopyLogs
 
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.workspace_naming import (
     create_fitted_workspace_name,
@@ -341,7 +341,12 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
             return None
 
         parameters = self._get_parameters_for_tf_asymmetry_conversion(fit_function, workspace_names)
-        return ConvertFitFunctionForMuonTFAsymmetry(StoreInADS=False, **parameters)
+        alg = AlgorithmManager.createUnmanaged("ConvertFitFunctionForMuonTFAsymmetry")
+        alg.initialize()
+        alg.setAlwaysStoreInADS(False)
+        alg.setProperties(parameters)
+        alg.execute()
+        return alg.getProperty("OutputFunction").value
 
     def _get_parameters_for_tf_asymmetry_conversion(self, fit_function: IFunction, workspace_names: list) -> dict:
         """Returns the parameters used to convert a normal function to a TF Asymmetry fit function."""


### PR DESCRIPTION
This fixes an intermittent error that can appear when an unmanaged algorithm is destroyed.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Used the `AlgorithmManager` to call `ConvertFitFunctionForMuonTFAsymmetry` instead of calling it directly.


Fixes #36742. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
See #36742 for how to reproduce.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
