### PR TITLE
34369 avoid engdiff fit window loading non-existing spectras

### DIFF
--- a/docs/source/release/v6.10.0/Diffraction/Engineering/Bugfixes/34369.rst
+++ b/docs/source/release/v6.10.0/Diffraction/Engineering/Bugfixes/34369.rst
@@ -1,0 +1,1 @@
+- Avoid loading non existing spectra in the :ref:`Engineering Diffraction interface <Engineering_Diffraction-ref>` :ref:`Fitting tab <ui engineering fitting>` when doing a fit following an ADS clear.

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -308,8 +308,9 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
                 line.remove()
 
         if self.fit_result_ws_name:
-            ws = AnalysisDataService.retrieve(self.fit_result_ws_name)
-            self.get_axes().remove_workspace_artists(ws)
+            if AnalysisDataService.doesExist(self.fit_result_ws_name):
+                ws = AnalysisDataService.retrieve(self.fit_result_ws_name)
+                self.get_axes().remove_workspace_artists(ws)
             self.fit_result_ws_name = ""
         self.update_legend()
 

--- a/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowser.py
+++ b/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowser.py
@@ -149,7 +149,11 @@ class FitPropertyBrowserTest(unittest.TestCase):
         workspaceList = property_browser.getWorkspaceList()
         self.assertEqual(3, workspaceList.count())
 
-        AnalysisDataService.clear()
+        # Removing the specific workspaces created during the test
+        AnalysisDataService.remove(name_1)
+        AnalysisDataService.remove(name_1 + "_Workspace")
+        AnalysisDataService.remove(name_1 + "_Parameters")
+        AnalysisDataService.remove(name_1 + "_NormalisedCovarianceMatrix")
 
         name_2 = "ws_2"
         ws = CreateWorkspace(OutputWorkspace=name_2, DataX=np.arange(10), DataY=2 + np.arange(10), NSpec=5)

--- a/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowser.py
+++ b/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowser.py
@@ -132,6 +132,40 @@ class FitPropertyBrowserTest(unittest.TestCase):
         self.assertEqual(name + "_Parameters", workspaceList.item(1).text())
         self.assertEqual(name + "_Workspace", workspaceList.item(2).text())
 
+    def test_fitting_done_follows_ads_clear_fitting_done_another(self):
+        name_1 = "ws_1"
+        fig, canvas, _ = self._create_and_plot_matrix_workspace(name_1)
+        property_browser = self._create_widget(canvas=canvas)
+        property_browser.setOutputName(name_1)
+
+        # create fake fit output results
+        matrixWorkspace = WorkspaceFactory.Instance().create("Workspace2D", NVectors=3, YLength=5, XLength=5)
+        tableWorkspace = WorkspaceFactory.createTable()
+        AnalysisDataService.Instance().addOrReplace(name_1 + "_Workspace", matrixWorkspace)
+        AnalysisDataService.Instance().addOrReplace(name_1 + "_Parameters", tableWorkspace)
+        AnalysisDataService.Instance().addOrReplace(name_1 + "_NormalisedCovarianceMatrix", tableWorkspace)
+
+        property_browser.fitting_done_slot(name_1 + "_Workspace")
+        workspaceList = property_browser.getWorkspaceList()
+        self.assertEqual(3, workspaceList.count())
+
+        AnalysisDataService.clear()
+
+        name_2 = "ws_2"
+        ws = CreateWorkspace(OutputWorkspace=name_2, DataX=np.arange(10), DataY=2 + np.arange(10), NSpec=5)
+        property_browser.do_plot(ws)
+
+        # create fake fit output results
+        matrixWorkspace = WorkspaceFactory.Instance().create("Workspace2D", NVectors=3, YLength=5, XLength=5)
+        tableWorkspace = WorkspaceFactory.createTable()
+        AnalysisDataService.Instance().addOrReplace(name_2 + "_Workspace", matrixWorkspace)
+        AnalysisDataService.Instance().addOrReplace(name_2 + "_Parameters", tableWorkspace)
+        AnalysisDataService.Instance().addOrReplace(name_2 + "_NormalisedCovarianceMatrix", tableWorkspace)
+
+        property_browser.fitting_done_slot(name_2 + "_Workspace")
+        self.assertEqual(property_browser.fit_result_ws_name, name_2 + "_Workspace")
+        self.assertEqual(3, property_browser.getWorkspaceList().count())
+
     def test_fit_result_matrix_workspace_in_browser_is_viewed_when_clicked(self):
         from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
 


### PR DESCRIPTION
### Description of work
The Engineering diffraction's fitting tab tries to load a non-existing workspace when a fit is called on a workspace that is different to the previous fit workspace following an ADS.clear(). A fix was added to check whether the workspace is available before trying to load from the ADS. 


Fixes #34369. 

### To test:
See instructions in Test 7 of manual testing instructions (latest version not merged yet)
https://github.com/mantidproject/mantid/blob/33e61abf3a7ed9a3e352ca91886efe03d9afc5b8/dev-docs/source/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.rst

(1) Plot a run
(2) Fit a run
(3) Click Remove Selected to remove a run from the table (the browser should close)
(4) Clear the ADS
(5) Load in other runs
(6) Fit a different run from before

#### Expected behavior
On `_Workspace` workspace being deleted the fit browser would remove the fitted curves (think this happened) and would not try to remove them again on a subsequent fit (i.e. would forget about them).

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
