### PR TITLE
Improve error messages in CreateDetectorTable algorithm

### DIFF
--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -40,22 +40,23 @@ void CreateDetectorTable::exec() {
   std::vector<int> indices = getProperty("WorkspaceIndices");
 
   ITableWorkspace_sptr detectorTable;
-  // Standard MatrixWorkspace
-  auto matrix = std::dynamic_pointer_cast<MatrixWorkspace>(inputWS);
-  if (matrix) {
+
+  if (auto matrix = std::dynamic_pointer_cast<MatrixWorkspace>(inputWS)) {
+    IComponent_const_sptr sample = matrix->getInstrument()->getSample();
+    if (sample == nullptr) {
+      throw std::runtime_error("Matrix workspace has no instrument information");
+    }
     detectorTable = createDetectorTableWorkspace(matrix, indices, includeData, g_log);
 
     if (detectorTable == nullptr) {
-      throw std::runtime_error("The instrument has no sample.");
+      throw std::runtime_error("Unknown error while creating detector table for matrix workspace");
+    }
+  } else if (auto peaks = std::dynamic_pointer_cast<IPeaksWorkspace>(inputWS)) {
+    detectorTable = peaks->createDetectorTable();
+    if (detectorTable == nullptr) {
+      throw std::runtime_error("Unknown error while creating detector table for peak workspace");
     }
   } else {
-    auto peaks = std::dynamic_pointer_cast<IPeaksWorkspace>(inputWS);
-    if (peaks) {
-      detectorTable = peaks->createDetectorTable();
-    }
-  }
-
-  if (detectorTable == nullptr) {
     throw std::runtime_error("Detector table can only be created for matrix and peaks workspaces.");
   }
 
@@ -103,11 +104,7 @@ std::map<std::string, std::string> CreateDetectorTable::validateInputs() {
  */
 ITableWorkspace_sptr createDetectorTableWorkspace(const MatrixWorkspace_sptr &ws, const std::vector<int> &indices,
                                                   const bool includeData, Logger &logger) {
-
   IComponent_const_sptr sample = ws->getInstrument()->getSample();
-  if (!sample) {
-    return nullptr;
-  }
 
   // check if efixed value is available
   bool calcQ{true};


### PR DESCRIPTION
### Description of work
This pull request improves the error messages in the CreateDetectorTable algorithm. Previously, when a user tried to show detectors for a workspace that had no instrument, the error message was confusing.


Fixes #36110. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

1. Create a new sample workspace using the "CreateSampleWorkspace" algorithm.
2. Right-click on the workspace and select "Show Detectors".
3. The new error message will appear.
4. Load any workspace with an instrument.
5. Again, go to "Show Detectors" and the error should not appear.
6. Create a peak workspace from the real workspace.
7. Once again, go to "Show Detectors" and the error should not appear. 

Let me know if you have any further questions.
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
