### PR TITLE
Improve wallclock filtering in LoadEventNexus

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/PulseIndexer.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/PulseIndexer.h
@@ -55,7 +55,8 @@ public:
 private:
   PulseIndexer(); // do not allow empty constructor
 
-  size_t determineFirstPulseIndex(const std::size_t firstEventIndex) const;
+  size_t determineFirstPulseIndex() const;
+  size_t determineLastPulseIndex() const;
 
   /// vector of indices (length of # of pulses) into the event arrays
   const std::shared_ptr<std::vector<uint64_t>> m_event_index;
@@ -69,7 +70,8 @@ private:
 
   /**
    * Total number of events tof/detid that should be processed. This can be less than the total number of events in the
-   * actual array.
+   * actual array. This value plus the m_firstEventIndex should be <= the total events in the NXevent_data being
+   * processed.
    */
   std::size_t m_numEvents;
 

--- a/Framework/DataHandling/inc/MantidDataHandling/PulseIndexer.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/PulseIndexer.h
@@ -35,36 +35,52 @@ public:
   PulseIndexer(std::shared_ptr<std::vector<uint64_t>> event_index, const std::size_t firstEventIndex,
                const std::size_t numEvents, const std::string &entry_name);
 
-  /// Which element in the event_index array is the one to use
+  /// Which element in the event_index array is the first one to use
   size_t getFirstPulseIndex() const;
+  /// Which element in the event_index array is the last one to use
+  size_t getLastPulseIndex() const;
   /// The range of event(tof,detid) indices to read for this pulse
   std::pair<size_t, size_t> getEventIndexRange(const size_t pulseIndex) const;
   /**
-   * The first event(tof,detid) index to read for this pulse.
-   * This is only public for testing.
+   * The first event(tof,detid) index to read for this pulse. When this is after the event indices to use, it returns
+   * the value of getStopEventIndex. This is only public for testing.
    */
   size_t getStartEventIndex(const size_t pulseIndex) const;
   /**
-   * The one past the last event(tof,detid) index to read for this pulse
-   * This is only public for testing.
+   * The one past the last event(tof,detid) index to read for this pulse. When this is before the event indices to use,
+   * it returns the value of getStartEventIndex. This is only public for testing.
    */
   size_t getStopEventIndex(const size_t pulseIndex) const;
 
 private:
   PulseIndexer(); // do not allow empty constructor
 
-  /// vector of event index (length of # of pulses)
+  size_t determineFirstPulseIndex(const std::size_t firstEventIndex) const;
+
+  /// vector of indices (length of # of pulses) into the event arrays
   const std::shared_ptr<std::vector<uint64_t>> m_event_index;
 
   /**
-   * How far into the array of events the tof/detid are already.
-   * This is used when data is read in chunks.
+   * How far into the array of events the tof/detid are already. This is used when data is read in chunks.
+   * It is generally taken from the zeroth element of the event_index array, but is also used for chunking by
+   * pulse-time.
    */
   std::size_t m_firstEventIndex;
+
+  /**
+   * Total number of events tof/detid that should be processed. This can be less than the total number of events in the
+   * actual array.
+   */
+  std::size_t m_numEvents;
+
+  /**
+   * Alternating values describe ranges of [use, don't). There will always be a gap between neighboring values.
+   */
+  std::vector<std::size_t> m_roi;
+
   /// Total number of pulsetime/pulseindex
   std::size_t m_numPulses;
-  /// Total number of events tof/detid
-  std::size_t m_numEvents;
+
   /// Name of the NXentry to be used in exceptions
   const std::string m_entry_name;
 };

--- a/Framework/DataHandling/inc/MantidDataHandling/PulseIndexer.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/PulseIndexer.h
@@ -65,6 +65,9 @@ private:
    * How far into the array of events the tof/detid are already. This is used when data is read in chunks.
    * It is generally taken from the zeroth element of the event_index array, but is also used for chunking by
    * pulse-time.
+   *
+   * Another way to think of this value is the offset into the tof/detid arrays from disk that are actually in memory.
+   * Because of this, all indices into the event arrays (tof/detid) have this value subtracted off.
    */
   std::size_t m_firstEventIndex;
 
