### PR TITLE
36593 FindpeaksConvolve at Engdiff fit browser

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeakFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeakFunction.cpp
@@ -32,5 +32,7 @@ void export_IPeakFunction() {
            "parameters.")
       .def("setIntensity", &IPeakFunction::setIntensity, (arg("self"), arg("new_intensity")),
            "Changes the integral intensity of the peak function by setting its "
-           "height.");
+           "height.")
+      .def("setHeight", &IPeakFunction::setHeight, arg("self"), "Sets height of the peak function.")
+      .def("setCentre", &IPeakFunction::setCentre, arg("self"), "Sets setCentre of the peak function.");
 }

--- a/docs/source/release/v6.10.0/Diffraction/Engineering/New_features/36593.rst
+++ b/docs/source/release/v6.10.0/Diffraction/Engineering/New_features/36593.rst
@@ -1,1 +1,1 @@
-- Added functionality to call FindPeaksConvolve algorithm with good default values for ENGIN-X from the fitproperty browser in the Engineering UI :ref:`Fitting tab <ui engineering fitting>`
+- Added functionality to call FindPeaksConvolve algorithm with good default values for ENGIN-X from the fitproperty browser in the Engineering UI :ref:`Fitting tab <ui engineering fitting>` resulting to add peaks found in the range specified with the sliders on the X axis.

--- a/docs/source/release/v6.10.0/Diffraction/Engineering/New_features/36593.rst
+++ b/docs/source/release/v6.10.0/Diffraction/Engineering/New_features/36593.rst
@@ -1,0 +1,1 @@
+- Added functionality to call FindPeaksConvolve algorithm with good default values for ENGIN-X from the fitproperty browser in the Engineering UI :ref:`Fitting tab <ui engineering fitting>`

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -36,6 +36,7 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         self.fit_started_notifier = GenericObservable()
         self.algorithmStarted.connect(self.fitting_started_slot)
         self.algorithmFailed.connect(self.fitting_failed_slot)
+        self.function_changed_notifier = GenericObservable()
 
     def set_output_window_names(self):
         """
@@ -171,6 +172,7 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         """
         super(EngDiffFitPropertyBrowser, self).function_changed_slot()
         self.fit_enabled_notifier.notify_subscribers(self.isFitEnabled() and self.isVisible())
