### PR TITLE
Add support for 1D MDHisto workspace to SaveASCII

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/SaveAscii2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveAscii2.h
@@ -11,6 +11,7 @@
 //----------------------------------------------------------------------
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/Axis.h"
+#include "MantidAPI/IMDHistoWorkspace_fwd.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
@@ -65,6 +66,8 @@ private:
   void exec() override;
   void writeTableWorkspace(const API::ITableWorkspace_const_sptr &tws, const std::string &filename, bool appendToFile,
                            bool writeHeader, int prec, bool scientific, const std::string &comment);
+  void write1DHistoCut(const API::IMDHistoWorkspace_const_sptr &mdws, const std::string &filename, bool appendToFile,
+                       bool writeHeader, int prec, bool scientific, const std::string &comment);
   /// Writes a spectrum to the file using a workspace index
   void writeSpectrum(const int &wsIndex, std::ofstream &file);
   std::vector<std::string> stringListToVector(std::string &inputString);

--- a/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Framework/DataHandling/src/SaveAscii2.cpp
@@ -611,15 +611,15 @@ void SaveAscii2::write1DHistoCut(const IMDHistoWorkspace_const_sptr &mdws, const
                                  bool appendToFile, bool writeHeader, int prec, bool scientific,
                                  const std::string &comment) {
   int count = 0;
-  int dimIndex = -1;
-  for (auto i = 0; i < mdws->getNumDims(); i++) {
+  size_t dimIndex = -1;
+  for (size_t i = 0; i < mdws->getNumDims(); i++) {
     if (mdws->getDimension(i)->getNBins() > 1) {
       ++count;
       dimIndex = i;
     }
   }
 
-  if (count != 1 || dimIndex == -1) {
+  if (count != 1) {
     throw std::runtime_error("SaveAscii does not support saving multidimentional MDHistoWorkspace, and only supports "
                              "1D MDHistoWorkspaces cuts");
   }
@@ -660,16 +660,17 @@ void SaveAscii2::write1DHistoCut(const IMDHistoWorkspace_const_sptr &mdws, const
 
   auto start = binMin + binWidth;
   auto end = binMax - binWidth;
-  auto step = (end - start) / (nbins - 1);
+  auto step = (end - start) / float(nbins - 1);
 
   auto nPoints = mdws->getNPoints();
   auto signal = mdws->getSignalArray();
   auto error = mdws->getErrorSquaredArray();
 
-  Progress progress(this, 0.0, 1.0, nPoints);
+  Progress progress(this, 0.0, 1.0, nbins);
 
-  for (size_t i = 0; i < nbins; ++i) {
-    file << start + step * i << m_sep << signal[i] << m_sep << error[i] << "\n";
+  for (size_t i = 0; i < nPoints; ++i) {
+    file << start + step * float(i) << m_sep << signal[i] << m_sep << error[i] << "\n";
+    progress.report();
   }
 
   file.unsetf(std::ios_base::floatfield);

--- a/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Framework/DataHandling/src/SaveAscii2.cpp
@@ -11,6 +11,8 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/SpectrumInfo.h"
+#include "MantidAPI/WorkspaceHistory.h"
+#include "MantidDataObjects/MDHistoWorkspace.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/ArrayProperty.h"
@@ -128,6 +130,7 @@ void SaveAscii2::exec() {
   Workspace_const_sptr ws = getProperty("InputWorkspace");
   m_ws = std::dynamic_pointer_cast<const MatrixWorkspace>(ws);
   ITableWorkspace_const_sptr tws = std::dynamic_pointer_cast<const ITableWorkspace>(ws);
+  IMDHistoWorkspace_const_sptr mdws = std::dynamic_pointer_cast<const IMDHistoWorkspace>(ws);
 
   // Get the properties valid for all workspaces
   const bool writeHeader = getProperty("ColumnHeader");
@@ -158,10 +161,11 @@ void SaveAscii2::exec() {
     m_sep = ",";
   }
 
+  // handle table and 1 histo cuts workspaces
   if (tws) {
-    writeTableWorkspace(tws, filename, appendToFile, writeHeader, prec, scientific, comment);
-    // return here as the rest of the class is all about matrix workspace saving
-    return;
+    return writeTableWorkspace(tws, filename, appendToFile, writeHeader, prec, scientific, comment);
+  } else if (mdws) {
+    return write1DHistoCut(mdws, filename, appendToFile, writeHeader, prec, scientific, comment);
   }
 
   if (!m_ws) {
@@ -603,4 +607,74 @@ void SaveAscii2::writeFileHeader(const std::vector<std::string> &logList, std::o
   outputFile << '\n';
 }
 
+void SaveAscii2::write1DHistoCut(const IMDHistoWorkspace_const_sptr &mdws, const std::string &filename,
+                                 bool appendToFile, bool writeHeader, int prec, bool scientific,
+                                 const std::string &comment) {
+  int count = 0;
+  int dimIndex = -1;
+  for (auto i = 0; i < mdws->getNumDims(); i++) {
+    if (mdws->getDimension(i)->getNBins() > 1) {
+      ++count;
+      dimIndex = i;
+    }
+  }
+
+  if (count != 1 || dimIndex == -1) {
+    throw std::runtime_error("SaveAscii does not support saving multidimentional MDHistoWorkspace, and only supports "
+                             "1D MDHistoWorkspaces cuts");
+  }
+
+  std::ofstream file(filename.c_str(), (appendToFile ? std::ios::app : std::ios::out));
+
+  if (file.bad()) {
+    throw Exception::FileError("Unable to create file: ", filename);
+  }
+
+  if (prec != EMPTY_INT()) {
+    file.precision(prec);
+  }
+
+  if (scientific) {
+    file << std::scientific;
+  }
+
+  auto lastAlg = mdws->getHistory().lastAlgorithm();
+  auto propsVec = lastAlg->getProperties();
+
+  if (writeHeader) {
+    file << comment << " {";
+    for (size_t i = 0; i < propsVec.size(); i++) {
+      file << propsVec[i]->name() << ": " << propsVec[i]->valueAsPrettyStr();
+      if (i < propsVec.size() - 1)
+        file << ", ";
+    }
+    file << " }\n";
+  }
+
+  auto dim = mdws->getDimension(dimIndex);
+  auto nbins = dim->getNBins();
+
+  auto binWidth = dim->getBinWidth() / 2;
+  auto binMax = dim->getMaximum();
+  auto binMin = dim->getMinimum();
+
+  auto start = binMin + binWidth;
+  auto end = binMax - binWidth;
+  auto step = (end - start) / (nbins - 1);
+
+  auto nPoints = mdws->getNPoints();
+  auto signal = mdws->getSignalArray();
+  auto error = mdws->getErrorSquaredArray();
+
+  Progress progress(this, 0.0, 1.0, nPoints);
+
+  for (size_t i = 0; i < nbins; ++i) {
+    file << start + step * i << m_sep << signal[i] << m_sep << error[i] << "\n";
+  }
+
+  file.unsetf(std::ios_base::floatfield);
+  file.close();
+
+  return;
+}
 } // namespace Mantid::DataHandling

--- a/Framework/DataHandling/test/SaveAscii2Test.h
+++ b/Framework/DataHandling/test/SaveAscii2Test.h
@@ -545,7 +545,7 @@ public:
 
     TS_ASSERT_THROWS_ANYTHING(save.execute());
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -561,7 +561,7 @@ public:
     TS_ASSERT_THROWS_ANYTHING(save.setPropertyValue("InputWorkspace", "NotARealWS"));
     TS_ASSERT_THROWS_ANYTHING(save.execute());
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
   }
 
@@ -580,7 +580,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -596,18 +596,18 @@ public:
     TS_ASSERT_THROWS_ANYTHING(save.setProperty("WorkspaceIndexMin", -1));
     // then check the workspace bounds testing
     TS_ASSERT_THROWS_NOTHING(save.setPropertyValue("WorkspaceIndexMin", "5"));
-    // the problem is that this'll throw regardless as no numbers below zero can
+    // the problem is that this"ll throw regardless as no numbers below zero can
     // get in so i have to go over the bounds
     // so i have to either force Max higher or overlap, and both are tested
     // separatly
     // the validator seems to replace "-1" with the same as EMPTY_INT() so the
-    // bounds aren't checked
+    // bounds aren"t checked
     TS_ASSERT_THROWS_NOTHING(save.setPropertyValue("WorkspaceIndexMax", "7"));
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm didn't run so there should be no file
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm didn"t run so there should be no file
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -641,7 +641,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -676,7 +676,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -693,7 +693,7 @@ public:
 
     TS_ASSERT_THROWS_NOTHING(save.execute());
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(Poco::File(filename).exists());
 
     // Now make some checks on the content of the file
@@ -769,7 +769,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -786,7 +786,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -803,7 +803,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -820,7 +820,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -838,7 +838,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -856,7 +856,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -874,7 +874,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -892,7 +892,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -942,7 +942,7 @@ public:
 
     TS_ASSERT_THROWS_ANYTHING(save.execute());
 
-    // the algorithm shouldn't have written a file to disk
+    // the algorithm shouldn"t have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -1185,6 +1185,43 @@ public:
     AnalysisDataService::Instance().remove(m_name);
   }
 
+  void test_1DHistoCuts() {
+    write1MDHistoWS(m_name);
+
+    SaveAscii2 save;
+    std::string filename = initSaveAscii2(save);
+
+    TS_ASSERT_THROWS_NOTHING(save.execute());
+
+    // has the algorithm written a file to disk?
+    TS_ASSERT(Poco::File(filename).exists());
+
+    // Now make some checks on the content of the file
+    std::ifstream in(filename.c_str());
+
+    // Test the first three lines
+    std::vector<std::string> lines(3, "");
+    for (int i = 0; i < 3; i++) {
+      std::getline(in, lines[i]);
+    }
+    TS_ASSERT_EQUALS(
+        lines[0],
+        "# {InputWorkspace: SaveAscii2WS, AxisAligned: 0, AlignedDim0: , AlignedDim1: , AlignedDim2: , AlignedDim3: , "
+        "AlignedDim4: , AlignedDim5: , BasisVector0: (0.0+1.0x 0.0 0.0), in 7.26 Ang^-1, 1.0,0.0,0.0, BasisVector1: "
+        "u2, in 7.26 Ang ^ -1, 0.0, 1.0, 0.0, BasisVector2: u3, in 3.14 Ang ^ -1,0.0,0.0,1.0, BasisVector3: , "
+        "BasisVector4: , BasisVector5: , Translation: , OutputExtents: -2.5,2.5,-0.16,0.16,-0.05,0.05, OutputBins: "
+        "50,1,1, NormalizeBasisVectors: 1, ForceOrthogonal: 0, ImplicitFunctionXML: , IterateEvents: 1, Parallel: 0, "
+        "TemporaryDataWorkspace: , OutputWorkspace: " +
+            m_name + " }");
+    TS_ASSERT_EQUALS(lines[1], "-2.45,1,1");
+    TS_ASSERT_EQUALS(lines[2], "-2.35,0,0");
+
+    in.close();
+
+    Poco::File(filename).remove();
+    AnalysisDataService::Instance().remove(m_name);
+  }
+
   // public as it is used in LoadAsciiTest as well.
   static ITableWorkspace_sptr writeTableWS(const std::string &name) {
     auto table = WorkspaceFactory::Instance().createTable();
@@ -1247,6 +1284,21 @@ private:
 
     wsToSave = WorkspaceCreationHelper::createProcessedInelasticWS(l2, polar, azimutal, nBins);
     AnalysisDataService::Instance().add(m_name, wsToSave);
+  }
+
+  void write1MDHistoWS(const std::string name) {
+    FrameworkManager::Instance().exec("CreateMDWorkspace", 16, "Dimensions", "3", "Extents", "-5,5,-4,4,-3,3", "Names",
+                                      "H,K,L", "Units", "r.l.u., r.l.u., r.l.u.", "Frames", "HKL,HKL,HKL", "SplitInto",
+                                      "2", "SplitThreshold", "50", "OutputWorkspace", name.c_str());
+
+    FrameworkManager::Instance().exec("FakeMDEventData", 8, "InputWorkspace", name.c_str(), "UniformParams", "100000",
+                                      "PeakParams", "100000,0,0,1,0.3", "RandomSeed", "3873875");
+
+    FrameworkManager::Instance().exec(
+        "BinMD", 18, "InputWorkspace", name.c_str(), "AxisAligned", "0", "BasisVector0",
+        "(0.0+1.0x 0.0 0.0), in 7.26 Ang^-1, 1.0,0.0,0.0", "BasisVector1", "u2, in 7.26 Ang ^ -1, 0.0, 1.0, 0.0",
+        "BasisVector2", "u3, in 3.14 Ang ^ -1,0.0,0.0,1.0", "OutputExtents", "-2.5,2.5,-0.16,0.16,-0.05,0.05",
+        "OutputBins", "50,1,1", "NormalizeBasisVectors", "1", "OutputWorkspace", name.c_str());
   }
 
   std::string initSaveAscii2(SaveAscii2 &save, std::vector<std::string> logList = {}) {

--- a/Framework/DataHandling/test/SaveAscii2Test.h
+++ b/Framework/DataHandling/test/SaveAscii2Test.h
@@ -545,7 +545,7 @@ public:
 
     TS_ASSERT_THROWS_ANYTHING(save.execute());
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -561,7 +561,7 @@ public:
     TS_ASSERT_THROWS_ANYTHING(save.setPropertyValue("InputWorkspace", "NotARealWS"));
     TS_ASSERT_THROWS_ANYTHING(save.execute());
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
   }
 
@@ -580,7 +580,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -596,18 +596,18 @@ public:
     TS_ASSERT_THROWS_ANYTHING(save.setProperty("WorkspaceIndexMin", -1));
     // then check the workspace bounds testing
     TS_ASSERT_THROWS_NOTHING(save.setPropertyValue("WorkspaceIndexMin", "5"));
-    // the problem is that this"ll throw regardless as no numbers below zero can
+    // the problem is that this will throw regardless as no numbers below zero can
     // get in so i have to go over the bounds
     // so i have to either force Max higher or overlap, and both are tested
     // separatly
     // the validator seems to replace "-1" with the same as EMPTY_INT() so the
-    // bounds aren"t checked
+    // bounds aren't checked
     TS_ASSERT_THROWS_NOTHING(save.setPropertyValue("WorkspaceIndexMax", "7"));
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm didn"t run so there should be no file
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm didn't run so there should be no file
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -641,7 +641,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -676,7 +676,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -693,7 +693,7 @@ public:
 
     TS_ASSERT_THROWS_NOTHING(save.execute());
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(Poco::File(filename).exists());
 
     // Now make some checks on the content of the file
@@ -769,7 +769,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -786,7 +786,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -803,7 +803,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -820,7 +820,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -838,7 +838,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -856,7 +856,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -874,7 +874,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -892,7 +892,7 @@ public:
 
     TS_ASSERT_THROWS(save.execute(), const std::invalid_argument &);
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -942,7 +942,7 @@ public:
 
     TS_ASSERT_THROWS_ANYTHING(save.execute());
 
-    // the algorithm shouldn"t have written a file to disk
+    // the algorithm shouldn't have written a file to disk
     TS_ASSERT(!Poco::File(filename).exists());
 
     AnalysisDataService::Instance().remove(m_name);
@@ -1199,22 +1199,23 @@ public:
     // Now make some checks on the content of the file
     std::ifstream in(filename.c_str());
 
-    // Test the first three lines
-    std::vector<std::string> lines(3, "");
-    for (int i = 0; i < 3; i++) {
+    // Check the first four lines
+    std::vector<std::string> lines(4, "");
+    for (int i = 0; i < 4; i++) {
       std::getline(in, lines[i]);
     }
     TS_ASSERT_EQUALS(
         lines[0],
         "# {InputWorkspace: SaveAscii2WS, AxisAligned: 0, AlignedDim0: , AlignedDim1: , AlignedDim2: , AlignedDim3: , "
         "AlignedDim4: , AlignedDim5: , BasisVector0: (0.0+1.0x 0.0 0.0), in 7.26 Ang^-1, 1.0,0.0,0.0, BasisVector1: "
-        "u2, in 7.26 Ang ^ -1, 0.0, 1.0, 0.0, BasisVector2: u3, in 3.14 Ang ^ -1,0.0,0.0,1.0, BasisVector3: , "
-        "BasisVector4: , BasisVector5: , Translation: , OutputExtents: -2.5,2.5,-0.16,0.16,-0.05,0.05, OutputBins: "
-        "50,1,1, NormalizeBasisVectors: 1, ForceOrthogonal: 0, ImplicitFunctionXML: , IterateEvents: 1, Parallel: 0, "
+        "u2, in 7.26 Ang^-1, 0.0,1.0,0.0, BasisVector2: u3, in 3.14 Ang^-1,0.0,0.0,1.0, BasisVector3: , BasisVector4: "
+        ", BasisVector5: , Translation: , OutputExtents: -2.5,2.5,-0.16,0.16,-0.05,0.05, OutputBins: 1,50,1, "
+        "NormalizeBasisVectors: 1, ForceOrthogonal: 0, ImplicitFunctionXML: , IterateEvents: 1, Parallel: 0, "
         "TemporaryDataWorkspace: , OutputWorkspace: " +
             m_name + " }");
-    TS_ASSERT_EQUALS(lines[1], "-2.45,1,1");
-    TS_ASSERT_EQUALS(lines[2], "-2.35,0,0");
+    TS_ASSERT_EQUALS(lines[1], "# u2 in 7.26 Ang^-1, Signal, Error");
+    TS_ASSERT_EQUALS(lines[2], "-0.1568,3,1.73205");
+    TS_ASSERT_EQUALS(lines[3], "-0.1504,0,0");
 
     in.close();
 
@@ -1296,9 +1297,9 @@ private:
 
     FrameworkManager::Instance().exec(
         "BinMD", 18, "InputWorkspace", name.c_str(), "AxisAligned", "0", "BasisVector0",
-        "(0.0+1.0x 0.0 0.0), in 7.26 Ang^-1, 1.0,0.0,0.0", "BasisVector1", "u2, in 7.26 Ang ^ -1, 0.0, 1.0, 0.0",
-        "BasisVector2", "u3, in 3.14 Ang ^ -1,0.0,0.0,1.0", "OutputExtents", "-2.5,2.5,-0.16,0.16,-0.05,0.05",
-        "OutputBins", "50,1,1", "NormalizeBasisVectors", "1", "OutputWorkspace", name.c_str());
+        "(0.0+1.0x 0.0 0.0), in 7.26 Ang^-1, 1.0,0.0,0.0", "BasisVector1", "u2, in 7.26 Ang^-1, 0.0,1.0,0.0",
+        "BasisVector2", "u3, in 3.14 Ang^-1,0.0,0.0,1.0", "OutputExtents", "-2.5,2.5,-0.16,0.16,-0.05,0.05",
+        "OutputBins", "1,50,1", "NormalizeBasisVectors", "1", "OutputWorkspace", name.c_str());
   }
 
   std::string initSaveAscii2(SaveAscii2 &save, std::vector<std::string> logList = {}) {

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -772,7 +772,7 @@ useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveDiffCal.cpp:1
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveDiffCal.cpp:164
 unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveGSASInstrumentFile.cpp:67
 unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveGSASInstrumentFile.cpp:68
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveAscii2.cpp:416
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveAscii2.cpp:420
 shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadTOFRawNexus.cpp:285
 shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadTOFRawNexus.cpp:357
 uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveFocusedXYE.cpp:73

--- a/docs/source/algorithms/SaveAscii-v2.rst
+++ b/docs/source/algorithms/SaveAscii-v2.rst
@@ -16,6 +16,11 @@ the X-values, followed by pairs of Y and E values. Columns are separated by
 commas. The resulting file can normally be loaded into a workspace by the
 :ref:`algm-LoadAscii` algorithm.
 
+There is limited support for MDHistoWorkspaces, and the algorithm only allows for the saving of 1D MDHisto Workspaces.
+This functionality is specifically used to save cuts made using sliceviewr.
+The saved format consists of a header comment that contains all of the workspace properties,
+followed by three separate columns corresponding to X, Y, and E, respectively.
+
 It is possible to create a header for the ASCII file containing selected sample log entries and its unit,
 specified through `LogList` property. In case the requested log does not exist, it will be printed as
 `Not defined`. This feature is not enabled for :ref:`TableWorkspace <Table Workspaces>`.

--- a/docs/source/release/v6.10.0/Framework/Algorithms/New_features/36994.rst
+++ b/docs/source/release/v6.10.0/Framework/Algorithms/New_features/36994.rst
@@ -1,0 +1,1 @@
+- Add support for 1D MDHisto workspace to SaveASCII


### PR DESCRIPTION
### Description of work
This PR adds support for saving 1D MDHisto cuts using SaveASCII2

Fixes #36646. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
(1) Generate a 1D MDHisto workspace
```
CreateMDWorkspace(Dimensions=3, Extents='-5,5,-4,4,-3,3', Names='H,K,L', Units='r.l.u.,r.l.u.,r.l.u.', Frames='HKL,HKL,HKL', SplitInto='2', SplitThreshold=50, OutputWorkspace='ws') # 2023-10-18T13:20:50.683328000 execCount: 19
FakeMDEventData(InputWorkspace='ws', UniformParams='100000', PeakParams='100000,0,0,1,0.3', RandomSeed=3873875) # 2023-10-18T13:20:50.737205000 execCount: 24
ws_cut = BinMD(InputWorkspace='ws', AxisAligned=False, BasisVector0='(0.0+1.0x 0.0 0.0), in 7.26 Ang^-1, 1.0,0.0,0.0', BasisVector1='u2, in 7.26 Ang^-1, 0.0,1.0,0.0', BasisVector2='u3, in 3.14 Ang^-1, 0.0,0.0,1.0', 
               OutputExtents='-2.5,2.5,-0.16,0.16,-0.05,0.05', OutputBins='50,1,1', NormalizeBasisVectors=False, OutputWorkspace='ws_1Dcut') # 2023-10-18T13:21:00.379543000 execCount: 26

```

(2) Save 1D MDHisto workspace `ws_1Dcut`
```
# save it to file
SaveAscii(InputWorkspace=ws_1Dcut, Filename=r"C:\Users\test.text")
```
check if the cut is saved in your preferred path

(3) Try to load the file using Load and it should be loaded as a Workspace2D
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
