### PR TITLE
Fixed instrument view title upon renaming workspace

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/InstrumentViewer/Bugfixes/36936.rst
+++ b/docs/source/release/v6.10.0/Workbench/InstrumentViewer/Bugfixes/36936.rst
@@ -1,0 +1,1 @@
+`` - Fixed bug where title on InstrumentView window did not update upon renaming the workspace.``

--- a/docs/source/release/v6.10.0/Workbench/InstrumentViewer/Bugfixes/36936.rst
+++ b/docs/source/release/v6.10.0/Workbench/InstrumentViewer/Bugfixes/36936.rst
@@ -1,1 +1,1 @@
-`` - Fixed bug where title on InstrumentView window did not update upon renaming the workspace.``
+- Fixed bug where title on InstrumentView window did not update upon renaming the workspace.

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/view.py
@@ -48,7 +48,7 @@ class InstrumentView(QWidget, ObservingView):
 
         self.name = name
 
-        self.setWindowTitle(name)
+        self.setWindowTitle("Instrument - " + name)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
         self.setWindowFlags(window_flags)
 

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -210,15 +210,12 @@ InstrumentWidget::InstrumentWidget(QString wsName, QWidget *parent, bool resetGe
   observeRename();
   observeADSClear();
 
-  const int windowWidth = 800;
-  const int tabsSize = windowWidth / 4;
+  const int tabsSize = 200;
   QList<int> sizes;
-  sizes << tabsSize << windowWidth - tabsSize;
+  sizes << tabsSize << 600;
   m_controlPanelLayout->setSizes(sizes);
   m_controlPanelLayout->setStretchFactor(0, 0);
   m_controlPanelLayout->setStretchFactor(1, 1);
-
-  resize(windowWidth, 650);
 
   tabChanged(0);
   updateInfoText("Loading instrument...");

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -227,8 +227,6 @@ InstrumentWidget::InstrumentWidget(QString wsName, QWidget *parent, bool resetGe
                        SLOT(setIntegrationRange(double, double)), Qt::QueuedConnection);
   setAcceptDrops(true);
 
-  setWindowTitle(QString("Instrument - ") + m_workspaceName);
-
   // finish widget init now if not using the background thread
   if (!m_useThread) {
     initWidget(true, true);
@@ -1595,7 +1593,7 @@ void InstrumentWidget::afterReplaceHandle(const std::string &wsName, const std::
 void InstrumentWidget::renameHandle(const std::string &oldName, const std::string &newName) {
   if (hasWorkspace(oldName)) {
     renameWorkspace(newName);
-    setWindowTitle(QString("Instrument - ") + getWorkspaceName());
+    nativeParentWidget()->setWindowTitle(QString("Instrument - ") + getWorkspaceName());
   }
 }
 


### PR DESCRIPTION
### Description of work
Fixed bug where renaming a workspace with the instrument view opened did not update the title of the InstrumentView window.

#### Summary of work
- Fixed title of window when InstrumentView is initialised
- Fixed renaming bug
- Removed unused call to resize() of window

Fixes #36733 .

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
The instrument view widget is written in C++ but the window is controlled by a Python wrapper. The title upon initialisation is set on the python wrapper side. The rename is handled on the C++ side by including a call to `nativeParentWidget()`. Finally, I removed a call to resize() on the C++ since it was already being ignored.

### To test:
- Load a workspace
- Open InstrumentView
- Check title is of form `Instrument - <INSTRUMENTNAME>`
- Rename workspace
- Check window title is correctly updated

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
