### PR TITLE
Improved numerical validation in Filter Events Interface 

### DIFF
--- a/dev-docs/source/Testing/Utility/FilterEventsInterfaceTest.rst
+++ b/dev-docs/source/Testing/Utility/FilterEventsInterfaceTest.rst
@@ -10,8 +10,6 @@ Filter Events Interface Testing
 
 - Download the `Usage Examples <https://www.mantidproject.org/installation/index#sample-data>`
 
-*Note: At the time of writing this test, there's an issue pending with data validation on this interface(#36073); if this issue hasn't been
-corrected yet, please remind the team about it, else update documentation and remove this note.*
 
 Filter Events
 --------------
@@ -26,13 +24,14 @@ Filter Events
 #. Click ``Load``. After a few seconds, plot should be updated with a graph of summed up Counts vs.Time.
 #. ``_Summed_..`` workspace should be generated on the ADS, as well as ``CNCS_7860_Event`` workspace.
 #. Clicking on the ``Refresh`` button should update the drop-down list with the name of the loaded workspace.
-#. Check Vertical Range Sliders work properly. You can't overlap the sliders or cross the sliders.
-#. Check Horizontal Range Sliders work properly. You can't overlap or cross the sliders.
+#. Check Vertical Range Sliders work properly. You can't cross the sliders.
+#. Check Horizontal Range Sliders work properly. You can't cross the sliders.
 #. Check that the Text Edits for ``Starting Time`` and ``Stopping Time`` work correctly:
 
-   - Position of vertical bars on the plot are updated appropiately when changing the numerical value of the edits and clicking ``Set``.
+   - Position of vertical bars on the plot are updated appropriately when changing the numerical value of the edits and clicking ``Set``.
    - Setting a value on ``Starting Time`` larger than the current value on ``Stopping Time`` is not allowed, and viceversa.
-   - Data Validation is working, you can't set non-numeric characters on the edits (except for `-` sign, see note).
+   - Data Validation is working, you can't set non-numeric characters on the edits.
+   - A red label with information is displayed on top of the plot whenever the input validation is wrong.
 
 #. Clicking anywhere on the plot raises a dialog with the `(x,y)` position clicked on the graph.
 #. On ``Output Name`` write `FilteredTemp`.

--- a/dev-docs/source/Testing/Utility/FilterEventsInterfaceTest.rst
+++ b/dev-docs/source/Testing/Utility/FilterEventsInterfaceTest.rst
@@ -28,7 +28,7 @@ Filter Events
 #. Check Horizontal Range Sliders work properly. You can't cross the sliders.
 #. Check that the Text Edits for ``Starting Time`` and ``Stopping Time`` work correctly:
 
-   - Position of vertical bars on the plot are updated appropriately when changing the numerical value of the edits and clicking ``Set``.
+   - Position of vertical bars on the plot are updated appropriately when changing the numerical value of the edits and pressing `Enter`.
    - Setting a value on ``Starting Time`` larger than the current value on ``Stopping Time`` is not allowed, and viceversa.
    - Data Validation is working, you can't set non-numeric characters on the edits.
    - A red label with information is displayed on top of the plot whenever the input validation is wrong.
@@ -44,7 +44,7 @@ Filter Events
    the same as selected with the sliders in the interface.
 #. Back to the filter events interface, click on the ``Refresh`` button. The drop-down list should refresh with the available event workspaces on the ADS (``CNCS_7860_Event`` and ``FilteredTemp_0``).
 #. Select ``FilteredTemp_0`` and click on ``Use`` button. Plot should update accordingly.
-#. On output name write `FilteredTime`, on ``Starting Time`` text edit write ``80`` and then click ``Set``. On ``Stopping Time`` text edit write ``100`` and then click ``Set``.
+#. On output name write `FilteredTime`, on ``Starting Time`` text edit write ``80`` and then press ``Enter``. On ``Stopping Time`` text edit write ``100`` and press ``Enter``.
 #. Select ``Filtered by Time`` tab and on ``Time Interval`` text edit write ``10``. Then click on ``Filter`` button. Two table workspaces ending with ``_info``, ``_splitters`` and a group workspace named ``FilteredTime`` containing two
    event workspaces named ``FilteredTime_0`` and ``FilteredTime_1`` appear on ADS.
 #. Double-click on ``FilteredTemp_0_info`` table workspace. The table should contain two rows, indicating two time intervals of approximately 10 seconds each, and the corresponding workspace group index.

