### PR TITLE
36842 Fix duplicates in Selectfunctiondialog

### DIFF
--- a/docs/source/release/v6.10.0/Framework/Fit_Functions/Bugfixes/36956.rst
+++ b/docs/source/release/v6.10.0/Framework/Fit_Functions/Bugfixes/36956.rst
@@ -1,0 +1,1 @@
+- Updated search box for fitting functions so that function suggestions do not show repeated functions

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SelectFunctionDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SelectFunctionDialog.h
@@ -46,7 +46,7 @@ protected:
 
 private:
   /// Complete QComboBox for searching functions with available functions
-  void completeSearchBox(const std::vector<std::string> &registeredFunctions);
+  void addSearchBoxFunctionNames(const std::vector<std::string> &registeredFunctions);
   /// Construct QTreeWidget with categories and functions
   void constructFunctionTree(const std::map<std::string, std::vector<std::string>> &categoryFunctionsMap,
                              const std::vector<std::string> &restrictions);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SelectFunctionDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SelectFunctionDialog.h
@@ -45,6 +45,8 @@ protected:
   Ui::SelectFunctionDialog *m_form;
 
 private:
+  /// Complete QComboBox for searching functions with available functions
+  void completeSearchBox(const std::vector<std::string> &registeredFunctions);
   /// Construct QTreeWidget with categories and functions
   void constructFunctionTree(const std::map<std::string, std::vector<std::string>> &categoryFunctionsMap,
                              const std::vector<std::string> &restrictions);

--- a/qt/widgets/common/src/SelectFunctionDialog.cpp
+++ b/qt/widgets/common/src/SelectFunctionDialog.cpp
@@ -71,8 +71,9 @@ SelectFunctionDialog::SelectFunctionDialog(QWidget *parent, const std::vector<st
   m_form->searchBox->completer()->setCompletionMode(QCompleter::PopupCompletion);
   m_form->searchBox->completer()->setFilterMode(Qt::MatchContains);
 
-  // Function to uncoment once debugging is complete
-  // completeSearchBox(registeredFunctions);
+  // Complete suggestions in search box,
+  // number of suggestions same as number of registeredFunctions
+  completeSearchBox(registeredFunctions);
 
   connect(m_form->searchBox, SIGNAL(editTextChanged(const QString &)), this, SLOT(searchBoxChanged(const QString &)));
 
@@ -80,27 +81,6 @@ SelectFunctionDialog::SelectFunctionDialog(QWidget *parent, const std::vector<st
   // their respective fit functions.
   constructFunctionTree(categories, restrictions);
   setMinimumHeightOfFunctionTree();
-
-  // Check that number of registered functions should match number in box
-  QTreeWidgetItemIterator it(m_form->fitTree);
-  std::vector<std::string> unique_functions{};
-  while (*it) {
-    std::string fun = (*it)->text(0).toStdString();
-    if (std::find(unique_functions.begin(), unique_functions.end(), fun) == unique_functions.end()) {
-      unique_functions.push_back(fun);
-    }
-    ++it;
-  }
-  std::sort(unique_functions.begin(), unique_functions.end());
-  for (auto f : unique_functions)
-    std::cout << f << std::endl;
-  std::cout << "Number of items in tree: " << unique_functions.size() << std::endl;
-  std::cout << "Number of items in search box: " << m_form->searchBox->count() << std::endl;
-  std::cout << "Numner of items in registered functions: " << registeredFunctions.size() << std::endl;
-  // Output:
-  // Number of items in tree: 150
-  // Number of items in search box: 136
-  // Numner of items in registered functions: 136
 
   connect(m_form->fitTree, SIGNAL(itemDoubleClicked(QTreeWidgetItem *, int)), this,
           SLOT(functionDoubleClicked(QTreeWidgetItem *)));
@@ -119,7 +99,6 @@ SelectFunctionDialog::SelectFunctionDialog(QWidget *parent, const std::vector<st
  * @param registeredFunctions :: [input] Vector of avaiblable functions
  */
 void SelectFunctionDialog::completeSearchBox(const std::vector<std::string> &registeredFunctions) {
-
   for (const auto &function : registeredFunctions) {
     m_form->searchBox->addItem(QString::fromStdString(function));
   }
@@ -160,8 +139,6 @@ void SelectFunctionDialog::constructFunctionTree(
           for (const auto &function : entry.second) {
             QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
             fit->setText(0, QString::fromStdString(function));
-            if (m_form->searchBox->findText(QString::fromStdString(function)) == -1)
-              m_form->searchBox->addItem(QString::fromStdString(function));
           }
         }
       } else {
@@ -196,8 +173,6 @@ void SelectFunctionDialog::constructFunctionTree(
               for (const auto &function : entry.second) {
                 QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
                 fit->setText(0, QString::fromStdString(function));
-                if (m_form->searchBox->findText(QString::fromStdString(function)) == -1)
-                  m_form->searchBox->addItem(QString::fromStdString(function));
               }
             }
           }

--- a/qt/widgets/common/src/SelectFunctionDialog.cpp
+++ b/qt/widgets/common/src/SelectFunctionDialog.cpp
@@ -70,7 +70,7 @@ SelectFunctionDialog::SelectFunctionDialog(QWidget *parent, const std::vector<st
 
   // Complete suggestions in search box,
   // number of suggestions same as number of registeredFunctions
-  completeSearchBox(registeredFunctions);
+  addSearchBoxFunctionNames(registeredFunctions);
 
   connect(m_form->searchBox, SIGNAL(editTextChanged(const QString &)), this, SLOT(searchBoxChanged(const QString &)));
 
@@ -95,7 +95,7 @@ SelectFunctionDialog::SelectFunctionDialog(QWidget *parent, const std::vector<st
  * Complete the QComboBox with the available functions for fitting
  * @param registeredFunctions :: [input] Vector of avaiblable functions
  */
-void SelectFunctionDialog::completeSearchBox(const std::vector<std::string> &registeredFunctions) {
+void SelectFunctionDialog::addSearchBoxFunctionNames(const std::vector<std::string> &registeredFunctions) {
   for (const auto &function : registeredFunctions) {
     m_form->searchBox->addItem(QString::fromStdString(function));
   }

--- a/qt/widgets/common/src/SelectFunctionDialog.cpp
+++ b/qt/widgets/common/src/SelectFunctionDialog.cpp
@@ -28,9 +28,6 @@
 #include <QTreeWidget>
 #include <QVBoxLayout>
 
-#include <QTreeWidgetItemIterator>
-#include <algorithm>
-#include <iostream>
 namespace MantidQt::MantidWidgets {
 
 /**


### PR DESCRIPTION
### Description of work
The dialog for selecting fit functions was displaying some functions several times, described in #36842. It's not anymore.

#### Summary of work
- This behaviour was coming from the function that constructs the tree of categories of functions in the same dialog. Some functions were being added multiple times because they belong to several categories. 
- I separated the completion of the search box from the completion of the tree, by creating a new function that edits the options in the search box only.


Fixes #36842. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->


#### Further detail of work
I checked that the number of functions that should be displayed in the search box is the exact same as the number of functions from the variable `registeredFunctions`. This was to make sure that by handling the search box separately from the tree of functions I don't accidentally remove an option. I checked this in my first commit and confirmed that my implementation keeps all the intended functions only once and does not remove any function. 

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

1. Add a workspace
2. Plot a spectra
3. Click `Fit` to open the fit interface
4. Righ-click on `Functions` and choose `Add function` to open the dialog
5. Search for `Gaussian` and check this only appears once
---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
