### PR TITLE
Fix Muon crash when adding function with no data selected

### DIFF
--- a/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/36801.rst
+++ b/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/36801.rst
@@ -1,0 +1,1 @@
+- Fixed a crash caused by unselecting all loaded data in the Grouping tab before adding a Fit Function.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/fitting_contexts/basic_fitting_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/fitting_contexts/basic_fitting_context.py
@@ -103,8 +103,7 @@ class BasicFittingContext(FittingContext):
     @current_dataset_index.setter
     def current_dataset_index(self, index: int) -> None:
         """Sets the index of the currently selected dataset."""
-        if index is not None and index >= self.number_of_datasets:
-            raise RuntimeError(f"The provided dataset index ({index}) is too large.")
+        assert index is None or index < self.number_of_datasets, f"The dataset index ({index}) is too large."
 
         self._current_dataset_index = index
 
@@ -141,8 +140,7 @@ class BasicFittingContext(FittingContext):
     @single_fit_functions.setter
     def single_fit_functions(self, fit_functions: list) -> None:
         """Sets all of the single fit functions stored in the model."""
-        if len(fit_functions) != self.number_of_datasets:
-            raise RuntimeError("The provided number of functions is not equal to the number of datasets.")
+        assert len(fit_functions) == self.number_of_datasets, "The number of functions is not equal to the number of datasets."
 
         self._single_fit_functions = fit_functions
 
@@ -164,8 +162,7 @@ class BasicFittingContext(FittingContext):
     @fit_statuses.setter
     def fit_statuses(self, fit_statuses: list) -> None:
         """Sets the value of all fit statuses."""
-        if len(fit_statuses) != self.number_of_datasets:
-            raise RuntimeError("The provided number of fit statuses is not equal to the number of datasets.")
+        assert len(fit_statuses) == self.number_of_datasets, "The number of fit statuses is not equal to the number of datasets."
 
         self._fit_statuses = fit_statuses
 
@@ -187,8 +184,7 @@ class BasicFittingContext(FittingContext):
     @chi_squared.setter
     def chi_squared(self, chi_squared: list) -> None:
         """Sets all of the chi squared values."""
-        if len(chi_squared) != self.number_of_datasets:
-            raise RuntimeError("The provided number of chi squared is not equal to the number of datasets.")
+        assert len(chi_squared) == self.number_of_datasets, "The number of chi squared is not equal to the number of datasets."
 
         self._chi_squared = chi_squared
 
@@ -295,8 +291,7 @@ class BasicFittingContext(FittingContext):
     @start_xs.setter
     def start_xs(self, start_xs: list) -> None:
         """Sets all of the start Xs in the model."""
-        if len(start_xs) != self.number_of_datasets:
-            raise RuntimeError("The provided number of start Xs is not equal to the number of datasets.")
+        assert len(start_xs) == self.number_of_datasets, "The number of start Xs is not equal to the number of datasets."
 
         self._start_xs = start_xs
 
@@ -308,8 +303,7 @@ class BasicFittingContext(FittingContext):
     @end_xs.setter
     def end_xs(self, end_xs: list) -> None:
         """Sets all of the end Xs in the model."""
-        if len(end_xs) != self.number_of_datasets:
-            raise RuntimeError("The provided number of end Xs is not equal to the number of datasets.")
+        assert len(end_xs) == self.number_of_datasets, "The number of end Xs is not equal to the number of datasets."
 
         self._end_xs = end_xs
 
@@ -331,8 +325,7 @@ class BasicFittingContext(FittingContext):
     @exclude_start_xs.setter
     def exclude_start_xs(self, start_xs: list) -> None:
         """Sets the exclude start Xs stored by the context."""
-        if len(start_xs) != self.number_of_datasets:
-            raise RuntimeError("The provided number of exclude start Xs is not equal to the number of datasets.")
+        assert len(start_xs) == self.number_of_datasets, "The number of exclude start Xs is not equal to the number of datasets."
 
         self._exclude_start_xs = start_xs
 
@@ -344,8 +337,7 @@ class BasicFittingContext(FittingContext):
     @exclude_end_xs.setter
     def exclude_end_xs(self, end_xs: list) -> None:
         """Sets the exclude end Xs stored by the context."""
