### PR TITLE
Add a new option for output name of the total scattering pdf 

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -447,6 +447,21 @@ class TotalScatteringPdfTypeTest(systemtesting.MantidSystemTest):
         # to be updated very frequently. In the meantime, the expected peak in the PDF at ~3.9 Angstrom will be checked.
         idx = get_bin_number_at_given_r(self.pdf_output.dataX(0), 3.9)
         self.assertAlmostEqual(self.pdf_output.dataY(0)[idx], 2.8955, places=3)
+        self.assertEqual(self.pdf_output.name(), "98533_pdf_g(r)")
+
+
+class TotalScatteringPdfNameTest(systemtesting.MantidSystemTest):
+    pdf_output = None
+
+    def runTest(self):
+        setup_mantid_paths()
+        # Load Focused ws
+        mantid.LoadNexus(Filename=total_scattering_input_file, OutputWorkspace="98533-ResultTOF")
+        q_lims = np.array([2.5, 3, 4, 6, 7, 3.5, 5, 7, 11, 40]).reshape((2, 5))
+        self.pdf_output = run_total_scattering("98533", True, q_lims=q_lims, pdf_type="g(r)", pdf_output_name="test_pdf_output")
+
+    def validate(self):
+        self.assertEqual(self.pdf_output.name(), "test_pdf_output")
 
 
 class TotalScatteringFourierFilterTest(systemtesting.MantidSystemTest):
