### PR TITLE
Better organise CMakeLists in Indirect/Inelastic interface categories

### DIFF
--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -10,11 +10,6 @@ set(ALL_SRC_FILES
     Reduction/ISISEnergyTransferView.cpp
     Reduction/ISISEnergyTransferPresenter.cpp
     Reduction/ReductionAlgorithmUtils.cpp
-    Simulation/DensityOfStates.cpp
-    Simulation/IndirectMolDyn.cpp
-    Simulation/IndirectSassena.cpp
-    Simulation/IndirectSimulation.cpp
-    Simulation/IndirectSimulationTab.cpp
 )
 
 set(ALL_MOC_FILES
@@ -26,11 +21,6 @@ set(ALL_MOC_FILES
     Reduction/ISISDiagnostics.h
     Reduction/ISISEnergyTransferView.h
     Reduction/ISISEnergyTransferPresenter.h
-    Simulation/DensityOfStates.h
-    Simulation/IndirectMolDyn.h
-    Simulation/IndirectSassena.h
-    Simulation/IndirectSimulation.h
-    Simulation/IndirectSimulationTab.h
 )
 
 set(ALL_INC_FILES
@@ -38,23 +28,15 @@ set(ALL_INC_FILES
     Reduction/ISISEnergyTransferModelUtils.h Reduction/ISISEnergyTransferModel.h Reduction/ReductionAlgorithmUtils.h
 )
 
-set(ALL_UI_FILES
-    Reduction/IndirectDataReduction.ui
-    Reduction/IndirectTransmission.ui
-    Reduction/ILLEnergyTransfer.ui
-    Reduction/ISISCalibration.ui
-    Reduction/ISISDiagnostics.ui
-    Reduction/ISISEnergyTransfer.ui
-    Simulation/DensityOfStates.ui
-    Simulation/IndirectMolDyn.ui
-    Simulation/IndirectSassena.ui
-    Simulation/IndirectSimulation.ui
+set(ALL_UI_FILES Reduction/IndirectDataReduction.ui Reduction/IndirectTransmission.ui Reduction/ILLEnergyTransfer.ui
+                 Reduction/ISISCalibration.ui Reduction/ISISDiagnostics.ui Reduction/ISISEnergyTransfer.ui
 )
 
 set(ALL_RES_FILES ../Inelastic/Common/InterfaceResources.qrc)
 
 add_subdirectory(Common)
 add_subdirectory(Diffraction)
+add_subdirectory(Simulation)
 add_subdirectory(Tools)
 
 # XML is required to parse the settings file

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -1,6 +1,4 @@
-set(SRC_FILES
-    Common/DetectorGroupingOptions.cpp
-    Common/IndirectInstrumentConfig.cpp
+set(ALL_SRC_FILES
     Diffraction/IndirectDiffractionReduction.cpp
     Reduction/IndirectDataReduction.cpp
     Reduction/IndirectDataReductionTab.cpp
@@ -23,9 +21,7 @@ set(SRC_FILES
     Tools/IndirectTransmissionCalc.cpp
 )
 
-set(MOC_FILES
-    Common/DetectorGroupingOptions.h
-    Common/IndirectInstrumentConfig.h
+set(ALL_MOC_FILES
     Diffraction/IndirectDiffractionReduction.h
     Reduction/IndirectDataReduction.h
     Reduction/IndirectDataReductionTab.h
@@ -45,14 +41,12 @@ set(MOC_FILES
     Tools/IndirectTransmissionCalc.h
 )
 
-set(INC_FILES
+set(ALL_INC_FILES
     DllConfig.h Reduction/ISISEnergyTransferData.h Reduction/ISISEnergyTransferValidator.h
     Reduction/ISISEnergyTransferModelUtils.h Reduction/ISISEnergyTransferModel.h Reduction/ReductionAlgorithmUtils.h
 )
 
-set(UI_FILES
-    Common/DetectorGroupingOptions.ui
-    Common/IndirectInstrumentConfig.ui
+set(ALL_UI_FILES
     Diffraction/IndirectDiffractionReduction.ui
     Reduction/IndirectDataReduction.ui
     Reduction/IndirectTransmission.ui
@@ -68,7 +62,9 @@ set(UI_FILES
     Tools/IndirectTransmissionCalc.ui
 )
 
-set(RES_FILES ../Inelastic/Common/InterfaceResources.qrc)
+set(ALL_RES_FILES ../Inelastic/Common/InterfaceResources.qrc)
+
+add_subdirectory(Common)
 
 # XML is required to parse the settings file
 find_package(
@@ -80,11 +76,11 @@ find_package(
 mtd_add_qt_library(
   TARGET_NAME MantidScientificInterfacesIndirect
   QT_VERSION 5
-  SRC ${SRC_FILES}
-  MOC ${MOC_FILES}
-  NOMOC ${INC_FILES}
-  UI ${UI_FILES}
-  RES ${RES_FILES}
+  SRC ${ALL_SRC_FILES}
+  MOC ${ALL_MOC_FILES}
+  NOMOC ${ALL_INC_FILES}
+  UI ${ALL_UI_FILES}
+  RES ${ALL_RES_FILES}
   DEFS IN_MANTIDQT_INDIRECT PRECOMPILED PrecompiledHeader.h
   INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
   LINK_LIBS ${CORE_MANTIDLIBS}

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -15,9 +15,6 @@ set(ALL_SRC_FILES
     Simulation/IndirectSassena.cpp
     Simulation/IndirectSimulation.cpp
     Simulation/IndirectSimulationTab.cpp
-    Tools/IndirectTools.cpp
-    Tools/IndirectToolsTab.cpp
-    Tools/IndirectTransmissionCalc.cpp
 )
 
 set(ALL_MOC_FILES
@@ -34,9 +31,6 @@ set(ALL_MOC_FILES
     Simulation/IndirectSassena.h
     Simulation/IndirectSimulation.h
     Simulation/IndirectSimulationTab.h
-    Tools/IndirectTools.h
-    Tools/IndirectToolsTab.h
-    Tools/IndirectTransmissionCalc.h
 )
 
 set(ALL_INC_FILES
@@ -55,14 +49,13 @@ set(ALL_UI_FILES
     Simulation/IndirectMolDyn.ui
     Simulation/IndirectSassena.ui
     Simulation/IndirectSimulation.ui
-    Tools/IndirectTools.ui
-    Tools/IndirectTransmissionCalc.ui
 )
 
 set(ALL_RES_FILES ../Inelastic/Common/InterfaceResources.qrc)
 
 add_subdirectory(Common)
 add_subdirectory(Diffraction)
+add_subdirectory(Tools)
 
 # XML is required to parse the settings file
 find_package(

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(ALL_SRC_FILES
-    Diffraction/IndirectDiffractionReduction.cpp
     Reduction/IndirectDataReduction.cpp
     Reduction/IndirectDataReductionTab.cpp
     Reduction/IndirectTransmission.cpp
@@ -22,7 +21,6 @@ set(ALL_SRC_FILES
 )
 
 set(ALL_MOC_FILES
-    Diffraction/IndirectDiffractionReduction.h
     Reduction/IndirectDataReduction.h
     Reduction/IndirectDataReductionTab.h
     Reduction/IndirectTransmission.h
@@ -47,7 +45,6 @@ set(ALL_INC_FILES
 )
 
 set(ALL_UI_FILES
-    Diffraction/IndirectDiffractionReduction.ui
     Reduction/IndirectDataReduction.ui
     Reduction/IndirectTransmission.ui
     Reduction/ILLEnergyTransfer.ui
@@ -65,6 +62,7 @@ set(ALL_UI_FILES
 set(ALL_RES_FILES ../Inelastic/Common/InterfaceResources.qrc)
 
 add_subdirectory(Common)
+add_subdirectory(Diffraction)
 
 # XML is required to parse the settings file
 find_package(

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -1,41 +1,12 @@
-set(ALL_SRC_FILES
-    Reduction/IndirectDataReduction.cpp
-    Reduction/IndirectDataReductionTab.cpp
-    Reduction/IndirectTransmission.cpp
-    Reduction/ILLEnergyTransfer.cpp
-    Reduction/ISISCalibration.cpp
-    Reduction/ISISDiagnostics.cpp
-    Reduction/ISISEnergyTransferValidator.cpp
-    Reduction/ISISEnergyTransferModel.cpp
-    Reduction/ISISEnergyTransferView.cpp
-    Reduction/ISISEnergyTransferPresenter.cpp
-    Reduction/ReductionAlgorithmUtils.cpp
-)
-
-set(ALL_MOC_FILES
-    Reduction/IndirectDataReduction.h
-    Reduction/IndirectDataReductionTab.h
-    Reduction/IndirectTransmission.h
-    Reduction/ILLEnergyTransfer.h
-    Reduction/ISISCalibration.h
-    Reduction/ISISDiagnostics.h
-    Reduction/ISISEnergyTransferView.h
-    Reduction/ISISEnergyTransferPresenter.h
-)
-
-set(ALL_INC_FILES
-    DllConfig.h Reduction/ISISEnergyTransferData.h Reduction/ISISEnergyTransferValidator.h
-    Reduction/ISISEnergyTransferModelUtils.h Reduction/ISISEnergyTransferModel.h Reduction/ReductionAlgorithmUtils.h
-)
-
-set(ALL_UI_FILES Reduction/IndirectDataReduction.ui Reduction/IndirectTransmission.ui Reduction/ILLEnergyTransfer.ui
-                 Reduction/ISISCalibration.ui Reduction/ISISDiagnostics.ui Reduction/ISISEnergyTransfer.ui
-)
-
+set(ALL_SRC_FILES)
+set(ALL_MOC_FILES)
+set(ALL_INC_FILES DllConfig.h PrecompiledHeader.h)
+set(ALL_UI_FILES)
 set(ALL_RES_FILES ../Inelastic/Common/InterfaceResources.qrc)
 
 add_subdirectory(Common)
 add_subdirectory(Diffraction)
+add_subdirectory(Reduction)
 add_subdirectory(Simulation)
 add_subdirectory(Tools)
 

--- a/qt/scientific_interfaces/Indirect/Common/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/Common/CMakeLists.txt
@@ -1,0 +1,24 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(SRC_FILES DetectorGroupingOptions.cpp IndirectInstrumentConfig.cpp)
+
+set(MOC_FILES DetectorGroupingOptions.h IndirectInstrumentConfig.h)
+
+set(UI_FILES DetectorGroupingOptions.ui IndirectInstrumentConfig.ui)
+
+list(TRANSFORM SRC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM MOC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM UI_FILES PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_SRC_FILES
+    ${ALL_SRC_FILES} ${SRC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_MOC_FILES
+    ${ALL_MOC_FILES} ${MOC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_UI_FILES
+    ${ALL_UI_FILES} ${UI_FILES}
+    PARENT_SCOPE
+)

--- a/qt/scientific_interfaces/Indirect/Diffraction/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/Diffraction/CMakeLists.txt
@@ -1,0 +1,24 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(SRC_FILES IndirectDiffractionReduction.cpp)
+
+set(MOC_FILES IndirectDiffractionReduction.h)
+
+set(UI_FILES IndirectDiffractionReduction.ui)
+
+list(TRANSFORM SRC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM MOC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM UI_FILES PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_SRC_FILES
+    ${ALL_SRC_FILES} ${SRC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_MOC_FILES
+    ${ALL_MOC_FILES} ${MOC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_UI_FILES
+    ${ALL_UI_FILES} ${UI_FILES}
+    PARENT_SCOPE
+)

--- a/qt/scientific_interfaces/Indirect/Reduction/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/Reduction/CMakeLists.txt
@@ -1,0 +1,56 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(SRC_FILES
+    IndirectDataReduction.cpp
+    IndirectDataReductionTab.cpp
+    IndirectTransmission.cpp
+    ILLEnergyTransfer.cpp
+    ISISCalibration.cpp
+    ISISDiagnostics.cpp
+    ISISEnergyTransferValidator.cpp
+    ISISEnergyTransferModel.cpp
+    ISISEnergyTransferView.cpp
+    ISISEnergyTransferPresenter.cpp
+    ReductionAlgorithmUtils.cpp
+)
+
+set(INC_FILES ISISEnergyTransferData.h ISISEnergyTransferValidator.h ISISEnergyTransferModelUtils.h
+              ISISEnergyTransferModel.h ReductionAlgorithmUtils.h
+)
+
+set(MOC_FILES
+    IndirectDataReduction.h
+    IndirectDataReductionTab.h
+    IndirectTransmission.h
+    ILLEnergyTransfer.h
+    ISISCalibration.h
+    ISISDiagnostics.h
+    ISISEnergyTransferView.h
+    ISISEnergyTransferPresenter.h
+)
+
+set(UI_FILES IndirectDataReduction.ui IndirectTransmission.ui ILLEnergyTransfer.ui ISISCalibration.ui
+             ISISDiagnostics.ui ISISEnergyTransfer.ui
+)
+
+list(TRANSFORM SRC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM INC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM MOC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM UI_FILES PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_SRC_FILES
+    ${ALL_SRC_FILES} ${SRC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_INC_FILES
+    ${ALL_INC_FILES} ${INC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_MOC_FILES
+    ${ALL_MOC_FILES} ${MOC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_UI_FILES
+    ${ALL_UI_FILES} ${UI_FILES}
+    PARENT_SCOPE
+)

--- a/qt/scientific_interfaces/Indirect/Simulation/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/Simulation/CMakeLists.txt
@@ -1,0 +1,26 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(SRC_FILES DensityOfStates.cpp IndirectMolDyn.cpp IndirectSassena.cpp IndirectSimulation.cpp
+              IndirectSimulationTab.cpp
+)
+
+set(MOC_FILES DensityOfStates.h IndirectMolDyn.h IndirectSassena.h IndirectSimulation.h IndirectSimulationTab.h)
+
+set(UI_FILES DensityOfStates.ui IndirectMolDyn.ui IndirectSassena.ui IndirectSimulation.ui)
+
+list(TRANSFORM SRC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM MOC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM UI_FILES PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_SRC_FILES
+    ${ALL_SRC_FILES} ${SRC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_MOC_FILES
+    ${ALL_MOC_FILES} ${MOC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_UI_FILES
+    ${ALL_UI_FILES} ${UI_FILES}
+    PARENT_SCOPE
+)

--- a/qt/scientific_interfaces/Indirect/Tools/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/Tools/CMakeLists.txt
@@ -1,0 +1,24 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(SRC_FILES IndirectTools.cpp IndirectToolsTab.cpp IndirectTransmissionCalc.cpp)
+
+set(MOC_FILES IndirectTools.h IndirectToolsTab.h IndirectTransmissionCalc.h)
+
+set(UI_FILES IndirectTools.ui IndirectTransmissionCalc.ui)
+
+list(TRANSFORM SRC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM MOC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM UI_FILES PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_SRC_FILES
+    ${ALL_SRC_FILES} ${SRC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_MOC_FILES
+    ${ALL_MOC_FILES} ${MOC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_UI_FILES
+    ${ALL_UI_FILES} ${UI_FILES}
+    PARENT_SCOPE
+)

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -1,14 +1,13 @@
-# Testing
-set(TEST_FILES Reduction/ISISEnergyTransferModelTest.h Reduction/ISISEnergyTransferModelUtilsTest.h
-               Reduction/ReductionAlgorithmUtilsTest.h
-)
+set(ALL_TEST_FILES)
+
+add_subdirectory(Reduction)
 
 set(CXXTEST_EXTRA_HEADER_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/InterfacesIndirectTestInitialization.h)
 
 mtd_add_qt_tests(
   TARGET_NAME MantidQtInterfacesIndirectTest
   QT_VERSION 5
-  SRC ${TEST_FILES}
+  SRC ${ALL_TEST_FILES}
   INCLUDE_DIRS ../../../../Framework/DataObjects/inc ../
   LINK_LIBS ${CORE_MANTIDLIBS}
             Mantid::DataObjects

--- a/qt/scientific_interfaces/Indirect/test/Reduction/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/Reduction/CMakeLists.txt
@@ -1,0 +1,10 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(TEST_FILES ISISEnergyTransferModelTest.h ISISEnergyTransferModelUtilsTest.h ReductionAlgorithmUtilsTest.h)
+
+list(TRANSFORM TEST_FILES PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_TEST_FILES
+    ${ALL_TEST_FILES} ${TEST_FILES}
+    PARENT_SCOPE
+)

--- a/qt/scientific_interfaces/Inelastic/Analysis/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/Analysis/CMakeLists.txt
@@ -1,0 +1,145 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(SRC_FILES
+    ConvFitAddWorkspaceDialog.cpp
+    ConvFitModel.cpp
+    ConvFitDataView.cpp
+    ConvFitDataPresenter.cpp
+    DataAnalysis.cpp
+    DataAnalysisTab.cpp
+    DataAnalysisTabFactory.cpp
+    DockWidgetArea.cpp
+    EditResultsDialog.cpp
+    FitStatusWidget.cpp
+    FitData.cpp
+    FitDataModel.cpp
+    FitDataPresenter.cpp
+    FitDataView.cpp
+    FitOutput.cpp
+    FitOutputOptionsModel.cpp
+    FitOutputOptionsPresenter.cpp
+    FitOutputOptionsView.cpp
+    FitPlotModel.cpp
+    FitPlotPresenter.cpp
+    FitPlotView.cpp
+    FittingModel.cpp
+    FqFitAddWorkspaceDialog.cpp
+    FqFitDataPresenter.cpp
+    FqFitDataView.cpp
+    FqFitModel.cpp
+    FunctionBrowser/ConvFunctionTemplateModel.cpp
+    FunctionBrowser/FitTypes.cpp
+    FunctionBrowser/FunctionTemplateView.cpp
+    FunctionBrowser/FunctionTemplatePresenter.cpp
+    FunctionBrowser/FqFunctionModel.cpp
+    FunctionBrowser/IqtFunctionTemplateModel.cpp
+    FunctionBrowser/IqtFunctionTemplateView.cpp
+    FunctionBrowser/IqtTemplatePresenter.cpp
+    FunctionBrowser/MSDFunctionModel.cpp
+    FunctionBrowser/SingleFunctionTemplateModel.cpp
+    FunctionBrowser/SingleFunctionTemplateView.cpp
+    FunctionBrowser/SingleFunctionTemplatePresenter.cpp
+    FunctionBrowser/MultiFunctionTemplateModel.cpp
+    FunctionBrowser/MultiFunctionTemplatePresenter.cpp
+    FunctionBrowser/MultiFunctionTemplateView.cpp
+    IDAFunctionParameterEstimation.cpp
+    InelasticFitPropertyBrowser.cpp
+    IqtFitModel.cpp
+    MSDFitModel.cpp
+)
+
+set(INC_FILES
+    ConvFitDataPresenter.h
+    ConvFitModel.h
+    DataAnalysisTabFactory.h
+    FitData.h
+    FitDataModel.h
+    FitDataPresenter.h
+    FitOutput.h
+    FitOutputOptionsModel.h
+    FitOutputOptionsPresenter.h
+    FitPlotModel.h
+    FitPlotPresenter.h
+    FittingModel.h
+    FitTabConstants.h
+    FqFitDataPresenter.h
+    FqFitModel.h
+    FunctionBrowser/ConvFunctionTemplateModel.h
+    FunctionBrowser/FitTypes.h
+    FunctionBrowser/FunctionTemplatePresenter.h
+    FunctionBrowser/FqFunctionModel.h
+    FunctionBrowser/ITemplatePresenter.h
+    FunctionBrowser/IqtFunctionTemplateModel.h
+    FunctionBrowser/IqtTemplatePresenter.h
+    FunctionBrowser/MSDFunctionModel.h
+    FunctionBrowser/ParamID.h
+    FunctionBrowser/SingleFunctionTemplatePresenter.h
+    FunctionBrowser/MultiFunctionTemplateModel.h
+    FunctionBrowser/MultiFunctionTemplatePresenter.h
+    FunctionBrowser/TemplateSubType.h
+    IDAFunctionParameterEstimation.h
+    IFitDataModel.h
+    IFitDataView.h
+    IFitOutput.h
+    IFitOutputOptionsModel.h
+    IFitOutputOptionsView.h
+    IFitPlotView.h
+    IFittingModel.h
+    IqtFitModel.h
+    MSDFitModel.h
+    ParameterEstimation.h
+)
+
+set(MOC_FILES
+    ConvFitAddWorkspaceDialog.h
+    ConvFitDataView.h
+    DataAnalysis.h
+    DataAnalysisTab.h
+    DockWidgetArea.h
+    EditResultsDialog.h
+    FqFitAddWorkspaceDialog.h
+    FqFitDataView.h
+    FitStatusWidget.h
+    FitDataView.h
+    FitOutputOptionsView.h
+    FitPlotView.h
+    FunctionBrowser/FunctionTemplateView.h
+    FunctionBrowser/IqtFunctionTemplateView.h
+    FunctionBrowser/SingleFunctionTemplateView.h
+    FunctionBrowser/MultiFunctionTemplateView.h
+    InelasticFitPropertyBrowser.h
+)
+
+set(UI_FILES
+    ConvFitAddWorkspaceDialog.ui
+    DataAnalysis.ui
+    EditResultsDialog.ui
+    FitDataView.ui
+    FitPreviewPlot.ui
+    FitOutputOptions.ui
+    FitTab.ui
+    FqFitAddWorkspaceDialog.ui
+    SpectrumSelector.ui
+)
+
+list(TRANSFORM SRC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM INC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM MOC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM UI_FILES PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_SRC_FILES
+    ${ALL_SRC_FILES} ${SRC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_INC_FILES
+    ${ALL_INC_FILES} ${INC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_MOC_FILES
+    ${ALL_MOC_FILES} ${MOC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_UI_FILES
+    ${ALL_UI_FILES} ${UI_FILES}
+    PARENT_SCOPE
+)

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/CMakeLists.txt
@@ -1,0 +1,24 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(SRC_FILES BayesFitting.cpp BayesFittingTab.cpp Quasi.cpp ResNorm.cpp Stretch.cpp)
+
+set(MOC_FILES BayesFitting.h BayesFittingTab.h Quasi.h ResNorm.h Stretch.h)
+
+set(UI_FILES BayesFitting.ui Quasi.ui ResNorm.ui Stretch.ui)
+
+list(TRANSFORM SRC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM MOC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM UI_FILES PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_SRC_FILES
+    ${ALL_SRC_FILES} ${SRC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_MOC_FILES
+    ${ALL_MOC_FILES} ${MOC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_UI_FILES
+    ${ALL_UI_FILES} ${UI_FILES}
+    PARENT_SCOPE
+)

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -44,23 +44,6 @@ set(ALL_SRC_FILES
     Analysis/FunctionBrowser/MultiFunctionTemplateModel.cpp
     Analysis/FunctionBrowser/MultiFunctionTemplateView.cpp
     Analysis/FunctionBrowser/MultiFunctionTemplatePresenter.cpp
-    Manipulation/InelasticDataManipulation.cpp
-    Manipulation/InelasticDataManipulationElwinTab.cpp
-    Manipulation/InelasticDataManipulationElwinTabModel.cpp
-    Manipulation/InelasticDataManipulationElwinTabView.cpp
-    Manipulation/InelasticDataManipulationIqtTab.cpp
-    Manipulation/InelasticDataManipulationIqtTabView.cpp
-    Manipulation/InelasticDataManipulationIqtTabModel.cpp
-    Manipulation/InelasticDataManipulationMomentsTab.cpp
-    Manipulation/InelasticDataManipulationMomentsTabModel.cpp
-    Manipulation/InelasticDataManipulationMomentsTabView.cpp
-    Manipulation/InelasticDataManipulationTab.cpp
-    Manipulation/InelasticDataManipulationSqwTab.cpp
-    Manipulation/InelasticDataManipulationSqwTabModel.cpp
-    Manipulation/InelasticDataManipulationSqwTabView.cpp
-    Manipulation/InelasticDataManipulationSymmetriseTab.cpp
-    Manipulation/InelasticDataManipulationSymmetriseTabView.cpp
-    Manipulation/InelasticDataManipulationSymmetriseTabModel.cpp
 )
 
 set(ALL_MOC_FILES
@@ -81,13 +64,6 @@ set(ALL_MOC_FILES
     Analysis/FunctionBrowser/IqtFunctionTemplateView.h
     Analysis/FunctionBrowser/SingleFunctionTemplateView.h
     Analysis/FunctionBrowser/MultiFunctionTemplateView.h
-    Manipulation/InelasticDataManipulation.h
-    Manipulation/InelasticDataManipulationElwinTabView.h
-    Manipulation/InelasticDataManipulationIqtTabView.h
-    Manipulation/InelasticDataManipulationMomentsTabView.h
-    Manipulation/InelasticDataManipulationSqwTabView.h
-    Manipulation/InelasticDataManipulationSymmetriseTabView.h
-    Manipulation/InelasticDataManipulationTab.h
 )
 
 set(ALL_INC_FILES
@@ -131,21 +107,6 @@ set(ALL_INC_FILES
     Analysis/FunctionBrowser/MultiFunctionTemplateModel.h
     Analysis/FunctionBrowser/MultiFunctionTemplatePresenter.h
     Analysis/FunctionBrowser/TemplateSubType.h
-    Manipulation/InelasticDataManipulationElwinTabModel.h
-    Manipulation/InelasticDataManipulationElwinTab.h
-    Manipulation/InelasticDataManipulationIqtTabModel.h
-    Manipulation/InelasticDataManipulationIqtTab.h
-    Manipulation/InelasticDataManipulationMomentsTabModel.h
-    Manipulation/InelasticDataManipulationMomentsTab.h
-    Manipulation/InelasticDataManipulationSqwTabModel.h
-    Manipulation/InelasticDataManipulationSqwTab.h
-    Manipulation/InelasticDataManipulationSymmetriseTabModel.h
-    Manipulation/InelasticDataManipulationSymmetriseTab.h
-    Manipulation/ISqwView.h
-    Manipulation/IMomentsView.h
-    Manipulation/ISymmetriseView.h
-    Manipulation/IElwinView.h
-    Manipulation/IIqtView.h
 )
 
 set(ALL_UI_FILES
@@ -158,12 +119,6 @@ set(ALL_UI_FILES
     Analysis/FitOutputOptions.ui
     Analysis/FitTab.ui
     Analysis/SpectrumSelector.ui
-    Manipulation/InelasticDataManipulation.ui
-    Manipulation/InelasticDataManipulationElwinTab.ui
-    Manipulation/InelasticDataManipulationIqtTab.ui
-    Manipulation/InelasticDataManipulationMomentsTab.ui
-    Manipulation/InelasticDataManipulationSqwTab.ui
-    Manipulation/InelasticDataManipulationSymmetriseTab.ui
 )
 
 set(RES_FILES Common/InterfaceResources.qrc)
@@ -171,6 +126,7 @@ set(RES_FILES Common/InterfaceResources.qrc)
 add_subdirectory(BayesFitting)
 add_subdirectory(Common)
 add_subdirectory(Corrections)
+add_subdirectory(Manipulation)
 
 # XML is required to parse the settings file
 find_package(

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -1,128 +1,10 @@
-set(ALL_SRC_FILES
-    Analysis/ConvFitAddWorkspaceDialog.cpp
-    Analysis/ConvFitModel.cpp
-    Analysis/ConvFitDataView.cpp
-    Analysis/ConvFitDataPresenter.cpp
-    Analysis/DataAnalysis.cpp
-    Analysis/DataAnalysisTab.cpp
-    Analysis/DataAnalysisTabFactory.cpp
-    Analysis/DockWidgetArea.cpp
-    Analysis/EditResultsDialog.cpp
-    Analysis/FitStatusWidget.cpp
-    Analysis/FitData.cpp
-    Analysis/FitDataModel.cpp
-    Analysis/FitDataPresenter.cpp
-    Analysis/FitDataView.cpp
-    Analysis/FitOutput.cpp
-    Analysis/FitOutputOptionsModel.cpp
-    Analysis/FitOutputOptionsPresenter.cpp
-    Analysis/FitOutputOptionsView.cpp
-    Analysis/FitPlotModel.cpp
-    Analysis/FitPlotPresenter.cpp
-    Analysis/FitPlotView.cpp
-    Analysis/InelasticFitPropertyBrowser.cpp
-    Analysis/FittingModel.cpp
-    Analysis/FqFitAddWorkspaceDialog.cpp
-    Analysis/FqFitDataPresenter.cpp
-    Analysis/FqFitDataView.cpp
-    Analysis/FqFitModel.cpp
-    Analysis/IqtFitModel.cpp
-    Analysis/MSDFitModel.cpp
-    Analysis/IDAFunctionParameterEstimation.cpp
-    Analysis/FunctionBrowser/ConvFunctionTemplateModel.cpp
-    Analysis/FunctionBrowser/FitTypes.cpp
-    Analysis/FunctionBrowser/FunctionTemplateView.cpp
-    Analysis/FunctionBrowser/FunctionTemplatePresenter.cpp
-    Analysis/FunctionBrowser/FqFunctionModel.cpp
-    Analysis/FunctionBrowser/IqtFunctionTemplateModel.cpp
-    Analysis/FunctionBrowser/IqtFunctionTemplateView.cpp
-    Analysis/FunctionBrowser/IqtTemplatePresenter.cpp
-    Analysis/FunctionBrowser/MSDFunctionModel.cpp
-    Analysis/FunctionBrowser/SingleFunctionTemplateModel.cpp
-    Analysis/FunctionBrowser/SingleFunctionTemplateView.cpp
-    Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.cpp
-    Analysis/FunctionBrowser/MultiFunctionTemplateModel.cpp
-    Analysis/FunctionBrowser/MultiFunctionTemplateView.cpp
-    Analysis/FunctionBrowser/MultiFunctionTemplatePresenter.cpp
-)
+set(ALL_SRC_FILES)
+set(ALL_MOC_FILES)
+set(ALL_INC_FILES DllConfig.h PrecompiledHeader.h)
+set(ALL_UI_FILES)
+set(ALL_RES_FILES Common/InterfaceResources.qrc)
 
-set(ALL_MOC_FILES
-    Analysis/ConvFitAddWorkspaceDialog.h
-    Analysis/ConvFitDataView.h
-    Analysis/DataAnalysis.h
-    Analysis/DataAnalysisTab.h
-    Analysis/DockWidgetArea.h
-    Analysis/EditResultsDialog.h
-    Analysis/FqFitAddWorkspaceDialog.h
-    Analysis/FqFitDataView.h
-    Analysis/FitStatusWidget.h
-    Analysis/FitDataView.h
-    Analysis/FitOutputOptionsView.h
-    Analysis/FitPlotView.h
-    Analysis/InelasticFitPropertyBrowser.h
-    Analysis/FunctionBrowser/FunctionTemplateView.h
-    Analysis/FunctionBrowser/IqtFunctionTemplateView.h
-    Analysis/FunctionBrowser/SingleFunctionTemplateView.h
-    Analysis/FunctionBrowser/MultiFunctionTemplateView.h
-)
-
-set(ALL_INC_FILES
-    DllConfig.h
-    PrecompiledHeader.h
-    Analysis/ConvFitDataPresenter.h
-    Analysis/DataAnalysisTabFactory.h
-    Analysis/FqFitDataPresenter.h
-    Analysis/IDAFunctionParameterEstimation.h
-    Analysis/FqFitModel.h
-    Analysis/IqtFitModel.h
-    Analysis/MSDFitModel.h
-    Analysis/ConvFitModel.h
-    Analysis/FitTabConstants.h
-    Analysis/IFitDataModel.h
-    Analysis/IFitDataView.h
-    Analysis/IFitOutput.h
-    Analysis/IFitOutputOptionsModel.h
-    Analysis/IFitOutputOptionsView.h
-    Analysis/IFitPlotView.h
-    Analysis/IFittingModel.h
-    Analysis/FitData.h
-    Analysis/FitDataModel.h
-    Analysis/FitDataPresenter.h
-    Analysis/FitOutput.h
-    Analysis/FitOutputOptionsModel.h
-    Analysis/FitOutputOptionsPresenter.h
-    Analysis/FitPlotModel.h
-    Analysis/FitPlotPresenter.h
-    Analysis/FittingModel.h
-    Analysis/ParameterEstimation.h
-    Analysis/FunctionBrowser/ConvFunctionTemplateModel.h
-    Analysis/FunctionBrowser/FitTypes.h
-    Analysis/FunctionBrowser/FunctionTemplatePresenter.h
-    Analysis/FunctionBrowser/FqFunctionModel.h
-    Analysis/FunctionBrowser/ITemplatePresenter.h
-    Analysis/FunctionBrowser/IqtTemplatePresenter.h
-    Analysis/FunctionBrowser/MSDFunctionModel.h
-    Analysis/FunctionBrowser/ParamID.h
-    Analysis/FunctionBrowser/SingleFunctionTemplatePresenter.h
-    Analysis/FunctionBrowser/MultiFunctionTemplateModel.h
-    Analysis/FunctionBrowser/MultiFunctionTemplatePresenter.h
-    Analysis/FunctionBrowser/TemplateSubType.h
-)
-
-set(ALL_UI_FILES
-    Analysis/ConvFitAddWorkspaceDialog.ui
-    Analysis/FqFitAddWorkspaceDialog.ui
-    Analysis/DataAnalysis.ui
-    Analysis/EditResultsDialog.ui
-    Analysis/FitDataView.ui
-    Analysis/FitPreviewPlot.ui
-    Analysis/FitOutputOptions.ui
-    Analysis/FitTab.ui
-    Analysis/SpectrumSelector.ui
-)
-
-set(RES_FILES Common/InterfaceResources.qrc)
-
+add_subdirectory(Analysis)
 add_subdirectory(BayesFitting)
 add_subdirectory(Common)
 add_subdirectory(Corrections)
@@ -142,7 +24,7 @@ mtd_add_qt_library(
   MOC ${ALL_MOC_FILES}
   NOMOC ${ALL_INC_FILES}
   UI ${ALL_UI_FILES}
-  RES ${RES_FILES}
+  RES ${ALL_RES_FILES}
   DEFS IN_MANTIDQT_INELASTIC PRECOMPILED PrecompiledHeader.h
   INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
   LINK_LIBS ${CORE_MANTIDLIBS}

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -44,20 +44,6 @@ set(ALL_SRC_FILES
     Analysis/FunctionBrowser/MultiFunctionTemplateModel.cpp
     Analysis/FunctionBrowser/MultiFunctionTemplateView.cpp
     Analysis/FunctionBrowser/MultiFunctionTemplatePresenter.cpp
-    Common/IndirectDataValidationHelper.cpp
-    Common/IndirectInterface.cpp
-    Common/OutputPlotOptionsModel.cpp
-    Common/OutputPlotOptionsPresenter.cpp
-    Common/OutputPlotOptionsView.cpp
-    Common/Settings.cpp
-    Common/SettingsHelper.cpp
-    Common/SettingsModel.cpp
-    Common/SettingsPresenter.cpp
-    Common/SettingsView.cpp
-    Common/IndirectTab.cpp
-    Common/InterfaceUtils.cpp
-    Common/WorkspaceUtils.cpp
-    Common/ValidationUtils.cpp
     Corrections/AbsorptionCorrections.cpp
     Corrections/ApplyAbsorptionCorrections.cpp
     Corrections/CalculatePaalmanPings.cpp
@@ -101,11 +87,6 @@ set(ALL_MOC_FILES
     Analysis/FunctionBrowser/IqtFunctionTemplateView.h
     Analysis/FunctionBrowser/SingleFunctionTemplateView.h
     Analysis/FunctionBrowser/MultiFunctionTemplateView.h
-    Common/IndirectInterface.h
-    Common/OutputPlotOptionsView.h
-    Common/Settings.h
-    Common/SettingsView.h
-    Common/IndirectTab.h
     Corrections/AbsorptionCorrections.h
     Corrections/ApplyAbsorptionCorrections.h
     Corrections/CalculatePaalmanPings.h
@@ -162,15 +143,6 @@ set(ALL_INC_FILES
     Analysis/FunctionBrowser/MultiFunctionTemplateModel.h
     Analysis/FunctionBrowser/MultiFunctionTemplatePresenter.h
     Analysis/FunctionBrowser/TemplateSubType.h
-    Common/IndirectDataValidationHelper.h
-    Common/ISettingsView.h
-    Common/OutputPlotOptionsModel.h
-    Common/OutputPlotOptionsPresenter.h
-    Common/SettingsHelper.h
-    Common/SettingsPresenter.h
-    Common/InterfaceUtils.h
-    Common/WorkspaceUtils.h
-    Common/ValidationUtils.h
     Manipulation/InelasticDataManipulationElwinTabModel.h
     Manipulation/InelasticDataManipulationElwinTab.h
     Manipulation/InelasticDataManipulationIqtTabModel.h
@@ -198,8 +170,6 @@ set(ALL_UI_FILES
     Analysis/FitOutputOptions.ui
     Analysis/FitTab.ui
     Analysis/SpectrumSelector.ui
-    Common/InterfaceSettings.ui
-    Common/OutputPlotOptions.ui
     Corrections/AbsorptionCorrections.ui
     Corrections/ApplyAbsorptionCorrections.ui
     Corrections/CalculatePaalmanPings.ui
@@ -216,6 +186,7 @@ set(ALL_UI_FILES
 set(RES_FILES Common/InterfaceResources.qrc)
 
 add_subdirectory(BayesFitting)
+add_subdirectory(Common)
 
 # XML is required to parse the settings file
 find_package(

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SRC_FILES
+set(ALL_SRC_FILES
     Analysis/ConvFitAddWorkspaceDialog.cpp
     Analysis/ConvFitModel.cpp
     Analysis/ConvFitDataView.cpp
@@ -44,11 +44,6 @@ set(SRC_FILES
     Analysis/FunctionBrowser/MultiFunctionTemplateModel.cpp
     Analysis/FunctionBrowser/MultiFunctionTemplateView.cpp
     Analysis/FunctionBrowser/MultiFunctionTemplatePresenter.cpp
-    BayesFitting/BayesFitting.cpp
-    BayesFitting/BayesFittingTab.cpp
-    BayesFitting/Quasi.cpp
-    BayesFitting/ResNorm.cpp
-    BayesFitting/Stretch.cpp
     Common/IndirectDataValidationHelper.cpp
     Common/IndirectInterface.cpp
     Common/OutputPlotOptionsModel.cpp
@@ -88,7 +83,7 @@ set(SRC_FILES
     Manipulation/InelasticDataManipulationSymmetriseTabModel.cpp
 )
 
-set(MOC_FILES
+set(ALL_MOC_FILES
     Analysis/ConvFitAddWorkspaceDialog.h
     Analysis/ConvFitDataView.h
     Analysis/DataAnalysis.h
@@ -106,11 +101,6 @@ set(MOC_FILES
     Analysis/FunctionBrowser/IqtFunctionTemplateView.h
     Analysis/FunctionBrowser/SingleFunctionTemplateView.h
     Analysis/FunctionBrowser/MultiFunctionTemplateView.h
-    BayesFitting/BayesFitting.h
-    BayesFitting/BayesFittingTab.h
-    BayesFitting/Quasi.h
-    BayesFitting/ResNorm.h
-    BayesFitting/Stretch.h
     Common/IndirectInterface.h
     Common/OutputPlotOptionsView.h
     Common/Settings.h
@@ -131,7 +121,7 @@ set(MOC_FILES
     Manipulation/InelasticDataManipulationTab.h
 )
 
-set(INC_FILES
+set(ALL_INC_FILES
     DllConfig.h
     PrecompiledHeader.h
     Analysis/ConvFitDataPresenter.h
@@ -198,7 +188,7 @@ set(INC_FILES
     Manipulation/IIqtView.h
 )
 
-set(UI_FILES
+set(ALL_UI_FILES
     Analysis/ConvFitAddWorkspaceDialog.ui
     Analysis/FqFitAddWorkspaceDialog.ui
     Analysis/DataAnalysis.ui
@@ -208,10 +198,6 @@ set(UI_FILES
     Analysis/FitOutputOptions.ui
     Analysis/FitTab.ui
     Analysis/SpectrumSelector.ui
-    BayesFitting/BayesFitting.ui
-    BayesFitting/Quasi.ui
-    BayesFitting/ResNorm.ui
-    BayesFitting/Stretch.ui
     Common/InterfaceSettings.ui
     Common/OutputPlotOptions.ui
     Corrections/AbsorptionCorrections.ui
@@ -229,6 +215,8 @@ set(UI_FILES
 
 set(RES_FILES Common/InterfaceResources.qrc)
 
+add_subdirectory(BayesFitting)
+
 # XML is required to parse the settings file
 find_package(
   Qt5 ${QT_MIN_VERSION}
@@ -239,10 +227,10 @@ find_package(
 mtd_add_qt_library(
   TARGET_NAME MantidScientificInterfacesInelastic
   QT_VERSION 5
-  SRC ${SRC_FILES}
-  MOC ${MOC_FILES}
-  NOMOC ${INC_FILES}
-  UI ${UI_FILES}
+  SRC ${ALL_SRC_FILES}
+  MOC ${ALL_MOC_FILES}
+  NOMOC ${ALL_INC_FILES}
+  UI ${ALL_UI_FILES}
   RES ${RES_FILES}
   DEFS IN_MANTIDQT_INELASTIC PRECOMPILED PrecompiledHeader.h
   INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -44,12 +44,6 @@ set(ALL_SRC_FILES
     Analysis/FunctionBrowser/MultiFunctionTemplateModel.cpp
     Analysis/FunctionBrowser/MultiFunctionTemplateView.cpp
     Analysis/FunctionBrowser/MultiFunctionTemplatePresenter.cpp
-    Corrections/AbsorptionCorrections.cpp
-    Corrections/ApplyAbsorptionCorrections.cpp
-    Corrections/CalculatePaalmanPings.cpp
-    Corrections/ContainerSubtraction.cpp
-    Corrections/Corrections.cpp
-    Corrections/CorrectionsTab.cpp
     Manipulation/InelasticDataManipulation.cpp
     Manipulation/InelasticDataManipulationElwinTab.cpp
     Manipulation/InelasticDataManipulationElwinTabModel.cpp
@@ -87,12 +81,6 @@ set(ALL_MOC_FILES
     Analysis/FunctionBrowser/IqtFunctionTemplateView.h
     Analysis/FunctionBrowser/SingleFunctionTemplateView.h
     Analysis/FunctionBrowser/MultiFunctionTemplateView.h
-    Corrections/AbsorptionCorrections.h
-    Corrections/ApplyAbsorptionCorrections.h
-    Corrections/CalculatePaalmanPings.h
-    Corrections/ContainerSubtraction.h
-    Corrections/Corrections.h
-    Corrections/CorrectionsTab.h
     Manipulation/InelasticDataManipulation.h
     Manipulation/InelasticDataManipulationElwinTabView.h
     Manipulation/InelasticDataManipulationIqtTabView.h
@@ -170,11 +158,6 @@ set(ALL_UI_FILES
     Analysis/FitOutputOptions.ui
     Analysis/FitTab.ui
     Analysis/SpectrumSelector.ui
-    Corrections/AbsorptionCorrections.ui
-    Corrections/ApplyAbsorptionCorrections.ui
-    Corrections/CalculatePaalmanPings.ui
-    Corrections/ContainerSubtraction.ui
-    Corrections/Corrections.ui
     Manipulation/InelasticDataManipulation.ui
     Manipulation/InelasticDataManipulationElwinTab.ui
     Manipulation/InelasticDataManipulationIqtTab.ui
@@ -187,6 +170,7 @@ set(RES_FILES Common/InterfaceResources.qrc)
 
 add_subdirectory(BayesFitting)
 add_subdirectory(Common)
+add_subdirectory(Corrections)
 
 # XML is required to parse the settings file
 find_package(

--- a/qt/scientific_interfaces/Inelastic/Common/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/Common/CMakeLists.txt
@@ -1,0 +1,56 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(SRC_FILES
+    IndirectDataValidationHelper.cpp
+    IndirectInterface.cpp
+    OutputPlotOptionsModel.cpp
+    OutputPlotOptionsPresenter.cpp
+    OutputPlotOptionsView.cpp
+    Settings.cpp
+    SettingsHelper.cpp
+    SettingsModel.cpp
+    SettingsPresenter.cpp
+    SettingsView.cpp
+    IndirectTab.cpp
+    InterfaceUtils.cpp
+    WorkspaceUtils.cpp
+    ValidationUtils.cpp
+)
+
+set(INC_FILES
+    IndirectDataValidationHelper.h
+    ISettingsView.h
+    OutputPlotOptionsModel.h
+    OutputPlotOptionsPresenter.h
+    SettingsHelper.h
+    SettingsPresenter.h
+    InterfaceUtils.h
+    WorkspaceUtils.h
+    ValidationUtils.h
+)
+
+set(MOC_FILES IndirectInterface.h OutputPlotOptionsView.h Settings.h SettingsView.h IndirectTab.h)
+
+set(UI_FILES InterfaceSettings.ui OutputPlotOptions.ui)
+
+list(TRANSFORM SRC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM INC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM MOC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM UI_FILES PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_SRC_FILES
+    ${ALL_SRC_FILES} ${SRC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_INC_FILES
+    ${ALL_INC_FILES} ${INC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_MOC_FILES
+    ${ALL_MOC_FILES} ${MOC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_UI_FILES
+    ${ALL_UI_FILES} ${UI_FILES}
+    PARENT_SCOPE
+)

--- a/qt/scientific_interfaces/Inelastic/Corrections/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CMakeLists.txt
@@ -1,0 +1,30 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(SRC_FILES AbsorptionCorrections.cpp ApplyAbsorptionCorrections.cpp CalculatePaalmanPings.cpp
+              ContainerSubtraction.cpp Corrections.cpp CorrectionsTab.cpp
+)
+
+set(MOC_FILES AbsorptionCorrections.h ApplyAbsorptionCorrections.h CalculatePaalmanPings.h ContainerSubtraction.h
+              Corrections.h CorrectionsTab.h
+)
+
+set(UI_FILES AbsorptionCorrections.ui ApplyAbsorptionCorrections.ui CalculatePaalmanPings.ui ContainerSubtraction.ui
+             Corrections.ui
+)
+
+list(TRANSFORM SRC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM MOC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM UI_FILES PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_SRC_FILES
+    ${ALL_SRC_FILES} ${SRC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_MOC_FILES
+    ${ALL_MOC_FILES} ${MOC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_UI_FILES
+    ${ALL_UI_FILES} ${UI_FILES}
+    PARENT_SCOPE
+)

--- a/qt/scientific_interfaces/Inelastic/Manipulation/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/CMakeLists.txt
@@ -1,0 +1,76 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(SRC_FILES
+    InelasticDataManipulation.cpp
+    InelasticDataManipulationElwinTab.cpp
+    InelasticDataManipulationElwinTabModel.cpp
+    InelasticDataManipulationElwinTabView.cpp
+    InelasticDataManipulationIqtTab.cpp
+    InelasticDataManipulationIqtTabView.cpp
+    InelasticDataManipulationIqtTabModel.cpp
+    InelasticDataManipulationMomentsTab.cpp
+    InelasticDataManipulationMomentsTabModel.cpp
+    InelasticDataManipulationMomentsTabView.cpp
+    InelasticDataManipulationTab.cpp
+    InelasticDataManipulationSqwTab.cpp
+    InelasticDataManipulationSqwTabModel.cpp
+    InelasticDataManipulationSqwTabView.cpp
+    InelasticDataManipulationSymmetriseTab.cpp
+    InelasticDataManipulationSymmetriseTabView.cpp
+    InelasticDataManipulationSymmetriseTabModel.cpp
+)
+
+set(INC_FILES
+    InelasticDataManipulationElwinTabModel.h
+    InelasticDataManipulationElwinTab.h
+    InelasticDataManipulationIqtTabModel.h
+    InelasticDataManipulationIqtTab.h
+    InelasticDataManipulationMomentsTabModel.h
+    InelasticDataManipulationMomentsTab.h
+    InelasticDataManipulationSqwTabModel.h
+    InelasticDataManipulationSqwTab.h
+    InelasticDataManipulationSymmetriseTabModel.h
+    InelasticDataManipulationSymmetriseTab.h
+    ISqwView.h
+    IMomentsView.h
+    ISymmetriseView.h
+    IElwinView.h
+    IIqtView.h
+)
+
+set(MOC_FILES
+    InelasticDataManipulation.h
+    InelasticDataManipulationElwinTabView.h
+    InelasticDataManipulationIqtTabView.h
+    InelasticDataManipulationMomentsTabView.h
+    InelasticDataManipulationSqwTabView.h
+    InelasticDataManipulationSymmetriseTabView.h
+    InelasticDataManipulationTab.h
+)
+
+set(UI_FILES
+    InelasticDataManipulation.ui InelasticDataManipulationElwinTab.ui InelasticDataManipulationIqtTab.ui
+    InelasticDataManipulationMomentsTab.ui InelasticDataManipulationSqwTab.ui InelasticDataManipulationSymmetriseTab.ui
+)
+
+list(TRANSFORM SRC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM INC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM MOC_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM UI_FILES PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_SRC_FILES
+    ${ALL_SRC_FILES} ${SRC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_INC_FILES
+    ${ALL_INC_FILES} ${INC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_MOC_FILES
+    ${ALL_MOC_FILES} ${MOC_FILES}
+    PARENT_SCOPE
+)
+set(ALL_UI_FILES
+    ${ALL_UI_FILES} ${UI_FILES}
+    PARENT_SCOPE
+)

--- a/qt/scientific_interfaces/Inelastic/test/Analysis/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/test/Analysis/CMakeLists.txt
@@ -1,0 +1,36 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(TEST_FILES
+    ConvFitModelTest.h
+    ConvFitDataPresenterTest.h
+    ConvFunctionTemplateModelTest.h
+    FqFitDataPresenterTest.h
+    FqFitModelTest.h
+    IDAFunctionParameterEstimationTest.h
+    DataAnalysisTabTest.h
+    FitDataPresenterTest.h
+    FitDataTest.h
+    FitDataModelTest.h
+    FitOutputTest.h
+    FitOutputOptionsModelTest.h
+    FitOutputOptionsPresenterTest.h
+    FitPlotModelTest.h
+    FitPlotPresenterTest.h
+    InelasticFitPropertyBrowserTest.h
+    FittingModelTest.h
+    IqtFitModelTest.h
+)
+
+set(TEST_HELPERS MockObjects.h)
+
+list(TRANSFORM TEST_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM TEST_HELPERS PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_TEST_FILES
+    ${ALL_TEST_FILES} ${TEST_FILES}
+    PARENT_SCOPE
+)
+set(ALL_TEST_HELPERS
+    ${ALL_TEST_HELPERS} ${TEST_HELPERS}
+    PARENT_SCOPE
+)

--- a/qt/scientific_interfaces/Inelastic/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/test/CMakeLists.txt
@@ -1,48 +1,18 @@
-# Testing
-set(TEST_FILES
-    Analysis/ConvFitModelTest.h
-    Analysis/ConvFitDataPresenterTest.h
-    Analysis/ConvFunctionTemplateModelTest.h
-    Analysis/FqFitDataPresenterTest.h
-    Analysis/FqFitModelTest.h
-    Analysis/IDAFunctionParameterEstimationTest.h
-    Analysis/DataAnalysisTabTest.h
-    Analysis/FitDataPresenterTest.h
-    Analysis/FitDataTest.h
-    Analysis/FitDataModelTest.h
-    Analysis/FitOutputTest.h
-    Analysis/FitOutputOptionsModelTest.h
-    Analysis/FitOutputOptionsPresenterTest.h
-    Analysis/FitPlotModelTest.h
-    Analysis/FitPlotPresenterTest.h
-    Analysis/InelasticFitPropertyBrowserTest.h
-    Analysis/FittingModelTest.h
-    Analysis/IqtFitModelTest.h
-    Common/IndirectDataValidationHelperTest.h
-    Common/OutputPlotOptionsModelTest.h
-    Common/OutputPlotOptionsPresenterTest.h
-    Common/SettingsModelTest.h
-    Common/SettingsPresenterTest.h
-    Common/WorkspaceUtilsTest.h
-    Common/InterfaceUtilsTest.h
-    Common/ValidationUtilsTest.h
-    Manipulation/InelasticDataManipulationElwinTabModelTest.h
-    Manipulation/InelasticDataManipulationIqtTabModelTest.h
-    Manipulation/InelasticDataManipulationMomentsTabModelTest.h
-    Manipulation/InelasticDataManipulationSqwTabModelTest.h
-    Manipulation/InelasticDataManipulationSymmetriseTabModelTest.h
-)
+set(ALL_TEST_FILES)
+set(ALL_TEST_HELPERS)
 
-set(TEST_HELPERS Analysis/MockObjects.h Common/MockObjects.h)
+add_subdirectory(Analysis)
+add_subdirectory(Common)
+add_subdirectory(Manipulation)
 
 set(CXXTEST_EXTRA_HEADER_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/InterfacesInelasticTestInitialization.h)
 
 mtd_add_qt_tests(
   TARGET_NAME MantidQtInterfacesInelasticTest
   QT_VERSION 5
-  SRC ${TEST_FILES}
+  SRC ${ALL_TEST_FILES}
   INCLUDE_DIRS ../../../../Framework/DataObjects/inc ../
-  TEST_HELPER_SRCS ${TEST_HELPERS}
+  TEST_HELPER_SRCS ${ALL_TEST_HELPERS}
   LINK_LIBS ${CORE_MANTIDLIBS}
             Mantid::DataObjects
             gmock

--- a/qt/scientific_interfaces/Inelastic/test/Common/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/test/Common/CMakeLists.txt
@@ -1,0 +1,26 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(TEST_FILES
+    IndirectDataValidationHelperTest.h
+    OutputPlotOptionsModelTest.h
+    OutputPlotOptionsPresenterTest.h
+    SettingsModelTest.h
+    SettingsPresenterTest.h
+    WorkspaceUtilsTest.h
+    InterfaceUtilsTest.h
+    ValidationUtilsTest.h
+)
+
+set(TEST_HELPERS MockObjects.h)
+
+list(TRANSFORM TEST_FILES PREPEND ${SUB_DIRECTORY}/)
+list(TRANSFORM TEST_HELPERS PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_TEST_FILES
+    ${ALL_TEST_FILES} ${TEST_FILES}
+    PARENT_SCOPE
+)
+set(ALL_TEST_HELPERS
+    ${ALL_TEST_HELPERS} ${TEST_HELPERS}
+    PARENT_SCOPE
+)

--- a/qt/scientific_interfaces/Inelastic/test/Manipulation/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/test/Manipulation/CMakeLists.txt
@@ -1,0 +1,14 @@
+get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
+
+set(TEST_FILES
+    InelasticDataManipulationElwinTabModelTest.h InelasticDataManipulationIqtTabModelTest.h
+    InelasticDataManipulationMomentsTabModelTest.h InelasticDataManipulationSqwTabModelTest.h
+    InelasticDataManipulationSymmetriseTabModelTest.h
+)
+
+list(TRANSFORM TEST_FILES PREPEND ${SUB_DIRECTORY}/)
+
+set(ALL_TEST_FILES
+    ${ALL_TEST_FILES} ${TEST_FILES}
+    PARENT_SCOPE
+)


### PR DESCRIPTION
### Description of work
This PR organises the CMakeLists in the Indirect and Inelastic categories a bit better. This makes it clearer which files belong to which interfaces, and also will make it easier to rename interfaces in the future.

Fixes #37064

### To test:
Build and tests should pass

1. Check that you can open each of the Indirect interfaces
2. Check that you can open each of the Inelastic interfaces

*This does not require release notes* because **it is an internal change**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
