### PR TITLE
Fix load current run for MUSR in Muon Analysis

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -353,10 +353,6 @@ public:
   /// The argument is the property name. Default - do nothing.
   void afterPropertySet(const std::string &) override;
 
-  void filterByProperty(const Kernel::TimeSeriesProperty<bool> & /*filter*/, const std::vector<std::string> &
-                        /* excludedFromFiltering */) override {
-    throw(std::runtime_error("Not yet implmented"));
-  }
   Kernel::Property *getPointerToProperty(const std::string &name) const override;
   Kernel::Property *getPointerToPropertyOrdinal(const int &index) const override;
 

--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -31,6 +31,7 @@ template <typename TYPE> class TimeSeriesProperty;
 class SplittingInterval;
 using SplittingIntervalVec = std::vector<SplittingInterval>;
 class PropertyManager;
+class LogFilter;
 class TimeROI;
 struct TimeSeriesPropertyStatistics;
 } // namespace Kernel
@@ -83,7 +84,7 @@ public:
   void copyAndFilterProperties(const LogManager &other, const Kernel::TimeROI &timeROI);
 
   /// Filter the run by the given boolean log
-  void filterByLog(const Kernel::TimeSeriesProperty<bool> &filter,
+  void filterByLog(Mantid::Kernel::LogFilter *filter,
                    const std::vector<std::string> &excludedFromFiltering = std::vector<std::string>());
 
   /// Return an approximate memory size for the object in bytes

--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -83,7 +83,7 @@ public:
   /// Copy properties from another LogManager; filter copied time series properties according to TimeROI
   void copyAndFilterProperties(const LogManager &other, const Kernel::TimeROI &timeROI);
 
-  /// Filter the run by the given boolean log
+  /// Filter the run by the given log filter
   void filterByLog(Mantid::Kernel::LogFilter *filter,
                    const std::vector<std::string> &excludedFromFiltering = std::vector<std::string>());
 

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -325,12 +325,11 @@ void LogManager::removeDataOutsideTimeROI() {
 /**
  * Filter the run by the given boolean log. It replaces all time
  * series properties with filtered time series properties
- * @param filter :: A boolean time series to filter each log on
+ * @param filter :: A LogFilter instance to filter each log on
  * @param excludedFromFiltering :: A string list of logs that
  * will be excluded from filtering
  */
-void LogManager::filterByLog(const Kernel::TimeSeriesProperty<bool> &filter,
-                             const std::vector<std::string> &excludedFromFiltering) {
+void LogManager::filterByLog(Mantid::Kernel::LogFilter *filter, const std::vector<std::string> &excludedFromFiltering) {
   // This will invalidate the cache
   this->clearSingleValueCache();
   m_manager->filterByProperty(filter, excludedFromFiltering);

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -652,8 +652,7 @@ void LogManager::loadNexus(::NeXus::File *file, const Mantid::Kernel::NexusHDF5D
   // Only load from NXlog entries
   const auto &allEntries = fileInfo.getAllEntries();
   auto itNxLogEntries = allEntries.find("NXlog");
-  const std::set<std::string> &nxLogEntries =
-      (itNxLogEntries != allEntries.end()) ? itNxLogEntries->second : std::set<std::string>{};
+  const auto nxLogEntries = (itNxLogEntries != allEntries.end()) ? itNxLogEntries->second : std::set<std::string>{};
 
   const auto levels = std::count(prefix.begin(), prefix.end(), '/');
 

--- a/Framework/DataHandling/src/ISISRunLogs.cpp
+++ b/Framework/DataHandling/src/ISISRunLogs.cpp
@@ -70,7 +70,6 @@ void ISISRunLogs::addPeriodLogs(const int period, API::Run &exptRun) {
  * @param exptRun :: The run for this period
  */
 void ISISRunLogs::applyLogFiltering(Mantid::API::Run &exptRun) {
-  const TimeSeriesProperty<bool> *maskProp{nullptr};
   std::unique_ptr<LogFilter> logFilter{nullptr};
   try {
     auto runningLog = exptRun.getTimeSeriesProperty<bool>(LogParser::statusLogName());
@@ -102,16 +101,14 @@ void ISISRunLogs::applyLogFiltering(Mantid::API::Run &exptRun) {
   if (multiperiod) {
     if (logFilter) {
       logFilter->addFilter(*currentPeriodLog);
-      maskProp = logFilter->filter();
-    } else
-      maskProp = currentPeriodLog;
-  } else if (logFilter) {
-    maskProp = logFilter->filter();
+    } else if (currentPeriodLog) {
+      logFilter = std::make_unique<LogFilter>(*currentPeriodLog);
+    }
   }
 
   // Filter logs if we have anything to filter on
-  if (maskProp) {
-    exptRun.filterByLog(*maskProp, ISISRunLogs::getLogNamesExcludedFromFiltering(exptRun));
+  if (logFilter) {
+    exptRun.filterByLog(logFilter.get(), ISISRunLogs::getLogNamesExcludedFromFiltering(exptRun));
   }
 }
 

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -309,7 +309,7 @@ public:
     TS_ASSERT_EQUALS(pclog2->nthValue(1), false);
     TS_ASSERT_EQUALS(pclog2->nthValue(2), false);
 
-    // force the filtering by passing in an empty log
+    // force the filtering by passing in a log filter
     auto timeSeries = new Mantid::Kernel::TimeSeriesProperty<bool>("filter");
     timeSeries->addValue("2007-11-30T16:16:50", true);
     timeSeries->addValue("2007-11-30T16:17:25", false);

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -15,6 +15,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataHandling/LoadNexusLogs.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidKernel/LogFilter.h"
 #include "MantidKernel/PhysicalConstants.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 
@@ -309,8 +310,12 @@ public:
     TS_ASSERT_EQUALS(pclog2->nthValue(2), false);
 
     // force the filtering by passing in an empty log
-    auto emptyProperty = new TimeSeriesProperty<bool>("empty");
-    run.filterByLog(*emptyProperty);
+    auto timeSeries = new Mantid::Kernel::TimeSeriesProperty<bool>("filter");
+    timeSeries->addValue("2007-11-30T16:16:50", true);
+    timeSeries->addValue("2007-11-30T16:17:25", false);
+    timeSeries->addValue("2007-11-30T16:17:39", true);
+    auto filter = std::make_unique<LogFilter>(*timeSeries);
+    run.filterByLog(filter.get());
 
     auto pclogFiltered1 = dynamic_cast<TimeSeriesProperty<double> *>(run.getLogData("cryo_temp1"));
     // middle value is invalid and is filtered out

--- a/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
@@ -41,6 +41,7 @@ class OptionalBool;
 class Property;
 class PropertyManager;
 class SplittingInterval;
+class LogFilter;
 template <typename T> class TimeSeriesProperty;
 template <typename T> class Matrix;
 
@@ -333,8 +334,10 @@ public:
   /// Get the list of managed properties in a given group.
   std::vector<Property *> getPropertiesInGroup(const std::string &group) const;
 
-  virtual void filterByProperty(const TimeSeriesProperty<bool> & /*filter*/, const std::vector<std::string> &
-                                /* excludedFromFiltering */) = 0;
+  virtual void filterByProperty(Mantid::Kernel::LogFilter * /*logFilter*/, const std::vector<std::string> &
+                                /* excludedFromFiltering */) {
+    throw std::logic_error("Not implemented yet.");
+  }
 
 protected:
   /// Get a property by an index

--- a/Framework/Kernel/inc/MantidKernel/PropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyManager.h
@@ -22,6 +22,7 @@ namespace Kernel {
 class SplittingInterval;
 template <typename T> class TimeSeriesProperty;
 class TimeROI;
+class LogFilter;
 
 /**
  Property manager helper class.
@@ -55,7 +56,7 @@ public:
   PropertyManager &operator=(const PropertyManager &);
   PropertyManager &operator+=(const PropertyManager &rhs);
 
-  void filterByProperty(const TimeSeriesProperty<bool> &filter,
+  void filterByProperty(Mantid::Kernel::LogFilter *logFilter,
                         const std::vector<std::string> &excludedFromFiltering = std::vector<std::string>()) override;
 
   // Create a new PropertyManager with a partial copy of its time series properties according to TimeROI

--- a/Framework/Kernel/inc/MantidKernel/PropertyManagerOwner.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyManagerOwner.h
@@ -96,11 +96,6 @@ public:
   /// The argument is the property name. Default - do nothing.
   void afterPropertySet(const std::string &) override;
 
-  void filterByProperty(const TimeSeriesProperty<bool> & /*filter*/, const std::vector<std::string> &
-                        /* excludedFromFiltering */) override {
-    throw(std::runtime_error("Not yet implmented"));
-  }
-
 public:
   Property *getPointerToProperty(const std::string &name) const override;
   Property *getPointerToPropertyOrdinal(const int &index) const override;

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -139,22 +139,22 @@ void PropertyManager::filterByProperty(Mantid::Kernel::LogFilter *logFilter,
                                        const std::vector<std::string> &excludedFromFiltering) {
   auto filter = logFilter->filter();
   for (auto &orderedProperty : m_orderedProperties) {
-    if (std::find(excludedFromFiltering.cbegin(), excludedFromFiltering.cend(), orderedProperty->name()) !=
+    auto const propName = orderedProperty->name();
+    if (std::find(excludedFromFiltering.cbegin(), excludedFromFiltering.cend(), propName) !=
         excludedFromFiltering.cend()) {
       // this log should be excluded from filtering
       continue;
     }
 
-    Property *currentProp = orderedProperty;
-    if (auto doubleSeries = dynamic_cast<TimeSeriesProperty<double> *>(currentProp)) {
+    if (auto doubleSeries = dynamic_cast<TimeSeriesProperty<double> *>(orderedProperty)) {
       // don't filter the invalid values filters
-      if (PropertyManager::isAnInvalidValuesFilterLog(currentProp->name()))
+      if (PropertyManager::isAnInvalidValuesFilterLog(propName))
         break;
       std::unique_ptr<Property> filtered(nullptr);
-      if (this->existsProperty(PropertyManager::getInvalidValuesFilterLogName(currentProp->name()))) {
+      if (this->existsProperty(PropertyManager::getInvalidValuesFilterLogName(propName))) {
 
         // add the filter to the passed in filters
-        auto filterProp = getPointerToProperty(PropertyManager::getInvalidValuesFilterLogName(currentProp->name()));
+        auto filterProp = getPointerToProperty(PropertyManager::getInvalidValuesFilterLogName(propName));
         auto tspFilterProp = dynamic_cast<TimeSeriesProperty<bool> *>(filterProp);
         if (!tspFilterProp)
           break;
@@ -168,7 +168,7 @@ void PropertyManager::filterByProperty(Mantid::Kernel::LogFilter *logFilter,
       if (filtered) {
         // Now replace in the map
         orderedProperty = filtered.get();
-        this->m_properties[createKey(currentProp->name())] = std::move(filtered);
+        this->m_properties[createKey(propName)] = std::move(filtered);
       }
     }
   }

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -131,12 +131,13 @@ PropertyManager &PropertyManager::operator+=(const PropertyManager &rhs) {
 /**
  * Filter the managed properties by the given boolean property mask. It replaces
  * all time series properties with filtered time series properties
- * @param filter :: A boolean time series to filter each property on
+ * @param logFilter :: A LogFilter instance to filter each log on
  * @param excludedFromFiltering :: A string list of properties that
  * will be excluded from filtering
  */
-void PropertyManager::filterByProperty(const Kernel::TimeSeriesProperty<bool> &filter,
+void PropertyManager::filterByProperty(Mantid::Kernel::LogFilter *logFilter,
                                        const std::vector<std::string> &excludedFromFiltering) {
+  auto filter = logFilter->filter();
   for (auto &orderedProperty : m_orderedProperties) {
     if (std::find(excludedFromFiltering.cbegin(), excludedFromFiltering.cend(), orderedProperty->name()) !=
         excludedFromFiltering.cend()) {
@@ -153,7 +154,6 @@ void PropertyManager::filterByProperty(const Kernel::TimeSeriesProperty<bool> &f
       if (this->existsProperty(PropertyManager::getInvalidValuesFilterLogName(currentProp->name()))) {
 
         // add the filter to the passed in filters
-        auto logFilter = std::make_unique<LogFilter>(filter);
         auto filterProp = getPointerToProperty(PropertyManager::getInvalidValuesFilterLogName(currentProp->name()));
         auto tspFilterProp = dynamic_cast<TimeSeriesProperty<bool> *>(filterProp);
         if (!tspFilterProp)
@@ -161,9 +161,9 @@ void PropertyManager::filterByProperty(const Kernel::TimeSeriesProperty<bool> &f
         logFilter->addFilter(*tspFilterProp);
 
         filtered = std::make_unique<FilteredTimeSeriesProperty<double>>(doubleSeries, *logFilter->filter());
-      } else if (filter.size() > 0) {
+      } else if (filter->size() > 0) {
         // attach the filter to the TimeSeriesProperty, thus creating  the FilteredTimeSeriesProperty<double>
-        filtered = std::make_unique<FilteredTimeSeriesProperty<double>>(doubleSeries, filter);
+        filtered = std::make_unique<FilteredTimeSeriesProperty<double>>(doubleSeries, *filter);
       }
       if (filtered) {
         // Now replace in the map

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -81,8 +81,8 @@ constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Math/Optimization
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp:1352
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp:1476
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp:1733
-invalidLifetime:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/PropertyManager.cpp:141
-virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/PropertyManager.h:105
+invalidLifetime:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/PropertyManager.cpp:142
+virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/PropertyManager.h:106
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/PropertyManager.cpp:158
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/PropertyManager.cpp:189
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/PropertyManager.cpp:538
@@ -333,7 +333,6 @@ virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/IPowder
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/ITableWorkspace.cpp:118
 operatorEqVarError:${CMAKE_SOURCE_DIR}/Framework/API/src/ISpectrum.cpp:156
 operatorEqVarError:${CMAKE_SOURCE_DIR}/Framework/API/src/ISpectrum.cpp:167
-danglingTemporaryLifetime:${CMAKE_SOURCE_DIR}/Framework/API/src/LogManager.cpp:661
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/LogManager.cpp:205
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/LogManager.cpp:235
 knownPointerToBool:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiDomainFunction.cpp:108

--- a/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/36800.rst
+++ b/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/36800.rst
@@ -1,0 +1,2 @@
+- Fixed a bug when you click 'Load Current Run' for the MUSR instrument.
+- Improved the warning message displayed when a file fails to load.

--- a/qt/python/mantidqt/mantidqt/utils/asynchronous.py
+++ b/qt/python/mantidqt/mantidqt/utils/asynchronous.py
@@ -206,10 +206,13 @@ class AsyncTaskFailure(AsyncTaskResult):
     def __str__(self):
         error_name = type(self.exc_value).__name__
         filename, lineno, _, _ = extract_tb(self.stack)[-1]
+        return f"{error_name} on line {lineno} of '{filename}': {self.exception_msg()}"
+
+    def exception_msg(self):
         msg = self.exc_value.args
         if msg and isinstance(msg, tuple):
             msg = msg[0]
-        return f"{error_name} on line {lineno} of '{filename}': {msg}"
+        return msg
 
     @property
     def success(self):

--- a/qt/python/mantidqt/mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
@@ -178,9 +178,9 @@ class SampleLogsModelTest(unittest.TestCase):
         self.assertEqual(get_value(all_logs[21]), "{} (2 entries)".format(model.get_statistics("C9_SLAVE_PHASE").mean))
         self.assertEqual(get_value(all_logs[21]), "{} (2 entries)".format(model.get_statistics("C9_SLAVE_PHASE").maximum))
 
-        # Valid log with 4 identical value entries
-        self.assertEqual(get_value(all_logs[38]), "{} (4 entries)".format(model.get_statistics("x").mean))
-        self.assertEqual(get_value(all_logs[38]), "{} (4 entries)".format(model.get_statistics("x").maximum))
+        # Valid log with 6 identical value entries
+        self.assertEqual(get_value(all_logs[38]), "{} (6 entries)".format(model.get_statistics("x").mean))
+        self.assertEqual(get_value(all_logs[38]), "{} (6 entries)".format(model.get_statistics("x").maximum))
 
         # Valid log with multiple different value entries
         self.assertEqual(get_value(all_logs[29]), "({} entries)".format(all_logs[29].size()))  # cryo_Sample

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_file_widget/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_file_widget/presenter.py
@@ -101,7 +101,7 @@ class BrowseFileWidgetPresenter(object):
         try:
             self._model.execute()
         except ValueError as error:
-            self._view.warning_popup(error.args[0])
+            self._view.warning_popup(str(error))
             self.filenames = self._model.current_filenames
         self.on_loading_finished()
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_run_widget/load_run_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_run_widget/load_run_model.py
@@ -32,16 +32,13 @@ class LoadRunWidgetModel(object):
         for filename in self._filenames:
             try:
                 ws, run, filename, _ = load_utils.load_workspace_from_filename(filename)
-            except ValueError as error:
+            except (RuntimeError, ValueError) as error:
                 failed_files += [(filename, error)]
                 continue
             self._loaded_data_store.remove_data(run=[run])
             self._loaded_data_store.add_data(run=[run], workspace=ws, filename=filename, instrument=self._data_context.instrument)
         if failed_files:
-            message = (
-                "The requested run could not be found. This could be due to: \n - The run does not yet exist."
-                "\n - The file was not found locally (please check the user directories)."
-            )
+            message = load_utils.exception_message_for_failed_files(failed_files)
             raise ValueError(message)
 
     def cancel(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_run_widget/load_run_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_run_widget/load_run_presenter.py
@@ -216,7 +216,7 @@ class LoadRunWidgetPresenter(object):
         try:
             self._model.execute()
         except ValueError as error:
-            self._view.warning_popup(error.args[0])
+            self._view.warning_popup(str(error))
             self.run_list = flatten_run_list(self._model.current_runs)
         finished_callback()
 
@@ -232,10 +232,10 @@ class LoadRunWidgetPresenter(object):
         self._load_thread.loadData(filenames)
         self._load_thread.start()
 
-    def error_callback(self, error_message):
+    def error_callback(self, async_failure):
         self.thread_success = False
         self.enable_notifier.notify_subscribers()
-        self._view.warning_popup(error_message)
+        self._view.warning_popup(async_failure.exception_msg())
 
     def handle_load_thread_finished(self):
         if self._load_thread is not None:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/load_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/load_utils.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
+from mantid import logger
 import mantid.simpleapi as mantid
 from mantid.api import AnalysisDataService, ITableWorkspace, WorkspaceGroup
 from mantid.simpleapi import CloneWorkspace, DeleteWorkspace, mtd, Plus, UnGroupWorkspace
@@ -172,7 +173,11 @@ def load_dead_time_from_filename(filename):
     :param filename: The full path to the .nxs file.
     :return: The name of the workspace in the ADS.
     """
-    loaded_data, run, _, _ = load_workspace_from_filename(filename)
+    try:
+        loaded_data, _, _, _ = load_workspace_from_filename(filename)
+    except RuntimeError as ex:
+        logger.warning(str(ex))
+        return ""
 
     if is_workspace_group(loaded_data["OutputWorkspace"]):
         dead_times = loaded_data["DataDeadTimeTable"][0]
@@ -213,9 +218,12 @@ def load_workspace_from_filename(filename, input_properties=DEFAULT_INPUTS, outp
         alg, psi_data = create_load_algorithm(filename.split(os.sep)[-1], input_properties)
         alg.execute()
 
-    filename = get_correct_file_path(filename, alg)
+    loaded_ws_name = alg.getProperty("OutputWorkspace").valueAsStr
+    if not AnalysisDataService.doesExist(loaded_ws_name):
+        raise RuntimeError("See the logs for why this file failed to load.")
 
-    workspace = AnalysisDataService.retrieve(alg.getProperty("OutputWorkspace").valueAsStr)
+    filename = get_correct_file_path(filename, alg)
+    workspace = AnalysisDataService.retrieve(loaded_ws_name)
     if is_workspace_group(workspace):
         # handle multi-period data
         load_result = _get_algorithm_properties(alg, output_properties)
@@ -331,5 +339,5 @@ def flatten_run_list(run_list):
 def exception_message_for_failed_files(failed_file_list):
     message = "Could not load the following files : \n "
     for failure in failed_file_list:
-        message += "{} ; {}".format(os.path.split(failure[0])[-1], failure[1])
+        message += f"{os.path.split(failure[0])[-1]} ; {failure[1]}".replace("\n", "")
     return message

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/load_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/load_utils.py
@@ -337,7 +337,7 @@ def flatten_run_list(run_list):
 
 
 def exception_message_for_failed_files(failed_file_list):
-    message = "Could not load the following files : \n "
+    message = "Could not load the following files:\n"
     for failure in failed_file_list:
-        message += f"{os.path.split(failure[0])[-1]} ; {failure[1]}".replace("\n", "")
+        message += f"- {os.path.split(failure[0])[-1]} : {failure[1]}".replace("\n", "")
     return message


### PR DESCRIPTION
### Description of work
This PR fixes a bug caused when creating a `LogFilter` object and then creating another `LogFilter` by re-using the time series passed to the first `LogFilter` object. Each time a `LogFilter` object is created, some clean up is performed on the time series such as the elimination of duplicates, and then the removal of the last value if the time series is "open ended". This removal causes the subsequent `LogFilter` object to be given a time series which is one smaller than what the previous `LogFilter` recieved. This would cause an error when there is a small number of non-duplicate values in the time series.

The solution I went for was to ensure the `LogFilter` object is not needlessly created twice, and instead the orginal object is used. 

Fixes #36800

### To test:
1. Open Muon Analysis interface
2. Select MUSR instrument
3. Click `Load Current Run`
4. It should load with no popup or red error message in the logger. It is fine if the plot looks uninteresting

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
