### PR TITLE
Fix pause batch execution functionality in Reflectometry GUI

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1207,8 +1207,6 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/AlgorithmProperti
 constVariablePointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp:404
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp:294
 constVariablePointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/AlgorithmHistoryWindow.cpp:716
-constVariableReference:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/BatchAlgorithmRunner.cpp:116
-constVariableReference:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/BatchAlgorithmRunner.cpp:208
 uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/UnaryOperationMD.cpp:59
 internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp:0
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/TransposeMD.cpp:83

--- a/docs/source/release/v6.10.0/Reflectometry/Bugfixes/36958.rst
+++ b/docs/source/release/v6.10.0/Reflectometry/Bugfixes/36958.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where it was not possible to pause execution of a batch of table rows.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/BatchAlgorithmRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/BatchAlgorithmRunner.h
@@ -149,9 +149,9 @@ private:
 
   /// User has requested to cancel processing
   bool m_cancelRequested;
-  std::recursive_mutex m_mutex;
+  std::recursive_mutex m_executeMutex;
   std::recursive_mutex m_cancelMutex;
-  std::recursive_mutex m_notificationCentreMutex;
+  std::recursive_mutex m_notificationMutex;
   void resetState();
   bool cancelRequested();
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/BatchAlgorithmRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/BatchAlgorithmRunner.h
@@ -126,6 +126,10 @@ private:
   bool executeBatchAsyncImpl(const Poco::Void & /*unused*/);
   /// Sets up and executes an algorithm
   bool executeAlgo(const IConfiguredAlgorithm_sptr &algorithm);
+  /// Post a poco notification
+  void postNotification(Poco::Notification *notification);
+  // Sets cancel requested flag
+  void setCancelRequested(bool const cancel);
 
   /// Handlers for notifications
   void handleBatchComplete(const Poco::AutoPtr<BatchCompleteNotification> &pNf);
@@ -146,6 +150,8 @@ private:
   /// User has requested to cancel processing
   bool m_cancelRequested;
   std::recursive_mutex m_mutex;
+  std::recursive_mutex m_cancelMutex;
+  std::recursive_mutex m_notificationCentreMutex;
   void resetState();
   bool cancelRequested();
 

--- a/qt/widgets/common/src/BatchAlgorithmRunner.cpp
+++ b/qt/widgets/common/src/BatchAlgorithmRunner.cpp
@@ -54,12 +54,10 @@ BatchAlgorithmRunner::BatchAlgorithmRunner(QObject *parent)
       m_algorithmErrorObserver(*this, &BatchAlgorithmRunner::handleAlgorithmError),
       m_executeAsync(this, &BatchAlgorithmRunner::executeBatchAsyncImpl) {}
 
