### PR TITLE
Leave Q resolution column unit blank in ISIS Reflectometry ORSO file header

### DIFF
--- a/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
+++ b/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
@@ -155,8 +155,8 @@ class MantidORSODataColumns:
         reflectivity_error: Optional[np.ndarray] = None,
         q_resolution: Optional[np.ndarray] = None,
         q_unit: Unit = Unit.Angstrom,
-        r_error_value_is: ErrorValue = ErrorValue.Sigma,
-        q_error_value_is: ErrorValue = ErrorValue.Sigma,
+        r_error_value_is: Optional[ErrorValue] = ErrorValue.Sigma,
+        q_error_value_is: Optional[ErrorValue] = ErrorValue.Sigma,
     ):
         self._header_info = []
         self._data = []
@@ -197,8 +197,10 @@ class MantidORSODataColumns:
         self._header_info.append(Column(name=name, unit=unit, physical_quantity=physical_quantity))
         self._data.append(data)
 
-    def _add_error_column(self, error_of: str, error_type: ErrorType, value_is: ErrorValue, data: np.ndarray) -> None:
-        self._header_info.append(ErrorColumn(error_of=error_of, error_type=error_type.value, value_is=value_is.value))
+    def _add_error_column(self, error_of: str, error_type: ErrorType, value_is: Optional[ErrorValue], data: np.ndarray) -> None:
+        self._header_info.append(
+            ErrorColumn(error_of=error_of, error_type=error_type.value, value_is=None if value_is is None else value_is.value)
+        )
         self._data.append(data)
 
     def _ensure_recommended_columns_are_present(self, data: np.ndarray) -> None:

--- a/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
@@ -118,7 +118,7 @@ class SaveISISReflectometryORSO(PythonAlgorithm):
         reflectivity_error = point_data.extractE()[0]
         q_resolution = resolution if resolution is None else q_data * resolution
 
-        data_columns = MantidORSODataColumns(q_data, reflectivity, reflectivity_error, q_resolution)
+        data_columns = MantidORSODataColumns(q_data, reflectivity, reflectivity_error, q_resolution, q_error_value_is=None)
 
         return data_columns
 
@@ -163,7 +163,7 @@ class SaveISISReflectometryORSO(PythonAlgorithm):
         if not self.getProperty(Prop.WRITE_RESOLUTION).value:
             return None
 
-        # Attempt to get the resolution from the workspace history if it hasn't been passed in
+        # Attempt to get the resolution from the workspace history
         history = ws.getHistory()
         if not history.empty():
             for history in reversed(history.getAlgorithmHistories()):

--- a/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
@@ -64,6 +64,29 @@ class MantidORSODataColumnsTest(unittest.TestCase):
         )
         self._check_column_data(columns, col_values, col_length)
 
+    def test_error_columns_with_empty_units(self):
+        col_length = 5
+        col_values = [1, 2, 3, 4]
+
+        columns = MantidORSODataColumns(
+            np.full(col_length, col_values[0]),
+            np.full(col_length, col_values[1]),
+            np.full(col_length, col_values[2]),
+            np.full(col_length, col_values[3]),
+            q_unit=MantidORSODataColumns.Unit.Nm,
+            r_error_value_is=None,
+            q_error_value_is=None,
+        )
+
+        self._check_default_header(
+            columns,
+            len(col_values),
+            MantidORSODataColumns.Unit.Nm,
+            None,
+            None,
+        )
+        self._check_column_data(columns, col_values, col_length)
+
     def test_adding_additional_columns(self):
         col_length = 5
         col_values = [1, 2, 3, 4, 5, 6]
@@ -150,7 +173,7 @@ class MantidORSODataColumnsTest(unittest.TestCase):
         self.assertIsInstance(column, ErrorColumn)
         self.assertEqual(error_of, column.error_of)
         self.assertEqual(error_is.value, column.error_type)
-        self.assertEqual(value_is.value, column.value_is)
+        self.assertEqual(None if value_is is None else value_is.value, column.value_is)
 
     def _check_column_data(self, columns, col_values, col_length):
         """Checks the data returned from the MantidORSODataColumns class.

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
@@ -180,6 +180,9 @@ class SaveISISReflectometryORSOTest(unittest.TestCase):
 
         expected_header_values.append(f"data_set: {reduced_ws.name()}")
 
+        # We currently want the resolution unit to be left blank. This will be populated at some point in the future.
+        expected_header_values.append("- {error_of: Qz, error_type: resolution}\n")
+
         return expected_header_values
 
     def _get_reduction_history_for_reduced_ws(self, reduced_ws):


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Sets the unit for the Q resolution (`Qz` column) in the ORSO file to blank. We previously had this set to `sigma`, but this is not correct and our scientists need more time to determine what it should be. We agreed to change it to be blank for the 6.9 release.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36805. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

1) Go to `Interfaces -> Reflectometry -> ISIS Reflectometry`.
1) On the Runs tab, enter Investigation ID `1120015` and Cycle `11_3`. Click the Search button.
1) From the search results, click to highlight runs `11934`, `11935` and `11936` and click the Transfer button to transfer them into the batch table on the right hand side. Click the Process button to reduce the data.
1) Go to the Save ASCII tab. Set a Save Path for saving the file to.
1) In the File Format section, select `ORSO ASCII (*.ort)` from the drop-down.
1) Tick the Q resolution checkbox.
1) From the List of Workspaces section on the left, select workspace `IvsQ_11934_11935+11936` to highlight it.
1) Click the big Save button on the right hand side to save to file. There should be a successful call to `SaveISISReflectometryORSO` recorded in the messages pane. If you navigate to the save path you set in the Save ASCII tab, you should see a `.ort` file. You should be able to open this in a text editor and see that there is a header populated with some information and 4 columns of data. There should be the following section at the bottom of the header - check that it appears exactly as shown below:
```
# columns:
# - {name: Qz, unit: 1/angstrom, physical_quantity: normal_wavevector_transfer}
# - {name: R, physical_quantity: reflectivity}
# - {error_of: R, error_type: uncertainty, value_is: sigma}
# - {error_of: Qz, error_type: resolution}
```
1) Go back to the Save ASCII tab. Enter a File Name Prefix in the box (this is to avoid overwriting the previous file).
1) Untick the Q resolution checkbox and click the big Save button.
1) The file should be saved out with the prefix applied to the file name. When opened, there should only be 3 columns of data (the Q resolution should have been excluded) and the section at the bottom of the header should now be as follows:
```
# columns:
# - {name: Qz, unit: 1/angstrom, physical_quantity: normal_wavevector_transfer}
# - {name: R, physical_quantity: reflectivity}
# - {error_of: R, error_type: uncertainty, value_is: sigma}
```


*This does not require release notes* because **it is an amendment to functionality that will be introduced in version 6.9 and is already covered by a release note.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
