### PR TITLE
Refactor setInstrumentDefault option in ISIS Energy Transfer View

### DIFF
--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransfer.ui
@@ -463,19 +463,6 @@
                </widget>
               </item>
               <item>
-               <spacer name="horizontalSpacer_7">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
                <widget class="QLabel" name="lbRebinWidth">
                 <property name="text">
                  <string>Width:</string>
@@ -510,19 +497,6 @@
                  <string>*</string>
                 </property>
                </widget>
-              </item>
-              <item>
-               <spacer name="horizontalSpacer_8">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
               </item>
               <item>
                <widget class="QLabel" name="lbRebinHigh">

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransfer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>660</width>
-    <height>841</height>
+    <width>670</width>
+    <height>840</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -26,23 +26,32 @@
       <string>Input</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="1">
-       <widget class="QCheckBox" name="ckSumFiles">
-        <property name="toolTip">
-         <string>Sum multiple files together.</string>
+      <item row="0" column="0">
+       <widget class="MantidQt::API::FileFinderWidget" name="dsRunFiles" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>41</verstretch>
+         </sizepolicy>
         </property>
-        <property name="text">
-         <string>Sum Files</string>
+        <property name="label" stdset="0">
+         <string>Input Runs</string>
+        </property>
+        <property name="multipleFiles" stdset="0">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="ckUseCalib">
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="ckLoadLogFiles">
         <property name="toolTip">
-         <string>Use calibration file to adjust for detector efficiency.</string>
+         <string>Load log files</string>
         </property>
         <property name="text">
-         <string>Use Calib File</string>
+         <string>Load Log Files</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -71,32 +80,23 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="ckLoadLogFiles">
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="ckSumFiles">
         <property name="toolTip">
-         <string>Load log files</string>
+         <string>Sum multiple files together.</string>
         </property>
         <property name="text">
-         <string>Load Log Files</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
+         <string>Sum Files</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="MantidQt::API::FileFinderWidget" name="dsRunFiles" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>41</verstretch>
-         </sizepolicy>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="ckUseCalib">
+        <property name="toolTip">
+         <string>Use calibration file to adjust for detector efficiency.</string>
         </property>
-        <property name="label" stdset="0">
-         <string>Input Runs</string>
-        </property>
-        <property name="multipleFiles" stdset="0">
-         <bool>true</bool>
+        <property name="text">
+         <string>Use Calib File</string>
         </property>
        </widget>
       </item>
@@ -393,146 +393,218 @@
            <number>0</number>
           </property>
           <widget class="QWidget" name="pgSingleRebin">
-           <layout class="QVBoxLayout" name="verticalLayout_16">
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
             <item>
-             <layout class="QHBoxLayout" name="loSingleRebin">
-              <property name="spacing">
-               <number>6</number>
-              </property>
-              <property name="leftMargin">
-               <number>6</number>
-              </property>
-              <property name="topMargin">
-               <number>6</number>
-              </property>
-              <property name="rightMargin">
-               <number>6</number>
-              </property>
-              <property name="bottomMargin">
-               <number>6</number>
-              </property>
+             <layout class="QVBoxLayout" name="verticalLayout">
               <item>
-               <widget class="QLabel" name="lbRebinLow">
-                <property name="text">
-                 <string>Low:</string>
+               <spacer name="horizontalSpacer_7">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
                 </property>
-               </widget>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>568</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
               </item>
               <item>
