### PR TITLE
Add a temporary developer flag to allow users to test `quickBayes` in Bayes Fitting interface

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
@@ -132,6 +132,7 @@ class BayesQuasi(PythonAlgorithm):
         self._res_norm = self.getProperty("UseResNorm").value
         self._wfile = self.getPropertyValue("WidthFile")
         self._loop = self.getProperty("Loop").value
+        self._output_fit_name = self.getPropertyValue("OutputWorkspaceFit")
 
     # pylint: disable=too-many-locals,too-many-statements
     def PyExec(self):
@@ -297,7 +298,7 @@ class BayesQuasi(PythonAlgorithm):
             datY = np.append(datY, res1)
             datE = np.append(datE, dataG)
             nsp = 3
-            names = "data,fit.1,diff.1"
+            names = "data,fit 1,diff 1"
             res_plot = [0, 1, 2]
             if self._program == "QL":
                 workflow_prog.report("Processing Lorentzian result data")
@@ -310,7 +311,7 @@ class BayesQuasi(PythonAlgorithm):
                 datY = np.append(datY, res2)
                 datE = np.append(datE, dataG)
                 nsp += 2
-                names += ",fit.2,diff.2"
+                names += ",fit 2,diff 2"
 
                 dataF3 = yfit_list[3]
                 datX = np.append(datX, dataX)
@@ -321,7 +322,7 @@ class BayesQuasi(PythonAlgorithm):
                 datY = np.append(datY, res3)
                 datE = np.append(datE, dataG)
                 nsp += 2
-                names += ",fit.3,diff.3"
+                names += ",fit 3,diff 3"
 
                 res_plot.append(4)
                 prob0.append(yprob[0])
@@ -330,7 +331,7 @@ class BayesQuasi(PythonAlgorithm):
                 prob3.append(yprob[3])
 
             # create result workspace
