### PR TITLE
Add method to python api of instrument view

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/InstrumentViewer/New_features/37054.rst
+++ b/docs/source/release/v6.10.0/Workbench/InstrumentViewer/New_features/37054.rst
@@ -1,0 +1,1 @@
+- Added method to python API of Instrument Viewer to set maintain aspect ratio option by calling `myiv.set_maintain_aspect_ratio(False)`.

--- a/docs/source/workbench/instrumentviewer.rst
+++ b/docs/source/workbench/instrumentviewer.rst
@@ -299,6 +299,14 @@ To select the projection type (surface type), use:
                               # 4: SPHERICAL_X,   5: SPHERICAL_Y,   6: SPHERICAL_Z,
                               # 7: SideBySide
 
+To change the option to maintain aspect ratio, use:
+
+.. code-block:: python
+
+   myiv.set_maintain_aspect_ratio(False)
+
+Please note that this command is ignored when the surface type is set to 0 (Full 3D).
+
 To switch to a different viewing axis, use:
 
 .. code-block:: python

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/_instrumentview.sip
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/_instrumentview.sip
@@ -289,6 +289,17 @@ public:
              7: SideBySide
 %End
 
+  // set maintain aspect ratio
+  void setMaintainAspectRatio(int index);
+%Docstring
+    void setMaintainAspectRatio(int index)
+    ------------------------------
+    Set the maintain aspect ratio of the current window.
+
+    Args:
+      on: boolean indicating whether to turn on or off
+%End
+
   void setMinValue(double value, bool apply);
 %Docstring
     void setMinValue(double value, bool apply)

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/_instrumentview.sip
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/_instrumentview.sip
@@ -290,14 +290,14 @@ public:
 %End
 
   // set maintain aspect ratio
-  void setMaintainAspectRatio(int index);
+  void setMaintainAspectRatio(bool on);
 %Docstring
-    void setMaintainAspectRatio(int index)
+    void setMaintainAspectRatio(bool on)
     ------------------------------
-    Set the maintain aspect ratio of the current window.
+    Set the maintain aspect ratio option in the current window.
 
     Args:
-      on: boolean indicating whether to turn on or off
+      on: boolean indicating whether to turn maintain aspect ratio on or off
 %End
 
   void setMinValue(double value, bool apply);

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/api.py
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/api.py
@@ -39,6 +39,7 @@ def get_instrumentview(workspace, wait=True):
     ivp.reset_view = ivp.get_render_tab().resetView
     ivp.select_tab = ivp.container.select_tab
     ivp.select_surface_type = ivp.get_render_tab().setSurfaceType
+    ivp.set_maintain_aspect_ratio = ivp.get_render_tab().setMaintainAspectRatio
     ivp.set_auto_scaling = ivp.get_render_tab().setColorMapAutoscaling
     ivp.set_axis = ivp.get_render_tab().setAxis
     ivp.set_bin_range = safe_qthread(ivp.container.widget.setBinRange)

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -218,6 +218,7 @@ signals:
   void createDetectorTable(const QString & /*_t1*/, const std::vector<int> & /*_t2*/, bool /*_t3*/);
   void needSetIntegrationRange(double /*_t1*/, double /*_t2*/);
   void surfaceTypeChanged(int /*_t1*/);
+  void maintainAspectRatioChanged(bool /*on*/);
   void colorMapChanged();
   void colorMapMinValueChanged(double /*_t1*/);
   void colorMapMaxValueChanged(double /*_t1*/);

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetRenderTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetRenderTab.h
@@ -69,6 +69,7 @@ public slots:
   void setLegendScaleType(int /*index*/);
   void changeColorMap(const QString &filename = "", const bool highlightZeroDets = false);
   void setSurfaceType(int /*index*/);
+  void setMaintainAspectRatio(bool /*on*/);
   void flipUnwrappedView(bool /*on*/);
   void resetView();
   void saveImage(const QString &filename = "");
@@ -79,6 +80,7 @@ private slots:
   void displaySettingsAboutToshow();
   /// Change the type of the surfac
   void surfaceTypeChanged(int index);