-BatchAlgorithmRunner::~BatchAlgorithmRunner() {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
-  removeAllObservers();
-}
+BatchAlgorithmRunner::~BatchAlgorithmRunner() { removeAllObservers(); }
 
 void BatchAlgorithmRunner::addAllObservers() {
+  std::lock_guard<std::recursive_mutex> lock(m_notificationCentreMutex);
   m_notificationCenter.addObserver(m_batchCompleteObserver);
   m_notificationCenter.addObserver(m_batchCancelledObserver);
   m_notificationCenter.addObserver(m_algorithmStartedObserver);
@@ -68,6 +66,7 @@ void BatchAlgorithmRunner::addAllObservers() {
 }
 
 void BatchAlgorithmRunner::removeAllObservers() {
+  std::lock_guard<std::recursive_mutex> lock(m_notificationCentreMutex);
   m_notificationCenter.removeObserver(m_batchCompleteObserver);
   m_notificationCenter.removeObserver(m_batchCancelledObserver);
   m_notificationCenter.removeObserver(m_algorithmStartedObserver);
@@ -131,7 +130,10 @@ void BatchAlgorithmRunner::clearQueue() {
 /**
  * Returns the number of algorithms in the queue.
  */
-size_t BatchAlgorithmRunner::queueLength() { return m_algorithms.size(); }
+size_t BatchAlgorithmRunner::queueLength() {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  return m_algorithms.size();
+}
 
 /**
  * Executes the algorithms on a separate thread and waits for their completion.
@@ -170,16 +172,15 @@ void BatchAlgorithmRunner::executeAlgorithmAsync(IConfiguredAlgorithm_sptr algor
  * Cancel execution of remaining queued items
  */
 void BatchAlgorithmRunner::cancelBatch() {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   // If the queue is empty, notify straight away that the batch has been
   // cancelled. Otherwise, set a flag so that it will be cancelled after the
   // current algorithm finishes processing
   if (queueLength() < 1) {
     addAllObservers();
-    m_notificationCenter.postNotification(new BatchCancelledNotification());
+    postNotification(new BatchCancelledNotification());
     removeAllObservers();
   } else {
-    m_cancelRequested = true;
+    setCancelRequested(true);
   }
 }
 
@@ -187,14 +188,13 @@ void BatchAlgorithmRunner::cancelBatch() {
  * Reset state ready for executing a new batch
  */
 void BatchAlgorithmRunner::resetState() {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   removeAllObservers();
   clearQueue();
-  m_cancelRequested = false;
+  setCancelRequested(false);
 }
 
 bool BatchAlgorithmRunner::cancelRequested() {
-  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_cancelMutex);
   return m_cancelRequested;
 }
 
@@ -228,9 +228,9 @@ bool BatchAlgorithmRunner::executeBatchAsyncImpl(const Poco::Void & /*unused*/) 
 
   // Notify observers
   if (cancelRequested())
-    m_notificationCenter.postNotification(new BatchCancelledNotification());
+    postNotification(new BatchCancelledNotification());
   else
-    m_notificationCenter.postNotification(new BatchCompleteNotification(false, errorFlag));
+    postNotification(new BatchCompleteNotification(false, errorFlag));
 
   resetState();
 
@@ -257,14 +257,14 @@ bool BatchAlgorithmRunner::executeAlgo(const IConfiguredAlgorithm_sptr &algorith
     g_log.information() << "Starting next algorithm in queue: " << m_currentAlgorithm->name() << "\n";
 
     // Start algorithm running
-    m_notificationCenter.postNotification(new AlgorithmStartedNotification(algorithm));
+    postNotification(new AlgorithmStartedNotification(algorithm));
     auto result = m_currentAlgorithm->execute();
 
     if (!result) {
       auto message = std::string("Algorithm") + algorithm->algorithm()->name() + std::string(" execution failed");
-      m_notificationCenter.postNotification(new AlgorithmErrorNotification(algorithm, message));
+      postNotification(new AlgorithmErrorNotification(algorithm, message));
     } else {
-      m_notificationCenter.postNotification(new AlgorithmCompleteNotification(algorithm));
+      postNotification(new AlgorithmCompleteNotification(algorithm));
     }
 
     return result;
@@ -273,7 +273,7 @@ bool BatchAlgorithmRunner::executeAlgo(const IConfiguredAlgorithm_sptr &algorith
   catch (Mantid::Kernel::Exception::NotFoundError &notFoundEx) {
     UNUSED_ARG(notFoundEx);
     g_log.warning("Algorithm property does not exist.\nStopping queue execution.");
-    m_notificationCenter.postNotification(new AlgorithmErrorNotification(algorithm, notFoundEx.what()));
+    postNotification(new AlgorithmErrorNotification(algorithm, notFoundEx.what()));
     return false;
   }
   // If a property was assigned a value of the wrong type
@@ -281,20 +281,29 @@ bool BatchAlgorithmRunner::executeAlgo(const IConfiguredAlgorithm_sptr &algorith
     UNUSED_ARG(invalidArgEx);
     g_log.warning("Algorithm property given value of incorrect type.\nStopping "
                   "queue execution.");
-    m_notificationCenter.postNotification(new AlgorithmErrorNotification(algorithm, invalidArgEx.what()));
+    postNotification(new AlgorithmErrorNotification(algorithm, invalidArgEx.what()));
     return false;
   }
   // For anything else that could go wrong
   catch (std::exception &ex) {
     g_log.warning("Error starting batch algorithm");
-    m_notificationCenter.postNotification(new AlgorithmErrorNotification(algorithm, ex.what()));
+    postNotification(new AlgorithmErrorNotification(algorithm, ex.what()));
     return false;
   } catch (...) {
     g_log.warning("Unknown error starting next batch algorithm");
-    m_notificationCenter.postNotification(
-        new AlgorithmErrorNotification(algorithm, "Unknown error starting algorithm"));
+    postNotification(new AlgorithmErrorNotification(algorithm, "Unknown error starting algorithm"));
     return false;
   }
+}
+
+void BatchAlgorithmRunner::postNotification(Poco::Notification *notification) {
+  std::lock_guard<std::recursive_mutex> lock(m_notificationCentreMutex);
+  m_notificationCenter.postNotification(notification);
+}
+
+void BatchAlgorithmRunner::setCancelRequested(bool const cancel) {
+  std::lock_guard<std::recursive_mutex> lock(m_cancelMutex);
+  m_cancelRequested = cancel;
 }
 
 /**

--- a/qt/widgets/common/src/BatchAlgorithmRunner.cpp
+++ b/qt/widgets/common/src/BatchAlgorithmRunner.cpp
@@ -112,7 +112,7 @@ void BatchAlgorithmRunner::addAlgorithm(const IAlgorithm_sptr &algo, std::unique
  */
 void BatchAlgorithmRunner::setQueue(std::deque<IConfiguredAlgorithm_sptr> algorithms) {
   g_log.debug() << "Set batch queue to algorithm list:\n";
-  for (auto &algorithm : algorithms)
+  for (auto const &algorithm : algorithms)
     g_log.debug() << algorithm->algorithm()->name() << "\n";
 
   std::lock_guard<std::recursive_mutex> lock(m_executeMutex);
@@ -206,7 +206,7 @@ bool BatchAlgorithmRunner::executeBatchAsyncImpl(const Poco::Void & /*unused*/) 
   std::lock_guard<std::recursive_mutex> lock(m_executeMutex);
 
   bool errorFlag = false;
-  for (auto &it : m_algorithms) {
+  for (auto const &it : m_algorithms) {
     if (cancelRequested()) {
       g_log.information("Stopping batch algorithm execution: cancelled");
       break;

--- a/qt/widgets/common/test/BatchAlgorithmRunnerTest.h
+++ b/qt/widgets/common/test/BatchAlgorithmRunnerTest.h
@@ -328,7 +328,7 @@ public:
     TS_ASSERT_EQUALS(args.at(0).toBool(), false);
   }
 
-  void test_cancelBatchWithQueue() {
+  void test_cancelBatch_before_executing_queue() {
     BatchAlgorithmRunner runner(nullptr);
 
     QSignalSpy batchCompleteSpy(&runner, &BatchAlgorithmRunner::batchComplete);
@@ -344,11 +344,11 @@ public:
     runner.cancelBatch();
     runner.executeBatch();
 
-    // No algorithms are run if they were in the queue before we cancelled
-    TS_ASSERT_EQUALS(batchCompleteSpy.count(), 0);
+    // All algorithms are run if cancelBatch() is called before execution has started
+    TS_ASSERT_EQUALS(batchCompleteSpy.count(), 1);
     TS_ASSERT_EQUALS(batchCancelledSpy.count(), 1);
-    TS_ASSERT_EQUALS(algStartSpy.count(), 0);
-    TS_ASSERT_EQUALS(algCompleteSpy.count(), 0);
+    TS_ASSERT_EQUALS(algStartSpy.count(), 3);
+    TS_ASSERT_EQUALS(algCompleteSpy.count(), 3);
     TS_ASSERT_EQUALS(algErrorSpy.count(), 0);
   }
 


### PR DESCRIPTION
### Description of work
This PR fixes a bug introduced in 6.8 where requesting to cancel a batch algorithm execution would not work because the same mutex for setting the `m_cancelRequested = true` member variable was used as the mutex used when executing the algorithms. This meant we would need to wait for the algorithm execution to finish before setting `m_cancelRequested = true`, at which point it was too late to cancel algorithm execution.

The solution was to use a separate mutex for updating the `m_cancelRequested` member variable. I also added a mutex to make posting notifications safer.

Fixes #36919

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1) Go to `Interfaces` -> `Reflectometry` -> `ISIS Reflectometry`
1) On the Runs tab, enter Investigation Id `1120015` and Cycle `11_3` and click the `Search` button.
1) Select several rows (from the ones not highlighted blue) and click the `Transfer` button to move them into the runs table on the right hand side.
1) Click the Process button above the table. This should start reducing all rows in the table and will enable the Pause button that is just to the right of it.
1) Click the Pause button. The processing will just continue as before until all rows are reduced.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