--- a/docs/source/release/v6.10.0/Framework/Python/Bugfixes/36073.rst
+++ b/docs/source/release/v6.10.0/Framework/Python/Bugfixes/36073.rst
@@ -1,3 +1,3 @@
 - Input validation errors have been corrected for numerical line edits of the Filter Events interface.
-- Fix crash occurring when incorrect `TOF Correction To Sample` value is selected for the input workspace. Now error message is displayed instead of crash.
+- Fix crash occurring when an incorrect `TOF Correction To Sample` value is selected for the input workspace. Now error message is displayed instead of crash.
 - Fix bug that allowed the two sliders to cross each other for certain values of the line edits controlling the sliders.

--- a/docs/source/release/v6.10.0/Framework/Python/Bugfixes/36073.rst
+++ b/docs/source/release/v6.10.0/Framework/Python/Bugfixes/36073.rst
@@ -1,0 +1,3 @@
+- Input validation errors have been corrected for numerical line edits of the Filter Events interface.
+- Fix crash occurring when incorrect `TOF Correction To Sample` value is selected for the input workspace. Now error message is displayed instead of crash.
+- Fix bug that allowed the two sliders to cross each other for certain values of the line edits controlling the sliders.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/MainWindow.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/MainWindow.ui
@@ -200,20 +200,23 @@
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_25">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+         <widget class="QLabel" name="labelFeedback">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Preferred</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
+          <property name="minimumSize">
            <size>
-            <width>40</width>
-            <height>20</height>
+            <width>250</width>
+            <height>0</height>
            </size>
           </property>
-         </spacer>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>
@@ -286,23 +289,26 @@
           </property>
          </widget>
         </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
-         <spacer name="horizontalSpacer_2">
+         <spacer name="horizontalSpacer_10">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
-            <height>20</height>
+            <width>27</width>
+            <height>27</height>
            </size>
           </property>
          </spacer>
         </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
          <widget class="QLabel" name="label_3">
           <property name="text">
@@ -314,7 +320,7 @@
          <widget class="QLineEdit" name="leStartTime"/>
         </item>
         <item>
-         <spacer name="horizontalSpacer_9">
+         <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -335,6 +341,19 @@
         </item>
         <item>
          <widget class="QLineEdit" name="leStopTime"/>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_9">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </item>
@@ -405,7 +424,7 @@
                <x>0</x>
                <y>0</y>
                <width>674</width>
-               <height>285</height>
+               <height>288</height>
               </rect>
              </property>
              <layout class="QGridLayout" name="gridLayout_5">
@@ -941,7 +960,7 @@
                <x>0</x>
                <y>0</y>
                <width>674</width>
-               <height>285</height>
+               <height>288</height>
               </rect>
              </property>
              <layout class="QGridLayout" name="gridLayout_6">

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/MainWindow.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/MainWindow.ui
@@ -261,19 +261,6 @@
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_10">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
          <widget class="QSlider" name="horizontalSlider_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -283,8 +270,12 @@
           </property>
          </widget>
         </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
-         <spacer name="horizontalSpacer_11">
+         <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -296,10 +287,6 @@
           </property>
          </spacer>
         </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
          <widget class="QLabel" name="label_3">
           <property name="text">
@@ -308,17 +295,10 @@
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="lineEdit_3"/>
+         <widget class="QLineEdit" name="leStartTime"/>
         </item>
         <item>
-         <widget class="QPushButton" name="pushButton_setT0">
-          <property name="text">
-           <string>Set</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_12">
+         <spacer name="horizontalSpacer_9">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -338,14 +318,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QLineEdit" name="lineEdit_4"/>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_setTf">
-          <property name="text">
-           <string>Set</string>
-          </property>
-         </widget>
+         <widget class="QLineEdit" name="leStopTime"/>
         </item>
        </layout>
       </item>
@@ -416,7 +389,7 @@
                <x>0</x>
                <y>0</y>
                <width>674</width>
-               <height>283</height>
+               <height>285</height>
               </rect>
              </property>
              <layout class="QGridLayout" name="gridLayout_5">
@@ -619,7 +592,7 @@
                    </widget>
                   </item>
                   <item>
