### PR TITLE
Fix Workspace Calculator Incorrectly Scaling the RHS if both the LHS and RHS Are the Same

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/Bugfixes/36827.rst
+++ b/docs/source/release/v6.10.0/Workbench/Bugfixes/36827.rst
@@ -1,0 +1,1 @@
+- Fix incorrect scaling when operating on the same workspace on both sides.

--- a/qt/python/mantidqt/mantidqt/widgets/workspacecalculator/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacecalculator/model.py
@@ -206,9 +206,9 @@ class WorkspaceCalculatorModel:
         DeleteWorkspace(Workspace=scale_ws)
 
     def _scale_input_workspaces(self):
-        lhs_ws = self._lhs_ws + "_tmp"
+        lhs_ws = self._lhs_ws + "_tmp_lhs"
         CloneWorkspace(InputWorkspace=self._lhs_ws, OutputWorkspace=lhs_ws)
-        rhs_ws = self._rhs_ws + "_tmp"
+        rhs_ws = self._rhs_ws + "_tmp_rhs"
         CloneWorkspace(InputWorkspace=self._rhs_ws, OutputWorkspace=rhs_ws)
 
         if self._md_lhs:

--- a/qt/python/mantidqt/mantidqt/widgets/workspacecalculator/test/test_workspacecalculator_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacecalculator/test/test_workspacecalculator_model.py
@@ -198,6 +198,20 @@ class WorkspaceCalculatorModelTest(unittest.TestCase):
         value = mtd[output_ws].readY(0)[0]
         self.assertAlmostEqual(value, -26.9626, delta=1e-4)
 
+    def test_model_matrix_same(self):
+        """Tests binary operations on MatrixWorkspaces with having two of the same workspace."""
+        lhs_scaling = 3
+        rhs_scaling = 2
+        output_ws = "test_model_matrix_scaling"
+        model = WorkspaceCalculatorModel(
+            lhs_scale=lhs_scaling, lhs_ws=self.matrix_lhs, rhs_scale=rhs_scaling, rhs_ws=self.matrix_lhs, output_ws=output_ws, operation="+"
+        )
+        valid_lhs, valid_rhs, err_msg = model.performOperation()
+        self.assertTrue(mtd[output_ws])
+        self.check_validity(lhs_validation=valid_lhs, rhs_validation=valid_rhs, err_msg=err_msg, passed=True)
+        value = mtd[output_ws].readY(0)[0]
+        self.assertEqual(value, 1.5)
+
     def test_model_matrix_groups(self):
         """Tests binary operations on equal size groups containing MatrixWorkspaces."""
         for operation in self.operations:


### PR DESCRIPTION
### Description of work

#### Summary of work
Fix a bug where the temp workspace created for the LHS and RHS had the same name, so the same scale was applied to both. 

Fixes #36827 

### To test:
1. Load a workspace 
2. Plot it 
3. Apply the workspace to the LHS and RHS of the workspace calculator
4. Enter a scale factor of 2 in the RHS scale factor.
5. Enter an output workspace
6. Set the sign to `+`
7. Go!
8. Plot this new output workspace over the original
9. The new workspace should be 3x the counts of the original. (Before, it would have been 4x)

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
