### PR TITLE
Fix muon simultaneous global tie bug

### DIFF
--- a/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/36925.rst
+++ b/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/36925.rst
@@ -1,0 +1,1 @@
+- Fixed an unreliable error when loading a new group of runs after doing a simultaneous fit.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -218,6 +218,9 @@ class GeneralFittingModel(BasicFittingModel):
 
     def _add_global_ties_to_simultaneous_function(self) -> None:
         """Creates and adds ties to the simultaneous function to represent the global parameters."""
+        assert self.simultaneous_fit_function is not None, "This method assumes the simultaneous fit function is not None."
+        self._remove_non_existing_global_parameters()
+
         current_dataset_index = self.fitting_context.current_dataset_index
 
         for global_parameter in self.fitting_context.global_parameters:
@@ -226,11 +229,17 @@ class GeneralFittingModel(BasicFittingModel):
 
     def _create_global_tie_string(self, index: int, global_parameter: str) -> str:
         """Create a string to represent the tying of a global parameter."""
-        ties = [
-            "f" + str(i) + "." + global_parameter for i in range(self.fitting_context.simultaneous_fit_function.nFunctions()) if i != index
-        ]
+        ties = ["f" + str(i) + "." + global_parameter for i in range(self.simultaneous_fit_function.nFunctions()) if i != index]
         ties.append("f" + str(index) + "." + global_parameter)
         return "=".join(ties)
+
+    def _remove_non_existing_global_parameters(self) -> None:
+        """Removes non-existing parameters from the global parameters list."""
+        self.global_parameters = [
+            global_parameter
+            for global_parameter in self.global_parameters
+            if self.simultaneous_fit_function.hasParameter(f"f0.{global_parameter}")
+        ]
 
     def _get_plot_guess_fit_function(self) -> IFunction:
         """Returns the fit function to evaluate when plotting a guess."""

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -575,6 +575,51 @@ class GeneralFittingModelTest(unittest.TestCase):
         self.model.update_ws_fit_function_parameters(self.model.dataset_names[1:], [1.0, 2.0])
         self.assertEqual(self.model.get_fit_function_parameter_values(self.model.simultaneous_fit_function), ([1.0, 2.0], [0.0, 0.0]))
 
+    def test_remove_non_existing_global_parameters_will_remove_non_existing_ties(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+
+        # Add a non-existing parameter as a global parameter
+        self.model.fitting_context.global_parameters = ["f0.A0"]
+
+        self.model._remove_non_existing_global_parameters()
+
+        self.assertEqual([], self.model.fitting_context.global_parameters)
+
+    def test_remove_non_existing_global_parameters_will_not_remove_existing_ties(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+
+        # Add an existing parameter as a global parameter
+        self.model.fitting_context.global_parameters = ["A0"]
+
+        self.model._remove_non_existing_global_parameters()
+
+        self.assertEqual(["A0"], self.model.fitting_context.global_parameters)
+
+    def test_add_global_ties_to_simultaneous_function_will_remove_non_existing_ties_before_adding_ties(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+
+        # Add a non-existing parameter as a global parameter
+        self.model.fitting_context.global_parameters = ["f0.A0"]
+
+        # There should be no error on this line
+        self.model._add_global_ties_to_simultaneous_function()
+
+        self.assertEqual([], self.model.fitting_context.global_parameters)
+
+    def test_add_global_ties_to_simultaneous_function_will_raise_assertion_if_the_simultaneous_function_is_none(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = None
+        self.model.simultaneous_fitting_mode = True
+
+        with self.assertRaisesRegex(AssertionError, "This method assumes the simultaneous fit function is not None."):
+            self.model._add_global_ties_to_simultaneous_function()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of work
This PR adds a safety check to the simultaneous fitting code in the Muon Analysis interface. When new data is loaded, the interface attempts to copy over the fitting functions and global ties used for the previously loaded data. The interface used to try to apply global ties without checking if they still existed. This change makes sure it will check the global parameters still exist before attempting to add the ties.

Fixes #36925

### To test:
I could not replicate the problem manually in the attached issue. I think the best thing to do is a code review and make sure the new tests pass.

1. Open `Muon`->`Muon Analysis`
2. Select EMU instrument
3. Load runs `123054-123057`
4. Go to the fitting tab
5. Tick `Simultaneous by`
6. Right click the blank space and add function `Flat Background`
7. Repeat and add a `Product Function`
8. Right click the product function and add `DynamicKuboToyabe` and `ExpDecayMuon`
9. Make the `Asym` parameter global
10. Click `Fit`
11. The fit should succeed

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
