### PR TITLE
Pin conda-build to 3.28.4

### DIFF
--- a/buildconfig/Jenkins/Conda/package-standalone
+++ b/buildconfig/Jenkins/Conda/package-standalone
@@ -60,7 +60,7 @@ done
 
 # Mamba
 setup_mamba $WORKSPACE/mambaforge "package-standalone"
-mamba install --yes conda-build mamba
+mamba install --yes mamba conda-build=3.28.4
 
 # Build packages
 # Setup a local conda channel to find our locally built packages package. It is


### PR DESCRIPTION
### Description of work

#### Summary of work
I think we need to pin this to 3.28.4 to avoid problems with` conda index`.



### To test:

Observe the branch builds properly: https://builds.mantidproject.org/job/build_packages_from_branch/748/

*This does not require release notes* because **this is not visible to an external user**


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
