### PR TITLE
Removed pre-setup of IDAaaS instances from release checklist

### DIFF
--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -130,8 +130,6 @@ Beta Testing Ends - Prepare for Smoke Testing
 * Send an invite to developers for 1.5 hours maximum Smoke Testing. Include an introduction message to assign all testers to a certain operating system.
   Link to the release pipeline builds where the release packages *WILL* be. Encourage testers to download
   in the 30 minutes before smoke testing. Inform that ticking on a testing issue means that someone has assigned themselves and will tackle that task.
-* The QA manager should pre-setup 3 ISIS IDAaaS Mantid dev instances and manually install the release package before testing
-  so the 1.5 hours is clear for testing time. Then share the instances with the relevant testers from the IDAaaS workspace settings.
 
 Smoke Testing
 #############


### PR DESCRIPTION
### Description of work

#### Summary of work

The QA manager does not pre-setup 3 ISIS IDAaaS Mantid dev instances for smoke testing anymore. Instead, testers are setting up these IDAaaS instances themselves. Therefore, we removed the corresponding section from the release checklist.

*There is no associated issue.*


### To test:

Build the developer documentation and see the change in the section **Beta Testing Ends - Prepare for Smoke Testing** in the **Release Checklist**.

https://developer.mantidproject.org/ReleaseChecklist.html#quality-assurance-managers-checklist

*This does not require release notes* because **it is an update in the developer documentation.**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