-        if len(end_xs) != self.number_of_datasets:
-            raise RuntimeError("The provided number of exclude end Xs is not equal to the number of datasets.")
+        assert len(end_xs) == self.number_of_datasets, "The number of exclude end Xs is not equal to the number of datasets."
 
         self._exclude_end_xs = end_xs
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/fitting_contexts/general_fitting_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/fitting_contexts/general_fitting_context.py
@@ -84,8 +84,9 @@ class GeneralFittingContext(BasicFittingContext):
     @simultaneous_fit_function.setter
     def simultaneous_fit_function(self, fit_function: IFunction) -> None:
         """Sets the simultaneous fit function stored in the model."""
-        if fit_function is not None and self.number_of_datasets == 0:
-            raise RuntimeError("Cannot set a simultaneous fit function when there are no datasets in the model.")
+        assert (
+            fit_function is None or self.number_of_datasets > 0
+        ), "Cannot set a simultaneous fit function when there are no datasets in the model."
 
         self._simultaneous_fit_function = fit_function
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/fitting_contexts/model_fitting_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/fitting_contexts/model_fitting_context.py
@@ -53,8 +53,7 @@ class ModelFittingContext(BasicFittingContext):
     @current_result_table_index.setter
     def current_result_table_index(self, index: int) -> None:
         """Sets the index of the currently selected result table."""
-        if index is not None and index >= self.number_of_result_tables():
-            raise RuntimeError(f"The provided result table index ({index}) is too large.")
+        assert index is None or index < self.number_of_result_tables(), f"The result table index ({index}) is too large."
 
         self._current_result_table_index = index
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -99,11 +99,6 @@ class BasicFittingPresenter:
         """Handle when there is a clear or remove workspace event in the ADS."""
         self.update_and_reset_all_data()
 
-        if self.model.number_of_datasets == 0:
-            self.view.disable_view()
-        else:
-            self.enable_editing_notifier.notify_subscribers()
-
     def handle_gui_changes_made(self, changed_values: dict) -> None:
         """Handle when the good data checkbox is changed in the home tab."""
         for key in changed_values.keys():
@@ -116,11 +111,6 @@ class BasicFittingPresenter:
 
         self.view.plot_guess, self.model.plot_guess = False, False
         self.clear_undo_data()
-
-        if self.model.number_of_datasets == 0:
-            self.view.disable_view()
-        else:
-            self.enable_editing_notifier.notify_subscribers()
 
     def handle_instrument_changed(self) -> None:
         """Handles when an instrument is changed and switches to normal fitting mode. Overridden by child."""
@@ -399,6 +389,11 @@ class BasicFittingPresenter:
         self.view.set_datasets_in_function_browser(self.model.dataset_names)
         self.view.update_dataset_name_combo_box(self.model.dataset_names)
         self.model.current_dataset_index = self.view.current_dataset_index
