### PR TITLE
Modify atexit function so the ADS is always available

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
@@ -41,8 +41,10 @@ AnalysisDataServiceImpl &instance() {
     // Passing True as an argument suppresses a warning that is normally
     // displayed when calling AnalysisDataService.clear()
     PyRun_SimpleString("import atexit\n"
-                       "from mantid.api import AnalysisDataService\n"
-                       "atexit.register(lambda: AnalysisDataService.clear(True))");
+                       "def cleanup_ADS():\n"
+                       "    from mantid.api import AnalysisDataService\n"
+                       "    AnalysisDataService.clear(True)\n"
+                       "atexit.register(cleanup_ADS)");
   });
   return ads;
 }


### PR DESCRIPTION
The `atexit()` function currently assumes that AnalysisDataService is in the namespace when it is executed. This is not always the case and makes an error on exit from ipython.

To reproduce
```sh
$ ipython
Python 3.10.13 | packaged by conda-forge | (main, Oct 26 2023, 18:07:37) [GCC 12.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.21.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import mantid.simpleapi as ms
FrameworkManager-[Notice] Welcome to Mantid 6.8.20240207.1235.dev125
FrameworkManager-[Notice] Please cite: http://dx.doi.org/10.1016/j.nima.2014.07.029 and this release: http://dx.doi.org/10.5286/Software/Mantid

In [2]: w = ms.CreateSingleValuedWorkspace(42)
CreateSingleValuedWorkspace-[Notice] CreateSingleValuedWorkspace started
CreateSingleValuedWorkspace-[Notice] CreateSingleValuedWorkspace successful, Duration 0.00 seconds

In [3]: quit
Exception ignored in atexit callback: <function <lambda> at 0x7fbdfc51a320>
Traceback (most recent call last):
  File "<string>", line 3, in <lambda>
NameError: name 'AnalysisDataService' is not defined
```

by changing this to be a function and adding an `import`, python no longer errors on cleanup. This will not be seen from `mantidworkbench` because the `AnalysisDataService` is in the namespace from lots of other places.

*There is no associated issue.*

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

Run the test described above.

*This does not require release notes* because it is covered by other release notes concerning the ADS `atexit()` registration such as #36548, #36774, and #36791.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
