### PR TITLE
Remove local tags before generating nightly tag in Jenkins pipeline

### DIFF
--- a/buildconfig/Jenkins/Conda/generate-version-number
+++ b/buildconfig/Jenkins/Conda/generate-version-number
@@ -8,6 +8,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # where for these commands.
 cd ${SCRIPT_DIR}
 
+# Remove any local tags that are not published
+git fetch -p -P
+
 # Find the latest version tag. Anything that starts with v is considered
 # The '-' prefixing version:refname sorts in descending order
 LATEST_VERSION_TAG=$(git tag --list  --sort -version:refname 'v*' | head -n 1)

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -107,6 +107,19 @@ pipeline {
         }
       }
     }
+    // Generate the git tag only once to avoid issues where tags are not up to date on
+    // certain agents. In particular, this can be a problem when the branch being built
+    // is on a fork.
+    stage('Generate git tag') {
+      agent { label 'linux-64' }
+      steps {
+        checkoutSource("${GIT_SHA}")
+        script {
+          env.GIT_TAG = generate_git_tag()
+        }
+      }
+    }
+
     // Verify developer environment build/test while also building conda packages
     // in parallel. Running both steps in parallel reduces the overall pipeline
     // time, however if either part breaks then no publishing occurs.
@@ -417,7 +430,7 @@ pipeline {
         sh 'tar -cvf conda-packages.tar ${WORKSPACE}/conda-packages/'
         // Publish to github. Single quotes are required for token variables to avoid them leaking
         sh "${CISCRIPT_DIR}/publish-to-github ${WORKSPACE}" + ' ${GITHUB_TOKEN} ' +\
-          "${GITHUB_RELEASES_REPO} ${generate_git_tag()} ${GIT_SHA} ${prerelease_option()} " +\
+          "${GITHUB_RELEASES_REPO} ${GIT_TAG} ${GIT_SHA} ${prerelease_option()} " +\
           "${WORKSPACE}/standalone-packages/* ${WORKSPACE}/conda-packages.tar"
       }
     }
@@ -505,7 +518,7 @@ def package_conda_options(platform, base_or_workbench) {
     package_flags = "--build-workbench"
   }
 
-  package_options = "${package_flags} --git-tag ${generate_git_tag()}"
+  package_options = "${package_flags} --git-tag ${GIT_TAG}"
   return package_options.trim()
 }
 

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -117,6 +117,7 @@ pipeline {
         script {
           env.GIT_TAG = generate_git_tag()
         }
+        echo "${env.GIT_TAG}"
       }
     }
 


### PR DESCRIPTION
### Description of work
Make nightly version number generation more robust.

Some information to help understand what's going on:
- If a version number is specified when starting the nightly pipeline, that is used as the git tag
- If no version number is specified, a nightly tag is automatically generated based on
  - the most recent existing tag (used for the major and minor version numbers)
  - the date and time of the last commit
  - so a nightly generated after a v6.9.0 tag could be e.g. `v6.9.20240306.1724`
- Nightly releases are automatically published, so the tags are also published
- Release candidates built with specified version numbers are drafts, so the tags are not published

The following scenario (just before the release of v6.9.0) revealed a problem:
1. Built a release candidate for smoke testing with version number `v6.9.0rc1`. This was a draft release, so that tag was not published.
2. The next nightly build had different nightly version numbers generated depending on which machines the various stages were run on
    1. if a stage was run on a machine that was used to create the smoke testing candidate, the version number started with `6.9`
    2. otherwise it started with `6.8`
3. On some OS, this caused a failure because the version used for `mantidworkbench` was different to `mantid`, `mantidqt` and `mantiddocs`. The conda recipe enforces consistent version numbers across mantid packages on a given OS.

#### Summary of work
To fix the problem, the version number is now generated only once near the start of the pipeline. This alone means that job will not fail due to inconsistent version numbers across different stages/nodes. However, it does not guarantee a correct version number: the version number generating stage may run on a node with an unpublished tag. Therefore, in addition the command:
`git fetch -p -P`
has been added to the version generation script to remove any local tags that aren't published.

This work will also fix an old issue that was encountered when building packages from a fork with out-of-date tags.

Fixes #36916
Fixes #35337

### To test:
Two test nodes were created, and a series of linux packaging test jobs were run. The orignal problem was recreated before it was resolved by the code changes. Details are listed below.
1. Created a release-candidate-like build with version number `v6.10.0rc1`. This left the new, unpublished tags on the nodes: 
https://builds.mantidproject.org/job/Core_Team_test_pipeline/79/
2. The node that build the `mantidworkbench` was thoroughly cleaned to make sure the new local `v6.10.0rc1` tag was not present.
3. A nightly run was set off. The mantid, mantidqt and mantiddocs packages were created with `v6.10.20240306.1657` and the mantidworkbench packaging tried to use `v6.9.20240306.1657`, causing a failure:
https://builds.mantidproject.org/job/Core_Team_test_pipeline/80/
4. Moving the git tag (synonymous with version number) generation to a single place resulted in the pipeline succeeding, albeit with the wrong version number, because at this point the local tags weren't being pruned:
https://builds.mantidproject.org/job/Core_Team_test_pipeline/85/
5. After adding the command to prune the local tags, you can see it working in the output for that stage:
https://builds.mantidproject.org/job/Core_Team_test_pipeline/86/execution/node/67/log/
6. The output from this build verifies that it still works when specifying a release number with a custom tag:
https://builds.mantidproject.org/job/Core_Team_test_pipeline/89/execution/node/67/log/
7. Here is a complete linux build with the changes:
https://builds.mantidproject.org/job/Core_Team_test_pipeline/88/

*This does not require release notes* because **it's not a change to how the software functions for the end user**.


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
