### PR TITLE
Clean up bin_width after modification by Abins Algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/Abins.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins.py
@@ -28,6 +28,9 @@ class Abins(AbinsAlgorithm, PythonAlgorithm):
         self._scale = None
         self._setting = None
 
+        # Save a copy of bin_width for cleanup after it is mutated
+        self._initial_parameters_bin_width = abins.parameters.sampling["bin_width"]
+
     def category(self) -> str:
         return "Simulation"
 
@@ -116,6 +119,9 @@ class Abins(AbinsAlgorithm, PythonAlgorithm):
         )
         s_calculator.progress_reporter = prog_reporter
         s_data = s_calculator.get_formatted_data()
+
+        # Clean up parameter modified by _get_properties()
+        abins.parameters.sampling["bin_width"] = self._initial_parameters_bin_width
 
         # Hold reporter at 80% for this message
         prog_reporter.resetNumSteps(1, 0.8, 0.80000001)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsAdvancedParametersTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsAdvancedParametersTest.py
@@ -40,6 +40,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
         }
         abins.parameters.hdf_groups = {"ab_initio_data": "PhononAB", "powder_data": "Powder", "crystal_data": "Crystal", "s_data": "S"}
         abins.parameters.sampling = {
+            "bin_width": None,
             "pkt_per_peak": 50,
             "max_wavenumber": 4100.0,
             "min_wavenumber": 0.0,

--- a/docs/source/release/v6.10.0/Framework/Algorithms/Bugfixes/36808.rst
+++ b/docs/source/release/v6.10.0/Framework/Algorithms/Bugfixes/36808.rst
@@ -1,0 +1,13 @@
+- Remove unwanted interaction between Abins and Abins2D
+
+  - Abins algorithm sets the value
+    ``abins.parameters.sampling["bin_width"]`` while running. This
+    would override the default sampling of Abins2D instruments if set.
+
+  - This would not cause results to be incorrect, but would sample
+    them on a different mesh to the expected one and could limit
+    resolution.
+
+  - The value is now saved and restored after use by Abins; it can
+    still be modified by users who wish to fiddle with the Abins2D
+    behaviour.


### PR DESCRIPTION
### Description of work
#### Summary of work
The Abins algorithm sets a "bin_width" parameter as a bit of pseudo-global state. (It wasn't my idea.) Here we record the initial state and restore it after the Algorithm has run.


#### Purpose of work
I have noticed some odd failures of the AbinsCRYSTAL2D systemtest: on a clean Linux install,`./systemtest` passes, `./systemtest -R Abins` fails, `./systemtest -R Abins -j 16` sometimes passes, `./systemtest -R AbinsC` fails, `./systemtest -R AbinsCRYSTAL` passes.

This seems to be caused by Abins (1D) tests running before Abins2D. If Abins2D is run after Abins has set `bin_width`, it results in unexpected sampling meshes as the modified parameter is used. I can reproduce this in a regular workbench session, so it is a bug that could affect users.

Fixes #35830 


#### Further detail of work

This fix is not brilliant: there could still be surprises if multiple instances are run in parallel and can modify the same state. A better solution would be to explicitly pass bins around, but this is a) a much larger change to the code and b) likely to become obsolete with future work. (I want to remove bin_width from the Algorithm parameters anyway.)

For now, this fix is only a couple of lines and "strictly better" than the status quo.

### To test:

Try to reproduce the systemtest error on `main` with the commands listed above. This branch should fix them.

For a closer look, try running Abins2D followed by Abins and then Abins2D again (with a new workspace name) and compare the number/spacing of energy bins in the output data.

*This does require release notes* but I don't see a directory to put them in yet?

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