+        self.function_changed_notifier.notify_subscribers()
 
     @Slot()
     def fitting_started_slot(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
@@ -178,11 +178,12 @@ class FittingPlotModel(object):
     def get_fit_results(self):
         return self._fit_results
 
-    def run_find_peaks_convolve(self, input_ws_name, peak_type):
+    def run_find_peaks_convolve(self, input_ws_name, peak_type, x_range):
         """
         Run FindPeaksConvolve algorithm with default values for ENGIN-X
         :param input_ws_name: Name of the input workspace to run against
         :param peak_type: Name of the selected peak type
+        :param x_range: min and max values of the fitting range
         :return string: Function wrapper string for the peaks detected via the algorithm, None otherwise
         """
         if not ADS.doesExist(input_ws_name):
@@ -208,13 +209,15 @@ class FittingPlotModel(object):
             logger.error("Failed extracting columns from FindPeakConvolve output")
             return None
 
-        return self._get_func_wrapper_str_for_peak_x_y(peak_x_values, peak_y_values, peak_type, fit_prop_ws)
+        return self._get_func_wrapper_str_for_peak_x_y(peak_x_values, peak_y_values, peak_type, fit_prop_ws, x_range)
 
-    def _get_func_wrapper_str_for_peak_x_y(self, peak_x_values, peak_y_values, peak_type, fit_prop_ws):
+    def _get_func_wrapper_str_for_peak_x_y(self, peak_x_values, peak_y_values, peak_type, fit_prop_ws, x_range):
         if set(peak_x_values.keys()) == set(peak_y_values.keys()):
             logger.notice(f"Adding {len(peak_x_values)} peaks found via FindPeaksConvolve")
             func_wrapper = None
             for col, x_value in peak_x_values.items():
+                if x_value < x_range[0] or x_value > x_range[1]:
+                    continue
                 y_value = peak_y_values[col]
                 peak_func = FunctionFactory.Instance().createPeakFunction(peak_type)
                 peak_func.setCentre(x_value)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
@@ -12,10 +12,11 @@ from collections import defaultdict
 from mantid import FunctionFactory
 from mantid.api import TextAxis
 from mantid.kernel import UnitConversion, DeltaEModeType, UnitParams
-from mantid.simpleapi import logger, CreateEmptyTableWorkspace, GroupWorkspaces, CreateWorkspace
+from mantid.simpleapi import logger, CreateEmptyTableWorkspace, GroupWorkspaces, CreateWorkspace, FindPeaksConvolve
 from mantid.api import AnalysisDataService as ADS
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common.output_sample_logs import write_table_row
 from mantid.api import CompositeFunction
+from mantid.fitfunctions import FunctionWrapper
 
 
 class FittingPlotModel(object):
@@ -176,3 +177,65 @@ class FittingPlotModel(object):
 
     def get_fit_results(self):
         return self._fit_results
+
+    def run_find_peaks_convolve(self, input_ws_name, peak_type):
+        """
+        Run FindPeaksConvolve algorithm with default values for ENGIN-X
+        :param input_ws_name: Name of the input workspace to run against
+        :param peak_type: Name of the selected peak type
+        :return string: Function wrapper string for the peaks detected via the algorithm, None otherwise
+        """
+        if not ADS.doesExist(input_ws_name):
+            logger.error(f"{input_ws_name} does not exist!")
+            return None
+        fit_prop_ws = ADS.retrieve(input_ws_name)
+        groupWs = FindPeaksConvolve(
+            InputWorkspace=fit_prop_ws,
+            OutputWorkspace="FindPeaksConvolve_" + input_ws_name,
+            IOverSigmaThreshold=10,
+            EstimatedPeakExtent=200,
+            StoreInADS=True,
+        )
+        peak_x_values = dict()
+        peak_y_values = dict()
+        for tab_ws in groupWs:
+            if tab_ws.getName() == "PeakCentre":
+                peak_x_values = self._re_organize_keys_find_peaks_convolve(tab_ws)
+            elif tab_ws.getName() == "PeakYPosition":
+                peak_y_values = self._re_organize_keys_find_peaks_convolve(tab_ws)
+
+        if peak_x_values is None or peak_y_values is None:
+            logger.error("Failed extracting columns from FindPeakConvolve output")
+            return None
+
+        return self._get_func_wrapper_str_for_peak_x_y(peak_x_values, peak_y_values, peak_type, fit_prop_ws)
+
+    def _get_func_wrapper_str_for_peak_x_y(self, peak_x_values, peak_y_values, peak_type, fit_prop_ws):
+        if set(peak_x_values.keys()) == set(peak_y_values.keys()):
+            logger.notice(f"Adding {len(peak_x_values)} peaks found via FindPeaksConvolve")
+            func_wrapper = None
+            for col, x_value in peak_x_values.items():
+                y_value = peak_y_values[col]
+                peak_func = FunctionFactory.Instance().createPeakFunction(peak_type)
+                peak_func.setCentre(x_value)
+                peak_func.setHeight(y_value)
+                peak_func.setMatrixWorkspace(fit_prop_ws, 0, 0, 0)
+                f_wrapper = FunctionWrapper(peak_func)
+                if func_wrapper is None:
+                    func_wrapper = f_wrapper
+                else:
+                    func_wrapper += f_wrapper
+            if func_wrapper is not None:
+                return str(func_wrapper)
+            else:
+                logger.error("No peak functions were created from the results of FindPeaksConvolve")
+        else:
+            logger.error("Incompatible columns returned from FindPeaksConvolve!")
+        return None
+
+    def _re_organize_keys_find_peaks_convolve(self, table_ws):
+        if table_ws.rowCount() == 1:
+            table_dict = table_ws.row(0)
+            table_dict.pop("SpecIndex", None)
+            return {col_name.split("_")[-1]: value for col_name, value in table_dict.items()}
+        return None

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -115,7 +115,9 @@ class FittingPlotPresenter(object):
         self.find_peaks_convolve_started_notifier.notify_subscribers()
         try:
             input_ws_name = self.view.fit_browser.workspaceName()
-            func_wrapper_str = self.model.run_find_peaks_convolve(input_ws_name, self.view.fit_browser.defaultPeakType())
+            func_wrapper_str = self.model.run_find_peaks_convolve(
+                input_ws_name, self.view.fit_browser.defaultPeakType(), (self.view.fit_browser.startX(), self.view.fit_browser.endX())
+            )
             if func_wrapper_str is not None:
                 self.is_waiting_convolve_peaks = True
                 self.view.fit_browser.loadFunction(func_wrapper_str)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -67,6 +67,8 @@ class FittingPlotPresenter(object):
             self.view.remove_ws_from_fitbrowser(ws)
         self.view.update_figure()
         self.set_progress_bar_zero()
+        if len(self.model.get_plotted_workspaces()) == 0:
+            self.view.set_find_peaks_convolve_button_status(False)
 
     def clear_plot(self):
         for ax in self.view.get_axes():

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_toolbar.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_toolbar.py
@@ -14,6 +14,7 @@ class FittingPlotToolbar(MantidNavigationToolbar):
     sig_serial_fit_clicked = QtCore.Signal()
     sig_seq_fit_clicked = QtCore.Signal()
     sig_toggle_legend = QtCore.Signal()
+    sig_find_peaks_convolve = QtCore.Signal()
 
     toolitems = (
         MantidNavigationTool("Home", "Center display on contents", "mdi.home", "on_home_clicked", None),
@@ -26,6 +27,9 @@ class FittingPlotToolbar(MantidNavigationToolbar):
         MantidNavigationTool("Serial Fit", "Fit each spec with the starting guess.", None, "serial_fit", None),
         MantidNavigationTool("Sequential Fit", "Fit each spec using the output of a previous run", None, "seq_fit", None),
         MantidNavigationTool("Hide Legend", "Toggle the legend box on/off", None, "toggle_legend", False),
+        MantidNavigationTool(
+            "FindPeaksConvolve", "Run FindPeaksConvolve algorithm on the selected workspace", None, "run_find_peak_convolve", None
+        ),
     )
 
     def __init__(self, canvas, parent, coordinates=True):
@@ -57,6 +61,9 @@ class FittingPlotToolbar(MantidNavigationToolbar):
 
     def toggle_legend(self):
         self.sig_toggle_legend.emit()
+
+    def run_find_peak_convolve(self):
+        self.sig_find_peaks_convolve.emit()
 
     def get_show_legend_value(self):
         return not self._actions["toggle_legend"].isChecked()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -83,9 +83,6 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         fit_enabled_observer = GenericObserverWithArgPassing(self.set_sequential_serial_fit_enabled)
         self.fit_browser.fit_enabled_notifier.add_subscriber(fit_enabled_observer)
 
-        fit_enabled_find_peaks_convolve_observer = GenericObserverWithArgPassing(self.set_find_peaks_convolve_button_status)
-        self.fit_browser.fit_enabled_notifier.add_subscriber(fit_enabled_find_peaks_convolve_observer)
-
         self.vLayout_fitprop.addWidget(self.fit_browser)
         self.hide_fit_browser()
         self.hide_fit_progress_bar()
@@ -149,9 +146,9 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
     def set_slot_for_find_peaks_convolve(self, presenter_func):
         self.toolbar.sig_find_peaks_convolve.connect(presenter_func)
 
-    def add_subscriber_for_convolve_peak_added(self, presenter_func):
-        peak_added_observer = GenericObserver(presenter_func)
-        self.fit_browser.function_changed_notifier.add_subscriber(peak_added_observer)
+    def set_subscriber_for_function_changed(self, presenter_func):
+        func_changed_observer = GenericObserver(presenter_func)
+        self.fit_browser.function_changed_notifier.add_subscriber(func_changed_observer)
 
     def toggle_legend(self):
         self.update_legend(self.get_axes()[0])

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -14,7 +14,7 @@ from mantidqt.MPLwidgets import FigureCanvas
 from .EngDiff_fitpropertybrowser import EngDiffFitPropertyBrowser
 from workbench.plotting.toolbar import ToolbarStateManager
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_toolbar import FittingPlotToolbar
-from mantidqt.utils.observer_pattern import GenericObserverWithArgPassing
+from mantidqt.utils.observer_pattern import GenericObserverWithArgPassing, GenericObserver
 
 Ui_plot, _ = load_ui(__file__, "plot_widget.ui")
 
@@ -83,10 +83,14 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         fit_enabled_observer = GenericObserverWithArgPassing(self.set_sequential_serial_fit_enabled)
         self.fit_browser.fit_enabled_notifier.add_subscriber(fit_enabled_observer)
 
+        fit_enabled_find_peaks_convolve_observer = GenericObserverWithArgPassing(self.set_find_peaks_convolve_button_status)
+        self.fit_browser.fit_enabled_notifier.add_subscriber(fit_enabled_find_peaks_convolve_observer)
+
         self.vLayout_fitprop.addWidget(self.fit_browser)
         self.hide_fit_browser()
         self.hide_fit_progress_bar()
         self.show_cancel_button(False)
+        self.set_find_peaks_convolve_button_status(False)
 
     def mouse_click(self, event):
         if event.button == event.canvas.buttond.get(Qt.RightButton):
@@ -142,6 +146,13 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
     def set_slot_for_legend_toggled(self):
         self.toolbar.sig_toggle_legend.connect(self.toggle_legend)
 
+    def set_slot_for_find_peaks_convolve(self, presenter_func):
+        self.toolbar.sig_find_peaks_convolve.connect(presenter_func)
+
+    def add_subscriber_for_convolve_peak_added(self, presenter_func):
+        peak_added_observer = GenericObserver(presenter_func)
+        self.fit_browser.function_changed_notifier.add_subscriber(peak_added_observer)
+
     def toggle_legend(self):
         self.update_legend(self.get_axes()[0])
         self.figure.canvas.draw()
@@ -158,6 +169,12 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
 
     def hide_fit_progress_bar(self):
         self.fit_progress_bar.hide()
+
+    def set_find_peaks_convolve_button_status(self, status):
+        if self.fit_browser.isVisible() is False:
+            self.toolbar.set_action_enabled("FindPeaksConvolve", False)
+        else:
+            self.toolbar.set_action_enabled("FindPeaksConvolve", status)
 
     def show_fit_progress_bar(self):
         self.fit_progress_bar.show()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_model.py
@@ -13,6 +13,7 @@ from mantid import FunctionFactory
 from mantid.kernel import UnitParams, UnitParametersMap
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.plotting import plot_model
 from mantid.api import CompositeFunction
+from mantid.simpleapi import CreateEmptyTableWorkspace, GroupWorkspaces
 
 plot_model_path = "mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_model"
 
@@ -459,6 +460,50 @@ class FittingPlotModelTest(unittest.TestCase):
 
         self.assertAlmostEqual(tof / d, 18000, delta=1e-10)
         self.assertAlmostEqual(d_error / d, tof_error / tof, delta=1e-10)
+
+    def _get_sample_findpeaksconvolve_group_ws(self):
+        peak_centers = CreateEmptyTableWorkspace(OutputWorkspace="PeakCentre")
+        peak_centers.addColumn("int", "SpecIndex")
+        peak_centers.addColumn("double", "PeakCentre_0")
+        peak_centers.addRow([1, 0.09])
+
+        peak_y = CreateEmptyTableWorkspace(OutputWorkspace="PeakYPosition")
+        peak_y.addColumn("int", "SpecIndex")
+        peak_y.addColumn("double", "PeakYPosition_0")
+        peak_y.addRow([1, 798])
+
+        i_over_sigma = CreateEmptyTableWorkspace(OutputWorkspace="PeakIOverSigma")
+        i_over_sigma.addColumn("int", "SpecIndex")
+        i_over_sigma.addColumn("double", "PeakIOverSigma_0")
+        i_over_sigma.addRow([1, 12.5])
+        return GroupWorkspaces([peak_centers, peak_y, i_over_sigma], OutputWorkspace="test")
+
+    @mock.patch(plot_model_path + ".FunctionWrapper")
+    @mock.patch(plot_model_path + ".FunctionFactory")
+    @mock.patch(plot_model_path + ".FindPeaksConvolve")
+    @mock.patch(plot_model_path + ".logger.error")
+    @mock.patch(plot_model_path + ".ADS")
+    def test_run_find_peaks_convolve_existing_ws(self, mock_ads, mock_error, mock_find_peaks_convolve, mock_func_fac, mock_func_wrapper):
+        mock_ads.doesExist.return_value = True
+        mock_ads.retrieve.return_value = mock.MagicMock()
+        mock_find_peaks_convolve.return_value = self._get_sample_findpeaksconvolve_group_ws()
+        mock_peak_func = mock.MagicMock()
+        mock_func_fac.Instance().createPeakFunction.return_value = mock_peak_func
+
+        ret_str = self.model.run_find_peaks_convolve("ws_1", "BackToBackExponential")
+        self.assertNotEqual(ret_str, None)
+        mock_peak_func.setCentre.assert_called_once()
+        mock_peak_func.setHeight.assert_called_once()
+        mock_peak_func.setMatrixWorkspace.assert_called_once()
+        mock_error.assert_not_called()
+
+    @mock.patch(plot_model_path + ".logger.error")
+    @mock.patch(plot_model_path + ".ADS")
+    def test_run_find_peaks_convolve_non_existing_ws(self, mock_ads, mock_error):
+        mock_ads.doesExist.return_value = False
+        ret_str = self.model.run_find_peaks_convolve("non_existing_ws", "BackToBackExponential")
+        self.assertEqual(ret_str, None)
+        mock_error.assert_called()
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_model.py
@@ -465,17 +465,23 @@ class FittingPlotModelTest(unittest.TestCase):
         peak_centers = CreateEmptyTableWorkspace(OutputWorkspace="PeakCentre")
         peak_centers.addColumn("int", "SpecIndex")
         peak_centers.addColumn("double", "PeakCentre_0")
-        peak_centers.addRow([1, 0.09])
+        peak_centers.addColumn("double", "PeakCentre_1")
+        peak_centers.addColumn("double", "PeakCentre_2")
+        peak_centers.addRow([1, 0.09, 0.15, 0.30])
 
         peak_y = CreateEmptyTableWorkspace(OutputWorkspace="PeakYPosition")
         peak_y.addColumn("int", "SpecIndex")
         peak_y.addColumn("double", "PeakYPosition_0")
-        peak_y.addRow([1, 798])
+        peak_y.addColumn("double", "PeakYPosition_1")
+        peak_y.addColumn("double", "PeakYPosition_2")
+        peak_y.addRow([1, 798, 800, 984])
 
         i_over_sigma = CreateEmptyTableWorkspace(OutputWorkspace="PeakIOverSigma")
         i_over_sigma.addColumn("int", "SpecIndex")
         i_over_sigma.addColumn("double", "PeakIOverSigma_0")
-        i_over_sigma.addRow([1, 12.5])
+        i_over_sigma.addColumn("double", "PeakIOverSigma_1")
+        i_over_sigma.addColumn("double", "PeakIOverSigma_2")
+        i_over_sigma.addRow([1, 12.5, 13.2, 15.2])
         return GroupWorkspaces([peak_centers, peak_y, i_over_sigma], OutputWorkspace="test")
 
     @mock.patch(plot_model_path + ".FunctionWrapper")
@@ -483,25 +489,46 @@ class FittingPlotModelTest(unittest.TestCase):
     @mock.patch(plot_model_path + ".FindPeaksConvolve")
     @mock.patch(plot_model_path + ".logger.error")
     @mock.patch(plot_model_path + ".ADS")
-    def test_run_find_peaks_convolve_existing_ws(self, mock_ads, mock_error, mock_find_peaks_convolve, mock_func_fac, mock_func_wrapper):
+    def test_run_find_peaks_convolve_existing_ws_1(self, mock_ads, mock_error, mock_find_peaks_convolve, mock_func_fac, mock_func_wrapper):
         mock_ads.doesExist.return_value = True
-        mock_ads.retrieve.return_value = mock.MagicMock()
+        mock_ws = mock.MagicMock()
+        mock_ads.retrieve.return_value = mock_ws
         mock_find_peaks_convolve.return_value = self._get_sample_findpeaksconvolve_group_ws()
         mock_peak_func = mock.MagicMock()
         mock_func_fac.Instance().createPeakFunction.return_value = mock_peak_func
 
-        ret_str = self.model.run_find_peaks_convolve("ws_1", "BackToBackExponential")
+        ret_str = self.model.run_find_peaks_convolve("ws_1", "BackToBackExponential", (0.08, 0.10))
         self.assertNotEqual(ret_str, None)
-        mock_peak_func.setCentre.assert_called_once()
-        mock_peak_func.setHeight.assert_called_once()
-        mock_peak_func.setMatrixWorkspace.assert_called_once()
+        mock_peak_func.setCentre.assert_called_once_with(0.09)
+        mock_peak_func.setHeight.assert_called_once_with(798)
+        mock_peak_func.setMatrixWorkspace.assert_called_once_with(mock_ws, 0, 0, 0)
+        mock_error.assert_not_called()
+
+    @mock.patch(plot_model_path + ".FunctionWrapper")
+    @mock.patch(plot_model_path + ".FunctionFactory")
+    @mock.patch(plot_model_path + ".FindPeaksConvolve")
+    @mock.patch(plot_model_path + ".logger.error")
+    @mock.patch(plot_model_path + ".ADS")
+    def test_run_find_peaks_convolve_existing_ws_2(self, mock_ads, mock_error, mock_find_peaks_convolve, mock_func_fac, mock_func_wrapper):
+        mock_ads.doesExist.return_value = True
+        mock_ws = mock.MagicMock()
+        mock_ads.retrieve.return_value = mock_ws
+        mock_find_peaks_convolve.return_value = self._get_sample_findpeaksconvolve_group_ws()
+        mock_peak_func = mock.MagicMock()
+        mock_func_fac.Instance().createPeakFunction.return_value = mock_peak_func
+
+        ret_str = self.model.run_find_peaks_convolve("ws_1", "BackToBackExponential", (0.15, 0.30))
+        self.assertNotEqual(ret_str, None)
+        mock_peak_func.setCentre.assert_has_calls([call(0.15), call(0.30)])
+        mock_peak_func.setHeight.assert_has_calls([call(800), call(984)])
+        mock_peak_func.setMatrixWorkspace.assert_has_calls([call(mock_ws, 0, 0, 0), call(mock_ws, 0, 0, 0)])
         mock_error.assert_not_called()
 
     @mock.patch(plot_model_path + ".logger.error")
     @mock.patch(plot_model_path + ".ADS")
     def test_run_find_peaks_convolve_non_existing_ws(self, mock_ads, mock_error):
         mock_ads.doesExist.return_value = False
-        ret_str = self.model.run_find_peaks_convolve("non_existing_ws", "BackToBackExponential")
+        ret_str = self.model.run_find_peaks_convolve("non_existing_ws", "BackToBackExponential", (10, 20))
         self.assertEqual(ret_str, None)
         mock_error.assert_called()
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
@@ -278,6 +278,8 @@ class FittingPlotPresenterTest(unittest.TestCase):
     def test_run_find_peaks_convolve_success(self, mock_error):
         self.view = mock.MagicMock()
         self.view.fit_browser.workspaceName.return_value = "ws_1"
+        self.view.fit_browser.startX.return_value = 1000
+        self.view.fit_browser.endX.return_value = 2000
         self.presenter.view = self.view
         self.presenter.find_peaks_convolve_started_notifier = mock.MagicMock()
         self.presenter.find_peaks_convolve_done_notifier = mock.MagicMock()
@@ -287,6 +289,7 @@ class FittingPlotPresenterTest(unittest.TestCase):
 
         self.presenter.run_find_peaks_convolve()
 
+        self.model.run_find_peaks_convolve.assert_called_once_with("ws_1", "BackToBackExponential", (1000, 2000))
         self.assertEqual(self.presenter.is_waiting_convolve_peaks, True)
         self.presenter.find_peaks_convolve_started_notifier.notify_subscribers.assert_called_once()
         self.view.fit_browser.loadFunction.assert_called_once_with(fun_wrap_str)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
@@ -34,6 +34,12 @@ class FittingPresenter(object):
         self.fit_complete_observer = GenericObserverWithArgPassing(self.fit_done)
         self.plot_widget.view.fit_browser.fit_notifier.add_subscriber(self.fit_complete_observer)
 
+        self.find_peaks_convolve_started_observer = GenericObserver(self.find_peaks_convolve_started)
+        self.plot_widget.find_peaks_convolve_started_notifier.add_subscriber(self.find_peaks_convolve_started_observer)
+
+        self.find_peaks_convolve_completed_observer = GenericObserverWithArgPassing(self.find_peaks_convolve_completed)
+        self.plot_widget.find_peaks_convolve_done_notifier.add_subscriber(self.find_peaks_convolve_completed_observer)
+
         self.connect_view_signals()
 
     def fit_all_started(self, do_sequential):
@@ -76,6 +82,17 @@ class FittingPresenter(object):
             )
         else:
             self.plot_widget.set_final_state_progress_bar(None, status="Failed, invalid fit.")