@@ -499,6 +514,7 @@ def run_total_scattering(
     freq_params=None,
     lorch_filter=True,
     per_detector=False,
+    pdf_output_name=None,
 ):
     pdf_inst_obj = setup_inst_object(mode="PDF")
     return pdf_inst_obj.create_total_scattering_pdf(
@@ -511,6 +527,7 @@ def run_total_scattering(
         lorch_filter=lorch_filter,
         freq_params=freq_params,
         per_detector_vanadium=per_detector,
+        pdf_output_name=pdf_output_name,
     )
 
 

--- a/docs/source/release/v6.10.0/Diffraction/Powder/New_features/37042.rst
+++ b/docs/source/release/v6.10.0/Diffraction/Powder/New_features/37042.rst
@@ -1,0 +1,2 @@
+- The default format of the total scattering pdf name created by ``create_total_scattering_pdf`` in polaris script has been changed to include the pdf type as a suffix
+- Add a new parameter ``pdf_output_name`` to ``create_total_scattering_pdf`` in polaris script, which modifies the output name of the total scattering pdf

--- a/docs/source/techniques/ISISPowder-Polaris-v1.rst
+++ b/docs/source/techniques/ISISPowder-Polaris-v1.rst
@@ -223,6 +223,7 @@ The output PDF can be customized with the following parameters:
 - By calling with `debug=True` which will retain the intermediate self scattering correction workspace.
 - By calling with `placzek_order` the Placzek correction order can be specified, with the option of 1 or 2 (defaults to 1).
 - By calling with `sample_temp` the user can override the sample temperature provided in the logs. It defaults to using values from the logs if available.
+- By calling with pdf_output_name, the name of the output PDF will be set to the user-provided name. If not specified, the output will be the run number suffixed with the PDF type.
 
 Example
 =======

--- a/docs/source/techniques/ISISPowder-Polaris-v1.rst
+++ b/docs/source/techniques/ISISPowder-Polaris-v1.rst
@@ -223,7 +223,7 @@ The output PDF can be customized with the following parameters:
 - By calling with `debug=True` which will retain the intermediate self scattering correction workspace.
 - By calling with `placzek_order` the Placzek correction order can be specified, with the option of 1 or 2 (defaults to 1).
 - By calling with `sample_temp` the user can override the sample temperature provided in the logs. It defaults to using values from the logs if available.
-- By calling with pdf_output_name, the name of the output PDF will be set to the user-provided name. If not specified, the output will be the run number suffixed with the PDF type.
+- By calling with `pdf_output_name`, the name of the output PDF will be set to the user-provided name. If not specified, the output will be the run number suffixed with the PDF type.
 
 Example
 =======

--- a/scripts/Diffraction/isis_powder/polaris.py
+++ b/scripts/Diffraction/isis_powder/polaris.py
@@ -108,6 +108,7 @@ class Polaris(AbstractInst):
             freq_params=self._inst_settings.freq_params,
             per_detector=self._inst_settings.per_detector_vanadium,
             debug=self._inst_settings.debug,
+            pdf_output_name=self._inst_settings.pdf_output_name,
         )
         return pdf_output
 

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -85,6 +85,7 @@ def generate_ts_pdf(
     freq_params=None,
     per_detector=False,
     debug=False,
+    pdf_output_name=None,
 ):
     if sample_details is None:
         raise RuntimeError(
@@ -142,18 +143,20 @@ def generate_ts_pdf(
     # Rename output ws
     if "merged_ws" in locals():
         mantid.RenameWorkspace(InputWorkspace="merged_ws", OutputWorkspace=run_number + "_merged_Q")
+
     mantid.RenameWorkspace(InputWorkspace="focused_ws", OutputWorkspace=run_number + "_focused_Q")
-    target_focus_ws_name = run_number + "_focused_Q_"
-    target_pdf_ws_name = run_number + "_pdf_R_"
     if isinstance(focused_ws, WorkspaceGroup):
+        target_focus_ws_name = run_number + "_focused_Q_"
         for i in range(len(focused_ws)):
             if str(focused_ws[i]) != (target_focus_ws_name + str(i + 1)):
                 mantid.RenameWorkspace(InputWorkspace=focused_ws[i], OutputWorkspace=target_focus_ws_name + str(i + 1))
-    mantid.RenameWorkspace(InputWorkspace="pdf_output", OutputWorkspace=run_number + "_pdf_R")
+
+    target_pdf_ws_name = f"{run_number}_pdf_{pdf_type}" if not pdf_output_name else pdf_output_name
+    mantid.RenameWorkspace(InputWorkspace="pdf_output", OutputWorkspace=target_pdf_ws_name)
     if isinstance(pdf_output, WorkspaceGroup):
         for i in range(len(pdf_output)):
             if str(pdf_output[i]) != (target_pdf_ws_name + str(i + 1)):
-                mantid.RenameWorkspace(InputWorkspace=pdf_output[i], OutputWorkspace=target_pdf_ws_name + str(i + 1))
+                mantid.RenameWorkspace(InputWorkspace=pdf_output[i], OutputWorkspace=f"{target_pdf_ws_name}_{str(i + 1)}")
     return pdf_output
 
 

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
@@ -61,5 +61,6 @@ attr_mapping = [
     ParamMapEntry(ext_name="vanadium_peaks_masking_file", int_name="masking_file_name"),
     ParamMapEntry(ext_name="keep_raw_workspace", int_name="keep_raw_workspace", optional=True),
     ParamMapEntry(ext_name="mayers_mult_scat_events", int_name="mayers_mult_scat_events", optional=True),
+    ParamMapEntry(ext_name="pdf_output_name", int_name="pdf_output_name", optional=True),
 ]
 attr_mapping.extend(COMMON_PARAM_MAPPING)


### PR DESCRIPTION

### Description of work
This pull request introduces a new parameter, "pdf_output_name," to the "create_total_scattering_pdf" function. With this new parameter, users can customise the output file name for the total scattering PDF. Additionally, the default file name for the PDF has been updated to include the PDF type as a suffix.

Fixes #34750. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
1- Run the following script:

```python
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from isis_powder import polaris, SampleDetails

config_file_path = r"C:\Users\xhg73778\Downloads\POLARISPowderDiffractionFolderSmall\polaris_config_example.yaml"
polaris = polaris.Polaris(config_file=config_file_path, user_name="test", mode="PDF")

sample_details = SampleDetails(height=4.0, radius=0.2985, center=[0, 0, 0], shape='cylinder')
sample_details.set_material(chemical_formula='Si', packing_fraction=0.6)
polaris.set_sample_details(sample=sample_details)

polaris.create_vanadium(first_cycle_run_no="125706", multiple_scattering=True, 
                         do_absorb_corrections=True, mayers_mult_scat_events=1)                  

polaris.focus(run_number="125754", input_mode='Summed', do_absorb_corrections=False,
              do_van_normalisation=False, van_normalisation_method="Relative",
              keep_raw_workspace=False)  # input_mode='individual', input_mode='Summed'

q_lim = [[2.5, 3, 4, 6, 7], [3.5, 5, 7, 11, 40]]
polaris.create_total_scattering_pdf(run_number='125754', merge_banks=True, q_lims=q_lim, pdf_type='g(r)')

```
2- Check the output name of the pdf in the workspaces window and it should be '125754_pdf_g(r)'
3- Run the same above script and the parameter `pdf_output_name='test_output'` to `create_total_scattering_pdf`
4- Check the output name of the pdf in the workspaces window and it should be 'test_output'
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
