### PR TITLE
Add possibility for external 3D Surface plotting in Inelastic Interfaces

### DIFF
--- a/docs/source/release/v6.10.0/Inelastic/New_features/36837.rst
+++ b/docs/source/release/v6.10.0/Inelastic/New_features/36837.rst
@@ -1,0 +1,1 @@
+- Added the possibility to make an external call from selected Inelastic/Indirect interfaces for plotting data as a 3D Surface.

--- a/qt/scientific_interfaces/Indirect/Diffraction/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Diffraction/IndirectDiffractionReduction.cpp
@@ -771,6 +771,24 @@ void IndirectDiffractionReduction::runFilesFound() {
     m_uiForm.ckSumFiles->setChecked(false);
 }
 
+/**
+ * Handles the user toggling the manual grouping check box.
+ *
+ * @param state The selection state of the check box
+ */
+void IndirectDiffractionReduction::manualGroupingToggled(int state) {
+  switch (state) {
+  case Qt::Unchecked:
+    m_plotOptionsPresenter->setPlotType(PlotWidget::SpectraUnit);
+    break;
+  case Qt::Checked:
+    m_plotOptionsPresenter->setPlotType(PlotWidget::SpectraSliceSurfaceUnit);
+    break;
+  default:
+    return;
+  }
+}
+
 void IndirectDiffractionReduction::setRunIsRunning(bool running) {
   m_uiForm.pbRun->setText(running ? "Running..." : "Run");
   setButtonsEnabled(!running);

--- a/qt/scientific_interfaces/Indirect/Diffraction/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Diffraction/IndirectDiffractionReduction.cpp
@@ -771,24 +771,6 @@ void IndirectDiffractionReduction::runFilesFound() {
     m_uiForm.ckSumFiles->setChecked(false);
 }
 
-/**
- * Handles the user toggling the manual grouping check box.
- *
- * @param state The selection state of the check box
- */
-void IndirectDiffractionReduction::manualGroupingToggled(int state) {
-  switch (state) {
-  case Qt::Unchecked:
-    m_plotOptionsPresenter->setPlotType(PlotWidget::SpectraUnit);
-    break;
-  case Qt::Checked:
-    m_plotOptionsPresenter->setPlotType(PlotWidget::SpectraSliceSurfaceUnit);
-    break;
-  default:
-    return;
-  }
-}
-
 void IndirectDiffractionReduction::setRunIsRunning(bool running) {
   m_uiForm.pbRun->setText(running ? "Running..." : "Run");
   setButtonsEnabled(!running);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
@@ -30,7 +30,7 @@ IETPresenter::IETPresenter(IndirectDataReduction *idrUI, QWidget *parent)
       m_view(std::make_unique<IETView>(this, parent)) {
 
   setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptionsView(), PlotWidget::SpectraSlice));
+      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptionsView(), PlotWidget::SpectraSliceSurface));
 
   connect(this, SIGNAL(newInstrumentConfiguration()), this, SLOT(setInstrumentDefault()));
 

--- a/qt/scientific_interfaces/Indirect/Simulation/IndirectMolDyn.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/IndirectMolDyn.cpp
@@ -19,7 +19,7 @@ namespace MantidQt::CustomInterfaces {
 IndirectMolDyn::IndirectMolDyn(QWidget *parent) : IndirectSimulationTab(parent) {
   m_uiForm.setupUi(parent);
   setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSlice, "0"));
+      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface, "0"));
 
   connect(m_uiForm.ckCropEnergy, SIGNAL(toggled(bool)), m_uiForm.dspMaxEnergy, SLOT(setEnabled(bool)));
   connect(m_uiForm.ckResolution, SIGNAL(toggled(bool)), m_uiForm.dsResolution, SLOT(setEnabled(bool)));

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.cpp
@@ -102,6 +102,7 @@ constructActions(std::optional<std::map<std::string, std::string>> const &availa
   actions.insert({"Plot Bins", "Plot Bins"});
   actions.insert({"Open Slice Viewer", "Open Slice Viewer"});
   actions.insert({"Plot Tiled", "Plot Tiled"});
+  actions.insert({"Plot 3D Surface", "Plot 3D Surface"});
   return actions;
 }
 
