### PR TITLE
Fix domain check bug

### DIFF
--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -965,7 +965,7 @@ size_t CompositeFunction::getNumberDomains() const {
   }
   size_t nd = getFunction(0)->getNumberDomains();
   for (size_t iFun = 1; iFun < n; ++iFun) {
-    if (getFunction(0)->getNumberDomains() != nd) {
+    if (getFunction(iFun)->getNumberDomains() != nd) {
       throw std::runtime_error("CompositeFunction has members with "
                                "inconsistent domain numbers.");
     }

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -148,14 +148,17 @@ public:
 
   // Override pure virtual functions.
   std::string name() const override { return "FunctionWithNDomains"; }
-
   double fwhm() const override { return 1; }
-  void setFwhm(const double w) override {}
-  void functionLocal(double *out, const double *xValues, const size_t nData) const override {}
+  void setFwhm(const double w) override { UNUSED_ARG(w); }
+  void functionLocal(double *out, const double *xValues, const size_t nData) const override {
+    UNUSED_ARG(out);
+    UNUSED_ARG(xValues);
+    UNUSED_ARG(nData);
+  }
   double centre() const override { return 1; }
   double height() const override { return 1; }
-  void setCentre(const double c) override {}
-  void setHeight(const double h) override {}
+  void setCentre(const double c) override { UNUSED_ARG(c); }
+  void setHeight(const double h) override { UNUSED_ARG(h); }
 
 private:
   size_t m_nDomains;

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -139,6 +139,28 @@ public:
   void setFwhm(const double w) override { setParameter(2, w); }
 };
 
+// Create class with configurable number of domains for ease of testing.
+class FunctionWithNDomains : public IPeakFunction {
+public:
+  FunctionWithNDomains(int nDomains) : m_nDomains(nDomains) {}
+
+  size_t getNumberDomains() const override { return m_nDomains; }
+
+  // Override pure virtual functions.
+  std::string name() const override { return "FunctionWithNDomains"; }
+
+  double fwhm() const override { return 1; }
+  void setFwhm(const double w) override {}
+  void functionLocal(double *out, const double *xValues, const size_t nData) const override {}
+  double centre() const override { return 1; }
+  double height() const override { return 1; }
+  void setCentre(const double c) override {}
+  void setHeight(const double h) override {}
+
+private:
+  size_t m_nDomains;
+};
+
 template <bool withAttributes = false> class Linear : public ParamFunction, public IFunction1D {
 public:
   Linear() {
@@ -1515,6 +1537,19 @@ public:
     TS_ASSERT_EQUALS(composite->getFunction(0)->calculateStepSize(parameterValue2), parameterValue2 * sqrtEpsilon);
     TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameterValue1), parameterValue1 * sqrtEpsilon);
     TS_ASSERT_EQUALS(composite->getFunction(1)->calculateStepSize(parameterValue2), parameterValue2 * sqrtEpsilon);
+  }
+
+  void test_getNumberDomains_throws_with_inconsistent_domain_numbers() {
+    IFunction_sptr f1 = IFunction_sptr(new FunctionWithNDomains(7));
+    IFunction_sptr f2 = IFunction_sptr(new FunctionWithNDomains(13));
+
+    CompositeFunction fun;
+
+    fun.addFunction(f1);
+    fun.addFunction(f2);
+
+    TS_ASSERT_THROWS_EQUALS(fun.getNumberDomains(), const std::runtime_error &e, std::string(e.what()),
+                            "CompositeFunction has members with inconsistent domain numbers.");
   }
 
 private:

--- a/Framework/API/test/CompositeFunctionTest.h
+++ b/Framework/API/test/CompositeFunctionTest.h
@@ -1359,7 +1359,7 @@ public:
     TS_ASSERT_EQUALS(mfun->getAttribute("NumDeriv").asBool(), true);
   }
 
-  void test_set_attribute_thorws_if_attribute_not_recongized() {
+  void test_set_attribute_throws_if_attribute_not_recongized() {
     auto mfun = std::make_unique<CompositeFunction>();
     auto gauss = std::make_shared<Gauss<true>>();
     auto background = std::make_shared<Linear<true>>();

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -321,7 +321,6 @@ constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/BoostOptionalToAlgor
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/BoostOptionalToAlgorithmProperty.cpp:33
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/BoostOptionalToAlgorithmProperty.cpp:30
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/SmoothNeighbours.cpp:317
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/API/src/CompositeFunction.cpp:968
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/CompositeFunction.cpp:560
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/CompositeFunction.cpp:879
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/CompositeFunction.cpp:906

--- a/docs/source/release/v6.10.0/Framework/Fit_Functions/Bugfixes/36970.rst
+++ b/docs/source/release/v6.10.0/Framework/Fit_Functions/Bugfixes/36970.rst
@@ -1,0 +1,1 @@
+- CompositeFunction will now throw an exception if getNumberDomains() is called and there is an inconsistent number of domains in any of the member functions.


### PR DESCRIPTION
### Description of work
Fixes a bug highlighted by cppcheck, and adds a test to confirm correct behaviour.

*There is no associated issue.*

### To test:
Not sure how you would functionally test this. Maybe reviewing the code and new test would suffice.



<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