+
+    def find_peaks_convolve_started(self):
+        self.plot_widget.set_progress_bar_zero()
+        self.disable_view()
+
+    def find_peaks_convolve_completed(self, is_success):
+        if is_success:
+            self.plot_widget.set_progress_bar_success(status="success")
+            self.enable_view()
+        else:
+            self.plot_widget.set_progress_bar_failed(status="failed")
 
     def disable_view(self, _=None, fit_all=False):
         self.data_widget.view.setEnabled(False)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
@@ -84,15 +84,15 @@ class FittingPresenter(object):
             self.plot_widget.set_final_state_progress_bar(None, status="Failed, invalid fit.")
 
     def find_peaks_convolve_started(self):
-        self.plot_widget.set_progress_bar_zero()
+        self.plot_widget.set_progress_bar_to_in_progress()
         self.disable_view()
 
     def find_peaks_convolve_completed(self, is_success):
         if is_success:
             self.plot_widget.set_progress_bar_success(status="success")
-            self.enable_view()
         else:
             self.plot_widget.set_progress_bar_failed(status="failed")
+        self.enable_view()
 
     def disable_view(self, _=None, fit_all=False):
         self.data_widget.view.setEnabled(False)


### PR DESCRIPTION
### Description of work
Currently the find peaks algorithm can be selected through the fit browser menu Setup > Peak Finding Algorithms > FindPeaksConvovle - which will open up the algorithm GUI. A new button was added to the Eng diff fitting tab to call FindPeaksConvovle algorithm with good default values(EstimatedPeakExtent=200 and IOverSigmaThreshold=4) for Engin-X.


