### PR TITLE
Adding monochromatic Lorentz correction for single crystal diffraction MDEs

### DIFF
--- a/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
+++ b/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
@@ -135,6 +135,10 @@ void ConvertHFIRSCDtoMDE::init() {
       std::make_unique<PropertyWithValue<double>>(
           "Wavelength", DBL_MAX, std::make_shared<BoundedValidator<double>>(0.0, 100.0, true), Direction::Input),
       "Wavelength");
+  declareProperty(std::make_unique<PropertyWithValue<bool>>("LorentzCorrection", false, Direction::Input),
+                  "Correct the weights of events or signals and errors transformed into "
+                  "reciprocal space by multiplying them "
+                  "by the Lorentz multiplier:\n :math:`sin(2\\theta)cos(\\phi)/\\lambda^3`");
   declareProperty(std::make_unique<ArrayProperty<double>>("MinValues", "-10,-10,-10"),
                   "It has to be 3 comma separated values, one for each dimension in "
                   "q_sample."
@@ -157,6 +161,7 @@ void ConvertHFIRSCDtoMDE::init() {
  */
 void ConvertHFIRSCDtoMDE::exec() {
   double wavelength = this->getProperty("Wavelength");
+  bool lorentz = getProperty("LorentzCorrection");
 
   API::IMDHistoWorkspace_sptr inputWS = this->getProperty("InputWorkspace");
   auto &expInfo = *(inputWS->getExperimentInfo(static_cast<uint16_t>(0)));
@@ -205,19 +210,24 @@ void ConvertHFIRSCDtoMDE::exec() {
   float coeff = static_cast<float>(cop);
 
   float k = boost::math::float_constants::two_pi / static_cast<float>(wavelength);
+  float inv_wl_cube = static_cast<float>(1 / (wavelength * wavelength * wavelength));
   // check convention to determine the sign of k
   std::string convention = Kernel::ConfigService::Instance().getString("Q.convention");
   if (convention == "Crystallography") {
     k *= -1.f;
   }
   std::vector<Eigen::Vector3f> q_lab_pre;
+  std::vector<float> lorentz_pre;
   q_lab_pre.reserve(azimuthal.size());
+  lorentz_pre.reserve(azimuthal.size());
   for (size_t m = 0; m < azimuthal.size(); ++m) {
     auto twotheta_f = static_cast<float>(twotheta[m]);
     auto azimuthal_f = static_cast<float>(azimuthal[m]);
     q_lab_pre.push_back({-std::sin(twotheta_f) * std::cos(azimuthal_f) * k,
                          -std::sin(twotheta_f) * std::sin(azimuthal_f) * k * coeff, (1.f - std::cos(twotheta_f)) * k});
+    lorentz_pre.push_back(std::abs(std::sin(twotheta_f) * std::cos(azimuthal_f)) * inv_wl_cube);
   }
+  float factor = 1;
   const auto run = inputWS->getExperimentInfo(0)->run();
   for (size_t n = 0; n < inputWS->getDimension(2)->getNBins(); n++) {
     auto gon = run.getGoniometerMatrix(n);
@@ -232,7 +242,10 @@ void ConvertHFIRSCDtoMDE::exec() {
       coord_t signal = static_cast<coord_t>(inputWS->getSignalAt(idx));
       if (signal > 0.f && std::isfinite(signal)) {
         Eigen::Vector3f q_sample = goniometer * q_lab_pre[m];
-        inserter.insertMDEvent(signal, signal, 0, goniometerIndex, 0, q_sample.data());
+        if (lorentz) {
+          factor = lorentz_pre[m];
+        }
+        inserter.insertMDEvent(signal * factor, signal * factor, 0, goniometerIndex, 0, q_sample.data());
       }
     }
   }

--- a/Testing/SystemTests/tests/framework/ConvertHFIRSCDtoMDETest.py
+++ b/Testing/SystemTests/tests/framework/ConvertHFIRSCDtoMDETest.py
@@ -78,6 +78,16 @@ class ConvertHFIRSCDtoMDETest(systemtesting.MantidSystemTest):
         g = peak0.getGoniometerMatrix()
         self.assertDelta(np.rad2deg(np.arccos(g[0][0])), 77.5, 1e-2)
 
+        ConvertHFIRSCDtoMDETest_Qlorentz = ConvertHFIRSCDtoMDE(
+            InputWorkspace="ConvertHFIRSCDtoMDETest_data", LorentzCorrection=True, Wavelength=1.488
+        )
+
+        ConvertHFIRSCDtoMDETest_peaks = FindPeaksMD(
+            InputWorkspace=ConvertHFIRSCDtoMDETest_Qlorentz, PeakDistanceThreshold=2.2, CalculateGoniometerForCW=True, Wavelength=1.488
+        )
+
+        self.assertEqual(ConvertHFIRSCDtoMDETest_peaks.getNumberPeaks(), 14)
+
 
 class ConvertHFIRSCDtoMDE_HB3A_Test(systemtesting.MantidSystemTest):
     def skipTests(self):
@@ -123,6 +133,22 @@ class ConvertHFIRSCDtoMDE_HB3A_Test(systemtesting.MantidSystemTest):
 
         self.assertEqual(ConvertHFIRSCDtoMDETest_peaks2.getNumberPeaks(), 1)
         np.testing.assert_allclose(ConvertHFIRSCDtoMDETest_peaks2.getPeak(0).getQSampleFrame(), [-0.417683, 1.792265, 2.238072], rtol=1e-3)
+
+        ConvertHFIRSCDtoMDETest_Qlorentz = ConvertHFIRSCDtoMDE(
+            InputWorkspace="ConvertHFIRSCDtoMDE_HB3ATest_data", LorentzCorrection=True, Wavelength=1.008
+        )
+
+        ConvertHFIRSCDtoMDETest_peaks = FindPeaksMD(
+            InputWorkspace=ConvertHFIRSCDtoMDETest_Qlorentz,
+            PeakDistanceThreshold=0.25,
+            DensityThresholdFactor=20000,
+            CalculateGoniometerForCW=True,
+            Wavelength=1.008,
+            FlipX=True,
+            InnerGoniometer=False,
+        )
+
+        self.assertEqual(ConvertHFIRSCDtoMDETest_peaks.getNumberPeaks(), 1)
 
     def validate(self):
         results = "ConvertHFIRSCDtoMDETest_Q"

--- a/docs/source/algorithms/ConvertHFIRSCDtoMDE-v1.rst
+++ b/docs/source/algorithms/ConvertHFIRSCDtoMDE-v1.rst
@@ -21,6 +21,8 @@ convert to HKL using :ref:`algm-ConvertWANDSCDtoQ`
 . :ref:`algm-IntegratePeaksMD` will also work on the output of this
 algorithm.
 
+There is an option to apply the LorentzCorrection using the formula :math:`|\sin(2\theta)\cos(\phi)|/\lambda^3`. This helps lower the sloping background at low :math:`Q`.
+
 Usage
 -----
 

--- a/docs/source/release/v6.10.0/Diffraction/Single_Crystal/New_features/37027.rst
+++ b/docs/source/release/v6.10.0/Diffraction/Single_Crystal/New_features/37027.rst
@@ -1,0 +1,1 @@
+- New option to apply ``LorentzCorrection`` to ``ConvertHFIRSCDtoMDE`` for monochromatic single crystal diffraction with rotation about the vertical axis.


### PR DESCRIPTION
### Description of work

`ConvertHFIRSCDtoMDE` currently does not have a Lorentz correction like `ConvertToMD`. This PR adds this functionality.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

The Lorentz correction for two-axis scans about the vertical axis is :math:`|sin(2\theta)\cos(phi)|/\lambda^3`.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

This is a useful feature for lowering the low-Q sloping background needed for find peaks.

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

HB2C test
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

IPTS = 7776
runs = range(26640, 27944)

wavelength = 1.488
Q_max = 4*np.pi/wavelength

filename = '/HFIR/HB2C/IPTS-{}/nexus/HB2C_{}.nxs.h5'
filenames = ','.join([filename.format(IPTS, run) for run in runs])

LoadWANDSCD(Filename=filenames,
            Grouping='4x4',
            OutputWorkspace='data')

SetGoniometer(Workspace='data',
              Axis0='s1,0,1,0,1',
              Average=False)

two_theta = mtd['data'].getExperimentInfo(0).run().getProperty('TwoTheta').value
Q_max = 4*np.pi/wavelength*np.sin(0.5*max(two_theta))

ConvertHFIRSCDtoMDE(InputWorkspace='data', 
                  LorentzCorrection=True,
                  Wavelength=wavelength,
                  MinValues=[-Q_max,-Q_max,-Q_max],
                  MaxValues=[+Q_max,+Q_max,+Q_max],
                  OutputWorkspace='md_lorentz')

ConvertHFIRSCDtoMDE(InputWorkspace='data', 
                  LorentzCorrection=False,
                  Wavelength=wavelength,
                  MinValues=[-Q_max,-Q_max,-Q_max],
                  MaxValues=[+Q_max,+Q_max,+Q_max],
                  OutputWorkspace='md')
```
![image](https://github.com/mantidproject/mantid/assets/13754794/ba66c3c0-16c0-4662-a36c-e16ecc312910)


HB3A test
```python

# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

IPTS = 9884
exp = 817
scan = 2

wavelength = 1.003

filename = '/HFIR/HB3A/IPTS-{}/shared/autoreduce/HB3A_exp{:04}_scan{:04}.nxs'.format(IPTS, exp, scan)

HB3AAdjustSampleNorm(Filename=filename,
                     OutputType='Detector',
                     NormaliseBy='None',
                     OutputWorkspace='data')

SetGoniometer(Workspace='data',
              Axis0='omega,0,1,0,-1',
              Axis1='chi,0,0,1,-1',
              Axis2='phi,0,1,0,-1',
              Average=False)

ei = mtd['data'].getExperimentInfo(0)
si = ei.spectrumInfo()

two_theta = [si.twoTheta(i) for i in range(ei.getInstrument().getNumberDetectors())]
Q_max = 4*np.pi/wavelength*np.sin(0.5*max(two_theta))

ConvertHFIRSCDtoMDE(InputWorkspace='data', 
                  LorentzCorrection=False,
                  Wavelength=wavelength,
                  MinValues=[-Q_max,-Q_max,-Q_max],
                  MaxValues=[+Q_max,+Q_max,+Q_max],
                  OutputWorkspace='md')

ConvertHFIRSCDtoMDE(InputWorkspace='data', 
                  LorentzCorrection=True,
                  Wavelength=wavelength,
                  MinValues=[-Q_max,-Q_max,-Q_max],
                  MaxValues=[+Q_max,+Q_max,+Q_max],
                  OutputWorkspace='md_lorentz')

```

![image](https://github.com/mantidproject/mantid/assets/13754794/12e5b0c0-e578-4c86-bb62-6b0d8257895d)


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
