### PR TITLE
Load instrument after sample logs in ReflectometryReductionOneLiveData

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -18,10 +18,13 @@ class LiveValue:
     approach altogether in the long run so this is sufficient for now.
     """
 
-    def __init__(self, value, unit, alternative_name):
+    LOG_TYPE_NUM_SERIES = "Number Series"
+
+    def __init__(self, value, unit, alternative_name, log_type):
         self.value = value
         self.unit = unit
         self.alternative_name = alternative_name
+        self.log_type = log_type
 
 
 class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
@@ -117,11 +120,13 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
         """Set up the workspace ready for the reduction"""
         in_ws_name = self.getPropertyValue("InputWorkspace")
         self._temp_ws_name = "__" + self.getPropertyValue("OutputWorkspace")
+        self._instrument = self.getProperty("Instrument").value
         # Set up a clone for the output because we need to do some in-place manipulations
         CloneWorkspace(InputWorkspace=in_ws_name, OutputWorkspace=self._temp_ws_name)
-        self._setup_instrument()
         liveValues = self._get_live_values_from_instrument()
         self._setup_sample_logs(liveValues)
+        # Set up the instrument after adding the sample logs in case the IDF uses any log values
+        self._setup_instrument()
         self._setup_slits(liveValues)
 
     def _setup_reduction_algorithm(self):
@@ -144,15 +149,23 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
 
     def _setup_instrument(self):
         """Sets the instrument name and loads the instrument on the workspace"""
-        self._instrument = self.getProperty("Instrument").value
         LoadInstrument(Workspace=self._temp_ws_name, RewriteSpectraMap=True, InstrumentName=self._instrument)
 
     def _setup_sample_logs(self, liveValues):
         """Set up the sample logs based on live values from the instrument"""
-        logNames = [key for key in liveValues]
-        logValues = [liveValues[key].value for key in liveValues]
-        logUnits = [liveValues[key].unit for key in liveValues]
-        AddSampleLogMultiple(Workspace=self._temp_ws_name, LogNames=logNames, LogValues=logValues, LogUnits=logUnits)
+        log_names = []
+        log_values = []
+        log_units = []
+        log_types = []
+        for key, live_values in liveValues.items():
+            log_names.append(key)
+            log_values.append(live_values.value)
+            log_units.append(live_values.unit)
+            log_types.append(live_values.log_type)
+
+        AddSampleLogMultiple(
+            Workspace=self._temp_ws_name, LogNames=log_names, LogValues=log_values, LogUnits=log_units, LogTypes=log_types, ParseType=False
+        )
 
     def _setup_slits(self, liveValues):
         """Set up instrument parameters for the slits"""
@@ -188,9 +201,9 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
     def _live_value_list(self):
         """Get the list of required live value names and their unit type"""
         liveValues = {
-            self._theta_name(): LiveValue(None, "deg", self._alternative_theta_name()),
-            self._s1vg_name(): LiveValue(None, "m", self._alternative_s1vg_name()),
-            self._s2vg_name(): LiveValue(None, "m", self._alternative_s2vg_name()),
+            self._theta_name(): LiveValue(None, "deg", self._alternative_theta_name(), LiveValue.LOG_TYPE_NUM_SERIES),
+            self._s1vg_name(): LiveValue(None, "m", self._alternative_s1vg_name(), LiveValue.LOG_TYPE_NUM_SERIES),
+            self._s2vg_name(): LiveValue(None, "m", self._alternative_s2vg_name(), LiveValue.LOG_TYPE_NUM_SERIES),
         }
         return liveValues
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -158,11 +158,11 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         workspace = self._run_algorithm_with_defaults()
         expected = [
             "CloneWorkspace",
-            "LoadInstrument",
             "GetFakeLiveInstrumentValue",
             "GetFakeLiveInstrumentValue",
             "GetFakeLiveInstrumentValue",
             "AddSampleLogMultiple",
+            "LoadInstrument",
             "SetInstrumentParameter",
             "SetInstrumentParameter",
             "ReflectometryISISLoadAndProcess",
@@ -269,11 +269,11 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         workspace = self._run_algorithm_with_zero_theta()
         expected = [
             "CloneWorkspace",
-            "LoadInstrument",
             "GetFakeLiveInstrumentValuesWithZeroTheta",
             "GetFakeLiveInstrumentValuesWithZeroTheta",
             "GetFakeLiveInstrumentValuesWithZeroTheta",
             "AddSampleLogMultiple",
+            "LoadInstrument",
             "SetInstrumentParameter",
             "SetInstrumentParameter",
             "ReflectometryISISLoadAndProcess",

--- a/docs/source/algorithms/SaveISISReflectometryORSO-v1.rst
+++ b/docs/source/algorithms/SaveISISReflectometryORSO-v1.rst
@@ -83,7 +83,7 @@ Usage
         print(myFile.readline())
 
 .. testoutput:: SaveISISReflectometryORSO_general_usage
-   :options: +NORMALIZE_WHITESPACE
+   :options: +ELLIPSIS +NORMALIZE_WHITESPACE
 
    # # ORSO reflectivity data file | ... standard | YAML encoding | https://www.reflectometry.org/
 

--- a/docs/source/algorithms/SaveISISReflectometryORSO-v1.rst
+++ b/docs/source/algorithms/SaveISISReflectometryORSO-v1.rst
@@ -85,7 +85,7 @@ Usage
 .. testoutput:: SaveISISReflectometryORSO_general_usage
    :options: +NORMALIZE_WHITESPACE
 
-   # # ORSO reflectivity data file | 1.0 standard | YAML encoding | https://www.reflectometry.org/
+   # # ORSO reflectivity data file | ... standard | YAML encoding | https://www.reflectometry.org/
 
 .. testcleanup:: SaveISISReflectometryORSO_general_usage
 


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
This PR changes `ReflectometryReductionOneLiveData` so that we load the sample logs into the live data workspace that's passed into the reduction before loading the instrument. We also load the sample logs as number series types. These changes together mean that when the instrument is loaded into the workspace the theta value can be picked up by the INTER IDF and used to calculate the correct detector pixel y positions. As a result, the detector pixel theta values are set correctly and this prevents an error when running the reduction using summation in Q (which relies on correct theta values).

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37043. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

**Report to:** Max and Becky at ISIS

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
This fixes the main problem reported on the linked issue. As noted on the issue, I intend to continue investigating why the bank summing step (i.e. the call to `ReflectometryISISSumBanks` that produces the summed segment workspace) seems to be impacting the theta value used when summing in Q. The result of this investigation shouldn't impact on this fix, though, and if a further fix is required for that it will be done under a separate issue.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
See instructions on linked issue. This time there should not be an error. Also, if you compare the theta values for the detectors (using Show Detectors) in the `TOF_live` and `TOF_summed_segment` workspaces then those in `TOF_summed_segment` should now be different.

Note that you may find you need to be plugged in on site to run live data. You will also need to have the following dependency installed in your conda environment: `conda install -c paulscherrerinstitute cachannel`. When running live data on Windows you can get a dialog popping up with an error about caRepeater, but this can be closed and ignored.

*This does not require release notes* because **it will be covered by the patch release notes**.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.