### PR TITLE
Hide signal value in sliceview non-orthog view

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/SliceViewer/New_features/32318.rst
+++ b/docs/source/release/v6.10.0/Workbench/SliceViewer/New_features/32318.rst
@@ -1,0 +1,1 @@
+- In non-orthogonal view, the signal will now be hidden (previously was ``-``).

--- a/qt/python/mantidqt/mantidqt/_common.sip
+++ b/qt/python/mantidqt/mantidqt/_common.sip
@@ -1029,6 +1029,7 @@ class ImageInfoWidget : public QTableWidget {
 public:
     ImageInfoWidget(QWidget *parent = nullptr);
     void cursorAt(const double x, const double y, const double signal, const QMap<QString, QString>& extraValues) throw(std::exception);
+    void setShowSignal(const bool showSignal);
     void setWorkspace(SIP_PYOBJECT) throw(std::exception);
     %MethodCode
       using boost::python::extract;

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -311,6 +311,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
         :param state: If true a request is being made to turn them on, else they should be turned off
         """
         data_view = self.view.data_view
+        data_view.image_info_widget.setShowSignal(not state)
         if state:
             data_view.deactivate_and_disable_tool(ToolItemText.REGIONSELECTION)
             data_view.disable_tool_button(ToolItemText.LINEPLOTS)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -310,6 +310,16 @@ class SliceViewerTest(unittest.TestCase):
 
         self.assertTrue(mock.call(ToolItemText.NONAXISALIGNEDCUTS) not in data_view_mock.enable_tool_button.call_args_list)
 
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceInfo")
+    def test_non_orthognoal_axes_toggled_will_hide_or_show_the_signal(self, mock_sliceinfo_cls):
+        presenter, data_view_mock = _create_presenter(
+            self.model, self.view, mock_sliceinfo_cls, enable_nonortho_axes=True, supports_nonortho=True
+        )
+        for button_state in {False, True}:
+            data_view_mock.image_info_widget.setShowSignal.reset_mock()
+            presenter.nonorthogonal_axes(button_state)
+            data_view_mock.image_info_widget.setShowSignal.assert_called_once_with(not button_state)
+
     def test_cut_view_button_disabled_if_model_cannot_support_it(self):
         self.patched_deps["WorkspaceInfo"].get_ws_type.return_value = WS_TYPE.MATRIX
         self.model.can_support_non_axis_cuts.return_value = False

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
@@ -9,6 +9,7 @@
 #include "DllOption.h"
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidQtWidgets/Common/ImageInfoModel.h"
+#include <QTableWidget>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -21,6 +22,10 @@ public:
   virtual void showInfo(const ImageInfoModel::ImageInfo &info) = 0;
   virtual void setWorkspace(const Mantid::API::Workspace_sptr &ws) = 0;
   virtual void setRowCount(const int count) = 0;
+  virtual void setColumnCount(const int count) = 0;
+  virtual void setItem(const int rowIndex, const int columnIndex, QTableWidgetItem *item) = 0;
+  virtual void hideColumn(const int index) = 0;
+  virtual void showColumn(const int index) = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoPresenter.h
@@ -27,10 +27,13 @@ public:
 
   void cursorAt(const double x, const double y, const double signal, const QMap<QString, QString> extraValues);
   void setWorkspace(const Mantid::API::Workspace_sptr &ws);
+  void fillTableCells(const ImageInfoModel::ImageInfo &info);
+  inline void setShowSignal(const bool showSignal) { m_showSignal = showSignal; }
 
 private:
   std::unique_ptr<ImageInfoModel> m_model;
   IImageInfoWidget *m_view;
+  bool m_showSignal;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidget.h
@@ -32,9 +32,11 @@ public:
   void setWorkspace(const Mantid::API::Workspace_sptr &ws) override;
   void showInfo(const ImageInfoModel::ImageInfo &info) override;
   void setRowCount(const int count) override;
+  inline void setShowSignal(const bool showSignal) { m_showSignal = showSignal; };
 
 private:
   std::unique_ptr<ImageInfoPresenter> m_presenter;
+  bool m_showSignal;
 };
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidget.h
@@ -11,7 +11,6 @@
 #include "MantidQtWidgets/Common/IImageInfoWidget.h"
 #include "MantidQtWidgets/Common/ImageInfoPresenter.h"
 #include <QMap>
-#include <QTableWidget>
 
 namespace MantidQt::MantidWidgets {
 
@@ -32,11 +31,14 @@ public:
   void setWorkspace(const Mantid::API::Workspace_sptr &ws) override;
   void showInfo(const ImageInfoModel::ImageInfo &info) override;
   void setRowCount(const int count) override;
-  inline void setShowSignal(const bool showSignal) { m_showSignal = showSignal; };
+  void setColumnCount(const int count) override;
+  void setItem(const int rowIndex, const int columnIndex, QTableWidgetItem *item) override;
+  void hideColumn(const int index) override;
+  void showColumn(const int index) override;
+  void setShowSignal(const bool showSignal);
 
 private:
   std::unique_ptr<ImageInfoPresenter> m_presenter;
-  bool m_showSignal;
 };
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidgetMini.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidgetMini.h
@@ -32,6 +32,10 @@ public:
   void setWorkspace(const Mantid::API::Workspace_sptr &ws) override;
   void showInfo(const ImageInfoModel::ImageInfo &info) override;
   void setRowCount(const int count) override;
+  void setColumnCount(const int count) override;
+  void setItem(const int rowIndex, const int columnIndex, QTableWidgetItem *item) override;
+  void hideColumn(const int index) override;
+  void showColumn(const int index) override;
 
 private:
   std::unique_ptr<ImageInfoPresenter> m_presenter;

--- a/qt/widgets/common/src/ImageInfoPresenter.cpp
+++ b/qt/widgets/common/src/ImageInfoPresenter.cpp
@@ -9,6 +9,8 @@
 #include "MantidQtWidgets/Common/ImageInfoModelMD.h"
 #include "MantidQtWidgets/Common/ImageInfoModelMatrixWS.h"
 
+#include <QTableWidget>
+
 using Mantid::API::MatrixWorkspace;
 
 namespace MantidQt::MantidWidgets {
@@ -17,7 +19,9 @@ namespace MantidQt::MantidWidgets {
  * Constructor
  * @param view A pointer to a view object that displays the information
  */
-ImageInfoPresenter::ImageInfoPresenter(IImageInfoWidget *view) : m_model(), m_view(view) { m_view->setRowCount(2); }
+ImageInfoPresenter::ImageInfoPresenter(IImageInfoWidget *view) : m_model(), m_view(view), m_showSignal(true) {
+  m_view->setRowCount(2);
+}
 
 /**
  * @param x X position on an image of the workspace
@@ -40,6 +44,38 @@ void ImageInfoPresenter::setWorkspace(const Mantid::API::Workspace_sptr &workspa
     m_model = std::make_unique<ImageInfoModelMatrixWS>(matrixWS);
   else {
     m_model = std::make_unique<ImageInfoModelMD>();
+  }
+}
+
+/**
+ * Fill the view table cells using the model
+ * @param info A reference to a collection of header/value pairs
+ */
+void ImageInfoPresenter::fillTableCells(const ImageInfoModel::ImageInfo &info) {
+  if (info.empty())
+    return;
+  int signalIndex = -1;
+
+  const auto itemCount(info.size());
+  m_view->setColumnCount(itemCount);
+  for (int i = 0; i < itemCount; ++i) {
+    const auto name = info.name(i);
+    if (name == "Signal") {
+      signalIndex = i;
+    }
+    auto header = new QTableWidgetItem(name);
+    header->setFlags(header->flags() & ~Qt::ItemIsEditable);
+    m_view->setItem(0, i, header);
+    auto value = new QTableWidgetItem(info.value(i));
+    value->setFlags(header->flags() & ~Qt::ItemIsEditable);
+    m_view->setItem(1, i, value);
+  }
+  if (signalIndex >= 0) {
+    if (!m_showSignal) {
+      m_view->hideColumn(signalIndex);
+    } else {
+      m_view->showColumn(signalIndex);
+    }
   }
 }
 

--- a/qt/widgets/common/src/ImageInfoPresenter.cpp
+++ b/qt/widgets/common/src/ImageInfoPresenter.cpp
@@ -56,10 +56,10 @@ void ImageInfoPresenter::fillTableCells(const ImageInfoModel::ImageInfo &info) {
     return;
   int signalIndex = -1;
 
-  const auto itemCount(info.size());
+  const auto &itemCount(info.size());
   m_view->setColumnCount(itemCount);
   for (int i = 0; i < itemCount; ++i) {
-    const auto name = info.name(i);
+    const auto &name = info.name(i);
     if (name == "Signal") {
       signalIndex = i;
     }

--- a/qt/widgets/common/src/ImageInfoPresenter.cpp
+++ b/qt/widgets/common/src/ImageInfoPresenter.cpp
@@ -54,14 +54,17 @@ void ImageInfoPresenter::setWorkspace(const Mantid::API::Workspace_sptr &workspa
 void ImageInfoPresenter::fillTableCells(const ImageInfoModel::ImageInfo &info) {
   if (info.empty())
     return;
-  int signalIndex = -1;
 
   const auto &itemCount(info.size());
   m_view->setColumnCount(itemCount);
   for (int i = 0; i < itemCount; ++i) {
     const auto &name = info.name(i);
     if (name == "Signal") {
-      signalIndex = i;
+      if (m_showSignal) {
+        m_view->showColumn(i);
+      } else {
+        m_view->hideColumn(i);
+      }
     }
     auto header = new QTableWidgetItem(name);
     header->setFlags(header->flags() & ~Qt::ItemIsEditable);
@@ -69,13 +72,6 @@ void ImageInfoPresenter::fillTableCells(const ImageInfoModel::ImageInfo &info) {
     auto value = new QTableWidgetItem(info.value(i));
     value->setFlags(header->flags() & ~Qt::ItemIsEditable);
     m_view->setItem(1, i, value);
-  }
-  if (signalIndex >= 0) {
-    if (!m_showSignal) {
-      m_view->hideColumn(signalIndex);
-    } else {
-      m_view->showColumn(signalIndex);
-    }
   }
 }
 

--- a/qt/widgets/common/src/ImageInfoWidget.cpp
+++ b/qt/widgets/common/src/ImageInfoWidget.cpp
@@ -19,7 +19,7 @@ namespace MantidQt::MantidWidgets {
  * @param parent A QWidget to act as the parent widget
  */
 ImageInfoWidget::ImageInfoWidget(QWidget *parent)
-    : QTableWidget(0, 0, parent), m_presenter(std::make_unique<ImageInfoPresenter>(this)) {
+    : QTableWidget(0, 0, parent), m_presenter(std::make_unique<ImageInfoPresenter>(this)), m_showSignal(true) {
   setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
   setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
   horizontalHeader()->hide();
@@ -44,16 +44,28 @@ void ImageInfoWidget::cursorAt(const double x, const double y, const double sign
 void ImageInfoWidget::showInfo(const ImageInfoModel::ImageInfo &info) {
   if (info.empty())
     return;
+  int signalIndex = -1;
 
   const auto itemCount(info.size());
   setColumnCount(itemCount);
   for (int i = 0; i < itemCount; ++i) {
-    auto header = new QTableWidgetItem(info.name(i));
+    const auto name = info.name(i);
+    if (name == "Signal") {
+      signalIndex = i;
+    }
+    auto header = new QTableWidgetItem(name);
     header->setFlags(header->flags() & ~Qt::ItemIsEditable);
     setItem(0, i, header);
     auto value = new QTableWidgetItem(info.value(i));
     value->setFlags(header->flags() & ~Qt::ItemIsEditable);
     setItem(1, i, value);
+  }
+  if (signalIndex >= 0) {
+    if (!m_showSignal) {
+      hideColumn(signalIndex);
+    } else {
+      showColumn(signalIndex);
+    }
   }
   horizontalHeader()->setMinimumSectionSize(50);
   resizeColumnsToContents();

--- a/qt/widgets/common/src/ImageInfoWidget.cpp
+++ b/qt/widgets/common/src/ImageInfoWidget.cpp
@@ -19,7 +19,7 @@ namespace MantidQt::MantidWidgets {
  * @param parent A QWidget to act as the parent widget
  */
 ImageInfoWidget::ImageInfoWidget(QWidget *parent)
-    : QTableWidget(0, 0, parent), m_presenter(std::make_unique<ImageInfoPresenter>(this)), m_showSignal(true) {
+    : QTableWidget(0, 0, parent), m_presenter(std::make_unique<ImageInfoPresenter>(this)) {
   setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
   setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
   horizontalHeader()->hide();
@@ -42,31 +42,7 @@ void ImageInfoWidget::cursorAt(const double x, const double y, const double sign
  * @param info A reference to a collection of header/value pairs
  */
 void ImageInfoWidget::showInfo(const ImageInfoModel::ImageInfo &info) {
-  if (info.empty())
-    return;
-  int signalIndex = -1;
-
-  const auto itemCount(info.size());
-  setColumnCount(itemCount);
-  for (int i = 0; i < itemCount; ++i) {
-    const auto name = info.name(i);
-    if (name == "Signal") {
-      signalIndex = i;
-    }
-    auto header = new QTableWidgetItem(name);
-    header->setFlags(header->flags() & ~Qt::ItemIsEditable);
-    setItem(0, i, header);
-    auto value = new QTableWidgetItem(info.value(i));
-    value->setFlags(header->flags() & ~Qt::ItemIsEditable);
-    setItem(1, i, value);
-  }
-  if (signalIndex >= 0) {
-    if (!m_showSignal) {
-      hideColumn(signalIndex);
-    } else {
-      showColumn(signalIndex);
-    }
-  }
+  m_presenter->fillTableCells(info);
   horizontalHeader()->setMinimumSectionSize(50);
   resizeColumnsToContents();
 }
@@ -78,5 +54,18 @@ void ImageInfoWidget::showInfo(const ImageInfoModel::ImageInfo &info) {
 void ImageInfoWidget::setWorkspace(const Mantid::API::Workspace_sptr &ws) { m_presenter->setWorkspace(ws); }
 
 void ImageInfoWidget::setRowCount(const int count) { QTableWidget::setRowCount(count); }
+
+void ImageInfoWidget::setColumnCount(const int count) { QTableWidget::setColumnCount(count); }
+
+void ImageInfoWidget::setItem(const int rowIndex, const int columnIndex, QTableWidgetItem *item) {
+  QTableWidget::setItem(rowIndex, columnIndex, item);
+}
+
+void ImageInfoWidget::hideColumn(const int index) { QTableWidget::hideColumn(index); }
+
+void ImageInfoWidget::showColumn(const int index) { QTableWidget::showColumn(index); }
+
+// Set presenter flag for wether to show or hide the signal column
+void ImageInfoWidget::setShowSignal(const bool showSignal) { m_presenter->setShowSignal(showSignal); }
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/src/ImageInfoWidgetMini.cpp
+++ b/qt/widgets/common/src/ImageInfoWidgetMini.cpp
@@ -56,5 +56,9 @@ void ImageInfoWidgetMini::showInfo(const ImageInfoModel::ImageInfo &info) {
 void ImageInfoWidgetMini::setWorkspace(const Mantid::API::Workspace_sptr &ws) { m_presenter->setWorkspace(ws); }
 
 void ImageInfoWidgetMini::setRowCount(const int /*count*/) {}
+void ImageInfoWidgetMini::setColumnCount(const int /*count*/) {}
+void ImageInfoWidgetMini::setItem(const int /*rowIndex*/, const int /*columnIndex*/, QTableWidgetItem * /*item*/) {}
+void ImageInfoWidgetMini::hideColumn(const int /*index*/) {}
+void ImageInfoWidgetMini::showColumn(const int /*index*/) {}
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/test/ImageInfoPresenterTest.h
+++ b/qt/widgets/common/test/ImageInfoPresenterTest.h
@@ -33,6 +33,10 @@ public:
   MOCK_METHOD1(showInfo, void(const ImageInfoModel::ImageInfo &info));
   MOCK_METHOD1(setWorkspace, void(const Mantid::API::Workspace_sptr &ws));
   MOCK_METHOD1(setRowCount, void(const int count));
+  MOCK_METHOD1(setColumnCount, void(const int count));
+  MOCK_METHOD3(setItem, void(const int rowIndex, const int columnIndex, QTableWidgetItem *item));
+  MOCK_METHOD1(hideColumn, void(const int index));
+  MOCK_METHOD1(showColumn, void(const int index));
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE


### PR DESCRIPTION
### Description of work

Previously in the Image Info Widget, Signal has been `-` in non-orthogonal view. This Pr hides the signal column, as suggested in the attached issue.

Fixes #32318

### To test:

- Run the script from the issue and open in the slice viewer
- Toggling non-orthogonal view should hide / show the signal column in the image info widget.
- Try some other tests, like closing the sliceviewer with non-orthogonal view enabled and reopening with different data.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
