### PR TITLE
Add release note for project recovery improvement

### DIFF
--- a/docs/source/release/v6.9.0/mantidworkbench.rst
+++ b/docs/source/release/v6.9.0/mantidworkbench.rst
@@ -12,6 +12,7 @@ New Features
 - Editing a plot's title will now automatically update its name in the plot selector (and vice versa).
 - Monitor for external changes to script files that are open in Mantid to prevent loss of work.
 - An email is now required to submit an error report.
+- Project recovery performance has been improved by saving one python file for all workspaces, rather than one python file per workspace. Caution: recovering a backup by opening 6.9.0 after a crash in 6.8.0 or earlier will not work.
 
 
 Bugfixes


### PR DESCRIPTION
### Description of work
This will potentially be visible to users so needs a release note.

*There is no associated issue.*

### To test:
Proof read.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