+  void maintainAspectRatioChanged(bool on);
   void colorMapChanged();
   void scaleTypeChanged(int /*type*/);
   void nthPowerChanged(double /*nth_power*/);

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -1093,10 +1093,12 @@ void InstrumentWidget::setWireframe(bool on) {
 }
 
 void InstrumentWidget::setMaintainAspectRatio(bool on) {
-  m_maintainAspectRatio = on;
-  setSurfaceType(m_surfaceType);
-  updateInstrumentView();
-  emit maintainAspectRatioChanged(on);
+  if (m_maintainAspectRatio != on) {
+    m_maintainAspectRatio = on;
+    setSurfaceType(m_surfaceType);
+    updateInstrumentView();
+    emit maintainAspectRatioChanged(on);
+  }
 }
 
 /**

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -1096,6 +1096,7 @@ void InstrumentWidget::setMaintainAspectRatio(bool on) {
   m_maintainAspectRatio = on;
   setSurfaceType(m_surfaceType);
   updateInstrumentView();
+  emit maintainAspectRatioChanged(on);
 }
 
 /**

--- a/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
@@ -88,6 +88,7 @@ InstrumentWidgetRenderTab::~InstrumentWidgetRenderTab() = default;
 void InstrumentWidgetRenderTab::connectInstrumentWidgetSignals() const {
   // Connect to InstrumentWindow signals
   connect(m_instrWidget, SIGNAL(surfaceTypeChanged(int)), this, SLOT(surfaceTypeChanged(int)));
+  connect(m_instrWidget, SIGNAL(maintainAspectRatioChanged(bool)), this, SLOT(maintainAspectRatioChanged(bool)));
   connect(m_instrWidget, SIGNAL(colorMapChanged()), this, SLOT(colorMapChanged()));
   connect(m_instrWidget, SIGNAL(colorMapMaxValueChanged(double)), this, SLOT(setMaxValue(double)));
   connect(m_instrWidget, SIGNAL(colorMapMinValueChanged(double)), this, SLOT(setMinValue(double)));
@@ -187,7 +188,7 @@ QPushButton *InstrumentWidgetRenderTab::setupDisplaySettings() {
   m_maintainAspectRatio = new QAction("Maintain Aspect Ratio", this);
   m_maintainAspectRatio->setCheckable(true);
   m_maintainAspectRatio->setChecked(true);
-  connect(m_maintainAspectRatio, SIGNAL(toggled(bool)), m_instrWidget, SLOT(setMaintainAspectRatio(bool)));
+  connect(m_maintainAspectRatio, SIGNAL(toggled(bool)), this, SLOT(setMaintainAspectRatio(bool)));
   m_tooltipInfo = new QAction("Tooltip", this);
   m_tooltipInfo->setToolTip("Show detector info in a tooltip when hovering.");
   m_tooltipInfo->setCheckable(true);
@@ -741,6 +742,16 @@ void InstrumentWidgetRenderTab::setSurfaceType(int index) {
 }
 
 /**
+ * Set to maintain aspect ratio.
+ * @param on:: Whether or not to maintain aspect ratio.
+ */
+void InstrumentWidgetRenderTab::setMaintainAspectRatio(bool on) {
+  if (m_instrWidget->getSurfaceType() != InstrumentWidget::FULL3D) {
+    m_instrWidget->setMaintainAspectRatio(on);
+  }
+}
+
+/**
  * Respond to surface change from script.
  * @param index :: Index selected in the surface type combo box.
  */
@@ -755,6 +766,16 @@ void InstrumentWidgetRenderTab::surfaceTypeChanged(int index) {
     action->setChecked(true);
   }
   showOrHideBoxes(index);