-            fitWS = fname + "_Workspaces"
+            fitWS = self._output_fit_name
             fout = fname + "_Workspace_" + str(spectrum)
 
             workflow_prog.report("Creating OutputWorkspace")

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
@@ -291,11 +291,12 @@ void Quasi::updateMiniPlot() {
     return;
 
   auto const fitGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(m_outputFitGroup);
-  if (!fitGroup || fitGroup->getNumberOfEntries() == 0) {
+  if (!fitGroup || fitGroup->getNumberOfEntries() <= m_previewSpec) {
     return;
   }
 
-  auto const outputWorkspace = std::dynamic_pointer_cast<MatrixWorkspace>(fitGroup->getItem(0));
+  auto const outputWorkspace =
+      std::dynamic_pointer_cast<MatrixWorkspace>(fitGroup->getItem(static_cast<std::size_t>(m_previewSpec)));
 
   TextAxis *axis = dynamic_cast<TextAxis *>(outputWorkspace->getAxis(1));
 
@@ -352,7 +353,7 @@ void Quasi::handleSampleInputReady(const QString &filename) {
 void Quasi::plotCurrentPreview() {
   auto const errorBars = SettingsHelper::externalPlotErrorBars();
 
-  if (m_uiForm.ppPlot->hasCurve("fit.1")) {
+  if (m_uiForm.ppPlot->hasCurve("fit 1")) {
     QString program = m_uiForm.cbProgram->currentText();
     auto fitName = m_QuasiAlg->getPropertyValue("OutputWorkspaceFit");
     checkADSForPlotSaveWorkspace(fitName, false);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
@@ -515,10 +515,10 @@ void Quasi::plotClicked() {
   auto const errorBars = SettingsHelper::externalPlotErrorBars();
 
   // Output options
-  std::string const plot = m_uiForm.cbPlot->currentText().toStdString();
+  std::string const plot = m_uiForm.cbPlot->currentText().toLower().toStdString();
   QString const program = m_uiForm.cbProgram->currentText();
   auto const resultName = m_QuasiAlg->getPropertyValue("OutputWorkspaceResult");
-  if ((plot == "Prob" || plot == "All") && (program == "Lorentzians")) {
+  if ((plot == "prob" || plot == "all") && (program == "Lorentzians")) {
     auto const probWS = m_QuasiAlg->getPropertyValue("OutputWorkspaceProb");
     // Check workspace exists
     IndirectTab::checkADSForPlotSaveWorkspace(probWS, true);
@@ -528,13 +528,16 @@ void Quasi::plotClicked() {
   auto const resultWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(resultName);
   int const numSpectra = (int)resultWS->getNumberHistograms();
   IndirectTab::checkADSForPlotSaveWorkspace(resultName, true);
-  auto const paramNames = {"Amplitude", "FWHM", "Beta"};
+  auto const paramNames = {"amplitude", "fwhm", "beta"};
   for (std::string const &paramName : paramNames) {
 
-    if (plot == paramName || plot == "All") {
+    if (plot == paramName || plot == "all") {
       std::vector<std::size_t> spectraIndices = {};
       for (auto i = 0u; i < static_cast<std::size_t>(numSpectra); i++) {
         auto axisLabel = resultWS->getAxis(1)->label(i);
+        // Convert to lower case
+        std::transform(axisLabel.begin(), axisLabel.end(), axisLabel.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
 
         auto const found = axisLabel.find(paramName);
         if (found != std::string::npos) {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
@@ -63,7 +63,7 @@ private:
   void setRunIsRunning(bool running);
   void setPlotResultIsPlotting(bool plotting);
 
-  std::string m_outputFitGroup;
+  std::string m_outputBaseName;
   /// Current preview spectrum
   int m_previewSpec;
   /// The ui form

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
@@ -63,6 +63,7 @@ private:
   void setRunIsRunning(bool running);
   void setPlotResultIsPlotting(bool plotting);
 
+  std::string m_outputFitGroup;
   /// Current preview spectrum
   int m_previewSpec;
   /// The ui form

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
@@ -107,6 +107,12 @@ bool Stretch::validate() {
     return false;
   }
 
+  auto const useQuickBayes = SettingsHelper::hasDevelopmentFlag("quickbayes");
+  if (useQuickBayes && m_uiForm.cbBackground->currentText() == "Sloping") {
+    emit showMessageBox("The 'quickBayes' package does not support a 'Sloping' background type.");
+    return false;
+  }
+
   return true;
 }
 
@@ -141,20 +147,28 @@ void Stretch::run() {
   m_fitWorkspaceName = baseName + "_Stretch_Fit";
   m_contourWorkspaceName = baseName + "_Stretch_Contour";
 
-  auto stretch = AlgorithmManager::Instance().create("BayesStretch");
+  // Temporary developer flag to allow the testing of quickBayes in the Bayes fitting interface
+  auto const useQuickBayes = SettingsHelper::hasDevelopmentFlag("quickbayes");
+
+  std::string const algorithmName = useQuickBayes ? "BayesStretch2" : "BayesStretch";
+  auto stretch = AlgorithmManager::Instance().create(algorithmName);
   stretch->initialize();
   stretch->setProperty("SampleWorkspace", sampleName);
   stretch->setProperty("ResolutionWorkspace", resName);
   stretch->setProperty("EMin", eMin);
   stretch->setProperty("EMax", eMax);
-  stretch->setProperty("SampleBins", nBins);
-  stretch->setProperty("Elastic", elasticPeak);
-  stretch->setProperty("Background", background);
-  stretch->setProperty("NumberSigma", sigma);
   stretch->setProperty("NumberBeta", beta);
-  stretch->setProperty("Loop", sequence);
+  stretch->setProperty("Elastic", elasticPeak);
   stretch->setProperty("OutputWorkspaceFit", m_fitWorkspaceName);
   stretch->setProperty("OutputWorkspaceContour", m_contourWorkspaceName);
+  if (useQuickBayes) {
+    stretch->setProperty("Background", background == "Flat" ? background : "None");
+  } else {
+    stretch->setProperty("Background", background);
+    stretch->setProperty("SampleBins", nBins);
+    stretch->setProperty("NumberSigma", sigma);
+    stretch->setProperty("Loop", sequence);
+  }
 
   m_batchAlgoRunner->addAlgorithm(stretch);
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
@@ -261,20 +261,20 @@ int Stretch::displaySaveDirectoryMessage() {
  */
 void Stretch::plotWorkspaces() {
   setPlotResultIsPlotting(true);
-  WorkspaceGroup_sptr fitWorkspace = WorkspaceUtils::getADSWorkspace<WorkspaceGroup>(m_fitWorkspaceName);
 
-  auto sigma = QString::fromStdString(fitWorkspace->getItem(0)->getName());
-  auto beta = QString::fromStdString(fitWorkspace->getItem(1)->getName());
-  // Check Sigma and Beta workspaces exist
-  if (sigma.right(5).compare("Sigma") == 0 && beta.right(4).compare("Beta") == 0) {
+  std::string const plotType = m_uiForm.cbPlot->currentText().toStdString();
+  auto const plotErrors = SettingsHelper::externalPlotErrorBars();
+  auto const plotSigma = (plotType == "All" || plotType == "Sigma");
+  auto const plotBeta = (plotType == "All" || plotType == "Beta");
 
-    std::string const plotType = m_uiForm.cbPlot->currentText().toStdString();
-    if (plotType == "All" || plotType == "Beta")
-      m_plotter->plotSpectra(beta.toStdString(), "0", SettingsHelper::externalPlotErrorBars());
-    if (plotType == "All" || plotType == "Sigma")
-      m_plotter->plotSpectra(sigma.toStdString(), "0", SettingsHelper::externalPlotErrorBars());
-  } else {
-    g_log.error("Beta and Sigma workspace were not found and could not be plotted.");
+  auto const fitWorkspace = WorkspaceUtils::getADSWorkspace<WorkspaceGroup>(m_fitWorkspaceName);
+  for (auto it = fitWorkspace->begin(); it < fitWorkspace->end(); ++it) {
+    auto const name = (*it)->getName();
+    if (plotSigma && name.substr(name.length() - 5) == "Sigma") {
+      m_plotter->plotSpectra(name, "0", plotErrors);
+    } else if (plotBeta && name.substr(name.length() - 4) == "Beta") {
+      m_plotter->plotSpectra(name, "0", plotErrors);
+    }
   }
   setPlotResultIsPlotting(false);
 }


### PR DESCRIPTION
**Report to:** Spencer, Sanghamitra, Anthony

### Description of work
This PR adds a Developer Feature flag described [here](https://docs.mantidproject.org/nightly/interfaces/indirect/Indirect%20Settings.html#id2) for use by advanced Indirect/Inelastic users. The introduction of this flag will allow users to test this feature by setting a "flag" in the settings interface, without having the feature rolled out to all users of the software.

To use the `quickBayes` package instead of `quasielasticbayes`, users need to set the flag "quickbayes" (no capitals) in their settings interface e.g.

![image](https://github.com/mantidproject/mantid/assets/40830825/9ee08a5d-9018-457e-98f2-52b7766abd42)

**NOTE: These flags are temporary, and should only be used for the purposes of testing and recieving feedback from users. When we are happy `quickBayes` is a good replacement for `quasielasticbayes`, the plan is to remove this flag.**

### To test:
1. Open `Inelastic->Bayes fitting`
2. Go to the `Quasi` tab
3. Load these data sets from the SampleData
Sample `irs26176_graphite002_red`
Resolution `irs26173_graphite002_res`

4. Click `Run`. It should say missing package `quasielasticbayes`
5. Open the Settings widget in the bottom left corner
6. Type "quickbayes" (no capitals) in the developer flags box, and click `Apply`
7. Close the Settings widget
8. Change `Background` to `Flat`
9. Click `Run`. It should say missing package `quickBayes`

Repeat the test instructions, but this time install the `quasielasticbayes` and `quickBayes` packages using the instructions on this page
https://docs.mantidproject.org/nightly/concepts/PipInstall.html

10. Similar plots should be plotted each time. The plots should change when you change the Preview Spectrum

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