-               <widget class="QDoubleSpinBox" name="spRebinLow">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="decimals">
-                 <number>5</number>
-                </property>
-                <property name="minimum">
-                 <double>-999.990000000000009</double>
-                </property>
-                <property name="maximum">
-                 <double>999.990000000000009</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
+               <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <item>
+                 <widget class="QLabel" name="lbRebinLow">
+                  <property name="minimumSize">
+                   <size>
+                    <width>32</width>
+                    <height>16</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Low:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QDoubleSpinBox" name="spRebinLow">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>50</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="decimals">
+                   <number>5</number>
+                  </property>
+                  <property name="minimum">
+                   <double>-999.990000000000009</double>
+                  </property>
+                  <property name="maximum">
+                   <double>999.990000000000009</double>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.100000000000000</double>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="valRebinLow">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>16</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">color: rgb(255, 0, 4)</string>
+                  </property>
+                  <property name="text">
+                   <string>*</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="lbRebinWidth">
+                  <property name="minimumSize">
+                   <size>
+                    <width>32</width>
+                    <height>16</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Width:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QDoubleSpinBox" name="spRebinWidth">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>50</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="decimals">
+                   <number>5</number>
+                  </property>
+                  <property name="minimum">
+                   <double>-999.990000000000009</double>
+                  </property>
+                  <property name="maximum">
+                   <double>999.990000000000009</double>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.010000000000000</double>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="valRebinWidth">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>16</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">color: rgb(255, 0, 4)</string>
+                  </property>
+                  <property name="text">
+                   <string>*</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="lbRebinHigh">
+                  <property name="minimumSize">
+                   <size>
+                    <width>32</width>
+                    <height>16</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>High:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QDoubleSpinBox" name="spRebinHigh">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>50</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="decimals">
+                   <number>5</number>
+                  </property>
+                  <property name="minimum">
+                   <double>-999.990000000000009</double>
+                  </property>
+                  <property name="maximum">
+                   <double>999.990000000000009</double>
+                  </property>
+                  <property name="singleStep">
+                   <double>0.100000000000000</double>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="valRebinHigh">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>16</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">color: rgb(255, 0, 4)</string>
+                  </property>
+                  <property name="text">
+                   <string>*</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </item>
               <item>
-               <widget class="QLabel" name="valRebinLow">
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 4)</string>
+               <spacer name="horizontalSpacer_5">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
                 </property>
-                <property name="text">
-                 <string>*</string>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>628</width>
+                  <height>20</height>
+                 </size>
                 </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="lbRebinWidth">
-                <property name="text">
-                 <string>Width:</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QDoubleSpinBox" name="spRebinWidth">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="decimals">
-                 <number>5</number>
-                </property>
-                <property name="minimum">
-                 <double>-999.990000000000009</double>
-                </property>
-                <property name="maximum">
-                 <double>999.990000000000009</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.010000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="valRebinWidth">
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 4)</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="lbRebinHigh">
-                <property name="text">
-                 <string>High:</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QDoubleSpinBox" name="spRebinHigh">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="decimals">
-                 <number>5</number>
-                </property>
-                <property name="minimum">
-                 <double>-999.990000000000009</double>
-                </property>
-                <property name="maximum">
-                 <double>999.990000000000009</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLabel" name="valRebinHigh">
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 4)</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
+               </spacer>
               </item>
              </layout>
             </item>
@@ -983,7 +1055,6 @@
   <tabstop>ckDetailedBalance</tabstop>
   <tabstop>spDetailedBalance</tabstop>
   <tabstop>ckDoNotRebin</tabstop>
