### PR TITLE
Fix Efixed not updating for OSIRIS graphite reduction

### DIFF
--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h
@@ -54,7 +54,8 @@ Mantid::API::MatrixWorkspace_sptr setWorkspaceProperties(Mantid::API::MatrixWork
                                                          int const &xLength, int const &yLength);
 Mantid::API::MatrixWorkspace_sptr createWorkspaceWithInstrument(int const &xLength, int const &yLength);
 Mantid::API::MatrixWorkspace_sptr createWorkspaceWithInelasticInstrument(int const &yLength);
-Mantid::API::MatrixWorkspace_sptr createWorkspaceWithIndirectInstrumentAndParameters();
+Mantid::API::MatrixWorkspace_sptr
+createWorkspaceWithIndirectInstrumentAndParameters(std::string const &analyser = "graphite");
 
 /// Simple struct used to access features of the ADS
 /// No destructor so ensure you tearDown the ADS

--- a/Framework/TestHelpers/src/IndirectFitDataCreationHelper.cpp
+++ b/Framework/TestHelpers/src/IndirectFitDataCreationHelper.cpp
@@ -109,12 +109,12 @@ MatrixWorkspace_sptr createWorkspaceWithInelasticInstrument(int const &yLength) 
   return inputWS;
 }
 
-MatrixWorkspace_sptr createWorkspaceWithIndirectInstrumentAndParameters() {
+MatrixWorkspace_sptr createWorkspaceWithIndirectInstrumentAndParameters(std::string const &analyser) {
 
   auto testWorkspace = createWorkspace(1, 5);
   std::string idfdirectory = Mantid::Kernel::ConfigService::Instance().getString("instrumentDefinition.directory");
   // IRIS instrument with graphite detector.
-  auto const ipfFilename = idfdirectory + "IRIS" + "_" + "graphite" + "_" + "002" + "_Parameters.xml";
+  auto const ipfFilename = idfdirectory + "IRIS" + "_" + analyser + "_" + "002" + "_Parameters.xml";
 
   auto loadInst = AlgorithmManager::Instance().create("LoadInstrument");
   loadInst->setLogging(true);

--- a/docs/source/release/v6.10.0/Indirect/Bugfixes/37011.rst
+++ b/docs/source/release/v6.10.0/Indirect/Bugfixes/37011.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where the EFixed when switching to the 'graphite' analyser would not be updated on the :ref:`Indirect Data Reduction <interface-indirect-data-reduction>` interface.

--- a/qt/scientific_interfaces/Indirect/Reduction/IndirectDataReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/IndirectDataReduction.cpp
@@ -10,6 +10,7 @@
 #include "IndirectDataReduction.h"
 #include "Common/Settings.h"
 
+#include "Common/WorkspaceUtils.h"
 #include "ILLEnergyTransfer.h"
 #include "ISISCalibration.h"
 #include "ISISDiagnostics.h"
@@ -237,9 +238,9 @@ void IndirectDataReduction::loadInstrumentDetails() {
 
   // List of values to get from IPF
   std::vector<std::string> ipfElements{
-      "analysis-type",     "spectra-min",       "spectra-max",        "Efixed",        "peak-start",
-      "peak-end",          "back-start",        "back-end",           "rebin-default", "cm-1-convert-choice",
-      "save-nexus-choice", "save-ascii-choice", "fold-frames-choice", "resolution"};
+      "analysis-type",     "spectra-min",        "spectra-max",   "peak-start",          "peak-end",
+      "back-start",        "back-end",           "rebin-default", "cm-1-convert-choice", "save-nexus-choice",
+      "save-ascii-choice", "fold-frames-choice", "resolution"};
 
   // In the IRIS IPF there is no fmica component
   if (instrumentName == "IRIS" && analyser == "fmica")
@@ -249,6 +250,9 @@ void IndirectDataReduction::loadInstrumentDetails() {
   auto const instWorkspace = instrumentWorkspace();
   if (!instWorkspace) {
     return;
+  }
+  if (auto const eFixed = WorkspaceUtils::getEFixed(instWorkspace)) {
+    m_instDetails["Efixed"] = QString::number(*eFixed);
   }
 
   auto const instrument = instWorkspace->getInstrument();

--- a/qt/scientific_interfaces/Indirect/Reduction/IndirectDataReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/IndirectDataReduction.cpp
@@ -253,6 +253,8 @@ void IndirectDataReduction::loadInstrumentDetails() {
   }
   if (auto const eFixed = WorkspaceUtils::getEFixed(instWorkspace)) {
     m_instDetails["Efixed"] = QString::number(*eFixed);
+  } else {
+    m_instDetails["Efixed"] = "";
   }
 
   auto const instrument = instWorkspace->getInstrument();

--- a/qt/scientific_interfaces/Indirect/Reduction/IndirectDataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/IndirectDataReductionTab.cpp
@@ -234,7 +234,6 @@ std::map<std::string, double> IndirectDataReductionTab::getRangesFromInstrument(
   loadParamAlg->execute();
   energyWs = loadParamAlg->getProperty("Workspace");
 
-  double efixed = WorkspaceUtils::getEFixed(energyWs);
   auto spectraMinDbl = energyWs->getInstrument()->getNumberParameter("spectra-min")[0];
   Mantid::specnum_t spectraMin = boost::lexical_cast<Mantid::specnum_t>(spectraMinDbl);
 
@@ -250,7 +249,9 @@ std::map<std::string, double> IndirectDataReductionTab::getRangesFromInstrument(
   convUnitsAlg->setProperty("OutputWorkspace", "__tof");
   convUnitsAlg->setProperty("Target", "TOF");
   convUnitsAlg->setProperty("EMode", "Indirect");
-  convUnitsAlg->setProperty("EFixed", efixed);
+  if (auto const efixed = WorkspaceUtils::getEFixed(energyWs)) {
+    convUnitsAlg->setProperty("EFixed", *efixed);
+  }
   convUnitsAlg->execute();
   MatrixWorkspace_sptr tofWs = convUnitsAlg->getProperty("OutputWorkspace");
 

--- a/qt/scientific_interfaces/Inelastic/Common/WorkspaceUtils.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/WorkspaceUtils.cpp
@@ -108,25 +108,24 @@ std::string getEMode(const Mantid::API::MatrixWorkspace_sptr &ws) {
  * @param ws Pointer to the workspace
  * @return eFixed value
  */
-double getEFixed(const Mantid::API::MatrixWorkspace_sptr &ws) {
+std::optional<double> getEFixed(const Mantid::API::MatrixWorkspace_sptr &ws) {
   Mantid::Geometry::Instrument_const_sptr inst = ws->getInstrument();
   if (!inst)
-    throw std::runtime_error("No instrument on workspace");
+    return std::nullopt;
 
-  // Try to get the parameter form the base instrument
-  if (inst->hasParameter("Efixed"))
-    return inst->getNumberParameter("Efixed")[0];
-
-  // Try to get it form the analyser component
+  // Try to get it from the analyser component
   if (inst->hasParameter("analyser")) {
-    std::string analyserName = inst->getStringParameter("analyser")[0];
-    auto analyserComp = inst->getComponentByName(analyserName);
+    auto const analyserName = inst->getStringParameter("analyser")[0];
+    auto const analyserComp = inst->getComponentByName(analyserName != "fmica" ? analyserName : "mica");
 
     if (analyserComp && analyserComp->hasParameter("Efixed"))
       return analyserComp->getNumberParameter("Efixed")[0];
   }
 
-  throw std::runtime_error("Instrument has no efixed parameter");
+  // Try to get the parameter form the base instrument
+  if (inst->hasParameter("Efixed"))
+    return inst->getNumberParameter("Efixed")[0];
+  return std::nullopt;
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/Common/WorkspaceUtils.h
+++ b/qt/scientific_interfaces/Inelastic/Common/WorkspaceUtils.h
@@ -11,6 +11,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "QPair"
+#include <optional>
 #include <string>
 
 namespace MantidQt {
@@ -23,7 +24,7 @@ MANTIDQT_INELASTIC_DLL std::unordered_map<std::string, size_t>
 extractAxisLabels(const Mantid::API::MatrixWorkspace_const_sptr &workspace, const size_t &axisIndex);
 
 MANTIDQT_INELASTIC_DLL std::string getEMode(const Mantid::API::MatrixWorkspace_sptr &ws);
-MANTIDQT_INELASTIC_DLL double getEFixed(const Mantid::API::MatrixWorkspace_sptr &ws);
+MANTIDQT_INELASTIC_DLL std::optional<double> getEFixed(const Mantid::API::MatrixWorkspace_sptr &ws);
 
 MANTIDQT_INELASTIC_DLL bool getResolutionRangeFromWs(const std::string &workspace, QPair<double, double> &res);
 MANTIDQT_INELASTIC_DLL bool getResolutionRangeFromWs(const Mantid::API::MatrixWorkspace_const_sptr &workspace,

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
@@ -518,9 +518,9 @@ void AbsorptionCorrections::convertSpectrumAxes(const WorkspaceGroup_sptr &corre
 void AbsorptionCorrections::convertSpectrumAxes(const MatrixWorkspace_sptr &correction,
                                                 const MatrixWorkspace_sptr &sample) {
   if (correction && sample && sample->getEMode() == DeltaEMode::Type::Indirect) {
-    try {
-      convertSpectrumAxis(correction, WorkspaceUtils::getEFixed(correction));
-    } catch (std::runtime_error const &) {
+    if (auto const eFixed = WorkspaceUtils::getEFixed(correction)) {
+      convertSpectrumAxis(correction, *eFixed);
+    } else {
       convertSpectrumAxis(correction);
     }
   }

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
@@ -66,10 +66,9 @@ MatrixWorkspace_sptr convertUnits(const MatrixWorkspace_sptr &workspace, std::st
   convertAlg->setChild(true);
   convertAlg->setProperty("InputWorkspace", workspace);
   convertAlg->setProperty("OutputWorkspace", "__converted");
-  auto eMode = workspace->getEMode();
-  convertAlg->setProperty("EMode", DeltaEMode::asString(eMode));
-  if ((eMode == DeltaEMode::Type::Direct) || (eMode == DeltaEMode::Type::Indirect)) {
-    convertAlg->setProperty("EFixed", workspace->getEFixed(workspace->getDetector(0)));
+  convertAlg->setProperty("EMode", DeltaEMode::asString(workspace->getEMode()));
+  if (auto const eFixed = MantidQt::CustomInterfaces::WorkspaceUtils::getEFixed(workspace)) {
+    convertAlg->setProperty("EFixed", *eFixed);
   }
   convertAlg->setProperty("Target", target);
   convertAlg->execute();

--- a/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
@@ -349,10 +349,10 @@ void CalculatePaalmanPings::absCorComplete(bool error) {
         convertSpecAlgo->setProperty("Target", "ElasticQ");
         convertSpecAlgo->setProperty("EMode", "Indirect");
 
-        try {
-          convertSpecAlgo->setProperty("EFixed", WorkspaceUtils::getEFixed(factorWs));
-        } catch (std::runtime_error &) {
+        if (auto const eFixed = WorkspaceUtils::getEFixed(factorWs)) {
+          convertSpecAlgo->setProperty("EFixed", *eFixed);
         }
+
         m_batchAlgoRunner->addAlgorithm(convertSpecAlgo);
       }
     }
@@ -420,10 +420,8 @@ void CalculatePaalmanPings::fillCorrectionDetails(const QString &wsName) {
     return;
   }
 
-  try {
-    m_uiForm.doubleEfixed->setValue(WorkspaceUtils::getEFixed(ws));
-  } catch (std::runtime_error &) {
-    // do nothing if there is no efixed
+  if (auto const eFixed = WorkspaceUtils::getEFixed(ws)) {
+    m_uiForm.doubleEfixed->setValue(*eFixed);
   }
 
   auto emode = QString::fromStdString(WorkspaceUtils::getEMode(ws));

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
@@ -112,9 +112,9 @@ boost::optional<std::string> CorrectionsTab::addConvertUnitsStep(const MatrixWor
   convertAlg->setProperty("EMode", eMode);
 
   if (eMode == "Indirect" && eFixed == 0.0) {
-    try {
-      eFixed = WorkspaceUtils::getEFixed(ws);
-    } catch (std::exception const &) {
+    if (auto const eFixedFromWs = WorkspaceUtils::getEFixed(ws)) {
+      eFixed = *eFixedFromWs;
+    } else {
       showMessageBox("Please enter an Efixed value.");
       return boost::none;
     }

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSqwTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationSqwTab.cpp
@@ -48,13 +48,14 @@ void InelasticDataManipulationSqwTab::setup() {}
 void InelasticDataManipulationSqwTab::handleDataReady(std::string const &dataName) {
   if (m_view->validate()) {
     m_model->setInputWorkspace(dataName);
-    try {
-      double eFixed = WorkspaceUtils::getEFixed(AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(dataName));
-      m_model->setEFixed(eFixed);
-    } catch (std::runtime_error const &ex) {
-      m_view->showMessageBox(ex.what());
+    auto &ads = AnalysisDataService::Instance();
+    if (auto const eFixed = WorkspaceUtils::getEFixed(ads.retrieveWS<MatrixWorkspace>(dataName))) {
+      m_model->setEFixed(*eFixed);
+    } else {
+      m_view->showMessageBox("An 'Efixed' value could not be found in the provided workspace.");
       return;
     }
+
     plotRqwContour();
     m_view->setDefaultQAndEnergy();
   }

--- a/qt/scientific_interfaces/Inelastic/test/Common/WorkspaceUtilsTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Common/WorkspaceUtilsTest.h
@@ -69,9 +69,32 @@ public:
     TS_ASSERT_EQUALS(getEMode(testWorkspace), "Indirect");
   }
 
-  void test_getEFixed_throws_for_no_instrument() {
+  void test_getEFixed_returns_std_nullopt_for_no_instrument() {
     auto const testWorkspace = createWorkspace(5);
-    TS_ASSERT_THROWS(getEFixed(testWorkspace), const std::runtime_error &);
+    TS_ASSERT(!getEFixed(testWorkspace));
+  }
+
+  void test_getEFixed_returns_std_nullopt_for_instrument_but_no_efixed_parameter() {
+    auto const testWorkspace = createWorkspaceWithInelasticInstrument(2);
+    TS_ASSERT(!getEFixed(testWorkspace));
+  }
+
+  void test_getEFixed_returns_an_efixed_for_a_workspace_with_parameters() {
+    auto const testWorkspace = createWorkspaceWithIndirectInstrumentAndParameters();
+
+    auto const efixed = getEFixed(testWorkspace);
+
+    TS_ASSERT(efixed);
+    TS_ASSERT_EQUALS(1.845, *efixed);
+  }
+
+  void test_getEFixed_returns_an_efixed_for_fmica_analyser() {
+    auto const testWorkspace = createWorkspaceWithIndirectInstrumentAndParameters("fmica");
+
+    auto const efixed = getEFixed(testWorkspace);
+
+    TS_ASSERT(efixed);
+    TS_ASSERT_DELTA(0.2067, *efixed, 0.00001);
   }
 
   void test_extractAxisLabels_gives_labels() {


### PR DESCRIPTION
### Description of work
This PR fixes a bug where the EFixed displayed in the Energy Transfer interface would not be updated when changing the analyser to silicon and then back to graphite. The problem happened because the Efixed was being retrieved from a cache rather than from the analyer component of the instrument. The solution was to make sure we attempt to fetch the Efixed from the analyser component first, and then if that doesn't work then we can use the cached value.

Fixes #37011

### To test:
1. Open `Indirect`->`Data Reduction`
2. Select `OSIRIS` instrument
3. Notice the EFixed. Change the Analyser to silicon
4. The EFixed should change
5. Change analyser back to graphite
6. The EFixed should change back to its original value

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
