### PR TITLE
Add method to BaseSX to plot result of IntegratePeaksMD and save in pdf

### DIFF
--- a/docs/source/release/v6.10.0/Diffraction/Single_Crystal/New_features/36947.rst
+++ b/docs/source/release/v6.10.0/Diffraction/Single_Crystal/New_features/36947.rst
@@ -1,0 +1,1 @@
+- Add method ``plot_integrated_peaks_MD`` to ``BaseSX`` to plot result of IntegratePeaksMD and save in pdf

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -628,6 +628,7 @@ class BaseSX(ABC):
         log_norm: Optional[bool] = True,
     ):
         """
+        Function to plot summary of IntegratePeaksMD integration comprising 3 colorfill plots per peak saved in a pdf.
         :param wsMD:  MD workspace to plot
         :param peaks: integrated peaks using IntegratePeaksMD
         :param filename: filename to store pdf output
@@ -742,7 +743,6 @@ class BaseSX(ABC):
         # call BinMD
         ws_cut = mantid.BinMD(
             InputWorkspace=wsMD,
-            OutputWorkspace="__ws_cut",
             AxisAligned=False,
             BasisVector0=r"Q$_0$,unit," + ",".join(np.array2string(evecs[:, 0], precision=6).strip("[]").split()),
             BasisVector1=r"Q$_1$,unit," + ",".join(np.array2string(evecs[:, 1], precision=6).strip("[]").split()),
@@ -756,6 +756,16 @@ class BaseSX(ABC):
 
     @staticmethod
     def _get_ellipsoid_params_from_peak(peak_shape: PeakShape, ndims: int):
+        """
+        Extract ellipsoid parameters (eigenvectors, radii etc.) from PeakShape object
+        :param peak_shape: PeakShape object of a integrated peak
+        :param ndims: number of dimensions in the MD workspace
+        :return radii: array of ellipsoid radii (3 sigma) defining peak region
+        :return bg_inner_radii: array of inner radii for ellipsoid background shell
+        :return bg_outer_radii: array of outer radii for ellipsoid background shell
+        :return evecs: ndims x ndims array of eignevectors - each column corresponds to an ellipsoid axis
+        :return translation: translation of the ellipsoid center in the coordinates/frame of the MD workspace integrated
+        """
         shape_info = json_loads(peak_shape.toJSON())
         if peak_shape.shapeName().lower() == "spherical":
             BaseSX.convert_spherical_representation_to_ellipsoid(shape_info)
@@ -774,6 +784,10 @@ class BaseSX(ABC):
 
     @staticmethod
     def _convert_spherical_representation_to_ellipsoid(shape_info: dict):
+        """
+        Update shape_info dict of a spherical peak shape to have same keys/fields as an ellipsoid
+        :param shape_info: dictionary of JSON shape representation
+        """
         # copied from mantidqt.widgets.sliceviewer.peaksviewer.representation.ellipsoid - can't import here though
         # convert shape_info dict from sphere to ellipsoid for plotting
         for key in ["radius", "background_inner_radius", "background_outer_radius"]:

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -691,7 +691,7 @@ class BaseSX(ABC):
                     mantid.DeleteWorkspace(ws_cut)
         except OSError:
             raise RuntimeError(
-                f"OutputFile ({output_file}) could not be opened - please check it is not open by "
+                f"OutputFile ({filename}) could not be opened - please check it is not open by "
                 f"another programme and that the user has permission to write to that directory."
             )
 

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -665,7 +665,7 @@ class BaseSX(ABC):
                         patch = Circle((0, 0), radii[imax] / box_lengths[imax], facecolor="none", edgecolor="r", ls="--")
                         ax.add_patch(patch)
                         # add background shell
-                        if np.all(bg_outer_radii > 1e-10):
+                        if not np.allclose(bg_outer_radii, 0.0):
                             patch = Circle(
                                 (0, 0), bg_outer_radii[imax] / box_lengths[imax], facecolor="none", edgecolor=3 * [0.7]
                             )  # outer radius
@@ -720,7 +720,7 @@ class BaseSX(ABC):
         cen = getattr(pk, frame_to_peak_centre_attr)()
         cen = np.matmul(evecs.T, np.array(cen) + translation)
         # get extents
-        box_lengths = bg_outer_radii if np.all(bg_outer_radii > 1e-10) else radii
+        box_lengths = bg_outer_radii if not np.allclose(bg_outer_radii, 0.0) else radii
         box_lengths = box_lengths * extent
         extents = np.vstack((cen - box_lengths, cen + box_lengths))
         # get nbins along each axis
@@ -768,10 +768,7 @@ class BaseSX(ABC):
         # copied from mantidqt.widgets.sliceviewer.peaksviewer.representation.ellipsoid - can't import here though
         # convert shape_info dict from sphere to ellipsoid for plotting
         for key in ["radius", "background_inner_radius", "background_outer_radius"]:
-            if key in shape_info:
-                shape_info[f"{key}{0}"] = shape_info.pop(key)
-            else:
-                shape_info[f"{key}{0}"] = 0.0  # null value
+            shape_info[f"{key}{0}"] = shape_info.pop(key) if key in shape_info else 0.0
             for idim in [1, 2]:
                 shape_info[f"{key}{idim}"] = shape_info[f"{key}{0}"]
         # add axes along basis vecs of frame and set 0 translation

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -722,6 +722,10 @@ class BaseSX(ABC):
         extents = np.vstack((cen - box_lengths, cen + box_lengths))
         # get nbins along each axis
         nbins = [int(nbins_max * radii[iax] / radii[imax]) for iax in range(len(radii))]
+        # ensure minimum of 3 bins inside radius along each dim
+        min_nbins_in_radius = np.min(nbins * radii / box_lengths)
+        if min_nbins_in_radius < 3:
+            nbins = nbins * 3 / min_nbins_in_radius
         # call BinMD
         ws_cut = mantid.BinMD(
             InputWorkspace=ws,
@@ -731,7 +735,7 @@ class BaseSX(ABC):
             BasisVector1=r"Q$_1$,unit," + ",".join(np.array2string(evecs[:, 1], precision=6).strip("[]").split()),
             BasisVector2=r"Q$_2$,unit," + ",".join(np.array2string(evecs[:, 2], precision=6).strip("[]").split()),
             OutputExtents=extents.flatten(order="F"),
-            OutputBins=nbins,
+            OutputBins=nbins.astype(int),
             EnableLogging=False,
         )
         return ws_cut, radii, bg_inner_radii, bg_outer_radii, box_lengths

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -642,7 +642,6 @@ class BaseSX(ABC):
         # loop over peaks and plot
         try:
             with PdfPages(filename) as pdf:
-                ws_cut = None
                 for ipk, pk in enumerate(peaks):
                     peak_shape = pk.getPeakShape()
                     if peak_shape.shapeName().lower() == "none":
@@ -691,9 +690,6 @@ class BaseSX(ABC):
                     fig.tight_layout()
                     pdf.savefig(fig)
                     close(fig)
-
-                if ws_cut is not None:
-                    mantid.DeleteWorkspace(ws_cut)
         except OSError:
             raise RuntimeError(
                 f"OutputFile ({filename}) could not be opened - please check it is not open by "
@@ -745,6 +741,7 @@ class BaseSX(ABC):
             OutputExtents=extents.flatten(order="F"),
             OutputBins=nbins.astype(int),
             EnableLogging=False,
+            StoreInADS=False,
         )
         return ws_cut, radii, bg_inner_radii, bg_outer_radii, box_lengths, imax
 


### PR DESCRIPTION
### Description of work

Add static method to `BaseSX` class to allow single-crystal users of SXD and WISH to plot result of IntegratePeaksMD and save in pdf

It plots 3 colorfill plots for each peak, taking the axes and extent for the call to `BinMD` from the peak shape (typically ellipsoid or sphere).

The axes of the cut are along the eigenvectors of the ellipsoid and the extents along each axis are +/- the outer background shell radius multiplied by some scale factor (it uses the peak radius if no background is supplied). This means that if the colorfill axes extents are set to [-1,1] (i.e. the axes are normalised by the  radii along the ellipsoid axes) then the ellipse in each plot can be plotted as a circle.

Fixes #35708

**Report to:** Pascal (WISH)

### To test:

(1) Run this script

```
from mantid.simpleapi import *
from Diffraction.single_crystal.base_sx import BaseSX

Load(Filename=r'SXD23767.raw', OutputWorkspace='SXD23767')
ws = ConvertToDiffractionMDWorkspace(InputWorkspace='SXD23767', OutputWorkspace='SXD23767_MD', 
                                OneEventPerBin=False, SplitThreshold=30)
peaks = FindPeaksMD(InputWorkspace='SXD23767_MD', PeakDistanceThreshold=0.4, MaxPeaks=10, 
            PeakFindingStrategy='NumberOfEventsNormalization', SignalThresholdFactor=10, 
            OutputType='Peak', OutputWorkspace='SingleCrystalPeakTable', EdgePixels=1) 
AddPeak(PeaksWorkspace=peaks, RunWorkspace='SXD23767', TOF=1364.7318584074724, DetectorID=35004, Height=384, BinCount=19.811577095134769)

peaks_int = IntegratePeaksMD(InputWorkspace='SXD23767_MD', PeakRadius='0.12', BackgroundInnerRadius='0.13', BackgroundOuterRadius='0.19', PeaksWorkspace='SingleCrystalPeakTable', OutputWorkspace='peaks_int', Ellipsoid=True, FixQAxis=True, CylinderLength=1, PercentBackground=1, UseOnePercentBackgroundCorrection=False, UseCentroid=True, MaskEdgeTubes=False)

BaseSX.plot_integrated_peaks_MD(ws, peaks_int, "/babylon/Public/RWaite/test_plot_MD.pdf", nbins_max=21, extent=1.5, log_norm=True)
```

A typical peak will look like this
![image](https://github.com/mantidproject/mantid/assets/55979119/8cd2a4ab-078e-4a41-a638-f4c7d0992918)

(2) Integrate peaks without a background and re-run
```
peaks_int = IntegratePeaksMD(InputWorkspace='SXD23767_MD', PeakRadius='0.12',  PeaksWorkspace='SingleCrystalPeakTable', OutputWorkspace='peaks_int', Ellipsoid=True, FixQAxis=True, CylinderLength=1, PercentBackground=1, UseOnePercentBackgroundCorrection=False, UseCentroid=True, MaskEdgeTubes=False)
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
