### PR TITLE
Initialise background colour in projection surface

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/InstrumentViewer/Bugfixes/36912.rst
+++ b/docs/source/release/v6.10.0/Workbench/InstrumentViewer/Bugfixes/36912.rst
@@ -1,0 +1,1 @@
+- Fix rendering issue on linux when OpenGl is disabled.

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -929,7 +929,7 @@ void InstrumentWidget::setExponent(double nth_power) { emit nthPowerChanged(nth_
  * and then sets it.
  */
 void InstrumentWidget::pickBackgroundColor() {
-  QColor color = QColorDialog::getColor(Qt::green, this);
+  QColor color = QColorDialog::getColor(Qt::black, this);
   setBackgroundColor(color);
 }
 

--- a/qt/widgets/instrumentview/src/ProjectionSurface.cpp
+++ b/qt/widgets/instrumentview/src/ProjectionSurface.cpp
@@ -48,7 +48,7 @@ ProjectionSurface::ProjectionSurface(const IInstrumentActor *rootActor)
     : m_instrActor(rootActor), m_viewImage(nullptr), m_pickImage(nullptr), m_viewRect(), m_selectRect(),
       m_interactionMode(MoveMode), m_isLightingOn(false), m_peakLabelPrecision(2), m_showPeakRows(false),
       m_showPeakLabels(false), m_showPeakRelativeIntensity(false), m_peakShapesStyle(0), m_viewChanged(true),
-      m_redrawPicking(true) {
+      m_redrawPicking(true), m_backgroundColor(Qt::black) {
   connect(rootActor, SIGNAL(colorMapChanged()), this, SLOT(colorMapChanged()));
   connect(rootActor, SIGNAL(refreshView()), this, SLOT(refreshView()));
   connect(&m_maskShapes, SIGNAL(shapeCreated()), this, SIGNAL(shapeCreated()));

--- a/qt/widgets/instrumentview/src/ProjectionSurface.cpp
+++ b/qt/widgets/instrumentview/src/ProjectionSurface.cpp
@@ -45,10 +45,10 @@ namespace MantidQt::MantidWidgets {
  * instrument
  */
 ProjectionSurface::ProjectionSurface(const IInstrumentActor *rootActor)
-    : m_instrActor(rootActor), m_viewImage(nullptr), m_pickImage(nullptr), m_viewRect(), m_selectRect(),
-      m_interactionMode(MoveMode), m_isLightingOn(false), m_peakLabelPrecision(2), m_showPeakRows(false),
-      m_showPeakLabels(false), m_showPeakRelativeIntensity(false), m_peakShapesStyle(0), m_viewChanged(true),
-      m_redrawPicking(true), m_backgroundColor(Qt::black) {
+    : m_instrActor(rootActor), m_viewImage(nullptr), m_pickImage(nullptr), m_backgroundColor(Qt::black), m_viewRect(),
+      m_selectRect(), m_interactionMode(MoveMode), m_isLightingOn(false), m_peakLabelPrecision(2),
+      m_showPeakRows(false), m_showPeakLabels(false), m_showPeakRelativeIntensity(false), m_peakShapesStyle(0),
+      m_viewChanged(true), m_redrawPicking(true) {
   connect(rootActor, SIGNAL(colorMapChanged()), this, SLOT(colorMapChanged()));
   connect(rootActor, SIGNAL(refreshView()), this, SLOT(refreshView()));
   connect(&m_maskShapes, SIGNAL(shapeCreated()), this, SIGNAL(shapeCreated()));


### PR DESCRIPTION
Co-authored by: Tom Hampson <thomas.hampson@stfc.ac.uk>

### Description of work

Background colour of the instrument view projection surface was uninitialised. This lead to weird rendering problems on linux when OpenGl was disabled. Also set the default colour in the colour picker to black instead of bright green.

*There is no associated issue.*

### To test:
https://builds.mantidproject.org/job/build_packages_from_branch/751/

1. FIRST try to reproduce the bug on 6.8 on IDAaaS to confirm that it's there:
- Load data and open instrument viewer
- Disable OpenGL if enabled
- Zoom in by clicking and dragging
2. Install the test package with the proposed fix and launch workbench:
```
mamba create -n mantid_iview_render_test
mamba activate mantid_iview_render_test
mamba install -c thomashampson/label/iview_render_test
mantidworkbench
```
3. repeat step 1 to confirm bug is fixed in the new package.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
