### PR TITLE
Fix bug when no peak found IntegratePeaksShoeboxTOF

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
@@ -299,9 +299,9 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
         if self.getProperty("GetNBinsFromBackToBackParams").value:
             # check at least first peak in workspace has back to back params
             if not inst.getComponentByName(pk_ws.column("BankName")[0]).hasParameter("B"):
-                issues[
-                    "GetNBinsFromBackToBackParams"
-                ] = "Workspace doesn't have back to back exponential coefficients defined in the parameters.xml file."
+                issues["GetNBinsFromBackToBackParams"] = (
+                    "Workspace doesn't have back to back exponential coefficients defined in the parameters.xml file."
+                )
         return issues
 
     def PyExec(self):
@@ -366,7 +366,7 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
                 ipos_predicted = [peak_data.irow, peak_data.icol, ix]
                 det_edges = peak_data.det_edges if not integrate_on_edge else None
 
-                intens, sigma, status, ispecs, ipos, nrows, ncols, nbins = integrate_peak(
+                intens, sigma, status, ipos, nrows, ncols, nbins = integrate_peak(
                     ws,
                     peaks,
                     ipk,
@@ -506,6 +506,8 @@ def integrate_peak(
     ipos = find_nearest_peak_in_data_window(intens_over_sig, ispecs, x, ws, peaks, ipk, *ipos_predicted)
 
     # perform final integration if required
+    intens, sigma = 0.0, 0.0
+    status = PEAK_STATUS.NO_PEAK
     if ipos is not None:
         # integrate at that position (without smoothing I/sigma)
         intens, sigma, status = integrate_shoebox_at_pos(y, esq, kernel, ipos, weak_peak_threshold, det_edges)
@@ -514,7 +516,7 @@ def integrate_peak(
             kernel = make_kernel(nrows, ncols, nbins)
             # re-integrate but this time check for overlap with edge
             intens, sigma, status = integrate_shoebox_at_pos(y, esq, kernel, ipos, weak_peak_threshold, det_edges)
-    return intens, sigma, status, ispecs, ipos, nrows, ncols, nbins
+    return intens, sigma, status, ipos, nrows, ncols, nbins
 
 
 def round_up_to_odd_number(number):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksShoeboxTOFTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksShoeboxTOFTest.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+from unittest import mock
 from mantid.simpleapi import (
     IntegratePeaksShoeboxTOF,
     CreatePeaksWorkspace,
@@ -186,6 +187,22 @@ class FindSXPeaksConvolveTest(unittest.TestCase):
         )
         # check output file saved
         self.assertTrue(path.exists(out_file))
+
+    @mock.patch("IntegratePeaksShoeboxTOF.find_nearest_peak_in_data_window")
+    def test_exec_no_peak(self, mock_find_ipos):
+        mock_find_ipos.return_value = None
+        out = IntegratePeaksShoeboxTOF(
+            InputWorkspace=self.ws,
+            PeaksWorkspace=self.peaks,
+            OutputWorkspace="peaks6",
+            GetNBinsFromBackToBackParams=True,
+            NRows=3,
+            NCols=3,
+            WeakPeakThreshold=0.0,
+            OptimiseShoebox=False,
+            IntegrateIfOnEdge=True,
+        )
+        self._assert_found_correct_peaks(out, i_over_sigs=2 * [0.0])
 
 
 if __name__ == "__main__":

--- a/docs/source/release/v6.10.0/Diffraction/Single_Crystal/Bugfixes/36965.rst
+++ b/docs/source/release/v6.10.0/Diffraction/Single_Crystal/Bugfixes/36965.rst
@@ -1,0 +1,1 @@
+- Fix error when no peak found in vicinity of predicted position in ``IntegratePeaksShoeboxTOF``


### PR DESCRIPTION
### Description of work

Fix bug when no peak found in detector window in `IntegratePeaksShoeboxTOF`.

Had error `intens` referenced before assignment - this is now fixed by defaulting to `intens=0.0`, `sigma=0` and `status=PEAK_STATUS.NO_PEAK`

*There is no associated issue.*

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

(1) Download this file
(2) Run this script

```
Load(Filename=r'\\isis.cclrc.ac.uk\inst$\ndxsxd\instrument\data\cycle_10_3\SXD23767.raw', OutputWorkspace='SXD23767')
LoadNexus(Filename='peaks.nxs', OutputWorkspace='peaks')
IntegratePeaksShoeboxTOF(InputWorkspace='SXD23767', PeaksWorkspace='peaks', 
                         OutputWorkspace='peaks_int', GetNBinsFromBackToBackParams=True, NFWHM='8', OptimiseShoebox=False, IntegrateIfOnEdge=True, LorentzCorrection=False)

```
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
