### PR TITLE
Remove finished algorithms in the algorithm manager before the GIL is released 

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmManager.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmManager.h
@@ -44,6 +44,8 @@ public:
   IAlgorithm_sptr create(const std::string &algName, const int &version = -1);
   /// Creates an unmanaged algorithm with the option of choosing a version
   std::shared_ptr<Algorithm> createUnmanaged(const std::string &algName, const int &version = -1) const;
+  /// Creates a managed algorithm with the option of choosing a version (used by python interface)
+  IAlgorithm_sptr createFromPython(const std::string &algName, const int &version = -1);
 
   std::size_t size() const;
 
@@ -59,6 +61,9 @@ public:
   Poco::NotificationCenter notificationCenter;
   void notifyAlgorithmStarting(AlgorithmID id);
 
+  /// Removes any finished algorithms from the list of managed algorithms
+  void removeFinishedAlgorithms();
+
   void clear();
   void cancelAll();
   void shutdown();
@@ -73,9 +78,6 @@ private:
   AlgorithmManagerImpl(const AlgorithmManagerImpl &);
   /// Unimplemented assignment operator
   AlgorithmManagerImpl &operator=(const AlgorithmManagerImpl &);
-
-  /// Removes any finished algorithms from the list of managed algorithms
-  size_t removeFinishedAlgorithms();
 
   /// The list of managed algorithms
   std::deque<IAlgorithm_sptr> m_managed_algs; ///<  pointers to managed algorithms [policy???]

--- a/Framework/API/inc/MantidAPI/AlgorithmManager.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmManager.h
@@ -45,7 +45,7 @@ public:
   /// Creates an unmanaged algorithm with the option of choosing a version
   std::shared_ptr<Algorithm> createUnmanaged(const std::string &algName, const int &version = -1) const;
   /// Creates a managed algorithm with the option of choosing a version (used by python interface)
-  IAlgorithm_sptr createFromPython(const std::string &algName, const int &version = -1);
+  IAlgorithm_sptr createGILSafe(const std::string &algName, const int &version = -1);
 
   std::size_t size() const;
 
@@ -74,6 +74,9 @@ private:
   AlgorithmManagerImpl();
   ~AlgorithmManagerImpl();
 
+  // Common code used by create and createGILSafe to create a managed algorithm
+  IAlgorithm_sptr create(const std::string &algName, const int &version = -1, const bool &removeFinished = true);
+
   /// Unimplemented copy constructor
   AlgorithmManagerImpl(const AlgorithmManagerImpl &);
   /// Unimplemented assignment operator
@@ -82,7 +85,7 @@ private:
   /// The list of managed algorithms
   std::deque<IAlgorithm_sptr> m_managed_algs; ///<  pointers to managed algorithms [policy???]
   /// Mutex for modifying/accessing the m_managed_algs member.
-  mutable std::mutex m_managedMutex;
+  mutable std::recursive_mutex m_managedMutex;
 };
 
 using AlgorithmManager = Mantid::Kernel::SingletonHolder<AlgorithmManagerImpl>;

--- a/Framework/API/inc/MantidAPI/AlgorithmManager.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmManager.h
@@ -74,9 +74,6 @@ private:
   AlgorithmManagerImpl();
   ~AlgorithmManagerImpl();
 
