### PR TITLE
Allowing workspace tabs of Inelastic Elwin interface to add multiple workspaces at once

### DIFF
--- a/docs/source/release/v6.10.0/Inelastic/New_features/33319.rst
+++ b/docs/source/release/v6.10.0/Inelastic/New_features/33319.rst
@@ -1,0 +1,1 @@
+- Added new workspace dialog widget with the capacity to select and open multiple compatible workspaces at once. For use in :ref:`Elwin Tab <elwin>` of  :ref:`Data Manipulation Interface <interface-inelastic-data-manipulation>`

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
@@ -41,7 +41,7 @@ public:
 
   virtual void plotInput(Mantid::API::MatrixWorkspace_sptr inputWS, int spectrum) = 0;
   virtual void newInputFiles() = 0;
-  virtual void newInputFilesFromDialog(IDA::IAddWorkspaceDialog const *dialog) = 0;
+  virtual void newInputFilesFromDialog(std::vector<std::string> const &names) = 0;
   virtual void clearPreviewFile() = 0;
   virtual void clearInputFiles() = 0;
   virtual void setRunIsRunning(const bool running) = 0;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
@@ -18,7 +18,7 @@
 
 #include <algorithm>
 
-#include "MantidQtWidgets/Common/AddWorkspaceDialog.h"
+#include "MantidQtWidgets/Common/AddWorkspaceMultiDialog.h"
 
 using namespace Mantid::API;
 using namespace MantidQt::API;
