### PR TITLE
Keep project recoveries from 6.9 onwards separate

### DIFF
--- a/docs/source/release/v6.9.0/mantidworkbench.rst
+++ b/docs/source/release/v6.9.0/mantidworkbench.rst
@@ -12,7 +12,7 @@ New Features
 - Editing a plot's title will now automatically update its name in the plot selector (and vice versa).
 - Monitor for external changes to script files that are open in Mantid to prevent loss of work.
 - An email is now required to submit an error report.
-- Project recovery performance has been improved by saving one python file for all workspaces, rather than one python file per workspace. Caution: recovering a backup by opening 6.9.0 after a crash in 6.8.0 or earlier will not work.
+- Project recovery performance has been improved by saving one python file for all workspaces, rather than one python file per workspace. Caution: it will not be possible in 6.9.0 to recover a backup created in 6.8.0 or earlier, and vice versa.
 
 
 Bugfixes

--- a/qt/applications/workbench/workbench/projectrecovery/projectrecovery.py
+++ b/qt/applications/workbench/workbench/projectrecovery/projectrecovery.py
@@ -33,7 +33,7 @@ RECOVERY_ENABLED_KEY = "projectRecovery.enabled"
 
 class ProjectRecovery(object):
     recovery_ordered_recovery_file_name = "ordered_recovery.py"
-    recovery_workbench_recovery_name = "workbench-recovery"
+    recovery_workbench_recovery_name = "workbench-recovery-6_9-onwards"
     recovery_file_ext = ".recfile"
     lock_file_name = "projectrecovery.lock"
 

--- a/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecovery.py
+++ b/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecovery.py
@@ -69,14 +69,15 @@ class ProjectRecoveryTest(unittest.TestCase):
 
     def test_constructor_settings_are_set(self):
         # Test the paths set in the constructor that are generated.
-        self.assertEqual(self.pr.recovery_directory, os.path.join(ConfigService.getAppDataDirectory(), "workbench-recovery"))
+        recovery_folder = "workbench-recovery-6_9-onwards"
+        self.assertEqual(self.pr.recovery_directory, os.path.join(ConfigService.getAppDataDirectory(), recovery_folder))
         self.assertEqual(
             self.pr.recovery_directory_hostname,
-            os.path.join(ConfigService.getAppDataDirectory(), "workbench-recovery", socket.gethostname()),
+            os.path.join(ConfigService.getAppDataDirectory(), recovery_folder, socket.gethostname()),
         )
         self.assertEqual(
             self.pr.recovery_directory_pid,
-            os.path.join(ConfigService.getAppDataDirectory(), "workbench-recovery", socket.gethostname(), str(os.getpid())),
+            os.path.join(ConfigService.getAppDataDirectory(), recovery_folder, socket.gethostname(), str(os.getpid())),
         )
         self.assertEqual(
             self.pr.recovery_order_workspace_history_file, os.path.join(ConfigService.getAppDataDirectory(), "ordered_recovery.py")


### PR DESCRIPTION
The format of the project recovery folder changed in 6.9, see #36859. This PR changes the project recovery folder so that pre-6.9 and 6.9-onwards backups are kept separate. This fixes a bug where if you tried to start 6.9 with a backup from 6.8, Workbench would not open.

### Description of work
- Changed name of project recovery folder

### To test:
- Follow all testing instructions in #36859 
- Open 6.8 (or earlier), load at least one file (otherwise a backup won't be created), wait for a backup to be created.
- Deliberately crash 6.8 (Segfault algorithm)
- Open 6.9.
- Try the above but with the opposite version order.

Fixes #36900

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