@@ -235,6 +236,17 @@ void OutputPlotOptionsModel::showSliceViewer() {
   }
 }
 
+void OutputPlotOptionsModel::plot3DSurface() {
+  auto const workspaceName = workspace();
+  auto const unitName = unit();
+
+  if (workspaceName) {
+    std::string plotWorkspaceName =
+        unitName ? convertUnit(workspaceName.value(), unitName.value()) : workspaceName.value();
+    m_plotter->plot3DSurface(plotWorkspaceName);
+  }
+}
+
 void OutputPlotOptionsModel::plotTiled() {
   auto const workspaceName = workspace();
   auto const indicesString = indices();
@@ -263,7 +275,7 @@ std::optional<std::string> OutputPlotOptionsModel::checkWorkspaceSize(std::strin
         auto msg1 = checkWorkspaceBinSize(matrixWs).value_or("");
         auto msg2 = checkWorkspaceSpectrumSize(matrixWs).value_or("");
         if (!msg1.empty() || !msg2.empty())
-          return "Open Slice viewer failed: " + msg1 + " " + msg2;
+          return "Plotting data failed: " + msg1 + " " + msg2;
         else
           return std::nullopt;
       }

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.h
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.h
@@ -48,6 +48,7 @@ public:
   virtual void plotSpectra();
   virtual void plotBins(std::string const &binIndices);
   virtual void plotTiled();
+  virtual void plot3DSurface();
   virtual void showSliceViewer();
 
   std::optional<std::string> singleDataPoint(MantidAxis const &axisType) const;

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.cpp
@@ -133,7 +133,7 @@ void OutputPlotOptionsPresenter::clearWorkspaces() {
 }
 
 void OutputPlotOptionsPresenter::setUnit(std::string const &unit) {
-  if (m_plotType == PlotWidget::SpectraUnit || m_plotType == PlotWidget::SpectraSliceUnit) {
+  if (m_plotType == PlotWidget::SpectraUnit || m_plotType == PlotWidget::SpectraSliceSurfaceUnit) {
     m_model->setUnit(unit);
   }
 }
@@ -188,6 +188,14 @@ void OutputPlotOptionsPresenter::handleShowSliceViewerClicked() {
   if (validateWorkspaceSize(MantidAxis::Both)) {
     setPlotting(true);
     m_model->showSliceViewer();
+    setPlotting(false);
+  }
+}
+
+void OutputPlotOptionsPresenter::handlePlot3DClicked() {
+  if (validateWorkspaceSize(MantidAxis::Both)) {
+    setPlotting(true);
+    m_model->plot3DSurface();
     setPlotting(false);
   }
 }

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.h
@@ -27,6 +27,7 @@ public:
   virtual void handlePlotBinsClicked() = 0;
   virtual void handleShowSliceViewerClicked() = 0;
   virtual void handlePlotTiledClicked() = 0;
+  virtual void handlePlot3DClicked() = 0;
 };
 
 class MANTIDQT_INELASTIC_DLL OutputPlotOptionsPresenter final : public IOutputPlotOptionsPresenter {
@@ -46,6 +47,7 @@ public:
   void handlePlotSpectraClicked() override;
   void handlePlotBinsClicked() override;
   void handleShowSliceViewerClicked() override;
+  void handlePlot3DClicked() override;
   void handlePlotTiledClicked() override;
 
   void setPlotType(PlotWidget const &plotType);

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsView.cpp
@@ -199,7 +199,7 @@ void OutputPlotOptionsView::setPlotType(PlotWidget const &plotType,
     break;
   default:
     throw std::runtime_error("Plot option not found. Plot types are Spectra, "
-                             "SpectraSliceSurfaced or SpectraTiled.");
+                             "SpectraBin, SpectraSliceSurface or SpectraTiled.");
   }
   m_plotOptions->tbPlot->setMenu(plotMenu);
   m_plotOptions->tbPlot->setDefaultAction(plotSpectraAction);

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsView.cpp
@@ -58,6 +58,8 @@ QIcon showSliceViewerIcon() { return MantidQt::Icons::getIcon("mdi.chart-scatter
 
 QIcon plotTiledIcon() { return MantidQt::Icons::getIcon("mdi.chart-line-stacked"); }
 
+QIcon plot3DIcon() { return MantidQt::Icons::getIcon("mdi.panorama"); }
+
 } // namespace
 
 namespace MantidQt::CustomInterfaces {
@@ -128,6 +130,11 @@ void OutputPlotOptionsView::notifyShowSliceViewerClicked() {
   m_presenter->handleShowSliceViewerClicked();
 }
 
+void OutputPlotOptionsView::notifyPlot3DClicked() {
+  notifySelectedIndicesChanged();
+  m_presenter->handlePlot3DClicked();
+}
+
 void OutputPlotOptionsView::notifyPlotTiledClicked() {
   notifySelectedIndicesChanged();
   m_presenter->handlePlotTiledClicked();
@@ -145,11 +152,14 @@ void OutputPlotOptionsView::setPlotType(PlotWidget const &plotType,
   showSliceViewerAction->setIcon(showSliceViewerIcon());
   auto plotTiledAction = new QAction(getAction(availableActions, "Plot Tiled"), this);
   plotTiledAction->setIcon(plotTiledIcon());
+  auto plot3DAction = new QAction(getAction(availableActions, "Plot 3D Surface"), this);
+  plot3DAction->setIcon(plot3DIcon());
 
   connect(plotSpectraAction, SIGNAL(triggered()), this, SLOT(notifyPlotSpectraClicked()));
   connect(plotBinAction, SIGNAL(triggered()), this, SLOT(notifyPlotBinsClicked()));
   connect(showSliceViewerAction, SIGNAL(triggered()), this, SLOT(notifyShowSliceViewerClicked()));
   connect(plotTiledAction, SIGNAL(triggered()), this, SLOT(notifyPlotTiledClicked()));
+  connect(plot3DAction, SIGNAL(triggered()), this, SLOT(notifyPlot3DClicked()));
 
   m_plotOptions->tbPlot->setVisible(true);
   m_plotOptions->pbPlotSpectra->setVisible(true);
@@ -165,10 +175,11 @@ void OutputPlotOptionsView::setPlotType(PlotWidget const &plotType,
     plotMenu->addAction(plotSpectraAction);
     plotMenu->addAction(plotBinAction);
     break;
-  case PlotWidget::SpectraSlice:
+  case PlotWidget::SpectraSliceSurface:
     m_plotOptions->pbPlotSpectra->setVisible(false);
     plotMenu->addAction(plotSpectraAction);
     plotMenu->addAction(showSliceViewerAction);
+    plotMenu->addAction(plot3DAction);
     break;
   case PlotWidget::SpectraTiled:
     m_plotOptions->pbPlotSpectra->setVisible(false);
@@ -179,15 +190,16 @@ void OutputPlotOptionsView::setPlotType(PlotWidget const &plotType,
     m_plotOptions->tbPlot->setVisible(false);
     m_plotOptions->cbPlotUnit->setVisible(true);
     break;
-  case PlotWidget::SpectraSliceUnit:
+  case PlotWidget::SpectraSliceSurfaceUnit:
     m_plotOptions->pbPlotSpectra->setVisible(false);
     m_plotOptions->cbPlotUnit->setVisible(true);
     plotMenu->addAction(plotSpectraAction);
     plotMenu->addAction(showSliceViewerAction);
+    plotMenu->addAction(plot3DAction);
     break;
   default:
     throw std::runtime_error("Plot option not found. Plot types are Spectra, "
-                             "SpectraSliced or SpectraTiled.");
+                             "SpectraSliceSurfaced or SpectraTiled.");
   }
   m_plotOptions->tbPlot->setMenu(plotMenu);
   m_plotOptions->tbPlot->setDefaultAction(plotSpectraAction);

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsView.h
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsView.h
@@ -24,7 +24,7 @@ namespace CustomInterfaces {
 
 class IOutputPlotOptionsPresenter;
 
-enum PlotWidget { Spectra, SpectraBin, SpectraSlice, SpectraTiled, SpectraUnit, SpectraSliceUnit };
+enum PlotWidget { Spectra, SpectraBin, SpectraSliceSurface, SpectraTiled, SpectraUnit, SpectraSliceSurfaceUnit };
 
 class MANTIDQT_INELASTIC_DLL IOutputPlotOptionsView {
 public:
@@ -99,6 +99,7 @@ private slots:
   void notifyPlotBinsClicked();
   void notifyShowSliceViewerClicked();
   void notifyPlotTiledClicked();
+  void notifyPlot3DClicked();
 
 private:
   void setupView();

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
@@ -33,7 +33,7 @@ ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent) : Correc
   m_spectra = 0;
   m_uiForm.setupUi(parent);
   setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSlice));
+      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface));
 
   connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this, SLOT(newSample(const QString &)));
   connect(m_uiForm.dsContainer, SIGNAL(dataReady(const QString &)), this, SLOT(newContainer(const QString &)));

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
@@ -26,7 +26,7 @@ namespace MantidQt::CustomInterfaces {
 ContainerSubtraction::ContainerSubtraction(QWidget *parent) : CorrectionsTab(parent), m_spectra(0) {
   m_uiForm.setupUi(parent);
   setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSlice));
+      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface));
 
   connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this, SLOT(newSample(const QString &)));
   connect(m_uiForm.dsContainer, SIGNAL(dataReady(const QString &)), this, SLOT(newContainer(const QString &)));

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSqwTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSqwTab.cpp
@@ -36,7 +36,7 @@ InelasticDataManipulationSqwTab::InelasticDataManipulationSqwTab(QWidget *parent
       m_view(view) {
   m_view->subscribePresenter(this);
   setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraSlice));
