### PR TITLE
Disable fitbrowser and superplot for MDHisto workspaces

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/Bugfixes/37067.rst
+++ b/docs/source/release/v6.10.0/Workbench/Bugfixes/37067.rst
@@ -1,0 +1,1 @@
+- Remove Fit and Superplot buttons from toolbar of non mantid axes and plots of 1D :ref:`MDHistoWorkspace <MDHistoWorkspace>` (for which the data have no workspace index).

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -72,6 +72,16 @@ class ToolBarTest(unittest.TestCase):
         self.assertFalse(self._is_button_enabled(fig, "toggle_superplot"))
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_fitbrowser_and_superplot_disabled_for_non_MantidAxes(self, mock_qappthread):
+        mock_qappthread.return_value = mock_qappthread
+
+        fig, axes = plt.subplots()
+        axes.plot([-10, 10], [1, 2])
+
+        self.assertFalse(self._is_button_enabled(fig, "toggle_fit"))
+        self.assertFalse(self._is_button_enabled(fig, "toggle_superplot"))
+
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
     def test_line_color_selection_buttons_correctly_enabled_for_contour_wireframe_plots(self, mock_qappthread):
         """Checks that line_colour selection button is correctly enabled for wireframe and contour plots"""
         mock_qappthread.return_value = mock_qappthread
@@ -85,6 +95,8 @@ class ToolBarTest(unittest.TestCase):
 
             # line_colour button should be enabled for contour and wireframe plots
             self.assertTrue(self._is_button_enabled(fig, "line_colour"))
+            self.assertFalse(self._is_button_enabled(fig, "toggle_fit"))
+            self.assertFalse(self._is_button_enabled(fig, "toggle_superplot"))
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")
     def test_button_unchecked_for_plot_with_no_grid(self, mock_qappthread):

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -19,7 +19,7 @@ from mantidqt.plotting import functions
 from workbench.plotting.figuremanager import MantidFigureCanvas, FigureManagerWorkbench
 from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 from mantid.plots.plotfunctions import plot
-from mantid.simpleapi import CreateSampleWorkspace
+from mantid.simpleapi import CreateSampleWorkspace, CreateMDHistoWorkspace
 
 
 @start_qapplication
@@ -50,6 +50,26 @@ class ToolBarTest(unittest.TestCase):
         self.assertTrue(self._is_button_enabled(fig, "waterfall_offset_amount"))
         self.assertTrue(self._is_button_enabled(fig, "waterfall_reverse_order"))
         self.assertTrue(self._is_button_enabled(fig, "waterfall_fill_area"))
+
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_fitbrowser_and_superplot_disabled_for_MDHisto_plots(self, mock_qappthread):
+        mock_qappthread.return_value = mock_qappthread
+        # make workspace
+        ws_histo = CreateMDHistoWorkspace(
+            SignalInput="1,1",
+            ErrorInput="1,1",
+            Dimensionality=3,
+            Extents="-1,1,-1,1,-1,1",
+            NumberOfBins="2,1,1",
+            Names="H,K,L",
+            Units="rlu,rlu,rlu",
+        )
+
+        fig, axes = plt.subplots(subplot_kw={"projection": "mantid"})
+        axes.plot(ws_histo)
+
+        self.assertFalse(self._is_button_enabled(fig, "toggle_fit"))
+        self.assertFalse(self._is_button_enabled(fig, "toggle_superplot"))
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")
     def test_line_color_selection_buttons_correctly_enabled_for_contour_wireframe_plots(self, mock_qappthread):

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -215,7 +215,6 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         if figure_type(fig) not in [FigureType.Line, FigureType.Errorbar] or len(fig.get_axes()) > 1:
             self.set_fit_enabled(False)
             self.set_superplot_enabled(False)
-
         # if any of the lines are a sample log plot disable fitting
         for ax in fig.get_axes():
             for artist in ax.get_lines():
@@ -226,6 +225,11 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
                 except Exception:
                     # The artist is not tracked - ignore this one and check the rest
                     continue
+            if isinstance(ax, MantidAxes):
+                for artists in ax.tracked_workspaces.values():
+                    if any([artist.workspace_index is None for artist in artists]):
+                        self.set_fit_enabled(False)
+                        self.set_superplot_enabled(False)
 
         # Plot-to-script currently doesn't work with waterfall plots so the button is hidden for that plot type.
         # There must be at least one MantidAxis plot with data for to generate a script, others will be skipped

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -212,10 +212,10 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
                 break
 
     def set_buttons_visibility(self, fig):
+        #  check if fitting and superplot should be enabled
         if figure_type(fig) not in [FigureType.Line, FigureType.Errorbar] or len(fig.get_axes()) > 1:
             self.set_fit_enabled(False)
             self.set_superplot_enabled(False)
-        # if any of the lines are a sample log plot disable fitting
         for ax in fig.get_axes():
             for artist in ax.get_lines():
                 try:
@@ -235,6 +235,8 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         # There must be at least one MantidAxis plot with data for to generate a script, others will be skipped
         if not any((isinstance(ax, MantidAxes) and curve_in_ax(ax)) for ax in fig.get_axes()) or fig.get_axes()[0].is_waterfall():
             self.set_generate_plot_script_enabled(False)
+            self.set_fit_enabled(False)
+            self.set_superplot_enabled(False)
 
         # reenable script generation for colormaps
         if self.is_colormap(fig):


### PR DESCRIPTION
### Description of work
Disable fitbrowser and superplot for MDHisto workspaces as both of these tools rely on artists/lines being associated with a workspace index, which isn't present in an MDHisto workspace. Long term it would be good to support 1D MDHisto workspaces in the fit browser though.



<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36637 


### To test:

(1) Run this script

```
ws_histo = CreateMDHistoWorkspace(SignalInput='1,1', ErrorInput='1,1', Dimensionality=3, Extents='-1,1,-1,1,-1,1', NumberOfBins='2,1,1', Names='H,K,L', Units='rlu,rlu,rlu', OutputWorkspace='ws_test')

fig, axes = plt.subplots(subplot_kw={'projection': 'mantid'})
axes.plot(ws_histo)
fig.show()
```
(2) Check the toolbar doesn't have the `Fit` or `Superplot` buttons - it should look like this

![image](https://github.com/mantidproject/mantid/assets/55979119/8ba1dfbd-7682-41e8-8ce4-f3802b95bf78)

(3) Plot a spectrum of a MatrixWorkspace  and check that it has the buttons as usual
```
ws = CreateSampleWorkspace()
fig, axes = plt.subplots(subplot_kw={'projection': 'mantid'})
axes.plot(ws, wkspIndex=0)
fig.show()
```
(4) Plot a table - there also should be the buttons visible (same behaviour as before)
```
CreateDetectorTable(InputWorkspace='ws', DetectorTableWorkspace='ws-Detectors')
```
Right-click > show Data > Set X and Y columns > plot

(5) Go to ipython terminal in workbench and enter
```
plt.plot(range(3)); plt.show()
```

This will open a figure with the fit and superplot buttons enabled, but clicking them will print a warning to the log and not cause an exception.

In the case of (5) I would prefer not to show the buttons in the first place (as done for MDHisto workspaces here) -  I do you want me to do this in this PR @thomashampson and @jhaigh0 ?

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