@@ -76,7 +79,8 @@ private:
   std::size_t m_numEvents;
 
   /**
-   * Alternating values describe ranges of [use, don't). There will always be a gap between neighboring values.
+   * Alternating values describe ranges of [use, don't) of pulse index ranges. There will always be a gap between
+   * neighboring values.
    */
   std::vector<std::size_t> m_roi;
 

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -97,7 +97,6 @@ void ProcessBankData::run() {
     throw std::runtime_error("Event index is not sorted");
 
   // And there are this many pulses
-  const auto NUM_PULSES = event_index->size();
   prog->report(entry_name + ": filling events");
 
   auto *alg = m_loader.alg;
@@ -113,8 +112,9 @@ void ProcessBankData::run() {
   const bool NO_TOF_FILTERING = !(alg->filter_tof_range);
 
   const PulseIndexer pulseIndexer(event_index, startAt, numEvents, entry_name);
-
-  for (std::size_t pulseIndex = pulseIndexer.getFirstPulseIndex(); pulseIndex < NUM_PULSES; pulseIndex++) {
+  const auto firstPulseIndex = pulseIndexer.getFirstPulseIndex(); // for whole file reading is 0
+  const auto lastPulseIndex = pulseIndexer.getLastPulseIndex();   // for whole file reading is event_index->size()
+  for (std::size_t pulseIndex = firstPulseIndex; pulseIndex < lastPulseIndex; pulseIndex++) {
     // determine range of events for the pulse
     const auto eventIndexRange = pulseIndexer.getEventIndexRange(pulseIndex);
     if (eventIndexRange.first > numEvents)

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -115,17 +115,17 @@ void ProcessBankData::run() {
   const PulseIndexer pulseIndexer(event_index, startAt, numEvents, entry_name);
 
   for (std::size_t pulseIndex = pulseIndexer.getFirstPulseIndex(); pulseIndex < NUM_PULSES; pulseIndex++) {
-    // Save the pulse time at this index for creating those events
-    const auto &pulsetime = thisBankPulseTimes->pulseTime(pulseIndex);
-    const int logPeriodNumber = thisBankPulseTimes->periodNumber(pulseIndex);
-    const int periodIndex = logPeriodNumber - 1;
-
     // determine range of events for the pulse
     const auto eventIndexRange = pulseIndexer.getEventIndexRange(pulseIndex);
     if (eventIndexRange.first > numEvents)
       break;
     else if (eventIndexRange.first == eventIndexRange.second)
       continue;
+
+    // Save the pulse time at this index for creating those events
+    const auto &pulsetime = thisBankPulseTimes->pulseTime(pulseIndex);
+    const int logPeriodNumber = thisBankPulseTimes->periodNumber(pulseIndex);
+    const int periodIndex = logPeriodNumber - 1;
 
     // loop through events associated with a single pulse
     for (std::size_t eventIndex = eventIndexRange.first; eventIndex < eventIndexRange.second; ++eventIndex) {

--- a/Framework/DataHandling/src/PulseIndexer.cpp
+++ b/Framework/DataHandling/src/PulseIndexer.cpp
@@ -132,8 +132,6 @@ size_t PulseIndexer::getStartEventIndex(const size_t pulseIndex) const {
   size_t eventIndex;
   if (pulseIndex <= m_roi.front()) {
     eventIndex = m_event_index->operator[](m_roi.front());
-  } else if (pulseIndex >= m_roi.back()) {
-    eventIndex = m_numEvents;
   } else {
     eventIndex = m_event_index->operator[](pulseIndex);
   }

--- a/Framework/DataHandling/src/PulseIndexer.cpp
+++ b/Framework/DataHandling/src/PulseIndexer.cpp
@@ -21,14 +21,6 @@ PulseIndexer::PulseIndexer(std::shared_ptr<std::vector<uint64_t>> event_index, c
   m_roi.push_back(this->determineFirstPulseIndex());
   // for now, use all pulses up to the end
   m_roi.push_back(this->determineLastPulseIndex());
-
-  /*
-  if (firstEventIndex > 0) { // REMOVE
-    std::stringstream msg;
-    msg << "firstEventIndex=" << firstEventIndex;
-    throw std::runtime_error(msg.str());
-  }
-  */
 }
 
 /**
@@ -96,10 +88,6 @@ size_t PulseIndexer::determineLastPulseIndex() const {
   return static_cast<size_t>(m_event_index->size() - std::distance(m_event_index->crbegin(), event_index_iter));
 }
 
-/**
- * This performs a linear search because it is much more likely that the index
- * to look for is at the beginning.
- */
 size_t PulseIndexer::getFirstPulseIndex() const { return m_roi.front(); }
 size_t PulseIndexer::getLastPulseIndex() const { return m_roi.back(); }
 

--- a/Framework/DataHandling/src/PulseIndexer.cpp
+++ b/Framework/DataHandling/src/PulseIndexer.cpp
@@ -40,24 +40,36 @@ size_t PulseIndexer::determineFirstPulseIndex() const {
   if (1 >= m_event_index->size())
     return 1;
 
+  size_t firstPulseIndex = 0;
+
   // special case to stop from setting up temporary objects because the first event is in the first pulse
-  if (m_firstEventIndex == 0)
-    return 0;
+  if (m_firstEventIndex != 0) {
+    // linear search is used because it is more likely that the pulse index is earlier in the array.
+    // a bisecting search would win if most of the time the first event_index is much after the first quarter of the
+    // pulse_index array.
+    const auto event_index_end = m_event_index->cend();
+    auto event_index_iter = m_event_index->cbegin();
 
-  // linear search is used because it is more likely that the pulse index is earlier in the array.
-  // a bisecting search would win if most of the time the first event_index is much after the first quarter of the
-  // pulse_index array.
-  const auto event_index_end = m_event_index->cend();
-  auto event_index_iter = m_event_index->cbegin();
+    while ((m_firstEventIndex < *event_index_iter) || (m_firstEventIndex >= *(event_index_iter + 1))) {
+      event_index_iter++;
 
-  while ((m_firstEventIndex < *event_index_iter) || (m_firstEventIndex >= *(event_index_iter + 1))) {
-    event_index_iter++;
-
-    // make sure not to go past the end
-    if (event_index_iter + 1 == event_index_end)
-      break;
+      // make sure not to go past the end
+      if (event_index_iter + 1 == event_index_end)
+        break;
+    }
+    firstPulseIndex = static_cast<size_t>(std::distance(m_event_index->cbegin(), event_index_iter));
   }
-  return static_cast<size_t>(std::distance(m_event_index->cbegin(), event_index_iter));
+
+  // verify that there isn't a repeat right after the found value
+  if (firstPulseIndex + 1 != m_event_index->size()) {
+    for (; firstPulseIndex < m_event_index->size() - 1; ++firstPulseIndex) {
+      if (m_event_index->operator[](firstPulseIndex) != m_event_index->operator[](firstPulseIndex + 1)) {
+        break;
+      }
+    }
+  }
+
+  return firstPulseIndex;
 }
 
 /**
@@ -73,7 +85,7 @@ size_t PulseIndexer::determineLastPulseIndex() const {
   // pulse_index array.
   const auto event_index_end = m_event_index->crend();
   auto event_index_iter = m_event_index->crbegin();
-  while ((eventIndexValue > *event_index_iter) || (eventIndexValue <= *(event_index_iter + 1))) {
+  while ((eventIndexValue < *event_index_iter)) {
     event_index_iter++;
 
     // make sure not to go past the end
@@ -140,15 +152,18 @@ size_t PulseIndexer::getStopEventIndex(const size_t pulseIndex) const {
     return this->getStartEventIndex(pulseIndex);
 
   const auto pulseIndexEnd = pulseIndex + 1;
+
   // check if the requests have gone past the end - order of if/else matters
+  size_t eventIndex = m_event_index->operator[](pulseIndexEnd);
   if (pulseIndexEnd >= m_numPulses) // last pulse should read to the last event
-    return m_numEvents - m_firstEventIndex;
+    eventIndex = m_numEvents;
   else if (pulseIndexEnd >= m_roi.back()) // this can be equal to the number of pulses
-    return m_event_index->operator[](m_roi.back()) - m_firstEventIndex;
+    eventIndex = m_numEvents;
 
-  const size_t lastEventIndex = m_event_index->operator[](pulseIndexEnd) - m_firstEventIndex;
-
-  return std::min(lastEventIndex, m_numEvents - m_firstEventIndex);
+  if (eventIndex > m_firstEventIndex)
+    return eventIndex - m_firstEventIndex;
+  else
+    return m_numEvents;
 }
 
 } // namespace Mantid::DataHandling

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -85,8 +85,8 @@ class LoadEventNexusTest : public CxxTest::TestSuite {
 private:
   void do_test_filtering_start_and_end_filtered_loading(const bool metadataonly) {
     const std::string wsName = "test_filtering";
-    const double filterStart = 1;
-    const double filterEnd = 1000;
+    constexpr double filterStart = 1;
+    constexpr double filterEnd = 1000;
 
     LoadEventNexus ld;
     ld.initialize();
@@ -95,6 +95,7 @@ private:
     ld.setProperty("FilterByTimeStart", filterStart);
     ld.setProperty("FilterByTimeStop", filterEnd);
     ld.setProperty("MetaDataOnly", metadataonly);
+    ld.setProperty("NumberOfBins", 1); // only one bin to make validation easier
 
     TS_ASSERT(ld.execute());
 
@@ -110,6 +111,48 @@ private:
     auto filteredLogEndTime = sampleTemps->nthTime(sampleTemps->size() - 1);
     TS_ASSERT_EQUALS("2010-Mar-25 16:09:27.620000000", filteredLogStartTime.toSimpleString());
     TS_ASSERT_EQUALS("2010-Mar-25 16:11:51.558003540", filteredLogEndTime.toSimpleString());
+
+    // check the events themselves
+    const auto NUM_HIST = outWs->getNumberHistograms();
+    TS_ASSERT_EQUALS(NUM_HIST, 51200); // observed value
+    if (metadataonly) {
+      // check that no events were created
+      TS_ASSERT_EQUALS(outWs->getNumberEvents(), 0);
+    } else {
+      // total number of events
+      TS_ASSERT_EQUALS(outWs->getNumberEvents(), 110969); // observed value
+
+      // check some particular spectra - observed values
+      TS_ASSERT_EQUALS(outWs->getSpectrum(0).getNumberEvents(), 0);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(2).getNumberEvents(), 1);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(3).getNumberEvents(), 0);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(5).getNumberEvents(), 4);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(7).getNumberEvents(), 2);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(11).getNumberEvents(), 0);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(13).getNumberEvents(), 0);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(17).getNumberEvents(), 2);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(29).getNumberEvents(), 1);
+      constexpr size_t bank2offset = 128 * 12; // half way into bank2
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank2offset + 0).getNumberEvents(), 0);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank2offset + 2).getNumberEvents(), 0);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank2offset + 3).getNumberEvents(), 0);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank2offset + 5).getNumberEvents(), 0);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank2offset + 7).getNumberEvents(), 1);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank2offset + 11).getNumberEvents(), 2);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank2offset + 13).getNumberEvents(), 1);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank2offset + 17).getNumberEvents(), 1);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank2offset + 29).getNumberEvents(), 1);
+      constexpr size_t bank4offset = 128 * 8 * 4 + 128 * 4; // half way into bank4
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank4offset + 0).getNumberEvents(), 0);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank4offset + 2).getNumberEvents(), 0);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank4offset + 3).getNumberEvents(), 0);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank4offset + 5).getNumberEvents(), 2);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank4offset + 7).getNumberEvents(), 1);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank4offset + 11).getNumberEvents(), 0);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank4offset + 13).getNumberEvents(), 2);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank4offset + 17).getNumberEvents(), 1);
+      TS_ASSERT_EQUALS(outWs->getSpectrum(bank4offset + 29).getNumberEvents(), 3);
+    }
   }
 
   void validate_pulse_time_sorting(EventWorkspace_sptr eventWS) {

--- a/Framework/DataHandling/test/PulseIndexerTest.h
+++ b/Framework/DataHandling/test/PulseIndexerTest.h
@@ -50,17 +50,18 @@ public:
       TS_ASSERT_EQUALS(indexer.getStopEventIndex(i), eventIndices->operator[](i + 1) - start_event_index);
     }
 
+    const auto exp_stop_event = (total_events >= start_event_index) ? (total_events - start_event_index) : total_events;
     // last element is a little different
     {
       const size_t i = myLastPulseIndex - 1;
       TS_ASSERT_EQUALS(indexer.getStartEventIndex(i), eventIndices->operator[](i) - start_event_index);
-      TS_ASSERT_EQUALS(indexer.getStopEventIndex(i), total_events - start_event_index);
+      TS_ASSERT_EQUALS(indexer.getStopEventIndex(i), exp_stop_event);
     }
 
     // check past the end
     for (size_t i = myLastPulseIndex; i < eventIndices->size() + 2; ++i) {
       TS_ASSERT_EQUALS(indexer.getStartEventIndex(i), indexer.getStopEventIndex(i));
-      TS_ASSERT_EQUALS(indexer.getStartEventIndex(i), total_events - start_event_index);
+      TS_ASSERT_EQUALS(indexer.getStopEventIndex(i), exp_stop_event);
     }
   }
 
@@ -82,7 +83,7 @@ public:
     eventIndices->push_back(10);
     eventIndices->push_back(12);
     eventIndices->push_back(15);
-    eventIndices->push_back(16);
+    eventIndices->push_back(18);
 
     TS_ASSERT_EQUALS(eventIndices->size(), 4);
 
@@ -126,5 +127,19 @@ public:
     const size_t total_events{eventIndices->back() - eventIndices->operator[](first_pulse_index) - 1};
 
     run_test(eventIndices, start_event_index, total_events, first_pulse_index, last_pulse_index);
+  }
+
+  void test_repeatingZeros() {
+    // the values are taken from LoadEventNexusTest::test_load_ILL_no_triggers
+    // in essence, the pulse information isn't supplied
+    auto eventIndices = std::make_shared<std::vector<uint64_t>>();
+    eventIndices->push_back(0);
+    eventIndices->push_back(0);
+
+    constexpr size_t start_event_index{0};
+    constexpr size_t total_events{1000};
+    constexpr size_t first_pulse_index{1};
+
+    run_test(eventIndices, start_event_index, total_events, first_pulse_index);
   }
 };

--- a/Framework/DataHandling/test/PulseIndexerTest.h
+++ b/Framework/DataHandling/test/PulseIndexerTest.h
@@ -7,10 +7,15 @@
 #pragma once
 
 #include <cxxtest/TestSuite.h>
+#include <iostream>
 
 #include "MantidDataHandling/PulseIndexer.h"
 
 using Mantid::DataHandling::PulseIndexer;
+
+namespace {
+const std::string entry_name("junk_name");
+}
 
 class PulseIndexerTest : public CxxTest::TestSuite {
 public:
@@ -21,21 +26,40 @@ public:
 
   void run_test(std::shared_ptr<std::vector<uint64_t>> eventIndices, const size_t start_event_index,
                 const size_t total_events, const size_t firstPulseIndex = 0) {
-    PulseIndexer indexer(eventIndices, start_event_index, total_events, "junk_name");
+    // create the object to test
+    PulseIndexer indexer(eventIndices, start_event_index, total_events, entry_name);
 
-    // test locating the first pulse entirely containing the event index
+    // test locating the range of pulse entirely containing the event indices
     TS_ASSERT_EQUALS(indexer.getFirstPulseIndex(), firstPulseIndex);
+    TS_ASSERT_EQUALS(indexer.getLastPulseIndex(), eventIndices->size());
+
+    // things before
+    const auto exp_start_event = eventIndices->operator[](firstPulseIndex) - start_event_index;
+    for (size_t i = 0; i < firstPulseIndex; ++i) {
+      TS_ASSERT_EQUALS(indexer.getStartEventIndex(i), indexer.getStopEventIndex(i));
+      TS_ASSERT_EQUALS(indexer.getStartEventIndex(i), exp_start_event); // TODO check
+    }
 
     // test locating the first event index for the pulse
     // how start_event_index affects values is baked in from how code worked pre 2024
-    for (size_t i = 0; i < eventIndices->size(); ++i)
+    for (size_t i = firstPulseIndex; i < eventIndices->size() - 1; ++i) {
+      // std::cout << "==> " << i << "\n";
       TS_ASSERT_EQUALS(indexer.getStartEventIndex(i), eventIndices->operator[](i) - start_event_index);
-
-    // test locating the flast event index for the pulse
-    // how start_event_index affects values is baked in from how code worked pre 2024
-    for (size_t i = 0; i < eventIndices->size() - 1; ++i)
       TS_ASSERT_EQUALS(indexer.getStopEventIndex(i), eventIndices->operator[](i + 1) - start_event_index);
-    TS_ASSERT_EQUALS(indexer.getStopEventIndex(eventIndices->size() - 1), total_events);
+    }
+
+    // last element is a little different
+    if (false) {
+      const size_t i = eventIndices->size() - 1;
+      TS_ASSERT_EQUALS(indexer.getStartEventIndex(i), eventIndices->operator[](i) - start_event_index);
+      TS_ASSERT_EQUALS(indexer.getStopEventIndex(i), total_events);
+    }
+
+    // check past the end
+    for (size_t i = eventIndices->size(); i < eventIndices->size() + 2; ++i) {
+      TS_ASSERT_EQUALS(indexer.getStartEventIndex(i), indexer.getStopEventIndex(i));
+      TS_ASSERT_EQUALS(indexer.getStartEventIndex(i), total_events - start_event_index);
+    }
   }
 
   void test_Simple() {
@@ -74,8 +98,20 @@ public:
   void test_nonConstantWithOffset() {
     auto eventIndices = generate_nonConstant();
 
+    constexpr size_t start_event_index{2};
+    constexpr size_t total_events{20};
+    constexpr size_t first_pulse_index{3};
+
+    run_test(eventIndices, start_event_index, total_events, first_pulse_index);
+  }
+
+  void test_nonConstantWithOffset2() {
+    auto eventIndices = generate_nonConstant();
+
+    constexpr size_t first_pulse_index{1};
+    const auto start_event_index = eventIndices->operator[](1);
     constexpr size_t total_events{20};
 
-    run_test(eventIndices, 2, total_events, 3);
+    run_test(eventIndices, start_event_index, total_events, first_pulse_index);
   }
 };

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -435,8 +435,8 @@ void EventWorkspace::getEventXMinMax(double &xmin, double &xmax) const {
 /// The total number of events across all of the spectra.
 /// @returns The total number of events
 size_t EventWorkspace::getNumberEvents() const {
-  return std::accumulate(data.begin(), data.end(), size_t{0},
-                         [](size_t total, auto &list) { return total + list->getNumberEvents(); });
+  return std::accumulate(data.cbegin(), data.cend(), size_t{0},
+                         [](const auto total, const auto &list) { return total + list->getNumberEvents(); });
 }
 
 /** Get the EventType of the most-specialized EventList in the workspace


### PR DESCRIPTION
As part of [EWM3412](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3412), the `PulseIndexer` class needs improvements to allow for only processing pulses that are requested. This is a start in that direction and provides a mechanism for skipping the pulses at the beginning and end of the arrays in the file. 

Question for the reviewer: should this implement special cases for using all of the pulses?

Refs #36594 and [EWM3412](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3412)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

This is mostly an internal refactor. As a result, this is probably best tested by looking through the changes and additional tests.

*This does not require release notes* because it is an internal improvement that will be covered by release notes in a future story.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