+      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraSliceSurface));
 }
 
 void InelasticDataManipulationSqwTab::setup() {}

--- a/qt/scientific_interfaces/Inelastic/test/Common/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/Common/MockObjects.h
@@ -78,6 +78,7 @@ public:
   MOCK_METHOD1(plotBins, void(std::string const &binIndices));
   MOCK_METHOD0(showSliceViewer, void());
   MOCK_METHOD0(plotTiled, void());
+  MOCK_METHOD0(plot3DSurface, void());
 };
 
 class MockSettingsView : public ISettingsView {

--- a/qt/scientific_interfaces/Inelastic/test/Common/OutputPlotOptionsModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Common/OutputPlotOptionsModelTest.h
@@ -69,6 +69,8 @@ constructActions(std::optional<std::map<std::string, std::string>> const &availa
     actions["Open Slice Viewer"] = "Open Slice Viewer";
   if (actions.find("Plot Tiled") == actions.end())
     actions["Plot Tiled"] = "Plot Tiled";
+  if (actions.find("Plot 3D Surface") == actions.end())
+    actions["Plot 3D Surface"] = "Plot 3D Surface";
   return actions;
 }
 
@@ -93,6 +95,7 @@ public:
                void(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars));
   MOCK_METHOD3(plotBins, void(std::string const &workspaceName, std::string const &binIndices, bool errorBars));
   MOCK_METHOD1(showSliceViewer, void(std::string const &workspaceName));
