### PR TITLE
Fix freeze when deleting ws with muon analysis open

### DIFF
--- a/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/36824.rst
+++ b/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/36824.rst
@@ -1,0 +1,1 @@
+- Fixed a freeze in the Muon Analysis interface after deleting a workspace which is not loaded into the interface.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -95,8 +95,11 @@ class BasicFittingPresenter:
         self.model.evaluation_type = self.view.evaluation_type
         self.model.fit_to_raw = self.view.fit_to_raw
 
-    def handle_ads_clear_or_remove_workspace_event(self, _: str = None) -> None:
+    def handle_ads_clear_or_remove_workspace_event(self, name: str) -> None:
         """Handle when there is a clear or remove workspace event in the ADS."""
+        if name not in self.model.dataset_names:
+            return
+
         self.update_and_reset_all_data()
 
         if self.model.number_of_datasets == 0:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter.py
@@ -35,9 +35,9 @@ class TFAsymmetryFittingPresenter(GeneralFittingPresenter):
         self._switch_to_normal_fitting()
         super().handle_instrument_changed()
 
-    def handle_ads_clear_or_remove_workspace_event(self, _: str = None) -> None:
+    def handle_ads_clear_or_remove_workspace_event(self, name: str) -> None:
         """Handle when there is a clear or remove workspace event in the ADS."""
-        super().handle_ads_clear_or_remove_workspace_event()
+        super().handle_ads_clear_or_remove_workspace_event(name)
 
         if self.model.number_of_datasets == 0:
             self._switch_to_normal_fitting()

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -73,16 +73,21 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
         self.view = None
 
     def test_that_handle_ads_clear_or_remove_workspace_event_will_attempt_to_reset_all_the_data_and_enable_gui(self):
-        self.presenter.handle_ads_clear_or_remove_workspace_event()
+        self.mock_model_dataset_names = mock.PropertyMock(return_value=["Name"])
+        type(self.model).dataset_names = self.mock_model_dataset_names
+
+        self.presenter.handle_ads_clear_or_remove_workspace_event("Name")
 
         self.presenter.update_and_reset_all_data.assert_called_with()
         self.presenter.enable_editing_notifier.notify_subscribers.assert_called_once_with()
 
     def test_that_handle_ads_clear_or_remove_workspace_event_will_disable_the_tab_if_no_data_is_loaded(self):
+        self.mock_model_dataset_names = mock.PropertyMock(return_value=["Name"])
+        type(self.model).dataset_names = self.mock_model_dataset_names
         self.mock_model_number_of_datasets = mock.PropertyMock(return_value=0)
         type(self.model).number_of_datasets = self.mock_model_number_of_datasets
 
-        self.presenter.handle_ads_clear_or_remove_workspace_event()
+        self.presenter.handle_ads_clear_or_remove_workspace_event("Name")
 
         self.presenter.update_and_reset_all_data.assert_called_with()
         self.view.disable_view.assert_called_once_with()

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
@@ -104,9 +104,11 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.assertEqual(self.mock_model_tf_asymmetry_mode.call_count, 1)
 
     def test_that_handle_ads_clear_or_remove_workspace_event_will_attempt_to_reset_all_the_data_and_enable_gui(self):
+        self.mock_model_dataset_names = mock.PropertyMock(return_value=["Name"])
+        type(self.model).dataset_names = self.mock_model_dataset_names
         self.presenter.update_and_reset_all_data = mock.Mock()
 
-        self.presenter.handle_ads_clear_or_remove_workspace_event()
+        self.presenter.handle_ads_clear_or_remove_workspace_event("Name")
 
         self.presenter.update_and_reset_all_data.assert_called_with()
         self.presenter.enable_editing_notifier.notify_subscribers.assert_called_once_with()
@@ -114,11 +116,13 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.assertEqual(self.mock_model_tf_asymmetry_mode.call_count, 1)
 
     def test_that_handle_ads_clear_or_remove_workspace_event_will_attempt_to_reset_all_the_data_and_enable_gui_with_no_datasets(self):
+        self.mock_model_dataset_names = mock.PropertyMock(return_value=["Name"])
+        type(self.model).dataset_names = self.mock_model_dataset_names
         self.mock_model_number_of_datasets = mock.PropertyMock(return_value=0)
         type(self.model).number_of_datasets = self.mock_model_number_of_datasets
         self.presenter.update_and_reset_all_data = mock.Mock()
 
-        self.presenter.handle_ads_clear_or_remove_workspace_event()
+        self.presenter.handle_ads_clear_or_remove_workspace_event("Name")
 
         self.presenter.update_and_reset_all_data.assert_called_with()
         self.view.disable_view.assert_called_once_with()


### PR DESCRIPTION
### Description of work
Fixes a freeze on the Muon Analysis interface when deleting an ADS workspace which has been loaded separately.

Fixes #36824 

### To test:
Follow the testing instructions on the issue.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
