### PR TITLE
Inelastic Template presenters are no longer QObjects

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1435,5 +1435,3 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Anal
 accessMoved:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/IndirectFittingModel.cpp:278
 postfixOperator:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/IndirectFittingModel.cpp:123
 postfixOperator:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/IndirectFittingModel.cpp:187
-constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp:45
-constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp:66

--- a/qt/scientific_interfaces/Inelastic/Analysis/DataAnalysisTabFactory.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/DataAnalysisTabFactory.cpp
@@ -12,10 +12,14 @@
 #include "FqFitModel.h"
 #include "FunctionBrowser/ConvFunctionModel.h"
 #include "FunctionBrowser/ConvTemplateBrowser.h"
+#include "FunctionBrowser/ConvTemplatePresenter.h"
 #include "FunctionBrowser/FqFunctionModel.h"
 #include "FunctionBrowser/IqtFunctionModel.h"
 #include "FunctionBrowser/IqtTemplateBrowser.h"
+#include "FunctionBrowser/IqtTemplatePresenter.h"
 #include "FunctionBrowser/MSDFunctionModel.h"
+#include "FunctionBrowser/SingleFunctionTemplateBrowser.h"
+#include "FunctionBrowser/SingleFunctionTemplatePresenter.h"
 #include "IndirectDataAnalysisTab.h"
 #include "IndirectFitDataPresenter.h"
 #include "IqtFitModel.h"
