### PR TITLE
Expose PeakShapes and IPeak.setPeakShape to Python

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -29,7 +29,7 @@ Mantid::Geometry::PeakShape_sptr getPeakShape(const IPeak &peak) {
   // Use clone to make a copy of the PeakShape.
   return Mantid::Geometry::PeakShape_sptr(peak.getPeakShape().clone());
 }
-void setPeakShape(IPeak &peak, Mantid::Geometry::PeakShape_sptr shape) { peak.setPeakShape(shape); }
+void setPeakShape(IPeak &peak, Mantid::Geometry::PeakShape_sptr shape) { peak.setPeakShape(shape->clone()); }
 void setQLabFrame1(IPeak &peak, Mantid::Kernel::V3D qLabFrame) {
   // Set the q lab frame. No explicit detector distance.
   return peak.setQLabFrame(qLabFrame, boost::none);

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -29,6 +29,7 @@ Mantid::Geometry::PeakShape_sptr getPeakShape(const IPeak &peak) {
   // Use clone to make a copy of the PeakShape.
   return Mantid::Geometry::PeakShape_sptr(peak.getPeakShape().clone());
 }
+void setPeakShape(IPeak &peak, Mantid::Geometry::PeakShape_sptr shape) { peak.setPeakShape(shape); }
 void setQLabFrame1(IPeak &peak, Mantid::Kernel::V3D qLabFrame) {
   // Set the q lab frame. No explicit detector distance.
   return peak.setQLabFrame(qLabFrame, boost::none);
@@ -181,6 +182,7 @@ void export_IPeak() {
            "Return the L2 flight path length (:class:`~mantid.api.Sample` to "
            ":class:`~mantid.geometry.Detector`), in meters.")
       .def("getPeakShape", getPeakShape, arg("self"), "Get the peak shape")
+      .def("setPeakShape", setPeakShape, (arg("self"), arg("shape")), "Set the peak shape")
       .def("getAbsorptionWeightedPathLength", &IPeak::getAbsorptionWeightedPathLength, arg("self"),
            "Get the absorption weighted path length")
       .def("getReferenceFrame", (std::shared_ptr<const ReferenceFrame>(IPeak::*)()) & IPeak::getReferenceFrame,

--- a/Framework/PythonInterface/mantid/dataobjects/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/dataobjects/CMakeLists.txt
@@ -24,6 +24,7 @@ set(EXPORT_FILES
     src/Exports/SplittersWorkspace.cpp
     src/Exports/WorkspaceSingleValue.cpp
     src/Exports/NoShape.cpp
+    src/Exports/PeakShapeSpherical.cpp
 )
 
 set(MODULE_DEFINITION ${CMAKE_CURRENT_BINARY_DIR}/dataobjects.cpp)

--- a/Framework/PythonInterface/mantid/dataobjects/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/dataobjects/CMakeLists.txt
@@ -25,6 +25,7 @@ set(EXPORT_FILES
     src/Exports/WorkspaceSingleValue.cpp
     src/Exports/NoShape.cpp
     src/Exports/PeakShapeSpherical.cpp
+    src/Exports/PeakShapeEllipsoid.cpp
 )
 
 set(MODULE_DEFINITION ${CMAKE_CURRENT_BINARY_DIR}/dataobjects.cpp)

--- a/Framework/PythonInterface/mantid/dataobjects/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/dataobjects/CMakeLists.txt
@@ -23,6 +23,7 @@ set(EXPORT_FILES
     src/Exports/TableWorkspace.cpp
     src/Exports/SplittersWorkspace.cpp
     src/Exports/WorkspaceSingleValue.cpp
+    src/Exports/NoShape.cpp
 )
 
 set(MODULE_DEFINITION ${CMAKE_CURRENT_BINARY_DIR}/dataobjects.cpp)

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/NoShape.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/NoShape.cpp
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/NoShape.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/NoShape.cpp
@@ -1,0 +1,13 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataObjects/NoShape.h"
+#include <boost/python/class.hpp>
+
+using namespace boost::python;
+using namespace Mantid::DataObjects;
+
+void export_NoShape() { class_<NoShape, bases<Mantid::Geometry::PeakShape>, boost::noncopyable>("NoShape"); }

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeEllipsoid.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeEllipsoid.cpp
@@ -1,0 +1,35 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataObjects/PeakShapeEllipsoid.h"
+#include "MantidKernel/V3D.h"
+#include "MantidPythonInterface/core/Converters/PySequenceToVector.h"
+#include <boost/python/class.hpp>
+#include <boost/python/list.hpp>
+#include <boost/python/make_constructor.hpp>
+
+using namespace boost::python;
+using namespace Mantid::DataObjects;
+using Mantid::Kernel::SpecialCoordinateSystem;
+using Mantid::Kernel::V3D;
+using Mantid::PythonInterface::Converters::PySequenceToVector;
+
+PeakShapeEllipsoid *initPeakShapeEllipsoid(const boost::python::list &directions, const boost::python::list &abcRadii,
+                                           const boost::python::list &abcRadiiBackgroundInner,
+                                           const boost::python::list abcRadiiBackgroundOuter,
+                                           SpecialCoordinateSystem frame) {
+  return new PeakShapeEllipsoid(PySequenceToVector<V3D>(directions)(), PySequenceToVector<double>(abcRadii)(),
+                                PySequenceToVector<double>(abcRadiiBackgroundInner)(),
+                                PySequenceToVector<double>(abcRadiiBackgroundOuter)(), frame);
+}
+
+void export_PeakShapeEllipsoid() {
+  class_<PeakShapeEllipsoid, bases<Mantid::Geometry::PeakShape>, boost::noncopyable>("PeakShapeEllipsoid", no_init)
+      .def("__init__",
+           make_constructor(&initPeakShapeEllipsoid, default_call_policies(),
+                            (arg("directions"), arg("abcRadii"), arg("abcRadiiBackgroundInner"),
+                             arg("abcRadiiBackgroundOuter"), arg("frame") = SpecialCoordinateSystem::QSample)));
+}

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeSpherical.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeSpherical.cpp
@@ -1,0 +1,22 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataObjects/PeakShapeSpherical.h"
+#include <boost/python/class.hpp>
+
+using namespace boost::python;
+using namespace Mantid::DataObjects;
+using Mantid::Kernel::SpecialCoordinateSystem;
+
+void export_PeakShapeSpherical() {
+
+  class_<PeakShapeSpherical, bases<Mantid::Geometry::PeakShape>, boost::noncopyable>("PeakShapeSpherical", no_init)
+      .def(init<const double &, SpecialCoordinateSystem>(
+          (arg("peakRadius"), arg("frame") = SpecialCoordinateSystem::QSample)))
+      .def(init<const double &, const double &, const double &, SpecialCoordinateSystem>(
+          (arg("peakRadius"), arg("backgroundInnerRadius"), arg("backgroundOuterRadius"),
+           arg("frame") = SpecialCoordinateSystem::QSample)));
+}

--- a/Framework/PythonInterface/test/python/mantid/dataobjects/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/dataobjects/CMakeLists.txt
@@ -1,6 +1,8 @@
 # mantid.dataobjects tests
 
-set(TEST_PY_FILES EventListTest.py GroupingWorkspaceTest.py SpecialWorkspace2DTest.py Workspace2DPickleTest.py)
+set(TEST_PY_FILES EventListTest.py GroupingWorkspaceTest.py SpecialWorkspace2DTest.py Workspace2DPickleTest.py
+                  PeakShapes.py
+)
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 

--- a/Framework/PythonInterface/test/python/mantid/dataobjects/PeakShapes.py
+++ b/Framework/PythonInterface/test/python/mantid/dataobjects/PeakShapes.py
@@ -1,0 +1,72 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+import json
+from mantid.kernel import V3D, SpecialCoordinateSystem
+from mantid.geometry import PeakShape
+from mantid.dataobjects import NoShape, PeakShapeSpherical, PeakShapeEllipsoid
+
+
+class PeakShapeDataObjects(unittest.TestCase):
+    def test_NoShape(self):
+        shape = NoShape()
+
+        self.assertTrue(isinstance(shape, NoShape))
+        self.assertTrue(isinstance(shape, PeakShape))
+
+        self.assertEqual(shape.shapeName(), "none")
+        self.assertEqual(shape.toJSON(), '{"shape":"none"}')
+
+    def test_PeakShapeSpherical(self):
+        sphere1 = PeakShapeSpherical(0.5)
+
+        self.assertTrue(isinstance(sphere1, PeakShapeSpherical))
+        self.assertTrue(isinstance(sphere1, PeakShape))
+
+        self.assertEqual(sphere1.shapeName(), "spherical")
+
+        data = json.loads(sphere1.toJSON())
+        self.assertEqual(data["radius"], 0.5)
+        self.assertEqual(data["shape"], "spherical")
+        self.assertEqual(data["frame"], 2)
+        self.assertTrue("background_inner_radius" not in data)
+        self.assertTrue("background_outer_radius" not in data)
+
+        sphere2 = PeakShapeSpherical(0.5, 0.6, 0.7, SpecialCoordinateSystem.HKL)
+        data = json.loads(sphere2.toJSON())
+        self.assertEqual(data["radius"], 0.5)
+        self.assertEqual(data["shape"], "spherical")
+        self.assertEqual(data["frame"], 3)
+        self.assertEqual(data["background_inner_radius"], 0.6)
+        self.assertEqual(data["background_outer_radius"], 0.7)
+
+    def test_PeakShapeEllipsoid(self):
+        ellipse = PeakShapeEllipsoid([V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)], [0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9])
+
+        self.assertTrue(isinstance(ellipse, PeakShapeEllipsoid))
+        self.assertTrue(isinstance(ellipse, PeakShape))
+        self.assertEqual(ellipse.shapeName(), "ellipsoid")
+
+        data = json.loads(ellipse.toJSON())
+        self.assertEqual(data["shape"], "ellipsoid")
+        self.assertEqual(data["frame"], 2)
+        self.assertEqual(data["direction0"], "1 0 0")
+        self.assertEqual(data["direction1"], "0 1 0")
+        self.assertEqual(data["direction2"], "0 0 1")
+        self.assertEqual(data["radius0"], 0.1)
+        self.assertEqual(data["radius1"], 0.2)
+        self.assertEqual(data["radius2"], 0.3)
+        self.assertEqual(data["background_inner_radius0"], 0.4)
+        self.assertEqual(data["background_inner_radius1"], 0.5)
+        self.assertEqual(data["background_inner_radius2"], 0.6)
+        self.assertEqual(data["background_outer_radius0"], 0.7)
+        self.assertEqual(data["background_outer_radius1"], 0.8)
+        self.assertEqual(data["background_outer_radius2"], 0.9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.kernel import V3D
+from mantid.dataobjects import NoShape, PeakShapeSpherical, PeakShapeEllipsoid
 from mantid.simpleapi import CreateSimulationWorkspace, CreatePeaksWorkspace, LoadInstrument
 import numpy as np
 import numpy.testing as npt
@@ -167,6 +168,22 @@ class IPeakTest(unittest.TestCase):
         test_vector = V3D(0.5, 0, 0.2)
         self._peak.setIntHKL(test_vector)
         self.assertEqual(self._peak.getIntHKL(), V3D(1, 0, 0))
+
+    def test_set_peak_shape(self):
+        no_shape = NoShape()
+        sphere = PeakShapeSpherical(1)
+        ellipse = PeakShapeEllipsoid([V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)], [0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9])
+
+        self.assertEqual(self._peak.getPeakShape().shapeName(), "none")
+
+        self._peak.setPeakShape(sphere)
+        self.assertEqual(self._peak.getPeakShape().shapeName(), "spherical")
+
+        self._peak.setPeakShape(ellipse)
+        self.assertEqual(self._peak.getPeakShape().shapeName(), "ellipsoid")
+
+        self._peak.setPeakShape(no_shape)
+        self.assertEqual(self._peak.getPeakShape().shapeName(), "none")
 
 
 if __name__ == "__main__":

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -914,10 +914,10 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api
 unusedScopedObject:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp:287
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp:44
 unusedScopedObject:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IEventWorkspace.cpp:58
-passedByValue:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp:32
-passedByValue:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp:36
-passedByValue:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp:41
-passedByValue:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp:46
+passedByValue:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp:33
+passedByValue:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp:37
+passedByValue:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp:42
+passedByValue:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp:47
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp:81
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp:251
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp:58

--- a/docs/source/concepts/PeaksWorkspace.rst
+++ b/docs/source/concepts/PeaksWorkspace.rst
@@ -38,13 +38,42 @@ Each peak object contains several pieces of information. Not all of them are nec
 The Peak Shape
 ~~~~~~~~~~~~~~
 
-Each Peak object contains a PeakShape. Only the integration algorithms which act on, and return PeaksWorkspaces set the shape of the peaks. The PeakShape is owned by the Peak, not the PeaksWorkspace, so when PeaksWorkspaces are split, or concatinated, the integration shapes are unaltered. Aside from the Null Peak Shape, each peak shape contains at least the following information.
+Each Peak object contains a PeakShape. Typically the integration algorithms which act on, and return PeaksWorkspaces set the shape of the peaks. The PeakShape is owned by the Peak, not the PeaksWorkspace, so when PeaksWorkspaces are split, or concatinated, the integration shapes are unaltered. Aside from the Null Peak Shape, each peak shape contains at least the following information.
 
 * The algorithm used to perform the integration
 * The version of the algorithm used to perform the integration
 * The frame in which the integration has been performed
 
 Subtypes of PeakShape will then provide additional information. For example PeakShapeSpherical provides the radius as well as background inner, and background outer radius.
+
+Creating peak shapes in Python
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can manually create the peak shape and set it on a peak from Python. This peak shape is not used by any integration algorithm but will allow you to visualize the shapes with :ref:`SliceViewer`.
+
+.. code-block:: python
+
+    from mantid.kernel import V3D
+    from mantid.dataobjects import NoShape, PeakShapeSpherical, PeakShapeEllipsoid
+
+    pws = mtd['name_of_peaks_workspace']
+
+    no_shape = NoShape()
+    pws.getPeak(0).setPeakShape(no_shape)
+
+    sphere = PeakShapeSpherical(peakRadius=0.5)
+    pws.getPeak(1).setPeakShape(sphere)
+
+    sphere_with_background = PeakShapeSpherical(peakRadius=0.5,
+                                                backgroundInnerRadius=0.6,
+                                                backgroundOuterRadius=0.7)
+    pws.getPeak(2).setPeakShape(sphere_with_background)
+
+    ellipse = PeakShapeEllipsoid(directions=[V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)],
+                                 abcRadii=[0.1, 0.2, 0.3],
+                                 abcRadiiBackgroundInner=[0.4, 0.5, 0.6],
+                                 abcRadiiBackgroundOuter=[0.7, 0.8, 0.9])
+    pws.getPeak(3).setPeakShape(ellipse)
 
 
 Calculate Goniometer For Constant Wavelength

--- a/docs/source/release/v6.10.0/Framework/Python/New_features/36786.rst
+++ b/docs/source/release/v6.10.0/Framework/Python/New_features/36786.rst
@@ -1,0 +1,1 @@
+- The :ref:`Peak Shapes <the-peak-shape>` (NoShape, PeakShapeSpherical, PeakShapeEllipsoid) and :meth:`mantid.api.IPeak.setPeakShape` have been exposed to Python allowing you to manually create and set the peak shapes.


### PR DESCRIPTION

### Description of work

Expose the Peaks Shapes and allow them to be created and set to a peak from Python.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes Fixes [EWM975](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=975)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

```python
from mantid.simpleapi import *
from mantid.kernel import SpecialCoordinateSystem, V3D
from mantid.dataobjects import PeakShapeSpherical, NoShape, PeakShapeEllipsoid

md = CreateMDWorkspace(Dimensions=3, Extents="-3,3,-3,3,-3,3", Names="H,K,L", Units="r.l.u.,r.l.u.,r.l.u.", Frames="HKL,HKL,HKL")

peaks = CreatePeaksWorkspace(OutputType="LeanElasticPeak", NUmberOfPeaks=0)
SetUB(peaks)

peaks.addPeak([2,0,0], SpecialCoordinateSystem.HKL)
peaks.addPeak([-2,0,0], SpecialCoordinateSystem.HKL)
peaks.addPeak([0,2,0], SpecialCoordinateSystem.HKL)
peaks.addPeak([0,-2,0], SpecialCoordinateSystem.HKL)

peaks.getPeak(0).setPeakShape(PeakShapeSpherical(0.5))
peaks.getPeak(1).setPeakShape(PeakShapeSpherical(0.5, 0.6, 0.9))

peaks.getPeak(2).setPeakShape(PeakShapeEllipsoid([V3D(1,0,0), V3D(0,1,0), V3D(0,0,1)], [0.2, 0.5, 0.5], [0.3, 0.5, 0.5], [0.9, 0.5, 0.5]))
peaks.getPeak(3).setPeakShape(NoShape())
```

Open `md` in SliceViewer and overlay the peaks workspace, you should get
![image](https://github.com/mantidproject/mantid/assets/5595210/a37eaba4-d35e-466b-9f58-a216ff2e5725)


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