+  MOCK_METHOD1(plot3DSurface, void(std::string const &workspaceName));
   MOCK_METHOD3(plotTiled, void(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars));
 };
 
@@ -320,7 +323,7 @@ public:
   }
 
   void
-  test_that_singleDataPoint_will_return_a_no_error_message_if_the_workspace_has_more_than_one_data_points_to_open_slice_viewer() {
+  test_that_singleDataPoint_will_return_a_no_error_message_if_the_workspace_has_more_than_one_data_points_to_open_slice_viewer_or_3DSurface() {
     m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
     m_model->setWorkspace(WORKSPACE_NAME);
 
@@ -344,14 +347,15 @@ public:
   }
 
   void
-  test_that_singleDataPoint_will_return_an_error_message_if_the_workspace_has_one_histogram_to_open_slice_viewer() {
+  test_that_singleDataPoint_will_return_an_error_message_if_the_workspace_has_one_histogram_to_open_slice_viewer_or_3DSurface() {
     m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(1, 5));
     m_model->setWorkspace(WORKSPACE_NAME);
 
     TS_ASSERT(m_model->singleDataPoint(MantidAxis::Both));
   }
 
-  void test_that_singleDataPoint_will_return_an_error_message_if_the_workspace_has_one_bin_to_open_slice_viewer() {
+  void
+  test_that_singleDataPoint_will_return_an_error_message_if_the_workspace_has_one_bin_to_open_slice_viewer_or_3DSurface() {
     m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 1));
     m_model->setWorkspace(WORKSPACE_NAME);
 
@@ -359,7 +363,7 @@ public:
   }
 
   void
