### PR TITLE
Clone extracted IFunction to separate from python object

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmManager.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmManager.h
@@ -80,7 +80,7 @@ private:
   /// The list of managed algorithms
   std::deque<IAlgorithm_sptr> m_managed_algs; ///<  pointers to managed algorithms [policy???]
   /// Mutex for modifying/accessing the m_managed_algs member.
-  mutable std::mutex m_managedMutex;
+  mutable std::recursive_mutex m_managedMutex;
 };
 
 using AlgorithmManager = Mantid::Kernel::SingletonHolder<AlgorithmManagerImpl>;

--- a/Framework/API/src/AlgorithmManager.cpp
+++ b/Framework/API/src/AlgorithmManager.cpp
@@ -54,7 +54,7 @@ Algorithm_sptr AlgorithmManagerImpl::createUnmanaged(const std::string &algName,
  * @throw  std::runtime_error Thrown if properties string is ill-formed
  */
 IAlgorithm_sptr AlgorithmManagerImpl::create(const std::string &algName, const int &version) {
-  std::lock_guard<std::mutex> _lock(this->m_managedMutex);
+  std::lock_guard<std::recursive_mutex> _lock(this->m_managedMutex);
   IAlgorithm_sptr alg;
   try {
     alg = AlgorithmFactory::Instance().create(algName,
@@ -77,7 +77,7 @@ IAlgorithm_sptr AlgorithmManagerImpl::create(const std::string &algName, const i
  * Clears all managed algorithm objects that are not currently running.
  */
 void AlgorithmManagerImpl::clear() {
-  std::lock_guard<std::mutex> _lock(this->m_managedMutex);
+  std::lock_guard<std::recursive_mutex> _lock(this->m_managedMutex);
   for (auto itAlg = m_managed_algs.begin(); itAlg != m_managed_algs.end();) {
     if (!(*itAlg)->isRunning()) {
       itAlg = m_managed_algs.erase(itAlg);
@@ -95,7 +95,7 @@ std::size_t AlgorithmManagerImpl::size() const { return m_managed_algs.size(); }
  * @returns A shared pointer to the algorithm or nullptr if not found
  */
 IAlgorithm_sptr AlgorithmManagerImpl::getAlgorithm(AlgorithmID id) const {
-  std::lock_guard<std::mutex> _lock(this->m_managedMutex);
+  std::lock_guard<std::recursive_mutex> _lock(this->m_managedMutex);
   const auto found = std::find_if(m_managed_algs.cbegin(), m_managed_algs.cend(),
                                   [id](const auto &algorithm) { return algorithm->getAlgorithmID() == id; });
   if (found == m_managed_algs.cend()) {
@@ -110,7 +110,7 @@ IAlgorithm_sptr AlgorithmManagerImpl::getAlgorithm(AlgorithmID id) const {
  * @param id :: The ID of the algorithm
  */
 void AlgorithmManagerImpl::removeById(AlgorithmID id) {
-  std::lock_guard<std::mutex> _lock(this->m_managedMutex);
+  std::lock_guard<std::recursive_mutex> _lock(this->m_managedMutex);
   auto itend = m_managed_algs.end();
   for (auto it = m_managed_algs.begin(); it != itend; ++it) {
     if ((**it).getAlgorithmID() == id) {
@@ -141,7 +141,7 @@ void AlgorithmManagerImpl::notifyAlgorithmStarting(AlgorithmID id) {
 /// first
 std::vector<IAlgorithm_const_sptr> AlgorithmManagerImpl::runningInstancesOf(const std::string &algorithmName) const {
   std::vector<IAlgorithm_const_sptr> theRunningInstances;
-  std::lock_guard<std::mutex> _lock(this->m_managedMutex);
+  std::lock_guard<std::recursive_mutex> _lock(this->m_managedMutex);
   std::copy_if(
       m_managed_algs.cbegin(), m_managed_algs.cend(), std::back_inserter(theRunningInstances),
       [&algorithmName](const auto &algorithm) { return algorithm->name() == algorithmName && algorithm->isRunning(); });
@@ -152,7 +152,7 @@ std::vector<IAlgorithm_const_sptr> AlgorithmManagerImpl::runningInstancesOf(cons
 /// first
 std::vector<IAlgorithm_const_sptr> AlgorithmManagerImpl::runningInstances() const {
   std::vector<IAlgorithm_const_sptr> theRunningInstances;
-  std::lock_guard<std::mutex> _lock(this->m_managedMutex);
+  std::lock_guard<std::recursive_mutex> _lock(this->m_managedMutex);
   std::copy_if(m_managed_algs.cbegin(), m_managed_algs.cend(), std::back_inserter(theRunningInstances),
                [](const auto &algorithm) { return algorithm->isRunning(); });
   return theRunningInstances;
@@ -160,7 +160,7 @@ std::vector<IAlgorithm_const_sptr> AlgorithmManagerImpl::runningInstances() cons
 
 /// Requests cancellation of all running algorithms
 void AlgorithmManagerImpl::cancelAll() {
-  std::lock_guard<std::mutex> _lock(this->m_managedMutex);
+  std::lock_guard<std::recursive_mutex> _lock(this->m_managedMutex);
   for (auto &managed_alg : m_managed_algs) {
     if (managed_alg->isRunning())
       managed_alg->cancel();
@@ -168,10 +168,9 @@ void AlgorithmManagerImpl::cancelAll() {
 }
 
 /// Removes all of the finished algorithms
-/// this does not lock the mutex as the locking is already assumed to be in
-/// place
 size_t AlgorithmManagerImpl::removeFinishedAlgorithms() {
   std::vector<IAlgorithm_const_sptr> theCompletedInstances;
+  std::lock_guard<std::recursive_mutex> _lock(this->m_managedMutex);
   std::copy_if(m_managed_algs.cbegin(), m_managed_algs.cend(), std::back_inserter(theCompletedInstances),
                [](const auto &algorithm) { return (algorithm->isReadyForGarbageCollection()); });
   for (auto completedAlg : theCompletedInstances) {

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -9,18 +9,26 @@
 #include "MantidAPI/Jacobian.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidCurveFitting/Jacobian.h"
+#include "MantidKernel/IPropertyManager.h"
+#include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/api/FitFunctions/IFunctionAdapter.h"
 #include "MantidPythonInterface/core/GetPointer.h"
+#include "MantidPythonInterface/core/IsNone.h"
+#include "MantidPythonInterface/kernel/Registry/PropertyValueHandler.h"
 #include "MantidPythonInterface/kernel/Registry/TypeRegistry.h"
 #include "MantidPythonInterface/kernel/Registry/TypedPropertyValueHandler.h"
 
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
+#include <boost/python/extract.hpp>
 #include <boost/python/manage_new_object.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 #include <boost/python/to_python_value.hpp>
+
+#include <memory>
+#include <string>
 
 using Mantid::API::IFunction;
 using Mantid::API::IFunction_sptr;
@@ -32,6 +40,58 @@ GET_POINTER_SPECIALIZATION(IFunction)
 
 namespace {
 ///@cond
+
+/**
+ * Extracts a pointer to the C++ IFunction from the python object, and then clones the IFunction. The clone is necessary
+ * to force a separation from the python object to avoid GIL issues.
+ * @param value :: A boost python object that stores the value
+ * @returns A clone of the extracted IFunction C++ object.
+ */
+template <typename T> inline T extractValueAndClone(const boost::python::object &value) {
+  return boost::python::extract<T>(value)()->clone();
+}
+
+struct DLLExport FunctionPropertyValueHandler : public PropertyValueHandler {
+
+  /// Type required by TypeRegistry framework
+  using HeldType = std::shared_ptr<IFunction>;
+
+  /**
+   * Set function to handle Python -> C++ calls and get the correct type
+   * @param alg :: A pointer to an IPropertyManager
+   * @param name :: The name of the property
+   * @param value :: A boost python object that stores the value
+   */
+  void set(Mantid::Kernel::IPropertyManager *alg, const std::string &name,
+           const boost::python::object &value) const override {
+    alg->setProperty<HeldType>(name, extractValueAndClone<HeldType>(value));
+  }
+
+  /**
+   * Create a PropertyWithValue from the given python object value
+   * @param name :: The name of the property
+   * @param defaultValue :: The defaultValue of the property. The object
+   * attempts to extract
+   * a value of type ValueType from the python object
+   * @param validator :: A python object pointing to a validator instance, which
+   * can be None.
+   * @param direction :: The direction of the property
+   * @returns A pointer to a newly constructed property instance
+   */
+  std::unique_ptr<Mantid::Kernel::Property> create(const std::string &name, const boost::python::object &defaultValue,
+                                                   const boost::python::object &validator,
+                                                   const unsigned int direction) const override {
+    using Mantid::Kernel::IValidator;
+    using Mantid::Kernel::PropertyWithValue;
+    if (Mantid::PythonInterface::isNone(validator)) {
+      return std::make_unique<PropertyWithValue<HeldType>>(name, extractValueAndClone<HeldType>(defaultValue),
+                                                           direction);
+    }
+    const IValidator *propValidator = boost::python::extract<IValidator *>(validator);
+    return std::make_unique<PropertyWithValue<HeldType>>(name, extractValueAndClone<HeldType>(defaultValue),
+                                                         propValidator->clone(), direction);
+  }
+};
 
 //------------------------------------------------------------------------------------------------------
 /**
@@ -291,5 +351,5 @@ void export_IFunction() {
       //-- Python special methods --
       .def("__repr__", &IFunction::asString, arg("self"), "Return a string representation of the function");
 
-  TypeRegistry::subscribe<TypedPropertyValueHandler<IFunction_sptr>>();
+  TypeRegistry::subscribe<FunctionPropertyValueHandler>();
 }

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -288,7 +288,7 @@ operatorEqVarError:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmHistory.cpp:23
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmHistory.cpp:274
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmManager.cpp:112
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmManager.cpp:116
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmManager.cpp:180
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmManager.cpp:179
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/AnalysisDataService.h:138
 knownPointerToBool:${CMAKE_SOURCE_DIR}/Framework/API/src/Algorithm.cpp:386
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/Algorithm.cpp:620
@@ -920,7 +920,7 @@ passedByValue:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Expor
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp:81
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp:251
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp:58
-unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp:90
+unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp:150
 constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmProperty.cpp:30
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/SpectrumDefinition.cpp:40
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/dataobjects/src/Exports/EventList.cpp:37

--- a/docs/source/release/v6.9.0/Muon/Muon_Analysis/Bugfixes/36785.rst
+++ b/docs/source/release/v6.9.0/Muon/Muon_Analysis/Bugfixes/36785.rst
@@ -1,0 +1,1 @@
+- Fixed an unreliable crash when performing multiple TF Asymmetry fits.


### PR DESCRIPTION
### Description of work
The problem in the attached issue was caused when the AlgorithmManager was attempting to delete a finished algorithm. The finished algorithm destructor attempts to delete the properties of the finished algorithm. One of these properties was an `IFunction_sptr` with a custom "deleter" method which was in python. Attempting to delete this property means this python deleter method is entered and therefore the GIL needs to be held, but this was not the case.

It was determined that the IFunction_sptr algorithm property should not retain its python "deleter" method when it is passed to C++ via boost python. When passing the IFunction from python through the boost layer into C++, we should just have a shared pointer to the underlying C++ object. We attempted to extract a shared pointer reference to fix this issue, but this didn't seem to work for a particular case when the function passed to the algorithm was a Composite function. The compromise decided upon was to clone the IFunction C++ object after the extration from the python object, to ensure the lifetime of the object is now handled by a shared pointer rather than a "deleter"method written in python. 

Additional changes:
- The `AlgorithmManager::removeFinishedAlgorithms` function previously had to be called under the assumption that the mutex had already been locked. We have removed this assumption by making sure the mutex is locked at the top of the function. We think this was not done before because there was concern of causing a deadlock. By using a `std::recursive_mutex`, this concern is negated.

Fixes #36742

### To test:
1- Go to interfaces->muon->muon analysis
2- Load the run 62260
3- Go to the fitting tab
4- Change fitting type to tf asymmetry
5- Add the GausOsc function
6- Check simultaneous fit and press fit
7- Check/uncheck simultaneous fit multiple times
8- Make sure there is no crash
9- Try to do multiple fits using different types/functions

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
