### PR TITLE
Quiet down warnings in StepScanAnalysis

### DIFF
--- a/Framework/Algorithms/src/SumEventsByLogValue.cpp
+++ b/Framework/Algorithms/src/SumEventsByLogValue.cpp
@@ -240,7 +240,7 @@ void SumEventsByLogValue::createTableOutput(const Kernel::TimeSeriesProperty<int
       // of the main log
       // Have to (maybe inefficiently) fetch back column by name - move outside
       // loop if too slow
-      outputWorkspace->getColumn(otherLog.first)->cell<double>(row) = otherLog.second->timeAverageValue(&timeRoi);
+      outputWorkspace->getColumn(otherLog.first)->cell<double>(row) = run.getTimeAveragedValue(otherLog.first);
     }
 
     prog.report();

--- a/Testing/SystemTests/tests/framework/StepScan.py
+++ b/Testing/SystemTests/tests/framework/StepScan.py
@@ -25,4 +25,5 @@ class StepScanWorkflowAlgorithm(systemtesting.MantidSystemTest):
         )
 
     def validate(self):
+        self.tolerance = 1e-7
         return "StepScan", "StepScan.nxs"


### PR DESCRIPTION
### Description of work
Quiet down some warnings in StepScanAnalysis. Found in #36719

*There is no associated issue.*

### To test:
```
from mantid.simpleapi import *

Load(Filename='/SNS/HYS/IPTS-14344/nexus/HYS_111669.nxs.h5', OutputWorkspace='HYS_111669.nxs')
SumEventsByLogValue(InputWorkspace='HYS_111669.nxs', OutputWorkspace='test', LogName='scan_index')
```
There should be no warnings about `Calls to TimeSeriesProperty::timeAverageValue should be replaced with Run::getTimeAveragedValue`

*This does not require release notes* because **remove warning message added in this release**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