-  test_that_singleDataPoint_will_return_an_error_message_if_the_workspace_has_one_bin_and_one_histogram_to_open_slice_viewer() {
+  test_that_singleDataPoint_will_return_an_error_message_if_the_workspace_has_one_bin_and_one_histogram_to_open_slice_viewer_or_3DSurface() {
     m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(1, 1));
     m_model->setWorkspace(WORKSPACE_NAME);
 
@@ -378,6 +382,7 @@ public:
     m_model = std::make_unique<OutputPlotOptionsModel>(m_plotter, actions);
 
     actions["Open Slice Viewer"] = "Open Slice Viewer";
+    actions["Plot 3D Surface"] = "Plot 3D Surface";
     actions["Plot Tiled"] = "Plot Tiled";
     TS_ASSERT_EQUALS(m_model->availableActions(), actions);
   }

--- a/qt/scientific_interfaces/Inelastic/test/Common/OutputPlotOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Common/OutputPlotOptionsPresenterTest.h
@@ -35,6 +35,8 @@ constructActions(boost::optional<std::map<std::string, std::string>> const &avai
     actions["Open Slice Viewer"] = "Open Slice Viewer";
   if (actions.find("Plot Tiled") == actions.end())
     actions["Plot Tiled"] = "Plot Tiled";
+  if (actions.find("Plot 3D Surface") == actions.end())
+    actions["Plot 3D Surface"] = "Plot 3D Surface";
   return actions;
 }
 
@@ -190,6 +192,14 @@ public:
     setExpectationsForWidgetEnabling(true);
 
     m_presenter->handlePlotTiledClicked();