-                   <widget class="QLineEdit" name="lineEdit_5"/>
+                   <widget class="QLineEdit" name="leMinimumValue"/>
                   </item>
                   <item>
                    <spacer name="horizontalSpacer_15">
@@ -645,7 +618,7 @@
                    </widget>
                   </item>
                   <item>
-                   <widget class="QLineEdit" name="lineEdit_6"/>
+                   <widget class="QLineEdit" name="leMaximumValue"/>
                   </item>
                  </layout>
                 </item>
@@ -665,7 +638,7 @@
                    </widget>
                   </item>
                   <item>
-                   <widget class="QLineEdit" name="lineEdit_7">
+                   <widget class="QLineEdit" name="leStepSize">
                     <property name="maximumSize">
                      <size>
                       <width>200</width>
@@ -724,7 +697,7 @@
                    </widget>
                   </item>
                   <item>
-                   <widget class="QLineEdit" name="lineEdit_8">
+                   <widget class="QLineEdit" name="leValueTolerance">
                     <property name="maximumSize">
                      <size>
                       <width>200</width>
@@ -783,7 +756,7 @@
                    </widget>
                   </item>
                   <item>
-                   <widget class="QLineEdit" name="lineEdit_9">
+                   <widget class="QLineEdit" name="leTimeTolerance">
                     <property name="maximumSize">
                      <size>
                       <width>200</width>
@@ -952,7 +925,7 @@
                <x>0</x>
                <y>0</y>
                <width>674</width>
-               <height>283</height>
+               <height>285</height>
               </rect>
              </property>
              <layout class="QGridLayout" name="gridLayout_6">
@@ -1036,7 +1009,7 @@
                    </widget>
                   </item>
                   <item>
-                   <widget class="QLineEdit" name="lineEdit_Ei">
+                   <widget class="QLineEdit" name="leIncidentEnergy">
                     <property name="maximumSize">
                      <size>
                       <width>400</width>
@@ -1330,27 +1303,25 @@
   <tabstop>verticalSlider_2</tabstop>
   <tabstop>horizontalSlider</tabstop>
   <tabstop>horizontalSlider_2</tabstop>
-  <tabstop>lineEdit_3</tabstop>
-  <tabstop>pushButton_setT0</tabstop>
-  <tabstop>lineEdit_4</tabstop>
-  <tabstop>pushButton_setTf</tabstop>
+  <tabstop>leStartTime</tabstop>
+  <tabstop>leStopTime</tabstop>
   <tabstop>lineEdit_outwsname</tabstop>
   <tabstop>lineEdit_title</tabstop>
   <tabstop>filterTab</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>comboBox_2</tabstop>
   <tabstop>pushButton_4</tabstop>
-  <tabstop>lineEdit_5</tabstop>
-  <tabstop>lineEdit_6</tabstop>
-  <tabstop>lineEdit_7</tabstop>
+  <tabstop>leMinimumValue</tabstop>
+  <tabstop>leMaximumValue</tabstop>
+  <tabstop>leStepSize</tabstop>
   <tabstop>comboBox_4</tabstop>
-  <tabstop>lineEdit_8</tabstop>
+  <tabstop>leValueTolerance</tabstop>
   <tabstop>comboBox_5</tabstop>
-  <tabstop>lineEdit_9</tabstop>
+  <tabstop>leTimeTolerance</tabstop>
   <tabstop>pushButton_filterLog</tabstop>
   <tabstop>scrollArea_2</tabstop>
   <tabstop>comboBox_tofCorr</tabstop>
-  <tabstop>lineEdit_Ei</tabstop>
+  <tabstop>leIncidentEnergy</tabstop>
   <tabstop>comboBox_corrWS</tabstop>
   <tabstop>pushButton_refreshCorrWSList</tabstop>
   <tabstop>checkBox_fastLog</tabstop>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/MainWindow.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/MainWindow.ui
@@ -199,25 +199,6 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QLabel" name="labelFeedback">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>250</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
        </layout>
       </item>
       <item>
