### PR TITLE
Add flood and calibration file metadata to ISIS ORSO file

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
@@ -337,9 +337,10 @@ class SaveISISReflectometryORSO(PythonAlgorithm):
             return Path(flood_name).name, "Flood correction workspace or file"
 
         # It's possible that a flood workspace was created as the first step in the reduction
-        flood_history = reduction_history.getChildHistories()[0]
-        if flood_history.name() == self._CREATE_FLOOD_ALG:
-            return Path(flood_history.getPropertyValue("Filename")).name, "Flood correction run file"
+        if reduction_history:
+            flood_history = reduction_history.getChildHistories()[0]
+            if flood_history.name() == self._CREATE_FLOOD_ALG:
+                return Path(flood_history.getPropertyValue("Filename")).name, "Flood correction run file"
 
         return None
 

--- a/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
@@ -181,6 +181,10 @@ class SaveISISReflectometryORSO(PythonAlgorithm):
         if flood_entry:
             dataset.add_measurement_additional_file(flood_entry[0], comment=flood_entry[1])
 
+        calib_file_entry = self._get_calibration_file_entry(reduction_workflow_histories)
+        if calib_file_entry:
+            dataset.add_measurement_additional_file(calib_file_entry, comment="Calibration file")
+
     def _get_rb_number_and_doi(self, run) -> Union[Tuple[str, str], Tuple[None, None]]:
         """
         Check if the experiment RB number can be found in the workspace logs.
@@ -343,6 +347,14 @@ class SaveISISReflectometryORSO(PythonAlgorithm):
                 return Path(flood_history.getPropertyValue("Filename")).name, "Flood correction run file"
 
         return None
+
+    @staticmethod
+    def _get_calibration_file_entry(reduction_workflow_histories) -> Optional[str]:
+        """
+        Get the calibration file name from the reduction history.
+        """
+        calibration_file = reduction_workflow_histories[0].getPropertyValue("CalibrationFile")
+        return Path(calibration_file).name if calibration_file else None
 
     def _get_reduction_script(self, ws) -> Optional[str]:
         """

--- a/docs/source/release/v6.10.0/Reflectometry/New_features/36395.rst
+++ b/docs/source/release/v6.10.0/Reflectometry/New_features/36395.rst
@@ -1,1 +1,1 @@
-- Algorithm :ref:`algm-SaveISISReflectometryORSO` now outputs the individual angle and transmission files, and the reduction script in the ORSO file metadata.
+- Algorithm :ref:`algm-SaveISISReflectometryORSO` now outputs the individual angle and transmission files, flood correction files, calibration files and the reduction script in the ORSO file metadata.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Adds metadata to the ORSO file produced by `SaveISISReflectometryORSO` to identify any flood and calibration files that were used in the reduction.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36395. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

1) Go to `Interfaces -> Reflectometry -> ISIS Reflectometry`.
1) From the menu, click `Batch->Load` to load an OFFSPEC batch file (Rachel can provide this). This batch file will automatically populate various settings, including the path to an OFFSPEC flood file which is stored in the archive.
1) Save this test calibration file to your machine: 
[calibration_file_test_OFFSPEC.dat.txt](https://github.com/mantidproject/mantid/files/14523088/calibration_file_test_OFFSPEC.dat.txt)
Remove the `.txt` extension when you do, as the calibration file needs to be a `.dat` format (we just can't upload this file format to GitHub).
1) Go to the Instrument Settings tab and set the `CalibrationFile` input with the path you saved the calibration file to.
1) Go back to the Runs tab and highlight the first group (i.e. the first line) in the batch table on the right hand side (this will be the group containing runs 72805 and 72806). Click the Process button to reduce just this group. Wait for the reduction to complete.
1) Go to the Save ASCII tab. Set a Save Path for saving the final ORSO file to.
1) In the File Format section, select `ORSO ASCII (*.ort)` from the drop-down.
1) From the List of Workspaces section on the left, select workspace `IvsQ_72805_72806` to highlight it.
1) Click the big Save button on the right hand side to save to file. There should be a successful call to `SaveISISReflectometryORSO` recorded in the messages pane. If you navigate to the save path that you set in the Save ASCII tab, you should see a `.ort` file. You should be able to open this in a text editor and see that the flood and calibration file names are included in the `measurement`->`additional_files` section of the header.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
