### PR TITLE
Fix sliders not changing integration limits in Elwin tab

### DIFF
--- a/docs/source/release/v6.10.0/Inelastic/Bugfixes/37012.rst
+++ b/docs/source/release/v6.10.0/Inelastic/Bugfixes/37012.rst
@@ -1,0 +1,1 @@
+- Fix bug in  :ref:`Elwin Tab <elwin>` of  :ref:`Data Manipulation Interface <interface-inelastic-data-manipulation>` where changing integration range with the sliders did not change default integration range.

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
@@ -383,51 +383,25 @@ void InelasticDataManipulationElwinTabView::notifyCheckboxValueChanged(QtPropert
 }
 
 void InelasticDataManipulationElwinTabView::notifyMinChanged(double val) {
-  auto integrationRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange");
-  auto backgroundRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange");
-
   MantidWidgets::RangeSelector *from = qobject_cast<MantidWidgets::RangeSelector *>(sender());
-
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(notifyDoubleValueChanged(QtProperty *, double)));
-  if (from == integrationRangeSelector) {
-    m_dblManager->setValue(m_properties["IntegrationStart"], val);
-  } else if (from == backgroundRangeSelector) {
-    m_dblManager->setValue(m_properties["BackgroundStart"], val);
-  }
-
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(notifyDoubleValueChanged(QtProperty *, double)));
+  auto prop = (from == m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange")) ? m_properties["IntegrationStart"]
+                                                                                   : m_properties["BackgroundStart"];
+  m_dblManager->setValue(prop, val);
 }
 
 void InelasticDataManipulationElwinTabView::notifyMaxChanged(double val) {
-  auto integrationRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange");
-  auto backgroundRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange");
-
   MantidWidgets::RangeSelector *from = qobject_cast<MantidWidgets::RangeSelector *>(sender());
-
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(notifyDoubleValueChanged(QtProperty *, double)));
-
-  if (from == integrationRangeSelector) {
-    m_dblManager->setValue(m_properties["IntegrationEnd"], val);
-  } else if (from == backgroundRangeSelector) {
-    m_dblManager->setValue(m_properties["BackgroundEnd"], val);
-  }
-
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(notifyDoubleValueChanged(QtProperty *, double)));
+  auto prop = (from == m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange")) ? m_properties["IntegrationEnd"]
+                                                                                   : m_properties["BackgroundEnd"];
+  m_dblManager->setValue(prop, val);
 }
 
 void InelasticDataManipulationElwinTabView::notifyDoubleValueChanged(QtProperty *prop, double val) {
   auto integrationRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange");
   auto backgroundRangeSelector = m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange");
-
   m_presenter->handleValueChanged(prop->propertyName().toStdString(), val);
 
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(notifyDoubleValueChanged(QtProperty *, double)));
-
+  disconnectSignals();
   if (prop == m_properties["IntegrationStart"])
     setRangeSelectorMin(m_properties["IntegrationStart"], m_properties["IntegrationEnd"], integrationRangeSelector,
                         val);
@@ -438,9 +412,33 @@ void InelasticDataManipulationElwinTabView::notifyDoubleValueChanged(QtProperty 
     setRangeSelectorMin(m_properties["BackgroundStart"], m_properties["BackgroundEnd"], backgroundRangeSelector, val);
   else if (prop == m_properties["BackgroundEnd"])
     setRangeSelectorMax(m_properties["BackgroundStart"], m_properties["BackgroundEnd"], backgroundRangeSelector, val);
+  connectSignals();
+}
 
+void InelasticDataManipulationElwinTabView::disconnectSignals() {
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+             SLOT(notifyDoubleValueChanged(QtProperty *, double)));
+  disconnect(m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange"), SIGNAL(maxValueChanged(double)), this,
+             SLOT(notifyMaxChanged(double)));
+  disconnect(m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange"), SIGNAL(minValueChanged(double)), this,
+             SLOT(notifyMinChanged(double)));
+  disconnect(m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange"), SIGNAL(maxValueChanged(double)), this,
+             SLOT(notifyMaxChanged(double)));
+  disconnect(m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange"), SIGNAL(minValueChanged(double)), this,
+             SLOT(notifyMinChanged(double)));
+}
+
+void InelasticDataManipulationElwinTabView::connectSignals() {
   connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
           SLOT(notifyDoubleValueChanged(QtProperty *, double)));
+  connect(m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange"), SIGNAL(maxValueChanged(double)), this,
+          SLOT(notifyMaxChanged(double)));
+  connect(m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange"), SIGNAL(minValueChanged(double)), this,
+          SLOT(notifyMinChanged(double)));
+  connect(m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange"), SIGNAL(maxValueChanged(double)), this,
+          SLOT(notifyMaxChanged(double)));
+  connect(m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange"), SIGNAL(minValueChanged(double)), this,
+          SLOT(notifyMinChanged(double)));
 }
 
 void InelasticDataManipulationElwinTabView::setIntegrationStart(double value) {

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
@@ -101,6 +101,9 @@ private:
   void setHorizontalHeaders();
   void setDefaultSampleLog(const Mantid::API::MatrixWorkspace_const_sptr &ws);
 
+  void disconnectSignals();
+  void connectSignals();
+
   /// Function to set the range selector on the mini plot
   void setRangeSelector(MantidWidgets::RangeSelector *rs, QtProperty *lower, QtProperty *upper,
                         const QPair<double, double> &range,


### PR DESCRIPTION
### Description of work
This PR fixes #37012 , when elastic window integration limits are updated by using the slider on the plot, these limits were not passed to the presenter, and not updated in the model, so running the algorithm while changing the limits form the slider did not have any effect on the resulting computed elastic window. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37012 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1. In Mantid Workbench, open `Interfaces->Inelastic->Data Manipulation` interface and select the `Elwin` tab.
2. On File, browse for file `irs26173_graphite002_red.nxs` and click on `Run`. 
3. Plot the resulting spectra by clicking on `Plot` button. 
4. Change the integration range either by the Property browser or directly using the graph delimiters on the plot widget. 
5. Run again the algorithm, see that the results are changing in this case. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

_Added release notes_

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
