### PR TITLE
HRPD empty subtraction of vanadium respects subtract_empty_instrument

### DIFF
--- a/Testing/Data/SystemTest/ISIS_Powder/input/calibration/hrp/16_5/ISIS_Powder-HRPD-VanSplined_NoEmpty_66031_hrpd_new_072_01_corr.cal.nxs.md5
+++ b/Testing/Data/SystemTest/ISIS_Powder/input/calibration/hrp/16_5/ISIS_Powder-HRPD-VanSplined_NoEmpty_66031_hrpd_new_072_01_corr.cal.nxs.md5
@@ -1,0 +1,1 @@
+a3ef9363ecc8580ccaeda2ed41495c8b

--- a/docs/source/release/v6.10.0/Diffraction/Powder/Bugfixes/37069.rst
+++ b/docs/source/release/v6.10.0/Diffraction/Powder/Bugfixes/37069.rst
@@ -1,0 +1,1 @@
+- HRPD reduction :ref:`isis-powder-diffraction-hrpd-ref` now only subtracts empty run from the vanadium when it is subtracted from the sample run (i.e. when ``subtract_empty_instrument=True``) - note other ISIS instrument will always subtract an empty run from the vanadium.

--- a/scripts/Diffraction/isis_powder/abstract_inst.py
+++ b/scripts/Diffraction/isis_powder/abstract_inst.py
@@ -146,6 +146,12 @@ class AbstractInst(object):
         """
         return True
 
+    def should_subtract_empty_inst_from_vanadium(self):
+        """
+        :return: Whether the empty run should be subtracted from a vandium run
+        """
+        return True
+
     def perform_abs_vanadium_norm(self):
         """
         :return: Whether the sample run should undergo an absolute normalisation to

--- a/scripts/Diffraction/isis_powder/hrpd.py
+++ b/scripts/Diffraction/isis_powder/hrpd.py
@@ -73,6 +73,9 @@ class HRPD(AbstractInst):
     def should_subtract_empty_inst(self):
         return self._inst_settings.subtract_empty_inst
 
+    def should_subtract_empty_inst_from_vanadium(self):
+        return self.should_subtract_empty_inst()  # HRPD want to treat vanadium same as sample
+
     def create_solid_angle_corrections(self, vanadium, run_details):
         """
         Creates the solid angle corrections from a vanadium run, only applicable on HRPD otherwise return None

--- a/scripts/Diffraction/isis_powder/routines/calibrate.py
+++ b/scripts/Diffraction/isis_powder/routines/calibrate.py
@@ -28,7 +28,7 @@ def create_van(instrument, run_details, absorb, spline=True):
 
     instrument.create_solid_angle_corrections(corrected_van_ws, run_details)
 
-    if run_details.empty_inst_runs is not None:
+    if instrument.should_subtract_empty_inst_from_vanadium() and run_details.empty_inst_runs is not None:
         summed_empty_inst = common.generate_summed_runs(empty_ws_string=run_details.empty_inst_runs, instrument=instrument)
         mantid.SaveNexus(Filename=run_details.summed_empty_inst_file_path, InputWorkspace=summed_empty_inst)
         corrected_van_ws = common.subtract_summed_runs(ws_to_correct=corrected_van_ws, empty_ws=summed_empty_inst)
@@ -95,7 +95,7 @@ def create_van_per_detector(instrument, run_details, absorb):
     input_van_ws = input_van_ws_list[0]  # As we asked for a summed ws there should only be one returned
     instrument.create_solid_angle_corrections(input_van_ws, run_details)
 
-    if run_details.empty_inst_runs is not None:
+    if instrument.should_subtract_empty_inst_from_vanadium() and run_details.empty_inst_runs is not None:
         summed_empty = common.generate_summed_runs(empty_ws_string=run_details.empty_inst_runs, instrument=instrument)
         mantid.SaveNexus(Filename=run_details.summed_empty_inst_file_path, InputWorkspace=summed_empty)
         corrected_van_ws = common.subtract_summed_runs(ws_to_correct=input_van_ws, empty_ws=summed_empty)


### PR DESCRIPTION
### Description of work

Added a new method to instrument class to return whether to subtract empty run from vanadium. The default in `AbstractInst` is `True` which should preserve the current behaviour for other instruments.

For HRPD this has been overwritten to return the same answer as whether to subtract the empty from the sample run as requested by HRPD scientists - this the behaviour they require in all cases so a new setting has not been added.

It is not clear that other instruments want the same as HRPD, or want the user to choose whether to subtract empty from vanadium runs (which would require another setting/input). For now this change is for HRPD only to get this fix in - I will check with the other instruments.


Fixes #37068

**Report to:** Chris Howard (HRPD)

### To test:

Code review only 
This is a small change that only broke existing HRPD systems test  - if the CI passes with the new test added then it is working as expected!

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
