### PR TITLE
Improve workflow in Elwin tab of Data Manipulation Interface

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1553,5 +1553,5 @@ constParameterReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/C
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FitDataView.h:42
 internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/SliceMD.cpp:0
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp:23
-passedByValue:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp:98
+passedByValue:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp:102
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModelUtils.h:51

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1553,5 +1553,4 @@ constParameterReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/C
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FitDataView.h:42
 internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/SliceMD.cpp:0
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Analysis/FqFitDataPresenter.cpp:23
-passedByValue:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp:102
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModelUtils.h:51

--- a/dev-docs/source/Testing/Inelastic/DataManipulationTests.rst
+++ b/dev-docs/source/Testing/Inelastic/DataManipulationTests.rst
@@ -24,10 +24,10 @@ Elwin tab
 #. Go to ``Interfaces`` > ``Inelastic`` > ``Data Manipulation``
 #. Go to the ``Elwin`` tab
 #. Click on ``Add Workspaces``, a dialog window should prompt.
-#. Enter ``MAR27691_red.nxs`` in ``Input file``, table of the dialog should be populated with ``MAR2791_red`` workspace
-#. Select the workspace from the table and click on ``Add Data``, close dialog
+#. Enter ``MAR27691_red.nxs`` in ``Input file``. The table of the dialog should be populated with the ``MAR2791_red`` workspace.
+#. Select the workspace from the table and click on ``Add Data``. Close the dialog.
 #. Back on ``Elwin`` tab, click ``Run`` - this should produce 3 new workspaces ``_elf``, ``_eq`` and ``_eq2``
-#. Open again ``Add Workspaces`` dialog and in ``Input file`` choose ``browse``, navigate to the ISIS-Sample data and select the two files, ``MAR27691_red.nxs`` and ``MAR27698_red.nxs``, by using shift key
+#. Open the ``Add Workspaces`` dialog again, and in ``Input file`` choose ``browse``. Navigate to the ISIS-Sample data and select the two files, ``MAR27691_red.nxs`` and ``MAR27698_red.nxs`` using shift key.
 #. Add the loaded workspaces
 #. Click ``Run``
 #. This should result in three new workspaces again, this time with file ranges as their name
@@ -41,10 +41,10 @@ Elwin tab
 
 #. Go to ``Interfaces`` > ``Inelastic`` > ``Data Manipulation``
 #. Click on ``Add Workspaces``, a dialog window should prompt
-#. Enter ``irs26176_graphite002_red.nxs`` in ``Input file``, table of the dialog should be populated with ``irs26176_graphite002_red`` workspace
-#. Select the workspace from the table and click on ``Add Data``, close dialog
+#. Enter ``irs26176_graphite002_red.nxs`` in ``Input file``. The table of the dialog should be populated with the ``irs26176_graphite002_red`` workspace.
+#. Select the workspace from the table and click on ``Add Data``. Close the dialog.
 #. Back on ``Elwin`` tab, click ``Run`` - this should produce 3 new workspaces ``_elf``, ``_eq`` and ``_eq2``
-#. Open again ``Add Workspaces`` dialog and in ``Input file`` choose browse, navigate to the ISIS-Sample data and select the two files, ``irs26174_graphite002_red.nxs`` and ``irs26176_graphite002_red.nxs``, by using shift key
+#. Open the ``Add Workspaces`` dialog again, and in ``Input file`` choose ``browse``. Navigate to the ISIS-Sample data and select the two files, ``irs26174_graphite002_red.nxs`` and ``irs26176_graphite002_red.nxs`` using shift key.
 #. Add the loaded workspaces
 #. Change the integration range from -0.2 to 0.2
 #. Click ``Run``

--- a/dev-docs/source/Testing/Inelastic/DataManipulationTests.rst
+++ b/dev-docs/source/Testing/Inelastic/DataManipulationTests.rst
@@ -23,9 +23,12 @@ Elwin tab
 
 #. Go to ``Interfaces`` > ``Inelastic`` > ``Data Manipulation``
 #. Go to the ``Elwin`` tab
-#. Enter ``MAR27691_red.nxs`` in ``Input file``
-#. Click ``Run`` - this should produce 3 new workspaces ``_elf``, ``_eq`` and ``_eq2``
-#. Now in ``Input file`` choose browse, navigate to the ISIS-Sample data and select the two files, ``MAR27691_red.nxs`` and ``MAR27698_red.nxs``, by using shift key
+#. Click on ``Add Workspaces``, a dialog window should prompt.
+#. Enter ``MAR27691_red.nxs`` in ``Input file``, table of the dialog should be populated with ``MAR2791_red`` workspace
+#. Select the workspace from the table and click on ``Add Data``, close dialog
+#. Back on ``Elwin`` tab, click ``Run`` - this should produce 3 new workspaces ``_elf``, ``_eq`` and ``_eq2``
+#. Open again ``Add Workspaces`` dialog and in ``Input file`` choose ``browse``, navigate to the ISIS-Sample data and select the two files, ``MAR27691_red.nxs`` and ``MAR27698_red.nxs``, by using shift key
+#. Add the loaded workspaces
 #. Click ``Run``
 #. This should result in three new workspaces again, this time with file ranges as their name
 #. In the main GUI right-click on ``MAR27691-27698_graphite002_red_elwin_eq2`` and choose ``Plot Spectrum``, choose ``Plot All``
@@ -37,10 +40,12 @@ Elwin tab
 ################
 
 #. Go to ``Interfaces`` > ``Inelastic`` > ``Data Manipulation``
-#. Go to the ``Elwin`` tab
-#. Enter ``irs26176_graphite002_red.nxs`` in ``Input file``
-#. Click ``Run`` - this should produce 3 new workspaces ``_elf``, ``_eq`` and ``_eq2``
-#. Now in ``Input file`` choose browse, navigate to the ISIS-Sample data and select ``irs26176_graphite002_red.nxs`` and ``irs26174_graphite002_red.nxs`` simultaneously, by using shift key
+#. Click on ``Add Workspaces``, a dialog window should prompt
+#. Enter ``irs26176_graphite002_red.nxs`` in ``Input file``, table of the dialog should be populated with ``irs26176_graphite002_red`` workspace
+#. Select the workspace from the table and click on ``Add Data``, close dialog
+#. Back on ``Elwin`` tab, click ``Run`` - this should produce 3 new workspaces ``_elf``, ``_eq`` and ``_eq2``
+#. Open again ``Add Workspaces`` dialog and in ``Input file`` choose browse, navigate to the ISIS-Sample data and select the two files, ``irs26174_graphite002_red.nxs`` and ``irs26176_graphite002_red.nxs``, by using shift key
+#. Add the loaded workspaces
 #. Change the integration range from -0.2 to 0.2
 #. Click ``Run``
 #. This should result in three new workspaces again, this time with file ranges as their name

--- a/docs/source/release/v6.10.0/Inelastic/New_features/36160.rst
+++ b/docs/source/release/v6.10.0/Inelastic/New_features/36160.rst
@@ -1,0 +1,1 @@
+- The files tab of the :ref:`Elwin Tab <elwin>` of  :ref:`Data Manipulation Interface <interface-inelastic-data-manipulation>` has been removed. Workspaces can still be added from files in the multifile dialog of the workspaces tab.

--- a/docs/source/release/v6.10.0/Inelastic/New_features/36372.rst
+++ b/docs/source/release/v6.10.0/Inelastic/New_features/36372.rst
@@ -1,0 +1,1 @@
+- On :ref:`Elwin Tab <elwin>` of  :ref:`Data Manipulation Interface <interface-inelastic-data-manipulation>`, it is now possible to display in the workspace table either one row per spectra, or just one row per workspace.

--- a/docs/source/release/v6.10.0/Inelastic/New_features/36460.rst
+++ b/docs/source/release/v6.10.0/Inelastic/New_features/36460.rst
@@ -1,0 +1,1 @@
+- The files tab of the :ref:`Elwin Tab <elwin>` of  :ref:`Data Manipulation Interface <interface-inelastic-data-manipulation>` has been removed. Workspaces can still be added from files in the multifile dialog of the workspaces tab.

--- a/qt/scientific_interfaces/Inelastic/Common/WorkspaceUtils.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/WorkspaceUtils.cpp
@@ -188,6 +188,10 @@ bool doesExistInADS(std::string const &workspaceName) {
   return AnalysisDataService::Instance().doesExist(workspaceName);
 }
 
+std::vector<std::string> attachPrefix(std::vector<std::string> const &strings, std::string const &prefix) {
+  return transformElements(strings.begin(), strings.end(), [&prefix](std::string const &str) { return prefix + str; });
+}
+
 } // namespace WorkspaceUtils
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Common/WorkspaceUtils.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/WorkspaceUtils.cpp
@@ -13,6 +13,7 @@
 #include "MantidAPI/TextAxis.h"
 #include "MantidGeometry/Instrument.h"
 #include <boost/algorithm/string.hpp>