-  <tabstop>cbRebinType</tabstop>
   <tabstop>spRebinLow</tabstop>
   <tabstop>spRebinWidth</tabstop>
   <tabstop>spRebinHigh</tabstop>

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
@@ -91,7 +91,6 @@ void IETPresenter::setInstrumentDefault() {
         !rebinDefault.isEmpty() ? rebinDefault.split(",", Qt::SkipEmptyParts) : QStringList({"0", "0", "0"});
 
     int rebinTab = (int)(rebinParams.size() != 3);
-    std::cout << rebinDefault.toStdString() << "  rebin tab  " << rebinTab << std::endl;
     QString rebinString = !rebinDefault.isEmpty() ? rebinDefault : QString("");
     m_view->setInstrumentRebinning(rebinParams, rebinString, rebinDefault.isEmpty(), rebinTab);
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
@@ -219,17 +219,17 @@ void IETView::setInstrumentSpectraRange(int specMin, int specMax) {
   m_uiForm.spPlotTimeSpecMax->setValue(1);
 }
 
-void IETView::setInstrumentRebinning(QStringList const &rebinParams, QString const &rebinText, bool checked,
+void IETView::setInstrumentRebinning(std::vector<double> const &rebinParams, std::string const &rebinText, bool checked,
                                      int tabIndex) {
   m_uiForm.ckDoNotRebin->setChecked(checked);
   m_uiForm.cbRebinType->setCurrentIndex(tabIndex);
-  m_uiForm.spRebinLow->setValue(rebinParams[0].toDouble());
-  m_uiForm.spRebinWidth->setValue(rebinParams[1].toDouble());
-  m_uiForm.spRebinHigh->setValue(rebinParams[2].toDouble());
-  m_uiForm.leRebinString->setText(rebinText);
+  m_uiForm.spRebinLow->setValue(rebinParams[0]);
+  m_uiForm.spRebinWidth->setValue(rebinParams[1]);
+  m_uiForm.spRebinHigh->setValue(rebinParams[2]);
+  m_uiForm.leRebinString->setText(QString::fromStdString(rebinText));
 }
 
-void IETView::setInstrumentGrouping(QString const &instrumentName) {
+void IETView::setInstrumentGrouping(std::string const &instrumentName) {
 
   setGroupOutputCheckBoxVisible(instrumentName == "OSIRIS");
   setGroupOutputDropdownVisible(instrumentName == "IRIS");
@@ -243,12 +243,13 @@ void IETView::setInstrumentGrouping(QString const &instrumentName) {
   }
 }
 
-void IETView::setInstrumentEFixed(QString const &instrumentName, double eFixed) {
+void IETView::setInstrumentEFixed(std::string const &instrumentName, double eFixed) {
   QStringList qens;
   qens << "IRIS"
        << "OSIRIS";
-  m_uiForm.spEfixed->setEnabled(qens.contains(instrumentName));
-  m_uiForm.dsRunFiles->setInstrumentOverride(instrumentName);
+  auto instName = QString::fromStdString(instrumentName);
+  m_uiForm.spEfixed->setEnabled(qens.contains(instName));
+  m_uiForm.dsRunFiles->setInstrumentOverride(instName);
   m_uiForm.spEfixed->setValue(eFixed);
 }
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
@@ -76,9 +76,10 @@ public:
   void setOutputWorkspaces(std::vector<std::string> const &outputWorkspaces);
 
   void setInstrumentSpectraRange(int specMin, int specMax);
-  void setInstrumentRebinning(QStringList const &rebinParams, QString const &rebinText, bool checked, int tabIndex);
-  void setInstrumentEFixed(QString const &instrumentName, double eFixed);
-  void setInstrumentGrouping(QString const &instrumentName);
+  void setInstrumentRebinning(std::vector<double> const &rebinParams, std::string const &rebinText, bool checked,
+                              int tabIndex);
+  void setInstrumentEFixed(std::string const &instrumentName, double eFixed);
+  void setInstrumentGrouping(std::string const &instrumentName);
   void setInstrumentSpecDefault(std::map<std::string, bool> &specMap);
 
 public slots:

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
@@ -75,8 +75,13 @@ public:
   void setFileExtensionsByName(QStringList calibrationFbSuffixes, QStringList calibrationWSSuffixes);
   void setOutputWorkspaces(std::vector<std::string> const &outputWorkspaces);
 
+  void setInstrumentSpectraRange(int specMin, int specMax);
+  void setInstrumentRebinning(QStringList const &rebinParams, QString const &rebinText, bool checked, int tabIndex);
+  void setInstrumentEFixed(QString const &instrumentName, double eFixed);
+  void setInstrumentGrouping(QString const &instrumentName);
+  void setInstrumentSpecDefault(std::map<std::string, bool> &specMap);
+
 public slots:
-  void setInstrumentDefault(InstrumentData const &instrumentDetails);
   void updateRunButton(bool enabled = true, std::string const &enableOutputButtons = "unchanged",
                        QString const &message = "Run", QString const &tooltip = "");
 


### PR DESCRIPTION
### Description of work
As explained in #35962, the ``setInstrumentDefault`` function in the view class of the ISIS Energy Transfer interface may be too long for a view function, and could be refactored in 2 steps: 
 - Transferring most of the logic to the presenter 
 - Splitting the population or activation of UI elements into different setters.

This PR does both things.  It is also a stepping stone into the eventual refactoring of the whole ISIS Energy Transfer presenter class (#35912).

Fixes #35962. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
### To test:
- Build the workbench, select ISIS as default facility and open ``Indirect->Data Reduction`` interface. 
- In the instrument combo box, cycle between instruments (``IRIS, OSIRIS, TOSCA, TFXA``) and check that interface reacts as expected in changing the default values and populating/activating corresponding items on the interface(If you compare the default values against current release (6.9), note that some of the default grouping options were changed in #36894, so it won't be exactly the same for the default grouping selection. 

*This does not require release notes*

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
