### PR TITLE
Fix regular live data crashes on OFFSPEC

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -201,16 +201,16 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
         return "Theta"
 
     def _s1vg_name(self):
-        return "s1vgap" if self._instrument == "OFFSPEC" else "S1VG"
+        return "S1VG"
 
     def _alternative_s1vg_name(self):
-        return "S1VG" if self._instrument == "OFFSPEC" else "s1vg"
+        return "s1vg"
 
     def _s2vg_name(self):
-        return "s2vgap" if self._instrument == "OFFSPEC" else "S2VG"
+        return "S2VG"
 
     def _alternative_s2vg_name(self):
-        return "S2VG" if self._instrument == "OFFSPEC" else "s2vg"
+        return "s2vg"
 
     def _get_double_or_none(self, propertyName):
         value = self.getProperty(propertyName)

--- a/docs/source/release/v6.10.0/Reflectometry/Bugfixes/35400.rst
+++ b/docs/source/release/v6.10.0/Reflectometry/Bugfixes/35400.rst
@@ -1,0 +1,1 @@
+- Removed slit lookup that was specific to OFFSPEC in :ref:`algm-ReflectometryReductionOneLiveData` as it is no longer required and was causing regular crashes when running live data on OFFSPEC.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
When live data is run for the OFFSPEC instrument from the ISIS Reflectometry GUI there seem to be regular crashes. In `ReflectometryReductionLiveData` we were supporting instruments using different Controls systems by looking up different values for OFFSPEC. OFFSPEC have recently switched to IBEX, so we can now look up their values the same way as for other instruments. This reduces the number of errors that are logged and, from testing on IDAaaS, it appears to improve the stability of live data on OFFSPEC.

I am marking this PR as fixing the linked issue as I don't think there are any reproducible problems left on that ticket now.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #35400. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
I have tested with Conda packages on IDAaaS because checking the impact on stability requires running it for some time while the beam is on. I ran live data for OFFSPEC in the Nightly alongside running it from the Conda packages and found that in just under 24 hours the Nightly version crashed twice while the Conda packages didn't crash at all. I wouldn't suggest that this be repeated when testing this PR, but the following will ensure that live data is still working OK. I can't seem to run live data on my machine when not plugged into the network on site so I can give installation details for the Conda packages, or share an IDAaaS workspace, if anyone needs to test there instead.

1) Open the ISIS Reflectometry interface.
2) On the Runs tab, change the instrument to `OFFSPEC`.
3) In the Live Data section on this tab, click the `Start monitor` button.
4) Check that in the log messages pane you get something like:

```
THETA = ...
S1VG = ...
S2VG = ...
```

Rather than the below errors, which you would have seen in the past when trying to read the s1v and s2v values for OFFSPEC:

```
Error in execution of algorithm GetLiveInstrumentValue:
Error reading EPICS PV "IN:OFFSPEC:CS:SB:s1vgap":
```

5) Repeat the above for `INTER` to check that live data is still working OK for other instruments.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