+#include <regex>
 
 using namespace Mantid::API;
 
@@ -26,6 +27,7 @@ QPair<double, double> roundRangeToPrecision(double rangeStart, double rangeEnd, 
                                roundToPrecision(rangeEnd, precision) - precision);
 }
 
+auto const regDigits = std::regex("\\d+");
 } // namespace
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -190,6 +192,36 @@ bool doesExistInADS(std::string const &workspaceName) {
 
 std::vector<std::string> attachPrefix(std::vector<std::string> const &strings, std::string const &prefix) {
   return transformElements(strings.begin(), strings.end(), [&prefix](std::string const &str) { return prefix + str; });
+}
+
+/**
+ * Checks the name of the input workspace against a regexp for prefixes in the form `instrName#runNumber_...`, where
+ * #runNumber is a number indicating the specific instrument run number that the workspace refers to.
+ * As output, it returns a single string with format 'instrName#firstRunNumber-#finalRunNumber_...', if run numbers are
+ * found.
+ *
+ * @param workspaceNames :: a vector of strings containing a series of workspace names
+ */
+
+std::string parseRunNumbers(std::vector<std::string> const &workspaceNames) {
+  auto names = WorkspaceUtils::transformElements(workspaceNames.begin(), workspaceNames.end(),
+                                                 [](auto &name) { return name.substr(0, name.find_first_of('_')); });
+  std::smatch match;
+  std::vector<int> runNumbers;
+  std::string prefix;
+  std::string suffix = workspaceNames[0].substr(workspaceNames[0].find_first_of('_'));
+  for (auto const &name : names)
+    if (std::regex_search(name, match, regDigits)) {
+      runNumbers.push_back(std::stoi(match.str(0)));
+      if (prefix.empty())
+        prefix = match.prefix().str();
+    }
+  if (runNumbers.empty() || runNumbers.size() == 1)
+    return workspaceNames[0];
+  else {
+    auto [min, max] = std::minmax_element(runNumbers.cbegin(), runNumbers.cend());
+    return prefix + std::to_string(*min) + "-" + std::to_string(*max) + suffix;
+  }
 }
 
 } // namespace WorkspaceUtils

--- a/qt/scientific_interfaces/Inelastic/Common/WorkspaceUtils.h
+++ b/qt/scientific_interfaces/Inelastic/Common/WorkspaceUtils.h
@@ -48,6 +48,23 @@ getADSWorkspace(std::string const &workspaceName);
 template MANTIDQT_INELASTIC_DLL std::shared_ptr<Mantid::API::ITableWorkspace_sptr>
 getADSWorkspace(std::string const &workspaceName);
 
+template <typename Iterator, typename Functor>
+std::vector<std::string> transformElements(Iterator const fromIter, Iterator const toIter, Functor const &functor) {
+  std::vector<std::string> newVector;
+  newVector.reserve(toIter - fromIter);
+  std::transform(fromIter, toIter, std::back_inserter(newVector), functor);
+  return newVector;
+}
+
+template <typename T, typename Predicate> void removeElementsIf(std::vector<T> &vector, Predicate const &filter) {
+  auto const iter = std::remove_if(vector.begin(), vector.end(), filter);
+  if (iter != vector.end())
+    vector.erase(iter, vector.end());
+}
+
+MANTIDQT_INELASTIC_DLL std::vector<std::string> attachPrefix(std::vector<std::string> const &strings,
+                                                             std::string const &prefix);
+
 } // namespace WorkspaceUtils
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Common/WorkspaceUtils.h
+++ b/qt/scientific_interfaces/Inelastic/Common/WorkspaceUtils.h
@@ -65,6 +65,7 @@ template <typename T, typename Predicate> void removeElementsIf(std::vector<T> &
 MANTIDQT_INELASTIC_DLL std::vector<std::string> attachPrefix(std::vector<std::string> const &strings,
                                                              std::string const &prefix);
 
+MANTIDQT_INELASTIC_DLL std::string parseRunNumbers(std::vector<std::string> const &workspaceNames);
 } // namespace WorkspaceUtils
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
@@ -29,28 +29,20 @@ public:
   virtual void subscribePresenter(IElwinPresenter *presenter) = 0;
   virtual void setup() = 0;
   virtual OutputPlotOptionsView *getPlotOptions() const = 0;
-  virtual void setFBSuffixes(QStringList const &suffix) = 0;
 
   virtual void setAvailableSpectra(MantidWidgets::WorkspaceIndex minimum, MantidWidgets::WorkspaceIndex maximum) = 0;
   virtual void setAvailableSpectra(const std::vector<MantidWidgets::WorkspaceIndex>::const_iterator &from,
                                    const std::vector<MantidWidgets::WorkspaceIndex>::const_iterator &to) = 0;
 
-  virtual void newPreviewFileSelected(const Mantid::API::MatrixWorkspace_sptr &workspace) = 0;
-  virtual int getCurrentInputIndex() = 0;
-  virtual MantidQt::API::FileFinderWidget *getFileFinderWidget() = 0;
-
   virtual void plotInput(Mantid::API::MatrixWorkspace_sptr inputWS, int spectrum) = 0;
-  virtual void newInputFiles() = 0;
-  virtual void newInputFilesFromDialog(std::vector<std::string> const &names) = 0;
+  virtual void newInputDataFromDialog(std::vector<std::string> const &names) = 0;
   virtual void clearPreviewFile() = 0;
-  virtual void clearInputFiles() = 0;
   virtual void setRunIsRunning(const bool running) = 0;
   virtual void setSaveResultEnabled(const bool enabled) = 0;
   virtual int getPreviewSpec() = 0;
   virtual std::string getPreviewWorkspaceName(int index) const = 0;
   virtual std::string getPreviewFilename(int index) const = 0;
   virtual std::string getCurrentPreview() const = 0;
-  virtual QStringList getInputFilenames() = 0;
 
   // controls for dataTable
   virtual void clearDataTable() = 0;
@@ -59,7 +51,7 @@ public:
   virtual QModelIndexList getSelectedData() = 0;
 
   // boolean flags for LoadHistory/GroupInput Checkboxes
-  virtual bool isLoadHistory() = 0;
+  // virtual bool isLoadHistory() = 0;
   virtual bool isGroupInput() = 0;
 
   // getters/setters for m_properties

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
@@ -39,7 +39,7 @@ public:
   virtual void clearPreviewFile() = 0;
   virtual void setRunIsRunning(const bool running) = 0;
   virtual void setSaveResultEnabled(const bool enabled) = 0;
-  virtual int getPreviewSpec() = 0;
+  virtual int getPreviewSpec() const = 0;
 
   virtual std::string getPreviewWorkspaceName(int index) const = 0;
   virtual std::string getPreviewFilename(int index) const = 0;
@@ -52,8 +52,8 @@ public:
   virtual QModelIndexList getSelectedData() = 0;
 
   // boolean flags for LoadHistory/GroupInput Checkboxes
-  virtual bool isGroupInput() = 0;
-  virtual bool isRowCollapsed() = 0;
+  virtual bool isGroupInput() const = 0;
+  virtual bool isRowCollapsed() const = 0;
 
   // getters/setters for m_properties
   virtual bool getNormalise() = 0;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
@@ -54,6 +54,7 @@ public:
   // boolean flags for LoadHistory/GroupInput Checkboxes
   virtual bool isGroupInput() const = 0;
   virtual bool isRowCollapsed() const = 0;
+  virtual bool isTableEmpty() const = 0;
 
   // getters/setters for m_properties
   virtual bool getNormalise() = 0;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
@@ -40,6 +40,7 @@ public:
   virtual void setRunIsRunning(const bool running) = 0;
   virtual void setSaveResultEnabled(const bool enabled) = 0;
   virtual int getPreviewSpec() = 0;
+
   virtual std::string getPreviewWorkspaceName(int index) const = 0;
   virtual std::string getPreviewFilename(int index) const = 0;
   virtual std::string getCurrentPreview() const = 0;
@@ -51,8 +52,8 @@ public:
   virtual QModelIndexList getSelectedData() = 0;
 
   // boolean flags for LoadHistory/GroupInput Checkboxes
-  // virtual bool isLoadHistory() = 0;
   virtual bool isGroupInput() = 0;
+  virtual bool isRowCollapsed() = 0;
 
   // getters/setters for m_properties
   virtual bool getNormalise() = 0;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
@@ -46,7 +46,7 @@ public:
 
   // controls for dataTable
   virtual void clearDataTable() = 0;
-  virtual void addTableEntry(int row, std::string const &name, int spectrum) = 0;
+  virtual void addTableEntry(int row, std::string const &name, std::string const &wsIndexes) = 0;
 
   virtual QModelIndexList getSelectedData() = 0;
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
@@ -99,7 +99,6 @@ void InelasticDataManipulationElwinTab::runComplete(bool error) {
           checkForELTWorkspace()
               ? m_model->getOutputWorkspaceNames()
               : m_model->getOutputWorkspaceNames().substr(0, m_model->getOutputWorkspaceNames().find_last_of(','));
-      std::cout << outputNames << std::endl;
       m_model->groupAlgorithm(outputNames, "IDA_Elwin_Output");
     }
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
@@ -28,13 +28,6 @@ Mantid::Kernel::Logger g_log("Elwin");
 
 std::vector<std::string> getOutputWorkspaceSuffices() { return {"_eq", "_eq2", "_elf", "_elt"}; }
 