@@ -282,12 +282,12 @@ void InelasticDataManipulationElwinTab::newInputFiles() {
  *
  * Updates preview selection combo box.
  */
-void InelasticDataManipulationElwinTab::newInputFilesFromDialog(MantidWidgets::IAddWorkspaceDialog const *dialog) {
+void InelasticDataManipulationElwinTab::newInputFilesFromDialog() {
   // Clear the existing list of files
   if (m_dataModel->getNumberOfWorkspaces().value < 2)
     m_view->clearPreviewFile();
 
-  m_view->newInputFilesFromDialog(dialog);
+  m_view->newInputFilesFromDialog(m_dataModel->getWorkspaceNames());
 
   std::string const wsname = m_view->getPreviewWorkspaceName(0);
   auto const inputWs = WorkspaceUtils::getADSWorkspace(wsname);
@@ -399,10 +399,11 @@ std::string InelasticDataManipulationElwinTab::getOutputBasename() {
 
 void InelasticDataManipulationElwinTab::handleAddData(MantidWidgets::IAddWorkspaceDialog const *dialog) {
   try {
+    std::cout << "You reach here" << std::endl;
     addDataToModel(dialog);
     updateTableFromModel();
-
-    newInputFilesFromDialog(dialog);
+    std::cout << "You also reach here" << std::endl;
+    newInputFilesFromDialog();
     m_view->plotInput(getInputWorkspace(), getSelectedSpectrum());
   } catch (const std::runtime_error &ex) {
     displayWarning(ex.what());
@@ -412,7 +413,7 @@ void InelasticDataManipulationElwinTab::handleAddData(MantidWidgets::IAddWorkspa
 void InelasticDataManipulationElwinTab::handleAddDataFromFile(MantidWidgets::IAddWorkspaceDialog const *dialog) {
   try {
     UserInputValidator uiv;
-    const auto indirectDialog = dynamic_cast<MantidWidgets::AddWorkspaceDialog const *>(dialog);
+    const auto indirectDialog = dynamic_cast<MantidWidgets::AddWorkspaceMultiDialog const *>(dialog);
     QList<QString> allFiles;
     allFiles.append(QString::fromStdString(indirectDialog->getFileName()));
     auto const suffixes = getFilteredSuffixes(allFiles);
@@ -433,8 +434,12 @@ void InelasticDataManipulationElwinTab::handleAddDataFromFile(MantidWidgets::IAd
 }
 
 void InelasticDataManipulationElwinTab::addDataToModel(MantidWidgets::IAddWorkspaceDialog const *dialog) {
-  if (const auto indirectDialog = dynamic_cast<MantidWidgets::AddWorkspaceDialog const *>(dialog))
-    m_dataModel->addWorkspace(indirectDialog->workspaceName(), indirectDialog->workspaceIndices());
+  if (const auto indirectDialog = dynamic_cast<MantidWidgets::AddWorkspaceMultiDialog const *>(dialog)) {
+    auto const nameIndexPairs = indirectDialog->selectedNameIndexPairs();
+    for (auto const &pair : nameIndexPairs) {
+      m_dataModel->addWorkspace(pair.first, FunctionModelSpectra(pair.second));
+    }
+  }
 }
 
 void InelasticDataManipulationElwinTab::updateTableFromModel() {

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
@@ -284,9 +284,7 @@ void InelasticDataManipulationElwinTab::newInputFiles() {
  */
 void InelasticDataManipulationElwinTab::newInputFilesFromDialog() {
   // Clear the existing list of files
-  if (m_dataModel->getNumberOfWorkspaces().value < 2)
-    m_view->clearPreviewFile();
-
+  m_view->clearPreviewFile();
   m_view->newInputFilesFromDialog(m_dataModel->getWorkspaceNames());
 
   std::string const wsname = m_view->getPreviewWorkspaceName(0);
@@ -403,29 +401,6 @@ void InelasticDataManipulationElwinTab::handleAddData(MantidWidgets::IAddWorkspa
     updateTableFromModel();
     newInputFilesFromDialog();
     m_view->plotInput(getInputWorkspace(), getSelectedSpectrum());
-  } catch (const std::runtime_error &ex) {
-    displayWarning(ex.what());
-  }
-}
-
-void InelasticDataManipulationElwinTab::handleAddDataFromFile(MantidWidgets::IAddWorkspaceDialog const *dialog) {
-  try {
-    UserInputValidator uiv;
-    const auto indirectDialog = dynamic_cast<MantidWidgets::AddWorkspaceMultiDialog const *>(dialog);
-    QList<QString> allFiles;
-    // allFiles.append(QString::fromStdString(indirectDialog->getFileName()));
-    auto const suffixes = getFilteredSuffixes(allFiles);
-    if (suffixes.size() < 1) {
-      uiv.addErrorMessage("The input files must be all _red or all _sqw.");
-      m_view->clearInputFiles();
-    }
-    std::string error = uiv.generateErrorMessage().toStdString();
-
-    if (error.empty()) {
-      handleAddData(dialog);
-    } else {
-      m_view->showMessageBox(error);
-    }
   } catch (const std::runtime_error &ex) {
     displayWarning(ex.what());
   }

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
@@ -399,10 +399,8 @@ std::string InelasticDataManipulationElwinTab::getOutputBasename() {
 
 void InelasticDataManipulationElwinTab::handleAddData(MantidWidgets::IAddWorkspaceDialog const *dialog) {
   try {
-    std::cout << "You reach here" << std::endl;
     addDataToModel(dialog);
     updateTableFromModel();
-    std::cout << "You also reach here" << std::endl;
     newInputFilesFromDialog();
     m_view->plotInput(getInputWorkspace(), getSelectedSpectrum());
   } catch (const std::runtime_error &ex) {
@@ -415,7 +413,7 @@ void InelasticDataManipulationElwinTab::handleAddDataFromFile(MantidWidgets::IAd
     UserInputValidator uiv;
     const auto indirectDialog = dynamic_cast<MantidWidgets::AddWorkspaceMultiDialog const *>(dialog);
     QList<QString> allFiles;
-    allFiles.append(QString::fromStdString(indirectDialog->getFileName()));
+    // allFiles.append(QString::fromStdString(indirectDialog->getFileName()));
     auto const suffixes = getFilteredSuffixes(allFiles);
     if (suffixes.size() < 1) {
       uiv.addErrorMessage("The input files must be all _red or all _sqw.");

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
@@ -67,7 +67,7 @@ public:
 
 protected:
   void runComplete(bool error) override;
-  void newInputFilesFromDialog(MantidWidgets::IAddWorkspaceDialog const *dialog);
+  void newInputFilesFromDialog();
   virtual void addDataToModel(MantidWidgets::IAddWorkspaceDialog const *dialog);
 
 private:

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
@@ -35,7 +35,6 @@ public:
   virtual void handlePreviewSpectrumChanged(int spectrum) = 0;
   virtual void handlePreviewIndexChanged(int index) = 0;
   virtual void handleAddData(MantidWidgets::IAddWorkspaceDialog const *dialog) = 0;
-  virtual void handleAddDataFromFile(MantidWidgets::IAddWorkspaceDialog const *dialog) = 0;
   virtual void handleRemoveSelectedData() = 0;
   virtual void updateAvailableSpectra() = 0;
 };
@@ -61,7 +60,6 @@ public:
   void handlePreviewSpectrumChanged(int spectrum) override;
   void handlePreviewIndexChanged(int index) override;
   void handleAddData(MantidWidgets::IAddWorkspaceDialog const *dialog) override;
-  void handleAddDataFromFile(MantidWidgets::IAddWorkspaceDialog const *dialog) override;
   void handleRemoveSelectedData() override;
   void updateAvailableSpectra() override;
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
@@ -8,6 +8,7 @@
 #include "Common/InterfaceUtils.h"
 #include "Common/WorkspaceUtils.h"
 #include "MantidGeometry/Instrument.h"
+#include "MantidQtWidgets/Common/ParseKeyValueString.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 #include "MantidQtWidgets/Plotting/RangeSelector.h"

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
@@ -16,7 +16,7 @@
 
 #include <algorithm>
 
-#include "MantidQtWidgets/Common/AddWorkspaceDialog.h"
+#include "MantidQtWidgets/Common/AddWorkspaceMultiDialog.h"
 
 using namespace Mantid::API;
 using namespace MantidQt::API;
@@ -186,14 +186,14 @@ void InelasticDataManipulationElwinTabView::notifyRemoveDataClicked() { m_presen
 void InelasticDataManipulationElwinTabView::notifyAddWorkspaceDialog() { showAddWorkspaceDialog(); }
 
 void InelasticDataManipulationElwinTabView::showAddWorkspaceDialog() {
-  auto dialog = new MantidWidgets::AddWorkspaceDialog(parentWidget());
+  auto dialog = new MantidWidgets::AddWorkspaceMultiDialog(parentWidget());
   connect(dialog, SIGNAL(addData(MantidWidgets::IAddWorkspaceDialog *)), this,
           SLOT(notifyAddData(MantidWidgets::IAddWorkspaceDialog *)));
   auto const tabName("Elwin");
+  dialog->setup();
   dialog->setAttribute(Qt::WA_DeleteOnClose);
   dialog->setWSSuffices(InterfaceUtils::getSampleWSSuffixes(tabName));
   dialog->setFBSuffices(InterfaceUtils::getSampleFBSuffixes(tabName));
-  dialog->updateSelectedSpectra();
   dialog->show();
 }
 
@@ -207,7 +207,7 @@ void InelasticDataManipulationElwinTabView::notifyAddData(MantidWidgets::IAddWor
  */
 void InelasticDataManipulationElwinTabView::addDataWksOrFile(MantidWidgets::IAddWorkspaceDialog const *dialog) {
   try {
-    const auto indirectDialog = dynamic_cast<MantidWidgets::AddWorkspaceDialog const *>(dialog);
+    const auto indirectDialog = dynamic_cast<MantidWidgets::AddWorkspaceMultiDialog const *>(dialog);
     if (indirectDialog) {
       // getFileName will be empty if the addWorkspaceDialog is set to Workspace instead of File.
       if (indirectDialog->getFileName().empty()) {
@@ -316,15 +316,11 @@ void InelasticDataManipulationElwinTabView::newInputFiles() {
  *
  * Updates preview selection combo box.
  */
-void InelasticDataManipulationElwinTabView::newInputFilesFromDialog(MantidWidgets::IAddWorkspaceDialog const *dialog) {
+void InelasticDataManipulationElwinTabView::newInputFilesFromDialog(std::vector<std::string> const &names) {
   // Populate the combo box with the filenames
   QString workspaceNames;
   QString filename;
-  if (const auto indirectDialog = dynamic_cast<MantidWidgets::AddWorkspaceDialog const *>(dialog)) {
-    workspaceNames = QString::fromStdString(indirectDialog->workspaceName());
-    filename = QString::fromStdString(indirectDialog->getFileName());
-  }
-  m_uiForm.cbPreviewFile->addItem(workspaceNames, filename);
+  m_uiForm.cbPreviewFile->addItems(MantidWidgets::stdVectorToQStringList(names));
 
   // Default to the first file
   setPreviewToDefault();

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
@@ -209,14 +209,11 @@ void InelasticDataManipulationElwinTabView::addDataWksOrFile(MantidWidgets::IAdd
   try {
     const auto indirectDialog = dynamic_cast<MantidWidgets::AddWorkspaceMultiDialog const *>(dialog);
     if (indirectDialog) {
-      // getFileName will be empty if the addWorkspaceDialog is set to Workspace instead of File.
-      if (indirectDialog->getFileName().empty()) {
+      if (!indirectDialog->isEmpty())
         m_presenter->handleAddData(dialog);
-      } else
-        m_presenter->handleAddDataFromFile(dialog);
-    } else
-      (throw std::invalid_argument("Unable to access AddWorkspaceDialog"));
-
+      else
+        (throw std::runtime_error("Unable to access data: No available workspaces or not selected"));
+    }
   } catch (const std::runtime_error &ex) {
     QMessageBox::warning(this->parentWidget(), "Warning! ", ex.what());
   }

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "Analysis/IndirectFitDataModel.h"
-
 #include "IElwinView.h"
 #include "InelasticDataManipulationElwinTab.h"
 #include "InelasticDataManipulationTab.h"
@@ -16,6 +15,7 @@
 #include "MantidQtWidgets/Common/FileFinderWidget.h"
 #include "MantidQtWidgets/Common/FunctionModelSpectra.h"
 #include "MantidQtWidgets/Common/IAddWorkspaceDialog.h"
+#include "MantidQtWidgets/Common/ParseKeyValueString.h"
 #include "ui_InelasticDataManipulationElwinTab.h"
 
 namespace MantidQt {
@@ -46,7 +46,7 @@ public:
 
   void plotInput(MatrixWorkspace_sptr inputWS, int spectrum) override;
   void newInputFiles() override;
-  void newInputFilesFromDialog(MantidWidgets::IAddWorkspaceDialog const *dialog) override;
+  void newInputFilesFromDialog(std::vector<std::string> const &names) override;
   void clearPreviewFile() override;
   void clearInputFiles() override;
   void setRunIsRunning(const bool running) override;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
@@ -15,7 +15,6 @@
 #include "MantidQtWidgets/Common/FileFinderWidget.h"
 #include "MantidQtWidgets/Common/FunctionModelSpectra.h"
 #include "MantidQtWidgets/Common/IAddWorkspaceDialog.h"
-#include "MantidQtWidgets/Common/ParseKeyValueString.h"
 #include "ui_InelasticDataManipulationElwinTab.h"
 
 namespace MantidQt {

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SRC_FILES
     src/AddWorkspaceDialog.cpp
+    src/AddWorkspaceMultiDialog.cpp
     src/AlgorithmDialog.cpp
     src/AlgorithmHistoryWindow.cpp
     src/AlgorithmInputHistory.cpp
@@ -111,6 +112,7 @@ set(SRC_FILES
     src/WorkspacePresenter/WorkspaceTreeWidget.cpp
     src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
     src/WorkspaceSelector.cpp
+    src/WorkspaceMultiSelector.cpp
     src/AlgorithmProgress/AlgorithmProgressDialogPresenter.cpp
     src/AlgorithmProgress/AlgorithmProgressDialogWidget.cpp
     src/AlgorithmProgress/AlgorithmProgressModel.cpp
@@ -156,6 +158,7 @@ set(SRC_FILES
 
 set(QT5_MOC_FILES
     inc/MantidQtWidgets/Common/AddWorkspaceDialog.h
+    inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
     inc/MantidQtWidgets/Common/AlgorithmDialog.h
     inc/MantidQtWidgets/Common/AlgorithmHistoryWindow.h
     inc/MantidQtWidgets/Common/AlgorithmPropertiesWidget.h
@@ -229,6 +232,7 @@ set(QT5_MOC_FILES
     inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
     inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
     inc/MantidQtWidgets/Common/WorkspaceSelector.h
+    inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
     inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressDialogPresenter.h
     inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressDialogWidget.h
     inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenter.h
@@ -339,6 +343,7 @@ set(QT5_INC_FILES
 
 set(QT5_UI_FILES
     inc/MantidQtWidgets/Common/AddWorkspaceDialog.ui
+    inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.ui
     inc/MantidQtWidgets/Common/DataSelector.ui
     inc/MantidQtWidgets/Common/EditLocalParameterDialog.ui
     inc/MantidQtWidgets/Common/LogValueSelector.ui
@@ -437,6 +442,7 @@ set(MOC_FILES
     inc/MantidQtWidgets/Common/TrackedAction.h
     inc/MantidQtWidgets/Common/UserFunctionDialog.h
     inc/MantidQtWidgets/Common/WorkspaceSelector.h
+    inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
     inc/MantidQtWidgets/Common/LineEditWithClear.h
     inc/MantidQtWidgets/Common/LogValueSelector.h
     inc/MantidQtWidgets/Common/FindFilesThreadPoolManager.h
@@ -592,6 +598,7 @@ set(INC_FILES
 
 set(UI_FILES
     inc/MantidQtWidgets/Common/AddWorkspaceDialog.ui
+    inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.ui
     inc/MantidQtWidgets/Common/DataSelector.ui
     inc/MantidQtWidgets/Common/CatalogSearch.ui
     inc/MantidQtWidgets/Common/CatalogSelector.ui

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
@@ -1,0 +1,52 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllOption.h"
+#include "MantidQtWidgets/Common/FunctionModelSpectra.h"
+#include "MantidQtWidgets/Common/IAddWorkspaceDialog.h"
+#include "ui_AddWorkspaceMultiDialog.h"
+
+#include <vector>
+
+#include <QDialog>
+
+namespace MantidQt {
+namespace MantidWidgets {
+
+class EXPORT_OPT_MANTIDQT_COMMON AddWorkspaceMultiDialog : public QDialog, public IAddWorkspaceDialog {
+  Q_OBJECT
+public:
+  explicit AddWorkspaceMultiDialog(QWidget *parent);
+
+  std::vector<std::string> workspaceNames() const;
+  FunctionModelSpectra workspaceIndices() const;
+
+  void setWSSuffices(const QStringList &suffices) override;
+  void setFBSuffices(const QStringList &suffices) override;
+
+  void updateSelectedSpectra() override;
+
+  std::string getFileName() const;
+
+signals:
+  void addData(MantidWidgets::IAddWorkspaceDialog *dialog);
+
+private slots:
+  void selectAllSpectra(int state);
+  void workspaceChanged(const QString &workspaceName);
+  void emitAddData();
+
+private:
+  void setWorkspace(const std::string &workspace);
+  void setAllSpectraSelectionEnabled(bool doEnable);
+
+  Ui::AddWorkspaceMultiDialog m_uiForm;
+};
+
+} // namespace MantidWidgets
+} // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DllOption.h"
+#include "MantidQtWidgets/Common/FileFinderWidget.h"
 #include "MantidQtWidgets/Common/FunctionModelSpectra.h"
 #include "MantidQtWidgets/Common/IAddWorkspaceDialog.h"
 #include "ui_AddWorkspaceMultiDialog.h"
@@ -23,28 +24,24 @@ class EXPORT_OPT_MANTIDQT_COMMON AddWorkspaceMultiDialog : public QDialog, publi
 public:
   explicit AddWorkspaceMultiDialog(QWidget *parent);
 
-  std::vector<std::string> workspaceNames() const;
-  FunctionModelSpectra workspaceIndices() const;
+  std::string workspaceName() const override;
+  stringPairVec selectedNameIndexPairs() const;
 
   void setWSSuffices(const QStringList &suffices) override;
   void setFBSuffices(const QStringList &suffices) override;
-
-  void updateSelectedSpectra() override;
-
-  std::string getFileName() const;
+  void setup();
 
 signals:
   void addData(MantidWidgets::IAddWorkspaceDialog *dialog);
 
-private slots:
-  void selectAllSpectra(int state);
-  void workspaceChanged(const QString &workspaceName);
+public slots:
+  void selectAllSpectra();
+  void unifyRange();
+  void updateSelectedSpectra() override;
+  void handleFilesFound();
   void emitAddData();
 
 private:
-  void setWorkspace(const std::string &workspace);
-  void setAllSpectraSelectionEnabled(bool doEnable);
-
   Ui::AddWorkspaceMultiDialog m_uiForm;
 };
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
@@ -7,8 +7,6 @@
 #pragma once
 
 #include "DllOption.h"
-#include "MantidQtWidgets/Common/FileFinderWidget.h"
-#include "MantidQtWidgets/Common/FunctionModelSpectra.h"
 #include "MantidQtWidgets/Common/IAddWorkspaceDialog.h"
 #include "ui_AddWorkspaceMultiDialog.h"
 
@@ -35,10 +33,10 @@ public:
 signals:
   void addData(MantidWidgets::IAddWorkspaceDialog *dialog);
 
-public slots:
+private slots:
+  void updateSelectedSpectra() override;
   void selectAllSpectra();
   void unifyRange();
-  void updateSelectedSpectra() override;
   void handleFilesFound();
   void emitAddData();
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
@@ -27,6 +27,7 @@ public:
   std::string workspaceName() const override;
   stringPairVec selectedNameIndexPairs() const;
 
+  bool isEmpty() const;
   void setWSSuffices(const QStringList &suffices) override;
   void setFBSuffices(const QStringList &suffices) override;
   void setup();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>320</width>
-    <height>324</height>
+    <width>462</width>
+    <height>489</height>
    </rect>
   </property>
   <property name="palette">
@@ -50,130 +50,290 @@
   <property name="windowTitle">
    <string>Multi Data Selection </string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QGroupBox" name="gbSelectData">
-     <property name="title">
-      <string>Select data</string>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetMinAndMaxSize</enum>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <layout class="QGridLayout" name="loInput">
-        <item row="1" column="1">
-         <widget class="MantidQt::MantidWidgets::DataSelector" name="dsWorkspace" native="true">
-          <property name="ShowGroups" stdset="0">
-           <bool>true</bool>
+     <item>
+      <widget class="QGroupBox" name="gbSelectData">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>50</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="title">
+        <string>Select data</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="0" column="0">
+         <widget class="MantidQt::MantidWidgets::WorkspaceMultiSelector" name="tbWorkspace">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="showLoad" stdset="0">
+          <property name="minimumSize">
+           <size>
+            <width>200</width>
+            <height>200</height>
+           </size>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::StyledPanel</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Plain</enum>
+          </property>
+          <property name="sizeAdjustPolicy">
+           <enum>QAbstractScrollArea::AdjustToContents</enum>
+          </property>
+          <property name="alternatingRowColors">
            <bool>false</bool>
           </property>
-          <property name="autoLoad" stdset="0">
+          <property name="selectionBehavior">
+           <enum>QAbstractItemView::SelectRows</enum>
+          </property>
+          <property name="showGrid">
            <bool>true</bool>
           </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="lbWorkspaceIndices">
-          <property name="text">
-           <string>Workspace Indices</string>
+          <property name="gridStyle">
+           <enum>Qt::SolidLine</enum>
           </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QCheckBox" name="ckAllSpectra">
-          <property name="text">
-           <string>All Spectra</string>
+          <property name="rowCount">
+           <number>0</number>
           </property>
+          <property name="columnCount">
+           <number>0</number>
+          </property>
+          <attribute name="verticalHeaderVisible">
+           <bool>false</bool>
+          </attribute>
+          <attribute name="verticalHeaderHighlightSections">
+           <bool>false</bool>
+          </attribute>
          </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLineEdit" name="leWorkspaceIndices"/>
         </item>
         <item row="0" column="1">
-         <widget class="MantidQt::MantidWidgets::WorkspaceMultiSelector" name="lsWorkspace"/>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QPushButton" name="pbSelAll">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Select All</string>
+            </property>
+            <property name="checkable">
+             <bool>false</bool>
+            </property>
+            <property name="flat">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pbUnify">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Unify Range</string>
+            </property>
+            <property name="checkable">
+             <bool>false</bool>
+            </property>
+            <property name="flat">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pbResetDefault">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Reset Range</string>
+            </property>
+            <property name="checkable">
+             <bool>false</bool>
+            </property>
+            <property name="flat">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer">
+            <property name="minimumSize">
+             <size>
+              <width>196</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Expanding</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
-        <item row="0" column="0" alignment="Qt::AlignHCenter|Qt::AlignTop">
-         <widget class="QLabel" name="lbWorkspace">
-          <property name="text">
-           <string>Workspace</string>
+        <item row="1" column="0" rowspan="2" colspan="2">
+         <widget class="MantidQt::API::FileFinderWidget" name="dsInputFiles" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>30</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="findRunFiles" stdset="0">
+           <bool>false</bool>
+          </property>
+          <property name="label" stdset="0">
+           <string>Input File</string>
+          </property>
+          <property name="multipleFiles" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="fileExtensions" stdset="0">
+           <stringlist>
+            <string>_red.nxs</string>
+            <string>_sqw.nxs</string>
+           </stringlist>
           </property>
          </widget>
         </item>
        </layout>
-      </item>
-      <item>
-       <spacer name="spacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QFrame" name="frame">
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbAdd">
-        <property name="text">
-         <string>Add</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbClose">
-        <property name="text">
-         <string>Close</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QPushButton" name="pbAdd">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Add Data</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pbClose">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>20</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Close</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
+   <class>MantidQt::MantidWidgets::WorkspaceMultiSelector</class>
+   <extends>QTableWidget</extends>
+   <header>MantidQtWidgets/Common/WorkspaceMultiSelector.h</header>
   </customwidget>
   <customwidget>
-   <class>MantidQt::MantidWidgets::WorkspaceMultiSelector</class>
-   <extends>QListWidget</extends>
-   <header>MantidQtWidgets/Common/WorkspaceMultiSelector.h</header>
+   <class>MantidQt::API::FileFinderWidget</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.ui
@@ -1,17 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>AddWorkspaceDialog</class>
- <widget class="QDialog" name="AddWorkspaceDialog">
+ <class>AddWorkspaceMultiDialog</class>
+ <widget class="QDialog" name="AddWorkspaceMultiDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>393</width>
-    <height>181</height>
+    <width>320</width>
+    <height>324</height>
    </rect>
   </property>
+  <property name="palette">
+   <palette>
+    <active>
+     <colorrole role="Button">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>70</red>
+        <green>70</green>
+        <blue>70</blue>
+       </color>
+      </brush>
+     </colorrole>
+    </active>
+    <inactive>
+     <colorrole role="Button">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>70</red>
+        <green>70</green>
+        <blue>70</blue>
+       </color>
+      </brush>
+     </colorrole>
+    </inactive>
+    <disabled>
+     <colorrole role="Button">
+      <brush brushstyle="SolidPattern">
+       <color alpha="255">
+        <red>70</red>
+        <green>70</green>
+        <blue>70</blue>
+       </color>
+      </brush>
+     </colorrole>
+    </disabled>
+   </palette>
+  </property>
   <property name="windowTitle">
-   <string>Data Selection</string>
+   <string>Multi Data Selection </string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -22,7 +59,7 @@
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QGridLayout" name="loInput">
-        <item row="0" column="1">
+        <item row="1" column="1">
          <widget class="MantidQt::MantidWidgets::DataSelector" name="dsWorkspace" native="true">
           <property name="ShowGroups" stdset="0">
            <bool>true</bool>
@@ -35,27 +72,30 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
+        <item row="2" column="0">
          <widget class="QLabel" name="lbWorkspaceIndices">
           <property name="text">
            <string>Workspace Indices</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="lbWorkspace">
-          <property name="text">
-           <string>Workspace</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="leWorkspaceIndices"/>
-        </item>
-        <item row="2" column="1">
+        <item row="3" column="1">
          <widget class="QCheckBox" name="ckAllSpectra">
           <property name="text">
            <string>All Spectra</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLineEdit" name="leWorkspaceIndices"/>
+        </item>
+        <item row="0" column="1">
+         <widget class="MantidQt::MantidWidgets::WorkspaceMultiSelector" name="lsWorkspace"/>
+        </item>
+        <item row="0" column="0" alignment="Qt::AlignHCenter|Qt::AlignTop">
+         <widget class="QLabel" name="lbWorkspace">
+          <property name="text">
+           <string>Workspace</string>
           </property>
          </widget>
         </item>
@@ -129,6 +169,11 @@
    <class>MantidQt::MantidWidgets::DataSelector</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/DataSelector.h</header>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::WorkspaceMultiSelector</class>
+   <extends>QListWidget</extends>
+   <header>MantidQtWidgets/Common/WorkspaceMultiSelector.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
@@ -108,7 +108,8 @@ private:
   // show/hide workspace groups
   bool m_showGroups;
   /// Allows you to put limits on the size of the workspace i.e. number of bins
-  std::optional<std::pair<int, int>> m_binLimits;
+  std::optional<int> m_lowerBin;
+  std::optional<int> m_upperBin;
   QStringList m_suffix;
 
   // Mutex for synchronized event handling

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
@@ -62,8 +62,6 @@ public:
   QStringList getWSSuffixes() const;
   void setWorkspaceTypes(const QStringList &types);
   void setWSSuffixes(const QStringList &suffix);
-  void setLowerBinLimit(int numberOfBins);
-  void setUpperBinLimit(int numberOfBins);
 
   bool isValid() const;
 
@@ -83,7 +81,6 @@ private:
 
   bool checkEligibility(const std::string &name) const;
   bool hasValidSuffix(const std::string &name) const;
-  bool hasValidNumberOfBins(const Mantid::API::Workspace_sptr &object) const;
 
   void addItem(const std::string &name);
   void addItems(const std::vector<std::string> &names);
@@ -107,9 +104,6 @@ private:
   QStringList m_workspaceTypes;
   // show/hide workspace groups
   bool m_showGroups;
-  /// Allows you to put limits on the size of the workspace i.e. number of bins
-  std::optional<int> m_lowerBin;
-  std::optional<int> m_upperBin;
   QStringList m_suffix;
 
   // Mutex for synchronized event handling

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
@@ -11,6 +11,7 @@
 #include <QStringList>
 #include <QTableWidget>
 #include <mutex>
+#include <optional>
 
 #include <Poco/AutoPtr.h>
 #include <Poco/NObserver.h>
@@ -40,7 +41,6 @@ class EXPORT_OPT_MANTIDQT_COMMON WorkspaceMultiSelector : public QTableWidget {
   Q_PROPERTY(bool ShowHidden READ showHiddenWorkspaces WRITE showHiddenWorkspaces)
   Q_PROPERTY(bool ShowGroups READ showWorkspaceGroups WRITE showWorkspaceGroups)
   Q_PROPERTY(QStringList Suffix READ getWSSuffixes WRITE setWSSuffixes)
-  friend class AddWorkspaceMultiDialog;
 
 public:
   /// Default Constructor
@@ -86,7 +86,7 @@ private:
   void handleReplaceEvent(Mantid::API::WorkspaceAfterReplaceNotification_ptr pNf);
 
   bool checkEligibility(const std::string &name) const;
-  bool hasValidSuffix(const QString &name) const;
+  bool hasValidSuffix(const std::string &name) const;
   bool hasValidNumberOfBins(const Mantid::API::Workspace_sptr &object) const;
 
   void addItem(const std::string &name);
@@ -106,7 +106,6 @@ private:
   Poco::NObserver<WorkspaceMultiSelector, Mantid::API::WorkspaceAfterReplaceNotification> m_replaceObserver;
 
   bool m_init;
-  bool m_connected;
 
   /// A list of workspace types that should be shown in the QtableWidget
   QStringList m_workspaceTypes;
@@ -115,7 +114,7 @@ private:
   // show/hide workspace groups
   bool m_showGroups;
   /// Allows you to put limits on the size of the workspace i.e. number of bins
-  std::pair<int, int> m_binLimits;
+  std::optional<std::pair<int, int>> m_binLimits;
   QStringList m_suffix;
 
   // Mutex for synchronized event handling

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
@@ -38,7 +38,6 @@ class EXPORT_OPT_MANTIDQT_COMMON WorkspaceMultiSelector : public QTableWidget {
   Q_OBJECT
 
   Q_PROPERTY(QStringList WorkspaceTypes READ getWorkspaceTypes WRITE setWorkspaceTypes)
-  Q_PROPERTY(bool ShowHidden READ showHiddenWorkspaces WRITE showHiddenWorkspaces)
   Q_PROPERTY(bool ShowGroups READ showWorkspaceGroups WRITE showWorkspaceGroups)
   Q_PROPERTY(QStringList Suffix READ getWSSuffixes WRITE setWSSuffixes)
 
@@ -55,8 +54,6 @@ public:
   void resetIndexRangeToDefault();
   void unifyRange();
 
-  bool showHiddenWorkspaces() const;
-  void showHiddenWorkspaces(bool show);
   bool showWorkspaceGroups() const;
   void showWorkspaceGroups(bool show);
   stringPairVec retrieveSelectedNameIndexPairs();
@@ -69,7 +66,6 @@ public:
   void setUpperBinLimit(int numberOfBins);
 
   bool isValid() const;
-  bool isConnected() const;
 
   void connectObservers();
   void disconnectObservers();
@@ -109,8 +105,6 @@ private:
 
   /// A list of workspace types that should be shown in the QtableWidget
   QStringList m_workspaceTypes;
-  /// Whether to show "hidden" workspaces
-  bool m_showHidden;
   // show/hide workspace groups
   bool m_showGroups;
   /// Allows you to put limits on the size of the workspace i.e. number of bins

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
@@ -1,0 +1,138 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2011 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllOption.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include <QListWidget>
+#include <QStringList>
+#include <mutex>
+
+#include <Poco/AutoPtr.h>
+#include <Poco/NObserver.h>
+
+// Forward declarations
+namespace Mantid {
+namespace API {
+class Algorithm;
+}
+} // namespace Mantid
+
+namespace MantidQt {
+namespace MantidWidgets {
+/**
+This class defines a widget for selecting a workspace present in the
+AnalysisDataService
+
+Subscribes to the WorkspaceAddNotification and WorkspaceDeleteNotification from
+the ADS.
+
+Types of workspace to show can be restricted in several ways:
+
+ * By listing allowed WorkspaceIDs to show (Workspace2D, TableWorkspace, etc)
+ * By deciding whether or not to show "hidden" workspaces (identified with a
+double underscore at the start of the
+          workspace name
+ * By providing a suffix that the workspace name must have
+ * By giving the name of an algorithm, each workspace will be validated as an
+input to the workspaces first input WorkspaceProperty
+
+@author Michael Whitty
+@date 23/02/2011
+*/
+class EXPORT_OPT_MANTIDQT_COMMON WorkspaceMultiSelector : public QListWidget {
+  Q_OBJECT
+
+  Q_PROPERTY(QStringList WorkspaceTypes READ getWorkspaceTypes WRITE setWorkspaceTypes)
+  Q_PROPERTY(bool ShowHidden READ showHiddenWorkspaces WRITE showHiddenWorkspaces)
+  Q_PROPERTY(bool ShowGroups READ showWorkspaceGroups WRITE showWorkspaceGroups)
+  Q_PROPERTY(bool Optional READ isOptional WRITE setOptional)
+  Q_PROPERTY(QStringList Suffix READ getWSSuffixes WRITE setWSSuffixes)
+  friend class DataSelector;
+
+public:
+  // using QComboBox::currentIndexChanged;
+
+  /// Default Constructor
+  WorkspaceMultiSelector(QWidget *parent = nullptr, bool init = true);
+  /// Destructor
+  ~WorkspaceMultiSelector() override;
+
+  QStringList getWorkspaceTypes() const;
+  void setWorkspaceTypes(const QStringList &types);
+  bool showHiddenWorkspaces() const;
+  void showHiddenWorkspaces(bool show);
+  bool showWorkspaceGroups() const;
+  void showWorkspaceGroups(bool show);
+  bool isOptional() const;
+  void setOptional(bool optional);
+  QStringList getWSSuffixes() const;
+  void setWSSuffixes(const QStringList &suffix);
+  void setLowerBinLimit(int numberOfBins);
+  void setUpperBinLimit(int numberOfBins);
+  bool isValid() const;
+  void refresh();
+  void disconnectObservers();
+  void connectObservers();
+  bool isConnected() const;
+
+signals:
+  void emptied();
+  void focussed();
+
+private:
+  void handleAddEvent(Mantid::API::WorkspaceAddNotification_ptr pNf);
+  void handleRemEvent(Mantid::API::WorkspacePostDeleteNotification_ptr pNf);
+  void handleClearEvent(Mantid::API::ClearADSNotification_ptr pNf);
+  void handleRenameEvent(Mantid::API::WorkspaceRenameNotification_ptr pNf);
+  void handleReplaceEvent(Mantid::API::WorkspaceAfterReplaceNotification_ptr pNf);
+
+  bool checkEligibility(const QString &name, const Mantid::API::Workspace_sptr &object) const;
+  bool hasValidSuffix(const QString &name) const;
+  bool hasValidNumberOfBins(const Mantid::API::Workspace_sptr &object) const;
+
+protected:
+  // Method for handling drop events
+  void dropEvent(QDropEvent * /*unused*/) override;
+  // called when a drag event enters the class
+  void dragEnterEvent(QDragEnterEvent * /*unused*/) override;
+  // Method for handling focus in events
+  void focusInEvent(QFocusEvent * /*unused*/) override;
+
+private:
+  /// Poco Observers for ADS Notifications
+  Poco::NObserver<WorkspaceMultiSelector, Mantid::API::WorkspaceAddNotification> m_addObserver;
+  Poco::NObserver<WorkspaceMultiSelector, Mantid::API::WorkspacePostDeleteNotification> m_remObserver;
+  Poco::NObserver<WorkspaceMultiSelector, Mantid::API::ClearADSNotification> m_clearObserver;
+  Poco::NObserver<WorkspaceMultiSelector, Mantid::API::WorkspaceRenameNotification> m_renameObserver;
+  Poco::NObserver<WorkspaceMultiSelector, Mantid::API::WorkspaceAfterReplaceNotification> m_replaceObserver;
+
+  bool m_init;
+  bool m_connected;
+
+  /// A list of workspace types that should be shown in the ComboBox
+  QStringList m_workspaceTypes;
+  /// Whether to show "hidden" workspaces
+  bool m_showHidden;
+  // show/hide workspace groups
+  bool m_showGroups;
+  /// Whether to add an extra empty entry to the combobox
+  bool m_optional;
+  /// Allows you to put limits on the size of the workspace i.e. number of bins
+  std::pair<int, int> m_binLimits;
+  QStringList m_suffix;
+  QString m_algName;
+  QString m_algPropName;
+
+  // Algorithm to validate against
+  std::shared_ptr<Mantid::API::Algorithm> m_algorithm;
+
+  // Mutex for synchronized event handling
+  std::mutex m_adsMutex;
+};
+} // namespace MantidWidgets
+} // namespace MantidQt

--- a/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
+++ b/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
@@ -77,7 +77,7 @@ void AddWorkspaceMultiDialog::unifyRange() { return m_uiForm.tbWorkspace->unifyR
 
 void AddWorkspaceMultiDialog::handleFilesFound() {
   auto fileNames = m_uiForm.dsInputFiles->getFilenames();
-  for (auto &fileName : fileNames) {
+  for (auto const &fileName : fileNames) {
     loadFile(fileName);
   }
   return;

--- a/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
+++ b/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
@@ -1,0 +1,148 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidQtWidgets/Common/AddWorkspaceMultiDialog.h"
+
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/MatrixWorkspace.h"
+
+#include <boost/optional.hpp>
+#include <utility>
+
+namespace {
+using namespace Mantid::API;
+
+MatrixWorkspace_sptr getWorkspace(const std::string &name) {
+  return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
+}
+
+bool doesExistInADS(std::string const &workspaceName) {
+  return AnalysisDataService::Instance().doesExist(workspaceName);
+}
+
+bool validWorkspace(std::string const &name) { return !name.empty() && doesExistInADS(name); }
+
+boost::optional<std::size_t> maximumIndex(const MatrixWorkspace_sptr &workspace) {
+  if (workspace) {
+    const auto numberOfHistograms = workspace->getNumberHistograms();
+    if (numberOfHistograms > 0)
+      return numberOfHistograms - 1;
+  }
+  return boost::none;
+}
+
+QString getIndexString(const MatrixWorkspace_sptr &workspace) {
+  const auto maximum = maximumIndex(workspace);
+  if (maximum) {
+    if (*maximum > 0)
+      return QString("0-%1").arg(*maximum);
+    return "0";
+  }
+  return "";
+}
+
+QString getIndexString(const std::string &workspaceName) { return getIndexString(getWorkspace(workspaceName)); }
+
+std::unique_ptr<QRegExpValidator> createValidator(const QString &regex, QObject *parent) {
+  return std::make_unique<QRegExpValidator>(QRegExp(regex), parent);
+}
+
+QString OR(const QString &lhs, const QString &rhs) { return "(" + lhs + "|" + rhs + ")"; }
+
+QString NATURAL_NUMBER(std::size_t digits) { return OR("0", "[1-9][0-9]{," + QString::number(digits - 1) + "}"); }
+
+const QString EMPTY = "^$";
+const QString SPACE = "(\\s)*";
+const QString COMMA = SPACE + "," + SPACE;
+const QString MINUS = "\\-";
+
+const QString NUMBER = NATURAL_NUMBER(4);
+const QString NATURAL_RANGE = "(" + NUMBER + MINUS + NUMBER + ")";
+const QString NATURAL_OR_RANGE = OR(NATURAL_RANGE, NUMBER);
+const QString SPECTRA_LIST = "(" + NATURAL_OR_RANGE + "(" + COMMA + NATURAL_OR_RANGE + ")*)";
+} // namespace
+
+namespace MantidQt::MantidWidgets {
+
+AddWorkspaceMultiDialog::AddWorkspaceMultiDialog(QWidget *parent) : QDialog(parent) {
+  m_uiForm.setupUi(this);
+  m_uiForm.leWorkspaceIndices->setValidator(createValidator(SPECTRA_LIST, this).release());
+  setAllSpectraSelectionEnabled(false);
+
+  connect(m_uiForm.dsWorkspace, SIGNAL(dataReady(const QString &)), this, SLOT(workspaceChanged(const QString &)));
+  connect(m_uiForm.ckAllSpectra, SIGNAL(stateChanged(int)), this, SLOT(selectAllSpectra(int)));
+  connect(m_uiForm.pbAdd, SIGNAL(clicked()), this, SLOT(emitAddData()));
+  connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SLOT(close()));
+}
+
+std::vector<std::string> AddWorkspaceMultiDialog::workspaceNames() const {
+  std::vector<std::string> wkspNames;
+  auto selItems = m_uiForm.lsWorkspace->selectedItems();
+  wkspNames.reserve(static_cast<std::size_t>(selItems.size()));
+  for (auto item : selItems) {
+    std::string txt = item->text().toStdString();
+    if (txt != "") {
+      wkspNames.push_back(txt);
+    }
+  }
+  wkspNames.shrink_to_fit();
+  return wkspNames;
+}
+
+FunctionModelSpectra AddWorkspaceMultiDialog::workspaceIndices() const {
+  return FunctionModelSpectra(m_uiForm.leWorkspaceIndices->text().toStdString());
+}
+
+void AddWorkspaceMultiDialog::setWSSuffices(const QStringList &suffices) {
+  m_uiForm.lsWorkspace->setWSSuffixes(suffices);
+}
+
+void AddWorkspaceMultiDialog::setFBSuffices(const QStringList &suffices) {
+  m_uiForm.dsWorkspace->setFBSuffixes(suffices);
+}
+
+void AddWorkspaceMultiDialog::updateSelectedSpectra() {
+  auto const state = m_uiForm.ckAllSpectra->isChecked() ? Qt::Checked : Qt::Unchecked;
+  selectAllSpectra(state);
+}
+
+void AddWorkspaceMultiDialog::selectAllSpectra(int state) {
+  auto const name = workspaceName();
+  if (validWorkspace(name) && state == Qt::Checked) {
+    m_uiForm.leWorkspaceIndices->setText(getIndexString(name));
+    m_uiForm.leWorkspaceIndices->setEnabled(false);
+  } else
+    m_uiForm.leWorkspaceIndices->setEnabled(true);
+}
+
+void AddWorkspaceMultiDialog::workspaceChanged(const QString &workspaceName) {
+  const auto name = workspaceName.toStdString();
+  const auto workspace = getWorkspace(name);
+  if (workspace)
+    setWorkspace(name);
+  else
+    setAllSpectraSelectionEnabled(false);
+}
+
+void AddWorkspaceMultiDialog::emitAddData() { emit addData(this); }
+
+void AddWorkspaceMultiDialog::setWorkspace(const std::string &workspace) {
+  setAllSpectraSelectionEnabled(true);
+  if (m_uiForm.ckAllSpectra->isChecked()) {
+    m_uiForm.leWorkspaceIndices->setText(getIndexString(workspace));
+    m_uiForm.leWorkspaceIndices->setEnabled(false);
+  }
+}
+
+void AddWorkspaceMultiDialog::setAllSpectraSelectionEnabled(bool doEnable) {
+  m_uiForm.ckAllSpectra->setEnabled(doEnable);
+}
+
+std::string AddWorkspaceMultiDialog::getFileName() const {
+  return m_uiForm.dsWorkspace->getFullFilePath().toStdString();
+}
+
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
+++ b/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
@@ -37,7 +37,9 @@ AddWorkspaceMultiDialog::AddWorkspaceMultiDialog(QWidget *parent) : QDialog(pare
   connect(m_uiForm.pbAdd, SIGNAL(clicked()), this, SLOT(emitAddData()));
   connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SLOT(close()));
 }
-std::string AddWorkspaceMultiDialog::workspaceName() const { return std::string(""); }
+std::string AddWorkspaceMultiDialog::workspaceName() const {
+  throw std::logic_error("This method is not implemented in AddWorkspaceMultiDialog class and shouldn't be called");
+}
 
 void AddWorkspaceMultiDialog::setup() { m_uiForm.tbWorkspace->setupTable(); }
 

--- a/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
+++ b/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
@@ -18,16 +18,6 @@
 namespace {
 using namespace Mantid::API;
 
-MatrixWorkspace_sptr getWorkspace(const std::string &name) {
-  return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
-}
-
-bool doesExistInADS(std::string const &workspaceName) {
-  return AnalysisDataService::Instance().doesExist(workspaceName);
-}
-
-bool validWorkspace(std::string const &name) { return !name.empty() && doesExistInADS(name); }
-
 void loadFile(const QString &filename) {
   QFileInfo fileinfo(filename);
 
@@ -63,6 +53,10 @@ void AddWorkspaceMultiDialog::setup() {
 stringPairVec AddWorkspaceMultiDialog::selectedNameIndexPairs() const {
 
   return m_uiForm.tbWorkspace->retrieveSelectedNameIndexPairs();
+}
+
+bool AddWorkspaceMultiDialog::isEmpty() const {
+  return ((m_uiForm.tbWorkspace->rowCount() == 0) || (m_uiForm.tbWorkspace->selectedItems().isEmpty()));
 }
 
 void AddWorkspaceMultiDialog::setWSSuffices(const QStringList &suffices) {

--- a/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
+++ b/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
@@ -5,14 +5,8 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/AddWorkspaceMultiDialog.h"
-
 #include "MantidAPI/AlgorithmManager.h"
-#include "MantidAPI/AnalysisDataService.h"
-#include "MantidAPI/MatrixWorkspace.h"
-#include "MantidQtWidgets/Common/ParseKeyValueString.h"
 #include <QFileInfo>
-
-#include <boost/optional.hpp>
 #include <utility>
 
 namespace {
@@ -45,10 +39,7 @@ AddWorkspaceMultiDialog::AddWorkspaceMultiDialog(QWidget *parent) : QDialog(pare
 }
 std::string AddWorkspaceMultiDialog::workspaceName() const { return std::string(""); }
 
-void AddWorkspaceMultiDialog::setup() {
-  m_uiForm.tbWorkspace->setupTable();
-  return;
-}
+void AddWorkspaceMultiDialog::setup() { m_uiForm.tbWorkspace->setupTable(); }
 
 stringPairVec AddWorkspaceMultiDialog::selectedNameIndexPairs() const {
 
@@ -80,7 +71,6 @@ void AddWorkspaceMultiDialog::handleFilesFound() {
   for (auto const &fileName : fileNames) {
     loadFile(fileName);
   }
-  return;
 }
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
+++ b/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
@@ -6,8 +6,11 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/AddWorkspaceMultiDialog.h"
 
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidQtWidgets/Common/ParseKeyValueString.h"
+#include <QFileInfo>
 
 #include <boost/optional.hpp>
 #include <utility>
@@ -25,124 +28,65 @@ bool doesExistInADS(std::string const &workspaceName) {
 
 bool validWorkspace(std::string const &name) { return !name.empty() && doesExistInADS(name); }
 
-boost::optional<std::size_t> maximumIndex(const MatrixWorkspace_sptr &workspace) {
-  if (workspace) {
-    const auto numberOfHistograms = workspace->getNumberHistograms();
-    if (numberOfHistograms > 0)
-      return numberOfHistograms - 1;
-  }
-  return boost::none;
+void loadFile(const QString &filename) {
+  QFileInfo fileinfo(filename);
+
+  auto loader = AlgorithmManager::Instance().createUnmanaged("Load");
+  loader->initialize();
+  loader->setProperty("Filename", filename.toStdString());
+  loader->setProperty("OutputWorkspace", fileinfo.baseName().toStdString());
+  loader->execute();
+
+  return;
 }
-
-QString getIndexString(const MatrixWorkspace_sptr &workspace) {
-  const auto maximum = maximumIndex(workspace);
-  if (maximum) {
-    if (*maximum > 0)
-      return QString("0-%1").arg(*maximum);
-    return "0";
-  }
-  return "";
-}
-
-QString getIndexString(const std::string &workspaceName) { return getIndexString(getWorkspace(workspaceName)); }
-
-std::unique_ptr<QRegExpValidator> createValidator(const QString &regex, QObject *parent) {
-  return std::make_unique<QRegExpValidator>(QRegExp(regex), parent);
-}
-
-QString OR(const QString &lhs, const QString &rhs) { return "(" + lhs + "|" + rhs + ")"; }
-
-QString NATURAL_NUMBER(std::size_t digits) { return OR("0", "[1-9][0-9]{," + QString::number(digits - 1) + "}"); }
-
-const QString EMPTY = "^$";
-const QString SPACE = "(\\s)*";
-const QString COMMA = SPACE + "," + SPACE;
-const QString MINUS = "\\-";
-
-const QString NUMBER = NATURAL_NUMBER(4);
-const QString NATURAL_RANGE = "(" + NUMBER + MINUS + NUMBER + ")";
-const QString NATURAL_OR_RANGE = OR(NATURAL_RANGE, NUMBER);
-const QString SPECTRA_LIST = "(" + NATURAL_OR_RANGE + "(" + COMMA + NATURAL_OR_RANGE + ")*)";
 } // namespace
 
 namespace MantidQt::MantidWidgets {
 
 AddWorkspaceMultiDialog::AddWorkspaceMultiDialog(QWidget *parent) : QDialog(parent) {
   m_uiForm.setupUi(this);
-  m_uiForm.leWorkspaceIndices->setValidator(createValidator(SPECTRA_LIST, this).release());
-  setAllSpectraSelectionEnabled(false);
 
-  connect(m_uiForm.dsWorkspace, SIGNAL(dataReady(const QString &)), this, SLOT(workspaceChanged(const QString &)));
-  connect(m_uiForm.ckAllSpectra, SIGNAL(stateChanged(int)), this, SLOT(selectAllSpectra(int)));
+  connect(m_uiForm.pbSelAll, SIGNAL(clicked()), this, SLOT(selectAllSpectra()));
+  connect(m_uiForm.pbResetDefault, SIGNAL(clicked()), this, SLOT(updateSelectedSpectra()));
+  connect(m_uiForm.dsInputFiles, SIGNAL(filesFound()), this, SLOT(handleFilesFound()));
+  connect(m_uiForm.pbUnify, SIGNAL(clicked()), this, SLOT(unifyRange()));
   connect(m_uiForm.pbAdd, SIGNAL(clicked()), this, SLOT(emitAddData()));
   connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SLOT(close()));
 }
+std::string AddWorkspaceMultiDialog::workspaceName() const { return std::string(""); }
 
-std::vector<std::string> AddWorkspaceMultiDialog::workspaceNames() const {
-  std::vector<std::string> wkspNames;
-  auto selItems = m_uiForm.lsWorkspace->selectedItems();
-  wkspNames.reserve(static_cast<std::size_t>(selItems.size()));
-  for (auto item : selItems) {
-    std::string txt = item->text().toStdString();
-    if (txt != "") {
-      wkspNames.push_back(txt);
-    }
-  }
-  wkspNames.shrink_to_fit();
-  return wkspNames;
+void AddWorkspaceMultiDialog::setup() {
+  m_uiForm.tbWorkspace->setupTable();
+  return;
 }
 
-FunctionModelSpectra AddWorkspaceMultiDialog::workspaceIndices() const {
-  return FunctionModelSpectra(m_uiForm.leWorkspaceIndices->text().toStdString());
+stringPairVec AddWorkspaceMultiDialog::selectedNameIndexPairs() const {
+
+  return m_uiForm.tbWorkspace->retrieveSelectedNameIndexPairs();
 }
 
 void AddWorkspaceMultiDialog::setWSSuffices(const QStringList &suffices) {
-  m_uiForm.lsWorkspace->setWSSuffixes(suffices);
+  m_uiForm.tbWorkspace->setWSSuffixes(suffices);
 }
 
 void AddWorkspaceMultiDialog::setFBSuffices(const QStringList &suffices) {
-  m_uiForm.dsWorkspace->setFBSuffixes(suffices);
+  return m_uiForm.dsInputFiles->setFileExtensions(suffices);
 }
 
-void AddWorkspaceMultiDialog::updateSelectedSpectra() {
-  auto const state = m_uiForm.ckAllSpectra->isChecked() ? Qt::Checked : Qt::Unchecked;
-  selectAllSpectra(state);
-}
-
-void AddWorkspaceMultiDialog::selectAllSpectra(int state) {
-  auto const name = workspaceName();
-  if (validWorkspace(name) && state == Qt::Checked) {
-    m_uiForm.leWorkspaceIndices->setText(getIndexString(name));
-    m_uiForm.leWorkspaceIndices->setEnabled(false);
-  } else
-    m_uiForm.leWorkspaceIndices->setEnabled(true);
-}
-
-void AddWorkspaceMultiDialog::workspaceChanged(const QString &workspaceName) {
-  const auto name = workspaceName.toStdString();
-  const auto workspace = getWorkspace(name);
-  if (workspace)
-    setWorkspace(name);
-  else
-    setAllSpectraSelectionEnabled(false);
-}
+void AddWorkspaceMultiDialog::selectAllSpectra() { return m_uiForm.tbWorkspace->selectAll(); }
 
 void AddWorkspaceMultiDialog::emitAddData() { emit addData(this); }
 
-void AddWorkspaceMultiDialog::setWorkspace(const std::string &workspace) {
-  setAllSpectraSelectionEnabled(true);
-  if (m_uiForm.ckAllSpectra->isChecked()) {
-    m_uiForm.leWorkspaceIndices->setText(getIndexString(workspace));
-    m_uiForm.leWorkspaceIndices->setEnabled(false);
+void AddWorkspaceMultiDialog::updateSelectedSpectra() { return m_uiForm.tbWorkspace->resetIndexRangeToDefault(); }
+
+void AddWorkspaceMultiDialog::unifyRange() { return m_uiForm.tbWorkspace->unifyRange(); }
+
+void AddWorkspaceMultiDialog::handleFilesFound() {
+  auto fileNames = m_uiForm.dsInputFiles->getFilenames();
+  for (auto &fileName : fileNames) {
+    loadFile(fileName);
   }
-}
-
-void AddWorkspaceMultiDialog::setAllSpectraSelectionEnabled(bool doEnable) {
-  m_uiForm.ckAllSpectra->setEnabled(doEnable);
-}
-
-std::string AddWorkspaceMultiDialog::getFileName() const {
-  return m_uiForm.dsWorkspace->getFullFilePath().toStdString();
+  return;
 }
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -40,8 +40,6 @@ bool doesExistInADS(std::string const &workspaceName) {
   return AnalysisDataService::Instance().doesExist(workspaceName);
 }
 
-bool validWorkspace(std::string const &name) { return !name.empty() && doesExistInADS(name); }
-
 boost::optional<std::size_t> maximumIndex(const MatrixWorkspace_sptr &workspace) {
   if (workspace) {
     const auto numberOfHistograms = workspace->getNumberHistograms();

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -36,10 +36,6 @@ MatrixWorkspace_sptr getWorkspace(const std::string &name) {
   return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
 }
 
-bool doesExistInADS(std::string const &workspaceName) {
-  return AnalysisDataService::Instance().doesExist(workspaceName);
-}
-
 boost::optional<std::size_t> maximumIndex(const MatrixWorkspace_sptr &workspace) {
   if (workspace) {
     const auto numberOfHistograms = workspace->getNumberHistograms();

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -117,7 +117,7 @@ WorkspaceMultiSelector::WorkspaceMultiSelector(QWidget *parent, bool init)
       m_clearObserver(*this, &WorkspaceMultiSelector::handleClearEvent),
       m_renameObserver(*this, &WorkspaceMultiSelector::handleRenameEvent),
       m_replaceObserver(*this, &WorkspaceMultiSelector::handleReplaceEvent), m_init(init), m_workspaceTypes(),
-      m_showHidden(false), m_showGroups(false), m_binLimits(std::nullopt), m_suffix() {
+      m_showGroups(false), m_binLimits(std::nullopt), m_suffix() {
 
   if (init) {
     connectObservers();
@@ -177,17 +177,6 @@ QStringList WorkspaceMultiSelector::getWorkspaceTypes() const { return m_workspa
 void WorkspaceMultiSelector::setWorkspaceTypes(const QStringList &types) {
   if (types != m_workspaceTypes) {
     m_workspaceTypes = types;
-    if (m_init) {
-      refresh();
-    }
-  }
-}
-
-bool WorkspaceMultiSelector::showHiddenWorkspaces() const { return m_showHidden; }
-
-void WorkspaceMultiSelector::showHiddenWorkspaces(bool show) {
-  if (show != m_showHidden) {
-    m_showHidden = show;
     if (m_init) {
       refresh();
     }
@@ -294,10 +283,6 @@ void WorkspaceMultiSelector::unifyRange() {
 
 void WorkspaceMultiSelector::handleAddEvent(Mantid::API::WorkspaceAddNotification_ptr pNf) {
   const std::lock_guard<std::mutex> lock(m_adsMutex);
-  if (!showHiddenWorkspaces() &&
-      Mantid::API::AnalysisDataService::Instance().isHiddenDataServiceObject(pNf->objectName())) {
-    return;
-  }
   if (checkEligibility(pNf->objectName())) {
     addItem(pNf->objectName());
   }

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -254,7 +254,6 @@ void WorkspaceMultiSelector::renameItem(const std::string &newName, int row) {
 }
 
 void WorkspaceMultiSelector::addItems(const std::vector<std::string> &names) {
-  auto nItems = names.size();
   for (auto const &name : names) {
     if (checkEligibility(name)) {
       addItem(name);
@@ -362,7 +361,6 @@ void WorkspaceMultiSelector::handleRenameEvent(Mantid::API::WorkspaceRenameNotif
 void WorkspaceMultiSelector::handleReplaceEvent(Mantid::API::WorkspaceAfterReplaceNotification_ptr pNf) {
   const std::lock_guard<std::mutex> lock(m_adsMutex);
   QString name = QString::fromStdString(pNf->objectName());
-  auto &ads = Mantid::API::AnalysisDataService::Instance();
   bool eligible = checkEligibility(pNf->objectName());
   auto items = findItems(name, Qt::MatchExactly);
 

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -117,7 +117,7 @@ WorkspaceMultiSelector::WorkspaceMultiSelector(QWidget *parent, bool init)
       m_clearObserver(*this, &WorkspaceMultiSelector::handleClearEvent),
       m_renameObserver(*this, &WorkspaceMultiSelector::handleRenameEvent),
       m_replaceObserver(*this, &WorkspaceMultiSelector::handleReplaceEvent), m_init(init), m_connected(false),
-      m_workspaceTypes(), m_showHidden(false), m_showGroups(true), m_binLimits(std::make_pair(0, -1)), m_suffix() {
+      m_workspaceTypes(), m_showHidden(false), m_showGroups(false), m_binLimits(std::make_pair(0, -1)), m_suffix() {
 
   if (init) {
     connectObservers();

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -206,7 +206,7 @@ void WorkspaceMultiSelector::showWorkspaceGroups(bool show) {
 }
 
 bool WorkspaceMultiSelector::isValid() const {
-  QTableWidgetItem *item = currentItem();
+  const QTableWidgetItem *item = currentItem();
   return (item != nullptr);
 }
 

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -117,7 +117,7 @@ WorkspaceMultiSelector::WorkspaceMultiSelector(QWidget *parent, bool init)
       m_clearObserver(*this, &WorkspaceMultiSelector::handleClearEvent),
       m_renameObserver(*this, &WorkspaceMultiSelector::handleRenameEvent),
       m_replaceObserver(*this, &WorkspaceMultiSelector::handleReplaceEvent), m_init(init), m_workspaceTypes(),
-      m_showGroups(false), m_lowerBin(std::nullopt), m_upperBin(std::nullopt), m_suffix() {
+      m_showGroups(false), m_suffix() {
 
   if (init) {
     connectObservers();
@@ -209,10 +209,6 @@ void WorkspaceMultiSelector::setWSSuffixes(const QStringList &suffix) {
     }
   }
 }
-
-void WorkspaceMultiSelector::setLowerBinLimit(int numberOfBins) { m_lowerBin = numberOfBins; }
-
-void WorkspaceMultiSelector::setUpperBinLimit(int numberOfBins) { m_upperBin = numberOfBins; }
 
 void WorkspaceMultiSelector::addItem(const std::string &name) {
   insertRow(rowCount());
@@ -350,7 +346,7 @@ bool WorkspaceMultiSelector::checkEligibility(const std::string &name) const {
   auto workspace = ads.retrieve(name);
   if ((!m_workspaceTypes.empty()) && m_workspaceTypes.indexOf(QString::fromStdString(workspace->id())) == -1)
     return false;
-  else if (!hasValidSuffix(name) || !hasValidNumberOfBins(workspace))
+  else if (!hasValidSuffix(name))
     return false;
   else if (!m_showGroups)
     return std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(workspace) == nullptr;
@@ -363,18 +359,6 @@ bool WorkspaceMultiSelector::hasValidSuffix(const std::string &name) const {
   if (name.find_last_of("_") < name.size())
     return m_suffix.contains(QString::fromStdString(name.substr(name.find_last_of("_"))));
   return false;
-}
-
-bool WorkspaceMultiSelector::hasValidNumberOfBins(const Mantid::API::Workspace_sptr &object) const {
-  if (m_lowerBin.has_value()) {
-    if (auto const workspace = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(object)) {
-      auto const numberOfBins = static_cast<int>(workspace->y(0).size());
-      if (m_upperBin.has_value())
-        return numberOfBins >= m_lowerBin && numberOfBins <= m_upperBin;
-      return numberOfBins >= m_lowerBin;
-    }
-  }
-  return true;
 }
 
 void WorkspaceMultiSelector::refresh() {

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -1,0 +1,342 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+//------------------------------------------------------
+// Includes
+//------------------------------------------------------
+#include "MantidQtWidgets/Common/WorkspaceMultiSelector.h"
+
+#include <Poco/AutoPtr.h>
+#include <Poco/NObserver.h>
+#include <Poco/Notification.h>
+#include <Poco/NotificationCenter.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+
+#include <QCompleter>
+#include <QDebug>
+#include <QDropEvent>
+#include <QLineEdit>
+#include <QMimeData>
+#include <QUrl>
+using namespace MantidQt::MantidWidgets;
+
+/**
+ * Default constructor
+ * @param parent :: A widget to act as this widget's parent (default = NULL)
+ * @param init :: If true then the widget will make calls to the framework
+ * (default = true)
+ */
+WorkspaceMultiSelector::WorkspaceMultiSelector(QWidget *parent, bool init)
+    : QListWidget(parent), m_addObserver(*this, &WorkspaceMultiSelector::handleAddEvent),
+      m_remObserver(*this, &WorkspaceMultiSelector::handleRemEvent),
+      m_clearObserver(*this, &WorkspaceMultiSelector::handleClearEvent),
+      m_renameObserver(*this, &WorkspaceMultiSelector::handleRenameEvent),
+      m_replaceObserver(*this, &WorkspaceMultiSelector::handleReplaceEvent), m_init(init), m_workspaceTypes(),
+      m_showHidden(false), m_showGroups(true), m_optional(false), m_binLimits(std::make_pair(0, -1)), m_suffix(),
+      m_algName(), m_algPropName(), m_algorithm() {
+  if (init) {
+    connectObservers();
+  }
+  this->setAcceptDrops(true);
+  this->setSelectionMode(QAbstractItemView::ExtendedSelection);
+  this->setSortingEnabled(true);
+}
+
+/**
+ * Destructor for WorkspaceMultiSelector
+ * De-subscribes this object from the Poco NotificationCentre
+ */
+WorkspaceMultiSelector::~WorkspaceMultiSelector() { disconnectObservers(); }
+
+/**
+ * De-subscribes this object from the Poco NotificationCentre
+ */
+void WorkspaceMultiSelector::disconnectObservers() {
+  if (m_init) {
+    Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_addObserver);
+    Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_remObserver);
+    Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_clearObserver);
+    Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_renameObserver);
+    Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_replaceObserver);
+    m_init = false;
+    m_connected = false;
+  }
+}
+
+/**
+ * Subscribes this object to the Poco NotificationCentre
+ */
+void WorkspaceMultiSelector::connectObservers() {
+  Mantid::API::AnalysisDataServiceImpl &ads = Mantid::API::AnalysisDataService::Instance();
+  ads.notificationCenter.addObserver(m_addObserver);
+  ads.notificationCenter.addObserver(m_remObserver);
+  ads.notificationCenter.addObserver(m_renameObserver);
+  ads.notificationCenter.addObserver(m_clearObserver);
+  ads.notificationCenter.addObserver(m_replaceObserver);
+  refresh();
+  m_init = true;
+  m_connected = true;
+}
+
+QStringList WorkspaceMultiSelector::getWorkspaceTypes() const { return m_workspaceTypes; }
+
+void WorkspaceMultiSelector::setWorkspaceTypes(const QStringList &types) {
+  if (types != m_workspaceTypes) {
+    m_workspaceTypes = types;
+    if (m_init) {
+      refresh();
+    }
+  }
+}
+
+bool WorkspaceMultiSelector::showHiddenWorkspaces() const { return m_showHidden; }
+
+void WorkspaceMultiSelector::showHiddenWorkspaces(bool show) {
+  if (show != m_showHidden) {
+    m_showHidden = show;
+    if (m_init) {
+      refresh();
+    }
+  }
+}
+
+bool WorkspaceMultiSelector::showWorkspaceGroups() const { return m_showGroups; }
+
+void WorkspaceMultiSelector::showWorkspaceGroups(bool show) {
+  if (show != m_showGroups) {
+    m_showGroups = show;
+    if (m_init) {
+      refresh();
+    }
+  }
+}
+
+bool WorkspaceMultiSelector::isValid() const {
+  QListWidgetItem *item = currentItem();
+  return (item->text() != "");
+}
+
+bool WorkspaceMultiSelector::isOptional() const { return m_optional; }
+
+void WorkspaceMultiSelector::setOptional(bool optional) {
+  if (optional != m_optional) {
+    m_optional = optional;
+    if (m_init)
+      refresh();
+  }
+}
+
+bool WorkspaceMultiSelector::isConnected() const { return m_connected; }
+
+QStringList WorkspaceMultiSelector::getWSSuffixes() const { return m_suffix; }
+
+void WorkspaceMultiSelector::setWSSuffixes(const QStringList &suffix) {
+  if (suffix != m_suffix) {
+    m_suffix = suffix;
+    if (m_init) {
+      refresh();
+    }
+  }
+}
+
+void WorkspaceMultiSelector::setLowerBinLimit(int numberOfBins) { m_binLimits.first = numberOfBins; }
+
+void WorkspaceMultiSelector::setUpperBinLimit(int numberOfBins) { m_binLimits.second = numberOfBins; }
+
+void WorkspaceMultiSelector::handleAddEvent(Mantid::API::WorkspaceAddNotification_ptr pNf) {
+  const std::lock_guard<std::mutex> lock(m_adsMutex);
+  if (!showHiddenWorkspaces() &&
+      Mantid::API::AnalysisDataService::Instance().isHiddenDataServiceObject(pNf->objectName())) {
+    return;
+  }
+  QString name = QString::fromStdString(pNf->objectName());
+  if (checkEligibility(name, pNf->object())) {
+    addItem(name);
+  }
+}
+
+void WorkspaceMultiSelector::handleRemEvent(Mantid::API::WorkspacePostDeleteNotification_ptr pNf) {
+  const std::lock_guard<std::mutex> lock(m_adsMutex);
+  QString name = QString::fromStdString(pNf->objectName());
+  auto items = findItems(name, Qt::MatchExactly);
+  if (!items.isEmpty()) {
+    for (auto item : items)
+      delete item;
+  }
+  if (count() <= 0) {
+    emit emptied();
+  }
+}
+
+void WorkspaceMultiSelector::handleClearEvent(Mantid::API::ClearADSNotification_ptr) {
+  const std::lock_guard<std::mutex> lock(m_adsMutex);
+  this->clear();
+  if (m_optional)
+    addItem("");
+  emit emptied();
+}
+
+void WorkspaceMultiSelector::handleRenameEvent(Mantid::API::WorkspaceRenameNotification_ptr pNf) {
+  const std::lock_guard<std::mutex> lock(m_adsMutex);
+  QString name = QString::fromStdString(pNf->objectName());
+  QString newName = QString::fromStdString(pNf->newObjectName());
+  auto &ads = Mantid::API::AnalysisDataService::Instance();
+  // 1 rename per notification?
+  bool eligible = checkEligibility(newName, ads.retrieve(pNf->newObjectName()));
+  auto items = findItems(name, Qt::MatchExactly);
+  std::cout << "I'm a rename event" << std::endl;
+  if (eligible) {
+    addItem(newName);
+  }
+  if (!items.isEmpty()) {
+    for (auto item : items) {
+      delete item;
+    }
+  }
+}
+
+void WorkspaceMultiSelector::handleReplaceEvent(Mantid::API::WorkspaceAfterReplaceNotification_ptr pNf) {
+  const std::lock_guard<std::mutex> lock(m_adsMutex);
+  QString name = QString::fromStdString(pNf->objectName());
+  auto &ads = Mantid::API::AnalysisDataService::Instance();
+
+  bool eligible = checkEligibility(name, ads.retrieve(pNf->objectName()));
+  auto items = findItems(name, Qt::MatchExactly);
+  std::cout << "I'm a replace event " << std::endl;
+  std::cout << name.toStdString() << std::endl;
+  if (!items.isEmpty()) {
+    std::cout << items[0]->text().toStdString() << std::endl;
+  }
+
+  // if it is inside and it is eligible do nothing
+  // if it is not inside and it is eligible insert
+  // if it is inside and it is not eligible remove
+  // if it is not inside and it is not eligible do nothing
+
+  if ((!items.isEmpty() && eligible) || (items.isEmpty() && !eligible))
+    return;
+  else if (items.isEmpty() && eligible) {
+    addItem(name);
+  } else { // (inside && !eligible)
+    for (auto item : items) {
+      delete item;
+    }
+  }
+}
+
+bool WorkspaceMultiSelector::checkEligibility(const QString &name, const Mantid::API::Workspace_sptr &object) const {
+  if (m_algorithm && !m_algPropName.isEmpty()) {
+    try {
+      m_algorithm->setPropertyValue(m_algPropName.toStdString(), name.toStdString());
+    } catch (std::invalid_argument &) {
+      return false;
+    }
+  } else if ((!m_workspaceTypes.empty()) && m_workspaceTypes.indexOf(QString::fromStdString(object->id())) == -1) {
+    return false;
+  } else if (!hasValidSuffix(name)) {
+    return false;
+  } else if (!hasValidNumberOfBins(object)) {
+    return false;
+  } else if (!m_showGroups) {
+    auto group = std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(object);
+    if (group != nullptr)
+      return false;
+  }
+
+  return true;
+}
+
+bool WorkspaceMultiSelector::hasValidSuffix(const QString &name) const {
+  if (m_suffix.isEmpty()) {
+    return true;
+  } else {
+    for (int i = 0; i < m_suffix.size(); ++i) {
+      if (name.endsWith(m_suffix[i])) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+bool WorkspaceMultiSelector::hasValidNumberOfBins(const Mantid::API::Workspace_sptr &object) const {
+  if (m_binLimits.first != 0 || m_binLimits.second != -1) {
+    if (auto const workspace = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(object)) {
+      auto const numberOfBins = static_cast<int>(workspace->y(0).size());
+      if (m_binLimits.second != -1)
+        return numberOfBins >= m_binLimits.first && numberOfBins <= m_binLimits.second;
+      return numberOfBins >= m_binLimits.first;
+    }
+  }
+  return true;
+}
+
+void WorkspaceMultiSelector::refresh() {
+  const std::lock_guard<std::mutex> lock(m_adsMutex);
+  clear();
+  if (m_optional)
+    addItem("");
+  auto &ads = Mantid::API::AnalysisDataService::Instance();
+  std::vector<std::string> items;
+  if (showHiddenWorkspaces()) {
+    items = ads.getObjectNames(Mantid::Kernel::DataServiceSort::Sorted, Mantid::Kernel::DataServiceHidden::Include);
+  } else {
+    items = ads.getObjectNames();
+  }
+
+  QStringList namesToAdd;
+  for (auto &item : items) {
+    QString name = QString::fromStdString(item);
+    if (checkEligibility(name, ads.retrieve(item))) {
+      namesToAdd << name;
+    }
+  }
+  addItems(namesToAdd);
+}
+
+/**
+ * Called when an item is dropped
+ * @param de :: the drop event data package
+ */
+void WorkspaceMultiSelector::dropEvent(QDropEvent *de) {
+  const std::lock_guard<std::mutex> lock(m_adsMutex);
+  const QMimeData *mimeData = de->mimeData();
+  QString text = mimeData->text();
+  int equal_pos = text.indexOf("=");
+  QString ws_name = text.left(equal_pos - 1);
+  QString ws_name_test = text.mid(equal_pos + 7, equal_pos - 1);
+  /* FOR THE MOMENT DONT FIDDLE WITH THIS UNTILS IS CLEARER HOW TO RUN IT
+  if (ws_name == ws_name_test) {
+    int index = findText(ws_name);
+    if (index >= 0) {
+      setCurrentIndex(index);
+      de->acceptProposedAction();
+    }
+  } */
+}
+
+/**
+ * Called when an item is dragged onto a control
+ * @param de :: the drag event data package
+ */
+void WorkspaceMultiSelector::dragEnterEvent(QDragEnterEvent *de) {
+  const std::lock_guard<std::mutex> lock(m_adsMutex);
+  const QMimeData *mimeData = de->mimeData();
+  if (mimeData->hasText()) {
+    QString text = mimeData->text();
+    if (text.contains(" = mtd[\""))
+      de->acceptProposedAction();
+  }
+}
+
+/**
+ * Called when there is an interaction with the widget.
+ */
+void WorkspaceMultiSelector::focusInEvent(QFocusEvent *) { emit focussed(); }

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -372,12 +372,9 @@ bool WorkspaceMultiSelector::checkEligibility(const std::string &name) const {
 bool WorkspaceMultiSelector::hasValidSuffix(const std::string &name) const {
   if (m_suffix.isEmpty())
     return true;
-  else {
-    if (name.find_last_of("_") < name.size())
-      return m_suffix.contains(QString::fromStdString(name.substr(name.find_last_of("_"))));
-    else
-      return false;
-  }
+  if (name.find_last_of("_") < name.size())
+    return m_suffix.contains(QString::fromStdString(name.substr(name.find_last_of("_"))));
+  return false;
 }
 
 bool WorkspaceMultiSelector::hasValidNumberOfBins(const Mantid::API::Workspace_sptr &object) const {


### PR DESCRIPTION
### Description of work
This PR adds the option to add multiple workspaces at once into the workspace table of the Elwin inelastic interface as requested in #33319.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Currently, the ELWIN tab of the Data Manipulation interface is working a bit different when files or workspaces are added. Actually the interface is a tab group with a ``Files`` tab and a ``Workspaces`` tab. It is possible to add multiple files at once from the ``Files`` tab but in order to do the same in the workspaces tab, the ``Add Workspaces`` dialog window has to be invoked multiple times, which makes for a slower workflow. 
In order to add the functionality to add multiple workspaces at once, I have considered that the best option in this case would be to design a new type of ``AddWorkspace`` dialog window that could handle adding multiple workspaces at once, with the possibility to select the indexes of the workspaces that are to be added. In order to do that, I have created a new custom widget that inherits from the `QTableWidget` class and shares some of the functionality of Mantid `WorkspaceSelector` widget (communication with the ADS through POCO notifications. ), which is itself a custom QComboBox.
Although the new dialog window is functionally integrated with the Elwin interface. There's no need to have separate file/workspaces tabs (#36460) and also the added workspaces don't need to be added as multiple rows, but rather one row per workspaces  (#36372 ). This PR is a first step in order to address these two issues.


Fixes #33319. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->


### To test:
- Testing the new widget: 
   1. Open 3 workspaces in the ADS with suffix `_red.nxs` or `_sqw.nxs`. (For example: ``iris26173_graphite002_red.nxs``, ``iris26176_graphite002_red.nxs`` and ``iris26173_graphite002_sqw.nxs``). 
   2. Go to `Inelastic->Data Manipulation->Elwin tab` interface. Click on ``Workspace`` tab and on the ``Add Workspace`` button. The multiple workspaces QDialog window should prompt, and the table widget should be filled with the added workspaces.
   3. From the ADS, remove one of the added workspaces, rename other one with a non-allowed suffix, and finally clear the ADS, all these changes should be reflected on table in the Workspace QDialog.
   4. Add files from the ``Browse`` button in the QDialog, see that those files are loaded into the ADS and the table (if suffices are allowed). 
   5. Test buttons on the dialog (``Select All``, ``Unify Range``, ``Reset Range``). 
   6. Select 1 or 2 workspaces from the table an click ``Add Data``. See that the data is added, with the appropriate selected indexes.
- Testing Elwin tab:
   1. Make ``Elwin Tab`` test in https://developer.mantidproject.org/Testing/Inelastic/DataManipulationTests.html


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