-  // Common code used by create and createGILSafe to create a managed algorithm
-  IAlgorithm_sptr create(const std::string &algName, const int &version = -1, const bool &removeFinished = true);
-
   /// Unimplemented copy constructor
   AlgorithmManagerImpl(const AlgorithmManagerImpl &);
   /// Unimplemented assignment operator

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -43,8 +43,9 @@ AlgorithmManagerImpl &instance() {
 }
 
 IAlgorithm_sptr create(AlgorithmManagerImpl *self, const std::string &algName, const int &version = -1) {
+  self->removeFinishedAlgorithms();
   ReleaseGlobalInterpreterLock releaseGIL;
-  return self->create(algName, version);
+  return self->createFromPython(algName, version);
 }
 
 std::shared_ptr<Algorithm> createUnmanaged(AlgorithmManagerImpl *self, const std::string &algName,

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -7,7 +7,6 @@
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/api/AlgorithmIDProxy.h"
-#include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 #include "MantidPythonInterface/core/ReleaseGlobalInterpreterLock.h"
 
 #include <boost/python/class.hpp>

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -7,6 +7,7 @@
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/api/AlgorithmIDProxy.h"
+#include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 #include "MantidPythonInterface/core/ReleaseGlobalInterpreterLock.h"
 
 #include <boost/python/class.hpp>
@@ -43,9 +44,10 @@ AlgorithmManagerImpl &instance() {
 }
 
 IAlgorithm_sptr create(AlgorithmManagerImpl *self, const std::string &algName, const int &version = -1) {
+  GlobalInterpreterLock gil;
   self->removeFinishedAlgorithms();
   ReleaseGlobalInterpreterLock releaseGIL;
-  return self->createFromPython(algName, version);
+  return self->createGILSafe(algName, version);
 }
 
 std::shared_ptr<Algorithm> createUnmanaged(AlgorithmManagerImpl *self, const std::string &algName,

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -44,7 +44,6 @@ AlgorithmManagerImpl &instance() {
 }
 
 IAlgorithm_sptr create(AlgorithmManagerImpl *self, const std::string &algName, const int &version = -1) {
-  GlobalInterpreterLock gil;
   self->removeFinishedAlgorithms();
   ReleaseGlobalInterpreterLock releaseGIL;
   return self->createGILSafe(algName, version);

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -287,9 +287,9 @@ unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/WeightedMeanOfWorksp
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmHasProperty.cpp:36
 operatorEqVarError:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmHistory.cpp:230
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmHistory.cpp:274
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmManager.cpp:112
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmManager.cpp:116
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmManager.cpp:180
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmManager.cpp:128
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmManager.cpp:132
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmManager.cpp:197
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/AnalysisDataService.h:138
 knownPointerToBool:${CMAKE_SOURCE_DIR}/Framework/API/src/Algorithm.cpp:386
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/Algorithm.cpp:620
@@ -897,7 +897,7 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/sr
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp:254
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp:74
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp:155
-unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp:127
+unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp:128
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/InstrumentFileFinder.cpp:36
 unusedScopedObject:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp:71
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp:251

--- a/docs/source/release/v6.9.0/Framework/Algorithms/Bugfixes/36785.rst
+++ b/docs/source/release/v6.9.0/Framework/Algorithms/Bugfixes/36785.rst
@@ -1,0 +1,1 @@
+- Fix a GIL error that happens when algorithm manager tries to remove python objects parameters


### PR DESCRIPTION
### Description of work
This pull request aims to fix a GIL error that occurs during the creation of an algorithm from Python code using the `AlgorithmManager`. The issue arises when the algorithm manager attempts to remove completed algorithms with Python object parameters. This results in a GIL error because the GIL is released before calling `create` in the Python interface. To address this error,  a new function called `createFromPython` has been added to `AlgorithmManager`. This function is similar to the `create` function but it does not remove completed algorithms. Then, we call `removeFinishedAlgorithms` before releasing the GIL in the Python interface. This should fix the issue.
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
- add `createFromPython` to the algorithm manager
- call `removeFinishedAlgorithms` before the GIL is released
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36742 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
For more context see #36742

### To test:
1- Go to interfaces->muon->muon analysis
2- Load the run 62260
3- Go to the fitting tab 
4- Change fitting type to tf asymmetry
5- Add the GausOsc function 
6- Check simultaneous fit and press fit
7- Check/uncheck simultaneous fit multiple times
8- Make sure there is no crash
9- Try to do multiple fits using different types/functions
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
