### PR TITLE
Fix for error when switching axes plot settings tab with un-entered invalid bound value

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/Bugfixes/36738.rst
+++ b/docs/source/release/v6.10.0/Workbench/Bugfixes/36738.rst
@@ -1,0 +1,1 @@
+- Fixed bug in the plot settings axes widget where setting an invalid axes limit and switching tabs could cause an error.

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
@@ -77,9 +77,13 @@ class AxesTabWidgetView(QWidget):
         self.show_minor_gridlines_check_box.setEnabled(enabled)
 
     def get_lower_limit(self):
+        if not self.lower_limit_line_edit.hasAcceptableInput():
+            self.lower_limit_line_edit.validator().fixup(self.lower_limit_line_edit.text())
         return float(self.lower_limit_line_edit.text())
 
     def get_upper_limit(self):
+        if not self.upper_limit_line_edit.hasAcceptableInput():
+            self.upper_limit_line_edit.validator().fixup(self.upper_limit_line_edit.text())
         return float(self.upper_limit_line_edit.text())
 
     def get_label(self):


### PR DESCRIPTION
#### Summary of work
Add a check to the validator when switching tabs (before casting the line edit text to a float).
If the user hasn't pressed return / clicked off of the line edit, it wasn't being validated.

Fixes #36738 

### To test:

- Follow recreation steps from the original issue #36738
- Also correct valid values in this way and check they are saved as normal

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