@@ -28,7 +32,8 @@ DataAnalysisTabFactory::DataAnalysisTabFactory(QTabWidget *tabWidget) : m_tabWid
 IndirectDataAnalysisTab *DataAnalysisTabFactory::makeMSDFitTab(int const index) const {
   auto tab = new IndirectDataAnalysisTab(MSDFit::TAB_NAME, MSDFit::HAS_RESOLUTION, m_tabWidget->widget(index));
   tab->setupFittingModel<MSDFitModel>();
-  tab->setupFitPropertyBrowser<SingleFunctionTemplateBrowser>(MSDFit::HIDDEN_PROPS);
+  tab->setupFitPropertyBrowser<SingleFunctionTemplateBrowser, SingleFunctionTemplatePresenter, MSDFunctionModel>(
+      MSDFit::HIDDEN_PROPS);
   tab->setupFitDataView<IndirectFitDataView>();
   tab->setupOutputOptionsPresenter();
   tab->setUpFitDataPresenter<IndirectFitDataPresenter>();
@@ -39,7 +44,7 @@ IndirectDataAnalysisTab *DataAnalysisTabFactory::makeMSDFitTab(int const index) 
 IndirectDataAnalysisTab *DataAnalysisTabFactory::makeIqtFitTab(int const index) const {
   auto tab = new IndirectDataAnalysisTab(IqtFit::TAB_NAME, IqtFit::HAS_RESOLUTION, m_tabWidget->widget(index));
   tab->setupFittingModel<IqtFitModel>();
-  tab->setupFitPropertyBrowser<IqtTemplateBrowser>(IqtFit::HIDDEN_PROPS);
+  tab->setupFitPropertyBrowser<IqtTemplateBrowser, IqtTemplatePresenter, IqtFunctionModel>(IqtFit::HIDDEN_PROPS);
   tab->setupFitDataView<IndirectFitDataView>();
   tab->setupOutputOptionsPresenter(true);
   tab->setUpFitDataPresenter<IndirectFitDataPresenter>();
@@ -50,7 +55,8 @@ IndirectDataAnalysisTab *DataAnalysisTabFactory::makeIqtFitTab(int const index) 
 IndirectDataAnalysisTab *DataAnalysisTabFactory::makeConvFitTab(int const index) const {
   auto tab = new IndirectDataAnalysisTab(ConvFit::TAB_NAME, ConvFit::HAS_RESOLUTION, m_tabWidget->widget(index));
   tab->setupFittingModel<ConvFitModel>();
-  tab->setupFitPropertyBrowser<ConvTemplateBrowser>(ConvFit::HIDDEN_PROPS, true);
+  tab->setupFitPropertyBrowser<ConvTemplateBrowser, ConvTemplatePresenter, ConvFunctionModel>(ConvFit::HIDDEN_PROPS,
+                                                                                              true);
   tab->setupFitDataView<ConvFitDataView>();
   tab->setupOutputOptionsPresenter(true);
   tab->setUpFitDataPresenter<ConvFitDataPresenter>();
@@ -61,7 +67,8 @@ IndirectDataAnalysisTab *DataAnalysisTabFactory::makeConvFitTab(int const index)
 IndirectDataAnalysisTab *DataAnalysisTabFactory::makeFqFitTab(int const index) const {
   auto tab = new IndirectDataAnalysisTab(FqFit::TAB_NAME, FqFit::HAS_RESOLUTION, m_tabWidget->widget(index));
   tab->setupFittingModel<FqFitModel>();
-  tab->setupFitPropertyBrowser<SingleFunctionTemplateBrowser>(FqFit::HIDDEN_PROPS);
+  tab->setupFitPropertyBrowser<SingleFunctionTemplateBrowser, SingleFunctionTemplatePresenter, FqFunctionModel>(
+      FqFit::HIDDEN_PROPS);
   tab->setupFitDataView<FqFitDataView>();
   tab->setupOutputOptionsPresenter();
   tab->setUpFitDataPresenter<FqFitDataPresenter>();

--- a/qt/scientific_interfaces/Inelastic/Analysis/DataAnalysisTabFactory.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/DataAnalysisTabFactory.cpp
@@ -28,7 +28,7 @@ DataAnalysisTabFactory::DataAnalysisTabFactory(QTabWidget *tabWidget) : m_tabWid
 IndirectDataAnalysisTab *DataAnalysisTabFactory::makeMSDFitTab(int const index) const {
   auto tab = new IndirectDataAnalysisTab(MSDFit::TAB_NAME, MSDFit::HAS_RESOLUTION, m_tabWidget->widget(index));
   tab->setupFittingModel<MSDFitModel>();
-  tab->setupFitPropertyBrowser<SingleFunctionTemplateBrowser, MSDFunctionModel>(MSDFit::HIDDEN_PROPS);
+  tab->setupFitPropertyBrowser<SingleFunctionTemplateBrowser>(MSDFit::HIDDEN_PROPS);
   tab->setupFitDataView<IndirectFitDataView>();
   tab->setupOutputOptionsPresenter();
   tab->setUpFitDataPresenter<IndirectFitDataPresenter>();
@@ -39,7 +39,7 @@ IndirectDataAnalysisTab *DataAnalysisTabFactory::makeMSDFitTab(int const index) 
 IndirectDataAnalysisTab *DataAnalysisTabFactory::makeIqtFitTab(int const index) const {
   auto tab = new IndirectDataAnalysisTab(IqtFit::TAB_NAME, IqtFit::HAS_RESOLUTION, m_tabWidget->widget(index));
   tab->setupFittingModel<IqtFitModel>();
-  tab->setupFitPropertyBrowser<IqtTemplateBrowser, IqtFunctionModel>(IqtFit::HIDDEN_PROPS);
+  tab->setupFitPropertyBrowser<IqtTemplateBrowser>(IqtFit::HIDDEN_PROPS);
   tab->setupFitDataView<IndirectFitDataView>();
   tab->setupOutputOptionsPresenter(true);
   tab->setUpFitDataPresenter<IndirectFitDataPresenter>();
@@ -50,7 +50,7 @@ IndirectDataAnalysisTab *DataAnalysisTabFactory::makeIqtFitTab(int const index) 
 IndirectDataAnalysisTab *DataAnalysisTabFactory::makeConvFitTab(int const index) const {
   auto tab = new IndirectDataAnalysisTab(ConvFit::TAB_NAME, ConvFit::HAS_RESOLUTION, m_tabWidget->widget(index));
   tab->setupFittingModel<ConvFitModel>();
-  tab->setupFitPropertyBrowser<ConvTemplateBrowser, ConvFunctionModel>(ConvFit::HIDDEN_PROPS, true);
+  tab->setupFitPropertyBrowser<ConvTemplateBrowser>(ConvFit::HIDDEN_PROPS, true);
   tab->setupFitDataView<ConvFitDataView>();
   tab->setupOutputOptionsPresenter(true);
   tab->setUpFitDataPresenter<ConvFitDataPresenter>();
@@ -61,7 +61,7 @@ IndirectDataAnalysisTab *DataAnalysisTabFactory::makeConvFitTab(int const index)
 IndirectDataAnalysisTab *DataAnalysisTabFactory::makeFqFitTab(int const index) const {
   auto tab = new IndirectDataAnalysisTab(FqFit::TAB_NAME, FqFit::HAS_RESOLUTION, m_tabWidget->widget(index));
   tab->setupFittingModel<FqFitModel>();
-  tab->setupFitPropertyBrowser<SingleFunctionTemplateBrowser, FqFunctionModel>(FqFit::HIDDEN_PROPS);
+  tab->setupFitPropertyBrowser<SingleFunctionTemplateBrowser>(FqFit::HIDDEN_PROPS);
   tab->setupFitDataView<FqFitDataView>();
   tab->setupOutputOptionsPresenter();
   tab->setUpFitDataPresenter<FqFitDataPresenter>();

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
@@ -71,13 +71,10 @@ void ConvTemplateBrowser::createProperties() {
 void ConvTemplateBrowser::boolChanged(QtProperty *prop) {
   if (!m_emitBoolChange)
     return;
-  auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter);
-  if (!presenter)
-    return;
   if (prop == m_deltaFunctionOn) {
-    presenter->setDeltaFunction(m_boolManager->value(prop));
+    m_presenter->setDeltaFunction(m_boolManager->value(prop));
   } else if (prop == m_tempCorrectionOn) {
-    presenter->setTempCorrection(m_boolManager->value(prop));
+    m_presenter->setTempCorrection(m_boolManager->value(prop));
   }
 }
 
@@ -130,14 +127,11 @@ void ConvTemplateBrowser::removeTempCorrection() {
 void ConvTemplateBrowser::enumChanged(QtProperty *prop) {
   if (!m_emitEnumChange)
     return;
-  auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter);
-  if (!presenter)
-    return;
   auto const index = m_enumManager->value(prop);
   auto propIt = std::find(m_subTypeProperties.begin(), m_subTypeProperties.end(), prop);
   if (propIt != m_subTypeProperties.end()) {
     auto const subTypeIndex = std::distance(m_subTypeProperties.begin(), propIt);
-    presenter->setSubType(subTypeIndex, index);
+    m_presenter->setSubType(subTypeIndex, index);
   }
 }
 
@@ -313,11 +307,8 @@ void ConvTemplateBrowser::setResolution(const std::vector<std::pair<std::string,
 }
 
 void ConvTemplateBrowser::intChanged(QtProperty *prop) {
-  if (prop != m_subTypeProperties[SubTypeIndex::Lorentzian] || !m_emitIntChange) {
-    return;
-  }
-  if (auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter)) {
-    presenter->setSubType(SubTypeIndex::Lorentzian, m_intManager->value(prop));
+  if (prop == m_subTypeProperties[SubTypeIndex::Lorentzian] && m_emitIntChange) {
+    m_presenter->setSubType(SubTypeIndex::Lorentzian, m_intManager->value(prop));
   }
 }
 } // namespace MantidQt::CustomInterfaces::IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
@@ -164,14 +164,10 @@ void ConvTemplateBrowser::globalChanged(QtProperty *, const QString &, bool) {}
 
 void ConvTemplateBrowser::parameterChanged(QtProperty *prop) {
   auto isGlobal = m_parameterManager->isGlobal(prop);
-  m_presenter.setGlobal(m_actualParameterNames[prop], isGlobal);
+  m_presenter.setGlobal(m_parameterNames[prop], isGlobal);
   if (m_emitParameterValueChange) {
-    emit parameterValueChanged(m_actualParameterNames[prop], m_parameterManager->value(prop));
+    emit parameterValueChanged(m_parameterNames[prop], m_parameterManager->value(prop));
   }
-}
-
-void ConvTemplateBrowser::parameterButtonClicked(QtProperty *prop) {
-  emit localParameterButtonClicked(m_actualParameterNames[prop]);
 }
 
 void ConvTemplateBrowser::updateMultiDatasetParameters(const IFunction &fun) {
@@ -187,12 +183,12 @@ void ConvTemplateBrowser::updateParameters(const IFunction &fun) { m_presenter.u
 void ConvTemplateBrowser::setCurrentDataset(int i) { m_presenter.setCurrentDataset(i); }
 
 void ConvTemplateBrowser::updateParameterNames(const QMap<int, std::string> &parameterNames) {
-  m_actualParameterNames.clear();
+  m_parameterNames.clear();
   ScopedFalse _false(m_emitParameterValueChange);
   for (auto const prop : m_parameterMap.keys()) {
     auto const i = m_parameterMap[prop];
     auto const name = parameterNames[static_cast<int>(i)];
-    m_actualParameterNames[prop] = name;
+    m_parameterNames[prop] = name;
     if (!name.empty()) {
       prop->setPropertyName(QString::fromStdString(name));
     }
@@ -220,14 +216,14 @@ void ConvTemplateBrowser::setGlobalParametersQuiet(const QStringList &globals) {
   ScopedFalse _(m_emitParameterValueChange);
   auto parameterProperies = m_parameterMap.keys();
   for (auto const prop : m_parameterMap.keys()) {
-    auto const name = m_actualParameterNames[prop];
+    auto const name = m_parameterNames[prop];
     if (globals.contains(QString::fromStdString(name))) {
       m_parameterManager->setGlobal(prop, true);
       parameterProperies.removeOne(prop);
     }
   }
   for (auto const prop : parameterProperies) {
-    if (!m_actualParameterNames[prop].empty()) {
+    if (!m_parameterNames[prop].empty()) {
       m_parameterManager->setGlobal(prop, false);
     }
   }

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
@@ -43,6 +43,7 @@ ConvTemplateBrowser::ConvTemplateBrowser(QWidget *parent) : FunctionTemplateBrow
   m_templateSubTypes.emplace_back(std::make_unique<LorentzianSubType>());
   m_templateSubTypes.emplace_back(std::make_unique<FitSubType>());
   m_templateSubTypes.emplace_back(std::make_unique<BackgroundSubType>());
+  init();
   // connect(&m_presenter, SIGNAL(functionStructureChanged()), this, SIGNAL(functionStructureChanged()));
 }
 
@@ -81,11 +82,7 @@ void ConvTemplateBrowser::boolChanged(QtProperty *prop) {
   }
 }
 
-void ConvTemplateBrowser::setQValues(const std::vector<double> &qValues) {
-  if (auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter)) {
-    presenter->setQValues(qValues);
-  }
-}
+void ConvTemplateBrowser::setQValues(const std::vector<double> &qValues) { m_presenter->setQValues(qValues); }
 
 void ConvTemplateBrowser::addDeltaFunction() {
   ScopedFalse _boolBlock(m_emitBoolChange);
@@ -156,9 +153,7 @@ void ConvTemplateBrowser::parameterChanged(QtProperty *prop) {
 }
 
 void ConvTemplateBrowser::updateMultiDatasetParameters(const ITableWorkspace &paramTable) {
-  if (auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter)) {
-    presenter->updateMultiDatasetParameters(paramTable);
-  }
+  m_presenter->updateMultiDatasetParameters(paramTable);
 }
 
 void ConvTemplateBrowser::updateParameters(const IFunction &fun) { m_presenter->updateParameters(fun); }
@@ -312,16 +307,10 @@ void ConvTemplateBrowser::updateParameterEstimationData(DataForParameterEstimati
 
 void ConvTemplateBrowser::estimateFunctionParameters() { m_presenter->estimateFunctionParameters(); }
 
-void ConvTemplateBrowser::setBackgroundA0(double value) {
-  if (auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter)) {
-    presenter->setBackgroundA0(value);
-  }
-}
+void ConvTemplateBrowser::setBackgroundA0(double value) { m_presenter->setBackgroundA0(value); }
 
 void ConvTemplateBrowser::setResolution(const std::vector<std::pair<std::string, size_t>> &fitResolutions) {
-  if (auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter)) {
-    presenter->setResolution(fitResolutions);
-  }
+  m_presenter->setResolution(fitResolutions);
 }
 
 void ConvTemplateBrowser::intChanged(QtProperty *prop) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
@@ -44,7 +44,6 @@ ConvTemplateBrowser::ConvTemplateBrowser(QWidget *parent) : FunctionTemplateBrow
   m_templateSubTypes.emplace_back(std::make_unique<FitSubType>());
   m_templateSubTypes.emplace_back(std::make_unique<BackgroundSubType>());
   init();
-  // connect(&m_presenter, SIGNAL(functionStructureChanged()), this, SIGNAL(functionStructureChanged()));
 }
 
 void ConvTemplateBrowser::createProperties() {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
@@ -147,7 +147,7 @@ void ConvTemplateBrowser::parameterChanged(QtProperty *prop) {
   auto isGlobal = m_parameterManager->isGlobal(prop);
   m_presenter->setGlobal(m_parameterNames[prop], isGlobal);
   if (m_emitParameterValueChange) {
-    emit parameterValueChanged(m_parameterNames[prop], m_parameterManager->value(prop));
+    m_presenter->handleParameterValueChanged(m_parameterNames[prop], m_parameterManager->value(prop));
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
@@ -68,41 +68,24 @@ void ConvTemplateBrowser::createProperties() {
   m_intManager->blockSignals(false);
 }
 
-void ConvTemplateBrowser::setFunction(std::string const &funStr) { m_presenter->setFunction(funStr); }
-
-IFunction_sptr ConvTemplateBrowser::getGlobalFunction() const { return m_presenter->getGlobalFunction(); }
-
-IFunction_sptr ConvTemplateBrowser::getFunction() const { return m_presenter->getFunction(); }
-
-int ConvTemplateBrowser::getCurrentDataset() { return m_presenter->getCurrentDataset(); }
-
-void ConvTemplateBrowser::setNumberOfDatasets(int n) { m_presenter->setNumberOfDatasets(n); }
-
-int ConvTemplateBrowser::getNumberOfDatasets() const { return m_presenter->getNumberOfDatasets(); }
-
-void ConvTemplateBrowser::setDatasets(const QList<FunctionModelDataset> &datasets) {
-  m_presenter->setDatasets(datasets);
-}
-
-std::vector<std::string> ConvTemplateBrowser::getGlobalParameters() const { return m_presenter->getGlobalParameters(); }
-
-std::vector<std::string> ConvTemplateBrowser::getLocalParameters() const { return m_presenter->getLocalParameters(); }
-
-void ConvTemplateBrowser::setGlobalParameters(std::vector<std::string> const &globals) {
-  m_presenter->setGlobalParameters(globals);
-}
-
 void ConvTemplateBrowser::boolChanged(QtProperty *prop) {
   if (!m_emitBoolChange)
     return;
+  auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter);
+  if (!presenter)
+    return;
   if (prop == m_deltaFunctionOn) {
-    m_presenter->setDeltaFunction(m_boolManager->value(prop));
+    presenter->setDeltaFunction(m_boolManager->value(prop));
   } else if (prop == m_tempCorrectionOn) {
-    m_presenter->setTempCorrection(m_boolManager->value(prop));
+    presenter->setTempCorrection(m_boolManager->value(prop));
   }
 }
 
-void ConvTemplateBrowser::setQValues(const std::vector<double> &qValues) { m_presenter->setQValues(qValues); }
+void ConvTemplateBrowser::setQValues(const std::vector<double> &qValues) {
+  if (auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter)) {
+    presenter->setQValues(qValues);
+  }
+}
 
 void ConvTemplateBrowser::addDeltaFunction() {
   ScopedFalse _boolBlock(m_emitBoolChange);
@@ -151,11 +134,14 @@ void ConvTemplateBrowser::removeTempCorrection() {
 void ConvTemplateBrowser::enumChanged(QtProperty *prop) {
   if (!m_emitEnumChange)
     return;
+  auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter);
+  if (!presenter)
+    return;
   auto const index = m_enumManager->value(prop);
   auto propIt = std::find(m_subTypeProperties.begin(), m_subTypeProperties.end(), prop);
   if (propIt != m_subTypeProperties.end()) {
     auto const subTypeIndex = std::distance(m_subTypeProperties.begin(), propIt);
-    m_presenter->setSubType(subTypeIndex, index);
+    presenter->setSubType(subTypeIndex, index);
   }
 }
 
@@ -169,17 +155,13 @@ void ConvTemplateBrowser::parameterChanged(QtProperty *prop) {
   }
 }
 
-void ConvTemplateBrowser::updateMultiDatasetParameters(const IFunction &fun) {
-  m_presenter->updateMultiDatasetParameters(fun);
-}
-
 void ConvTemplateBrowser::updateMultiDatasetParameters(const ITableWorkspace &paramTable) {
-  m_presenter->updateMultiDatasetParameters(paramTable);
+  if (auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter)) {
+    presenter->updateMultiDatasetParameters(paramTable);
+  }
 }
 
 void ConvTemplateBrowser::updateParameters(const IFunction &fun) { m_presenter->updateParameters(fun); }
-
-void ConvTemplateBrowser::setCurrentDataset(int i) { m_presenter->setCurrentDataset(i); }
 
 void ConvTemplateBrowser::updateParameterNames(const QMap<int, std::string> &parameterNames) {
   m_parameterNames.clear();
@@ -330,15 +312,24 @@ void ConvTemplateBrowser::updateParameterEstimationData(DataForParameterEstimati
 
 void ConvTemplateBrowser::estimateFunctionParameters() { m_presenter->estimateFunctionParameters(); }
 
-void ConvTemplateBrowser::setBackgroundA0(double value) { m_presenter->setBackgroundA0(value); }
+void ConvTemplateBrowser::setBackgroundA0(double value) {
+  if (auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter)) {
+    presenter->setBackgroundA0(value);
+  }
+}
 
 void ConvTemplateBrowser::setResolution(const std::vector<std::pair<std::string, size_t>> &fitResolutions) {
-  m_presenter->setResolution(fitResolutions);
+  if (auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter)) {
+    presenter->setResolution(fitResolutions);
+  }
 }
 
 void ConvTemplateBrowser::intChanged(QtProperty *prop) {
-  if (prop == m_subTypeProperties[SubTypeIndex::Lorentzian] && m_emitIntChange) {
-    m_presenter->setSubType(SubTypeIndex::Lorentzian, m_intManager->value(prop));
+  if (prop != m_subTypeProperties[SubTypeIndex::Lorentzian] || !m_emitIntChange) {
+    return;
+  }
+  if (auto presenter = dynamic_cast<ConvTemplatePresenter *>(m_presenter)) {
+    presenter->setSubType(SubTypeIndex::Lorentzian, m_intManager->value(prop));
   }
 }
 } // namespace MantidQt::CustomInterfaces::IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
@@ -39,12 +39,11 @@ public:
 
 } // namespace
 
-ConvTemplateBrowser::ConvTemplateBrowser(std::unique_ptr<ConvFunctionModel> functionModel, QWidget *parent)
-    : FunctionTemplateBrowser(parent), m_presenter(this, std::move(functionModel)) {
+ConvTemplateBrowser::ConvTemplateBrowser(QWidget *parent) : FunctionTemplateBrowser(parent) {
   m_templateSubTypes.emplace_back(std::make_unique<LorentzianSubType>());
   m_templateSubTypes.emplace_back(std::make_unique<FitSubType>());
   m_templateSubTypes.emplace_back(std::make_unique<BackgroundSubType>());
-  connect(&m_presenter, SIGNAL(functionStructureChanged()), this, SIGNAL(functionStructureChanged()));
+  // connect(&m_presenter, SIGNAL(functionStructureChanged()), this, SIGNAL(functionStructureChanged()));
 }
 
 void ConvTemplateBrowser::createProperties() {
@@ -69,41 +68,41 @@ void ConvTemplateBrowser::createProperties() {
   m_intManager->blockSignals(false);
 }
 
-void ConvTemplateBrowser::setFunction(std::string const &funStr) { m_presenter.setFunction(funStr); }
+void ConvTemplateBrowser::setFunction(std::string const &funStr) { m_presenter->setFunction(funStr); }
 
-IFunction_sptr ConvTemplateBrowser::getGlobalFunction() const { return m_presenter.getGlobalFunction(); }
+IFunction_sptr ConvTemplateBrowser::getGlobalFunction() const { return m_presenter->getGlobalFunction(); }
 
-IFunction_sptr ConvTemplateBrowser::getFunction() const { return m_presenter.getFunction(); }
+IFunction_sptr ConvTemplateBrowser::getFunction() const { return m_presenter->getFunction(); }
 
-int ConvTemplateBrowser::getCurrentDataset() { return m_presenter.getCurrentDataset(); }
+int ConvTemplateBrowser::getCurrentDataset() { return m_presenter->getCurrentDataset(); }
 
-void ConvTemplateBrowser::setNumberOfDatasets(int n) { m_presenter.setNumberOfDatasets(n); }
+void ConvTemplateBrowser::setNumberOfDatasets(int n) { m_presenter->setNumberOfDatasets(n); }
 
-int ConvTemplateBrowser::getNumberOfDatasets() const { return m_presenter.getNumberOfDatasets(); }
+int ConvTemplateBrowser::getNumberOfDatasets() const { return m_presenter->getNumberOfDatasets(); }
 
 void ConvTemplateBrowser::setDatasets(const QList<FunctionModelDataset> &datasets) {
-  m_presenter.setDatasets(datasets);
+  m_presenter->setDatasets(datasets);
 }
 
-std::vector<std::string> ConvTemplateBrowser::getGlobalParameters() const { return m_presenter.getGlobalParameters(); }
+std::vector<std::string> ConvTemplateBrowser::getGlobalParameters() const { return m_presenter->getGlobalParameters(); }
 
-std::vector<std::string> ConvTemplateBrowser::getLocalParameters() const { return m_presenter.getLocalParameters(); }
+std::vector<std::string> ConvTemplateBrowser::getLocalParameters() const { return m_presenter->getLocalParameters(); }
 
 void ConvTemplateBrowser::setGlobalParameters(std::vector<std::string> const &globals) {
-  m_presenter.setGlobalParameters(globals);
+  m_presenter->setGlobalParameters(globals);
 }
 
 void ConvTemplateBrowser::boolChanged(QtProperty *prop) {
   if (!m_emitBoolChange)
     return;
   if (prop == m_deltaFunctionOn) {
-    m_presenter.setDeltaFunction(m_boolManager->value(prop));
+    m_presenter->setDeltaFunction(m_boolManager->value(prop));
   } else if (prop == m_tempCorrectionOn) {
-    m_presenter.setTempCorrection(m_boolManager->value(prop));
+    m_presenter->setTempCorrection(m_boolManager->value(prop));
   }
 }
 
-void ConvTemplateBrowser::setQValues(const std::vector<double> &qValues) { m_presenter.setQValues(qValues); }
+void ConvTemplateBrowser::setQValues(const std::vector<double> &qValues) { m_presenter->setQValues(qValues); }
 
 void ConvTemplateBrowser::addDeltaFunction() {
   ScopedFalse _boolBlock(m_emitBoolChange);
@@ -156,7 +155,7 @@ void ConvTemplateBrowser::enumChanged(QtProperty *prop) {
   auto propIt = std::find(m_subTypeProperties.begin(), m_subTypeProperties.end(), prop);
   if (propIt != m_subTypeProperties.end()) {
     auto const subTypeIndex = std::distance(m_subTypeProperties.begin(), propIt);
-    m_presenter.setSubType(subTypeIndex, index);
+    m_presenter->setSubType(subTypeIndex, index);
   }
 }
 
@@ -164,23 +163,23 @@ void ConvTemplateBrowser::globalChanged(QtProperty *, const QString &, bool) {}
 
 void ConvTemplateBrowser::parameterChanged(QtProperty *prop) {
   auto isGlobal = m_parameterManager->isGlobal(prop);
-  m_presenter.setGlobal(m_parameterNames[prop], isGlobal);
+  m_presenter->setGlobal(m_parameterNames[prop], isGlobal);
   if (m_emitParameterValueChange) {
     emit parameterValueChanged(m_parameterNames[prop], m_parameterManager->value(prop));
   }
 }
 
 void ConvTemplateBrowser::updateMultiDatasetParameters(const IFunction &fun) {
-  m_presenter.updateMultiDatasetParameters(fun);
+  m_presenter->updateMultiDatasetParameters(fun);
 }
 
 void ConvTemplateBrowser::updateMultiDatasetParameters(const ITableWorkspace &paramTable) {
-  m_presenter.updateMultiDatasetParameters(paramTable);
+  m_presenter->updateMultiDatasetParameters(paramTable);
 }
 
-void ConvTemplateBrowser::updateParameters(const IFunction &fun) { m_presenter.updateParameters(fun); }
+void ConvTemplateBrowser::updateParameters(const IFunction &fun) { m_presenter->updateParameters(fun); }
 
-void ConvTemplateBrowser::setCurrentDataset(int i) { m_presenter.setCurrentDataset(i); }
+void ConvTemplateBrowser::setCurrentDataset(int i) { m_presenter->setCurrentDataset(i); }
 
 void ConvTemplateBrowser::updateParameterNames(const QMap<int, std::string> &parameterNames) {
   m_parameterNames.clear();
@@ -322,24 +321,24 @@ void ConvTemplateBrowser::setParameterValueQuiet(ParamID id, double value, doubl
 }
 
 EstimationDataSelector ConvTemplateBrowser::getEstimationDataSelector() const {
-  return m_presenter.getEstimationDataSelector();
+  return m_presenter->getEstimationDataSelector();
 }
 
 void ConvTemplateBrowser::updateParameterEstimationData(DataForParameterEstimationCollection &&data) {
-  m_presenter.updateParameterEstimationData(std::move(data));
+  m_presenter->updateParameterEstimationData(std::move(data));
 }
 
-void ConvTemplateBrowser::estimateFunctionParameters() { m_presenter.estimateFunctionParameters(); }
+void ConvTemplateBrowser::estimateFunctionParameters() { m_presenter->estimateFunctionParameters(); }
 
-void ConvTemplateBrowser::setBackgroundA0(double value) { m_presenter.setBackgroundA0(value); }
+void ConvTemplateBrowser::setBackgroundA0(double value) { m_presenter->setBackgroundA0(value); }
 
 void ConvTemplateBrowser::setResolution(const std::vector<std::pair<std::string, size_t>> &fitResolutions) {
-  m_presenter.setResolution(fitResolutions);
+  m_presenter->setResolution(fitResolutions);
 }
 
 void ConvTemplateBrowser::intChanged(QtProperty *prop) {
   if (prop == m_subTypeProperties[SubTypeIndex::Lorentzian] && m_emitIntChange) {
-    m_presenter.setSubType(SubTypeIndex::Lorentzian, m_intManager->value(prop));
+    m_presenter->setSubType(SubTypeIndex::Lorentzian, m_intManager->value(prop));
   }
 }
 } // namespace MantidQt::CustomInterfaces::IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.h
@@ -30,20 +30,8 @@ class MANTIDQT_INELASTIC_DLL ConvTemplateBrowser : public FunctionTemplateBrowse
   Q_OBJECT
 public:
   explicit ConvTemplateBrowser(QWidget *parent = nullptr);
-  void setFunction(std::string const &funStr) override;
-  IFunction_sptr getGlobalFunction() const override;
-  IFunction_sptr getFunction() const override;
-  void setNumberOfDatasets(int) override;
-  int getCurrentDataset() override;
-  int getNumberOfDatasets() const override;
-  void setDatasets(const QList<MantidWidgets::FunctionModelDataset> &datasets) override;
-  std::vector<std::string> getGlobalParameters() const override;
-  std::vector<std::string> getLocalParameters() const override;
-  void setGlobalParameters(std::vector<std::string> const &globals) override;
-  void updateMultiDatasetParameters(const IFunction &fun) override;
   void updateMultiDatasetParameters(const ITableWorkspace &paramTable) override;
   void updateParameters(const IFunction &fun) override;
-  void setCurrentDataset(int i) override;
   void updateParameterNames(const QMap<int, std::string> &parameterNames) override;
   void setErrorsEnabled(bool enabled) override;
   void clear() override;
@@ -104,6 +92,7 @@ private:
   bool m_emitBoolChange = true;
   bool m_emitEnumChange = true;
   bool m_emitIntChange = true;
+  friend class ConvTemplatePresenter;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.h
@@ -69,7 +69,6 @@ protected slots:
   void enumChanged(QtProperty *) override;
   void globalChanged(QtProperty *, const QString &, bool) override;
   void parameterChanged(QtProperty *) override;
-  void parameterButtonClicked(QtProperty *) override;
 
 private:
   void createProperties() override;
@@ -99,7 +98,6 @@ private:
 
   QMap<QtProperty *, ParamID> m_parameterMap;
   QMap<ParamID, QtProperty *> m_parameterReverseMap;
-  QMap<QtProperty *, std::string> m_actualParameterNames;
   QMap<QtProperty *, std::string> m_parameterDescriptions;
 
 private:

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.h
@@ -29,7 +29,7 @@ using namespace ConvTypes;
 class MANTIDQT_INELASTIC_DLL ConvTemplateBrowser : public FunctionTemplateBrowser {
   Q_OBJECT
 public:
-  explicit ConvTemplateBrowser(std::unique_ptr<ConvFunctionModel> functionModel, QWidget *parent = nullptr);
+  explicit ConvTemplateBrowser(QWidget *parent = nullptr);
   void setFunction(std::string const &funStr) override;
   IFunction_sptr getGlobalFunction() const override;
   IFunction_sptr getFunction() const override;
@@ -76,7 +76,6 @@ private:
   void setParameterPropertyValue(QtProperty *prop, double value, double error);
   void setGlobalParametersQuiet(const QStringList &globals);
   void createFunctionParameterProperties();
-  void createLorentzianFunctionProperties();
   void createDeltaFunctionProperties();
   void createTempCorrectionProperties();
   void setSubType(size_t subTypeIndex, int typeIndex);
@@ -101,12 +100,10 @@ private:
   QMap<QtProperty *, std::string> m_parameterDescriptions;
 
 private:
-  ConvTemplatePresenter m_presenter;
   bool m_emitParameterValueChange = true;
   bool m_emitBoolChange = true;
   bool m_emitEnumChange = true;
   bool m_emitIntChange = true;
-  friend class ConvTemplatePresenter;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplateBrowser.h
@@ -33,7 +33,6 @@ public:
   void updateMultiDatasetParameters(const ITableWorkspace &paramTable) override;
   void updateParameters(const IFunction &fun) override;
   void updateParameterNames(const QMap<int, std::string> &parameterNames) override;
-  void setErrorsEnabled(bool enabled) override;
   void clear() override;
   EstimationDataSelector getEstimationDataSelector() const override;
   void updateParameterEstimationData(DataForParameterEstimationCollection &&data) override;
@@ -61,7 +60,6 @@ protected slots:
 private:
   void createProperties() override;
   void popupMenu(const QPoint &) override;
-  void setParameterPropertyValue(QtProperty *prop, double value, double error);
   void setGlobalParametersQuiet(const QStringList &globals);
   void createFunctionParameterProperties();
   void createDeltaFunctionProperties();
@@ -88,10 +86,6 @@ private:
   QMap<QtProperty *, std::string> m_parameterDescriptions;
 
 private:
-  bool m_emitParameterValueChange = true;
-  bool m_emitBoolChange = true;
-  bool m_emitEnumChange = true;
-  bool m_emitIntChange = true;
   friend class ConvTemplatePresenter;
 };
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.cpp
@@ -35,8 +35,6 @@ ConvTemplatePresenter::ConvTemplatePresenter(ConvTemplateBrowser *view,
                                              std::unique_ptr<ConvFunctionModel> functionModel)
     : QObject(view), m_view(view), m_model(std::move(functionModel)) {
   m_view->subscribePresenter(this);
-  connect(m_view, SIGNAL(parameterValueChanged(std::string const &, double)), this,
-          SLOT(viewChangedParameterValue(std::string const &, double)));
 }
 
 // This function creates a Qt thread to run the model updates
@@ -273,7 +271,7 @@ void ConvTemplatePresenter::editLocalParameterFinish(int result) {
   m_view->emitFunctionStructureChanged();
 }
 
-void ConvTemplatePresenter::viewChangedParameterValue(std::string const &parameterName, double value) {
+void ConvTemplatePresenter::handleParameterValueChanged(std::string const &parameterName, double value) {
   if (parameterName.empty())
     return;
   if (m_model->isGlobal(parameterName)) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.cpp
@@ -149,8 +149,8 @@ void ConvTemplatePresenter::updateMultiDatasetParameters(const IFunction &fun) {
   updateViewParameters();
 }
 
-void ConvTemplatePresenter::updateMultiDatasetParameters(const ITableWorkspace &paramTable) {
-  m_model->updateMultiDatasetParameters(paramTable);
+void ConvTemplatePresenter::updateMultiDatasetParameters(const ITableWorkspace &table) {
+  m_model->updateMultiDatasetParameters(table);
   updateViewParameters();
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.cpp
@@ -33,7 +33,7 @@ using namespace MantidWidgets;
  */
 ConvTemplatePresenter::ConvTemplatePresenter(ConvTemplateBrowser *view,
                                              std::unique_ptr<ConvFunctionModel> functionModel)
-    : QObject(view), m_view(view), m_model(std::move(functionModel)) {
+    : m_view(view), m_model(std::move(functionModel)) {
   m_view->subscribePresenter(this);
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.cpp
@@ -55,7 +55,7 @@ void ConvTemplatePresenter::setSubType(size_t subTypeIndex, int typeIndex) {
   setErrorsEnabled(false);
   updateViewParameterNames();
   updateViewParameters();
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 void ConvTemplatePresenter::setDeltaFunction(bool on) {
@@ -70,7 +70,7 @@ void ConvTemplatePresenter::setDeltaFunction(bool on) {
   setErrorsEnabled(false);
   updateViewParameterNames();
   updateViewParameters();
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 void ConvTemplatePresenter::setTempCorrection(bool on) {
@@ -93,7 +93,7 @@ void ConvTemplatePresenter::setTempCorrection(bool on) {
   setErrorsEnabled(false);
   updateViewParameterNames();
   updateViewParameters();
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 void ConvTemplatePresenter::setNumberOfDatasets(int n) { m_model->setNumberDomains(n); }
@@ -116,7 +116,7 @@ void ConvTemplatePresenter::setFunction(std::string const &funStr) {
   setErrorsEnabled(false);
   updateViewParameterNames();
   updateViewParameters();
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 int ConvTemplatePresenter::getCurrentDataset() { return m_model->currentDomainIndex(); }
@@ -270,7 +270,7 @@ void ConvTemplatePresenter::editLocalParameterFinish(int result) {
   }
   m_editLocalParameterDialog = nullptr;
   updateViewParameters();
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 void ConvTemplatePresenter::viewChangedParameterValue(std::string const &parameterName, double value) {
@@ -289,7 +289,7 @@ void ConvTemplatePresenter::viewChangedParameterValue(std::string const &paramet
     }
     setLocalParameterValue(parameterName, i, value);
   }
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 EstimationDataSelector ConvTemplatePresenter::getEstimationDataSelector() const {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.cpp
@@ -239,36 +239,25 @@ void ConvTemplatePresenter::handleEditLocalParameter(std::string const &paramete
     const auto constraint = getLocalParameterConstraint(parameterName, i);
     constraints.push_back(QString::fromStdString(constraint));
   }
-
-  m_editLocalParameterDialog =
-      new EditLocalParameterDialog(m_view, parameterName, datasetNames, domainNames, values, fixes, ties, constraints);
-  connect(m_editLocalParameterDialog, SIGNAL(finished(int)), this, SLOT(editLocalParameterFinish(int)));
-  m_editLocalParameterDialog->open();
+  m_view->openEditLocalParameterDialog(parameterName, datasetNames, domainNames, values, fixes, ties, constraints);
 }
 
-void ConvTemplatePresenter::editLocalParameterFinish(int result) {
-  if (result == QDialog::Accepted) {
-    auto parName = m_editLocalParameterDialog->getParameterName();
-    auto values = m_editLocalParameterDialog->getValues();
-    auto fixes = m_editLocalParameterDialog->getFixes();
-    auto ties = m_editLocalParameterDialog->getTies();
-    auto constraints = m_editLocalParameterDialog->getConstraints();
-    assert(values.size() == getNumberOfDatasets());
-    for (int i = 0; i < values.size(); ++i) {
-      setLocalParameterValue(parName, i, values[i]);
-      if (!ties[i].isEmpty()) {
-        setLocalParameterTie(parName, i, ties[i].toStdString());
-      } else if (fixes[i]) {
-        setLocalParameterFixed(parName, i, fixes[i]);
-      } else {
-        setLocalParameterTie(parName, i, "");
-      }
-      m_model->setLocalParameterConstraint(parName, i, constraints[i].toStdString());
+void ConvTemplatePresenter::handleEditLocalParameterFinished(std::string const &parameterName,
+                                                             QList<double> const &values, QList<bool> const &fixes,
+                                                             QStringList const &ties, QStringList const &constraints) {
+  assert(values.size() == getNumberOfDatasets());
+  for (int i = 0; i < values.size(); ++i) {
+    setLocalParameterValue(parameterName, i, values[i]);
+    if (!ties[i].isEmpty()) {
+      setLocalParameterTie(parameterName, i, ties[i].toStdString());
+    } else if (fixes[i]) {
+      setLocalParameterFixed(parameterName, i, fixes[i]);
+    } else {
+      setLocalParameterTie(parameterName, i, "");
     }
+    m_model->setLocalParameterConstraint(parameterName, i, constraints[i].toStdString());
   }
-  m_editLocalParameterDialog = nullptr;
   updateViewParameters();
-  m_view->emitFunctionStructureChanged();
 }
 
 void ConvTemplatePresenter::handleParameterValueChanged(std::string const &parameterName, double value) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.cpp
@@ -34,8 +34,7 @@ using namespace MantidWidgets;
 ConvTemplatePresenter::ConvTemplatePresenter(ConvTemplateBrowser *view,
                                              std::unique_ptr<ConvFunctionModel> functionModel)
     : QObject(view), m_view(view), m_model(std::move(functionModel)) {
-  connect(m_view, SIGNAL(localParameterButtonClicked(std::string const &)), this,
-          SLOT(editLocalParameter(std::string const &)));
+  m_view->subscribePresenter(this);
   connect(m_view, SIGNAL(parameterValueChanged(std::string const &, double)), this,
           SLOT(viewChangedParameterValue(std::string const &, double)));
 }
@@ -224,7 +223,7 @@ void ConvTemplatePresenter::setLocalParameterFixed(std::string const &parameterN
   m_model->setLocalParameterFixed(parameterName, i, fixed);
 }
 
-void ConvTemplatePresenter::editLocalParameter(std::string const &parameterName) {
+void ConvTemplatePresenter::handleEditLocalParameter(std::string const &parameterName) {
   auto const datasetNames = getDatasetNames();
   auto const domainNames = getDatasetDomainNames();
   QList<double> values;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
@@ -8,7 +8,7 @@
 
 #include "ConvFunctionModel.h"
 #include "DllConfig.h"
-#include "ITemplatePresenter.h"
+#include "FunctionTemplatePresenter.h"
 
 #include <QMap>
 
@@ -28,7 +28,7 @@ class ConvTemplateBrowser;
  * and set properties that can be used to generate a fit function.
  *
  */
-class MANTIDQT_INELASTIC_DLL ConvTemplatePresenter : public ITemplatePresenter {
+class MANTIDQT_INELASTIC_DLL ConvTemplatePresenter : public FunctionTemplatePresenter {
 public:
   explicit ConvTemplatePresenter(ConvTemplateBrowser *view, std::unique_ptr<ConvFunctionModel> functionModel);
   FunctionTemplateBrowser *browser() override { return reinterpret_cast<FunctionTemplateBrowser *>(m_view); }

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
@@ -70,10 +70,10 @@ public:
   void setErrorsEnabled(bool enabled) override;
 
   void handleEditLocalParameter(std::string const &parameterName) override;
+  void handleParameterValueChanged(std::string const &parameterName, double value) override;
 
 private slots:
   void editLocalParameterFinish(int result);
-  void viewChangedParameterValue(std::string const &parameterName, double value);
 
 private:
   void updateViewParameters();

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
@@ -71,9 +71,6 @@ public:
 
   void handleEditLocalParameter(std::string const &parameterName) override;
 
-signals:
-  void functionStructureChanged();
-
 private slots:
   void editLocalParameterFinish(int result);
   void viewChangedParameterValue(std::string const &parameterName, double value);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
@@ -71,9 +71,9 @@ public:
 
   void handleEditLocalParameter(std::string const &parameterName) override;
   void handleParameterValueChanged(std::string const &parameterName, double value) override;
-
-private slots:
-  void editLocalParameterFinish(int result);
+  void handleEditLocalParameterFinished(std::string const &parameterName, QList<double> const &values,
+                                        QList<bool> const &fixes, QStringList const &ties,
+                                        QStringList const &constraints) override;
 
 private:
   void updateViewParameters();
@@ -89,7 +89,6 @@ private:
   void updateViewParameterNames();
   ConvTemplateBrowser *m_view;
   std::unique_ptr<ConvFunctionModel> m_model;
-  EditLocalParameterDialog *m_editLocalParameterDialog;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
@@ -11,7 +11,6 @@
 #include "ITemplatePresenter.h"
 
 #include <QMap>
-#include <QWidget>
 
 class QtProperty;
 
@@ -29,8 +28,7 @@ class ConvTemplateBrowser;
  * and set properties that can be used to generate a fit function.
  *
  */
-class MANTIDQT_INELASTIC_DLL ConvTemplatePresenter : public QObject, public ITemplatePresenter {
-  Q_OBJECT
+class MANTIDQT_INELASTIC_DLL ConvTemplatePresenter : public ITemplatePresenter {
 public:
   explicit ConvTemplatePresenter(ConvTemplateBrowser *view, std::unique_ptr<ConvFunctionModel> functionModel);
   FunctionTemplateBrowser *browser() override { return reinterpret_cast<FunctionTemplateBrowser *>(m_view); }

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
@@ -33,9 +33,9 @@ public:
   explicit ConvTemplatePresenter(ConvTemplateBrowser *view, std::unique_ptr<ConvFunctionModel> functionModel);
   FunctionTemplateBrowser *browser() override { return reinterpret_cast<FunctionTemplateBrowser *>(m_view); }
 
-  void setSubType(size_t subTypeIndex, int typeIndex);
-  void setDeltaFunction(bool);
-  void setTempCorrection(bool);
+  void setSubType(size_t subTypeIndex, int typeIndex) override;
+  void setDeltaFunction(bool) override;
+  void setTempCorrection(bool) override;
 
   void setNumberOfDatasets(int) override;
   int getNumberOfDatasets() const override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
@@ -50,8 +50,8 @@ public:
   void setGlobalParameters(std::vector<std::string> const &globals) override;
   void setGlobal(std::string const &parameterName, bool on) override;
 
-  void updateMultiDatasetParameters(const IFunction &fun) override;
-  void updateMultiDatasetParameters(const ITableWorkspace &paramTable) override;
+  void updateMultiDatasetParameters(const Mantid::API::IFunction &fun) override;
+  void updateMultiDatasetParameters(const Mantid::API::ITableWorkspace &table) override;
   void updateParameters(const IFunction &fun) override;
 
   void setCurrentDataset(int i) override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
@@ -33,31 +33,41 @@ class MANTIDQT_INELASTIC_DLL ConvTemplatePresenter : public QObject, public ITem
   Q_OBJECT
 public:
   explicit ConvTemplatePresenter(ConvTemplateBrowser *view, std::unique_ptr<ConvFunctionModel> functionModel);
+  FunctionTemplateBrowser *browser() override { return reinterpret_cast<FunctionTemplateBrowser *>(m_view); }
+
   void setSubType(size_t subTypeIndex, int typeIndex);
   void setDeltaFunction(bool);
   void setTempCorrection(bool);
-  void setNumberOfDatasets(int);
-  int getNumberOfDatasets() const;
-  int getCurrentDataset();
-  void setFunction(std::string const &funStr);
-  IFunction_sptr getGlobalFunction() const;
-  IFunction_sptr getFunction() const;
-  std::vector<std::string> getGlobalParameters() const;
-  std::vector<std::string> getLocalParameters() const;
-  void setGlobalParameters(std::vector<std::string> const &globals);
-  void setGlobal(std::string const &parameterName, bool on);
-  void updateMultiDatasetParameters(const IFunction &fun);
-  void updateMultiDatasetParameters(const ITableWorkspace &paramTable);
-  void updateParameters(const IFunction &fun);
-  void setCurrentDataset(int i);
-  void setDatasets(const QList<FunctionModelDataset> &datasets);
-  void setErrorsEnabled(bool enabled);
-  void setResolution(const std::vector<std::pair<std::string, size_t>> &fitResolutions);
-  void setBackgroundA0(double value);
-  void setQValues(const std::vector<double> &qValues);
-  EstimationDataSelector getEstimationDataSelector() const;
-  void updateParameterEstimationData(DataForParameterEstimationCollection &&data);
-  void estimateFunctionParameters();
+
+  void setNumberOfDatasets(int) override;
+  int getNumberOfDatasets() const override;
+  int getCurrentDataset() override;
+
+  void setFunction(std::string const &funStr) override;
+  IFunction_sptr getGlobalFunction() const override;
+  IFunction_sptr getFunction() const override;
+
+  std::vector<std::string> getGlobalParameters() const override;
+  std::vector<std::string> getLocalParameters() const override;
+  void setGlobalParameters(std::vector<std::string> const &globals) override;
+  void setGlobal(std::string const &parameterName, bool on) override;
+
+  void updateMultiDatasetParameters(const IFunction &fun) override;
+  void updateMultiDatasetParameters(const ITableWorkspace &paramTable) override;
+  void updateParameters(const IFunction &fun) override;
+
+  void setCurrentDataset(int i) override;
+  void setDatasets(const QList<FunctionModelDataset> &datasets) override;
+
+  void setResolution(const std::vector<std::pair<std::string, size_t>> &fitResolutions) override;
+  void setBackgroundA0(double value) override;
+  void setQValues(const std::vector<double> &qValues) override;
+
+  EstimationDataSelector getEstimationDataSelector() const override;
+  void updateParameterEstimationData(DataForParameterEstimationCollection &&data) override;
+  void estimateFunctionParameters() override;
+
+  void setErrorsEnabled(bool enabled) override;
 
   void handleEditLocalParameter(std::string const &parameterName) override;
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ConvTemplatePresenter.h
@@ -8,6 +8,7 @@
 
 #include "ConvFunctionModel.h"
 #include "DllConfig.h"
+#include "ITemplatePresenter.h"
 
 #include <QMap>
 #include <QWidget>
@@ -28,7 +29,7 @@ class ConvTemplateBrowser;
  * and set properties that can be used to generate a fit function.
  *
  */
-class MANTIDQT_INELASTIC_DLL ConvTemplatePresenter : public QObject {
+class MANTIDQT_INELASTIC_DLL ConvTemplatePresenter : public QObject, public ITemplatePresenter {
   Q_OBJECT
 public:
   explicit ConvTemplatePresenter(ConvTemplateBrowser *view, std::unique_ptr<ConvFunctionModel> functionModel);
@@ -58,11 +59,12 @@ public:
   void updateParameterEstimationData(DataForParameterEstimationCollection &&data);
   void estimateFunctionParameters();
 
+  void handleEditLocalParameter(std::string const &parameterName) override;
+
 signals:
   void functionStructureChanged();
 
 private slots:
-  void editLocalParameter(std::string const &parameterName);
   void editLocalParameterFinish(int result);
   void viewChangedParameterValue(std::string const &parameterName, double value);
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/FunctionTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/FunctionTemplatePresenter.cpp
@@ -1,0 +1,55 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "FunctionTemplatePresenter.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace IDA {
+
+FunctionTemplatePresenter::FunctionTemplatePresenter() {}
+
+void FunctionTemplatePresenter::init() {}
+
+void FunctionTemplatePresenter::updateAvailableFunctions(
+    const std::map<std::string, std::string> &functionInitialisationStrings) {
+  (void)functionInitialisationStrings;
+}
+
+void FunctionTemplatePresenter::setFitType(std::string const &name) { (void)name; }
+
+void FunctionTemplatePresenter::updateMultiDatasetParameters(const Mantid::API::ITableWorkspace &table) { (void)table; }
+
+void FunctionTemplatePresenter::setNumberOfExponentials(int nExponentials) { (void)nExponentials; }
+
+void FunctionTemplatePresenter::setStretchExponential(bool on) { (void)on; }
+
+void FunctionTemplatePresenter::setBackground(std::string const &name) { (void)name; }
+
+void FunctionTemplatePresenter::tieIntensities(bool on) { (void)on; }
+
+bool FunctionTemplatePresenter::canTieIntensities() const { return true; }
+
+void FunctionTemplatePresenter::setSubType(std::size_t subTypeIndex, int typeIndex) {
+  (void)subTypeIndex;
+  (void)typeIndex;
+}
+
+void FunctionTemplatePresenter::setDeltaFunction(bool on) { (void)on; }
+
+void FunctionTemplatePresenter::setTempCorrection(bool on) { (void)on; }
+
+void FunctionTemplatePresenter::setBackgroundA0(double value) { (void)value; }
+
+void FunctionTemplatePresenter::setResolution(const std::vector<std::pair<std::string, size_t>> &fitResolutions) {
+  (void)fitResolutions;
+}
+
+void FunctionTemplatePresenter::setQValues(const std::vector<double> &qValues) { (void)qValues; }
+
+} // namespace IDA
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/FunctionTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/FunctionTemplatePresenter.h
@@ -1,0 +1,46 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllConfig.h"
+#include "ITemplatePresenter.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace IDA {
+
+class MANTIDQT_INELASTIC_DLL FunctionTemplatePresenter : public ITemplatePresenter {
+public:
+  FunctionTemplatePresenter();
+
+  virtual void init() override;
+  virtual void
+  updateAvailableFunctions(const std::map<std::string, std::string> &functionInitialisationStrings) override;
+
+  virtual void setFitType(std::string const &name) override;
+
+  virtual void updateMultiDatasetParameters(const Mantid::API::ITableWorkspace &table) override;
+
+  /// Used by IqtTemplatePresenter
+  virtual void setNumberOfExponentials(int nExponentials) override;
+  virtual void setStretchExponential(bool on) override;
+  virtual void setBackground(std::string const &name) override;
+  virtual void tieIntensities(bool on) override;
+  virtual bool canTieIntensities() const override;
+
+  /// Used by ConvTemplatePresenter
+  virtual void setSubType(std::size_t subTypeIndex, int typeIndex) override;
+  virtual void setDeltaFunction(bool on) override;
+  virtual void setTempCorrection(bool on) override;
+  virtual void setBackgroundA0(double value) override;
+  virtual void setResolution(const std::vector<std::pair<std::string, size_t>> &fitResolutions) override;
+  virtual void setQValues(const std::vector<double> &qValues) override;
+};
+
+} // namespace IDA
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/FunctionTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/FunctionTemplatePresenter.h
@@ -13,6 +13,8 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
+class FunctionTemplateBrowser;
+
 class MANTIDQT_INELASTIC_DLL FunctionTemplatePresenter : public ITemplatePresenter {
 public:
   FunctionTemplatePresenter();

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/FunctionTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/FunctionTemplatePresenter.h
@@ -17,6 +17,8 @@ class FunctionTemplateBrowser;
 
 class MANTIDQT_INELASTIC_DLL FunctionTemplatePresenter : public ITemplatePresenter {
 public:
+  using ITemplatePresenter::updateMultiDatasetParameters;
+
   FunctionTemplatePresenter();
 
   virtual void init() override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
@@ -27,20 +27,16 @@ class FunctionTemplateBrowser;
 
 class MANTIDQT_INELASTIC_DLL ITemplatePresenter {
 public:
-  virtual ~ITemplatePresenter() = default;
-
   virtual FunctionTemplateBrowser *browser() = 0;
 
-  virtual void init() {}
-  virtual void updateAvailableFunctions(const std::map<std::string, std::string> &functionInitialisationStrings) {
-    (void)functionInitialisationStrings;
-  }
+  virtual void init() = 0;
+  virtual void updateAvailableFunctions(const std::map<std::string, std::string> &functionInitialisationStrings) = 0;
 
   virtual void setNumberOfDatasets(int) = 0;
   virtual int getNumberOfDatasets() const = 0;
   virtual int getCurrentDataset() = 0;
 
-  virtual void setFitType(std::string const &name) { (void)name; }
+  virtual void setFitType(std::string const &name) = 0;
 
   virtual void setFunction(std::string const &funStr) = 0;
   virtual Mantid::API::IFunction_sptr getGlobalFunction() const = 0;
@@ -52,7 +48,7 @@ public:
   virtual void setGlobal(std::string const &parameterName, bool on) = 0;
 
   virtual void updateMultiDatasetParameters(const Mantid::API::IFunction &fun) = 0;
-  virtual void updateMultiDatasetParameters(const Mantid::API::ITableWorkspace &table) { (void)table; }
+  virtual void updateMultiDatasetParameters(const Mantid::API::ITableWorkspace &table) = 0;
   virtual void updateParameters(const Mantid::API::IFunction &fun) = 0;
 
   virtual void setCurrentDataset(int i) = 0;
@@ -64,23 +60,18 @@ public:
 
   virtual void setErrorsEnabled(bool enabled) = 0;
 
-  virtual void setNumberOfExponentials(int nExponentials) { (void)nExponentials; }
-  virtual void setStretchExponential(bool on) { (void)on; }
-  virtual void setBackground(std::string const &name) { (void)name; }
-  virtual void tieIntensities(bool on) { (void)on; }
-  virtual bool canTieIntensities() const { return true; }
+  virtual void setNumberOfExponentials(int nExponentials) = 0;
+  virtual void setStretchExponential(bool on) = 0;
+  virtual void setBackground(std::string const &name) = 0;
+  virtual void tieIntensities(bool on) = 0;
+  virtual bool canTieIntensities() const = 0;
 
-  virtual void setSubType(std::size_t subTypeIndex, int typeIndex) {
-    (void)subTypeIndex;
-    (void)typeIndex;
-  }
-  virtual void setDeltaFunction(bool on) { (void)on; }
-  virtual void setTempCorrection(bool on) { (void)on; }
-  virtual void setBackgroundA0(double value) { (void)value; }
-  virtual void setResolution(const std::vector<std::pair<std::string, size_t>> &fitResolutions) {
-    (void)fitResolutions;
-  }
-  virtual void setQValues(const std::vector<double> &qValues) { (void)qValues; }
+  virtual void setSubType(std::size_t subTypeIndex, int typeIndex) = 0;
+  virtual void setDeltaFunction(bool on) = 0;
+  virtual void setTempCorrection(bool on) = 0;
+  virtual void setBackgroundA0(double value) = 0;
+  virtual void setResolution(const std::vector<std::pair<std::string, size_t>> &fitResolutions) = 0;
+  virtual void setQValues(const std::vector<double> &qValues) = 0;
 
   virtual void handleEditLocalParameter(std::string const &parameterName) = 0;
   virtual void handleParameterValueChanged(std::string const &parameterName, double value) = 0;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
@@ -27,6 +27,8 @@ class FunctionTemplateBrowser;
 
 class MANTIDQT_INELASTIC_DLL ITemplatePresenter {
 public:
+  virtual ~ITemplatePresenter() = default;
+
   virtual FunctionTemplateBrowser *browser() = 0;
 
   virtual void init() = 0;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
@@ -6,9 +6,16 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "Analysis/ParameterEstimation.h"
 #include "DllConfig.h"
+#include "MantidAPI/IFunction_fwd.h"
+#include "MantidQtWidgets/Common/FunctionModelDataset.h"
 
+#include <map>
 #include <string>
+#include <vector>
+
+#include <QList>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -16,6 +23,34 @@ namespace IDA {
 
 class MANTIDQT_INELASTIC_DLL ITemplatePresenter {
 public:
+  virtual void init() = 0;
+  virtual void updateAvailableFunctions(const std::map<std::string, std::string> &functionInitialisationStrings) = 0;
+
+  virtual void setNumberOfDatasets(int) = 0;
+  virtual int getNumberOfDatasets() const = 0;
+  virtual int getCurrentDataset() = 0;
+
+  virtual void setFitType(std::string const &name) = 0;
+
+  virtual void setFunction(std::string const &funStr) = 0;
+  virtual IFunction_sptr getGlobalFunction() const = 0;
+  virtual IFunction_sptr getFunction() const = 0;
+
+  virtual std::vector<std::string> getGlobalParameters() const = 0;
+  virtual std::vector<std::string> getLocalParameters() const = 0;
+  virtual void setGlobalParameters(std::vector<std::string> const &globals) = 0;
+  virtual void setGlobal(std::string const &parameterName, bool on) = 0;
+
+  virtual void updateMultiDatasetParameters(const IFunction &fun) = 0;
+  virtual void updateParameters(const IFunction &fun) = 0;
+
+  virtual void setCurrentDataset(int i) = 0;
+  virtual void setDatasets(const QList<FunctionModelDataset> &datasets) = 0;
+
+  virtual EstimationDataSelector getEstimationDataSelector() const = 0;
+  virtual void updateParameterEstimationData(DataForParameterEstimationCollection &&data) = 0;
+  virtual void estimateFunctionParameters() = 0;
+
   virtual void handleEditLocalParameter(std::string const &parameterName) = 0;
 };
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
@@ -27,6 +27,8 @@ class FunctionTemplateBrowser;
 
 class MANTIDQT_INELASTIC_DLL ITemplatePresenter {
 public:
+  virtual ~ITemplatePresenter() = default;
+
   virtual FunctionTemplateBrowser *browser() = 0;
 
   virtual void init() {}

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
@@ -72,6 +72,9 @@ public:
 
   virtual void handleEditLocalParameter(std::string const &parameterName) = 0;
   virtual void handleParameterValueChanged(std::string const &parameterName, double value) = 0;
+  virtual void handleEditLocalParameterFinished(std::string const &parameterName, QList<double> const &values,
+                                                QList<bool> const &fixes, QStringList const &ties,
+                                                QStringList const &constraints) = 0;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
@@ -9,6 +9,7 @@
 #include "Analysis/ParameterEstimation.h"
 #include "DllConfig.h"
 #include "MantidAPI/IFunction.h"
+#include "MantidAPI/ITableWorkspace.h"
 #include "MantidQtWidgets/Common/FunctionModelDataset.h"
 
 #include <map>
@@ -16,21 +17,28 @@
 #include <vector>
 
 #include <QList>
+#include <QWidget>
 
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
+class FunctionTemplateBrowser;
+
 class MANTIDQT_INELASTIC_DLL ITemplatePresenter {
 public:
-  virtual void init() = 0;
-  virtual void updateAvailableFunctions(const std::map<std::string, std::string> &functionInitialisationStrings) = 0;
+  virtual FunctionTemplateBrowser *browser() = 0;
+
+  virtual void init() {}
+  virtual void updateAvailableFunctions(const std::map<std::string, std::string> &functionInitialisationStrings) {
+    (void)functionInitialisationStrings;
+  }
 
   virtual void setNumberOfDatasets(int) = 0;
   virtual int getNumberOfDatasets() const = 0;
   virtual int getCurrentDataset() = 0;
 
-  virtual void setFitType(std::string const &name) = 0;
+  virtual void setFitType(std::string const &name) { (void)name; }
 
   virtual void setFunction(std::string const &funStr) = 0;
   virtual Mantid::API::IFunction_sptr getGlobalFunction() const = 0;
@@ -42,6 +50,7 @@ public:
   virtual void setGlobal(std::string const &parameterName, bool on) = 0;
 
   virtual void updateMultiDatasetParameters(const Mantid::API::IFunction &fun) = 0;
+  virtual void updateMultiDatasetParameters(const Mantid::API::ITableWorkspace &table) { (void)table; }
   virtual void updateParameters(const Mantid::API::IFunction &fun) = 0;
 
   virtual void setCurrentDataset(int i) = 0;
@@ -50,6 +59,14 @@ public:
   virtual EstimationDataSelector getEstimationDataSelector() const = 0;
   virtual void updateParameterEstimationData(DataForParameterEstimationCollection &&data) = 0;
   virtual void estimateFunctionParameters() = 0;
+
+  virtual void setErrorsEnabled(bool enabled) = 0;
+
+  virtual void setBackgroundA0(double value) { (void)value; }
+  virtual void setResolution(const std::vector<std::pair<std::string, size_t>> &fitResolutions) {
+    (void)fitResolutions;
+  }
+  virtual void setQValues(const std::vector<double> &qValues) { (void)qValues; }
 
   virtual void handleEditLocalParameter(std::string const &parameterName) = 0;
 };

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
@@ -1,0 +1,24 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllConfig.h"
+
+#include <string>
+
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace IDA {
+
+class MANTIDQT_INELASTIC_DLL ITemplatePresenter {
+public:
+  virtual void handleEditLocalParameter(std::string const &parameterName) = 0;
+};
+
+} // namespace IDA
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
@@ -64,6 +64,18 @@ public:
 
   virtual void setErrorsEnabled(bool enabled) = 0;
 
+  virtual void setNumberOfExponentials(int nExponentials) { (void)nExponentials; }
+  virtual void setStretchExponential(bool on) { (void)on; }
+  virtual void setBackground(std::string const &name) { (void)name; }
+  virtual void tieIntensities(bool on) { (void)on; }
+  virtual bool canTieIntensities() const { return true; }
+
+  virtual void setSubType(std::size_t subTypeIndex, int typeIndex) {
+    (void)subTypeIndex;
+    (void)typeIndex;
+  }
+  virtual void setDeltaFunction(bool on) { (void)on; }
+  virtual void setTempCorrection(bool on) { (void)on; }
   virtual void setBackgroundA0(double value) { (void)value; }
   virtual void setResolution(const std::vector<std::pair<std::string, size_t>> &fitResolutions) {
     (void)fitResolutions;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
@@ -8,7 +8,7 @@
 
 #include "Analysis/ParameterEstimation.h"
 #include "DllConfig.h"
-#include "MantidAPI/IFunction_fwd.h"
+#include "MantidAPI/IFunction.h"
 #include "MantidQtWidgets/Common/FunctionModelDataset.h"
 
 #include <map>
@@ -33,19 +33,19 @@ public:
   virtual void setFitType(std::string const &name) = 0;
 
   virtual void setFunction(std::string const &funStr) = 0;
-  virtual IFunction_sptr getGlobalFunction() const = 0;
-  virtual IFunction_sptr getFunction() const = 0;
+  virtual Mantid::API::IFunction_sptr getGlobalFunction() const = 0;
+  virtual Mantid::API::IFunction_sptr getFunction() const = 0;
 
   virtual std::vector<std::string> getGlobalParameters() const = 0;
   virtual std::vector<std::string> getLocalParameters() const = 0;
   virtual void setGlobalParameters(std::vector<std::string> const &globals) = 0;
   virtual void setGlobal(std::string const &parameterName, bool on) = 0;
 
-  virtual void updateMultiDatasetParameters(const IFunction &fun) = 0;
-  virtual void updateParameters(const IFunction &fun) = 0;
+  virtual void updateMultiDatasetParameters(const Mantid::API::IFunction &fun) = 0;
+  virtual void updateParameters(const Mantid::API::IFunction &fun) = 0;
 
   virtual void setCurrentDataset(int i) = 0;
-  virtual void setDatasets(const QList<FunctionModelDataset> &datasets) = 0;
+  virtual void setDatasets(const QList<MantidQt::MantidWidgets::FunctionModelDataset> &datasets) = 0;
 
   virtual EstimationDataSelector getEstimationDataSelector() const = 0;
   virtual void updateParameterEstimationData(DataForParameterEstimationCollection &&data) = 0;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/ITemplatePresenter.h
@@ -71,6 +71,7 @@ public:
   virtual void setQValues(const std::vector<double> &qValues) { (void)qValues; }
 
   virtual void handleEditLocalParameter(std::string const &parameterName) = 0;
+  virtual void handleParameterValueChanged(std::string const &parameterName, double value) = 0;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
@@ -224,7 +224,7 @@ void IqtTemplateBrowser::parameterChanged(QtProperty *prop) {
   auto isGlobal = m_parameterManager->isGlobal(prop);
   m_presenter->setGlobal(m_parameterNames[prop], isGlobal);
   if (m_emitParameterValueChange) {
-    emit parameterValueChanged(m_parameterNames[prop], m_parameterManager->value(prop));
+    m_presenter->handleParameterValueChanged(m_parameterNames[prop], m_parameterManager->value(prop));
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
@@ -184,26 +184,20 @@ void IqtTemplateBrowser::setStretchStretching(double value, double error) {
 void IqtTemplateBrowser::setA0(double value, double error) { setParameterPropertyValue(m_A0, value, error); }
 
 void IqtTemplateBrowser::intChanged(QtProperty *prop) {
-  if (prop != m_numberOfExponentials || !m_emitIntChange) {
-    return;
-  }
-  if (auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter)) {
-    presenter->setNumberOfExponentials(m_intManager->value(prop));
+  if (prop == m_numberOfExponentials && m_emitIntChange) {
+    m_presenter->setNumberOfExponentials(m_intManager->value(prop));
   }
 }
 
 void IqtTemplateBrowser::boolChanged(QtProperty *prop) {
   if (!m_emitBoolChange)
     return;
-  auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter);
-  if (!presenter)
-    return;
   auto const on = m_boolManager->value(prop);
   if (prop == m_stretchExponential) {
-    presenter->setStretchExponential(on);
+    m_presenter->setStretchExponential(on);
   }
   if (prop == m_tieIntensities) {
-    presenter->tieIntensities(on);
+    m_presenter->tieIntensities(on);
   }
 }
 
@@ -212,9 +206,7 @@ void IqtTemplateBrowser::enumChanged(QtProperty *prop) {
     return;
   if (prop == m_background) {
     auto background = m_enumManager->enumNames(prop)[m_enumManager->value(prop)];
-    if (auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter)) {
-      presenter->setBackground(background.toStdString());
-    }
+    m_presenter->setBackground(background.toStdString());
   }
 }
 
@@ -317,10 +309,7 @@ void IqtTemplateBrowser::setTieIntensitiesQuiet(bool on) {
 }
 
 void IqtTemplateBrowser::updateState() {
-  auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter);
-  if (!presenter)
-    return;
-  auto const on = presenter->canTieIntensities();
+  auto const on = m_presenter->canTieIntensities();
   if (!on && m_boolManager->value(m_tieIntensities)) {
     ScopedFalse _false(m_emitBoolChange);
     m_boolManager->setValue(m_tieIntensities, false);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
@@ -240,14 +240,10 @@ void IqtTemplateBrowser::globalChanged(QtProperty *, const QString &, bool) {}
 
 void IqtTemplateBrowser::parameterChanged(QtProperty *prop) {
   auto isGlobal = m_parameterManager->isGlobal(prop);
-  m_presenter.setGlobal(m_actualParameterNames[prop], isGlobal);
+  m_presenter.setGlobal(m_parameterNames[prop], isGlobal);
   if (m_emitParameterValueChange) {
-    emit parameterValueChanged(m_actualParameterNames[prop], m_parameterManager->value(prop));
+    emit parameterValueChanged(m_parameterNames[prop], m_parameterManager->value(prop));
   }
-}
-
-void IqtTemplateBrowser::parameterButtonClicked(QtProperty *prop) {
-  emit localParameterButtonClicked(m_actualParameterNames[prop]);
 }
 
 void IqtTemplateBrowser::updateMultiDatasetParameters(const IFunction &fun) {
@@ -265,12 +261,12 @@ void IqtTemplateBrowser::setCurrentDataset(int i) { m_presenter.setCurrentDatase
 int IqtTemplateBrowser::getCurrentDataset() { return m_presenter.getCurrentDataset(); }
 
 void IqtTemplateBrowser::updateParameterNames(const QMap<int, std::string> &parameterNames) {
-  m_actualParameterNames.clear();
+  m_parameterNames.clear();
   ScopedFalse _false(m_emitParameterValueChange);
   for (auto const prop : m_parameterMap.keys()) {
     auto const i = m_parameterMap[prop];
     auto const name = parameterNames[i];
-    m_actualParameterNames[prop] = name;
+    m_parameterNames[prop] = name;
     if (!name.empty()) {
       prop->setPropertyName(QString::fromStdString(name));
     }
@@ -327,7 +323,7 @@ void IqtTemplateBrowser::setGlobalParametersQuiet(std::vector<std::string> const
   ScopedFalse _false(m_emitParameterValueChange);
   auto parameterProperies = m_parameterMap.keys();
   for (auto const prop : m_parameterMap.keys()) {
-    auto const name = m_actualParameterNames[prop];
+    auto const name = m_parameterNames[prop];
     auto const findIter = std::find(globals.cbegin(), globals.cend(), name);
     if (findIter != globals.cend()) {
       m_parameterManager->setGlobal(prop, true);
@@ -335,7 +331,7 @@ void IqtTemplateBrowser::setGlobalParametersQuiet(std::vector<std::string> const
     }
   }
   for (auto const prop : parameterProperies) {
-    if (!m_actualParameterNames[prop].empty()) {
+    if (!m_parameterNames[prop].empty()) {
       m_parameterManager->setGlobal(prop, false);
     }
   }

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
@@ -68,7 +68,9 @@ void IqtTemplateBrowser::createProperties() {
   m_parameterMap[m_stretchExpStretching] = 6;
   m_parameterMap[m_A0] = 7;
 
-  m_presenter->setViewParameterDescriptions();
+  if (auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter)) {
+    presenter->setViewParameterDescriptions();
+  }
 
   m_parameterManager->setDescription(m_exp1Height, m_parameterDescriptions[m_exp1Height]);
   m_parameterManager->setDescription(m_exp1Lifetime, m_parameterDescriptions[m_exp1Lifetime]);
@@ -188,43 +190,27 @@ void IqtTemplateBrowser::setStretchStretching(double value, double error) {
 
 void IqtTemplateBrowser::setA0(double value, double error) { setParameterPropertyValue(m_A0, value, error); }
 
-void IqtTemplateBrowser::setFunction(std::string const &funStr) { m_presenter->setFunction(funStr); }
-
-IFunction_sptr IqtTemplateBrowser::getGlobalFunction() const { return m_presenter->getGlobalFunction(); }
-
-IFunction_sptr IqtTemplateBrowser::getFunction() const { return m_presenter->getFunction(); }
-
-void IqtTemplateBrowser::setNumberOfDatasets(int n) { m_presenter->setNumberOfDatasets(n); }
-
-int IqtTemplateBrowser::getNumberOfDatasets() const { return m_presenter->getNumberOfDatasets(); }
-
-void IqtTemplateBrowser::setDatasets(const QList<FunctionModelDataset> &datasets) {
-  m_presenter->setDatasets(datasets);
-}
-
-std::vector<std::string> IqtTemplateBrowser::getGlobalParameters() const { return m_presenter->getGlobalParameters(); }
-
-std::vector<std::string> IqtTemplateBrowser::getLocalParameters() const { return m_presenter->getLocalParameters(); }
-
-void IqtTemplateBrowser::setGlobalParameters(std::vector<std::string> const &globals) {
-  m_presenter->setGlobalParameters(globals);
-}
-
 void IqtTemplateBrowser::intChanged(QtProperty *prop) {
-  if (prop == m_numberOfExponentials && m_emitIntChange) {
-    m_presenter->setNumberOfExponentials(m_intManager->value(prop));
+  if (prop != m_numberOfExponentials || !m_emitIntChange) {
+    return;
+  }
+  if (auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter)) {
+    presenter->setNumberOfExponentials(m_intManager->value(prop));
   }
 }
 
 void IqtTemplateBrowser::boolChanged(QtProperty *prop) {
   if (!m_emitBoolChange)
     return;
+  auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter);
+  if (!presenter)
+    return;
   auto const on = m_boolManager->value(prop);
   if (prop == m_stretchExponential) {
-    m_presenter->setStretchExponential(on);
+    presenter->setStretchExponential(on);
   }
   if (prop == m_tieIntensities) {
-    m_presenter->tieIntensities(on);
+    presenter->tieIntensities(on);
   }
 }
 
@@ -233,7 +219,9 @@ void IqtTemplateBrowser::enumChanged(QtProperty *prop) {
     return;
   if (prop == m_background) {
     auto background = m_enumManager->enumNames(prop)[m_enumManager->value(prop)];
-    m_presenter->setBackground(background.toStdString());
+    if (auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter)) {
+      presenter->setBackground(background.toStdString());
+    }
   }
 }
 
@@ -247,19 +235,13 @@ void IqtTemplateBrowser::parameterChanged(QtProperty *prop) {
   }
 }
 
-void IqtTemplateBrowser::updateMultiDatasetParameters(const IFunction &fun) {
-  m_presenter->updateMultiDatasetParameters(fun);
-}
-
 void IqtTemplateBrowser::updateMultiDatasetParameters(const ITableWorkspace &paramTable) {
-  m_presenter->updateMultiDatasetParameters(paramTable);
+  if (auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter)) {
+    presenter->updateMultiDatasetParameters(paramTable);
+  }
 }
 
 void IqtTemplateBrowser::updateParameters(const IFunction &fun) { m_presenter->updateParameters(fun); }
-
-void IqtTemplateBrowser::setCurrentDataset(int i) { m_presenter->setCurrentDataset(i); }
-
-int IqtTemplateBrowser::getCurrentDataset() { return m_presenter->getCurrentDataset(); }
 
 void IqtTemplateBrowser::updateParameterNames(const QMap<int, std::string> &parameterNames) {
   m_parameterNames.clear();
@@ -304,7 +286,11 @@ void IqtTemplateBrowser::updateParameterEstimationData(DataForParameterEstimatio
 
 void IqtTemplateBrowser::estimateFunctionParameters() { m_presenter->estimateFunctionParameters(); }
 
-void IqtTemplateBrowser::setBackgroundA0(double value) { m_presenter->setBackgroundA0(value); }
+void IqtTemplateBrowser::setBackgroundA0(double value) {
+  if (auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter)) {
+    presenter->setBackgroundA0(value);
+  }
+}
 
 void IqtTemplateBrowser::popupMenu(const QPoint &) {}
 
@@ -344,7 +330,10 @@ void IqtTemplateBrowser::setTieIntensitiesQuiet(bool on) {
 }
 
 void IqtTemplateBrowser::updateState() {
-  auto const on = m_presenter->canTieIntensities();
+  auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter);
+  if (!presenter)
+    return;
+  auto const on = presenter->canTieIntensities();
   if (!on && m_boolManager->value(m_tieIntensities)) {
     ScopedFalse _false(m_emitBoolChange);
     m_boolManager->setValue(m_tieIntensities, false);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
@@ -36,6 +36,7 @@ namespace MantidQt::CustomInterfaces::IDA {
  */
 IqtTemplateBrowser::IqtTemplateBrowser(QWidget *parent) : FunctionTemplateBrowser(parent) {
   // connect(&m_presenter, SIGNAL(functionStructureChanged()), this, SIGNAL(functionStructureChanged()));
+  init();
 }
 
 void IqtTemplateBrowser::createProperties() {
@@ -68,10 +69,6 @@ void IqtTemplateBrowser::createProperties() {
   m_parameterMap[m_stretchExpStretching] = 6;
   m_parameterMap[m_A0] = 7;
 
-  if (auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter)) {
-    presenter->setViewParameterDescriptions();
-  }
-
   m_parameterManager->setDescription(m_exp1Height, m_parameterDescriptions[m_exp1Height]);
   m_parameterManager->setDescription(m_exp1Lifetime, m_parameterDescriptions[m_exp1Lifetime]);
   m_parameterManager->setDescription(m_exp2Height, m_parameterDescriptions[m_exp2Height]);
@@ -101,7 +98,6 @@ void IqtTemplateBrowser::createProperties() {
   m_parameterManager->blockSignals(false);
   m_enumManager->blockSignals(false);
   m_boolManager->blockSignals(false);
-  updateState();
 }
 
 void IqtTemplateBrowser::addExponentialOne() {
@@ -236,9 +232,7 @@ void IqtTemplateBrowser::parameterChanged(QtProperty *prop) {
 }
 
 void IqtTemplateBrowser::updateMultiDatasetParameters(const ITableWorkspace &paramTable) {
-  if (auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter)) {
-    presenter->updateMultiDatasetParameters(paramTable);
-  }
+  m_presenter->updateMultiDatasetParameters(paramTable);
 }
 
 void IqtTemplateBrowser::updateParameters(const IFunction &fun) { m_presenter->updateParameters(fun); }
@@ -286,11 +280,7 @@ void IqtTemplateBrowser::updateParameterEstimationData(DataForParameterEstimatio
 
 void IqtTemplateBrowser::estimateFunctionParameters() { m_presenter->estimateFunctionParameters(); }
 
-void IqtTemplateBrowser::setBackgroundA0(double value) {
-  if (auto presenter = dynamic_cast<IqtTemplatePresenter *>(m_presenter)) {
-    presenter->setBackgroundA0(value);
-  }
-}
+void IqtTemplateBrowser::setBackgroundA0(double value) { m_presenter->setBackgroundA0(value); }
 
 void IqtTemplateBrowser::popupMenu(const QPoint &) {}
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
@@ -100,88 +100,76 @@ void IqtTemplateBrowser::createProperties() {
 void IqtTemplateBrowser::addExponentialOne() {
   m_numberOfExponentials->addSubProperty(m_exp1Height);
   m_numberOfExponentials->addSubProperty(m_exp1Lifetime);
-  ScopedFalse _false(m_emitIntChange);
-  m_intManager->setValue(m_numberOfExponentials, 1);
+  setIntSilent(m_numberOfExponentials, 1);
 }
 
 void IqtTemplateBrowser::removeExponentialOne() {
   m_numberOfExponentials->removeSubProperty(m_exp1Height);
   m_numberOfExponentials->removeSubProperty(m_exp1Lifetime);
-  ScopedFalse _false(m_emitIntChange);
-  m_intManager->setValue(m_numberOfExponentials, 0);
+  setIntSilent(m_numberOfExponentials, 0);
 }
 
 void IqtTemplateBrowser::addExponentialTwo() {
   m_numberOfExponentials->addSubProperty(m_exp2Height);
   m_numberOfExponentials->addSubProperty(m_exp2Lifetime);
-  ScopedFalse _false(m_emitIntChange);
-  m_intManager->setValue(m_numberOfExponentials, 2);
+  setIntSilent(m_numberOfExponentials, 2);
 }
 
 void IqtTemplateBrowser::removeExponentialTwo() {
   m_numberOfExponentials->removeSubProperty(m_exp2Height);
   m_numberOfExponentials->removeSubProperty(m_exp2Lifetime);
-  ScopedFalse _false(m_emitIntChange);
-  m_intManager->setValue(m_numberOfExponentials, 1);
+  setIntSilent(m_numberOfExponentials, 1);
 }
 
 void IqtTemplateBrowser::addStretchExponential() {
   m_stretchExponential->addSubProperty(m_stretchExpHeight);
   m_stretchExponential->addSubProperty(m_stretchExpLifetime);
   m_stretchExponential->addSubProperty(m_stretchExpStretching);
-  ScopedFalse _false(m_emitBoolChange);
-  m_boolManager->setValue(m_stretchExponential, true);
+  setBoolSilent(m_stretchExponential, true);
 }
 
 void IqtTemplateBrowser::removeStretchExponential() {
   m_stretchExponential->removeSubProperty(m_stretchExpHeight);
   m_stretchExponential->removeSubProperty(m_stretchExpLifetime);
   m_stretchExponential->removeSubProperty(m_stretchExpStretching);
-  ScopedFalse _false(m_emitBoolChange);
-  m_boolManager->setValue(m_stretchExponential, false);
+  setBoolSilent(m_stretchExponential, false);
 }
 
 void IqtTemplateBrowser::addFlatBackground() {
   m_background->addSubProperty(m_A0);
-  ScopedFalse _false(m_emitEnumChange);
-  m_enumManager->setValue(m_background, 1);
+  setEnumSilent(m_background, 1);
 }
 
 void IqtTemplateBrowser::removeBackground() {
   m_background->removeSubProperty(m_A0);
-  ScopedFalse _false(m_emitEnumChange);
-  m_enumManager->setValue(m_background, 0);
+  setEnumSilent(m_background, 0);
 }
 
-void IqtTemplateBrowser::setExp1Height(double value, double error) {
-  setParameterPropertyValue(m_exp1Height, value, error);
-}
+void IqtTemplateBrowser::setExp1Height(double value, double error) { setParameterSilent(m_exp1Height, value, error); }
 
 void IqtTemplateBrowser::setExp1Lifetime(double value, double error) {
-  setParameterPropertyValue(m_exp1Lifetime, value, error);
+  setParameterSilent(m_exp1Lifetime, value, error);
 }
 
-void IqtTemplateBrowser::setExp2Height(double value, double error) {
-  setParameterPropertyValue(m_exp2Height, value, error);
-}
+void IqtTemplateBrowser::setExp2Height(double value, double error) { setParameterSilent(m_exp2Height, value, error); }
 
 void IqtTemplateBrowser::setExp2Lifetime(double value, double error) {
-  setParameterPropertyValue(m_exp2Lifetime, value, error);
+  setParameterSilent(m_exp2Lifetime, value, error);
 }
 
 void IqtTemplateBrowser::setStretchHeight(double value, double error) {
-  setParameterPropertyValue(m_stretchExpHeight, value, error);
+  setParameterSilent(m_stretchExpHeight, value, error);
 }
 
 void IqtTemplateBrowser::setStretchLifetime(double value, double error) {
-  setParameterPropertyValue(m_stretchExpLifetime, value, error);
+  setParameterSilent(m_stretchExpLifetime, value, error);
 }
 
 void IqtTemplateBrowser::setStretchStretching(double value, double error) {
-  setParameterPropertyValue(m_stretchExpStretching, value, error);
+  setParameterSilent(m_stretchExpStretching, value, error);
 }
 
-void IqtTemplateBrowser::setA0(double value, double error) { setParameterPropertyValue(m_A0, value, error); }
+void IqtTemplateBrowser::setA0(double value, double error) { setParameterSilent(m_A0, value, error); }
 
 void IqtTemplateBrowser::intChanged(QtProperty *prop) {
   if (prop == m_numberOfExponentials && m_emitIntChange) {
@@ -227,8 +215,8 @@ void IqtTemplateBrowser::updateMultiDatasetParameters(const ITableWorkspace &par
 void IqtTemplateBrowser::updateParameters(const IFunction &fun) { m_presenter->updateParameters(fun); }
 
 void IqtTemplateBrowser::updateParameterNames(const QMap<int, std::string> &parameterNames) {
+  MantidQt::MantidWidgets::ScopedFalse _parameterBlock(m_emitParameterValueChange);
   m_parameterNames.clear();
-  ScopedFalse _false(m_emitParameterValueChange);
   for (auto const prop : m_parameterMap.keys()) {
     auto const i = m_parameterMap[prop];
     auto const name = parameterNames[i];
@@ -245,11 +233,6 @@ void IqtTemplateBrowser::updateParameterDescriptions(const QMap<int, std::string
     auto const i = m_parameterMap[prop];
     m_parameterDescriptions[prop] = parameterDescriptions[i];
   }
-}
-
-void IqtTemplateBrowser::setErrorsEnabled(bool enabled) {
-  ScopedFalse _false(m_emitParameterValueChange);
-  m_parameterManager->setErrorsEnabled(enabled);
 }
 
 void IqtTemplateBrowser::clear() {
@@ -277,16 +260,8 @@ double IqtTemplateBrowser::getParameterPropertyValue(QtProperty *prop) const {
   return prop ? m_parameterManager->value(prop) : 0.0;
 }
 
-void IqtTemplateBrowser::setParameterPropertyValue(QtProperty *prop, double value, double error) {
-  if (prop) {
-    ScopedFalse _false(m_emitParameterValueChange);
-    m_parameterManager->setValue(prop, value);
-    m_parameterManager->setError(prop, error);
-  }
-}
-
 void IqtTemplateBrowser::setGlobalParametersQuiet(std::vector<std::string> const &globals) {
-  ScopedFalse _false(m_emitParameterValueChange);
+  MantidQt::MantidWidgets::ScopedFalse _paramBlock(m_emitParameterValueChange);
   auto parameterProperies = m_parameterMap.keys();
   for (auto const prop : m_parameterMap.keys()) {
     auto const name = m_parameterNames[prop];
@@ -303,16 +278,12 @@ void IqtTemplateBrowser::setGlobalParametersQuiet(std::vector<std::string> const
   }
 }
 
-void IqtTemplateBrowser::setTieIntensitiesQuiet(bool on) {
-  ScopedFalse _false(m_emitBoolChange);
-  m_boolManager->setValue(m_tieIntensities, on);
-}
+void IqtTemplateBrowser::setTieIntensitiesQuiet(bool on) { setBoolSilent(m_tieIntensities, on); }
 
 void IqtTemplateBrowser::updateState() {
   auto const on = m_presenter->canTieIntensities();
   if (!on && m_boolManager->value(m_tieIntensities)) {
-    ScopedFalse _false(m_emitBoolChange);
-    m_boolManager->setValue(m_tieIntensities, false);
+    setBoolSilent(m_tieIntensities, false);
   }
   m_tieIntensities->setEnabled(on);
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
@@ -34,10 +34,7 @@ namespace MantidQt::CustomInterfaces::IDA {
  * Constructor
  * @param parent :: The parent widget.
  */
-IqtTemplateBrowser::IqtTemplateBrowser(QWidget *parent) : FunctionTemplateBrowser(parent) {
-  // connect(&m_presenter, SIGNAL(functionStructureChanged()), this, SIGNAL(functionStructureChanged()));
-  init();
-}
+IqtTemplateBrowser::IqtTemplateBrowser(QWidget *parent) : FunctionTemplateBrowser(parent) { init(); }
 
 void IqtTemplateBrowser::createProperties() {
   m_parameterManager->blockSignals(true);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
@@ -34,9 +34,8 @@ namespace MantidQt::CustomInterfaces::IDA {
  * Constructor
  * @param parent :: The parent widget.
  */
-IqtTemplateBrowser::IqtTemplateBrowser(std::unique_ptr<IqtFunctionModel> functionModel, QWidget *parent)
-    : FunctionTemplateBrowser(parent), m_presenter(this, std::move(functionModel)) {
-  connect(&m_presenter, SIGNAL(functionStructureChanged()), this, SIGNAL(functionStructureChanged()));
+IqtTemplateBrowser::IqtTemplateBrowser(QWidget *parent) : FunctionTemplateBrowser(parent) {
+  // connect(&m_presenter, SIGNAL(functionStructureChanged()), this, SIGNAL(functionStructureChanged()));
 }
 
 void IqtTemplateBrowser::createProperties() {
@@ -69,7 +68,7 @@ void IqtTemplateBrowser::createProperties() {
   m_parameterMap[m_stretchExpStretching] = 6;
   m_parameterMap[m_A0] = 7;
 
-  m_presenter.setViewParameterDescriptions();
+  m_presenter->setViewParameterDescriptions();
 
   m_parameterManager->setDescription(m_exp1Height, m_parameterDescriptions[m_exp1Height]);
   m_parameterManager->setDescription(m_exp1Lifetime, m_parameterDescriptions[m_exp1Lifetime]);
@@ -189,29 +188,31 @@ void IqtTemplateBrowser::setStretchStretching(double value, double error) {
 
 void IqtTemplateBrowser::setA0(double value, double error) { setParameterPropertyValue(m_A0, value, error); }
 
-void IqtTemplateBrowser::setFunction(std::string const &funStr) { m_presenter.setFunction(funStr); }
+void IqtTemplateBrowser::setFunction(std::string const &funStr) { m_presenter->setFunction(funStr); }
 
-IFunction_sptr IqtTemplateBrowser::getGlobalFunction() const { return m_presenter.getGlobalFunction(); }
+IFunction_sptr IqtTemplateBrowser::getGlobalFunction() const { return m_presenter->getGlobalFunction(); }
 
-IFunction_sptr IqtTemplateBrowser::getFunction() const { return m_presenter.getFunction(); }
+IFunction_sptr IqtTemplateBrowser::getFunction() const { return m_presenter->getFunction(); }
 
-void IqtTemplateBrowser::setNumberOfDatasets(int n) { m_presenter.setNumberOfDatasets(n); }
+void IqtTemplateBrowser::setNumberOfDatasets(int n) { m_presenter->setNumberOfDatasets(n); }
 
-int IqtTemplateBrowser::getNumberOfDatasets() const { return m_presenter.getNumberOfDatasets(); }
+int IqtTemplateBrowser::getNumberOfDatasets() const { return m_presenter->getNumberOfDatasets(); }
 
-void IqtTemplateBrowser::setDatasets(const QList<FunctionModelDataset> &datasets) { m_presenter.setDatasets(datasets); }
+void IqtTemplateBrowser::setDatasets(const QList<FunctionModelDataset> &datasets) {
+  m_presenter->setDatasets(datasets);
+}
 
-std::vector<std::string> IqtTemplateBrowser::getGlobalParameters() const { return m_presenter.getGlobalParameters(); }
+std::vector<std::string> IqtTemplateBrowser::getGlobalParameters() const { return m_presenter->getGlobalParameters(); }
 
-std::vector<std::string> IqtTemplateBrowser::getLocalParameters() const { return m_presenter.getLocalParameters(); }
+std::vector<std::string> IqtTemplateBrowser::getLocalParameters() const { return m_presenter->getLocalParameters(); }
 
 void IqtTemplateBrowser::setGlobalParameters(std::vector<std::string> const &globals) {
-  m_presenter.setGlobalParameters(globals);
+  m_presenter->setGlobalParameters(globals);
 }
 
 void IqtTemplateBrowser::intChanged(QtProperty *prop) {
   if (prop == m_numberOfExponentials && m_emitIntChange) {
-    m_presenter.setNumberOfExponentials(m_intManager->value(prop));
+    m_presenter->setNumberOfExponentials(m_intManager->value(prop));
   }
 }
 
@@ -220,10 +221,10 @@ void IqtTemplateBrowser::boolChanged(QtProperty *prop) {
     return;
   auto const on = m_boolManager->value(prop);
   if (prop == m_stretchExponential) {
-    m_presenter.setStretchExponential(on);
+    m_presenter->setStretchExponential(on);
   }
   if (prop == m_tieIntensities) {
-    m_presenter.tieIntensities(on);
+    m_presenter->tieIntensities(on);
   }
 }
 
@@ -232,7 +233,7 @@ void IqtTemplateBrowser::enumChanged(QtProperty *prop) {
     return;
   if (prop == m_background) {
     auto background = m_enumManager->enumNames(prop)[m_enumManager->value(prop)];
-    m_presenter.setBackground(background.toStdString());
+    m_presenter->setBackground(background.toStdString());
   }
 }
 
@@ -240,25 +241,25 @@ void IqtTemplateBrowser::globalChanged(QtProperty *, const QString &, bool) {}
 
 void IqtTemplateBrowser::parameterChanged(QtProperty *prop) {
   auto isGlobal = m_parameterManager->isGlobal(prop);
-  m_presenter.setGlobal(m_parameterNames[prop], isGlobal);
+  m_presenter->setGlobal(m_parameterNames[prop], isGlobal);
   if (m_emitParameterValueChange) {
     emit parameterValueChanged(m_parameterNames[prop], m_parameterManager->value(prop));
   }
 }
 
 void IqtTemplateBrowser::updateMultiDatasetParameters(const IFunction &fun) {
-  m_presenter.updateMultiDatasetParameters(fun);
+  m_presenter->updateMultiDatasetParameters(fun);
 }
 
 void IqtTemplateBrowser::updateMultiDatasetParameters(const ITableWorkspace &paramTable) {
-  m_presenter.updateMultiDatasetParameters(paramTable);
+  m_presenter->updateMultiDatasetParameters(paramTable);
 }
 
-void IqtTemplateBrowser::updateParameters(const IFunction &fun) { m_presenter.updateParameters(fun); }
+void IqtTemplateBrowser::updateParameters(const IFunction &fun) { m_presenter->updateParameters(fun); }
 
-void IqtTemplateBrowser::setCurrentDataset(int i) { m_presenter.setCurrentDataset(i); }
+void IqtTemplateBrowser::setCurrentDataset(int i) { m_presenter->setCurrentDataset(i); }
 
-int IqtTemplateBrowser::getCurrentDataset() { return m_presenter.getCurrentDataset(); }
+int IqtTemplateBrowser::getCurrentDataset() { return m_presenter->getCurrentDataset(); }
 
 void IqtTemplateBrowser::updateParameterNames(const QMap<int, std::string> &parameterNames) {
   m_parameterNames.clear();
@@ -294,16 +295,16 @@ void IqtTemplateBrowser::clear() {
 }
 
 EstimationDataSelector IqtTemplateBrowser::getEstimationDataSelector() const {
-  return m_presenter.getEstimationDataSelector();
+  return m_presenter->getEstimationDataSelector();
 }
 
 void IqtTemplateBrowser::updateParameterEstimationData(DataForParameterEstimationCollection &&data) {
-  m_presenter.updateParameterEstimationData(std::move(data));
+  m_presenter->updateParameterEstimationData(std::move(data));
 }
 
-void IqtTemplateBrowser::estimateFunctionParameters() { m_presenter.estimateFunctionParameters(); }
+void IqtTemplateBrowser::estimateFunctionParameters() { m_presenter->estimateFunctionParameters(); }
 
-void IqtTemplateBrowser::setBackgroundA0(double value) { m_presenter.setBackgroundA0(value); }
+void IqtTemplateBrowser::setBackgroundA0(double value) { m_presenter->setBackgroundA0(value); }
 
 void IqtTemplateBrowser::popupMenu(const QPoint &) {}
 
@@ -343,7 +344,7 @@ void IqtTemplateBrowser::setTieIntensitiesQuiet(bool on) {
 }
 
 void IqtTemplateBrowser::updateState() {
-  auto const on = m_presenter.canTieIntensities();
+  auto const on = m_presenter->canTieIntensities();
   if (!on && m_boolManager->value(m_tieIntensities)) {
     ScopedFalse _false(m_emitBoolChange);
     m_boolManager->setValue(m_tieIntensities, false);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.h
@@ -27,7 +27,7 @@ namespace IDA {
 class MANTIDQT_INELASTIC_DLL IqtTemplateBrowser : public FunctionTemplateBrowser {
   Q_OBJECT
 public:
-  explicit IqtTemplateBrowser(std::unique_ptr<IqtFunctionModel> functionModel, QWidget *parent = nullptr);
+  explicit IqtTemplateBrowser(QWidget *parent = nullptr);
   void addExponentialOne();
   void removeExponentialOne();
   void addExponentialTwo();
@@ -103,12 +103,10 @@ private:
   QMap<QtProperty *, std::string> m_parameterDescriptions;
 
 private:
-  IqtTemplatePresenter m_presenter;
   bool m_emitParameterValueChange = true;
   bool m_emitIntChange = true;
   bool m_emitBoolChange = true;
   bool m_emitEnumChange = true;
-  friend class IqtTemplatePresenter;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.h
@@ -77,7 +77,6 @@ protected slots:
   void enumChanged(QtProperty *) override;
   void globalChanged(QtProperty *, const QString &, bool) override;
   void parameterChanged(QtProperty *) override;
-  void parameterButtonClicked(QtProperty *) override;
 
 private:
   void createProperties() override;
@@ -101,7 +100,6 @@ private:
   QtProperty *m_A0 = nullptr;
   QtProperty *m_tieIntensities = nullptr;
   QMap<QtProperty *, int> m_parameterMap;
-  QMap<QtProperty *, std::string> m_actualParameterNames;
   QMap<QtProperty *, std::string> m_parameterDescriptions;
 
 private:

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.h
@@ -46,20 +46,8 @@ public:
   void setStretchStretching(double, double);
   void setA0(double, double);
 
-  void setFunction(std::string const &funStr) override;
-  IFunction_sptr getGlobalFunction() const override;
-  IFunction_sptr getFunction() const override;
-  void setNumberOfDatasets(int) override;
-  int getNumberOfDatasets() const override;
-  void setDatasets(const QList<MantidWidgets::FunctionModelDataset> &datasets) override;
-  std::vector<std::string> getGlobalParameters() const override;
-  std::vector<std::string> getLocalParameters() const override;
-  void setGlobalParameters(std::vector<std::string> const &globals) override;
-  void updateMultiDatasetParameters(const IFunction &fun) override;
   void updateMultiDatasetParameters(const ITableWorkspace &paramTable) override;
   void updateParameters(const IFunction &fun) override;
-  void setCurrentDataset(int i) override;
-  int getCurrentDataset() override;
   void updateParameterNames(const QMap<int, std::string> &parameterNames) override;
   void updateParameterDescriptions(const QMap<int, std::string> &parameterNames); // override;
   void setErrorsEnabled(bool enabled) override;
@@ -107,6 +95,7 @@ private:
   bool m_emitIntChange = true;
   bool m_emitBoolChange = true;
   bool m_emitEnumChange = true;
+  friend class IqtTemplatePresenter;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplateBrowser.h
@@ -50,7 +50,6 @@ public:
   void updateParameters(const IFunction &fun) override;
   void updateParameterNames(const QMap<int, std::string> &parameterNames) override;
   void updateParameterDescriptions(const QMap<int, std::string> &parameterNames); // override;
-  void setErrorsEnabled(bool enabled) override;
   void clear() override;
   EstimationDataSelector getEstimationDataSelector() const override;
   void updateParameterEstimationData(DataForParameterEstimationCollection &&data) override;
@@ -70,7 +69,6 @@ private:
   void createProperties() override;
   void popupMenu(const QPoint &) override;
   double getParameterPropertyValue(QtProperty *prop) const;
-  void setParameterPropertyValue(QtProperty *prop, double value, double error);
   void setGlobalParametersQuiet(std::vector<std::string> const &globals);
   void setTieIntensitiesQuiet(bool on);
   void updateState();
@@ -91,10 +89,6 @@ private:
   QMap<QtProperty *, std::string> m_parameterDescriptions;
 
 private:
-  bool m_emitParameterValueChange = true;
-  bool m_emitIntChange = true;
-  bool m_emitBoolChange = true;
-  bool m_emitEnumChange = true;
   friend class IqtTemplatePresenter;
 };
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
@@ -23,8 +23,6 @@ IqtTemplatePresenter::IqtTemplatePresenter(IqtTemplateBrowser *view, std::unique
   m_view->subscribePresenter(this);
   setViewParameterDescriptions();
   m_view->updateState();
-  connect(m_view, SIGNAL(parameterValueChanged(std::string const &, double)), this,
-          SLOT(viewChangedParameterValue(std::string const &, double)));
 }
 
 void IqtTemplatePresenter::setNumberOfExponentials(int n) {
@@ -305,7 +303,7 @@ void IqtTemplatePresenter::editLocalParameterFinish(int result) {
   m_view->emitFunctionStructureChanged();
 }
 
-void IqtTemplatePresenter::viewChangedParameterValue(std::string const &parameterName, double const value) {
+void IqtTemplatePresenter::handleParameterValueChanged(std::string const &parameterName, double const value) {
   if (parameterName.empty())
     return;
   if (m_model->isGlobal(parameterName)) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
@@ -273,34 +273,25 @@ void IqtTemplatePresenter::handleEditLocalParameter(const std::string &parameter
     const auto constraint = getLocalParameterConstraint(parameterName, i);
     constraints.push_back(QString::fromStdString(constraint));
   }
-
-  m_editLocalParameterDialog =
-      new EditLocalParameterDialog(m_view, parameterName, datasetNames, domainNames, values, fixes, ties, constraints);
-  connect(m_editLocalParameterDialog, SIGNAL(finished(int)), this, SLOT(editLocalParameterFinish(int)));
-  m_editLocalParameterDialog->open();
+  m_view->openEditLocalParameterDialog(parameterName, datasetNames, domainNames, values, fixes, ties, constraints);
 }
 
-void IqtTemplatePresenter::editLocalParameterFinish(int result) {
-  if (result == QDialog::Accepted) {
-    auto parName = m_editLocalParameterDialog->getParameterName();
-    auto values = m_editLocalParameterDialog->getValues();
-    auto fixes = m_editLocalParameterDialog->getFixes();
-    auto ties = m_editLocalParameterDialog->getTies();
-    assert(values.size() == getNumberOfDatasets());
-    for (int i = 0; i < values.size(); ++i) {
-      setLocalParameterValue(parName, i, values[i]);
-      if (!ties[i].isEmpty()) {
-        setLocalParameterTie(parName, i, ties[i].toStdString());
-      } else if (fixes[i]) {
-        setLocalParameterFixed(parName, i, fixes[i]);
-      } else {
-        setLocalParameterTie(parName, i, "");
-      }
+void IqtTemplatePresenter::handleEditLocalParameterFinished(std::string const &parameterName,
+                                                            QList<double> const &values, QList<bool> const &fixes,
+                                                            QStringList const &ties, QStringList const &constraints) {
+  (void)constraints;
+  assert(values.size() == getNumberOfDatasets());
+  for (int i = 0; i < values.size(); ++i) {
+    setLocalParameterValue(parameterName, i, values[i]);
+    if (!ties[i].isEmpty()) {
+      setLocalParameterTie(parameterName, i, ties[i].toStdString());
+    } else if (fixes[i]) {
+      setLocalParameterFixed(parameterName, i, fixes[i]);
+    } else {
+      setLocalParameterTie(parameterName, i, "");
     }
   }
-  m_editLocalParameterDialog = nullptr;
   updateViewParameters();
-  m_view->emitFunctionStructureChanged();
 }
 
 void IqtTemplatePresenter::handleParameterValueChanged(std::string const &parameterName, double const value) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
@@ -66,7 +66,7 @@ void IqtTemplatePresenter::setNumberOfExponentials(int n) {
   m_model->setNumberOfExponentials(n);
   setErrorsEnabled(false);
   updateView();
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 void IqtTemplatePresenter::setStretchExponential(bool on) {
@@ -80,7 +80,7 @@ void IqtTemplatePresenter::setStretchExponential(bool on) {
   m_model->setStretchExponential(on);
   setErrorsEnabled(false);
   updateView();
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 void IqtTemplatePresenter::setBackground(std::string const &name) {
@@ -95,7 +95,7 @@ void IqtTemplatePresenter::setBackground(std::string const &name) {
   }
   setErrorsEnabled(false);
   updateView();
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 void IqtTemplatePresenter::setNumberOfDatasets(int n) { m_model->setNumberDomains(n); }
@@ -120,7 +120,7 @@ void IqtTemplatePresenter::setFunction(std::string const &funStr) {
     m_view->addExponentialTwo();
   }
   updateView();
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 IFunction_sptr IqtTemplatePresenter::getGlobalFunction() const { return m_model->getFitFunction(); }
@@ -175,7 +175,7 @@ void IqtTemplatePresenter::tieIntensities(bool on) {
   if (on && !canTieIntensities())
     return;
   m_model->tieIntensities(on);
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 bool IqtTemplatePresenter::canTieIntensities() const {
@@ -302,7 +302,7 @@ void IqtTemplatePresenter::editLocalParameterFinish(int result) {
   }
   m_editLocalParameterDialog = nullptr;
   updateViewParameters();
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 void IqtTemplatePresenter::viewChangedParameterValue(std::string const &parameterName, double const value) {
@@ -321,7 +321,7 @@ void IqtTemplatePresenter::viewChangedParameterValue(std::string const &paramete
     }
     setLocalParameterValue(parameterName, i, value);
   }
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 } // namespace MantidQt::CustomInterfaces::IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
@@ -21,6 +21,8 @@ using namespace MantidWidgets;
 IqtTemplatePresenter::IqtTemplatePresenter(IqtTemplateBrowser *view, std::unique_ptr<IqtFunctionModel> functionModel)
     : QObject(view), m_view(view), m_model(std::move(functionModel)) {
   m_view->subscribePresenter(this);
+  setViewParameterDescriptions();
+  m_view->updateState();
   connect(m_view, SIGNAL(parameterValueChanged(std::string const &, double)), this,
           SLOT(viewChangedParameterValue(std::string const &, double)));
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
@@ -144,8 +144,8 @@ void IqtTemplatePresenter::updateMultiDatasetParameters(const IFunction &fun) {
   updateViewParameters();
 }
 
-void IqtTemplatePresenter::updateMultiDatasetParameters(const ITableWorkspace &paramTable) {
-  m_model->updateMultiDatasetParameters(paramTable);
+void IqtTemplatePresenter::updateMultiDatasetParameters(const ITableWorkspace &table) {
+  m_model->updateMultiDatasetParameters(table);
   updateViewParameters();
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
@@ -20,8 +20,7 @@ using namespace MantidWidgets;
  */
 IqtTemplatePresenter::IqtTemplatePresenter(IqtTemplateBrowser *view, std::unique_ptr<IqtFunctionModel> functionModel)
     : QObject(view), m_view(view), m_model(std::move(functionModel)) {
-  connect(m_view, SIGNAL(localParameterButtonClicked(std::string const &)), this,
-          SLOT(editLocalParameter(std::string const &)));
+  m_view->subscribePresenter(this);
   connect(m_view, SIGNAL(parameterValueChanged(std::string const &, double)), this,
           SLOT(viewChangedParameterValue(std::string const &, double)));
 }
@@ -256,7 +255,7 @@ void IqtTemplatePresenter::setLocalParameterFixed(std::string const &parameterNa
   m_model->setLocalParameterFixed(parameterName, i, fixed);
 }
 
-void IqtTemplatePresenter::editLocalParameter(const std::string &parameterName) {
+void IqtTemplatePresenter::handleEditLocalParameter(const std::string &parameterName) {
   auto const datasetNames = getDatasetNames();
   auto const domainNames = getDatasetDomainNames();
   QList<double> values;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
@@ -19,7 +19,7 @@ using namespace MantidWidgets;
  * @param parent :: The parent widget.
  */
 IqtTemplatePresenter::IqtTemplatePresenter(IqtTemplateBrowser *view, std::unique_ptr<IqtFunctionModel> functionModel)
-    : QObject(view), m_view(view), m_model(std::move(functionModel)) {
+    : m_view(view), m_model(std::move(functionModel)) {
   m_view->subscribePresenter(this);
   setViewParameterDescriptions();
   m_view->updateState();

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
@@ -11,8 +11,6 @@
 #include "ITemplatePresenter.h"
 #include "IqtFunctionModel.h"
 
-#include <QWidget>
-
 class QtProperty;
 
 namespace MantidQt {
@@ -29,8 +27,7 @@ class IqtTemplateBrowser;
  * and set properties that can be used to generate a fit function.
  *
  */
-class MANTIDQT_INELASTIC_DLL IqtTemplatePresenter : public QObject, public ITemplatePresenter {
-  Q_OBJECT
+class MANTIDQT_INELASTIC_DLL IqtTemplatePresenter : public ITemplatePresenter {
 public:
   explicit IqtTemplatePresenter(IqtTemplateBrowser *view, std::unique_ptr<IqtFunctionModel> functionModel);
   FunctionTemplateBrowser *browser() override { return reinterpret_cast<FunctionTemplateBrowser *>(m_view); }

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
@@ -33,32 +33,43 @@ class MANTIDQT_INELASTIC_DLL IqtTemplatePresenter : public QObject, public ITemp
   Q_OBJECT
 public:
   explicit IqtTemplatePresenter(IqtTemplateBrowser *view, std::unique_ptr<IqtFunctionModel> functionModel);
+  FunctionTemplateBrowser *browser() override { return reinterpret_cast<FunctionTemplateBrowser *>(m_view); }
+
   void setNumberOfExponentials(int);
   void setStretchExponential(bool);
   void setBackground(std::string const &name);
-  void setNumberOfDatasets(int);
-  int getNumberOfDatasets() const;
-  void setFunction(std::string const &funStr);
-  IFunction_sptr getGlobalFunction() const;
-  IFunction_sptr getFunction() const;
-  std::vector<std::string> getGlobalParameters() const;
-  std::vector<std::string> getLocalParameters() const;
-  void setGlobalParameters(std::vector<std::string> const &globals);
-  void setGlobal(std::string const &parameterName, bool on);
-  void updateMultiDatasetParameters(const IFunction &fun);
-  void updateMultiDatasetParameters(const ITableWorkspace &paramTable);
-  void updateParameters(const IFunction &fun);
-  void setCurrentDataset(int i);
-  int getCurrentDataset();
-  void setDatasets(const QList<FunctionModelDataset> &datasets);
+
+  void setNumberOfDatasets(int) override;
+  int getNumberOfDatasets() const override;
+  int getCurrentDataset() override;
+
+  void setFunction(std::string const &funStr) override;
+  IFunction_sptr getGlobalFunction() const override;
+  IFunction_sptr getFunction() const override;
+
+  std::vector<std::string> getGlobalParameters() const override;
+  std::vector<std::string> getLocalParameters() const override;
+  void setGlobalParameters(std::vector<std::string> const &globals) override;
+  void setGlobal(std::string const &parameterName, bool on) override;
+
+  void updateMultiDatasetParameters(const IFunction &fun) override;
+  void updateMultiDatasetParameters(const ITableWorkspace &paramTable) override;
+  void updateParameters(const IFunction &fun) override;
+
+  void setCurrentDataset(int i) override;
+  void setDatasets(const QList<FunctionModelDataset> &datasets) override;
+
   void setViewParameterDescriptions();
-  void setErrorsEnabled(bool enabled);
   void tieIntensities(bool on);
   bool canTieIntensities() const;
-  EstimationDataSelector getEstimationDataSelector() const;
-  void updateParameterEstimationData(DataForParameterEstimationCollection &&data);
-  void estimateFunctionParameters();
-  void setBackgroundA0(double value);
+
+  EstimationDataSelector getEstimationDataSelector() const override;
+  void updateParameterEstimationData(DataForParameterEstimationCollection &&data) override;
+  void estimateFunctionParameters() override;
+
+  void setErrorsEnabled(bool enabled) override;
+
+  void setBackgroundA0(double value) override;
 
   void handleEditLocalParameter(std::string const &parameterName) override;
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
@@ -73,9 +73,6 @@ public:
 
   void handleEditLocalParameter(std::string const &parameterName) override;
 
-signals:
-  void functionStructureChanged();
-
 private slots:
   void editLocalParameterFinish(int result);
   void viewChangedParameterValue(std::string const &parameterName, double value);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
@@ -49,8 +49,8 @@ public:
   void setGlobalParameters(std::vector<std::string> const &globals) override;
   void setGlobal(std::string const &parameterName, bool on) override;
 
-  void updateMultiDatasetParameters(const IFunction &fun) override;
-  void updateMultiDatasetParameters(const ITableWorkspace &paramTable) override;
+  void updateMultiDatasetParameters(const Mantid::API::IFunction &fun) override;
+  void updateMultiDatasetParameters(const Mantid::API::ITableWorkspace &table) override;
   void updateParameters(const IFunction &fun) override;
 
   void setCurrentDataset(int i) override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
@@ -8,7 +8,7 @@
 
 #include "Analysis/ParameterEstimation.h"
 #include "DllConfig.h"
-#include "ITemplatePresenter.h"
+#include "FunctionTemplatePresenter.h"
 #include "IqtFunctionModel.h"
 
 class QtProperty;
@@ -27,7 +27,7 @@ class IqtTemplateBrowser;
  * and set properties that can be used to generate a fit function.
  *
  */
-class MANTIDQT_INELASTIC_DLL IqtTemplatePresenter : public ITemplatePresenter {
+class MANTIDQT_INELASTIC_DLL IqtTemplatePresenter : public FunctionTemplatePresenter {
 public:
   explicit IqtTemplatePresenter(IqtTemplateBrowser *view, std::unique_ptr<IqtFunctionModel> functionModel);
   FunctionTemplateBrowser *browser() override { return reinterpret_cast<FunctionTemplateBrowser *>(m_view); }

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
@@ -73,9 +73,9 @@ public:
 
   void handleEditLocalParameter(std::string const &parameterName) override;
   void handleParameterValueChanged(std::string const &parameterName, double value) override;
-
-private slots:
-  void editLocalParameterFinish(int result);
+  void handleEditLocalParameterFinished(std::string const &parameterName, QList<double> const &values,
+                                        QList<bool> const &fixes, QStringList const &ties,
+                                        QStringList const &constraints) override;
 
 private:
   void updateViewParameters();
@@ -92,7 +92,6 @@ private:
   void updateView();
   IqtTemplateBrowser *m_view;
   std::unique_ptr<IqtFunctionModel> m_model;
-  EditLocalParameterDialog *m_editLocalParameterDialog;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
@@ -72,10 +72,10 @@ public:
   void setBackgroundA0(double value) override;
 
   void handleEditLocalParameter(std::string const &parameterName) override;
+  void handleParameterValueChanged(std::string const &parameterName, double value) override;
 
 private slots:
   void editLocalParameterFinish(int result);
-  void viewChangedParameterValue(std::string const &parameterName, double value);
 
 private:
   void updateViewParameters();

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
@@ -32,9 +32,9 @@ public:
   explicit IqtTemplatePresenter(IqtTemplateBrowser *view, std::unique_ptr<IqtFunctionModel> functionModel);
   FunctionTemplateBrowser *browser() override { return reinterpret_cast<FunctionTemplateBrowser *>(m_view); }
 
-  void setNumberOfExponentials(int);
-  void setStretchExponential(bool);
-  void setBackground(std::string const &name);
+  void setNumberOfExponentials(int) override;
+  void setStretchExponential(bool) override;
+  void setBackground(std::string const &name) override;
 
   void setNumberOfDatasets(int) override;
   int getNumberOfDatasets() const override;
@@ -57,8 +57,8 @@ public:
   void setDatasets(const QList<FunctionModelDataset> &datasets) override;
 
   void setViewParameterDescriptions();
-  void tieIntensities(bool on);
-  bool canTieIntensities() const;
+  void tieIntensities(bool on) override;
+  bool canTieIntensities() const override;
 
   EstimationDataSelector getEstimationDataSelector() const override;
   void updateParameterEstimationData(DataForParameterEstimationCollection &&data) override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/IqtTemplatePresenter.h
@@ -8,6 +8,7 @@
 
 #include "Analysis/ParameterEstimation.h"
 #include "DllConfig.h"
+#include "ITemplatePresenter.h"
 #include "IqtFunctionModel.h"
 
 #include <QWidget>
@@ -28,7 +29,7 @@ class IqtTemplateBrowser;
  * and set properties that can be used to generate a fit function.
  *
  */
-class MANTIDQT_INELASTIC_DLL IqtTemplatePresenter : public QObject {
+class MANTIDQT_INELASTIC_DLL IqtTemplatePresenter : public QObject, public ITemplatePresenter {
   Q_OBJECT
 public:
   explicit IqtTemplatePresenter(IqtTemplateBrowser *view, std::unique_ptr<IqtFunctionModel> functionModel);
@@ -59,11 +60,12 @@ public:
   void estimateFunctionParameters();
   void setBackgroundA0(double value);
 
+  void handleEditLocalParameter(std::string const &parameterName) override;
+
 signals:
   void functionStructureChanged();
 
 private slots:
-  void editLocalParameter(std::string const &parameterName);
   void editLocalParameterFinish(int result);
   void viewChangedParameterValue(std::string const &parameterName, double value);
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
@@ -38,6 +38,7 @@ namespace MantidQt::CustomInterfaces::IDA {
  */
 SingleFunctionTemplateBrowser::SingleFunctionTemplateBrowser(QWidget *parent) : FunctionTemplateBrowser(parent) {
   // connect(&m_presenter, SIGNAL(functionStructureChanged()), this, SIGNAL(functionStructureChanged()));
+  init();
 }
 
 void SingleFunctionTemplateBrowser::createProperties() {
@@ -51,8 +52,6 @@ void SingleFunctionTemplateBrowser::createProperties() {
   m_parameterManager->blockSignals(false);
   m_enumManager->blockSignals(false);
   m_boolManager->blockSignals(false);
-
-  m_presenter->init();
 }
 
 void SingleFunctionTemplateBrowser::setDataType(std::vector<std::string> const &allowedFunctionsList) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
@@ -36,10 +36,8 @@ namespace MantidQt::CustomInterfaces::IDA {
  * Constructor
  * @param parent :: The parent widget.
  */
-SingleFunctionTemplateBrowser::SingleFunctionTemplateBrowser(std::unique_ptr<SingleFunctionTemplateModel> functionModel,
-                                                             QWidget *parent)
-    : FunctionTemplateBrowser(parent), m_presenter(this, std::move(functionModel)) {
-  connect(&m_presenter, SIGNAL(functionStructureChanged()), this, SIGNAL(functionStructureChanged()));
+SingleFunctionTemplateBrowser::SingleFunctionTemplateBrowser(QWidget *parent) : FunctionTemplateBrowser(parent) {
+  // connect(&m_presenter, SIGNAL(functionStructureChanged()), this, SIGNAL(functionStructureChanged()));
 }
 
 void SingleFunctionTemplateBrowser::createProperties() {
@@ -54,7 +52,7 @@ void SingleFunctionTemplateBrowser::createProperties() {
   m_enumManager->blockSignals(false);
   m_boolManager->blockSignals(false);
 
-  m_presenter.init();
+  m_presenter->init();
 }
 
 void SingleFunctionTemplateBrowser::setDataType(std::vector<std::string> const &allowedFunctionsList) {
@@ -79,32 +77,32 @@ void SingleFunctionTemplateBrowser::addParameter(std::string const &parameterNam
   m_parameterNames.insert(newParameter, parameterName);
 }
 
-int SingleFunctionTemplateBrowser::getCurrentDataset() { return m_presenter.getCurrentDataset(); }
+int SingleFunctionTemplateBrowser::getCurrentDataset() { return m_presenter->getCurrentDataset(); }
 
-void SingleFunctionTemplateBrowser::setFunction(std::string const &funStr) { m_presenter.setFunction(funStr); }
+void SingleFunctionTemplateBrowser::setFunction(std::string const &funStr) { m_presenter->setFunction(funStr); }
 
-IFunction_sptr SingleFunctionTemplateBrowser::getGlobalFunction() const { return m_presenter.getGlobalFunction(); }
+IFunction_sptr SingleFunctionTemplateBrowser::getGlobalFunction() const { return m_presenter->getGlobalFunction(); }
 
-IFunction_sptr SingleFunctionTemplateBrowser::getFunction() const { return m_presenter.getFunction(); }
+IFunction_sptr SingleFunctionTemplateBrowser::getFunction() const { return m_presenter->getFunction(); }
 
-void SingleFunctionTemplateBrowser::setNumberOfDatasets(int n) { m_presenter.setNumberOfDatasets(n); }
+void SingleFunctionTemplateBrowser::setNumberOfDatasets(int n) { m_presenter->setNumberOfDatasets(n); }
 
-int SingleFunctionTemplateBrowser::getNumberOfDatasets() const { return m_presenter.getNumberOfDatasets(); }
+int SingleFunctionTemplateBrowser::getNumberOfDatasets() const { return m_presenter->getNumberOfDatasets(); }
 
 void SingleFunctionTemplateBrowser::setDatasets(const QList<FunctionModelDataset> &datasets) {
-  m_presenter.setDatasets(datasets);
+  m_presenter->setDatasets(datasets);
 }
 
 std::vector<std::string> SingleFunctionTemplateBrowser::getGlobalParameters() const {
-  return m_presenter.getGlobalParameters();
+  return m_presenter->getGlobalParameters();
 }
 
 std::vector<std::string> SingleFunctionTemplateBrowser::getLocalParameters() const {
-  return m_presenter.getLocalParameters();
+  return m_presenter->getLocalParameters();
 }
 
 void SingleFunctionTemplateBrowser::setGlobalParameters(std::vector<std::string> const &globals) {
-  m_presenter.setGlobalParameters(globals);
+  m_presenter->setGlobalParameters(globals);
 }
 
 void SingleFunctionTemplateBrowser::enumChanged(QtProperty *prop) {
@@ -112,7 +110,7 @@ void SingleFunctionTemplateBrowser::enumChanged(QtProperty *prop) {
     return;
   if (prop == m_fitType) {
     auto fitType = m_enumManager->enumNames(prop)[m_enumManager->value(prop)].toStdString();
-    m_presenter.setFitType(fitType);
+    m_presenter->setFitType(fitType);
   }
 }
 
@@ -120,19 +118,19 @@ void SingleFunctionTemplateBrowser::globalChanged(QtProperty *, const QString &,
 
 void SingleFunctionTemplateBrowser::parameterChanged(QtProperty *prop) {
   auto isGlobal = m_parameterManager->isGlobal(prop);
-  m_presenter.setGlobal(m_parameterNames[prop], isGlobal);
+  m_presenter->setGlobal(m_parameterNames[prop], isGlobal);
   if (m_emitParameterValueChange) {
     emit parameterValueChanged(m_parameterNames[prop], m_parameterManager->value(prop));
   }
 }
 
 void SingleFunctionTemplateBrowser::updateMultiDatasetParameters(const IFunction &fun) {
-  m_presenter.updateMultiDatasetParameters(fun);
+  m_presenter->updateMultiDatasetParameters(fun);
 }
 
 void SingleFunctionTemplateBrowser::updateMultiDatasetParameters(const ITableWorkspace &) {}
 
-void SingleFunctionTemplateBrowser::updateParameters(const IFunction &fun) { m_presenter.updateParameters(fun); }
+void SingleFunctionTemplateBrowser::updateParameters(const IFunction &fun) { m_presenter->updateParameters(fun); }
 
 void SingleFunctionTemplateBrowser::setParameterValue(std::string const &parameterName, double parameterValue,
                                                       double parameterError) {
@@ -147,7 +145,7 @@ void SingleFunctionTemplateBrowser::setParameterValueQuietly(std::string const &
   m_parameterManager->setError(m_parameterMap[parameterName], parameterError);
 }
 
-void SingleFunctionTemplateBrowser::setCurrentDataset(int i) { m_presenter.setCurrentDataset(i); }
+void SingleFunctionTemplateBrowser::setCurrentDataset(int i) { m_presenter->setCurrentDataset(i); }
 
 void SingleFunctionTemplateBrowser::updateParameterNames(const QMap<int, std::string> &) {}
 
@@ -155,7 +153,7 @@ void SingleFunctionTemplateBrowser::updateParameterDescriptions(const QMap<int, 
 
 void SingleFunctionTemplateBrowser::updateAvailableFunctions(
     const std::map<std::string, std::string> &functionInitialisationStrings) {
-  m_presenter.updateAvailableFunctions(functionInitialisationStrings);
+  m_presenter->updateAvailableFunctions(functionInitialisationStrings);
 }
 
 void SingleFunctionTemplateBrowser::setErrorsEnabled(bool enabled) {
@@ -170,13 +168,14 @@ void SingleFunctionTemplateBrowser::clear() {
 }
 
 EstimationDataSelector SingleFunctionTemplateBrowser::getEstimationDataSelector() const {
-  return m_presenter.getEstimationDataSelector();
+  return m_presenter->getEstimationDataSelector();
 }
 
 void SingleFunctionTemplateBrowser::updateParameterEstimationData(DataForParameterEstimationCollection &&data) {
-  m_presenter.updateParameterEstimationData(std::move(data));
+  m_presenter->updateParameterEstimationData(std::move(data));
 }
-void SingleFunctionTemplateBrowser::estimateFunctionParameters() { m_presenter.estimateFunctionParameters(); }
+
+void SingleFunctionTemplateBrowser::estimateFunctionParameters() { m_presenter->estimateFunctionParameters(); }
 
 void SingleFunctionTemplateBrowser::popupMenu(const QPoint &) {}
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
@@ -126,10 +126,6 @@ void SingleFunctionTemplateBrowser::parameterChanged(QtProperty *prop) {
   }
 }
 
-void SingleFunctionTemplateBrowser::parameterButtonClicked(QtProperty *prop) {
-  emit localParameterButtonClicked(m_parameterNames[prop]);
-}
-
 void SingleFunctionTemplateBrowser::updateMultiDatasetParameters(const IFunction &fun) {
   m_presenter.updateMultiDatasetParameters(fun);
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
@@ -77,34 +77,6 @@ void SingleFunctionTemplateBrowser::addParameter(std::string const &parameterNam
   m_parameterNames.insert(newParameter, parameterName);
 }
 
-int SingleFunctionTemplateBrowser::getCurrentDataset() { return m_presenter->getCurrentDataset(); }
-
-void SingleFunctionTemplateBrowser::setFunction(std::string const &funStr) { m_presenter->setFunction(funStr); }
-
-IFunction_sptr SingleFunctionTemplateBrowser::getGlobalFunction() const { return m_presenter->getGlobalFunction(); }
-
-IFunction_sptr SingleFunctionTemplateBrowser::getFunction() const { return m_presenter->getFunction(); }
-
-void SingleFunctionTemplateBrowser::setNumberOfDatasets(int n) { m_presenter->setNumberOfDatasets(n); }
-
-int SingleFunctionTemplateBrowser::getNumberOfDatasets() const { return m_presenter->getNumberOfDatasets(); }
-
-void SingleFunctionTemplateBrowser::setDatasets(const QList<FunctionModelDataset> &datasets) {
-  m_presenter->setDatasets(datasets);
-}
-
-std::vector<std::string> SingleFunctionTemplateBrowser::getGlobalParameters() const {
-  return m_presenter->getGlobalParameters();
-}
-
-std::vector<std::string> SingleFunctionTemplateBrowser::getLocalParameters() const {
-  return m_presenter->getLocalParameters();
-}
-
-void SingleFunctionTemplateBrowser::setGlobalParameters(std::vector<std::string> const &globals) {
-  m_presenter->setGlobalParameters(globals);
-}
-
 void SingleFunctionTemplateBrowser::enumChanged(QtProperty *prop) {
   if (!m_emitEnumChange)
     return;
@@ -124,10 +96,6 @@ void SingleFunctionTemplateBrowser::parameterChanged(QtProperty *prop) {
   }
 }
 
-void SingleFunctionTemplateBrowser::updateMultiDatasetParameters(const IFunction &fun) {
-  m_presenter->updateMultiDatasetParameters(fun);
-}
-
 void SingleFunctionTemplateBrowser::updateMultiDatasetParameters(const ITableWorkspace &) {}
 
 void SingleFunctionTemplateBrowser::updateParameters(const IFunction &fun) { m_presenter->updateParameters(fun); }
@@ -144,8 +112,6 @@ void SingleFunctionTemplateBrowser::setParameterValueQuietly(std::string const &
   m_parameterManager->setValue(m_parameterMap[parameterName], parameterValue);
   m_parameterManager->setError(m_parameterMap[parameterName], parameterError);
 }
-
-void SingleFunctionTemplateBrowser::setCurrentDataset(int i) { m_presenter->setCurrentDataset(i); }
 
 void SingleFunctionTemplateBrowser::updateParameterNames(const QMap<int, std::string> &) {}
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
@@ -37,7 +37,6 @@ namespace MantidQt::CustomInterfaces::IDA {
  * @param parent :: The parent widget.
  */
 SingleFunctionTemplateBrowser::SingleFunctionTemplateBrowser(QWidget *parent) : FunctionTemplateBrowser(parent) {
-  // connect(&m_presenter, SIGNAL(functionStructureChanged()), this, SIGNAL(functionStructureChanged()));
   init();
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
@@ -90,7 +90,7 @@ void SingleFunctionTemplateBrowser::parameterChanged(QtProperty *prop) {
   auto isGlobal = m_parameterManager->isGlobal(prop);
   m_presenter->setGlobal(m_parameterNames[prop], isGlobal);
   if (m_emitParameterValueChange) {
-    emit parameterValueChanged(m_parameterNames[prop], m_parameterManager->value(prop));
+    m_presenter->handleParameterValueChanged(m_parameterNames[prop], m_parameterManager->value(prop));
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.cpp
@@ -54,15 +54,12 @@ void SingleFunctionTemplateBrowser::createProperties() {
 }
 
 void SingleFunctionTemplateBrowser::setDataType(std::vector<std::string> const &allowedFunctionsList) {
-  ScopedFalse _false(m_emitEnumChange);
+  MantidQt::MantidWidgets::ScopedFalse _enumBlock(m_emitEnumChange);
   m_enumManager->setEnumNames(m_fitType, stdVectorToQStringList(allowedFunctionsList));
   m_enumManager->setValue(m_fitType, 0);
 }
 
-void SingleFunctionTemplateBrowser::setEnumValue(int enumIndex) {
-  ScopedFalse _false(m_emitEnumChange);
-  m_enumManager->setValue(m_fitType, enumIndex);
-}
+void SingleFunctionTemplateBrowser::setEnumValue(int enumIndex) { setEnumSilent(m_fitType, enumIndex); }
 
 void SingleFunctionTemplateBrowser::addParameter(std::string const &parameterName,
                                                  std::string const &parameterDescription) {
@@ -89,6 +86,7 @@ void SingleFunctionTemplateBrowser::globalChanged(QtProperty *, const QString &,
 void SingleFunctionTemplateBrowser::parameterChanged(QtProperty *prop) {
   auto isGlobal = m_parameterManager->isGlobal(prop);
   m_presenter->setGlobal(m_parameterNames[prop], isGlobal);
+
   if (m_emitParameterValueChange) {
     m_presenter->handleParameterValueChanged(m_parameterNames[prop], m_parameterManager->value(prop));
   }
@@ -106,9 +104,7 @@ void SingleFunctionTemplateBrowser::setParameterValue(std::string const &paramet
 
 void SingleFunctionTemplateBrowser::setParameterValueQuietly(std::string const &parameterName, double parameterValue,
                                                              double parameterError) {
-  ScopedFalse _(m_emitParameterValueChange);
-  m_parameterManager->setValue(m_parameterMap[parameterName], parameterValue);
-  m_parameterManager->setError(m_parameterMap[parameterName], parameterError);
+  setParameterSilent(m_parameterMap[parameterName], parameterValue, parameterError);
 }
 
 void SingleFunctionTemplateBrowser::updateParameterNames(const QMap<int, std::string> &) {}
@@ -118,11 +114,6 @@ void SingleFunctionTemplateBrowser::updateParameterDescriptions(const QMap<int, 
 void SingleFunctionTemplateBrowser::updateAvailableFunctions(
     const std::map<std::string, std::string> &functionInitialisationStrings) {
   m_presenter->updateAvailableFunctions(functionInitialisationStrings);
-}
-
-void SingleFunctionTemplateBrowser::setErrorsEnabled(bool enabled) {
-  ScopedFalse _false(m_emitParameterValueChange);
-  m_parameterManager->setErrorsEnabled(enabled);
 }
 
 void SingleFunctionTemplateBrowser::clear() {
@@ -143,16 +134,8 @@ void SingleFunctionTemplateBrowser::estimateFunctionParameters() { m_presenter->
 
 void SingleFunctionTemplateBrowser::popupMenu(const QPoint &) {}
 
-void SingleFunctionTemplateBrowser::setParameterPropertyValue(QtProperty *prop, double value, double error) {
-  if (prop) {
-    ScopedFalse _false(m_emitParameterValueChange);
-    m_parameterManager->setValue(prop, value);
-    m_parameterManager->setError(prop, error);
-  }
-}
-
 void SingleFunctionTemplateBrowser::setGlobalParametersQuiet(std::vector<std::string> const &globals) {
-  ScopedFalse _false(m_emitParameterValueChange);
+  MantidQt::MantidWidgets::ScopedFalse _parameterBlock(m_emitParameterValueChange);
   for (auto const &parameterName : m_parameterMap.keys()) {
     auto const findIter = std::find(globals.cbegin(), globals.cend(), parameterName);
     m_parameterManager->setGlobal(m_parameterMap[parameterName], findIter != globals.cend());

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h
@@ -35,7 +35,6 @@ public:
   void updateParameters(const IFunction &fun) override;
   void updateParameterNames(const QMap<int, std::string> &parameterNames) override;
   void updateParameterDescriptions(const QMap<int, std::string> &parameterNames);
-  void setErrorsEnabled(bool enabled) override;
   void clear() override;
   EstimationDataSelector getEstimationDataSelector() const override;
   void updateParameterEstimationData(DataForParameterEstimationCollection &&data) override;
@@ -58,16 +57,12 @@ protected slots:
 private:
   void createProperties() override;
   void popupMenu(const QPoint &) override;
-  void setParameterPropertyValue(QtProperty *prop, double value, double error);
   void setGlobalParametersQuiet(std::vector<std::string> const &globals);
 
   QtProperty *m_fitType;
   QMap<std::string, QtProperty *> m_parameterMap;
 
 private:
-  bool m_emitParameterValueChange = true;
-  bool m_emitBoolChange = true;
-  bool m_emitEnumChange = true;
   friend class SingleFunctionTemplatePresenter;
 };
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h
@@ -30,19 +30,9 @@ class MANTIDQT_INELASTIC_DLL SingleFunctionTemplateBrowser : public FunctionTemp
 public:
   explicit SingleFunctionTemplateBrowser(QWidget *parent = nullptr);
   virtual ~SingleFunctionTemplateBrowser() = default;
-  void setFunction(std::string const &funStr) override;
-  IFunction_sptr getGlobalFunction() const override;
-  IFunction_sptr getFunction() const override;
-  void setNumberOfDatasets(int) override;
-  int getNumberOfDatasets() const override;
-  void setDatasets(const QList<MantidWidgets::FunctionModelDataset> &datasets) override;
-  std::vector<std::string> getGlobalParameters() const override;
-  std::vector<std::string> getLocalParameters() const override;
-  void setGlobalParameters(std::vector<std::string> const &globals) override;
-  void updateMultiDatasetParameters(const IFunction &fun) override;
+
   void updateMultiDatasetParameters(const ITableWorkspace &paramTable) override;
   void updateParameters(const IFunction &fun) override;
-  void setCurrentDataset(int i) override;
   void updateParameterNames(const QMap<int, std::string> &parameterNames) override;
   void updateParameterDescriptions(const QMap<int, std::string> &parameterNames);
   void setErrorsEnabled(bool enabled) override;
@@ -53,7 +43,6 @@ public:
   void setBackgroundA0(double) override;
   void setResolution(const std::vector<std::pair<std::string, size_t>> &) override;
   void setQValues(const std::vector<double> &) override;
-  int getCurrentDataset() override;
   void addParameter(std::string const &parameterName, std::string const &parameterDescription);
   void setParameterValue(std::string const &parameterName, double parameterValue, double parameterError);
   void setParameterValueQuietly(std::string const &parameterName, double parameterValue, double parameterError);
@@ -80,6 +69,7 @@ private:
   bool m_emitParameterValueChange = true;
   bool m_emitBoolChange = true;
   bool m_emitEnumChange = true;
+  friend class SingleFunctionTemplatePresenter;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h
@@ -28,8 +28,7 @@ class IDAFunctionParameterEstimation;
 class MANTIDQT_INELASTIC_DLL SingleFunctionTemplateBrowser : public FunctionTemplateBrowser {
   Q_OBJECT
 public:
-  explicit SingleFunctionTemplateBrowser(std::unique_ptr<SingleFunctionTemplateModel> functionModel,
-                                         QWidget *parent = nullptr);
+  explicit SingleFunctionTemplateBrowser(QWidget *parent = nullptr);
   virtual ~SingleFunctionTemplateBrowser() = default;
   void setFunction(std::string const &funStr) override;
   IFunction_sptr getGlobalFunction() const override;
@@ -78,11 +77,9 @@ private:
   QMap<QtProperty *, std::string> m_parameterNames;
 
 private:
-  SingleFunctionTemplatePresenter m_presenter;
   bool m_emitParameterValueChange = true;
   bool m_emitBoolChange = true;
   bool m_emitEnumChange = true;
-  friend class SingleFunctionTemplatePresenter;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h
@@ -63,7 +63,6 @@ private:
 
   QtProperty *m_fitType;
   QMap<std::string, QtProperty *> m_parameterMap;
-  QMap<QtProperty *, std::string> m_parameterNames;
 
 private:
   bool m_emitParameterValueChange = true;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h
@@ -66,7 +66,6 @@ protected slots:
   void enumChanged(QtProperty *) override;
   void globalChanged(QtProperty *, const QString &, bool) override;
   void parameterChanged(QtProperty *) override;
-  void parameterButtonClicked(QtProperty *) override;
 
 private:
   void createProperties() override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp
@@ -21,8 +21,6 @@ SingleFunctionTemplatePresenter::SingleFunctionTemplatePresenter(
     SingleFunctionTemplateBrowser *view, std::unique_ptr<SingleFunctionTemplateModel> functionModel)
     : QObject(view), m_view(view), m_model(std::move(functionModel)) {
   m_view->subscribePresenter(this);
-  connect(m_view, SIGNAL(parameterValueChanged(std::string const &, double)), this,
-          SLOT(viewChangedParameterValue(std::string const &, double)));
 }
 
 void SingleFunctionTemplatePresenter::init() {
@@ -218,7 +216,7 @@ void SingleFunctionTemplatePresenter::editLocalParameterFinish(int result) {
   m_view->emitFunctionStructureChanged();
 }
 
-void SingleFunctionTemplatePresenter::viewChangedParameterValue(std::string const &parameterName, double value) {
+void SingleFunctionTemplatePresenter::handleParameterValueChanged(std::string const &parameterName, double value) {
   if (parameterName.empty())
     return;
   if (m_model->isGlobal(parameterName)) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp
@@ -19,7 +19,7 @@ using namespace MantidWidgets;
  */
 SingleFunctionTemplatePresenter::SingleFunctionTemplatePresenter(
     SingleFunctionTemplateBrowser *view, std::unique_ptr<SingleFunctionTemplateModel> functionModel)
-    : QObject(view), m_view(view), m_model(std::move(functionModel)) {
+    : m_view(view), m_model(std::move(functionModel)) {
   m_view->subscribePresenter(this);
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp
@@ -39,7 +39,7 @@ void SingleFunctionTemplatePresenter::setFitType(std::string const &name) {
   m_view->clear();
   m_model->setFitType(name);
   auto functionParameters = m_model->getParameterNames();
-  for (auto &parameter : functionParameters) {
+  for (auto const &parameter : functionParameters) {
     m_view->addParameter(parameter, m_model->getParameterDescription(parameter));
   }
   setErrorsEnabled(false);
@@ -60,7 +60,7 @@ void SingleFunctionTemplatePresenter::setFunction(std::string const &funStr) {
   if (m_model->getFitType() == "None")
     return;
   auto functionParameters = m_model->getParameterNames();
-  for (auto &parameter : functionParameters) {
+  for (auto const &parameter : functionParameters) {
     m_view->addParameter(parameter, m_model->getParameterDescription(parameter));
   }
   m_view->setEnumValue(m_model->getEnumIndex());

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp
@@ -20,8 +20,7 @@ using namespace MantidWidgets;
 SingleFunctionTemplatePresenter::SingleFunctionTemplatePresenter(
     SingleFunctionTemplateBrowser *view, std::unique_ptr<SingleFunctionTemplateModel> functionModel)
     : QObject(view), m_view(view), m_model(std::move(functionModel)) {
-  connect(m_view, SIGNAL(localParameterButtonClicked(std::string const &)), this,
-          SLOT(editLocalParameter(std::string const &)));
+  m_view->subscribePresenter(this);
   connect(m_view, SIGNAL(parameterValueChanged(std::string const &, double)), this,
           SLOT(viewChangedParameterValue(std::string const &, double)));
 }
@@ -171,7 +170,7 @@ void SingleFunctionTemplatePresenter::setLocalParameterFixed(std::string const &
   m_model->setLocalParameterFixed(parameterName, i, fixed);
 }
 
-void SingleFunctionTemplatePresenter::editLocalParameter(std::string const &parameterName) {
+void SingleFunctionTemplatePresenter::handleEditLocalParameter(std::string const &parameterName) {
   auto const datasetNames = getDatasetNames();
   auto const domainNames = getDatasetDomainNames();
   QList<double> values;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp
@@ -186,34 +186,27 @@ void SingleFunctionTemplatePresenter::handleEditLocalParameter(std::string const
     const auto constraint = getLocalParameterConstraint(parameterName, i);
     constraints.push_back(QString::fromStdString(constraint));
   }
-
-  m_editLocalParameterDialog =
-      new EditLocalParameterDialog(m_view, parameterName, datasetNames, domainNames, values, fixes, ties, constraints);
-  connect(m_editLocalParameterDialog, SIGNAL(finished(int)), this, SLOT(editLocalParameterFinish(int)));
-  m_editLocalParameterDialog->open();
+  m_view->openEditLocalParameterDialog(parameterName, datasetNames, domainNames, values, fixes, ties, constraints);
 }
 
-void SingleFunctionTemplatePresenter::editLocalParameterFinish(int result) {
-  if (result == QDialog::Accepted) {
-    const auto parName = m_editLocalParameterDialog->getParameterName();
-    const auto values = m_editLocalParameterDialog->getValues();
-    const auto fixes = m_editLocalParameterDialog->getFixes();
-    const auto ties = m_editLocalParameterDialog->getTies();
-    assert(values.size() == getNumberOfDatasets());
-    for (int i = 0; i < values.size(); ++i) {
-      setLocalParameterValue(parName, i, values[i]);
-      if (!ties[i].isEmpty()) {
-        setLocalParameterTie(parName, i, ties[i].toStdString());
-      } else if (fixes[i]) {
-        setLocalParameterFixed(parName, i, fixes[i]);
-      } else {
-        setLocalParameterTie(parName, i, "");
-      }
+void SingleFunctionTemplatePresenter::handleEditLocalParameterFinished(std::string const &parameterName,
+                                                                       QList<double> const &values,
+                                                                       QList<bool> const &fixes,
+                                                                       QStringList const &ties,
+                                                                       QStringList const &constraints) {
+  (void)constraints;
+  assert(values.size() == getNumberOfDatasets());
+  for (int i = 0; i < values.size(); ++i) {
+    setLocalParameterValue(parameterName, i, values[i]);
+    if (!ties[i].isEmpty()) {
+      setLocalParameterTie(parameterName, i, ties[i].toStdString());
+    } else if (fixes[i]) {
+      setLocalParameterFixed(parameterName, i, fixes[i]);
+    } else {
+      setLocalParameterTie(parameterName, i, "");
     }
   }
-  m_editLocalParameterDialog = nullptr;
   updateView();
-  m_view->emitFunctionStructureChanged();
 }
 
 void SingleFunctionTemplatePresenter::handleParameterValueChanged(std::string const &parameterName, double value) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp
@@ -46,7 +46,7 @@ void SingleFunctionTemplatePresenter::setFitType(std::string const &name) {
   }
   setErrorsEnabled(false);
   updateView();
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 void SingleFunctionTemplatePresenter::setNumberOfDatasets(int n) { m_model->setNumberDomains(n); }
@@ -68,7 +68,7 @@ void SingleFunctionTemplatePresenter::setFunction(std::string const &funStr) {
   m_view->setEnumValue(m_model->getEnumIndex());
   setErrorsEnabled(false);
   updateView();
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 IFunction_sptr SingleFunctionTemplatePresenter::getGlobalFunction() const { return m_model->getFitFunction(); }
@@ -215,7 +215,7 @@ void SingleFunctionTemplatePresenter::editLocalParameterFinish(int result) {
   }
   m_editLocalParameterDialog = nullptr;
   updateView();
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 void SingleFunctionTemplatePresenter::viewChangedParameterValue(std::string const &parameterName, double value) {
@@ -234,7 +234,7 @@ void SingleFunctionTemplatePresenter::viewChangedParameterValue(std::string cons
     }
     setLocalParameterValue(parameterName, i, value);
   }
-  emit functionStructureChanged();
+  m_view->emitFunctionStructureChanged();
 }
 
 } // namespace MantidQt::CustomInterfaces::IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
@@ -9,7 +9,7 @@
 #include "Analysis/IDAFunctionParameterEstimation.h"
 #include "Analysis/ParameterEstimation.h"
 #include "DllConfig.h"
-#include "ITemplatePresenter.h"
+#include "FunctionTemplatePresenter.h"
 #include "SingleFunctionTemplateModel.h"
 #include <QMap>
 
@@ -29,7 +29,7 @@ class SingleFunctionTemplateBrowser;
  * and set properties that can be used to generate a fit function.
  *
  */
-class MANTIDQT_INELASTIC_DLL SingleFunctionTemplatePresenter : public ITemplatePresenter {
+class MANTIDQT_INELASTIC_DLL SingleFunctionTemplatePresenter : public FunctionTemplatePresenter {
 public:
   explicit SingleFunctionTemplatePresenter(SingleFunctionTemplateBrowser *view,
                                            std::unique_ptr<SingleFunctionTemplateModel> functionModel);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
@@ -35,29 +35,34 @@ class MANTIDQT_INELASTIC_DLL SingleFunctionTemplatePresenter : public QObject, p
 public:
   explicit SingleFunctionTemplatePresenter(SingleFunctionTemplateBrowser *view,
                                            std::unique_ptr<SingleFunctionTemplateModel> functionModel);
-  void updateAvailableFunctions(const std::map<std::string, std::string> &functionInitialisationStrings);
-  void setFitType(std::string const &name);
 
-  void init();
+  void init() override;
+  void updateAvailableFunctions(const std::map<std::string, std::string> &functionInitialisationStrings) override;
 
-  void setNumberOfDatasets(int);
-  int getNumberOfDatasets() const;
-  int getCurrentDataset();
-  void setFunction(std::string const &funStr);
-  IFunction_sptr getGlobalFunction() const;
-  IFunction_sptr getFunction() const;
-  std::vector<std::string> getGlobalParameters() const;
-  std::vector<std::string> getLocalParameters() const;
-  void setGlobalParameters(std::vector<std::string> const &globals);
-  void setGlobal(std::string const &parameterName, bool on);
-  void updateMultiDatasetParameters(const IFunction &fun);
-  void updateParameters(const IFunction &fun);
-  void setCurrentDataset(int i);
-  void setDatasets(const QList<FunctionModelDataset> &datasets);
-  void setErrorsEnabled(bool enabled);
-  EstimationDataSelector getEstimationDataSelector() const;
-  void updateParameterEstimationData(DataForParameterEstimationCollection &&data);
-  void estimateFunctionParameters();
+  void setNumberOfDatasets(int) override;
+  int getNumberOfDatasets() const override;
+  int getCurrentDataset() override;
+
+  void setFitType(std::string const &name) override;
+
+  void setFunction(std::string const &funStr) override;
+  IFunction_sptr getGlobalFunction() const override;
+  IFunction_sptr getFunction() const override;
+
+  std::vector<std::string> getGlobalParameters() const override;
+  std::vector<std::string> getLocalParameters() const override;
+  void setGlobalParameters(std::vector<std::string> const &globals) override;
+  void setGlobal(std::string const &parameterName, bool on) override;
+
+  void updateMultiDatasetParameters(const IFunction &fun) override;
+  void updateParameters(const IFunction &fun) override;
+
+  void setCurrentDataset(int i) override;
+  void setDatasets(const QList<FunctionModelDataset> &datasets) override;
+
+  EstimationDataSelector getEstimationDataSelector() const override;
+  void updateParameterEstimationData(DataForParameterEstimationCollection &&data) override;
+  void estimateFunctionParameters() override;
 
   void handleEditLocalParameter(std::string const &parameterName) override;
 
@@ -69,6 +74,7 @@ private slots:
   void viewChangedParameterValue(std::string const &parameterName, double value);
 
 private:
+  void setErrorsEnabled(bool enabled);
   QStringList getDatasetNames() const;
   QStringList getDatasetDomainNames() const;
   double getLocalParameterValue(std::string const &parameterName, int i) const;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
@@ -68,10 +68,10 @@ public:
   void setErrorsEnabled(bool enabled) override;
 
   void handleEditLocalParameter(std::string const &parameterName) override;
+  void handleParameterValueChanged(std::string const &parameterName, double value) override;
 
 private slots:
   void editLocalParameterFinish(int result);
-  void viewChangedParameterValue(std::string const &parameterName, double value);
 
 private:
   QStringList getDatasetNames() const;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
@@ -35,6 +35,7 @@ class MANTIDQT_INELASTIC_DLL SingleFunctionTemplatePresenter : public QObject, p
 public:
   explicit SingleFunctionTemplatePresenter(SingleFunctionTemplateBrowser *view,
                                            std::unique_ptr<SingleFunctionTemplateModel> functionModel);
+  FunctionTemplateBrowser *browser() override { return reinterpret_cast<FunctionTemplateBrowser *>(m_view); }
 
   void init() override;
   void updateAvailableFunctions(const std::map<std::string, std::string> &functionInitialisationStrings) override;
@@ -64,6 +65,8 @@ public:
   void updateParameterEstimationData(DataForParameterEstimationCollection &&data) override;
   void estimateFunctionParameters() override;
 
+  void setErrorsEnabled(bool enabled) override;
+
   void handleEditLocalParameter(std::string const &parameterName) override;
 
 signals:
@@ -74,7 +77,6 @@ private slots:
   void viewChangedParameterValue(std::string const &parameterName, double value);
 
 private:
-  void setErrorsEnabled(bool enabled);
   QStringList getDatasetNames() const;
   QStringList getDatasetDomainNames() const;
   double getLocalParameterValue(std::string const &parameterName, int i) const;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
@@ -69,9 +69,9 @@ public:
 
   void handleEditLocalParameter(std::string const &parameterName) override;
   void handleParameterValueChanged(std::string const &parameterName, double value) override;
-
-private slots:
-  void editLocalParameterFinish(int result);
+  void handleEditLocalParameterFinished(std::string const &parameterName, QList<double> const &values,
+                                        QList<bool> const &fixes, QStringList const &ties,
+                                        QStringList const &constraints) override;
 
 private:
   QStringList getDatasetNames() const;
@@ -86,7 +86,6 @@ private:
   void updateView();
   SingleFunctionTemplateBrowser *m_view;
   std::unique_ptr<SingleFunctionTemplateModel> m_model;
-  EditLocalParameterDialog *m_editLocalParameterDialog;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
@@ -31,6 +31,8 @@ class SingleFunctionTemplateBrowser;
  */
 class MANTIDQT_INELASTIC_DLL SingleFunctionTemplatePresenter : public FunctionTemplatePresenter {
 public:
+  using FunctionTemplatePresenter::updateMultiDatasetParameters;
+
   explicit SingleFunctionTemplatePresenter(SingleFunctionTemplateBrowser *view,
                                            std::unique_ptr<SingleFunctionTemplateModel> functionModel);
   FunctionTemplateBrowser *browser() override { return reinterpret_cast<FunctionTemplateBrowser *>(m_view); }
@@ -53,7 +55,7 @@ public:
   void setGlobalParameters(std::vector<std::string> const &globals) override;
   void setGlobal(std::string const &parameterName, bool on) override;
 
-  void updateMultiDatasetParameters(const IFunction &fun) override;
+  void updateMultiDatasetParameters(const Mantid::API::IFunction &fun) override;
   void updateParameters(const IFunction &fun) override;
 
   void setCurrentDataset(int i) override;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
@@ -69,9 +69,6 @@ public:
 
   void handleEditLocalParameter(std::string const &parameterName) override;
 
-signals:
-  void functionStructureChanged();
-
 private slots:
   void editLocalParameterFinish(int result);
   void viewChangedParameterValue(std::string const &parameterName, double value);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
@@ -12,7 +12,6 @@
 #include "ITemplatePresenter.h"
 #include "SingleFunctionTemplateModel.h"
 #include <QMap>
-#include <QWidget>
 
 class QtProperty;
 
@@ -30,8 +29,7 @@ class SingleFunctionTemplateBrowser;
  * and set properties that can be used to generate a fit function.
  *
  */
-class MANTIDQT_INELASTIC_DLL SingleFunctionTemplatePresenter : public QObject, public ITemplatePresenter {
-  Q_OBJECT
+class MANTIDQT_INELASTIC_DLL SingleFunctionTemplatePresenter : public ITemplatePresenter {
 public:
   explicit SingleFunctionTemplatePresenter(SingleFunctionTemplateBrowser *view,
                                            std::unique_ptr<SingleFunctionTemplateModel> functionModel);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
@@ -9,6 +9,7 @@
 #include "Analysis/IDAFunctionParameterEstimation.h"
 #include "Analysis/ParameterEstimation.h"
 #include "DllConfig.h"
+#include "ITemplatePresenter.h"
 #include "SingleFunctionTemplateModel.h"
 #include <QMap>
 #include <QWidget>
@@ -29,7 +30,7 @@ class SingleFunctionTemplateBrowser;
  * and set properties that can be used to generate a fit function.
  *
  */
-class MANTIDQT_INELASTIC_DLL SingleFunctionTemplatePresenter : public QObject {
+class MANTIDQT_INELASTIC_DLL SingleFunctionTemplatePresenter : public QObject, public ITemplatePresenter {
   Q_OBJECT
 public:
   explicit SingleFunctionTemplatePresenter(SingleFunctionTemplateBrowser *view,
@@ -58,11 +59,12 @@ public:
   void updateParameterEstimationData(DataForParameterEstimationCollection &&data);
   void estimateFunctionParameters();
 
+  void handleEditLocalParameter(std::string const &parameterName) override;
+
 signals:
   void functionStructureChanged();
 
 private slots:
-  void editLocalParameter(std::string const &parameterName);
   void editLocalParameterFinish(int result);
   void viewChangedParameterValue(std::string const &parameterName, double value);
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.cpp
@@ -101,6 +101,40 @@ void FunctionTemplateBrowser::subscribePresenter(ITemplatePresenter *presenter) 
 
 void FunctionTemplateBrowser::clear() { m_browser->clear(); }
 
+void FunctionTemplateBrowser::setFunction(std::string const &funStr) { m_presenter->setFunction(funStr); }
+
+IFunction_sptr FunctionTemplateBrowser::getGlobalFunction() const { return m_presenter->getGlobalFunction(); }
+
+IFunction_sptr FunctionTemplateBrowser::getFunction() const { return m_presenter->getFunction(); }
+
+void FunctionTemplateBrowser::setCurrentDataset(int i) { m_presenter->setCurrentDataset(i); }
+
+int FunctionTemplateBrowser::getCurrentDataset() { return m_presenter->getCurrentDataset(); }
+
+void FunctionTemplateBrowser::setNumberOfDatasets(int n) { m_presenter->setNumberOfDatasets(n); }
+
+int FunctionTemplateBrowser::getNumberOfDatasets() const { return m_presenter->getNumberOfDatasets(); }
+
+void FunctionTemplateBrowser::setDatasets(const QList<FunctionModelDataset> &datasets) {
+  m_presenter->setDatasets(datasets);
+}
+
+std::vector<std::string> FunctionTemplateBrowser::getGlobalParameters() const {
+  return m_presenter->getGlobalParameters();
+}
+
+std::vector<std::string> FunctionTemplateBrowser::getLocalParameters() const {
+  return m_presenter->getLocalParameters();
+}
+
+void FunctionTemplateBrowser::setGlobalParameters(std::vector<std::string> const &globals) {
+  m_presenter->setGlobalParameters(globals);
+}
+
+void FunctionTemplateBrowser::updateMultiDatasetParameters(const IFunction &fun) {
+  m_presenter->updateMultiDatasetParameters(fun);
+}
+
 void FunctionTemplateBrowser::parameterButtonClicked(QtProperty *prop) {
   m_presenter->handleEditLocalParameter(m_parameterNames[prop]);
 }

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.cpp
@@ -15,6 +15,7 @@
 #include "MantidAPI/IWorkspaceProperty.h"
 #include "MantidKernel/PropertyWithValue.h"
 
+#include "MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/ButtonEditorFactory.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/CompositeEditorFactory.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/DoubleDialogEditor.h"
@@ -100,6 +101,32 @@ void FunctionTemplateBrowser::init() {
 void FunctionTemplateBrowser::subscribePresenter(ITemplatePresenter *presenter) { m_presenter = presenter; }
 
 void FunctionTemplateBrowser::clear() { m_browser->clear(); }
+
+void FunctionTemplateBrowser::setEnumSilent(QtProperty *prop, int enumIndex) {
+  MantidQt::MantidWidgets::ScopedFalse _enumBlock(m_emitEnumChange);
+  m_enumManager->setValue(prop, enumIndex);
+}
+
+void FunctionTemplateBrowser::setIntSilent(QtProperty *prop, int value) {
+  MantidQt::MantidWidgets::ScopedFalse _intBlock(m_emitIntChange);
+  m_intManager->setValue(prop, value);
+}
+
+void FunctionTemplateBrowser::setBoolSilent(QtProperty *prop, bool value) {
+  MantidQt::MantidWidgets::ScopedFalse _boolBlock(m_emitBoolChange);
+  m_boolManager->setValue(prop, value);
+}
+
+void FunctionTemplateBrowser::setParameterSilent(QtProperty *prop, double value, double error) {
+  MantidQt::MantidWidgets::ScopedFalse _parameterBlock(m_emitParameterValueChange);
+  m_parameterManager->setValue(prop, value);
+  m_parameterManager->setError(prop, error);
+}
+
+void FunctionTemplateBrowser::setErrorsEnabled(bool enabled) {
+  MantidQt::MantidWidgets::ScopedFalse _parameterBlock(m_emitParameterValueChange);
+  m_parameterManager->setErrorsEnabled(enabled);
+}
 
 void FunctionTemplateBrowser::setFunction(std::string const &funStr) { m_presenter->setFunction(funStr); }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.cpp
@@ -6,6 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "FunctionTemplateBrowser.h"
 
+#include "FunctionBrowser/ITemplatePresenter.h"
+
 #include "MantidAPI/CostFunctionFactory.h"
 #include "MantidAPI/FuncMinimizerFactory.h"
 #include "MantidAPI/IAlgorithm.h"
@@ -32,7 +34,8 @@ namespace MantidQt::CustomInterfaces::IDA {
  * Constructor
  * @param parent :: The parent widget.
  */
-FunctionTemplateBrowser::FunctionTemplateBrowser(QWidget *parent) : QWidget(parent), m_decimals(6) {}
+FunctionTemplateBrowser::FunctionTemplateBrowser(QWidget *parent)
+    : QWidget(parent), m_parameterNames(), m_decimals(6) {}
 
 FunctionTemplateBrowser::~FunctionTemplateBrowser() {
   m_browser->unsetFactoryForManager(m_stringManager);
@@ -94,6 +97,12 @@ void FunctionTemplateBrowser::init() {
   layout->setContentsMargins(0, 0, 0, 0);
 }
 
+void FunctionTemplateBrowser::subscribePresenter(ITemplatePresenter *presenter) { m_presenter = presenter; }
+
 void FunctionTemplateBrowser::clear() { m_browser->clear(); }
+
+void FunctionTemplateBrowser::parameterButtonClicked(QtProperty *prop) {
+  m_presenter->handleEditLocalParameter(m_parameterNames[prop]);
+}
 
 } // namespace MantidQt::CustomInterfaces::IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.cpp
@@ -135,8 +135,30 @@ void FunctionTemplateBrowser::updateMultiDatasetParameters(const IFunction &fun)
   m_presenter->updateMultiDatasetParameters(fun);
 }
 
+void FunctionTemplateBrowser::openEditLocalParameterDialog(std::string const &parameterName,
+                                                           QStringList const &datasetNames,
+                                                           QStringList const &domainNames, QList<double> const &values,
+                                                           QList<bool> const &fixes, QStringList const &ties,
+                                                           QStringList const &constraints) {
+  m_editLocalParameterDialog =
+      new EditLocalParameterDialog(this, parameterName, datasetNames, domainNames, values, fixes, ties, constraints);
+  connect(m_editLocalParameterDialog, SIGNAL(finished(int)), this, SLOT(editLocalParameterFinished(int)));
+  m_editLocalParameterDialog->open();
+}
+
 void FunctionTemplateBrowser::parameterButtonClicked(QtProperty *prop) {
   m_presenter->handleEditLocalParameter(m_parameterNames[prop]);
+}
+
+void FunctionTemplateBrowser::editLocalParameterFinished(int result) {
+  if (result == QDialog::Accepted) {
+    m_presenter->handleEditLocalParameterFinished(
+        m_editLocalParameterDialog->getParameterName(), m_editLocalParameterDialog->getValues(),
+        m_editLocalParameterDialog->getFixes(), m_editLocalParameterDialog->getTies(),
+        m_editLocalParameterDialog->getConstraints());
+  }
+  m_editLocalParameterDialog = nullptr;
+  emitFunctionStructureChanged();
 }
 
 } // namespace MantidQt::CustomInterfaces::IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.cpp
@@ -15,6 +15,7 @@
 #include "MantidAPI/IWorkspaceProperty.h"
 #include "MantidKernel/PropertyWithValue.h"
 
+#include "MantidQtWidgets/Common/EditLocalParameterDialog.h"
 #include "MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/ButtonEditorFactory.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/CompositeEditorFactory.h"
@@ -167,24 +168,22 @@ void FunctionTemplateBrowser::openEditLocalParameterDialog(std::string const &pa
                                                            QStringList const &domainNames, QList<double> const &values,
                                                            QList<bool> const &fixes, QStringList const &ties,
                                                            QStringList const &constraints) {
-  m_editLocalParameterDialog =
+  auto dialog =
       new EditLocalParameterDialog(this, parameterName, datasetNames, domainNames, values, fixes, ties, constraints);
-  connect(m_editLocalParameterDialog, SIGNAL(finished(int)), this, SLOT(editLocalParameterFinished(int)));
-  m_editLocalParameterDialog->open();
+  connect(dialog, SIGNAL(dialogFinished(int, EditLocalParameterDialog *)), this,
+          SLOT(editLocalParameterFinished(int, EditLocalParameterDialog *)));
+  dialog->open();
 }
 
 void FunctionTemplateBrowser::parameterButtonClicked(QtProperty *prop) {
   m_presenter->handleEditLocalParameter(m_parameterNames[prop]);
 }
 
-void FunctionTemplateBrowser::editLocalParameterFinished(int result) {
+void FunctionTemplateBrowser::editLocalParameterFinished(int result, EditLocalParameterDialog *dialog) {
   if (result == QDialog::Accepted) {
-    m_presenter->handleEditLocalParameterFinished(
-        m_editLocalParameterDialog->getParameterName(), m_editLocalParameterDialog->getValues(),
-        m_editLocalParameterDialog->getFixes(), m_editLocalParameterDialog->getTies(),
-        m_editLocalParameterDialog->getConstraints());
+    m_presenter->handleEditLocalParameterFinished(dialog->getParameterName(), dialog->getValues(), dialog->getFixes(),
+                                                  dialog->getTies(), dialog->getConstraints());
   }
-  m_editLocalParameterDialog = nullptr;
   emitFunctionStructureChanged();
 }
 

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
@@ -50,21 +50,25 @@ public:
   void init();
   void subscribePresenter(ITemplatePresenter *presenter);
 
-  virtual void setFunction(std::string const &funStr) = 0;
-  virtual IFunction_sptr getGlobalFunction() const = 0;
-  virtual IFunction_sptr getFunction() const = 0;
-  virtual void setNumberOfDatasets(int) = 0;
-  virtual int getNumberOfDatasets() const = 0;
-  virtual void setDatasets(const QList<MantidWidgets::FunctionModelDataset> &datasets) = 0;
-  virtual std::vector<std::string> getGlobalParameters() const = 0;
-  virtual std::vector<std::string> getLocalParameters() const = 0;
-  virtual void setGlobalParameters(std::vector<std::string> const &globals) = 0;
-  virtual void updateMultiDatasetParameters(const IFunction &fun) = 0;
+  void setFunction(std::string const &funStr);
+  IFunction_sptr getGlobalFunction() const;
+  IFunction_sptr getFunction() const;
+
+  int getCurrentDataset();
+  void setCurrentDataset(int i);
+  void setNumberOfDatasets(int);
+  int getNumberOfDatasets() const;
+  void setDatasets(const QList<MantidWidgets::FunctionModelDataset> &datasets);
+
+  std::vector<std::string> getGlobalParameters() const;
+  std::vector<std::string> getLocalParameters() const;
+  void setGlobalParameters(std::vector<std::string> const &globals);
+
+  void updateMultiDatasetParameters(const IFunction &fun);
   virtual void updateMultiDatasetParameters(const ITableWorkspace &paramTable) = 0;
   virtual void updateParameters(const IFunction &fun) = 0;
-  virtual void setCurrentDataset(int i) = 0;
-  virtual int getCurrentDataset() = 0;
   virtual void updateParameterNames(const QMap<int, std::string> &parameterNames) = 0;
+
   virtual void setErrorsEnabled(bool enabled) = 0;
   virtual void clear() = 0;
   virtual EstimationDataSelector getEstimationDataSelector() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
@@ -51,6 +51,12 @@ public:
   void init();
   void subscribePresenter(ITemplatePresenter *presenter);
 
+  void setEnumSilent(QtProperty *prop, int fitType);
+  void setIntSilent(QtProperty *prop, int value);
+  void setBoolSilent(QtProperty *prop, bool value);
+  void setParameterSilent(QtProperty *prop, double value, double error);
+  void setErrorsEnabled(bool enabled);
+
   void setFunction(std::string const &funStr);
   IFunction_sptr getGlobalFunction() const;
   IFunction_sptr getFunction() const;
@@ -70,7 +76,6 @@ public:
   virtual void updateParameters(const IFunction &fun) = 0;
   virtual void updateParameterNames(const QMap<int, std::string> &parameterNames) = 0;
 
-  virtual void setErrorsEnabled(bool enabled) = 0;
   virtual void clear() = 0;
   virtual EstimationDataSelector getEstimationDataSelector() const = 0;
   virtual void updateParameterEstimationData(DataForParameterEstimationCollection &&data) = 0;
@@ -103,6 +108,11 @@ private:
   virtual void createProperties() = 0;
 
 protected:
+  bool m_emitParameterValueChange = true;
+  bool m_emitBoolChange = true;
+  bool m_emitEnumChange = true;
+  bool m_emitIntChange = true;
+
   QtBoolPropertyManager *m_boolManager;
   QtIntPropertyManager *m_intManager;
   QtDoublePropertyManager *m_doubleManager;

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
@@ -9,7 +9,6 @@
 #include "DllConfig.h"
 #include "MantidAPI/IFunction_fwd.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
-#include "MantidQtWidgets/Common/EditLocalParameterDialog.h"
 #include "MantidQtWidgets/Common/FunctionModelDataset.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 #include "ParameterEstimation.h"
@@ -30,6 +29,9 @@ class QtTreePropertyBrowser;
 class QtProperty;
 
 namespace MantidQt {
+namespace MantidWidgets {
+class EditLocalParameterDialog;
+}
 namespace CustomInterfaces {
 namespace IDA {
 
@@ -101,7 +103,7 @@ protected slots:
   virtual void globalChanged(QtProperty *, const QString &, bool) = 0;
   virtual void parameterChanged(QtProperty *) = 0;
   void parameterButtonClicked(QtProperty *);
-  void editLocalParameterFinished(int result);
+  void editLocalParameterFinished(int result, EditLocalParameterDialog *dialog);
 
 private:
   void createBrowser();
@@ -131,9 +133,6 @@ protected:
 
   /// The corresponding template presenter
   ITemplatePresenter *m_presenter;
-
-  /// The Edit local parameter dialog
-  EditLocalParameterDialog *m_editLocalParameterDialog;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
@@ -78,6 +78,8 @@ public:
   virtual void setResolution(const std::vector<std::pair<std::string, size_t>> &fitResolutions) = 0;
   virtual void setQValues(const std::vector<double> &qValues) = 0;
 
+  void emitFunctionStructureChanged() { emit functionStructureChanged(); }
+
 signals:
   void functionStructureChanged();
   void parameterValueChanged(std::string const &parameterName, double value);

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
@@ -35,6 +35,8 @@ namespace IDA {
 using namespace Mantid::API;
 using namespace MantidWidgets;
 
+class ITemplatePresenter;
+
 /**
  * Class FunctionTemplateBrowser implements QtPropertyBrowser to display
  * and set properties that can be used to generate a fit function.
@@ -46,6 +48,7 @@ public:
   FunctionTemplateBrowser(QWidget *parent = nullptr);
   virtual ~FunctionTemplateBrowser();
   void init();
+  void subscribePresenter(ITemplatePresenter *presenter);
 
   virtual void setFunction(std::string const &funStr) = 0;
   virtual IFunction_sptr getGlobalFunction() const = 0;
@@ -73,7 +76,6 @@ public:
 
 signals:
   void functionStructureChanged();
-  void localParameterButtonClicked(std::string const &parameterName);
   void parameterValueChanged(std::string const &parameterName, double value);
 
 protected slots:
@@ -83,7 +85,7 @@ protected slots:
   virtual void popupMenu(const QPoint &) = 0;
   virtual void globalChanged(QtProperty *, const QString &, bool) = 0;
   virtual void parameterChanged(QtProperty *) = 0;
-  virtual void parameterButtonClicked(QtProperty *) = 0;
+  void parameterButtonClicked(QtProperty *);
 
 private:
   void createBrowser();
@@ -98,11 +100,16 @@ protected:
   QtGroupPropertyManager *m_groupManager;
   ParameterPropertyManager *m_parameterManager;
 
+  QMap<QtProperty *, std::string> m_parameterNames;
+
   /// Qt property browser which displays properties
   QtTreePropertyBrowser *m_browser;
 
   /// Precision of doubles in m_doubleManager
   const int m_decimals;
+
+  /// The corresponding template presenter
+  ITemplatePresenter *m_presenter;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
@@ -14,6 +14,7 @@
 #include "ParameterEstimation.h"
 
 #include <QList>
+#include <QMap>
 #include <QPair>
 #include <QString>
 #include <QWidget>

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
@@ -82,7 +82,6 @@ public:
 
 signals:
   void functionStructureChanged();
-  void parameterValueChanged(std::string const &parameterName, double value);
 
 protected slots:
   virtual void intChanged(QtProperty *) {}

--- a/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/FunctionTemplateBrowser.h
@@ -9,6 +9,7 @@
 #include "DllConfig.h"
 #include "MantidAPI/IFunction_fwd.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
+#include "MantidQtWidgets/Common/EditLocalParameterDialog.h"
 #include "MantidQtWidgets/Common/FunctionModelDataset.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 #include "ParameterEstimation.h"
@@ -80,6 +81,10 @@ public:
 
   void emitFunctionStructureChanged() { emit functionStructureChanged(); }
 
+  void openEditLocalParameterDialog(std::string const &parameterName, QStringList const &datasetNames,
+                                    QStringList const &domainNames, QList<double> const &values,
+                                    QList<bool> const &fixes, QStringList const &ties, QStringList const &constraints);
+
 signals:
   void functionStructureChanged();
 
@@ -91,6 +96,7 @@ protected slots:
   virtual void globalChanged(QtProperty *, const QString &, bool) = 0;
   virtual void parameterChanged(QtProperty *) = 0;
   void parameterButtonClicked(QtProperty *);
+  void editLocalParameterFinished(int result);
 
 private:
   void createBrowser();
@@ -115,6 +121,9 @@ protected:
 
   /// The corresponding template presenter
   ITemplatePresenter *m_presenter;
+
+  /// The Edit local parameter dialog
+  EditLocalParameterDialog *m_editLocalParameterDialog;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
@@ -67,8 +67,8 @@ public:
   void setupFitPropertyBrowser(std::vector<std::string> const &hiddenProperties, bool const convolveMembers = false) {
     auto templateBrowser = new TemplateBrowser();
     auto functionModel = std::make_unique<FunctionModel>();
-    m_uiForm->dockArea->m_fitPropertyBrowser->setFunctionTemplatePresenter(
-        new TemplatePresenter(templateBrowser, std::move(functionModel)));
+    auto templatePresenter = std::make_unique<TemplatePresenter>(templateBrowser, std::move(functionModel));
+    m_uiForm->dockArea->m_fitPropertyBrowser->setFunctionTemplatePresenter(std::move(templatePresenter));
     m_uiForm->dockArea->m_fitPropertyBrowser->init();
     m_uiForm->dockArea->m_fitPropertyBrowser->setHiddenProperties(hiddenProperties);
     m_fitPropertyBrowser = m_uiForm->dockArea->m_fitPropertyBrowser;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
@@ -63,10 +63,9 @@ public:
 
   template <typename FittingModel> void setupFittingModel() { m_fittingModel = std::make_unique<FittingModel>(); }
 
-  template <typename TemplateBrowser, typename FunctionModel>
+  template <typename TemplateBrowser>
   void setupFitPropertyBrowser(std::vector<std::string> const &hiddenProperties, bool const convolveMembers = false) {
-    auto functionModel = std::make_unique<FunctionModel>();
-    m_uiForm->dockArea->m_fitPropertyBrowser->setFunctionTemplateBrowser(new TemplateBrowser(std::move(functionModel)));
+    m_uiForm->dockArea->m_fitPropertyBrowser->setFunctionTemplateBrowser(new TemplateBrowser());
     m_uiForm->dockArea->m_fitPropertyBrowser->init();
     m_uiForm->dockArea->m_fitPropertyBrowser->setHiddenProperties(hiddenProperties);
     m_fitPropertyBrowser = m_uiForm->dockArea->m_fitPropertyBrowser;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectDataAnalysisTab.h
@@ -63,9 +63,12 @@ public:
 
   template <typename FittingModel> void setupFittingModel() { m_fittingModel = std::make_unique<FittingModel>(); }
 
-  template <typename TemplateBrowser>
+  template <typename TemplateBrowser, typename TemplatePresenter, typename FunctionModel>
   void setupFitPropertyBrowser(std::vector<std::string> const &hiddenProperties, bool const convolveMembers = false) {
-    m_uiForm->dockArea->m_fitPropertyBrowser->setFunctionTemplateBrowser(new TemplateBrowser());
+    auto templateBrowser = new TemplateBrowser();
+    auto functionModel = std::make_unique<FunctionModel>();
+    m_uiForm->dockArea->m_fitPropertyBrowser->setFunctionTemplatePresenter(
+        new TemplatePresenter(templateBrowser, std::move(functionModel)));
     m_uiForm->dockArea->m_fitPropertyBrowser->init();
     m_uiForm->dockArea->m_fitPropertyBrowser->setHiddenProperties(hiddenProperties);
     m_fitPropertyBrowser = m_uiForm->dockArea->m_fitPropertyBrowser;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.cpp
@@ -173,11 +173,11 @@ void IndirectFitPropertyBrowser::init() {
   setWidget(w);
 }
 
-void IndirectFitPropertyBrowser::setFunctionTemplatePresenter(ITemplatePresenter *templatePresenter) {
+void IndirectFitPropertyBrowser::setFunctionTemplatePresenter(std::unique_ptr<ITemplatePresenter> templatePresenter) {
   if (m_templatePresenter) {
-    throw std::logic_error("Template browser already set.");
+    throw std::logic_error("Template presenter already set.");
   }
-  m_templatePresenter = templatePresenter;
+  m_templatePresenter = std::move(templatePresenter);
   m_templatePresenter->init();
   // m_templatePresenter->setObjectName("templateBrowser");
   // connect(m_templateBrowser, SIGNAL(functionStructureChanged()), this, SIGNAL(functionChanged()));
@@ -261,10 +261,7 @@ void IndirectFitPropertyBrowser::updateParameters(const IFunction &fun) {
 
 void IndirectFitPropertyBrowser::updateFunctionListInBrowser(
     const std::map<std::string, std::string> &functionStrings) {
-  auto presenter = dynamic_cast<SingleFunctionTemplatePresenter *>(m_templatePresenter);
-  if (presenter) {
-    presenter->updateAvailableFunctions(functionStrings);
-  }
+  m_templatePresenter->updateAvailableFunctions(functionStrings);
 }
 
 void IndirectFitPropertyBrowser::updateMultiDatasetParameters(const IFunction &fun) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.cpp
@@ -179,8 +179,7 @@ void IndirectFitPropertyBrowser::setFunctionTemplatePresenter(std::unique_ptr<IT
   }
   m_templatePresenter = std::move(templatePresenter);
   m_templatePresenter->init();
-  // m_templatePresenter->setObjectName("templateBrowser");
-  // connect(m_templateBrowser, SIGNAL(functionStructureChanged()), this, SIGNAL(functionChanged()));
+  connect(m_templatePresenter->browser(), SIGNAL(functionStructureChanged()), this, SIGNAL(functionChanged()));
 }
 
 void IndirectFitPropertyBrowser::setFunction(std::string const &funStr) {

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.h
@@ -40,6 +40,7 @@ using namespace MantidWidgets;
 
 class FunctionTemplateBrowser;
 class FitStatusWidget;
+class ITemplatePresenter;
 
 class MANTIDQT_INELASTIC_DLL IIndirectFitPropertyBrowser {
 public:
@@ -53,7 +54,7 @@ public:
   IndirectFitPropertyBrowser(QWidget *parent = nullptr);
 
   void init();
-  void setFunctionTemplateBrowser(FunctionTemplateBrowser *templateBrowser);
+  void setFunctionTemplatePresenter(ITemplatePresenter *templatePresenter);
   void setFunction(std::string const &funStr);
   int getNumberOfDatasets() const;
   QString getSingleFunctionStr() const;
@@ -124,7 +125,7 @@ private:
   QVBoxLayout *m_mainLayout;
   FunctionBrowser *m_functionBrowser;
   FitOptionsBrowser *m_fitOptionsBrowser;
-  FunctionTemplateBrowser *m_templateBrowser;
+  ITemplatePresenter *m_templatePresenter;
   FitStatusWidget *m_fitStatusWidget;
   QStackedWidget *m_functionWidget;
   QCheckBox *m_browserSwitcher;

--- a/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/Analysis/IndirectFitPropertyBrowser.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DllConfig.h"
+#include "FunctionBrowser/ITemplatePresenter.h"
 #include "MantidAPI/IFunction_fwd.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -40,7 +41,6 @@ using namespace MantidWidgets;
 
 class FunctionTemplateBrowser;
 class FitStatusWidget;
-class ITemplatePresenter;
 
 class MANTIDQT_INELASTIC_DLL IIndirectFitPropertyBrowser {
 public:
@@ -54,7 +54,7 @@ public:
   IndirectFitPropertyBrowser(QWidget *parent = nullptr);
 
   void init();
-  void setFunctionTemplatePresenter(ITemplatePresenter *templatePresenter);
+  void setFunctionTemplatePresenter(std::unique_ptr<ITemplatePresenter> templatePresenter);
   void setFunction(std::string const &funStr);
   int getNumberOfDatasets() const;
   QString getSingleFunctionStr() const;
@@ -74,7 +74,6 @@ public:
   void updateFitStatus(const FitDomainIndex index);
   void updateFitStatusData(const std::vector<std::string> &status, const std::vector<double> &chiSquared);
   FittingMode getFittingMode() const;
-  QString selectedFitType() const;
   void setConvolveMembers(bool convolveEnabled);
   void setOutputCompositeMembers(bool outputEnabled);
   void setFitEnabled(bool enable);
@@ -125,7 +124,7 @@ private:
   QVBoxLayout *m_mainLayout;
   FunctionBrowser *m_functionBrowser;
   FitOptionsBrowser *m_fitOptionsBrowser;
-  ITemplatePresenter *m_templatePresenter;
+  std::unique_ptr<ITemplatePresenter> m_templatePresenter;
   FitStatusWidget *m_fitStatusWidget;
   QStackedWidget *m_functionWidget;
   QCheckBox *m_browserSwitcher;

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -160,6 +160,7 @@ set(INC_FILES
     Analysis/ParameterEstimation.h
     Analysis/FunctionBrowser/ConvFunctionModel.h
     Analysis/FunctionBrowser/FqFunctionModel.h
+    Analysis/FunctionBrowser/ITemplatePresenter.h
     Analysis/FunctionBrowser/MSDFunctionModel.h
     Common/IndirectDataValidationHelper.h
     Common/ISettingsView.h

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SRC_FILES
     Analysis/FunctionBrowser/ConvFunctionModel.cpp
     Analysis/FunctionBrowser/ConvTemplateBrowser.cpp
     Analysis/FunctionBrowser/ConvTemplatePresenter.cpp
+    Analysis/FunctionBrowser/FunctionTemplatePresenter.cpp
     Analysis/FunctionBrowser/FqFunctionModel.cpp
     Analysis/FunctionBrowser/IqtFunctionModel.cpp
     Analysis/FunctionBrowser/IqtTemplateBrowser.cpp
@@ -157,6 +158,7 @@ set(INC_FILES
     Analysis/ParameterEstimation.h
     Analysis/FunctionBrowser/ConvFunctionModel.h
     Analysis/FunctionBrowser/ConvTemplatePresenter.h
+    Analysis/FunctionBrowser/FunctionTemplatePresenter.h
     Analysis/FunctionBrowser/FqFunctionModel.h
     Analysis/FunctionBrowser/ITemplatePresenter.h
     Analysis/FunctionBrowser/IqtTemplatePresenter.h

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -99,11 +99,8 @@ set(MOC_FILES
     Analysis/IndirectFitPlotView.h
     Analysis/IndirectFitPropertyBrowser.h
     Analysis/FunctionBrowser/ConvTemplateBrowser.h
-    Analysis/FunctionBrowser/ConvTemplatePresenter.h
     Analysis/FunctionBrowser/IqtTemplateBrowser.h
-    Analysis/FunctionBrowser/IqtTemplatePresenter.h
     Analysis/FunctionBrowser/SingleFunctionTemplateBrowser.h
-    Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
     BayesFitting/BayesFitting.h
     BayesFitting/BayesFittingTab.h
     BayesFitting/Quasi.h
@@ -159,9 +156,12 @@ set(INC_FILES
     Analysis/IndirectFittingModel.h
     Analysis/ParameterEstimation.h
     Analysis/FunctionBrowser/ConvFunctionModel.h
+    Analysis/FunctionBrowser/ConvTemplatePresenter.h
     Analysis/FunctionBrowser/FqFunctionModel.h
     Analysis/FunctionBrowser/ITemplatePresenter.h
+    Analysis/FunctionBrowser/IqtTemplatePresenter.h
     Analysis/FunctionBrowser/MSDFunctionModel.h
+    Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
     Common/IndirectDataValidationHelper.h
     Common/ISettingsView.h
     Common/OutputPlotOptionsModel.h

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/IndirectFitPropertyBrowserTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/IndirectFitPropertyBrowserTest.h
@@ -24,6 +24,7 @@
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidQtWidgets/Common/FitOptionsBrowser.h"
 #include "MantidQtWidgets/Common/FunctionModelDataset.h"
+#include "MockObjects.h"
 
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
@@ -36,47 +37,6 @@ namespace {
 TableWorkspace_sptr createTableWorkspace(std::size_t const &size) { return std::make_shared<TableWorkspace>(size); }
 } // namespace
 
-GNU_DIAG_OFF_SUGGEST_OVERRIDE
-
-class MockFunctionTemplateBrowser : public FunctionTemplateBrowser {
-public:
-  void emitFunctionStructureChanged() { emit functionStructureChanged(); }
-  // public methods
-  MOCK_METHOD1(setFunction, void(std::string const &funStr));
-  MOCK_CONST_METHOD0(getGlobalFunction, IFunction_sptr());
-  MOCK_CONST_METHOD0(getFunction, IFunction_sptr());
-  MOCK_METHOD1(setNumberOfDatasets, void(int));
-  MOCK_CONST_METHOD0(getNumberOfDatasets, int());
-  MOCK_METHOD1(setDatasets, void(const QList<FunctionModelDataset> &datasets));
-  MOCK_CONST_METHOD0(getGlobalParameters, std::vector<std::string>());
-  MOCK_CONST_METHOD0(getLocalParameters, std::vector<std::string>());
-  MOCK_METHOD1(setGlobalParameters, void(std::vector<std::string> const &globals));
-  MOCK_METHOD1(updateMultiDatasetParameters, void(const IFunction &fun));
-  MOCK_METHOD1(updateMultiDatasetParameters, void(const ITableWorkspace &paramTable));
-  MOCK_METHOD1(updateParameters, void(const IFunction &fun));
-  MOCK_METHOD1(setCurrentDataset, void(int i));
-  MOCK_METHOD0(getCurrentDataset, int());
-  MOCK_METHOD1(updateParameterNames, void(const QMap<int, std::string> &parameterNames));
-  MOCK_METHOD1(setErrorsEnabled, void(bool enabled));
-  MOCK_METHOD0(clear, void());
-  MOCK_CONST_METHOD0(getEstimationDataSelector, EstimationDataSelector());
-  MOCK_METHOD1(updateParameterEstimationData, void(DataForParameterEstimationCollection &&data));
-  MOCK_METHOD0(estimateFunctionParameters, void());
-  MOCK_METHOD1(setBackgroundA0, void(double value));
-  MOCK_METHOD2(setResolution, void(std::string const &name, WorkspaceID const &index));
-  MOCK_METHOD1(setResolution, void(const std::vector<std::pair<std::string, size_t>> &fitResolutions));
-  MOCK_METHOD1(setQValues, void(const std::vector<double> &qValues));
-  // protected Slots
-  MOCK_METHOD1(popupMenu, void(const QPoint &));
-  MOCK_METHOD3(globalChanged, void(QtProperty *, const QString &, bool));
-  MOCK_METHOD1(parameterChanged, void(QtProperty *));
-  MOCK_METHOD1(parameterButtonClicked, void(QtProperty *));
-  // Private methods
-  MOCK_METHOD0(createProperties, void());
-};
-
-GNU_DIAG_ON_SUGGEST_OVERRIDE
-
 class IndirectFitPropertyBrowserTest : public CxxTest::TestSuite {
 public:
   static IndirectFitPropertyBrowserTest *createSuite() { return new IndirectFitPropertyBrowserTest(); }
@@ -88,46 +48,47 @@ public:
     m_fitOptionsBrowser = std::make_unique<FitOptionsBrowser>(nullptr, FittingMode::SEQUENTIAL_AND_SIMULTANEOUS);
     m_browser->init();
     m_templateBrowser = std::make_unique<NiceMock<MockFunctionTemplateBrowser>>();
-    EXPECT_CALL(*m_templateBrowser, createProperties());
-    m_browser->setFunctionTemplateBrowser(m_templateBrowser.get());
+    auto templatePresenter = std::make_unique<NiceMock<MockFunctionTemplatePresenter>>(m_templateBrowser.get());
+    m_templatePresenter = templatePresenter.get();
+    m_browser->setFunctionTemplatePresenter(std::move(templatePresenter));
   }
 
   void tearDown() override {
     AnalysisDataService::Instance().clear();
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_templateBrowser.get()));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_templatePresenter));
+
     m_browser.reset();
     m_fitOptionsBrowser.reset();
     m_templateBrowser.reset();
   }
 
-  void test_setFunctionTemplateBrowser_sets_up_FunctionTemplateBrowser() {
-    TS_ASSERT_EQUALS(m_templateBrowser->objectName(), "templateBrowser");
-  }
-
   void test_setFunction_sets_function_in_template() {
     std::string funString = "FunctionString";
-    EXPECT_CALL(*m_templateBrowser, setFunction(funString)).Times(Exactly(1));
+    EXPECT_CALL(*m_templatePresenter, setFunction(funString)).Times(Exactly(1));
     m_browser->setFunction(funString);
   }
 
   void test_getNumberOfDatasets_returns_value_from_template() {
-    ON_CALL(*m_templateBrowser, getNumberOfDatasets()).WillByDefault(Return(5));
-    EXPECT_CALL(*m_templateBrowser, getNumberOfDatasets());
+    ON_CALL(*m_templatePresenter, getNumberOfDatasets()).WillByDefault(Return(5));
+    EXPECT_CALL(*m_templatePresenter, getNumberOfDatasets());
     TS_ASSERT_EQUALS(m_browser->getNumberOfDatasets(), 5);
   }
 
   void test_getSingleFunctionString_returns_from_template() {
     auto fun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=0,A1=0");
-    ON_CALL(*m_templateBrowser, getFunction()).WillByDefault(Return(fun));
-    EXPECT_CALL(*m_templateBrowser, getFunction()).Times(Exactly(1));
+    ON_CALL(*m_templatePresenter, getFunction()).WillByDefault(Return(fun));
+    EXPECT_CALL(*m_templatePresenter, getFunction()).Times(Exactly(1));
     m_browser->getSingleFunctionStr();
   }
 
   void test_getFitFunction_returns_modified_multi_domain_function_if_domains_0() {
     auto fun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=0,A1=0");
-    ON_CALL(*m_templateBrowser, getFunction()).WillByDefault(Return(fun));
-    EXPECT_CALL(*m_templateBrowser, getFunction());
-    ON_CALL(*m_templateBrowser, getNumberOfDatasets()).WillByDefault(Return(0));
-    EXPECT_CALL(*m_templateBrowser, getNumberOfDatasets());
+    ON_CALL(*m_templatePresenter, getFunction()).WillByDefault(Return(fun));
+    EXPECT_CALL(*m_templatePresenter, getFunction());
+    ON_CALL(*m_templatePresenter, getNumberOfDatasets()).WillByDefault(Return(0));
+    EXPECT_CALL(*m_templatePresenter, getNumberOfDatasets());
 
     auto returnFun = m_browser->getFitFunction();
 
@@ -139,10 +100,10 @@ public:
 
   void test_getFitFunction_returns_modified_multi_domain_function_if_domains_1() {
     auto fun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=0,A1=0");
-    ON_CALL(*m_templateBrowser, getGlobalFunction()).WillByDefault(Return(fun));
-    EXPECT_CALL(*m_templateBrowser, getGlobalFunction());
-    ON_CALL(*m_templateBrowser, getNumberOfDatasets()).WillByDefault(Return(1));
-    EXPECT_CALL(*m_templateBrowser, getNumberOfDatasets());
+    ON_CALL(*m_templatePresenter, getGlobalFunction()).WillByDefault(Return(fun));
+    EXPECT_CALL(*m_templatePresenter, getGlobalFunction());
+    ON_CALL(*m_templatePresenter, getNumberOfDatasets()).WillByDefault(Return(1));
+    EXPECT_CALL(*m_templatePresenter, getNumberOfDatasets());
 
     auto returnFun = m_browser->getFitFunction();
 
@@ -208,7 +169,7 @@ public:
 
   void test_updateParameters_calls_to_template() {
     auto fun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=0,A1=0");
-    EXPECT_CALL(*m_templateBrowser, updateParameters(_)).Times(Exactly(1));
+    EXPECT_CALL(*m_templatePresenter, updateParameters(_)).Times(Exactly(1));
     m_browser->updateParameters(*fun);
   }
 
@@ -228,7 +189,8 @@ public:
 
     auto browser = std::make_unique<IndirectFitPropertyBrowser>();
     auto templateBrowser = std::make_unique<NiceMock<MockFunctionTemplateBrowser>>();
-    browser->setFunctionTemplateBrowser(templateBrowser.get());
+    auto templatePresenter = std::make_unique<NiceMock<MockFunctionTemplatePresenter>>(templateBrowser.get());
+    browser->setFunctionTemplatePresenter(std::move(templatePresenter));
     browser->init();
 
     std::vector<std::string> status = {"success", "success"};
@@ -237,15 +199,15 @@ public:
   }
 
   void test_setCurrentDataset_calls_to_template() {
-    ON_CALL(*m_templateBrowser, getNumberOfDatasets()).WillByDefault(Return(1));
-    EXPECT_CALL(*m_templateBrowser, getNumberOfDatasets()).Times(Exactly(1));
-    EXPECT_CALL(*m_templateBrowser, setCurrentDataset(1)).Times(Exactly(1));
+    ON_CALL(*m_templatePresenter, getNumberOfDatasets()).WillByDefault(Return(1));
+    EXPECT_CALL(*m_templatePresenter, getNumberOfDatasets()).Times(Exactly(1));
+    EXPECT_CALL(*m_templatePresenter, setCurrentDataset(1)).Times(Exactly(1));
     m_browser->setCurrentDataset(FitDomainIndex{1});
   }
 
   void test_currentDataset_returns_from_template() {
-    ON_CALL(*m_templateBrowser, getCurrentDataset()).WillByDefault(Return(1));
-    EXPECT_CALL(*m_templateBrowser, getCurrentDataset()).Times(Exactly(1));
+    ON_CALL(*m_templatePresenter, getCurrentDataset()).WillByDefault(Return(1));
+    EXPECT_CALL(*m_templatePresenter, getCurrentDataset()).Times(Exactly(1));
     TS_ASSERT_EQUALS(m_browser->currentDataset(), FitDomainIndex{static_cast<size_t>(1)});
   }
 
@@ -260,15 +222,15 @@ public:
     }
     std::vector<double> qValues = {0.0, 1.0};
     std::vector<std::pair<std::string, size_t>> fitResolutions(1, std::make_pair<std::string, size_t>("resWS", 0));
-    EXPECT_CALL(*m_templateBrowser, setNumberOfDatasets(nData)).Times(Exactly(1));
-    EXPECT_CALL(*m_templateBrowser, setQValues(qValues)).Times(Exactly(1));
-    EXPECT_CALL(*m_templateBrowser, setResolution(fitResolutions)).Times(Exactly(1));
+    EXPECT_CALL(*m_templatePresenter, setNumberOfDatasets(nData)).Times(Exactly(1));
+    EXPECT_CALL(*m_templatePresenter, setQValues(qValues)).Times(Exactly(1));
+    EXPECT_CALL(*m_templatePresenter, setResolution(fitResolutions)).Times(Exactly(1));
     m_browser->updateFunctionBrowserData(nData, datasets, qValues, fitResolutions);
   }
 
   void test_setErrorsEnabled_calls_to_template() {
-    EXPECT_CALL(*m_templateBrowser, setErrorsEnabled(false)).Times(Exactly(1));
-    EXPECT_CALL(*m_templateBrowser, setErrorsEnabled(true)).Times(Exactly(1));
+    EXPECT_CALL(*m_templatePresenter, setErrorsEnabled(false)).Times(Exactly(1));
+    EXPECT_CALL(*m_templatePresenter, setErrorsEnabled(true)).Times(Exactly(1));
     m_browser->setErrorsEnabled(false);
     m_browser->setErrorsEnabled(true);
   }
@@ -281,17 +243,18 @@ public:
   }
 
   void test_estimateFunctionParameters_calls_template() {
-    EXPECT_CALL(*m_templateBrowser, estimateFunctionParameters()).Times(Exactly(1));
+    EXPECT_CALL(*m_templatePresenter, estimateFunctionParameters()).Times(Exactly(1));
     m_browser->estimateFunctionParameters();
   }
 
   void test_setBackgroundA0_calls_template() {
-    EXPECT_CALL(*m_templateBrowser, setBackgroundA0(1.0)).Times(Exactly(1));
+    EXPECT_CALL(*m_templatePresenter, setBackgroundA0(1.0)).Times(Exactly(1));
     m_browser->setBackgroundA0(1.0);
   }
 
 private:
   std::unique_ptr<IndirectFitPropertyBrowser> m_browser;
   std::unique_ptr<NiceMock<MockFunctionTemplateBrowser>> m_templateBrowser;
+  NiceMock<MockFunctionTemplatePresenter> *m_templatePresenter;
   std::unique_ptr<FitOptionsBrowser> m_fitOptionsBrowser;
 };

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/MockObjects.h
@@ -12,6 +12,8 @@
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 
+#include "Analysis/FunctionBrowser/ITemplatePresenter.h"
+#include "Analysis/FunctionTemplateBrowser.h"
 #include "Analysis/IIndirectFitDataView.h"
 #include "Analysis/IIndirectFitOutputOptionsModel.h"
 #include "Analysis/IIndirectFitOutputOptionsView.h"
@@ -254,6 +256,104 @@ public:
   MOCK_METHOD1(setResolutionFBSuffices, void(const QStringList &suffices));
 
   MOCK_METHOD1(displayWarning, void(std::string const &warning));
+};
+
+class MockFunctionTemplateBrowser : public FunctionTemplateBrowser {
+public:
+  virtual ~MockFunctionTemplateBrowser() = default;
+
+  MOCK_METHOD1(setFunction, void(std::string const &funStr));
+  MOCK_CONST_METHOD0(getGlobalFunction, IFunction_sptr());
+  MOCK_CONST_METHOD0(getFunction, IFunction_sptr());
+  MOCK_METHOD1(setNumberOfDatasets, void(int));
+  MOCK_CONST_METHOD0(getNumberOfDatasets, int());
+  MOCK_METHOD1(setDatasets, void(const QList<FunctionModelDataset> &datasets));
+  MOCK_CONST_METHOD0(getGlobalParameters, std::vector<std::string>());
+  MOCK_CONST_METHOD0(getLocalParameters, std::vector<std::string>());
+  MOCK_METHOD1(setGlobalParameters, void(std::vector<std::string> const &globals));
+  MOCK_METHOD1(updateMultiDatasetParameters, void(const IFunction &fun));
+  MOCK_METHOD1(updateMultiDatasetParameters, void(const ITableWorkspace &paramTable));
+  MOCK_METHOD1(updateParameters, void(const IFunction &fun));
+  MOCK_METHOD1(setCurrentDataset, void(int i));
+  MOCK_METHOD0(getCurrentDataset, int());
+  MOCK_METHOD1(updateParameterNames, void(const QMap<int, std::string> &parameterNames));
+  MOCK_METHOD1(setErrorsEnabled, void(bool enabled));
+  MOCK_METHOD0(clear, void());
+  MOCK_CONST_METHOD0(getEstimationDataSelector, EstimationDataSelector());
+  MOCK_METHOD1(updateParameterEstimationData, void(DataForParameterEstimationCollection &&data));
+  MOCK_METHOD0(estimateFunctionParameters, void());
+  MOCK_METHOD1(setBackgroundA0, void(double value));
+  MOCK_METHOD2(setResolution, void(std::string const &name, WorkspaceID const &index));
+  MOCK_METHOD1(setResolution, void(const std::vector<std::pair<std::string, size_t>> &fitResolutions));
+  MOCK_METHOD1(setQValues, void(const std::vector<double> &qValues));
+  // protected Slots
+  MOCK_METHOD1(popupMenu, void(const QPoint &));
+  MOCK_METHOD3(globalChanged, void(QtProperty *, const QString &, bool));
+  MOCK_METHOD1(parameterChanged, void(QtProperty *));
+  MOCK_METHOD1(parameterButtonClicked, void(QtProperty *));
+  // Private methods
+  MOCK_METHOD0(createProperties, void());
+};
+
+class MockFunctionTemplatePresenter : public ITemplatePresenter {
+public:
+  MockFunctionTemplatePresenter(MockFunctionTemplateBrowser *view) : m_view(view) {}
+  virtual ~MockFunctionTemplatePresenter() = default;
+
+  FunctionTemplateBrowser *browser() override { return m_view; }
+
+  MOCK_METHOD0(init, void());
+  MOCK_METHOD1(updateAvailableFunctions, void(const std::map<std::string, std::string> &functionInitialisationStrings));
+
+  MOCK_METHOD1(setNumberOfDatasets, void(int));
+  MOCK_CONST_METHOD0(getNumberOfDatasets, int());
+  MOCK_METHOD0(getCurrentDataset, int());
+
+  MOCK_METHOD1(setFitType, void(std::string const &name));
+
+  MOCK_METHOD1(setFunction, void(std::string const &funStr));
+  MOCK_CONST_METHOD0(getGlobalFunction, Mantid::API::IFunction_sptr());
+  MOCK_CONST_METHOD0(getFunction, Mantid::API::IFunction_sptr());
+
+  MOCK_CONST_METHOD0(getGlobalParameters, std::vector<std::string>());
+  MOCK_CONST_METHOD0(getLocalParameters, std::vector<std::string>());
+  MOCK_METHOD1(setGlobalParameters, void(std::vector<std::string> const &globals));
+  MOCK_METHOD2(setGlobal, void(std::string const &parameterName, bool on));
+
+  MOCK_METHOD1(updateMultiDatasetParameters, void(const Mantid::API::IFunction &fun));
+  MOCK_METHOD1(updateMultiDatasetParameters, void(const Mantid::API::ITableWorkspace &table));
+  MOCK_METHOD1(updateParameters, void(const Mantid::API::IFunction &fun));
+
+  MOCK_METHOD1(setCurrentDataset, void(int i));
+  MOCK_METHOD1(setDatasets, void(const QList<MantidQt::MantidWidgets::FunctionModelDataset> &datasets));
+
+  MOCK_CONST_METHOD0(getEstimationDataSelector, EstimationDataSelector());
+  MOCK_METHOD1(updateParameterEstimationData, void(DataForParameterEstimationCollection &&data));
+  MOCK_METHOD0(estimateFunctionParameters, void());
+
+  MOCK_METHOD1(setErrorsEnabled, void(bool enabled));
+
+  MOCK_METHOD1(setNumberOfExponentials, void(int nExponentials));
+  MOCK_METHOD1(setStretchExponential, void(bool on));
+  MOCK_METHOD1(setBackground, void(std::string const &name));
+  MOCK_METHOD1(tieIntensities, void(bool on));
+  MOCK_CONST_METHOD0(canTieIntensities, bool());
+
+  MOCK_METHOD2(setSubType, void(std::size_t subTypeIndex, int typeIndex));
+  MOCK_METHOD1(setDeltaFunction, void(bool on));
+  MOCK_METHOD1(setTempCorrection, void(bool on));
+  MOCK_METHOD1(setBackgroundA0, void(double value));
+  MOCK_METHOD1(setResolution, void(const std::vector<std::pair<std::string, size_t>> &fitResolutions));
+  MOCK_METHOD1(setQValues, void(const std::vector<double> &qValues));
+
+  MOCK_METHOD1(handleEditLocalParameter, void(std::string const &parameterName));
+  MOCK_METHOD2(handleParameterValueChanged, void(std::string const &parameterName, double value));
+  MOCK_METHOD5(handleEditLocalParameterFinished,
+               void(std::string const &parameterName, QList<double> const &values, QList<bool> const &fixes,
+                    QStringList const &ties, QStringList const &constraints));
+
+private:
+  FunctionTemplateBrowser *m_view;
 };
 
 class MockFitPropertyBrowser : public IIndirectFitPropertyBrowser {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/EditLocalParameterDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/EditLocalParameterDialog.h
@@ -48,8 +48,10 @@ public:
 
 signals:
   void logOptionsChecked(bool /*_t1*/);
+  void dialogFinished(int /*result*/, EditLocalParameterDialog * /*dialog*/);
 
 private slots:
+  void emitDialogFinished(int /*result*/);
   void valueChanged(int /*row*/, int /*col*/);
   void setAllValues(double /*value*/);
   void fixParameter(int /*index*/, bool /*fix*/);

--- a/qt/widgets/common/src/EditLocalParameterDialog.cpp
+++ b/qt/widgets/common/src/EditLocalParameterDialog.cpp
@@ -102,7 +102,11 @@ void EditLocalParameterDialog::doSetup(const std::string &parName, const QString
   connect(deleg, SIGNAL(setAllValuesToLog()), this, SLOT(setAllValuesToLog()));
 
   m_uiForm.tableWidget->installEventFilter(this);
+
+  connect(this, SIGNAL(finished(int)), this, SLOT(emitDialogFinished(int)));
 }
+
+void EditLocalParameterDialog::emitDialogFinished(int result) { emit dialogFinished(result, this); }
 
 /// Slot. Called when a value changes.
 /// @param row :: Row index of the changed cell.


### PR DESCRIPTION
### Description of work
This PR makes the `SingleFunctionTemplatePresenter`, `IqtTemplatePresenter` and `ConvTemplatePresenter` classes are not QObjects. This will make it easier to write automated tests for these classes in the future.

This PR also moves some of the common functionality into the `FunctionTemplateBrowser` and `FunctionTemplatePresenter` classes so we are not repeating code.

Fixes #36325

### To test:

To test Inelastic Data Analysis follow these instructions
https://developer.mantidproject.org/Testing/Inelastic/DataAnalysisTests.html

*This does not require release notes* because **it is not a user-facing change**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