-std::string extractLastOf(std::string const &str, std::string const &delimiter) {
-  auto const cutIndex = str.rfind(delimiter);
-  if (cutIndex != std::string::npos)
-    return str.substr(cutIndex + 1, str.size() - cutIndex);
-  return str;
-}
-
 template <typename Iterator, typename Functor>
 std::vector<std::string> transformElements(Iterator const fromIter, Iterator const toIter, Functor const &functor) {
   std::vector<std::string> newVector;
@@ -47,13 +40,6 @@ template <typename T, typename Predicate> void removeElementsIf(std::vector<T> &
   auto const iter = std::remove_if(vector.begin(), vector.end(), filter);
   if (iter != vector.end())
     vector.erase(iter, vector.end());
-}
-
-std::vector<std::string> extractSuffixes(QStringList const &files, std::string const &delimiter) {
-  return transformElements(files.begin(), files.end(), [&](QString const &file) {
-    QFileInfo const fileInfo(file);
-    return extractLastOf(fileInfo.baseName().toStdString(), delimiter);
-  });
 }
 
 std::vector<std::string> attachPrefix(std::vector<std::string> const &strings, std::string const &prefix) {
@@ -154,7 +140,7 @@ bool InelasticDataManipulationElwinTab::checkForELTWorkspace() {
   return true;
 }
 
-std::string InelasticDataManipulationElwinTab::prepareOutputPrefix(std::vector<std::string> &workspaceNames) {
+std::string InelasticDataManipulationElwinTab::prepareOutputPrefix(std::vector<std::string> workspaceNames) {
   std::transform(workspaceNames.cbegin(), workspaceNames.cend(), workspaceNames.begin(),
                  [](auto &name) { return name.substr(0, name.find_first_of('_')); });
   std::regex re("\\d+");

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.cpp
@@ -61,8 +61,8 @@ void InelasticDataManipulationElwinTab::run() {
   m_view->setRunIsRunning(true);
 
   // Get workspace names
-  std::string inputGroupWsName = "IDA_Elwin_Input";
-  std::string outputWsBasename = m_model->prepareOutputPrefix(m_dataModel->getWorkspaceNames());
+  std::string inputGroupWsName = "Elwin_Input";
+  std::string outputWsBasename = WorkspaceUtils::parseRunNumbers(m_dataModel->getWorkspaceNames());
   // Load input files
   std::string inputWorkspacesString;
   for (WorkspaceID i = 0; i < m_dataModel->getNumberOfWorkspaces(); ++i) {
@@ -93,13 +93,13 @@ void InelasticDataManipulationElwinTab::runComplete(bool error) {
 
   if (!error) {
     if (!m_view->isGroupInput()) {
-      m_model->ungroupAlgorithm("IDA_Elwin_Input");
+      m_model->ungroupAlgorithm("Elwin_Input");
     } else {
       std::string outputNames =
           checkForELTWorkspace()
               ? m_model->getOutputWorkspaceNames()
               : m_model->getOutputWorkspaceNames().substr(0, m_model->getOutputWorkspaceNames().find_last_of(','));
-      m_model->groupAlgorithm(outputNames, "IDA_Elwin_Output");
+      m_model->groupAlgorithm(outputNames, "Elwin_Output");
     }
 
     setOutputPlotOptionsWorkspaces(getOutputWorkspaceNames());

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
@@ -31,7 +31,6 @@ public:
   virtual void handleRunClicked() = 0;
   virtual void handleSaveClicked() = 0;
   virtual void handlePlotPreviewClicked() = 0;
-  virtual void handleFilesFound() = 0;
   virtual void handlePreviewSpectrumChanged(int spectrum) = 0;
   virtual void handlePreviewIndexChanged(int index) = 0;
   virtual void handleAddData(MantidWidgets::IAddWorkspaceDialog const *dialog) = 0;
@@ -56,7 +55,6 @@ public:
   void handleRunClicked() override;
   void handleSaveClicked() override;
   void handlePlotPreviewClicked() override;
-  void handleFilesFound() override;
   void handlePreviewSpectrumChanged(int spectrum) override;
   void handlePreviewIndexChanged(int index) override;
   void handleAddData(MantidWidgets::IAddWorkspaceDialog const *dialog) override;
@@ -65,16 +63,11 @@ public:
 
 protected:
   void runComplete(bool error) override;
-  void newInputFilesFromDialog();
+  void newInputDataFromDialog();
   virtual void addDataToModel(MantidWidgets::IAddWorkspaceDialog const *dialog);
 
 private:
-  void runFileInput();
-  void runWorkspaceInput();
-
-  void setFileExtensionsByName(bool filter) override;
   void updateTableFromModel();
-  void newInputFiles();
   void updateIntegrationRange();
 
   int getSelectedSpectrum() const;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
@@ -80,7 +80,7 @@ private:
   MatrixWorkspace_sptr getInputWorkspace() const;
   MatrixWorkspace_sptr getPreviewPlotWorkspace();
   bool checkForELTWorkspace();
-  std::string prepareOutputPrefix(std::vector<std::string> workspaceNames);
+  std::string prepareOutputPrefix(std::vector<std::string> const &workspaceNames) const;
   void setInputWorkspace(MatrixWorkspace_sptr inputWorkspace);
   void setPreviewPlotWorkspace(const MatrixWorkspace_sptr &previewPlotWorkspace);
   void newPreviewFileSelected(const std::string &workspaceName, const std::string &filename);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
@@ -80,7 +80,7 @@ private:
   MatrixWorkspace_sptr getInputWorkspace() const;
   MatrixWorkspace_sptr getPreviewPlotWorkspace();
   bool checkForELTWorkspace();
-  std::string prepareOutputPrefix(std::vector<std::string> &workspaceNames);
+  std::string prepareOutputPrefix(std::vector<std::string> workspaceNames);
   void setInputWorkspace(MatrixWorkspace_sptr inputWorkspace);
   void setPreviewPlotWorkspace(const MatrixWorkspace_sptr &previewPlotWorkspace);
   void newPreviewFileSelected(const std::string &workspaceName, const std::string &filename);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
@@ -80,6 +80,7 @@ private:
   MatrixWorkspace_sptr getInputWorkspace() const;
   MatrixWorkspace_sptr getPreviewPlotWorkspace();
   bool checkForELTWorkspace();
+  std::string prepareOutputPrefix(std::vector<std::string> &workspaceNames);
   void setInputWorkspace(MatrixWorkspace_sptr inputWorkspace);
   void setPreviewPlotWorkspace(const MatrixWorkspace_sptr &previewPlotWorkspace);
   void newPreviewFileSelected(const std::string &workspaceName, const std::string &filename);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
@@ -35,6 +35,7 @@ public:
   virtual void handlePreviewIndexChanged(int index) = 0;
   virtual void handleAddData(MantidWidgets::IAddWorkspaceDialog const *dialog) = 0;
   virtual void handleRemoveSelectedData() = 0;
+  virtual void handleRowModeChanged() = 0;
   virtual void updateAvailableSpectra() = 0;
 };
 
@@ -59,6 +60,7 @@ public:
   void handlePreviewIndexChanged(int index) override;
   void handleAddData(MantidWidgets::IAddWorkspaceDialog const *dialog) override;
   void handleRemoveSelectedData() override;
+  void handleRowModeChanged() override;
   void updateAvailableSpectra() override;
 
 protected:

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
@@ -77,7 +77,7 @@ private:
   std::string getOutputBasename();
   MatrixWorkspace_sptr getInputWorkspace() const;
   MatrixWorkspace_sptr getPreviewPlotWorkspace();
-  void checkForELTWorkspace();
+  bool checkForELTWorkspace();
   void setInputWorkspace(MatrixWorkspace_sptr inputWorkspace);
   void setPreviewPlotWorkspace(const MatrixWorkspace_sptr &previewPlotWorkspace);
   void newPreviewFileSelected(const std::string &workspaceName, const std::string &filename);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.h
@@ -80,7 +80,6 @@ private:
   MatrixWorkspace_sptr getInputWorkspace() const;
   MatrixWorkspace_sptr getPreviewPlotWorkspace();
   bool checkForELTWorkspace();
-  std::string prepareOutputPrefix(std::vector<std::string> const &workspaceNames) const;
   void setInputWorkspace(MatrixWorkspace_sptr inputWorkspace);
   void setPreviewPlotWorkspace(const MatrixWorkspace_sptr &previewPlotWorkspace);
   void newPreviewFileSelected(const std::string &workspaceName, const std::string &filename);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.ui
@@ -28,6 +28,12 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <widget class="QTabWidget" name="inputChoice">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.ui
@@ -288,29 +288,33 @@
      <property name="title">
       <string>Run</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
       <item>
-       <widget class="QCheckBox" name="ckGroupOutput">
-        <property name="text">
-         <string>Group Output</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Minimum</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QCheckBox" name="ckGroupOutput">
+          <property name="text">
+           <string>Group Output</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Expanding</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>125</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
       <item>
        <widget class="QPushButton" name="pbRun">
@@ -326,8 +330,8 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
-          <height>20</height>
+          <width>244</width>
+          <height>17</height>
          </size>
         </property>
        </spacer>

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.ui
@@ -384,6 +384,9 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
+     <property name="toolTip">
+      <string>For every workspace added, it checks whether to show every spectra of the each workspace as individual rows, or collapse all spectra into one row per workspace</string>
+     </property>
      <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0">
       <item row="0" column="1" alignment="Qt::AlignTop">
        <widget class="QFrame" name="frame_2">
@@ -411,6 +414,19 @@
           <widget class="QPushButton" name="wkspRemove">
            <property name="text">
             <string>Remove Selected</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="ckCollapse">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Collapse rows?</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
            </property>
           </widget>
          </item>

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.ui
@@ -290,9 +290,19 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <item>
+       <widget class="QCheckBox" name="ckGroupOutput">
+        <property name="text">
+         <string>Group Output?</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="horizontalSpacer">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Minimum</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -401,13 +411,6 @@
           <widget class="QPushButton" name="wkspRemove">
            <property name="text">
             <string>Remove Selected</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="ckGroupOutput">
-           <property name="text">
-            <string>Group Output?</string>
            </property>
           </widget>
          </item>

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
+    <width>620</width>
     <height>841</height>
    </rect>
   </property>
@@ -26,150 +26,6 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QTabWidget" name="inputChoice">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="file">
-      <attribute name="title">
-       <string>File</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,0">
-       <item row="0" column="0">
-        <widget class="MantidQt::API::FileFinderWidget" name="dsInputFiles" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>41</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="findRunFiles" stdset="0">
-          <bool>false</bool>
-         </property>
-         <property name="label" stdset="0">
-          <string>Input File</string>
-         </property>
-         <property name="multipleFiles" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="fileExtensions" stdset="0">
-          <stringlist>
-           <string>_red.nxs</string>
-           <string>_sqw.nxs</string>
-          </stringlist>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QFrame" name="frame">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <property name="spacing">
-           <number>3</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QCheckBox" name="ckGroupInput">
-            <property name="text">
-             <string>Group Input</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="ckLoadHistory">
-            <property name="text">
-             <string>Load History</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="workspace">
-      <attribute name="title">
-       <string>Workspace</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0">
-       <item row="0" column="1">
-        <widget class="QFrame" name="frame_2">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
-          <item>
-           <widget class="QPushButton" name="wkspAdd">
-            <property name="text">
-             <string>Add Workspace</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="wkspRemove">
-            <property name="text">
-             <string>Remove</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QTableWidget" name="tbElwinData">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>400</width>
-           <height>0</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
    <item row="1" column="0">
     <widget class="QSplitter" name="splitterPlot">
      <property name="sizePolicy">
@@ -211,26 +67,29 @@
            </property>
            <property name="minimumSize">
             <size>
-             <width>100</width>
-             <height>0</height>
+             <width>200</width>
+             <height>22</height>
             </size>
            </property>
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_4">
+          <spacer name="horizontalSpacer_5">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Maximum</enum>
+           </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>40</width>
+             <width>20</width>
              <height>20</height>
             </size>
            </property>
           </spacer>
          </item>
-         <item>
+         <item alignment="Qt::AlignVCenter">
           <widget class="QLabel" name="lbPreviewSpec">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -243,7 +102,7 @@
            </property>
           </widget>
          </item>
-         <item>
+         <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
           <widget class="QStackedWidget" name="elwinPreviewSpec">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -261,15 +120,15 @@
             <number>-1</number>
            </property>
            <property name="currentIndex">
-            <number>0</number>
+            <number>1</number>
            </property>
            <widget class="QWidget" name="pgPlotSpinBox">
             <widget class="QSpinBox" name="spPlotSpectrum">
              <property name="geometry">
               <rect>
                <x>0</x>
-               <y>15</y>
-               <width>33</width>
+               <y>13</y>
+               <width>73</width>
                <height>22</height>
               </rect>
              </property>
@@ -278,6 +137,18 @@
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>73</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <family>MS Shell Dlg 2</family>
+               <pointsize>10</pointsize>
+              </font>
              </property>
              <property name="maximum">
               <number>0</number>
@@ -289,7 +160,7 @@
              <property name="geometry">
               <rect>
                <x>0</x>
-               <y>15</y>
+               <y>14</y>
                <width>73</width>
                <height>22</height>
               </rect>
@@ -300,9 +171,30 @@
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
+             <property name="font">
+              <font>
+               <pointsize>10</pointsize>
+              </font>
+             </property>
             </widget>
            </widget>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::MinimumExpanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
@@ -474,6 +366,73 @@
      </layout>
     </widget>
    </item>
+   <item row="0" column="0">
+    <widget class="QFrame" name="inputChoice">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0">
+      <item row="0" column="1" alignment="Qt::AlignTop">
+       <widget class="QFrame" name="frame_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QPushButton" name="wkspAdd">
+           <property name="text">
+            <string>Add Workspaces</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="wkspRemove">
+           <property name="text">
+            <string>Remove Selected</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="ckGroupOutput">
+           <property name="text">
+            <string>Group Output?</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QTableWidget" name="tbElwinData">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>400</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -488,11 +447,6 @@
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Plotting/PreviewPlot.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>MantidQt::API::FileFinderWidget</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTab.ui
@@ -292,7 +292,7 @@
       <item>
        <widget class="QCheckBox" name="ckGroupOutput">
         <property name="text">
-         <string>Group Output?</string>
+         <string>Group Output</string>
         </property>
        </widget>
       </item>
@@ -423,7 +423,7 @@
             <bool>true</bool>
            </property>
            <property name="text">
-            <string>Collapse rows?</string>
+            <string>Collapse rows</string>
            </property>
            <property name="checked">
             <bool>true</bool>

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
@@ -99,7 +99,7 @@ void InelasticDataManipulationElwinTabModel::groupAlgorithm(std::string const &i
 }
 
 std::string InelasticDataManipulationElwinTabModel::createGroupedWorkspaces(MatrixWorkspace_sptr workspace,
-                                                                            FunctionModelSpectra &spectra) {
+                                                                            FunctionModelSpectra const &spectra) {
   auto extractSpectra = AlgorithmManager::Instance().create("ExtractSingleSpectrum");
   extractSpectra->setProperty<MatrixWorkspace_sptr>("InputWorkspace", workspace);
   extractSpectra->setProperty("OutputWorkspace", workspace->getName() + "_extracted_spectra");

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
@@ -12,19 +12,16 @@
 #include "MantidAPI/AlgorithmRuntimeProps.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidKernel/Strings.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 
 #include <QDoubleValidator>
 #include <QFileInfo>
-#include <regex>
 
 using namespace IndirectDataValidationHelper;
 using namespace Mantid::API;
 using namespace MantidQt::MantidWidgets;
 
-namespace {
-auto const regDigits = std::regex("\\d+");
-}
 namespace MantidQt::CustomInterfaces {
 
 //----------------------------------------------------------------------------------------------
@@ -142,28 +139,6 @@ std::string InelasticDataManipulationElwinTabModel::getOutputWorkspaceNames() co
   std::string outputWorkspaceNames = oss.str();
   outputWorkspaceNames.resize(outputWorkspaceNames.size() - 1);
   return outputWorkspaceNames;
-}
-
-std::string
-InelasticDataManipulationElwinTabModel::prepareOutputPrefix(std::vector<std::string> const &workspaceNames) const {
-  auto names = WorkspaceUtils::transformElements(workspaceNames.begin(), workspaceNames.end(),
-                                                 [](auto &name) { return name.substr(0, name.find_first_of('_')); });
-  std::smatch match;
-  std::vector<int> runNumbers;
-  std::string prefix;
-  std::string suffix = workspaceNames[0].substr(workspaceNames[0].find_first_of('_'));
-  for (auto const &name : names)
-    if (std::regex_search(name, match, regDigits)) {
-      runNumbers.push_back(std::stoi(match.str(0)));
-      if (prefix.empty())
-        prefix = match.prefix().str();
-    }
-  if (runNumbers.empty() || runNumbers.size() == 1)
-    return workspaceNames[0];
-  else {
-    auto [min, max] = std::minmax_element(runNumbers.cbegin(), runNumbers.cend());
-    return prefix + std::to_string(*min) + "-" + std::to_string(*max) + suffix;
-  }
 }
 
 void InelasticDataManipulationElwinTabModel::setIntegrationStart(double integrationStart) {

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
@@ -131,7 +131,7 @@ void InelasticDataManipulationElwinTabModel::setOutputWorkspaceNames(std::string
 
 std::string InelasticDataManipulationElwinTabModel::getOutputWorkspaceNames() {
   std::string outputWorkspaceNames;
-  for (auto &element : m_outputWorkspaceNames) {
+  for (auto const &element : m_outputWorkspaceNames) {
     outputWorkspaceNames += static_cast<std::string>(element.second) + ',';
   }
   outputWorkspaceNames.resize(outputWorkspaceNames.size() - 1);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
@@ -12,7 +12,6 @@
 #include "MantidAPI/AlgorithmRuntimeProps.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
-#include "MantidKernel/Strings.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 
 #include <QDoubleValidator>

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
@@ -82,24 +82,24 @@ void InelasticDataManipulationElwinTabModel::setupElasticWindowMultiple(
   batchAlgoRunner->addAlgorithm(elwinMultAlg, std::move(runtimeProps));
 }
 
-void InelasticDataManipulationElwinTabModel::ungroupAlgorithm(std::string const &InputWorkspace) {
+void InelasticDataManipulationElwinTabModel::ungroupAlgorithm(std::string const &inputWorkspace) const {
   auto ungroupAlg = AlgorithmManager::Instance().create("UnGroupWorkspace");
   ungroupAlg->initialize();
-  ungroupAlg->setProperty("InputWorkspace", InputWorkspace);
+  ungroupAlg->setProperty("InputWorkspace", inputWorkspace);
   ungroupAlg->execute();
 }
 
-void InelasticDataManipulationElwinTabModel::groupAlgorithm(std::string const &InputWorkspaces,
-                                                            std::string const &OutputWorkspace) {
+void InelasticDataManipulationElwinTabModel::groupAlgorithm(std::string const &inputWorkspaces,
+                                                            std::string const &outputWorkspace) const {
   auto groupAlg = AlgorithmManager::Instance().create("GroupWorkspaces");
   groupAlg->initialize();
-  groupAlg->setProperty("InputWorkspaces", InputWorkspaces);
-  groupAlg->setProperty("OutputWorkspace", OutputWorkspace);
+  groupAlg->setProperty("InputWorkspaces", inputWorkspaces);
+  groupAlg->setProperty("OutputWorkspace", outputWorkspace);
   groupAlg->execute();
 }
 
 std::string InelasticDataManipulationElwinTabModel::createGroupedWorkspaces(MatrixWorkspace_sptr workspace,
-                                                                            FunctionModelSpectra spectra) {
+                                                                            FunctionModelSpectra &spectra) {
   auto extractSpectra = AlgorithmManager::Instance().create("ExtractSingleSpectrum");
   extractSpectra->setProperty<MatrixWorkspace_sptr>("InputWorkspace", workspace);
   extractSpectra->setProperty("OutputWorkspace", workspace->getName() + "_extracted_spectra");
@@ -129,7 +129,7 @@ void InelasticDataManipulationElwinTabModel::setOutputWorkspaceNames(std::string
   m_outputWorkspaceNames["eltWorkspace"] = workspaceBaseName + elwinSuffix + "elt";
 }
 
-std::string InelasticDataManipulationElwinTabModel::getOutputWorkspaceNames() {
+std::string InelasticDataManipulationElwinTabModel::getOutputWorkspaceNames() const {
   std::string outputWorkspaceNames;
   for (auto const &element : m_outputWorkspaceNames) {
     outputWorkspaceNames += static_cast<std::string>(element.second) + ',';

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.cpp
@@ -135,10 +135,10 @@ void InelasticDataManipulationElwinTabModel::setOutputWorkspaceNames(std::string
 }
 
 std::string InelasticDataManipulationElwinTabModel::getOutputWorkspaceNames() const {
+  std::vector<std::string> keys = {"qWorkspace", "qSquaredWorkspace", "elfWorkspace", "eltWorkspace"};
   std::ostringstream oss;
-  std::transform(m_outputWorkspaceNames.cbegin(), m_outputWorkspaceNames.cend(),
-                 std::ostream_iterator<std::string>(oss, ","),
-                 [](const auto &element) { return static_cast<std::string>(element.second); });
+  std::transform(keys.cbegin(), keys.cend(), std::ostream_iterator<std::string>(oss, ","),
+                 [&outNames = m_outputWorkspaceNames](const auto &key) { return outNames.at(key); });
   std::string outputWorkspaceNames = oss.str();
   outputWorkspaceNames.resize(outputWorkspaceNames.size() - 1);
   return outputWorkspaceNames;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.h
@@ -34,12 +34,15 @@ public:
                                   std::string const &sampleEnvironmentLogName,
                                   std::string const &sampleEnvironmentLogValue);
   void ungroupAlgorithm(std::string const &InputWorkspace);
+  void groupAlgorithm(std::string const &InputWorkspaces, std::string const &OutputWorkspace);
   void setIntegrationStart(double integrationStart);
   void setIntegrationEnd(double integrationEnd);
   void setBackgroundStart(double backgroundStart);
   void setBackgroundEnd(double backgroundEnd);
   void setBackgroundSubtraction(bool backgroundSubtraction);
   void setNormalise(bool normalise);
+  void setOutputWorkspaceNames(std::string const &workspaceBaseName);
+  std::string getOutputWorkspaceNames();
 
 private:
   double m_integrationStart;
@@ -48,6 +51,7 @@ private:
   double m_backgroundEnd;
   bool m_backgroundSubtraction;
   bool m_normalise;
+  std::unordered_map<std::string, std::string> m_outputWorkspaceNames;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.h
@@ -43,7 +43,6 @@ public:
   void setNormalise(bool normalise);
   void setOutputWorkspaceNames(std::string const &workspaceBaseName);
   std::string getOutputWorkspaceNames() const;
-  std::string prepareOutputPrefix(std::vector<std::string> const &workspaceNames) const;
 
 private:
   double m_integrationStart;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.h
@@ -26,15 +26,15 @@ public:
   ~InelasticDataManipulationElwinTabModel() = default;
   void setupLoadAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::string const &filepath,
                           std::string const &outputName);
-  std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra spectra);
+  std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra &spectra);
   void setupGroupAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
                            std::string const &inputWorkspacesString, std::string const &inputGroupWsName);
   void setupElasticWindowMultiple(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
                                   std::string const &workspaceBaseName, std::string const &inputGroupWsName,
                                   std::string const &sampleEnvironmentLogName,
                                   std::string const &sampleEnvironmentLogValue);
-  void ungroupAlgorithm(std::string const &InputWorkspace);
-  void groupAlgorithm(std::string const &InputWorkspaces, std::string const &OutputWorkspace);
+  void ungroupAlgorithm(std::string const &inputWorkspace) const;
+  void groupAlgorithm(std::string const &inputWorkspaces, std::string const &outputWorkspace) const;
   void setIntegrationStart(double integrationStart);
   void setIntegrationEnd(double integrationEnd);
   void setBackgroundStart(double backgroundStart);
@@ -42,7 +42,7 @@ public:
   void setBackgroundSubtraction(bool backgroundSubtraction);
   void setNormalise(bool normalise);
   void setOutputWorkspaceNames(std::string const &workspaceBaseName);
-  std::string getOutputWorkspaceNames();
+  std::string getOutputWorkspaceNames() const;
 
 private:
   double m_integrationStart;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.h
@@ -26,7 +26,7 @@ public:
   ~InelasticDataManipulationElwinTabModel() = default;
   void setupLoadAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::string const &filepath,
                           std::string const &outputName);
-  std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra &spectra);
+  std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra const &spectra);
   void setupGroupAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
                            std::string const &inputWorkspacesString, std::string const &inputGroupWsName);
   void setupElasticWindowMultiple(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabModel.h
@@ -43,6 +43,7 @@ public:
   void setNormalise(bool normalise);
   void setOutputWorkspaceNames(std::string const &workspaceBaseName);
   std::string getOutputWorkspaceNames() const;
+  std::string prepareOutputPrefix(std::vector<std::string> const &workspaceNames) const;
 
 private:
   double m_integrationStart;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
@@ -144,7 +144,6 @@ void InelasticDataManipulationElwinTabView::setup() {
   connect(m_uiForm.wkspAdd, SIGNAL(clicked()), this, SLOT(notifyAddWorkspaceDialog()));
   connect(m_uiForm.wkspRemove, SIGNAL(clicked()), this, SLOT(notifyRemoveDataClicked()));
 
-  connect(m_uiForm.dsInputFiles, SIGNAL(filesFound()), this, SLOT(notifyFilesFound()));
   connect(m_uiForm.cbPreviewFile, SIGNAL(currentIndexChanged(int)), this, SLOT(notifyPreviewIndexChanged(int)));
   connect(m_uiForm.spPlotSpectrum, SIGNAL(valueChanged(int)), this, SLOT(notifySelectedSpectrumChanged(int)));
   connect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this, SLOT(notifySelectedSpectrumChanged(int)));
@@ -172,8 +171,6 @@ void InelasticDataManipulationElwinTabView::notifySaveClicked() { m_presenter->h
 
 void InelasticDataManipulationElwinTabView::notifyPlotPreviewClicked() { m_presenter->handlePlotPreviewClicked(); }
 
-void InelasticDataManipulationElwinTabView::notifyFilesFound() { m_presenter->handleFilesFound(); }
-
 void InelasticDataManipulationElwinTabView::notifySelectedSpectrumChanged(int index) {
   m_presenter->handlePreviewSpectrumChanged(index);
 }
@@ -199,14 +196,13 @@ void InelasticDataManipulationElwinTabView::showAddWorkspaceDialog() {
 }
 
 void InelasticDataManipulationElwinTabView::notifyAddData(MantidWidgets::IAddWorkspaceDialog *dialog) {
-  addDataWksOrFile(dialog);
+  addData(dialog);
 }
 
 /** This method checks whether a Workspace or a File is being uploaded through the AddWorkspaceDialog
- * A File requires additional checks to ensure a file of the correct type is being loaded. The Workspace list is
- * already filtered.
+ *
  */
-void InelasticDataManipulationElwinTabView::addDataWksOrFile(MantidWidgets::IAddWorkspaceDialog const *dialog) {
+void InelasticDataManipulationElwinTabView::addData(MantidWidgets::IAddWorkspaceDialog const *dialog) {
   try {
     const auto indirectDialog = dynamic_cast<MantidWidgets::AddWorkspaceMultiDialog const *>(dialog);
     if (indirectDialog) {
@@ -258,14 +254,6 @@ QModelIndexList InelasticDataManipulationElwinTabView::getSelectedData() {
   return m_uiForm.tbElwinData->selectionModel()->selectedIndexes();
 }
 
-MantidQt::API::FileFinderWidget *InelasticDataManipulationElwinTabView::getFileFinderWidget() {
-  return m_uiForm.dsInputFiles;
-}
-
-void InelasticDataManipulationElwinTabView::setFBSuffixes(QStringList const &suffix) {
-  m_uiForm.dsInputFiles->setFileExtensions(suffix);
-}
-
 void InelasticDataManipulationElwinTabView::setDefaultSampleLog(const Mantid::API::MatrixWorkspace_const_sptr &ws) {
   auto inst = ws->getInstrument();
   // Set sample environment log name
@@ -291,30 +279,7 @@ void InelasticDataManipulationElwinTabView::setDefaultSampleLog(const Mantid::AP
  *
  * Updates preview selection combo box.
  */
-void InelasticDataManipulationElwinTabView::newInputFiles() {
-  // Clear the existing list of files
-  m_uiForm.cbPreviewFile->clear();
-
-  // Populate the combo box with the filenames
-  QStringList filenames = getInputFilenames();
-  for (auto rawFilename : filenames) {
-    QFileInfo inputFileInfo(rawFilename);
-    QString sampleName = inputFileInfo.baseName();
-    // Add the item using the base filename as the display string and the raw
-    // filename as the data value
-    m_uiForm.cbPreviewFile->addItem(sampleName, rawFilename);
-  }
-
-  // Default to the first file
-  setPreviewToDefault();
-}
-
-/**
- * Handles a new set of input files being entered.
- *
- * Updates preview selection combo box.
- */
-void InelasticDataManipulationElwinTabView::newInputFilesFromDialog(std::vector<std::string> const &names) {
+void InelasticDataManipulationElwinTabView::newInputDataFromDialog(std::vector<std::string> const &names) {
   // Populate the combo box with the filenames
   QString workspaceNames;
   QString filename;
@@ -336,14 +301,6 @@ void InelasticDataManipulationElwinTabView::setPreviewToDefault() {
                    m_properties["IntegrationEnd"], range);
   setRangeSelector(m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange"), m_properties["BackgroundStart"],
                    m_properties["BackgroundEnd"], range);
-}
-
-void InelasticDataManipulationElwinTabView::newPreviewFileSelected(const MatrixWorkspace_sptr &workspace) {
-  if (m_uiForm.inputChoice->currentIndex() == 0) {
-    int const numHist = static_cast<int>(workspace->getNumberHistograms()) - 1;
-    m_uiForm.spPlotSpectrum->setMaximum(numHist);
-    m_uiForm.spPlotSpectrum->setValue(0);
-  }
 }
 
 /**
@@ -545,8 +502,6 @@ void InelasticDataManipulationElwinTabView::setSaveResultEnabled(const bool enab
   m_uiForm.pbSave->setEnabled(enabled);
 }
 
-void InelasticDataManipulationElwinTabView::clearInputFiles() { m_uiForm.dsInputFiles->clear(); }
-
 void InelasticDataManipulationElwinTabView::setAvailableSpectra(WorkspaceIndex minimum, WorkspaceIndex maximum) {
   m_uiForm.elwinPreviewSpec->setCurrentIndex(0);
   m_uiForm.spPlotSpectrum->setMinimum(boost::numeric_cast<int>(minimum.value));
@@ -555,17 +510,14 @@ void InelasticDataManipulationElwinTabView::setAvailableSpectra(WorkspaceIndex m
 
 void InelasticDataManipulationElwinTabView::setAvailableSpectra(const std::vector<WorkspaceIndex>::const_iterator &from,
                                                                 const std::vector<WorkspaceIndex>::const_iterator &to) {
-  disconnect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this,
-             SIGNAL(notifySelectedSpectrumChanged(int)));
+  disconnect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this, SLOT(notifySelectedSpectrumChanged(int)));
   m_uiForm.elwinPreviewSpec->setCurrentIndex(1);
   m_uiForm.cbPlotSpectrum->clear();
 
   for (auto spectrum = from; spectrum < to; ++spectrum)
     m_uiForm.cbPlotSpectrum->addItem(QString::number(spectrum->value));
-  connect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this, SIGNAL(notifySelectedSpectrumChanged(int)));
+  connect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this, SLOT(notifySelectedSpectrumChanged(int)));
 }
-
-int InelasticDataManipulationElwinTabView::getCurrentInputIndex() { return m_uiForm.inputChoice->currentIndex(); }
 
 std::string InelasticDataManipulationElwinTabView::getPreviewWorkspaceName(int index) const {
   return m_uiForm.cbPreviewFile->itemText(index).toStdString();
@@ -575,18 +527,16 @@ std::string InelasticDataManipulationElwinTabView::getPreviewFilename(int index)
   return m_uiForm.cbPreviewFile->itemData(index).toString().toStdString();
 }
 
-int InelasticDataManipulationElwinTabView::getPreviewSpec() { return m_uiForm.spPlotSpectrum->value(); }
+int InelasticDataManipulationElwinTabView::getPreviewSpec() {
+  int tabIndex = m_uiForm.elwinPreviewSpec->currentIndex();
+  return tabIndex == 0 ? m_uiForm.spPlotSpectrum->value() : m_uiForm.cbPlotSpectrum->currentText().toInt();
+}
 
 std::string InelasticDataManipulationElwinTabView::getCurrentPreview() const {
   return m_uiForm.cbPreviewFile->currentText().toStdString();
 }
 
-QStringList InelasticDataManipulationElwinTabView::getInputFilenames() { return m_uiForm.dsInputFiles->getFilenames(); }
-
-bool InelasticDataManipulationElwinTabView::isLoadHistory() { return m_uiForm.ckLoadHistory->isChecked(); }
-
-bool InelasticDataManipulationElwinTabView::isGroupInput() { return m_uiForm.ckGroupInput->isChecked(); }
-
+bool InelasticDataManipulationElwinTabView::isGroupInput() { return m_uiForm.ckGroupOutput->isChecked(); }
 bool InelasticDataManipulationElwinTabView::getNormalise() { return m_blnManager->value(m_properties["Normalise"]); }
 
 bool InelasticDataManipulationElwinTabView::getBackgroundSubtraction() {

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
@@ -531,7 +531,7 @@ std::string InelasticDataManipulationElwinTabView::getPreviewFilename(int index)
   return m_uiForm.cbPreviewFile->itemData(index).toString().toStdString();
 }
 
-int InelasticDataManipulationElwinTabView::getPreviewSpec() {
+int InelasticDataManipulationElwinTabView::getPreviewSpec() const {
   int tabIndex = m_uiForm.elwinPreviewSpec->currentIndex();
   return tabIndex == 0 ? m_uiForm.spPlotSpectrum->value() : m_uiForm.cbPlotSpectrum->currentText().toInt();
 }
@@ -540,8 +540,8 @@ std::string InelasticDataManipulationElwinTabView::getCurrentPreview() const {
   return m_uiForm.cbPreviewFile->currentText().toStdString();
 }
 
-bool InelasticDataManipulationElwinTabView::isGroupInput() { return m_uiForm.ckGroupOutput->isChecked(); }
-bool InelasticDataManipulationElwinTabView::isRowCollapsed() { return m_uiForm.ckCollapse->isChecked(); }
+bool InelasticDataManipulationElwinTabView::isGroupInput() const { return m_uiForm.ckGroupOutput->isChecked(); }
+bool InelasticDataManipulationElwinTabView::isRowCollapsed() const { return m_uiForm.ckCollapse->isChecked(); }
 bool InelasticDataManipulationElwinTabView::getNormalise() { return m_blnManager->value(m_properties["Normalise"]); }
 
 bool InelasticDataManipulationElwinTabView::getBackgroundSubtraction() {

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
@@ -147,6 +147,7 @@ void InelasticDataManipulationElwinTabView::setup() {
   connect(m_uiForm.cbPreviewFile, SIGNAL(currentIndexChanged(int)), this, SLOT(notifyPreviewIndexChanged(int)));
   connect(m_uiForm.spPlotSpectrum, SIGNAL(valueChanged(int)), this, SLOT(notifySelectedSpectrumChanged(int)));
   connect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this, SLOT(notifySelectedSpectrumChanged(int)));
+  connect(m_uiForm.ckCollapse, SIGNAL(stateChanged(int)), this, SLOT(notifyRowModeChanged()));
 
   // Handle plot and save
   connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(notifyRunClicked()));
@@ -178,6 +179,8 @@ void InelasticDataManipulationElwinTabView::notifySelectedSpectrumChanged(int in
 void InelasticDataManipulationElwinTabView::notifyPreviewIndexChanged(int index) {
   m_presenter->handlePreviewIndexChanged(index);
 }
+
+void InelasticDataManipulationElwinTabView::notifyRowModeChanged() { m_presenter->handleRowModeChanged(); }
 
 void InelasticDataManipulationElwinTabView::notifyRemoveDataClicked() { m_presenter->handleRemoveSelectedData(); }
 
@@ -538,6 +541,7 @@ std::string InelasticDataManipulationElwinTabView::getCurrentPreview() const {
 }
 
 bool InelasticDataManipulationElwinTabView::isGroupInput() { return m_uiForm.ckGroupOutput->isChecked(); }
+bool InelasticDataManipulationElwinTabView::isRowCollapsed() { return m_uiForm.ckCollapse->isChecked(); }
 bool InelasticDataManipulationElwinTabView::getNormalise() { return m_blnManager->value(m_properties["Normalise"]); }
 
 bool InelasticDataManipulationElwinTabView::getBackgroundSubtraction() {

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
@@ -233,7 +233,8 @@ void InelasticDataManipulationElwinTabView::setHorizontalHeaders() {
 
 void InelasticDataManipulationElwinTabView::clearDataTable() { m_uiForm.tbElwinData->setRowCount(0); }
 
-void InelasticDataManipulationElwinTabView::addTableEntry(int row, std::string const &name, int spectrum) {
+void InelasticDataManipulationElwinTabView::addTableEntry(int row, std::string const &name,
+                                                          std::string const &wsIndexes) {
   m_uiForm.tbElwinData->insertRow(static_cast<int>(row));
   auto cell = std::make_unique<QTableWidgetItem>(QString::fromStdString(name));
   auto flags = cell->flags();
@@ -241,7 +242,7 @@ void InelasticDataManipulationElwinTabView::addTableEntry(int row, std::string c
   cell->setFlags(flags);
   setCell(std::move(cell), row, 0);
 
-  cell = std::make_unique<QTableWidgetItem>(QString::number(spectrum));
+  cell = std::make_unique<QTableWidgetItem>(QString::fromStdString(wsIndexes));
   cell->setFlags(flags);
   setCell(std::move(cell), row, 1);
 }

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.cpp
@@ -542,6 +542,7 @@ std::string InelasticDataManipulationElwinTabView::getCurrentPreview() const {
 
 bool InelasticDataManipulationElwinTabView::isGroupInput() const { return m_uiForm.ckGroupOutput->isChecked(); }
 bool InelasticDataManipulationElwinTabView::isRowCollapsed() const { return m_uiForm.ckCollapse->isChecked(); }
+bool InelasticDataManipulationElwinTabView::isTableEmpty() const { return m_uiForm.tbElwinData->rowCount() == 0; }
 bool InelasticDataManipulationElwinTabView::getNormalise() { return m_blnManager->value(m_properties["Normalise"]); }
 
 bool InelasticDataManipulationElwinTabView::getBackgroundSubtraction() {

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
@@ -54,6 +54,7 @@ public:
 
   // boolean flags for LoadHistory/GroupInput Checkboxes
   bool isGroupInput() override;
+  bool isRowCollapsed() override;
 
   // getters/setters for m_properties
   bool getNormalise() override;
@@ -82,6 +83,7 @@ private slots:
   void notifySaveClicked();
   void notifySelectedSpectrumChanged(int);
   void notifyPreviewIndexChanged(int);
+  void notifyRowModeChanged();
   void notifyAddWorkspaceDialog();
   void notifyAddData(MantidWidgets::IAddWorkspaceDialog *dialog);
   void notifyRemoveDataClicked();

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
@@ -12,7 +12,6 @@
 #include "InelasticDataManipulationTab.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
-#include "MantidQtWidgets/Common/FileFinderWidget.h"
 #include "MantidQtWidgets/Common/FunctionModelSpectra.h"
 #include "MantidQtWidgets/Common/IAddWorkspaceDialog.h"
 #include "ui_InelasticDataManipulationElwinTab.h"
@@ -50,7 +49,7 @@ public:
 
   // controls for dataTable
   void clearDataTable() override;
-  void addTableEntry(int row, std::string const &name, int spectrum) override;
+  void addTableEntry(int row, std::string const &name, std::string const &wsIndexes) override;
   QModelIndexList getSelectedData() override;
 
   // boolean flags for LoadHistory/GroupInput Checkboxes

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
@@ -33,28 +33,20 @@ public:
   void setup() override;
 
   OutputPlotOptionsView *getPlotOptions() const override;
-  void setFBSuffixes(QStringList const &suffix) override;
 
   void setAvailableSpectra(WorkspaceIndex minimum, WorkspaceIndex maximum) override;
   void setAvailableSpectra(const std::vector<WorkspaceIndex>::const_iterator &from,
                            const std::vector<WorkspaceIndex>::const_iterator &to) override;
 
-  void newPreviewFileSelected(const MatrixWorkspace_sptr &workspace) override;
-  int getCurrentInputIndex() override;
-  MantidQt::API::FileFinderWidget *getFileFinderWidget() override;
-
   void plotInput(MatrixWorkspace_sptr inputWS, int spectrum) override;
-  void newInputFiles() override;
-  void newInputFilesFromDialog(std::vector<std::string> const &names) override;
+  void newInputDataFromDialog(std::vector<std::string> const &names) override;
   void clearPreviewFile() override;
-  void clearInputFiles() override;
   void setRunIsRunning(const bool running) override;
   void setSaveResultEnabled(const bool enabled) override;
   int getPreviewSpec() override;
   std::string getPreviewWorkspaceName(int index) const override;
   std::string getPreviewFilename(int index) const override;
   std::string getCurrentPreview() const override;
-  QStringList getInputFilenames() override;
 
   // controls for dataTable
   void clearDataTable() override;
@@ -62,7 +54,6 @@ public:
   QModelIndexList getSelectedData() override;
 
   // boolean flags for LoadHistory/GroupInput Checkboxes
-  bool isLoadHistory() override;
   bool isGroupInput() override;
 
   // getters/setters for m_properties
@@ -90,7 +81,6 @@ private slots:
   void notifyPlotPreviewClicked();
   void notifyRunClicked();
   void notifySaveClicked();
-  void notifyFilesFound();
   void notifySelectedSpectrumChanged(int);
   void notifyPreviewIndexChanged(int);
   void notifyAddWorkspaceDialog();
@@ -119,7 +109,7 @@ private:
   void setButtonsEnabled(const bool enabled);
   void setRunEnabled(const bool enabled);
   void setCell(std::unique_ptr<QTableWidgetItem> cell, int row, int column);
-  void addDataWksOrFile(MantidWidgets::IAddWorkspaceDialog const *dialog);
+  void addData(MantidWidgets::IAddWorkspaceDialog const *dialog);
 
   IElwinPresenter *m_presenter;
   QtTreePropertyBrowser *m_elwTree;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
@@ -42,7 +42,7 @@ public:
   void clearPreviewFile() override;
   void setRunIsRunning(const bool running) override;
   void setSaveResultEnabled(const bool enabled) override;
-  int getPreviewSpec() override;
+  int getPreviewSpec() const override;
   std::string getPreviewWorkspaceName(int index) const override;
   std::string getPreviewFilename(int index) const override;
   std::string getCurrentPreview() const override;
@@ -53,8 +53,8 @@ public:
   QModelIndexList getSelectedData() override;
 
   // boolean flags for LoadHistory/GroupInput Checkboxes
-  bool isGroupInput() override;
-  bool isRowCollapsed() override;
+  bool isGroupInput() const override;
+  bool isRowCollapsed() const override;
 
   // getters/setters for m_properties
   bool getNormalise() override;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/InelasticDataManipulationElwinTabView.h
@@ -55,6 +55,7 @@ public:
   // boolean flags for LoadHistory/GroupInput Checkboxes
   bool isGroupInput() const override;
   bool isRowCollapsed() const override;
+  bool isTableEmpty() const override;
 
   // getters/setters for m_properties
   bool getNormalise() override;

--- a/qt/scientific_interfaces/Inelastic/test/Common/WorkspaceUtilsTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Common/WorkspaceUtilsTest.h
@@ -109,4 +109,14 @@ public:
 
     TS_ASSERT_EQUALS(extractAxisLabels(testWorkspace, 1).size(), 0);
   }
+
+  void test_parseRunNumber_calls_with_different_inputs() {
+    std::vector<std::string> workspaces_with_run_numbers{"irs123_test", "irs280_test", "irs60"};
+    std::vector<std::string> workspaces_without_run_numbers{"irs_test", "irs213_test"};
+    std::vector<std::string> individual_workspace{"irs123_test"};
+
+    TS_ASSERT_EQUALS(parseRunNumbers(workspaces_with_run_numbers), "irs60-280_test");
+    TS_ASSERT_EQUALS(parseRunNumbers(workspaces_without_run_numbers), "irs_test");
+    TS_ASSERT_EQUALS(parseRunNumbers(individual_workspace), "irs123_test");
+  }
 };

--- a/qt/scientific_interfaces/Inelastic/test/Manipulation/InelasticDataManipulationElwinTabModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Manipulation/InelasticDataManipulationElwinTabModelTest.h
@@ -134,8 +134,10 @@ public:
 
   void test_getOutputWorkspaceNames_retrieves_correct_output_string() {
     m_model->setOutputWorkspaceNames("Workspace_name_out");
-    TS_ASSERT_EQUALS(m_model->getOutputWorkspaceNames(), "Workspace_name_out_elwin_eq,Workspace_name_out_elwin_eq2,"
-                                                         "Workspace_name_out_elwin_elf,Workspace_name_out_elwin_elt");
+    std::string stringOut1 = "Workspace_name_out_elwin_eq,Workspace_name_out_elwin_eq2,";
+    std::string stringOut2 = "Workspace_name_out_elwin_elf,Workspace_name_out_elwin_elt";
+
+    TS_ASSERT_EQUALS(m_model->getOutputWorkspaceNames(), stringOut1 + stringOut2);
   }
 
   void test_prepareOutputPrefix_calls_with_different_inputs() {

--- a/qt/scientific_interfaces/Inelastic/test/Manipulation/InelasticDataManipulationElwinTabModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Manipulation/InelasticDataManipulationElwinTabModelTest.h
@@ -132,6 +132,22 @@ public:
     TS_ASSERT(Mantid::API::AnalysisDataService::Instance().doesExist("groupedWS"));
   }
 
+  void test_getOutputWorkspaceNames_retrieves_correct_output_string() {
+    m_model->setOutputWorkspaceNames("Workspace_name_out");
+    TS_ASSERT_EQUALS(m_model->getOutputWorkspaceNames(), "Workspace_name_out_elwin_eq,Workspace_name_out_elwin_eq2,"
+                                                         "Workspace_name_out_elwin_elf,Workspace_name_out_elwin_elt");
+  }
+
+  void test_prepareOutputPrefix_calls_with_different_inputs() {
+    std::vector<std::string> workspaces_with_run_numbers{"irs123_test", "irs280_test", "irs60"};
+    std::vector<std::string> workspaces_without_run_numbers{"irs_test", "irs213_test"};
+    std::vector<std::string> individual_workspace{"irs123_test"};
+
+    TS_ASSERT_EQUALS(m_model->prepareOutputPrefix(workspaces_with_run_numbers), "irs60-280_test");
+    TS_ASSERT_EQUALS(m_model->prepareOutputPrefix(workspaces_without_run_numbers), "irs_test");
+    TS_ASSERT_EQUALS(m_model->prepareOutputPrefix(individual_workspace), "irs123_test");
+  }
+
   void test_LoadAlgorithm_set_up() {
     // The ElasticWindowMultiple algorithm is a python algorithm and so can not be called in c++ tests
 

--- a/qt/scientific_interfaces/Inelastic/test/Manipulation/InelasticDataManipulationElwinTabModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Manipulation/InelasticDataManipulationElwinTabModelTest.h
@@ -139,16 +139,6 @@ public:
                                                          "Workspace_name_out_elwin_elf,Workspace_name_out_elwin_elt");
   }
 
-  void test_prepareOutputPrefix_calls_with_different_inputs() {
-    std::vector<std::string> workspaces_with_run_numbers{"irs123_test", "irs280_test", "irs60"};
-    std::vector<std::string> workspaces_without_run_numbers{"irs_test", "irs213_test"};
-    std::vector<std::string> individual_workspace{"irs123_test"};
-
-    TS_ASSERT_EQUALS(m_model->prepareOutputPrefix(workspaces_with_run_numbers), "irs60-280_test");
-    TS_ASSERT_EQUALS(m_model->prepareOutputPrefix(workspaces_without_run_numbers), "irs_test");
-    TS_ASSERT_EQUALS(m_model->prepareOutputPrefix(individual_workspace), "irs123_test");
-  }
-
   void test_LoadAlgorithm_set_up() {
     // The ElasticWindowMultiple algorithm is a python algorithm and so can not be called in c++ tests
 

--- a/qt/scientific_interfaces/Inelastic/test/Manipulation/InelasticDataManipulationElwinTabModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Manipulation/InelasticDataManipulationElwinTabModelTest.h
@@ -127,6 +127,9 @@ public:
 
     m_model->ungroupAlgorithm("groupedWS");
     TS_ASSERT(!Mantid::API::AnalysisDataService::Instance().doesExist("groupedWS"));
+
+    m_model->groupAlgorithm(workspaceInputString, "groupedWS");
+    TS_ASSERT(Mantid::API::AnalysisDataService::Instance().doesExist("groupedWS"));
   }
 
   void test_LoadAlgorithm_set_up() {

--- a/qt/scientific_interfaces/Inelastic/test/Manipulation/InelasticDataManipulationElwinTabModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Manipulation/InelasticDataManipulationElwinTabModelTest.h
@@ -134,10 +134,9 @@ public:
 
   void test_getOutputWorkspaceNames_retrieves_correct_output_string() {
     m_model->setOutputWorkspaceNames("Workspace_name_out");
-    std::string stringOut1 = "Workspace_name_out_elwin_eq,Workspace_name_out_elwin_eq2,";
-    std::string stringOut2 = "Workspace_name_out_elwin_elf,Workspace_name_out_elwin_elt";
 
-    TS_ASSERT_EQUALS(m_model->getOutputWorkspaceNames(), stringOut1 + stringOut2);
+    TS_ASSERT_EQUALS(m_model->getOutputWorkspaceNames(), "Workspace_name_out_elwin_eq,Workspace_name_out_elwin_eq2,"
+                                                         "Workspace_name_out_elwin_elf,Workspace_name_out_elwin_elt");
   }
 
   void test_prepareOutputPrefix_calls_with_different_inputs() {


### PR DESCRIPTION
### Description of work
This PR improves the workflow and data handling in the `Elwin` tab of the `Data Manipulation` interface. It fixes issues #36372 and #36460 , and builds upon the changes done on the `Elwin` tab on #33319. 
In summary: 
- The `Files` tab of the `Elwin` interface has been removed in favour of the `Workspaces` tab, which now can load multiple workspaces at once as well as files. 
- Option to change between two modes of display in the workspace table has been added: Displaying one row per spectra per workspace, or displaying one row per workspace. It is possible to change dynamically between the two modes with a `Checkbox`. 

Additionally, I have detected other fixes that will benefit the interface: 
- Small cosmetic changes (Preview spectrum `combobox` and `spinbox` are slightly larger in size)
- Fix a bug where preview plot is not properly updated whenever spectrum selector is a `Combobox` instead of a `SpinBox`. 
- `Group Input` Checkbox has been renamed as `Group Output` and moved next to the `Run` button. Now when ticked, the input files used in `Elwin` algorithm are grouped as `IDA_Elwin_Input` and the output files are also grouped as `IDA_Elwin_Output`, while as before only the former were grouped. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36372, #36460. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

### To test:

- Build dev-docs from this branch, make sure they are no formatting issues, and follow updated test instructions. 
- On second test of test instructions, once two workspaces are added to the interface (`irs26173_...` and `irs26174_...`), test that checkbox `CollapseRows` is working as intended. When clicking on checkbox, display of workspaces changes from workspace-indexed rows to domain-indexed rows. 
- Check that when clicking `Run` with `Group Output` checkbox ticked, the resulting output workspaces are grouped. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

_Added release notes_

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