+}
+
+/**
+ * Respond to change to maintain aspect ratio from script.
+ * @param on :: Boolean to turn aspect ratio on or off.
+ */
+void InstrumentWidgetRenderTab::maintainAspectRatioChanged(bool on) {
+  if (m_maintainAspectRatio->isChecked() != on) {
+    m_maintainAspectRatio->setChecked(on);
+  }
 }
 
 /**

--- a/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
@@ -27,6 +27,7 @@
 #include <QVBoxLayout>
 
 #include "MantidKernel/ConfigService.h"
+#include "MantidKernel/Logger.h"
 #include "MantidQtWidgets/InstrumentView/BinDialog.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidget.h"
 
@@ -34,6 +35,9 @@
 #include <utility>
 
 namespace MantidQt::MantidWidgets {
+
+Mantid::Kernel::Logger g_log("InstrumentWidgetRenderTab");
+
 // QSettings entry names
 const char *EntryManualUCorrection = "ManualUCorrection";
 const char *EntryUCorrectionMin = "UCorrectionMin";
@@ -746,7 +750,9 @@ void InstrumentWidgetRenderTab::setSurfaceType(int index) {
  * @param on:: Whether or not to maintain aspect ratio.
  */
 void InstrumentWidgetRenderTab::setMaintainAspectRatio(bool on) {
-  if (m_instrWidget->getSurfaceType() != InstrumentWidget::FULL3D) {
+  if (m_instrWidget->getSurfaceType() == InstrumentWidget::FULL3D) {
+    g_log.warning("Instruction to set maintain aspect ratio was ignored because the surface type is 'Full 3D'");
+  } else {
     m_instrWidget->setMaintainAspectRatio(on);
   }
 }

--- a/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
@@ -746,18 +746,6 @@ void InstrumentWidgetRenderTab::setSurfaceType(int index) {
 }
 
 /**
- * Set to maintain aspect ratio.
- * @param on:: Whether or not to maintain aspect ratio.
- */
-void InstrumentWidgetRenderTab::setMaintainAspectRatio(bool on) {
-  if (m_instrWidget->getSurfaceType() == InstrumentWidget::FULL3D) {
-    g_log.warning("Instruction to set maintain aspect ratio was ignored because the surface type is 'Full 3D'");
-  } else {
-    m_instrWidget->setMaintainAspectRatio(on);
-  }
-}
-
-/**
  * Respond to surface change from script.
  * @param index :: Index selected in the surface type combo box.
  */
@@ -775,8 +763,20 @@ void InstrumentWidgetRenderTab::surfaceTypeChanged(int index) {
 }
 
 /**
+ * Set to maintain aspect ratio.
+ * @param on:: Boolean to turn maintain aspect ratio on or off.
+ */
+void InstrumentWidgetRenderTab::setMaintainAspectRatio(bool on) {
+  if (m_instrWidget->getSurfaceType() == InstrumentWidget::FULL3D) {
+    g_log.warning("Method to set maintain aspect ratio was ignored because the surface type is 'Full 3D'");
+  } else {
+    m_instrWidget->setMaintainAspectRatio(on);
+  }
+}
+
+/**
  * Respond to change to maintain aspect ratio from script.
- * @param on :: Boolean to turn aspect ratio on or off.
+ * @param on :: Boolean to turn maintain aspect ratio on or off.
  */
 void InstrumentWidgetRenderTab::maintainAspectRatioChanged(bool on) {
   if (m_maintainAspectRatio->isChecked() != on) {


### PR DESCRIPTION
### Description of work
Added method `set_maintain_aspect_ratio` to api of instrument view.

#### Summary of work
Looked at how other methods are set, e.g. `set_surface_type` and followed the same pattern in the code.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36990 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
- Most of the changes are boilerplate
- Needed to initialize g_log in the `InstrumentWidgetRenderTab.cpp` file
- The argument of `setMaintainAspectRatio()` is `on` to be consistent with all the other functions in that region of code

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Run the following script:
```python
from mantidqt.widgets.instrumentview.api import get_instrumentview

ws = LoadNexus(Filename="INTER45455.nxs")
myiv = get_instrumentview(ws)
myiv.show_view()

myiv.select_surface_type(1)

myiv.set_maintain_aspect_ratio(False)
``` 

and check that in the GUI Display Settings > Maintain Aspect Ratio is unchecked.
- Change the argument from False to True
- Highlight the line (double click with the mouse) to set aspect ratio and click run
- Should visually see the size of the boxes change
- Check that in the GUI Display Settings > Maintain Aspect Ratio is checked.
- Now change the argument of surface type from 1 to 0
- Highlight the line for changing surface type and click run
- Surface type should have changed to 'Full 3D'
- Now highlight line to set maintain aspect ratio and click run
- A warning should be displayed saying that aspect ratio option was ignored.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