@@ -959,8 +940,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>674</width>
-               <height>288</height>
+               <width>360</width>
+               <height>222</height>
               </rect>
              </property>
              <layout class="QGridLayout" name="gridLayout_6">

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/MainWindow.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/MainWindow.ui
@@ -220,7 +220,23 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
-         <widget class="QFrame" name="graphicsView"/>
+         <widget class="QFrame" name="graphicsView">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>329</height>
+           </size>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::StyledPanel</enum>
+          </property>
+         </widget>
         </item>
         <item>
          <layout class="QVBoxLayout" name="verticalLayout">

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/MainWindow.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/MainWindow.ui
@@ -15,6 +15,18 @@
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout_3">
+    <property name="leftMargin">
+     <number>15</number>
+    </property>
+    <property name="topMargin">
+     <number>15</number>
+    </property>
+    <property name="rightMargin">
+     <number>15</number>
+    </property>
+    <property name="bottomMargin">
+     <number>15</number>
+    </property>
     <item>
      <layout class="QVBoxLayout" name="verticalLayout_5">
       <item>
@@ -403,8 +415,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>688</width>
-               <height>270</height>
+               <width>674</width>
+               <height>283</height>
               </rect>
              </property>
              <layout class="QGridLayout" name="gridLayout_5">
@@ -939,8 +951,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>688</width>
-               <height>270</height>
+               <width>674</width>
+               <height>283</height>
               </rect>
              </property>
              <layout class="QGridLayout" name="gridLayout_6">
@@ -1305,16 +1317,6 @@
      </layout>
     </item>
    </layout>
-  </widget>
-  <widget class="QMenuBar" name="menubar">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>732</width>
-     <height>22</height>
-    </rect>
-   </property>
   </widget>
  </widget>
  <tabstops>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/eventFilterGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/FilterEvents/eventFilterGUI.py
@@ -8,7 +8,7 @@
 import numpy as np
 
 from qtpy.QtWidgets import QFileDialog, QMainWindow, QMessageBox, QSlider, QVBoxLayout, QWidget
-from qtpy.QtGui import QDoubleValidator, QDesktopServices, QPalette, QColor  # noqa
+from qtpy.QtGui import QDoubleValidator, QDesktopServices
 from qtpy.QtCore import QUrl, QLocale
 
 import mantid
@@ -217,12 +217,11 @@ class MainWindow(QMainWindow):
             self.ui.labelFeedback.setStyleSheet("color:green")
 
     def reformat_and_callback(self):
-        if self.dvalidator.validate(self.sender().text(), 0)[0] == QDoubleValidator.Acceptable:
-            self.sender().setText(f"{float(self.sender().text()):.6f}")
-            self.ui.labelFeedback.setText("")
-            callback = self.doubleLineEdits[self.sender().objectName()][1]
-            if callback is not None:
-                callback()
+        self.sender().setText(f"{float(self.sender().text()):.6f}")
+        self.ui.labelFeedback.setText("")
+        callback = self.doubleLineEdits[self.sender().objectName()][1]
+        if callback is not None:
+            callback()
 
     def populate_line_edits_default(self):
         ylim = self.ui.mainplot.get_ylim()


### PR DESCRIPTION
### Description of work
Some issues were found during manual testing for the Filter Events interface in the last two release periods (#36050, #36697). A few of them were summarized in #36073. This PR fixes the issues and adds small cosmetic changes to the interface.
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
The numerical inputs of the Filter Events interface were `QLineEdits` validated through regular expressions. Some incorrect values (like `-` sign) were causing the interface to crash, as the signals were called with incorrect values, and the conversion to float on string `-` failed. In this PR, the numerical line edits of the interface are reimplemented by using `QDoubleValidators` classes. Additionally, slots reacting to changes in line edits are call back using `editingFinished` signals, which is only called whenever the validators return an acceptable value, an therefore prevents converting with incorrect values without adding  intermediate validation functions. Additionally, a feedback label that indicates whenever a particular input value is wrong has been added. 
Other small fixes are: 
- A rounding error in which you could set for some numbers `StopTime` larger than `StartTime` and viceversa has been fixed. 
- Some padding has been added to the borders of the interface for better visualization, also the canvas frame has been slightly reshaped. `Set` buttons are no longer necessary.
- A bug where setting `TOF Correction to Sample` would crash if setting incorrect workspace has been fixed.
- Updated manual testing instructions. 

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36073. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Follow manual testing instructions: https://developer.mantidproject.org/Testing/Utility/FilterEventsInterfaceTest.html
- Filter events don't crash when following #36073 crash instructions 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

_Added release notes_

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
