### PR TITLE
Fix a bug that could crash Mantid when Open Slice Viewer from Indirect/Inelastic interfaces is called with 1 spectra workspace.

### DIFF
--- a/docs/source/release/v6.10.0/Inelastic/Bugfixes/36931.rst
+++ b/docs/source/release/v6.10.0/Inelastic/Bugfixes/36931.rst
@@ -1,0 +1,1 @@
+- Fixed a bug that crashed Mantid when calling Open Slice Viewer from Indirect/Inelastic interfaces when there are less than two histograms in the workspace.

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.cpp
@@ -89,11 +89,12 @@ boost::optional<std::string> checkWorkspaceSpectrumSize(const MatrixWorkspace_co
 
 boost::optional<std::string> checkWorkspaceBinSize(const MatrixWorkspace_const_sptr &workspace,
                                                    const std::string &caller = "") {
-  if (workspace->getNumberHistograms() < 2)
+  if (workspace->getNumberHistograms() < 2) {
     if (caller != "")
       return caller + ": Can't plot with less than two histograms in  " + workspace->getName() + ".";
     else
       return "Plot Bins failed: There is only one data point to plot in " + workspace->getName() + ".";
+  }
   return boost::none;
 }
 

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.cpp
@@ -254,7 +254,7 @@ std::optional<std::string> OutputPlotOptionsModel::checkWorkspaceSize(std::strin
   if (ads.doesExist(workspaceName)) {
     if (auto const matrixWs = ads.retrieveWS<MatrixWorkspace>(workspaceName)) {
       if (axisType == MantidAxis::Spectrum) {
-        auto msg = checkWorkspaceBinSize(matrixWs);
+        auto msg = checkWorkspaceSpectrumSize(matrixWs);
         return msg.has_value() ? "Plot Spectra Failed: " + msg.value() : msg;
       } else if (axisType == MantidAxis::Bin) {
         auto msg = checkWorkspaceBinSize(matrixWs);

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.cpp
@@ -87,9 +87,13 @@ boost::optional<std::string> checkWorkspaceSpectrumSize(const MatrixWorkspace_co
   return boost::none;
 }
 
-boost::optional<std::string> checkWorkspaceBinSize(const MatrixWorkspace_const_sptr &workspace) {
+boost::optional<std::string> checkWorkspaceBinSize(const MatrixWorkspace_const_sptr &workspace,
+                                                   const std::string &caller = "") {
   if (workspace->getNumberHistograms() < 2)
-    return "Plot Bins failed: There is only one data point to plot in " + workspace->getName() + ".";
+    if (caller != "")
+      return caller + ": Can't plot with less than two histograms in  " + workspace->getName() + ".";
+    else
+      return "Plot Bins failed: There is only one data point to plot in " + workspace->getName() + ".";
   return boost::none;
 }
 
@@ -253,6 +257,8 @@ boost::optional<std::string> OutputPlotOptionsModel::checkWorkspaceSize(std::str
     if (auto const matrixWs = ads.retrieveWS<MatrixWorkspace>(workspaceName)) {
       if (axisType == MantidAxis::Spectrum)
         return checkWorkspaceSpectrumSize(matrixWs);
+      else if (axisType == MantidAxis::SpectrumSlice)
+        return checkWorkspaceBinSize(matrixWs, "Open Slice Viewer");
       return checkWorkspaceBinSize(matrixWs);
     }
   }

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.cpp
@@ -81,28 +81,23 @@ void insertWorkspaceNames(std::vector<std::string> &allNames, std::string const 
   }
 }
 
-boost::optional<std::string> checkWorkspaceSpectrumSize(const MatrixWorkspace_const_sptr &workspace) {
+std::optional<std::string> checkWorkspaceSpectrumSize(const MatrixWorkspace_const_sptr &workspace) {
   if (workspace->y(0).size() < 2)
-    return "Plot Spectra failed: There is only one data point to plot in " + workspace->getName() + ".";
-  return boost::none;
+    return "There is only one data point to plot in " + workspace->getName() + ".";
+  return std::nullopt;
 }
 
-boost::optional<std::string> checkWorkspaceBinSize(const MatrixWorkspace_const_sptr &workspace,
-                                                   const std::string &caller = "") {
-  if (workspace->getNumberHistograms() < 2) {
-    if (caller != "")
-      return caller + ": Can't plot with less than two histograms in  " + workspace->getName() + ".";
-    else
-      return "Plot Bins failed: There is only one data point to plot in " + workspace->getName() + ".";
-  }
-  return boost::none;
+std::optional<std::string> checkWorkspaceBinSize(const MatrixWorkspace_const_sptr &workspace) {
+  if (workspace->getNumberHistograms() < 2)
+    return "There is only one histogram in " + workspace->getName() + ".";
+  return std::nullopt;
 }
 
 std::map<std::string, std::string>
-constructActions(boost::optional<std::map<std::string, std::string>> const &availableActions) {
+constructActions(std::optional<std::map<std::string, std::string>> const &availableActions) {
   std::map<std::string, std::string> actions;
   if (availableActions)
-    actions = availableActions.get();
+    actions = availableActions.value();
   actions.insert({"Plot Spectra", "Plot Spectra"});
   actions.insert({"Plot Bins", "Plot Bins"});
   actions.insert({"Open Slice Viewer", "Open Slice Viewer"});
@@ -115,15 +110,15 @@ constructActions(boost::optional<std::map<std::string, std::string>> const &avai
 namespace MantidQt::CustomInterfaces {
 
 OutputPlotOptionsModel::OutputPlotOptionsModel(
-    boost::optional<std::map<std::string, std::string>> const &availableActions)
-    : m_actions(constructActions(availableActions)), m_fixedIndices(false), m_workspaceIndices(boost::none),
-      m_workspaceName(boost::none), m_plotter(std::make_unique<ExternalPlotter>()) {}
+    std::optional<std::map<std::string, std::string>> const &availableActions)
+    : m_actions(constructActions(availableActions)), m_fixedIndices(false), m_workspaceIndices(std::nullopt),
+      m_workspaceName(std::nullopt), m_plotter(std::make_unique<ExternalPlotter>()) {}
 
 /// Used by the unit tests so that m_plotter can be mocked
 OutputPlotOptionsModel::OutputPlotOptionsModel(
-    ExternalPlotter *plotter, boost::optional<std::map<std::string, std::string>> const &availableActions)
-    : m_actions(constructActions(availableActions)), m_fixedIndices(false), m_workspaceIndices(boost::none),
-      m_workspaceName(boost::none), m_plotter(plotter) {}
+    ExternalPlotter *plotter, std::optional<std::map<std::string, std::string>> const &availableActions)
+    : m_actions(constructActions(availableActions)), m_fixedIndices(false), m_workspaceIndices(std::nullopt),
+      m_workspaceName(std::nullopt), m_plotter(plotter) {}
 
 OutputPlotOptionsModel::~OutputPlotOptionsModel() = default;
 
@@ -136,9 +131,9 @@ bool OutputPlotOptionsModel::setWorkspace(std::string const &workspaceName) {
   return false;
 }
 
-boost::optional<std::string> OutputPlotOptionsModel::workspace() const { return m_workspaceName; }
+std::optional<std::string> OutputPlotOptionsModel::workspace() const { return m_workspaceName; }
 
-void OutputPlotOptionsModel::removeWorkspace() { m_workspaceName = boost::none; }
+void OutputPlotOptionsModel::removeWorkspace() { m_workspaceName = std::nullopt; }
 
 std::vector<std::string>
 OutputPlotOptionsModel::getAllWorkspaceNames(std::vector<std::string> const &workspaceNames) const {
@@ -150,7 +145,7 @@ OutputPlotOptionsModel::getAllWorkspaceNames(std::vector<std::string> const &wor
 
 void OutputPlotOptionsModel::setUnit(std::string const &unit) { m_unit = unit; }
 
-boost::optional<std::string> OutputPlotOptionsModel::unit() { return m_unit; }
+std::optional<std::string> OutputPlotOptionsModel::unit() { return m_unit; }
 
 std::string OutputPlotOptionsModel::formatIndices(std::string const &indices) const {
   return formatIndicesString(indices);
@@ -169,16 +164,16 @@ bool OutputPlotOptionsModel::setIndices(std::string const &indices) {
   if (valid)
     m_workspaceIndices = indices;
   else
-    m_workspaceIndices = boost::none;
+    m_workspaceIndices = std::nullopt;
   return valid;
 }
 
-boost::optional<std::string> OutputPlotOptionsModel::indices() const { return m_workspaceIndices; }
+std::optional<std::string> OutputPlotOptionsModel::indices() const { return m_workspaceIndices; }
 
 bool OutputPlotOptionsModel::validateIndices(std::string const &indices, MantidAxis const &axisType) const {
   auto &ads = AnalysisDataService::Instance();
-  if (!indices.empty() && m_workspaceName && ads.doesExist(m_workspaceName.get())) {
-    if (auto const matrixWs = ads.retrieveWS<MatrixWorkspace>(m_workspaceName.get())) {
+  if (!indices.empty() && m_workspaceName && ads.doesExist(m_workspaceName.value())) {
+    if (auto const matrixWs = ads.retrieveWS<MatrixWorkspace>(m_workspaceName.value())) {
       if (axisType == MantidAxis::Spectrum)
         return validateSpectra(matrixWs, indices);
       return validateBins(matrixWs, indices);
@@ -218,14 +213,15 @@ void OutputPlotOptionsModel::plotSpectra() {
   auto const unitName = unit();
 
   if (workspaceName && indicesString) {
-    std::string plotWorkspaceName = unitName ? convertUnit(workspaceName.get(), unitName.get()) : workspaceName.get();
-    m_plotter->plotSpectra(plotWorkspaceName, indicesString.get(), SettingsHelper::externalPlotErrorBars());
+    std::string plotWorkspaceName =
+        unitName ? convertUnit(workspaceName.value(), unitName.value()) : workspaceName.value();
+    m_plotter->plotSpectra(plotWorkspaceName, indicesString.value(), SettingsHelper::externalPlotErrorBars());
   }
 }
 
 void OutputPlotOptionsModel::plotBins(std::string const &binIndices) {
   if (auto const workspaceName = workspace())
-    m_plotter->plotBins(workspaceName.get(), binIndices, SettingsHelper::externalPlotErrorBars());
+    m_plotter->plotBins(workspaceName.value(), binIndices, SettingsHelper::externalPlotErrorBars());
 }
 
 void OutputPlotOptionsModel::showSliceViewer() {
@@ -233,7 +229,8 @@ void OutputPlotOptionsModel::showSliceViewer() {
   auto const unitName = unit();
 
   if (workspaceName) {
-    std::string plotWorkspaceName = unitName ? convertUnit(workspaceName.get(), unitName.get()) : workspaceName.get();
+    std::string plotWorkspaceName =
+        unitName ? convertUnit(workspaceName.value(), unitName.value()) : workspaceName.value();
     m_plotter->showSliceViewer(plotWorkspaceName);
   }
 }
@@ -242,28 +239,37 @@ void OutputPlotOptionsModel::plotTiled() {
   auto const workspaceName = workspace();
   auto const indicesString = indices();
   if (workspaceName && indicesString)
-    m_plotter->plotTiled(workspaceName.get(), indicesString.get(), SettingsHelper::externalPlotErrorBars());
+    m_plotter->plotTiled(workspaceName.value(), indicesString.value(), SettingsHelper::externalPlotErrorBars());
 }
 
-boost::optional<std::string> OutputPlotOptionsModel::singleDataPoint(MantidAxis const &axisType) const {
+std::optional<std::string> OutputPlotOptionsModel::singleDataPoint(MantidAxis const &axisType) const {
   if (auto const workspaceName = workspace())
-    return checkWorkspaceSize(workspaceName.get(), axisType);
-  return boost::none;
+    return checkWorkspaceSize(workspaceName.value(), axisType);
+  return std::nullopt;
 }
 
-boost::optional<std::string> OutputPlotOptionsModel::checkWorkspaceSize(std::string const &workspaceName,
-                                                                        MantidAxis const &axisType) const {
+std::optional<std::string> OutputPlotOptionsModel::checkWorkspaceSize(std::string const &workspaceName,
+                                                                      MantidAxis const &axisType) const {
   auto &ads = AnalysisDataService::Instance();
   if (ads.doesExist(workspaceName)) {
     if (auto const matrixWs = ads.retrieveWS<MatrixWorkspace>(workspaceName)) {
-      if (axisType == MantidAxis::Spectrum)
-        return checkWorkspaceSpectrumSize(matrixWs);
-      else if (axisType == MantidAxis::SpectrumSlice)
-        return checkWorkspaceBinSize(matrixWs, "Open Slice Viewer");
-      return checkWorkspaceBinSize(matrixWs);
+      if (axisType == MantidAxis::Spectrum) {
+        auto msg = checkWorkspaceBinSize(matrixWs);
+        return msg.has_value() ? "Plot Spectra Failed: " + msg.value() : msg;
+      } else if (axisType == MantidAxis::Bin) {
+        auto msg = checkWorkspaceBinSize(matrixWs);
+        return msg.has_value() ? "Plot Bins Failed: " + msg.value() : msg;
+      } else {
+        auto msg1 = checkWorkspaceBinSize(matrixWs).value_or("");
+        auto msg2 = checkWorkspaceSpectrumSize(matrixWs).value_or("");
+        if (!msg1.empty() || !msg2.empty())
+          return "Open Slice viewer failed: " + msg1 + " " + msg2;
+        else
+          return std::nullopt;
+      }
     }
   }
-  return boost::none;
+  return std::nullopt;
 }
 
 std::map<std::string, std::string> OutputPlotOptionsModel::availableActions() const { return m_actions; }

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.h
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.h
@@ -11,8 +11,7 @@
 #include "DllConfig.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 
-#include <boost/none_t.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 using namespace MantidQt::Widgets::MplCpp;
 
@@ -21,10 +20,10 @@ namespace CustomInterfaces {
 
 class MANTIDQT_INELASTIC_DLL OutputPlotOptionsModel {
 public:
-  OutputPlotOptionsModel(boost::optional<std::map<std::string, std::string>> const &availableActions = boost::none);
+  OutputPlotOptionsModel(std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
   /// Used by the unit tests so that m_plotter can be mocked
   OutputPlotOptionsModel(ExternalPlotter *plotter,
-                         boost::optional<std::map<std::string, std::string>> const &availableActions = boost::none);
+                         std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
   virtual ~OutputPlotOptionsModel();
 
   virtual bool setWorkspace(std::string const &workspaceName);
@@ -32,26 +31,26 @@ public:
 
   virtual std::vector<std::string> getAllWorkspaceNames(std::vector<std::string> const &workspaceNames) const;
 
-  boost::optional<std::string> workspace() const;
+  std::optional<std::string> workspace() const;
 
   virtual void setFixedIndices(std::string const &indices);
   virtual bool indicesFixed() const;
 
   virtual void setUnit(std::string const &unit);
-  boost::optional<std::string> unit();
+  std::optional<std::string> unit();
 
   virtual std::string formatIndices(std::string const &indices) const;
   virtual bool validateIndices(std::string const &indices, MantidAxis const &axisType = MantidAxis::Spectrum) const;
   virtual bool setIndices(std::string const &indices);
 
-  boost::optional<std::string> indices() const;
+  std::optional<std::string> indices() const;
 
   virtual void plotSpectra();
   virtual void plotBins(std::string const &binIndices);
   virtual void plotTiled();
   virtual void showSliceViewer();
 
-  boost::optional<std::string> singleDataPoint(MantidAxis const &axisType) const;
+  std::optional<std::string> singleDataPoint(MantidAxis const &axisType) const;
 
   std::map<std::string, std::string> availableActions() const;
 
@@ -60,13 +59,13 @@ private:
   bool validateBins(const Mantid::API::MatrixWorkspace_sptr &workspace, std::string const &bins) const;
   std::string convertUnit(const std::string &workspaceName, const std::string &unit);
 
-  boost::optional<std::string> checkWorkspaceSize(std::string const &workspaceName, MantidAxis const &axisType) const;
+  std::optional<std::string> checkWorkspaceSize(std::string const &workspaceName, MantidAxis const &axisType) const;
 
   std::map<std::string, std::string> m_actions;
   bool m_fixedIndices;
-  boost::optional<std::string> m_workspaceIndices;
-  boost::optional<std::string> m_workspaceName;
-  boost::optional<std::string> m_unit;
+  std::optional<std::string> m_workspaceIndices;
+  std::optional<std::string> m_workspaceName;
+  std::optional<std::string> m_unit;
   std::unique_ptr<ExternalPlotter> m_plotter;
 };
 

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.cpp
@@ -36,7 +36,7 @@ namespace MantidQt::CustomInterfaces {
 
 OutputPlotOptionsPresenter::OutputPlotOptionsPresenter(
     IOutputPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
-    boost::optional<std::map<std::string, std::string>> const &availableActions)
+    std::optional<std::map<std::string, std::string>> const &availableActions)
     : m_wsRemovedObserver(*this, &OutputPlotOptionsPresenter::onWorkspaceRemoved),
       m_wsReplacedObserver(*this, &OutputPlotOptionsPresenter::onWorkspaceReplaced), m_view(view),
       m_model(std::make_unique<OutputPlotOptionsModel>(availableActions)) {
@@ -141,7 +141,7 @@ void OutputPlotOptionsPresenter::setUnit(std::string const &unit) {
 void OutputPlotOptionsPresenter::setIndices() {
   auto const selectedIndices = m_view->selectedIndices().toStdString();
   if (auto const indices = m_model->indices())
-    handleSelectedIndicesChanged(indices.get());
+    handleSelectedIndicesChanged(indices.value());
   else if (!selectedIndices.empty())
     handleSelectedIndicesChanged(selectedIndices);
   else
@@ -185,7 +185,7 @@ void OutputPlotOptionsPresenter::handlePlotBinsClicked() {
 }
 
 void OutputPlotOptionsPresenter::handleShowSliceViewerClicked() {
-  if (validateWorkspaceSize(MantidAxis::SpectrumSlice)) {
+  if (validateWorkspaceSize(MantidAxis::Both)) {
     setPlotting(true);
     m_model->showSliceViewer();
     setPlotting(false);
@@ -203,7 +203,7 @@ void OutputPlotOptionsPresenter::handlePlotTiledClicked() {
 bool OutputPlotOptionsPresenter::validateWorkspaceSize(MantidAxis const &axisType) {
   auto const errorMessage = m_model->singleDataPoint(axisType);
   if (errorMessage) {
-    m_view->displayWarning(QString::fromStdString(errorMessage.get()));
+    m_view->displayWarning(QString::fromStdString(errorMessage.value()));
     return false;
   }
   return true;

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.cpp
@@ -185,9 +185,11 @@ void OutputPlotOptionsPresenter::handlePlotBinsClicked() {
 }
 
 void OutputPlotOptionsPresenter::handleShowSliceViewerClicked() {
-  setPlotting(true);
-  m_model->showSliceViewer();
-  setPlotting(false);
+  if (validateWorkspaceSize(MantidAxis::SpectrumSlice)) {
+    setPlotting(true);
+    m_model->showSliceViewer();
+    setPlotting(false);
+  }
 }
 
 void OutputPlotOptionsPresenter::handlePlotTiledClicked() {

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.h
@@ -34,7 +34,7 @@ class MANTIDQT_INELASTIC_DLL OutputPlotOptionsPresenter final : public IOutputPl
 public:
   OutputPlotOptionsPresenter(IOutputPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
                              std::string const &fixedIndices = "",
-                             boost::optional<std::map<std::string, std::string>> const &availableActions = boost::none);
+                             std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
   /// Used by the unit tests so that the view and model can be mocked
   OutputPlotOptionsPresenter(IOutputPlotOptionsView *view, OutputPlotOptionsModel *model,
                              PlotWidget const &plotType = PlotWidget::Spectra, std::string const &fixedIndices = "");

--- a/qt/scientific_interfaces/Inelastic/test/Common/OutputPlotOptionsModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Common/OutputPlotOptionsModelTest.h
@@ -57,10 +57,10 @@ void createWorkspaceGroup(std::vector<std::string> const &workspaceNames, std::s
 }
 
 std::map<std::string, std::string>
-constructActions(boost::optional<std::map<std::string, std::string>> const &availableActions) {
+constructActions(std::optional<std::map<std::string, std::string>> const &availableActions) {
   std::map<std::string, std::string> actions;
   if (availableActions)
-    actions = availableActions.get();
+    actions = availableActions.value();
   if (actions.find("Plot Spectra") == actions.end())
     actions["Plot Spectra"] = "Plot Spectra";
   if (actions.find("Plot Bins") == actions.end())
@@ -131,7 +131,7 @@ public:
 
     TS_ASSERT(m_model->setWorkspace(WORKSPACE_NAME));
     TS_ASSERT(m_model->workspace());
-    TS_ASSERT_EQUALS(m_model->workspace().get(), WORKSPACE_NAME);
+    TS_ASSERT_EQUALS(m_model->workspace().value(), WORKSPACE_NAME);
   }
 
   void test_that_setWorkspace_will_not_set_the_workspace_if_the_workspace_provided_does_not_exist_in_the_ADS() {
@@ -161,7 +161,7 @@ public:
 
     TS_ASSERT(m_model->indicesFixed());
     TS_ASSERT(m_model->indices());
-    TS_ASSERT_EQUALS(m_model->indices().get(), WORKSPACE_INDICES);
+    TS_ASSERT_EQUALS(m_model->indices().value(), WORKSPACE_INDICES);
   }
 
   void test_that_setFixedIndices_will_not_set_the_indices_as_being_fixed_if_the_indices_are_empty() {
@@ -242,7 +242,7 @@ public:
 
     TS_ASSERT(m_model->setIndices(WORKSPACE_INDICES));
     TS_ASSERT(m_model->indices());
-    TS_ASSERT_EQUALS(m_model->indices().get(), WORKSPACE_INDICES);
+    TS_ASSERT_EQUALS(m_model->indices().value(), WORKSPACE_INDICES);
   }
 
   void test_that_setIndices_will_not_set_the_indices_if_they_are_invalid() {
@@ -320,6 +320,14 @@ public:
   }
 
   void
+  test_that_singleDataPoint_will_return_a_no_error_message_if_the_workspace_has_more_than_one_data_points_to_open_slice_viewer() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
+    m_model->setWorkspace(WORKSPACE_NAME);
+
+    TS_ASSERT(!m_model->singleDataPoint(MantidAxis::Both));
+  }
+
+  void
   test_that_singleDataPoint_will_return_an_error_message_if_the_workspace_has_a_single_data_point_to_plot_for_spectrum() {
     m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 1));
     m_model->setWorkspace(WORKSPACE_NAME);
@@ -335,8 +343,31 @@ public:
     TS_ASSERT(m_model->singleDataPoint(MantidAxis::Bin));
   }
 
+  void
+  test_that_singleDataPoint_will_return_an_error_message_if_the_workspace_has_one_histogram_to_open_slice_viewer() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(1, 5));
+    m_model->setWorkspace(WORKSPACE_NAME);
+
+    TS_ASSERT(m_model->singleDataPoint(MantidAxis::Both));
+  }
+
+  void test_that_singleDataPoint_will_return_an_error_message_if_the_workspace_has_one_bin_to_open_slice_viewer() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 1));
+    m_model->setWorkspace(WORKSPACE_NAME);
+
+    TS_ASSERT(m_model->singleDataPoint(MantidAxis::Both));
+  }
+
+  void
+  test_that_singleDataPoint_will_return_an_error_message_if_the_workspace_has_one_bin_and_one_histogram_to_open_slice_viewer() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(1, 1));
+    m_model->setWorkspace(WORKSPACE_NAME);
+
+    TS_ASSERT(m_model->singleDataPoint(MantidAxis::Both));
+  }
+
   void test_that_availableActions_will_return_the_default_actions_when_none_are_set() {
-    TS_ASSERT_EQUALS(m_model->availableActions(), constructActions(boost::none));
+    TS_ASSERT_EQUALS(m_model->availableActions(), constructActions(std::nullopt));
   }
 
   void test_that_availableActions_will_return_the_correct_actions_when_they_have_been_set() {

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ExternalPlotter.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ExternalPlotter.h
@@ -19,7 +19,7 @@ namespace MantidQt {
 namespace Widgets {
 namespace MplCpp {
 
-enum MantidAxis { Spectrum, Bin };
+enum MantidAxis { Spectrum, Bin, SpectrumSlice };
 
 /**
  @class ExternalPlotter

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ExternalPlotter.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ExternalPlotter.h
@@ -19,7 +19,7 @@ namespace MantidQt {
 namespace Widgets {
 namespace MplCpp {
 
-enum MantidAxis { Spectrum, Bin, SpectrumSlice };
+enum MantidAxis { Spectrum, Bin, Both };
 
 /**
  @class ExternalPlotter


### PR DESCRIPTION
### Description of work
It is possible to directly open Slice Viewer from several indirect/inelastic interfaces. However, the slice viewer interface does not work when the calling workspace contains less than 2 spectra. This validation step was not added at the time the option to call from the interfaces was integrated and it can cause a crash of the Workbench if the user tries to call the slice viewer with workspaces that are unfriendly to the slice viewer interface.  The issue is fixed in this PR. 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36931. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->


### To test:
  - Reproduce instructions in #36931 that lead to the crash, check that it does not crash anymore; instead a warning message is raised, describing the problem.
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*Added a release note*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
