### PR TITLE
Remove unnecessary DLLExport from anonymous namespace struct

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -51,7 +51,7 @@ template <typename T> inline T extractValueAndClone(const boost::python::object 
   return boost::python::extract<T>(value)()->clone();
 }
 
-struct DLLExport FunctionPropertyValueHandler : public PropertyValueHandler {
+struct FunctionPropertyValueHandler : public PropertyValueHandler {
 
   /// Type required by TypeRegistry framework
   using HeldType = std::shared_ptr<IFunction>;


### PR DESCRIPTION
### Description of work
This PR removes an unnecessary `DLLExport` that was causing the following error on some dev builds:
```
4>C:\mantid-conda\mantid\Framework\PythonInterface\mantid\api\src\Exports\IFunction.cpp(94,1): error C2201: 
'const `anonymous namespace'::FunctionPropertyValueHandler::`vftable'': must have external linkage in order to 
be exported/imported
```

It was introduced in #36798

### To test:
Richard has checked this fixes his issue

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
