### PR TITLE
Add variable to External Interfaces CMake file

### DIFF
--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -6,6 +6,7 @@ set(_mslice_external_root ${CMAKE_CURRENT_BINARY_DIR}/src/mslice)
 externalproject_add(
   mslice
   PREFIX ${_mslice_external_root}
+  UPDATE_DISCONNECTED "false"
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
   GIT_TAG be452d09a15b120282eac7691e116b2e87e50e8d
   EXCLUDE_FROM_ALL 1


### PR DESCRIPTION
### Description of work

#### Summary of work
Added UPDATE_DISCONNECTED variable for MSlice in the External Interfaces CMake file.

#### Purpose of work
We would like to upgrade to the latest version of Jenkins as this is more secure. In testing this on our staging server we found that pull requests in Windows in particular would fail as it would search for UPDATE_DISCONNECTED. In order to enable us to upgrade Jenkins I have added this variable against MSlice.

*There is no associated issue.*

### To test:
- All automated tests should pass

*This does not require release notes* because **this is not a user facing change**



---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
