### PR TITLE
35646 fixing a memory leak when loading nexus files

### DIFF
--- a/Framework/Kernel/src/NexusHDF5Descriptor.cpp
+++ b/Framework/Kernel/src/NexusHDF5Descriptor.cpp
@@ -105,6 +105,7 @@ std::pair<std::string, herr_t> readStringAttributeN(hid_t attr) {
   if (iRet >= 0) {
     attrData = vdat;
   }
+  free(vdat);
   return std::make_pair(attrData, iRet);
 }
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -72,7 +72,7 @@ cstyleCast:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/NexusHDF5Descriptor.cpp:58
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/NexusHDF5Descriptor.cpp:61
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/NexusHDF5Descriptor.cpp:68
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/NexusHDF5Descriptor.cpp:85
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/NexusHDF5Descriptor.cpp:225
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/NexusHDF5Descriptor.cpp:226
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp:280
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp:863
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp:1047

--- a/docs/source/release/v6.10.0/Workbench/Bugfixes/35646.rst
+++ b/docs/source/release/v6.10.0/Workbench/Bugfixes/35646.rst
@@ -1,0 +1,1 @@
+- Fixed a memory leak caused when loading nexus files from the disk.

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -65,7 +65,7 @@ WorkspaceTreeWidget::WorkspaceTreeWidget(MantidDisplayBase *mdb, bool viewOnly, 
   setupLoadButtonMenu();
 
   // Dialog box used for user to specify folder to save multiple workspaces into
-  m_saveFolderDialog = new QFileDialog;
+  m_saveFolderDialog = new QFileDialog(this);
   m_saveFolderDialog->setFileMode(QFileDialog::Directory);
   m_saveFolderDialog->setOption(QFileDialog::ShowDirsOnly);
 


### PR DESCRIPTION
### Description of work

There had been a memory leak due to not freeing up the dynamically allocated memory buffers when loading nexus files from the disk. And also there was a QFileDialog object being created without being deleted due to not having a parent QWidget.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #35646. 

### To test:

1. Load and save some nxs files
```
start = 50087
nruns = 6
for irun in range(nruns):
    run = start+irun
    ws_name = "WISH000"+str(run)
    Load(ws_name, OutputWorkspace=ws_name)
    SaveNexus(ws_name, <path to save ws> + ws_name + ".nxs")
AnalysisDataService.clear()
CleanFileCache()
```

2. Restart the workbench and update Search Data Archive to `off` in manage user directories so that files are loaded from the disk.
3. Run the below and see the memory usage before and after.
```
for ntries in range(10):
    start = 50087
    nruns = 6
    for irun in range(nruns):
        run = start+irun
        ws_name = "WISH000"+str(run)
        Load(ws_name, OutputWorkspace=ws_name)
    AnalysisDataService.clear()
    CleanFileCache()
```

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