+
+        if self.model.number_of_datasets == 0:
+            self.view.disable_view()
+        else:
+            self.enable_editing_notifier.notify_subscribers()
 
     def update_fit_statuses_and_chi_squared_in_model(self, fit_status: str, chi_squared: float) -> None:
         """Updates the fit status and chi squared stored in the model. This is used after a fit."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
@@ -241,6 +241,10 @@ class ModelFittingModel(BasicFittingModel):
         x_lower, _ = self.x_limits_of_workspace(workspace_name)
         return x_lower
 
+    def number_of_result_tables() -> int:
+        """Returns the number of results tables stored by the fitting context."""
+        return self.fitting_context.number_of_result_tables()
+
     def _reset_current_result_table_index(self) -> None:
         """Resets the current result table index stored by the context."""
         if self.fitting_context.number_of_result_tables() == 0:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
@@ -176,6 +176,11 @@ class ModelFittingPresenter(BasicFittingPresenter):
             # Triggers handle_results_table_changed
             self.view.update_result_table_names(self.model.result_table_names)
 
+        if self.model.number_of_result_tables() == 0:
+            self.view.disable_view()
+        else:
+            self.enable_editing_notifier.notify_subscribers()
+
     def update_fit_functions_in_model_from_view(self) -> None:
         """Update the fit function in the model only for the currently selected dataset."""
         self.model.current_single_fit_function = self.view.current_fit_function()

--- a/qt/python/mantidqtinterfaces/test/Muon/basic_fitting_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/basic_fitting_context_test.py
@@ -60,7 +60,7 @@ class BasicFittingContextTest(unittest.TestCase):
 
     def test_that_current_dataset_index_will_raise_if_the_index_is_greater_than_or_equal_to_the_number_of_datasets(self):
         self.fitting_context.dataset_names = self.dataset_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.fitting_context.current_dataset_index = 2
 
     def test_that_current_dataset_index_does_not_throw_when_provided_None_and_there_are_no_datasets_loaded(self):
@@ -72,37 +72,37 @@ class BasicFittingContextTest(unittest.TestCase):
 
     def test_that_start_xs_will_raise_if_the_number_of_xs_is_greater_than_or_equal_to_the_number_of_datasets(self):
         self.fitting_context.dataset_names = self.dataset_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.fitting_context.start_xs = [1.0, 2.0, 3.0]
 
     def test_that_end_xs_will_raise_if_the_number_of_xs_is_greater_than_or_equal_to_the_number_of_datasets(self):
         self.fitting_context.dataset_names = self.dataset_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.fitting_context.end_xs = [1.0, 2.0, 3.0]
 
     def test_that_exclude_start_xs_will_raise_if_the_number_of_xs_is_greater_than_or_equal_to_the_number_of_datasets(self):
         self.fitting_context.dataset_names = self.dataset_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.fitting_context.exclude_start_xs = [1.0, 2.0, 3.0]
 
     def test_that_exclude_end_xs_will_raise_if_the_number_of_xs_is_greater_than_or_equal_to_the_number_of_datasets(self):
         self.fitting_context.dataset_names = self.dataset_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.fitting_context.exclude_end_xs = [1.0, 2.0, 3.0]
 
     def test_that_single_fit_functions_will_raise_if_the_num_of_funcs_is_greater_than_or_equal_to_the_num_of_datasets(self):
         self.fitting_context.dataset_names = ["Name1"]
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.fitting_context.single_fit_functions = self.single_fit_functions
 
     def test_that_fit_statuses_will_raise_if_the_number_of_datasets_is_smaller_than_the_provided_list_size(self):
         self.fitting_context.dataset_names = self.dataset_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.fitting_context.fit_statuses = ["Success", "Success", "Success"]
 
     def test_that_chi_squared_will_raise_if_the_number_of_datasets_is_smaller_than_the_provided_list_size(self):
         self.fitting_context.dataset_names = self.dataset_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.fitting_context.chi_squared = [1.0, 2.0, 3.0]
 
     def test_that_guess_workspace_name_will_not_raise_if_the_workspace_does_not_exist(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -131,7 +131,7 @@ class BasicFittingModelTest(unittest.TestCase):
 
     def test_that_current_dataset_index_will_raise_if_the_index_is_greater_than_or_equal_to_the_number_of_datasets(self):
         self.model.dataset_names = self.dataset_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.model.current_dataset_index = 2
 
     def test_that_current_dataset_index_will_set_the_current_dataset_index_as_expected(self):
@@ -163,7 +163,7 @@ class BasicFittingModelTest(unittest.TestCase):
 
     def test_that_setting_the_start_xs_will_raise_if_the_number_of_xs_is_not_equal_to_the_number_of_datasets(self):
         self.model.dataset_names = self.dataset_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.model.start_xs = [0.0]
 
     def test_that_it_is_possible_to_set_the_current_start_x_as_expected(self):
@@ -195,7 +195,7 @@ class BasicFittingModelTest(unittest.TestCase):
 
     def test_that_setting_the_end_xs_will_raise_if_the_number_of_xs_is_not_equal_to_the_number_of_datasets(self):
         self.model.dataset_names = self.dataset_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.model.end_xs = [10.0]
 
     def test_that_it_is_possible_to_set_the_current_end_x_as_expected(self):
@@ -246,7 +246,7 @@ class BasicFittingModelTest(unittest.TestCase):
 
     def test_that_setting_the_single_fit_function_will_raise_if_the_number_of_functions_is_not_equal_to_the_number_of_datasets(self):
         self.model.dataset_names = self.dataset_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.model.single_fit_functions = [self.fit_function]
 
     def test_that_clear_single_fit_functions_will_clear_the_single_fit_functions_as_expected(self):
@@ -312,7 +312,7 @@ class BasicFittingModelTest(unittest.TestCase):
 
     def test_that_setting_the_fit_statuses_will_raise_if_the_number_of_fit_statuses_is_not_equal_to_the_number_of_datasets(self):
         self.model.dataset_names = self.dataset_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.model.fit_statuses = ["success"]
 
     def test_it_is_possible_to_set_the_currently_selected_fit_status(self):
@@ -326,7 +326,7 @@ class BasicFittingModelTest(unittest.TestCase):
 
     def test_that_setting_the_chi_squared_will_raise_if_the_number_of_chi_squared_is_not_equal_to_the_number_of_datasets(self):
         self.model.dataset_names = self.dataset_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.model.chi_squared = [0.0]
 
     def test_it_is_possible_to_set_the_currently_selected_chi_squared(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -76,7 +76,6 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
         self.presenter.handle_ads_clear_or_remove_workspace_event()
 
         self.presenter.update_and_reset_all_data.assert_called_with()
-        self.presenter.enable_editing_notifier.notify_subscribers.assert_called_once_with()
 
     def test_that_handle_ads_clear_or_remove_workspace_event_will_disable_the_tab_if_no_data_is_loaded(self):
         self.mock_model_number_of_datasets = mock.PropertyMock(return_value=0)
@@ -85,7 +84,6 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
         self.presenter.handle_ads_clear_or_remove_workspace_event()
 
         self.presenter.update_and_reset_all_data.assert_called_with()
-        self.view.disable_view.assert_called_once_with()
 
     def test_that_handle_gui_changes_made_will_reset_the_start_and_end_x_in_the_model_and_view(self):
         self.presenter.handle_gui_changes_made({"FirstGoodDataFromFile": True})
@@ -105,7 +103,6 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
         self.mock_view_plot_guess.assert_called_once_with(False)
         self.mock_model_plot_guess.assert_called_once_with(False)
         self.presenter.clear_undo_data.assert_called_with()
-        self.presenter.enable_editing_notifier.notify_subscribers.assert_called_once_with()
 
     def test_that_handle_new_data_loaded_will_disable_the_tab_if_no_data_is_loaded(self):
         self.presenter.clear_undo_data = mock.Mock()
@@ -118,7 +115,6 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
         self.mock_view_plot_guess.assert_called_once_with(False)
         self.mock_model_plot_guess.assert_called_once_with(False)
         self.presenter.clear_undo_data.assert_called_with()
-        self.view.disable_view.assert_called_once_with()
 
     def test_that_handle_dataset_name_changed_will_update_the_model_and_view(self):
         self.presenter.update_fit_statuses_and_chi_squared_in_view_from_model = mock.Mock()
@@ -472,6 +468,7 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
 
         self.model.get_workspace_names_to_display_from_context.assert_called_once_with()
         self.view.set_datasets_in_function_browser.assert_called_once_with(self.dataset_names)
+        self.presenter.enable_editing_notifier.notify_subscribers.assert_called_once_with()
 
     def test_that_update_fit_function_in_view_from_model_will_update_the_function_and_index_in_the_view(self):
         self.presenter.update_fit_function_in_view_from_model()

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -63,7 +63,7 @@ class GeneralFittingModelTest(unittest.TestCase):
 
     def test_that_setting_the_simultaneous_fit_function_to_an_ifunction_will_raise_if_the_number_of_datasets_is_zero(self):
         self.assertEqual(self.model.number_of_datasets, 0)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.model.simultaneous_fit_function = self.simultaneous_fit_function
 
     def test_that_setting_the_simultaneous_fit_function_to_a_none_will_not_raise_if_the_number_of_datasets_is_zero(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_model_test.py
@@ -84,7 +84,7 @@ class ModelFittingModelTest(unittest.TestCase):
 
     def test_that_current_result_table_index_will_raise_if_the_index_is_greater_than_or_equal_to_the_number_of_tables(self):
         self.model.result_table_names = self.result_table_names
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.model.current_result_table_index = 2
 
     def test_that_current_result_table_index_will_set_the_current_dataset_index_as_expected(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
@@ -109,7 +109,6 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.presenter.handle_ads_clear_or_remove_workspace_event()
 
         self.presenter.update_and_reset_all_data.assert_called_with()
-        self.presenter.enable_editing_notifier.notify_subscribers.assert_called_once_with()
         self.assertEqual(self.mock_view_tf_asymmetry_mode.call_count, 1)
         self.assertEqual(self.mock_model_tf_asymmetry_mode.call_count, 1)
 
@@ -121,7 +120,6 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.presenter.handle_ads_clear_or_remove_workspace_event()
 
         self.presenter.update_and_reset_all_data.assert_called_with()
-        self.view.disable_view.assert_called_once_with()
         self.mock_view_tf_asymmetry_mode.assert_called_with(False)
         self.mock_model_tf_asymmetry_mode.assert_called_with(False)
         self.assertEqual(self.mock_view_tf_asymmetry_mode.call_count, 2)
@@ -137,7 +135,6 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.mock_view_plot_guess.assert_called_once_with(False)
         self.mock_model_plot_guess.assert_called_once_with(False)
         self.presenter.clear_undo_data.assert_called_with()
-        self.presenter.enable_editing_notifier.notify_subscribers.assert_called_once_with()
         self.assertEqual(self.mock_view_tf_asymmetry_mode.call_count, 1)
         self.assertEqual(self.mock_model_tf_asymmetry_mode.call_count, 1)
 
@@ -153,7 +150,6 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.mock_view_plot_guess.assert_called_once_with(False)
         self.mock_model_plot_guess.assert_called_once_with(False)
         self.presenter.clear_undo_data.assert_called_with()
-        self.view.disable_view.assert_called_once_with()
         self.mock_view_tf_asymmetry_mode.assert_called_with(False)
         self.mock_model_tf_asymmetry_mode.assert_called_with(False)
         self.assertEqual(self.mock_view_tf_asymmetry_mode.call_count, 2)

--- a/qt/python/mantidqtinterfaces/test/Muon/general_fitting_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/general_fitting_context_test.py
@@ -62,7 +62,7 @@ class GeneralFittingContextTest(unittest.TestCase):
         self.assertEqual(self.fitting_context.global_parameters, [])
 
     def test_that_simultaneous_fit_function_will_raise_if_there_are_no_datasets_loaded(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.fitting_context.simultaneous_fit_function = self.simultaneous_fit_function
 
     def test_that_simultaneous_fit_function_will_not_raise_if_there_are_no_datasets_and_none_is_provided(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/model_fitting_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/model_fitting_context_test.py
@@ -58,14 +58,11 @@ class ModelFittingContextTest(unittest.TestCase):
         self.assertEqual(self.fitting_context.y_parameter_errors, {})
 
     def test_that_current_result_table_index_will_raise_if_the_index_provided_is_too_large(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(AssertionError):
             self.fitting_context.current_result_table_index = 4
 
     def test_that_current_result_table_index_will_not_raise_a_runtime_error_if_theres_no_datasets_and_none_is_provided(self):
-        try:
-            self.fitting_context.current_result_table_index = None
-        except RuntimeError:
-            self.fail("This should not have raised an exception.")
+        self.fitting_context.current_result_table_index = None
 
     def test_that_number_of_result_tables_will_return_the_expected_number_of_results_tables(self):
         self.assertEqual(self.fitting_context.number_of_result_tables(), 0)


### PR DESCRIPTION
### Description of work
This PR fixes an issues where the fitting tab was enabled even when there is no data selected in the plot. This allowed users to add functions when their was no domain data. The solution was to ensure the fitting tab was disabled when the number of datasets loaded into the fitting tab is zero.

This PR also makes some of the fitting contexts safer by removing the RuntimeErrors which were not covered by try-catch blocks. Instead it makes better sense to use `assert` so that an `AssertionError` is only raising when debugging as a developer, and not in our production code. The asserting statements indicate a logic problem in our code, rather than a problem caused by user-error.

Fixes #36801

### To test:
1. Open Muon Analysis interface
2. Select the EMU instrument
3. In the Grouping tab untick 'long'
4. Go to the Fitting tab, it should be disabled so you can't add a function

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
