### PR TITLE
  Fix failing doctest due to orso standard version changing for ornl-next

### DIFF
--- a/docs/source/algorithms/SaveISISReflectometryORSO-v1.rst
+++ b/docs/source/algorithms/SaveISISReflectometryORSO-v1.rst
@@ -83,7 +83,7 @@ Usage
         print(myFile.readline())
 
 .. testoutput:: SaveISISReflectometryORSO_general_usage
-   :options: +NORMALIZE_WHITESPACE
+   :options: +ELLIPSIS +NORMALIZE_WHITESPACE
 
    # # ORSO reflectivity data file | ... standard | YAML encoding | https://www.reflectometry.org/
 

--- a/docs/source/algorithms/SaveISISReflectometryORSO-v1.rst
+++ b/docs/source/algorithms/SaveISISReflectometryORSO-v1.rst
@@ -85,7 +85,7 @@ Usage
 .. testoutput:: SaveISISReflectometryORSO_general_usage
    :options: +NORMALIZE_WHITESPACE
 
-   # # ORSO reflectivity data file | 1.0 standard | YAML encoding | https://www.reflectometry.org/
+   # # ORSO reflectivity data file | ... standard | YAML encoding | https://www.reflectometry.org/
 
 .. testcleanup:: SaveISISReflectometryORSO_general_usage
 


### PR DESCRIPTION
This is a version of #36929 into `ornl-next`