### PR TITLE
Remove libmesa from linux dev requirements

### DIFF
--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -34,7 +34,7 @@ dependencies:
   - python=3.10.*
   - pyyaml>=5.4.1
   - qscintilla2
-  - qt=5.15.8 # Avoid unexpected qt upgrades
+  - qt==5.15.8 # Avoid unexpected qt upgrades
   - qtconsole>5.4.2,!=5.5.0 # 5.4.2 crashes the jupyter console. 5.5.0 raises a TypeError when using tab completion.
   - qtpy>=1.9.0
   - qt-gtk-platformtheme # Use native theme on GTK-based systems, which provides a significantly better performing file browser.
@@ -51,13 +51,11 @@ dependencies:
   - orsopy
 
   # Not Windows, OpenGL implementation:
-  - mesalib>=18.0.0
   - mesa-libgl-devel-cos7-x86_64>=18.3.4
-  - mesa-libgl-cos7-x86_64>=18.3.4
 
   # Linux only
   - gxx_linux-64==10.3.*
-  - libglu>=9.0.0
+  - libglu>=9.0
 
   # Needed for test suite on Linux
   - pciutils-libs-cos7-x86_64>=3.5.1

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -34,7 +34,7 @@ dependencies:
   - python.app
   - pyyaml>=5.4.1
   - qscintilla2
-  - qt=5.15.8 # Avoid unexpected qt upgrades
+  - qt==5.15.8 # Avoid unexpected qt upgrades
   - qtconsole>5.4.2,!=5.5.0 # 5.4.2 crashes the jupyter console. 5.5.0 raises a TypeError when using tab completion.
   - qtpy>=1.9.0
   - requests>=2.25.1

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -34,7 +34,7 @@ dependencies:
   - python=3.10.*
   - pyyaml>=5.4.1
   - qscintilla2
-  - qt=5.15.8 # Avoid unexpected qt upgrades
+  - qt==5.15.8 # Avoid unexpected qt upgrades
   - qtconsole>5.4.2,!=5.5.0 # 5.4.2 crashes the jupyter console. 5.5.0 raises a TypeError when using tab completion.
   - qtpy>=1.9.0
   - requests>=2.25.1


### PR DESCRIPTION
In early 2024, mantidworkbench could no longer be launched from a developer build on ubuntu 22.04. The issue was tracked down to opengl/mesa configuration and/or libraries. It turns out that dropping libmesa from the mantid developer requirements fixes the issue. 

One can recreate the fix by simply `conda remove libmesa` rather then delete and recreate their conda environment.

### Description of work

In addition to verifying the fix works by trying it, one can see that the system opengl headers aren't leaking into the build environment by making the following modification
```sh
$ git diff Framework/Geometry/CMakeLists.txt
diff --git a/Framework/Geometry/CMakeLists.txt b/Framework/Geometry/CMakeLists.txt
index c975042441d..ab9a51e391b 100644
--- a/Framework/Geometry/CMakeLists.txt
+++ b/Framework/Geometry/CMakeLists.txt
@@ -440,7 +440,9 @@ endif()
 
 if(ENABLE_OPENGL)
   list(APPEND INC_FILES inc/MantidGeometry/Rendering/OpenGL_Headers.h)
+  set_source_files_properties( inc/MantidGeometry/Rendering/OpenGL_Headers.h PROPERTIES COMPILE_FLAGS -H )
   list(APPEND SRC_FILES src/Rendering/RenderingHelpersOpenGL.cpp)
+  set_source_files_properties( src/Rendering/RenderingHelpersOpenGL.cpp PROPERTIES COMPILE_FLAGS -H )
 else()
   list(APPEND SRC_FILES src/Rendering/RenderingHelpersThrowing.cpp)
 endif()
```
This will print out the full path of where all of the headers are included from. It is recommended that you redirect the output to a file and make sure that `GL/gl.h` is included from the conda tree rather than system path.

*There is no associated issue,* but it is also described in [EWM4248](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4248).

### To test:

1. create a new build directory
2. remove the entire `~/.cache/ccache/` directory
3. make the change above to see where `GL/gl.h` is included from
4. build the workbench
5. launch the workbench

*This does not require release notes* because it is only an error for developers on ubuntu 22.04.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