Fixes #36593. 


### To test:
1. Follow the testing instructions for the fitting tab of Engineering Diffraction GUI. https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html#id8
2. Click on  `Load ` button to load some data having `Add to Plot` being clicked
4. In the Plot window below, `FindPeaksConvolve` should be available with greyed out.

![image](https://github.com/mantidproject/mantid/assets/142818102/cf8f8da3-5ba4-4a88-9748-67af802eeb28)

6. Click `Fit` button to open the fit property browser and this should enable `FindPeaksConvolve` button
7. The fit property browser should have no peaks added and look similar to this

![image](https://github.com/mantidproject/mantid/assets/142818102/7bdf4356-777f-4482-bf57-d8e56fbe727a)

8. Click on `FindPeaksConvolve` to run the algorithm on the selected `Workspace` from the fit property browser with the default values as mentioned above.
10. The progress bar below the fit property browser should be updated and marked as complete at the end by adding several peak functions to the fit property browser.
![image](https://github.com/mantidproject/mantid/assets/142818102/a955f0c1-5c45-4a2f-a737-3e0200c75eae)

12. Change the `Workspace` in the property browser and click on `FindPeaksConvolve` to run the algorithm on another workspace.
13. By right-clicking on the plot window change the selected peak type to some other function type.
14. Click on the `FindPeaksConvolve` button again to replace the old peak functions with newly selected peak functions.
15. Repeat steps 10 and 11 as many times to replace the existing peak types with new types.
16. Fit->fit should initiate the fit on the added peak functions (which has been there before)
17. Click on `Fit` button on the toolbar to hide the fit property browser which should disable the `FindPeaksConvolve` button.
18. Enable `Fit` button again to show the fit property browser with the last added peaks.
19. When enabled, unticking all the `Plot` ticks in the Run selection table should also disable the `FindPeaksConvolve` button.
20. Click on `Clear` in the workspace tree should also disable the `FindPeaksConvolve` button.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
