### PR TITLE
Expose missing Data Objects Workspace properties to python

### DIFF
--- a/Framework/PythonInterface/mantid/dataobjects/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/dataobjects/CMakeLists.txt
@@ -9,20 +9,27 @@ set(EXPORT_FILES
     src/Exports/EventWorkspace.cpp
     src/Exports/EventWorkspaceProperty.cpp
     src/Exports/Workspace2D.cpp
+    src/Exports/Workspace2DProperty.cpp
     src/Exports/RebinnedOutput.cpp
     src/Exports/SpecialWorkspace2D.cpp
+    src/Exports/SpecialWorkspace2DProperty.cpp
     src/Exports/GroupingWorkspace.cpp
+    src/Exports/GroupingWorkspaceProperty.cpp
     src/Exports/MaskWorkspace.cpp
     src/Exports/MaskWorkspaceProperty.cpp
     src/Exports/OffsetsWorkspace.cpp
+    src/Exports/OffsetsWorkspaceProperty.cpp
     src/Exports/MDEventWorkspace.cpp
     src/Exports/MDHistoWorkspace.cpp
     src/Exports/PeaksWorkspace.cpp
     src/Exports/LeanElasticPeaksWorkspace.cpp
     src/Exports/PeaksWorkspaceProperty.cpp
     src/Exports/TableWorkspace.cpp
+    src/Exports/TableWorkspaceProperty.cpp
     src/Exports/SplittersWorkspace.cpp
+    src/Exports/SplittersWorkspaceProperty.cpp
     src/Exports/WorkspaceSingleValue.cpp
+    src/Exports/WorkspaceSingleValueProperty.cpp
     src/Exports/NoShape.cpp
     src/Exports/PeakShapeSpherical.cpp
     src/Exports/PeakShapeEllipsoid.cpp

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/GroupingWorkspaceProperty.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/GroupingWorkspaceProperty.cpp
@@ -1,0 +1,18 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataObjects/GroupingWorkspace.h"
+#include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
+#include "MantidPythonInterface/core/GetPointer.h"
+
+using Mantid::DataObjects::GroupingWorkspace;
+
+GET_POINTER_SPECIALIZATION(Mantid::API::WorkspaceProperty<GroupingWorkspace>)
+
+void export_GroupingWorkspaceProperty() {
+  using Mantid::PythonInterface::WorkspacePropertyExporter;
+  WorkspacePropertyExporter<GroupingWorkspace>::define("GroupingWorkspaceProperty");
+}

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/OffsetsWorkspaceProperty.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/OffsetsWorkspaceProperty.cpp
@@ -1,0 +1,18 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataObjects/OffsetsWorkspace.h"
+#include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
+#include "MantidPythonInterface/core/GetPointer.h"
+
+using Mantid::DataObjects::OffsetsWorkspace;
+
+GET_POINTER_SPECIALIZATION(Mantid::API::WorkspaceProperty<OffsetsWorkspace>)
+
+void export_OffsetsWorkspaceProperty() {
+  using Mantid::PythonInterface::WorkspacePropertyExporter;
+  WorkspacePropertyExporter<OffsetsWorkspace>::define("OffsetsWorkspaceProperty");
+}

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/SpecialWorkspace2DProperty.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/SpecialWorkspace2DProperty.cpp
@@ -1,0 +1,18 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataObjects/SpecialWorkspace2D.h"
+#include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
+#include "MantidPythonInterface/core/GetPointer.h"
+
+using Mantid::DataObjects::SpecialWorkspace2D;
+
+GET_POINTER_SPECIALIZATION(Mantid::API::WorkspaceProperty<SpecialWorkspace2D>)
+
+void export_SpecialWorkspace2DProperty() {
+  using Mantid::PythonInterface::WorkspacePropertyExporter;
+  WorkspacePropertyExporter<SpecialWorkspace2D>::define("SpecialWorkspace2DProperty");
+}

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/SplittersWorkspaceProperty.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/SplittersWorkspaceProperty.cpp
@@ -1,0 +1,18 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataObjects/SplittersWorkspace.h"
+#include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
+#include "MantidPythonInterface/core/GetPointer.h"
+
+using Mantid::DataObjects::SplittersWorkspace;
+
+GET_POINTER_SPECIALIZATION(Mantid::API::WorkspaceProperty<SplittersWorkspace>)
+
+void export_SplittersWorkspaceProperty() {
+  using Mantid::PythonInterface::WorkspacePropertyExporter;
+  WorkspacePropertyExporter<SplittersWorkspace>::define("SplittersWorkspaceProperty");
+}

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/TableWorkspaceProperty.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/TableWorkspaceProperty.cpp
@@ -1,0 +1,18 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
+#include "MantidPythonInterface/core/GetPointer.h"
+
+using Mantid::DataObjects::TableWorkspace;
+
+GET_POINTER_SPECIALIZATION(Mantid::API::WorkspaceProperty<TableWorkspace>)
+
+void export_TableWorkspaceProperty() {
+  using Mantid::PythonInterface::WorkspacePropertyExporter;
+  WorkspacePropertyExporter<TableWorkspace>::define("TableWorkspaceProperty");
+}

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/Workspace2DProperty.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/Workspace2DProperty.cpp
@@ -1,0 +1,18 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
+#include "MantidPythonInterface/core/GetPointer.h"
+
+using Mantid::DataObjects::Workspace2D;
+
+GET_POINTER_SPECIALIZATION(Mantid::API::WorkspaceProperty<Workspace2D>)
+
+void export_Workspace2DProperty() {
+  using Mantid::PythonInterface::WorkspacePropertyExporter;
+  WorkspacePropertyExporter<Workspace2D>::define("Workspace2DProperty");
+}

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/WorkspaceSingleValueProperty.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/WorkspaceSingleValueProperty.cpp
@@ -1,0 +1,18 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataObjects/WorkspaceSingleValue.h"
+#include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
+#include "MantidPythonInterface/core/GetPointer.h"
+
+using Mantid::DataObjects::WorkspaceSingleValue;
+
+GET_POINTER_SPECIALIZATION(Mantid::API::WorkspaceProperty<WorkspaceSingleValue>)
+
+void export_WorkspaceSingleValueProperty() {
+  using Mantid::PythonInterface::WorkspacePropertyExporter;
+  WorkspacePropertyExporter<WorkspaceSingleValue>::define("WorkspaceSingleValueProperty");
+}


### PR DESCRIPTION
### Description of work
This PR fixes an issue where a number of workspaces in the `Mantid::DataObjects` library are not exposed to python as a potential workspace property. This means that in order to get an OutputWorkspace property back from a python algorithm call (when the OutputWorkspace property is a Data objects workspace), it **must** be stored in the ADS. This is not ideal in all circumstances. I would like to avoid putting output workspaces in the ADS so that I do not need to delete temporary workspaces later on.

### To test:
You will need this calibration file to run the script 
[osiris_041_RES10.zip](https://github.com/mantidproject/mantid/files/14603202/osiris_041_RES10.zip)

1. Run this python script. It should run successfully without error
```py
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

group_ws, _, _ = CreateGroupingWorkspace(InstrumentName="OSIRIS", OldCalFilename="C:\\Users\\mlc47243\\Documents\\mantid-data\\osiris_041_RES10.cal", StoreInADS=False)
```
2. Previously, this would show an error saying that the algorithm call only returns 2 arguments rather than 3. This was happening because the "GroupingWorkspace" WorkspaceProperty was not exposed to python, and the grouping workspace couldn't be found in the ADS.

*This does not require release notes* because **I think this is more developer-facing rather than user-facing**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