+  }
+
+  void test_that_the_plot3DdClicked_signal_will_attempt_to_plot_3D_Surface() {
+    setExpectationsForWidgetEnabling(false);
+    EXPECT_CALL(*m_model, plot3DSurface()).Times(1);
+    setExpectationsForWidgetEnabling(true);
+
+    m_presenter->handlePlot3DClicked();
   }
 
   ///----------------------------------------------------------------------

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Plot.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Plot.h
@@ -163,6 +163,19 @@ MANTID_MPLCPP_DLL Common::Python::Object pcolormesh(const QStringList &workspace
                                                     boost::optional<Common::Python::Object> fig = boost::none);
 
 /**
+ * Makes a call to mantidqt.plotting.plot_surface.
+ *
+ * @param workspaces A vector of workspace names that are present in the ADS
+ *
+ * @param fig The python object that represents the matplotlib figure.
+ *
+ * @return Returns the figure that was created by the
+ * function in Python
+ */
+MANTID_MPLCPP_DLL Common::Python::Object surface(const QStringList &workspaces,
+                                                 boost::optional<Common::Python::Object> fig = boost::none);
+
+/**
  * Externall call to slice viewer GUI
  *
  * @param workspace A shared pointer to the target workspace

--- a/qt/widgets/mplcpp/src/Plot.cpp
+++ b/qt/widgets/mplcpp/src/Plot.cpp
@@ -167,6 +167,19 @@ Python::Object pcolormesh(const QStringList &workspaces, boost::optional<Python:
   }
 }
 
+Python::Object surface(const QStringList &workspaces, boost::optional<Python::Object> fig) {
+  GlobalInterpreterLock lock;
+  try {
+    const auto args = constructArgs(workspaces);
+    Python::Dict kwargs;
+    if (fig)
+      kwargs["fig"] = fig.get();
+    return functionsModule().attr("plot_surface")(*args, **kwargs);
+  } catch (Python::ErrorAlreadySet &) {
+    throw PythonException();
+  }
+}
+
 Python::Object sliceviewer(const Workspace_sptr &workspace) {
   GlobalInterpreterLock lock;
   try {

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ExternalPlotter.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ExternalPlotter.h
@@ -42,6 +42,7 @@ public:
   virtual void plotBins(std::string const &workspaceName, std::string const &binIndices, bool errorBars);
   virtual void plotContour(std::string const &workspaceName);
   virtual void plotTiled(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars);
+  virtual void plot3DSurface(std::string const &workspaceName);
   virtual void showSliceViewer(std::string const &workspaceName);
   bool validate(std::string const &workspaceName, boost::optional<std::string> const &workspaceIndices = boost::none,
                 boost::optional<MantidAxis> const &axisType = boost::none) const;

--- a/qt/widgets/plotting/src/ExternalPlotter.cpp
+++ b/qt/widgets/plotting/src/ExternalPlotter.cpp
@@ -200,6 +200,17 @@ void ExternalPlotter::plotContour(std::string const &workspaceName) {
 }
 
 /**
+ * Produces an external call to 3D Surface Plot on the target workspace
+ *
+ * @param workspaceName The name of the workspace to use in slice viewer
+ */
+void ExternalPlotter::plot3DSurface(std::string const &workspaceName) {
+  if (validate(workspaceName)) {
+    surface(QStringList(QString::fromStdString(workspaceName)));
+  }
+}
+
+/**
  * Produces an external call to slice viewer on the target workspace
  *
  * @param workspaceName The name of the workspace to use in slice viewer


### PR DESCRIPTION
### Description of work
This PR adds the possibility to call 3D surface plotting for Inelastic/Indirect interfaces that generate an output that is compatible with 3D plotting. See #36837. 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
 The ``OutputPlotOptions`` class has been modified by adding a new action/slot pair which makes a call to the surface plotting module in python through the python/c++ interface.


Fixes #36837. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->


### To test:
 
- On Mantid Workbench, go to ``Inelastic->Data Manipulation`` interface. 
- On ``S(Q,w)`` tab: Select ``File`` and open ``irs26173_graphite002_red.nxs``.
-  Click ``Run``, after algorithm finishes ``Plot Spectra`` button should be enabled. 
-  By clicking on the arrow on the rightmost part of the button, you will see a menu with 3 choices: ``Plot Spectra``, ``Open Slice Viewer`` and ``Plot 3D Surface``. 
-  Select ``Plot 3D Surface``. 
-  A new plot window should open with the selected workspace being plot as a 3D Surface. 
- You can also assess that the option for adding 3D surface plot is available in other compatible interfaces (like ``Indirect->Data Reduction``). 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*As it is a new feature, release notes have been added*

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
