### PR TITLE
Add check if sample details exists before applying absorption correction in diffraction script

### DIFF
--- a/docs/source/release/v6.11.0/Diffraction/Powder/Bugfixes/36809.rst
+++ b/docs/source/release/v6.11.0/Diffraction/Powder/Bugfixes/36809.rst
@@ -1,0 +1,1 @@
+- Refine error message when applying absorption correction with missing sample details in powder diffraction scripts

--- a/scripts/Diffraction/isis_powder/abstract_inst.py
+++ b/scripts/Diffraction/isis_powder/abstract_inst.py
@@ -197,6 +197,13 @@ class AbstractInst(object):
         """
         return self._generate_inst_filename(run_number=run_number, file_ext=file_ext)
 
+    def _check_sample_details(self):
+        if self._sample_details is None:
+            raise ValueError(
+                "Absorption corrections cannot be run without sample details."
+                " Please set sample details using set_sample before running absorption corrections."
+            )
+
     def _apply_absorb_corrections(self, run_details, ws_to_correct):
         """
         Generates absorption corrections to compensate for the container. The overriding instrument

--- a/scripts/Diffraction/isis_powder/gem.py
+++ b/scripts/Diffraction/isis_powder/gem.py
@@ -207,6 +207,7 @@ class Gem(AbstractInst):
                 msevents=self._inst_settings.mayers_mult_scat_events,
             )
         else:
+            self._check_sample_details()
             return absorb_corrections.run_cylinder_absorb_corrections(
                 ws_to_correct=ws_to_correct,
                 multiple_scattering=self._inst_settings.multiple_scattering,

--- a/scripts/Diffraction/isis_powder/hrpd.py
+++ b/scripts/Diffraction/isis_powder/hrpd.py
@@ -135,12 +135,7 @@ class HRPD(AbstractInst):
                 multiple_scattering=self._inst_settings.multiple_scattering,
                 msevents=self._inst_settings.mayers_mult_scat_events,
             )
-        elif self._sample_details is None:
-            raise RuntimeError(
-                "Absorption corrections cannot be run without sample details."
-                " Please set sample details using set_sample before running absorption corrections."
-            )
-        elif self._sample_details.shape_type() == "slab":
+        elif self._check_sample_details() and self._sample_details.shape_type() == "slab":
             return hrpd_algs.calculate_slab_absorb_corrections(ws_to_correct=ws_to_correct, sample_details_obj=self._sample_details)
         else:
             return absorb_corrections.run_cylinder_absorb_corrections(

--- a/scripts/Diffraction/isis_powder/osiris.py
+++ b/scripts/Diffraction/isis_powder/osiris.py
@@ -184,13 +184,11 @@ class Osiris(AbstractInst):
         :param run_details: the run details of the workspace. Unused parameter added for API compatibility.
         :return: A workspace containing the corrections.
         """
+        self._check_sample_details()
         if self._inst_settings.simple_events_per_point:
             events_per_point = int(self._inst_settings.simple_events_per_point)
         else:
             events_per_point = 1000
-
-        if self._sample_details is None:
-            raise TypeError("To apply absorption correction you need to supply `sample_details` using `set_sample_details` method")
 
         container_geometry = self._sample_details.generate_container_geometry()
         container_material = self._sample_details.generate_container_material()

--- a/scripts/Diffraction/isis_powder/polaris.py
+++ b/scripts/Diffraction/isis_powder/polaris.py
@@ -124,6 +124,7 @@ class Polaris(AbstractInst):
 
     # Overrides
     def _apply_absorb_corrections(self, run_details, ws_to_correct):
+        self._check_sample_details()
         if self._is_vanadium:
             return polaris_algs.calculate_van_absorb_corrections(
                 ws_to_correct=ws_to_correct,


### PR DESCRIPTION
### Description of work
This PR adds a check before applying absorption corrections in powder diffraction scripts. Previously, the error wasn't clear. This addition is added to make sure the error message is clear.

Fixes #36017. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1-  Run the following script in Python editor (contact me for the files):
``` python
from mantid.simpleapi import *
from isis_powder.osiris import Osiris
from isis_powder import SampleDetails

osiris_focus = Osiris(
    user_name="Calib",
    output_directory=r"C:\Users\joy22959\Documents\test_files\osiris\OsirisCalibrationFiles\output",
    config_file=r"C:\Users\joy22959\Documents\test_files\osiris\OsirisCalibrationFiles\Config.yaml",
    calibration_directory=r"C:\Users\joy22959\Documents\test_files\osiris\OsirisCalibrationFiles\Calibration_files",
    calibration_mapping_file=r"C:\Users\joy22959\Documents\test_files\osiris\OsirisCalibrationFiles\Calibration_files\osiris_run_mapping.yaml"
)

sample_details = SampleDetails(radius=1.1, height=8, center=[0, 0, 0], shape='cylinder')
sample_details.set_material(chemical_formula='Cr2-Ga-N', number_density=10.0)
sample_details.set_container(
    chemical_formula='Al',
    mass_density=2.7,
    radius=1.2
)

# osiris_focus.set_sample_details(sample=sample_details)

osiris_focus.create_vanadium(run_number="120033")

osiris_focus.focus(
    run_number="120033",
    absorb_corrections=True,
    merge_drange=False
)
```
2- You should see a value error
3- Uncomment the `set_sample_details` call and the script should run normally

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
