### PR TITLE
Abins-v2: initial unsubscribed algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/Abins.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins.py
@@ -114,6 +114,11 @@ class Abins(AbinsAlgorithm, PythonAlgorithm):
         # so insert placeholder "1" for now.
         prog_reporter.resetNumSteps(1, 0.1, 0.8)
 
+        if self._autoconvolution:
+            autoconvolution_max = self._max_event_order
+        else:
+            autoconvolution_max = 0
+
         s_calculator = abins.SCalculatorFactory.init(
             filename=self._vibrational_or_phonon_data_file,
             temperature=self._temperature,
@@ -121,7 +126,7 @@ class Abins(AbinsAlgorithm, PythonAlgorithm):
             abins_data=ab_initio_data,
             instrument=self._instrument,
             quantum_order_num=self._num_quantum_order_events,
-            autoconvolution=self._autoconvolution,
+            autoconvolution_max=autoconvolution_max,
         )
         s_calculator.progress_reporter = prog_reporter
         s_data = s_calculator.get_formatted_data()

--- a/Framework/PythonInterface/plugins/algorithms/Abins2D.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins2D.py
@@ -24,13 +24,20 @@ class Abins2D(AbinsAlgorithm, PythonAlgorithm):
         super().__init__(*args, **kwargs)
         self._q_bins = None
 
-    def category(self) -> str:
+    @staticmethod
+    def category() -> str:
         return "Simulation"
 
-    def summary(self) -> str:
+    @staticmethod
+    def summary() -> str:
         return "Calculates inelastic neutron scattering over 2D (q,ω) space."
 
-    def seeAlso(self):
+    @staticmethod
+    def version() -> int:
+        return 1
+
+    @staticmethod
+    def seeAlso():
         return ["Abins"]
 
     def PyInit(self) -> None:
@@ -73,10 +80,9 @@ class Abins2D(AbinsAlgorithm, PythonAlgorithm):
             if (self.getProperty("ChopperFrequency").value) == "" and (default_frequency is None):
                 issues["ChopperFrequency"] = "This instrument does not have a default chopper frequency"
             elif self.getProperty("ChopperFrequency").value and int(self.getProperty("ChopperFrequency").value) not in allowed_frequencies:
-                issues[
-                    "ChopperFrequency"
-                ] = f"This chopper frequency is not valid for the instrument {instrument_name}. " "Valid frequencies: " + ", ".join(
-                    [str(freq) for freq in allowed_frequencies]
+                issues["ChopperFrequency"] = (
+                    f"This chopper frequency is not valid for the instrument {instrument_name}. "
+                    "Valid frequencies: " + ", ".join([str(freq) for freq in allowed_frequencies])
                 )
 
         if not isinstance(float(self.getProperty("IncidentEnergy").value), numbers.Real):

--- a/Framework/PythonInterface/plugins/algorithms/Abins2D.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins2D.py
@@ -124,12 +124,17 @@ class Abins2D(AbinsAlgorithm, PythonAlgorithm):
         # so insert placeholder "1" for now.
         prog_reporter.resetNumSteps(1, 0.1, 0.8)
 
+        if self._autoconvolution:
+            autoconvolution_max = self._max_event_order
+        else:
+            autoconvolution_max = 0
+
         s_calculator = abins.SCalculatorFactory.init(
             filename=self._vibrational_or_phonon_data_file,
             temperature=self._temperature,
             sample_form="Powder",
             abins_data=ab_initio_data,
-            autoconvolution=self._autoconvolution,
+            autoconvolution_max=autoconvolution_max,
             instrument=self._instrument,
             quantum_order_num=self._num_quantum_order_events,
         )

--- a/Framework/PythonInterface/test/python/plugins/algorithms/Abins2BasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/Abins2BasicTest.py
@@ -89,7 +89,7 @@ class AbinsBasicTest(unittest.TestCase):
             patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
         ):
 
-            Abins(VibrationalOrPhononFile="Si2-sc_wrong.phonon", OutputWorkspace=self._workspace_name, Version=2)
+            Abins(Version=2, VibrationalOrPhononFile="Si2-sc_wrong.phonon", OutputWorkspace=self._workspace_name)
 
         # wrong extension of phonon file in case of CASTEP
         with (
@@ -101,6 +101,7 @@ class AbinsBasicTest(unittest.TestCase):
         ):
 
             Abins(
+                Version=2,
                 VibrationalOrPhononFile="Si2-sc.wrong_phonon",
                 OutputWorkspace=self._workspace_name,
             )
@@ -114,13 +115,15 @@ class AbinsBasicTest(unittest.TestCase):
             patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
         ):
             Abins(
+                Version=2,
                 AbInitioProgram="CRYSTAL",
                 VibrationalOrPhononFile="MgO.wrong_out",
                 OutputWorkspace=self._workspace_name,
             )
 
         # no name for workspace
-        self.assertRaises(TypeError, Abins, VibrationalOrPhononFile=self._si2 + ".phonon", TemperatureInKelvin=self._temperature)
+        with self.assertRaises(TypeError), patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir):
+            Abins(Version=2, VibrationalOrPhononFile=self._si2 + ".phonon", TemperatureInKelvin=self._temperature)
 
         # keyword total in the name of the workspace
         with (
@@ -131,9 +134,22 @@ class AbinsBasicTest(unittest.TestCase):
             patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
         ):
             Abins(
+                Version=2,
                 VibrationalOrPhononFile=self._si2 + ".phonon",
                 TemperatureInKelvin=self._temperature,
                 OutputWorkspace=self._workspace_name + "total",
+            )
+
+        # non-existent parameter
+        with (
+            self.assertRaisesRegex(TypeError, "'SampleForm' is an invalid keyword argument"),
+            patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
+        ):
+            Abins(
+                Version=2,
+                VibrationalOrPhononFile=self._si2 + ".phonon",
+                OutputWorkspace=self._workspace_name,
+                SampleForm="Powder",
             )
 
         # negative temperature in K
@@ -145,6 +161,7 @@ class AbinsBasicTest(unittest.TestCase):
             patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
         ):
             Abins(
+                Version=2,
                 VibrationalOrPhononFile=self._si2 + ".phonon",
                 TemperatureInKelvin=-1.0,
                 OutputWorkspace=self._workspace_name,
@@ -156,14 +173,19 @@ class AbinsBasicTest(unittest.TestCase):
             patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
         ):
 
-            Abins(VibrationalOrPhononFile=self._si2 + ".phonon", Scale=-0.2, OutputWorkspace=self._workspace_name)
+            Abins(Version=2, VibrationalOrPhononFile=self._si2 + ".phonon", Scale=-0.2, OutputWorkspace=self._workspace_name)
 
         # unknown instrument
         with (
             self.assertRaisesRegex(ValueError, 'The value "UnknownInstrument" is not in the list of allowed values'),
             patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
         ):
-            Abins(VibrationalOrPhononFile=self._si2 + ".phonon", Instrument="UnknownInstrument", OutputWorkspace=self._workspace_name)
+            Abins(
+                Version=2,
+                VibrationalOrPhononFile=self._si2 + ".phonon",
+                Instrument="UnknownInstrument",
+                OutputWorkspace=self._workspace_name,
+            )
 
     # test if intermediate results are consistent
     def test_non_unique_elements(self):
@@ -175,6 +197,7 @@ class AbinsBasicTest(unittest.TestCase):
             patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
         ):
             Abins(
+                Version=2,
                 VibrationalOrPhononFile=self._squaricn + ".phonon",
                 Atoms="C,C,H",
                 OutputWorkspace=self._workspace_name,
@@ -190,6 +213,7 @@ class AbinsBasicTest(unittest.TestCase):
         ):
 
             Abins(
+                Version=2,
                 VibrationalOrPhononFile=self._squaricn + ".phonon",
                 Atoms="atom_1,atom_2,atom1",
                 OutputWorkspace=self._workspace_name,
@@ -206,6 +230,7 @@ class AbinsBasicTest(unittest.TestCase):
         ):
 
             Abins(
+                Version=2,
                 VibrationalOrPhononFile=self._squaricn + ".phonon",
                 Atoms="N",
                 OutputWorkspace=self._workspace_name,
@@ -262,6 +287,7 @@ class AbinsBasicTest(unittest.TestCase):
         """
         with patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir):
             wrk_ref = Abins(
+                Version=2,
                 AbInitioProgram=self._ab_initio_program,
                 VibrationalOrPhononFile=self._squaricn + ".phonon",
                 TemperatureInKelvin=self._temperature,
@@ -275,6 +301,7 @@ class AbinsBasicTest(unittest.TestCase):
             )
 
             wrk = Abins(
+                Version=2,
                 AbInitioProgram=self._ab_initio_program,
                 VibrationalOrPhononFile=self._squaricn + ".phonon",
                 TemperatureInKelvin=self._temperature,
@@ -295,6 +322,7 @@ class AbinsBasicTest(unittest.TestCase):
     def test_lagrange_exists(self):
         with patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir):
             Abins(
+                Version=2,
                 AbInitioProgram=self._ab_initio_program,
                 VibrationalOrPhononFile=(self._squaricn + ".phonon"),
                 TemperatureInKelvin=self._temperature,
@@ -315,6 +343,7 @@ class AbinsBasicTest(unittest.TestCase):
         """
         with patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir):
             Abins(
+                Version=2,
                 AbInitioProgram=self._ab_initio_program,
                 VibrationalOrPhononFile="benzene_Abins.phonon",
                 ExperimentalFile="benzene_Abins.dat",
@@ -343,6 +372,7 @@ class AbinsBasicTest(unittest.TestCase):
 
         with patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir):
             wrk_ref = Abins(
+                Version=2,
                 AbInitioProgram=self._ab_initio_program,
                 VibrationalOrPhononFile=self._squaricn + ".phonon",
                 ExperimentalFile=experimental_file,
@@ -357,6 +387,7 @@ class AbinsBasicTest(unittest.TestCase):
             )
 
             wks_all_atoms_explicitly = Abins(
+                Version=2,
                 VibrationalOrPhononFile=self._squaricn + ".phonon",
                 Atoms="H, C, O",
                 SumContributions=self._sum_contributions,
@@ -365,6 +396,7 @@ class AbinsBasicTest(unittest.TestCase):
             )
 
             wks_all_atoms_default = Abins(
+                Version=2,
                 VibrationalOrPhononFile=self._squaricn + ".phonon",
                 SumContributions=self._sum_contributions,
                 QuantumOrderEventsNumber=self._quantum_order_events_number,
@@ -393,6 +425,7 @@ class AbinsBasicTest(unittest.TestCase):
         """Simulated INS spectrum can also be resolved by numbered atoms. Check consistency with element totals"""
         with patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir):
             wrk_ref = Abins(
+                Version=2,
                 AbInitioProgram=self._ab_initio_program,
                 VibrationalOrPhononFile=self._squaricn + ".phonon",
                 Atoms=self._atoms,
@@ -404,6 +437,7 @@ class AbinsBasicTest(unittest.TestCase):
             numbered_workspace_name = "numbered"
             h_indices = ("1", "2", "3", "4")
             wks_numbered_atoms = Abins(
+                Version=2,
                 VibrationalOrPhononFile=self._squaricn + ".phonon",
                 Atoms=", ".join([ATOM_PREFIX + s for s in h_indices]),
                 SumContributions=self._sum_contributions,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/Abins2BasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/Abins2BasicTest.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
+# Register Abins2 before importing mantid modules
 from abins.abins2 import Abins as Abins2
 
 Abins2.subscribe()
@@ -24,6 +25,7 @@ import abins.io
 
 
 class AbinsBasicTest(unittest.TestCase):
+    # Define typical values for parameters
     _si2 = "Si2-sc_Abins"
     _squaricn = "squaricn_sum_Abins"
     _ab_initio_program = "CASTEP"
@@ -31,14 +33,13 @@ class AbinsBasicTest(unittest.TestCase):
     _instrument_name = "TOSCA"
     _atoms = ""  # if no atoms are specified then all atoms are taken into account
     _sum_contributions = True
-
-    # this is a string; once it is read it is converted internally to  integer
-    _quantum_order_events_number = str(FUNDAMENTALS)
+    _quantum_order_events_number = "1"
 
     _cross_section_factor = "Incoherent"
     _workspace_name = "output_workspace"
-    _tolerance = 0.0001
 
+    # Test-related parameters
+    _tolerance = 0.0001
     _tmp_cache_dir = None
 
     def get_cache_dir(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/Abins2BasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/Abins2BasicTest.py
@@ -51,16 +51,6 @@ class AbinsBasicTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        # Debugging: save the dir ls output so I can check it is actually used
-        import subprocess
-
-        process = subprocess.run(["ls", "-l", cls._tmp_cache_dir.name], capture_output=True)
-
-        with open("/home/prg49555/Desktop/cachedir.txt", "w") as f:
-            f.write(cls._tmp_cache_dir.name)
-            f.write("\n")
-            f.write(process.stdout.decode())
-
         cls._tmp_cache_dir.cleanup()
 
     def tearDown(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/Abins2BasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/Abins2BasicTest.py
@@ -4,6 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+import logging
 import os
 import tempfile
 import unittest
@@ -16,7 +17,6 @@ from abins.abins2 import Abins as Abins2
 Abins2.subscribe()
 
 import mantid.kernel
-from mantid import logger
 from mantid.simpleapi import mtd, Scale, CompareWorkspaces, Load, DeleteWorkspace, Abins
 import abins
 from abins.constants import ATOM_PREFIX, FUNDAMENTALS
@@ -53,6 +53,9 @@ class AbinsBasicTest(unittest.TestCase):
     def tearDownClass(cls):
         cls._tmp_cache_dir.cleanup()
 
+    def setUp(self):
+        self.logger = logging.getLogger("abins2-basic-test")
+
     def tearDown(self):
         abins.test_helpers.remove_output_files(
             list_of_names=[
@@ -68,6 +71,13 @@ class AbinsBasicTest(unittest.TestCase):
             ]
         )
         mtd.clear()
+
+    def test_subscribe_warning(self):
+        """Test that subscribing work-in-progress algorithm raises warning"""
+        with self.assertLogs(logger=self.logger, level="WARNING") as log_context:
+            Abins2.subscribe(logger=self.logger)
+
+            self.assertIn("breaking changes", log_context.output[0])
 
     def test_wrong_input(self):
         """Test if the correct behaviour of algorithm in case input is not valid"""

--- a/Framework/PythonInterface/test/python/plugins/algorithms/Abins2BasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/Abins2BasicTest.py
@@ -1,0 +1,430 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+
+from abins.abins2 import Abins as Abins2
+
+Abins2.subscribe()
+
+import mantid.kernel
+from mantid import logger
+from mantid.simpleapi import mtd, Scale, CompareWorkspaces, Load, DeleteWorkspace, Abins
+import abins
+from abins.constants import ATOM_PREFIX, FUNDAMENTALS
+import abins.io
+
+
+class AbinsBasicTest(unittest.TestCase):
+    _si2 = "Si2-sc_Abins"
+    _squaricn = "squaricn_sum_Abins"
+    _ab_initio_program = "CASTEP"
+    _temperature = 10.0  # temperature 10 K
+    _scale = 1.0
+    _instrument_name = "TOSCA"
+    _atoms = ""  # if no atoms are specified then all atoms are taken into account
+    _sum_contributions = True
+
+    # this is a string; once it is read it is converted internally to  integer
+    _quantum_order_events_number = str(FUNDAMENTALS)
+
+    _cross_section_factor = "Incoherent"
+    _workspace_name = "output_workspace"
+    _tolerance = 0.0001
+
+    _tmp_cache_dir = None
+
+    def get_cache_dir(self):
+        return self._tmp_cache_dir.name
+
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp_cache_dir = tempfile.TemporaryDirectory()
+
+    @classmethod
+    def tearDownClass(cls):
+        # Debugging: save the dir ls output so I can check it is actually used
+        import subprocess
+
+        process = subprocess.run(["ls", "-l", cls._tmp_cache_dir.name], capture_output=True)
+
+        with open("/home/prg49555/Desktop/cachedir.txt", "w") as f:
+            f.write(cls._tmp_cache_dir.name)
+            f.write("\n")
+            f.write(process.stdout.decode())
+
+        cls._tmp_cache_dir.cleanup()
+
+    def tearDown(self):
+        abins.test_helpers.remove_output_files(
+            list_of_names=[
+                "explicit",
+                "default",
+                "total",
+                "squaricn_sum_Abins",
+                "squaricn_scale",
+                "benzene_exp",
+                "benzene_Abins",
+                "experimental",
+                "numbered",
+            ]
+        )
+        mtd.clear()
+
+    def test_wrong_input(self):
+        """Test if the correct behaviour of algorithm in case input is not valid"""
+
+        #  invalid CASTEP file missing:  Number of branches     6 in the header file
+
+        with (
+            self.assertRaisesRegex(RuntimeError, "The third line should include 'Number of branches'."),
+            patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
+        ):
+
+            Abins(VibrationalOrPhononFile="Si2-sc_wrong.phonon", OutputWorkspace=self._workspace_name, Version=2)
+
+        # wrong extension of phonon file in case of CASTEP
+        with (
+            self.assertRaisesRegex(
+                RuntimeError,
+                "The expected extension of file is .phonon.",
+            ),
+            patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
+        ):
+
+            Abins(
+                VibrationalOrPhononFile="Si2-sc.wrong_phonon",
+                OutputWorkspace=self._workspace_name,
+            )
+
+        # wrong extension of phonon file in case of CRYSTAL
+        with (
+            self.assertRaisesRegex(
+                RuntimeError,
+                "The expected extension of file is .out.",
+            ),
+            patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
+        ):
+            Abins(
+                AbInitioProgram="CRYSTAL",
+                VibrationalOrPhononFile="MgO.wrong_out",
+                OutputWorkspace=self._workspace_name,
+            )
+
+        # no name for workspace
+        self.assertRaises(TypeError, Abins, VibrationalOrPhononFile=self._si2 + ".phonon", TemperatureInKelvin=self._temperature)
+
+        # keyword total in the name of the workspace
+        with (
+            self.assertRaisesRegex(
+                RuntimeError,
+                "Keyword: total cannot be used in the name of workspace.",
+            ),
+            patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
+        ):
+            Abins(
+                VibrationalOrPhononFile=self._si2 + ".phonon",
+                TemperatureInKelvin=self._temperature,
+                OutputWorkspace=self._workspace_name + "total",
+            )
+
+        # negative temperature in K
+        with (
+            self.assertRaisesRegex(
+                RuntimeError,
+                "Temperature must be positive.",
+            ),
+            patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
+        ):
+            Abins(
+                VibrationalOrPhononFile=self._si2 + ".phonon",
+                TemperatureInKelvin=-1.0,
+                OutputWorkspace=self._workspace_name,
+            )
+
+        # negative scale
+        with (
+            self.assertRaisesRegex(RuntimeError, "Scale must be positive."),
+            patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
+        ):
+
+            Abins(VibrationalOrPhononFile=self._si2 + ".phonon", Scale=-0.2, OutputWorkspace=self._workspace_name)
+
+        # unknown instrument
+        with (
+            self.assertRaisesRegex(ValueError, 'The value "UnknownInstrument" is not in the list of allowed values'),
+            patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
+        ):
+            Abins(VibrationalOrPhononFile=self._si2 + ".phonon", Instrument="UnknownInstrument", OutputWorkspace=self._workspace_name)
+
+    # test if intermediate results are consistent
+    def test_non_unique_elements(self):
+        """Test scenario in which a user specifies non-unique elements (for example in squaricn that would be "C,C,H").
+        In that case Abins should terminate and print a meaningful message.
+        """
+        with (
+            self.assertRaisesRegex(RuntimeError, r"User atom selection \(by symbol\) contains repeated species."),
+            patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
+        ):
+            Abins(
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                Atoms="C,C,H",
+                OutputWorkspace=self._workspace_name,
+            )
+
+    def test_non_unique_atoms(self):
+        """Test scenario in which a user specifies non-unique atoms (for example "atom_1,atom_2,atom1").
+        In that case Abins should terminate and print a meaningful message.
+        """
+        with (
+            self.assertRaisesRegex(RuntimeError, r"User atom selection \(by number\) contains repeated atom."),
+            patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
+        ):
+
+            Abins(
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                Atoms="atom_1,atom_2,atom1",
+                OutputWorkspace=self._workspace_name,
+            )
+
+    def test_non_existing_atoms(self):
+        """Test scenario in which  a user requests to create workspaces for atoms which do not exist in the system.
+        In that case Abins should terminate and give a user a meaningful message about wrong atoms to analyse.
+        """
+        # In _squaricn there are no N atoms
+        with (
+            self.assertRaisesRegex(RuntimeError, r"User defined atom selection \(by element\) 'N': not present in the system."),
+            patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir),
+        ):
+
+            Abins(
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                Atoms="N",
+                OutputWorkspace=self._workspace_name,
+            )
+
+    def test_atom_index_limits(self):
+        """Individual atoms may be indexed (counting from 1); if the index falls outside number of atoms, Abins should
+        terminate with a useful error message.
+        """
+        with patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir):
+            self.assertRaisesRegex(
+                RuntimeError,
+                r"Invalid user atom selection \(by number\)" + f" '{ATOM_PREFIX}0'",
+                Abins,
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                Atoms=ATOM_PREFIX + "0",
+                OutputWorkspace=self._workspace_name,
+            )
+            self.assertRaisesRegex(
+                RuntimeError,
+                r"Invalid user atom selection \(by number\)" + f" '{ATOM_PREFIX}61'",
+                Abins,
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                Atoms=ATOM_PREFIX + "61",
+                OutputWorkspace=self._workspace_name,
+            )
+
+    def test_atom_index_invalid(self):
+        """If the atoms field includes an unmatched entry (i.e. containing the prefix but not matching the '\d+' regex,
+        Abins should terminate with a useful error message.
+        """
+        with patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir):
+            self.assertRaisesRegex(
+                RuntimeError,
+                r"Not all user atom selections \('atoms' option\) were understood.",
+                Abins,
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                Atoms=ATOM_PREFIX + "-3",
+                OutputWorkspace=self._workspace_name,
+            )
+            self.assertRaisesRegex(
+                RuntimeError,
+                r"Not all user atom selections \('atoms' option\) were understood.",
+                Abins,
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                Atoms=ATOM_PREFIX + "_#4",
+                OutputWorkspace=self._workspace_name,
+            )
+
+    def test_scale(self):
+        """
+        Test if scaling is correct.
+        @return:
+        """
+        with patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir):
+            wrk_ref = Abins(
+                AbInitioProgram=self._ab_initio_program,
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                TemperatureInKelvin=self._temperature,
+                Instrument=self._instrument_name,
+                Atoms=self._atoms,
+                Scale=self._scale,
+                SumContributions=self._sum_contributions,
+                QuantumOrderEventsNumber=self._quantum_order_events_number,
+                ScaleByCrossSection=self._cross_section_factor,
+                OutputWorkspace=self._squaricn + "_ref",
+            )
+
+            wrk = Abins(
+                AbInitioProgram=self._ab_initio_program,
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                TemperatureInKelvin=self._temperature,
+                Instrument=self._instrument_name,
+                Atoms=self._atoms,
+                SumContributions=self._sum_contributions,
+                QuantumOrderEventsNumber=self._quantum_order_events_number,
+                Scale=10,
+                ScaleByCrossSection=self._cross_section_factor,
+                OutputWorkspace="squaricn_scale",
+            )
+
+        ref = Scale(wrk_ref, Factor=10)
+
+        (result, messages) = CompareWorkspaces(wrk, ref, Tolerance=self._tolerance)
+        self.assertEqual(result, True)
+
+    def test_lagrange_exists(self):
+        with patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir):
+            Abins(
+                AbInitioProgram=self._ab_initio_program,
+                VibrationalOrPhononFile=(self._squaricn + ".phonon"),
+                TemperatureInKelvin=self._temperature,
+                Instrument="Lagrange",
+                Setting="Cu(331) (Lagrange)",
+                Atoms=self._atoms,
+                Scale=self._scale,
+                SumContributions=self._sum_contributions,
+                QuantumOrderEventsNumber=self._quantum_order_events_number,
+                ScaleByCrossSection=self._cross_section_factor,
+                OutputWorkspace="squaricn-lagrange",
+            )
+
+    def test_exp(self):
+        """
+        Tests if experimental data is loaded correctly.
+        @return:
+        """
+        with patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir):
+            Abins(
+                AbInitioProgram=self._ab_initio_program,
+                VibrationalOrPhononFile="benzene_Abins.phonon",
+                ExperimentalFile="benzene_Abins.dat",
+                TemperatureInKelvin=self._temperature,
+                Instrument=self._instrument_name,
+                Atoms=self._atoms,
+                Scale=self._scale,
+                SumContributions=self._sum_contributions,
+                QuantumOrderEventsNumber=self._quantum_order_events_number,
+                ScaleByCrossSection=self._cross_section_factor,
+                OutputWorkspace="benzene_exp",
+            )
+
+            # load experimental data
+            Load(Filename="benzene.dat", OutputWorkspace="benzene_only_exp")
+
+            (result, messages) = CompareWorkspaces(
+                Workspace1=mtd["experimental_wrk"], Workspace2=mtd["benzene_only_exp"], CheckAxes=False, Tolerance=self._tolerance
+            )
+            self.assertEqual(result, True)
+
+    def test_partial_by_element(self):
+        """Check results of INS spectrum resolved by elements: default should match explicit list of elements"""
+
+        experimental_file = ""
+
+        with patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir):
+            wrk_ref = Abins(
+                AbInitioProgram=self._ab_initio_program,
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                ExperimentalFile=experimental_file,
+                TemperatureInKelvin=self._temperature,
+                Instrument=self._instrument_name,
+                Atoms=self._atoms,
+                Scale=self._scale,
+                SumContributions=self._sum_contributions,
+                QuantumOrderEventsNumber=self._quantum_order_events_number,
+                ScaleByCrossSection=self._cross_section_factor,
+                OutputWorkspace=self._squaricn + "_ref",
+            )
+
+            wks_all_atoms_explicitly = Abins(
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                Atoms="H, C, O",
+                SumContributions=self._sum_contributions,
+                QuantumOrderEventsNumber=self._quantum_order_events_number,
+                OutputWorkspace="explicit",
+            )
+
+            wks_all_atoms_default = Abins(
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                SumContributions=self._sum_contributions,
+                QuantumOrderEventsNumber=self._quantum_order_events_number,
+                OutputWorkspace="default",
+            )
+
+        # Python 3 has no guarantee of dict order so the workspaces in the group may be in
+        # a different order on Python 3
+        self.assertEqual(wks_all_atoms_explicitly.size(), wks_all_atoms_default.size())
+        explicit_names = wks_all_atoms_explicitly.getNames()
+        for i in range(len(explicit_names)):
+            explicit_name = explicit_names[i]
+            default_name = "default" + explicit_name[8:]
+            (result, messages) = CompareWorkspaces(explicit_name, default_name, Tolerance=self._tolerance)
+            self.assertEqual(result, True)
+
+        self.assertEqual(wrk_ref.size(), wks_all_atoms_default.size())
+        ref_names = wrk_ref.getNames()
+        for i in range(len(ref_names)):
+            ref_name = ref_names[i]
+            default_name = "default" + ref_name[len(self._squaricn + "_ref") :]
+            (result, messages) = CompareWorkspaces(ref_name, default_name, Tolerance=self._tolerance)
+            self.assertEqual(result, True)
+
+    def test_partial_by_number(self):
+        """Simulated INS spectrum can also be resolved by numbered atoms. Check consistency with element totals"""
+        with patch.object(abins.io.IO, "get_save_dir_path", side_effect=self.get_cache_dir):
+            wrk_ref = Abins(
+                AbInitioProgram=self._ab_initio_program,
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                Atoms=self._atoms,
+                QuantumOrderEventsNumber=self._quantum_order_events_number,
+                ScaleByCrossSection=self._cross_section_factor,
+                OutputWorkspace=self._squaricn + "_ref",
+            )
+
+            numbered_workspace_name = "numbered"
+            h_indices = ("1", "2", "3", "4")
+            wks_numbered_atoms = Abins(
+                VibrationalOrPhononFile=self._squaricn + ".phonon",
+                Atoms=", ".join([ATOM_PREFIX + s for s in h_indices]),
+                SumContributions=self._sum_contributions,
+                QuantumOrderEventsNumber=self._quantum_order_events_number,
+                ScaleByCrossSection=self._cross_section_factor,
+                OutputWorkspace=numbered_workspace_name,
+            )
+
+        wrk_ref_names = list(wrk_ref.getNames())
+        wrk_h_total = wrk_ref[wrk_ref_names.index(self._squaricn + "_ref_H_total")]
+
+        wks_numbered_atom_names = list(wks_numbered_atoms.getNames())
+        wrk_atom_totals = [
+            wks_numbered_atoms[wks_numbered_atom_names.index(name)]
+            for name in ["_".join((numbered_workspace_name, ATOM_PREFIX, s, "total")) for s in h_indices]
+        ]
+
+        assert_array_almost_equal(wrk_h_total.extractX(), wrk_atom_totals[0].extractX())
+
+        assert_array_almost_equal(wrk_h_total.extractY(), sum((wrk.extractY() for wrk in wrk_atom_totals)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(WorkflowAlgorithms)
 
 set(TEST_PY_FILES
     AbinsBasicTest.py
+    Abins2BasicTest.py
     AbinsAdvancedParametersTest.py
     AlignComponentsTest.py
     AngularAutoCorrelationsSingleAxisTest.py

--- a/scripts/abins/abins2.py
+++ b/scripts/abins/abins2.py
@@ -49,7 +49,7 @@ class Abins(AbinsAlgorithm, PythonAlgorithm):
         from abins.constants import ONE_DIMENSIONAL_INSTRUMENTS
 
         # Declare properties for all Abins Algorithms
-        self.declare_common_properties()
+        self.declare_common_properties(version=2)
 
         # Declare properties specific to 1D
         self.declareProperty(

--- a/scripts/abins/abins2.py
+++ b/scripts/abins/abins2.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 
-from typing import Dict
+from typing import Dict, Optional
 
 from mantid.api import AlgorithmFactory, FileAction, FileProperty, PythonAlgorithm, Progress
 from mantid.api import WorkspaceFactory, AnalysisDataService
@@ -15,6 +15,7 @@ from mantid.simpleapi import ConvertUnits, GroupWorkspaces, Load
 from mantid.kernel import Direction
 import abins
 from abins.abinsalgorithm import AbinsAlgorithm
+from abins.logging import get_logger, Logger
 
 
 # noinspection PyPep8Naming,PyMethodMayBeStatic
@@ -30,7 +31,10 @@ class Abins(AbinsAlgorithm, PythonAlgorithm):
         self._initial_parameters_bin_width = abins.parameters.sampling["bin_width"]
 
     @classmethod
-    def subscribe(cls) -> None:
+    def subscribe(cls, logger: Optional[Logger] = None) -> None:
+
+        logger = get_logger(logger=logger)
+        logger.warning("Registering Abins v2 algorithm. This is work-in-progress: breaking changes are expected until full release.")
         AlgorithmFactory.subscribe(cls)
 
     def category(self) -> str:

--- a/scripts/abins/abins2.py
+++ b/scripts/abins/abins2.py
@@ -29,7 +29,11 @@ class Abins(AbinsAlgorithm, PythonAlgorithm):
 
     @classmethod
     def subscribe(cls, logger: Optional[Logger] = None) -> None:
+        """Register Abins v2 with Algorithm Factory
 
+        You may need to importlib.reload(mantid.simpleapi) to make v2 the default version of the Algorithm.
+        Otherwise, provide a ``Version=2`` parameter when calling Abins to use this version.
+        """
         logger = get_logger(logger=logger)
         logger.warning("Registering Abins v2 algorithm. This is work-in-progress: breaking changes are expected until full release.")
         AlgorithmFactory.subscribe(cls)

--- a/scripts/abins/abinsalgorithm.py
+++ b/scripts/abins/abinsalgorithm.py
@@ -86,7 +86,7 @@ class AbinsAlgorithm:
     def get_instrument(self) -> Union[Instrument, None]:
         return self._instrument
 
-    def declare_common_properties(self) -> None:
+    def declare_common_properties(self, version: int = 1) -> None:
         """Declare properties common to Abins 1D and 2D versions"""
         self.declareProperty(
             FileProperty(
@@ -122,7 +122,9 @@ class AbinsAlgorithm:
         )
 
         self.declareProperty(
-            name="SumContributions", defaultValue=False, doc="Sum the partial dynamical structure factors into a single workspace."
+            name="SumContributions",
+            defaultValue=(False if version == 1 else True),
+            doc="Sum the partial dynamical structure factors into a single workspace.",
         )
 
         self.declareProperty(name="SaveAscii", defaultValue=False, doc="Write workspaces to .ascii files after computing them.")
@@ -134,19 +136,28 @@ class AbinsAlgorithm:
             doc="Scale the partial dynamical structure factors by the scattering cross section.",
         )
 
-        # Abins is supposed to support excitations up to fourth-order. Order 3 and 4 are currently disabled while the
-        # weighting is being investigated; these intensities were unreasonably large in hydrogenous test cases
-        self.declareProperty(
-            name="QuantumOrderEventsNumber",
-            defaultValue="1",
-            validator=StringListValidator(["1", "2"]),
-            doc="Number of quantum order effects included in the calculation "
-            "(1 -> FUNDAMENTALS, 2-> first overtone + FUNDAMENTALS + 2nd order combinations",
-        )
+        if version == 1:
+            self.declareProperty(
+                name="QuantumOrderEventsNumber",
+                defaultValue="1",
+                validator=StringListValidator(["1", "2"]),
+                doc="Number of quantum order effects included in the calculation "
+                "(1 -> FUNDAMENTALS, 2-> first overtone + FUNDAMENTALS + 2nd order combinations",
+            )
 
-        self.declareProperty(
-            name="Autoconvolution", defaultValue=False, doc="Estimate higher quantum orders by convolution with fundamental spectrum."
-        )
+            self.declareProperty(
+                name="Autoconvolution", defaultValue=False, doc="Estimate higher quantum orders by convolution with fundamental spectrum."
+            )
+
+        else:
+            autoconvolution_max = str(abins.parameters.autoconvolution["max_order"])
+            self.declareProperty(
+                name="QuantumOrderEventsNumber",
+                defaultValue=autoconvolution_max,
+                validator=StringListValidator(["1", "2", autoconvolution_max]),
+                doc="Number of quantum order effects included in the calculation "
+                "(1 -> Fundamentals, 2-> add first overtone and 2nd order combinations, 10-> add 8 orders by self-convolution",
+            )
 
         self.declareProperty(
             name="EnergyUnits",

--- a/scripts/abins/input/vasploader.py
+++ b/scripts/abins/input/vasploader.py
@@ -6,21 +6,18 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 from itertools import chain
-import logging
 import os
 import re
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional
 from xml.etree import ElementTree
 
-import mantid.kernel
 
 import numpy as np
 
 from abins import AbinsData
-from abins.input import AbInitioLoader, TextParser
 from abins.constants import COMPLEX_TYPE, FLOAT_TYPE, HZ2INV_CM, VASP_FREQ_TO_THZ
-
-Logger = Union[logging.Logger, mantid.kernel.Logger]
+from abins.input import AbInitioLoader, TextParser
+from abins.logging import get_logger, Logger
 
 
 class VASPLoader(AbInitioLoader):
@@ -37,7 +34,7 @@ class VASPLoader(AbInitioLoader):
     def _ab_initio_program(self) -> str:
         return "VASP"
 
-    def read_vibrational_or_phonon_data(self, logger: Logger = None) -> AbinsData:
+    def read_vibrational_or_phonon_data(self, logger: Optional[Logger] = None) -> AbinsData:
         input_filename = self._clerk.get_input_filename()
 
         if not os.path.isfile(input_filename):
@@ -49,11 +46,7 @@ class VASPLoader(AbInitioLoader):
             self._num_k = 1
 
         elif "OUTCAR" in input_filename:
-            if logger is None:
-                import mantid.kernel
-
-                mantid_logger: mantid.kernel.Logger = mantid.kernel.logger
-                logger = mantid_logger
+            logger = get_logger(logger=logger)
             logger.warning(
                 "Reading OUTCAR file. This feature is included for development purposes "
                 "and may be removed in future versions. Please use the vasprun.xml file where possible."

--- a/scripts/abins/instruments/instrument.py
+++ b/scripts/abins/instruments/instrument.py
@@ -5,16 +5,13 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 # noinspection PyPep8Naming
-import logging
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional
 
-import mantid.kernel
 import numpy as np
 
 from abins.constants import FLOAT_TYPE
+from abins.logging import get_logger, Logger
 import abins.parameters
-
-Logger = Union[logging.Logger, mantid.kernel.Logger]
 
 
 class Instrument:
@@ -170,7 +167,7 @@ class Instrument:
     def get_name(self):
         return self._name
 
-    def _check_setting(self, setting: str, logger: Logger = None) -> str:
+    def _check_setting(self, setting: str, logger: Optional[Logger] = None) -> str:
         """Sanity-check that setting is appropriate for selected instrument
 
         Return an appropriate value for setting: for example, '' may be set
@@ -195,9 +192,7 @@ class Instrument:
         """
         import abins.parameters
 
-        if logger is None:
-            mantid_logger: mantid.kernel.Logger = mantid.kernel.logger
-            logger = mantid_logger
+        logger = get_logger(logger=logger)
 
         if self.get_name() not in abins.parameters.instruments:
             # If an instrument lacks an entry in abins.parameters, we cannot

--- a/scripts/abins/instruments/pychop.py
+++ b/scripts/abins/instruments/pychop.py
@@ -1,11 +1,10 @@
-import logging
 from typing import Optional, Tuple, Union
 
 import numpy as np
-import mantid.kernel
 from pychop import Instruments as pychop_instruments
 
 from abins.constants import MILLI_EV_TO_WAVENUMBER
+from abins.logging import get_logger, Logger
 from .directinstrument import DirectInstrument
 
 
@@ -32,16 +31,13 @@ class PyChopInstrument(DirectInstrument):
         # Get detector 2θ limits from Pychop dataset
         self._tthlims = self._pychop_instrument.detector.tthlims
 
-    def _check_chopper_frequency(
-        self, chopper_frequency: Union[int, None], logger: Union[logging.Logger, mantid.kernel.Logger, None] = None
-    ) -> int:
+    def _check_chopper_frequency(self, chopper_frequency: Union[int, None], logger: Optional[Logger] = None) -> int:
 
         if chopper_frequency is None:
             chopper_frequency = self.get_parameter("chopper_frequency_default")
 
-            if logger is None:
-                mantid_logger: mantid.kernel.Logger = mantid.kernel.logger
-                logger = mantid_logger
+            logger = get_logger(logger=logger)
+            assert isinstance(logger, Logger)
 
             logger.notice(f"Using default chopper frequency for instrument {self._name}: " f"{chopper_frequency} Hz")
 

--- a/scripts/abins/io.py
+++ b/scripts/abins/io.py
@@ -56,8 +56,7 @@ class IO(object):
         else:
             core_name = filename  # e.g. OUTCAR -> OUTCAR (core_name) -> OUTCAR.hdf5
 
-        save_dir_path = ConfigService.getString("defaultsave.directory")
-        self._hdf_filename = os.path.join(save_dir_path, core_name + ".hdf5")  # name of hdf file
+        self._hdf_filename = os.path.join(self.get_save_dir_path(), core_name + ".hdf5")  # name of hdf file
 
         self._attributes = {}  # attributes for group
 
@@ -67,6 +66,10 @@ class IO(object):
         self._data = {}
 
         # Fields which have a form of empty dictionaries have to be set by an inheriting class.
+
+    @staticmethod
+    def get_save_dir_path() -> str:
+        return ConfigService.getString("defaultsave.directory")
 
     def _valid_hash(self):
         """

--- a/scripts/abins/io.py
+++ b/scripts/abins/io.py
@@ -131,6 +131,8 @@ class IO(object):
             return True
 
         if isinstance(new, (np.ndarray, float)):
+            if previous is None:
+                return False
             return np.allclose(previous, new)
         # Tuples are converted to list in caching
         elif isinstance(new, tuple):

--- a/scripts/abins/kpointsdata.py
+++ b/scripts/abins/kpointsdata.py
@@ -5,14 +5,14 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import collections.abc
-from typing import List, NamedTuple, overload, Type, TypedDict, TypeVar
+from typing import List, NamedTuple, Optional, overload, Type, TypedDict, TypeVar
 from math import isclose
 
 import numpy as np
 from numpy.linalg import norm
-from mantid.kernel import logger as mantid_logger
 
 from abins.constants import COMPLEX_ID, COMPLEX_TYPE, FLOAT_ID, FLOAT_TYPE
+from abins.logging import get_logger, Logger
 
 
 class KpointData(NamedTuple):
@@ -56,12 +56,11 @@ class KpointsData(collections.abc.Sequence):
         weights: np.ndarray,
         k_vectors: np.ndarray,
         unit_cell: np.ndarray,
-        logger=None
+        logger: Optional[Logger] = None,
     ) -> None:
         super().__init__()
 
-        if logger is None:
-            logger = mantid_logger
+        logger = get_logger(logger=logger)
 
         dim = 3
 
@@ -140,8 +139,7 @@ class KpointsData(collections.abc.Sequence):
         return self._weights.size
 
     @overload  # F811
-    def __getitem__(self, item: int) -> KpointData:
-        ...
+    def __getitem__(self, item: int) -> KpointData: ...
 
     @overload  # F811
     def __getitem__(self, item: slice) -> List[KpointData]:  # F811

--- a/scripts/abins/logging.py
+++ b/scripts/abins/logging.py
@@ -1,0 +1,17 @@
+from logging import Logger as PythonLogger
+from typing import Optional
+
+from mantid.kernel import logger as mantid_kernel_logger
+from mantid.kernel import Logger as MantidKernelLogger
+
+
+Logger = PythonLogger | MantidKernelLogger
+
+
+def get_logger(logger: Optional[Logger] = None) -> Logger:
+    """Get Mantid kernel logger if no logging.Logger provided"""
+
+    if logger is None:
+        return mantid_kernel_logger
+    else:
+        return logger

--- a/scripts/abins/parameters.py
+++ b/scripts/abins/parameters.py
@@ -160,7 +160,11 @@ sampling = {
 }
 
 # Parameters related to estimated of spectra of high quantum orders by repeated convolution with fundamentals
-autoconvolution = {"max_order": 10, "fine_bin_factor": 10}  # Highest quantum order accessed by autoconvolution
+autoconvolution = {
+    "fine_bin_factor": 10,  # Bin size reduction during autoconvolution
+    "max_order": 10,  # Highest quantum order accessed by autoconvolution
+    "min_order": 3,  # Lowest quantum order accessed by autoconvolution. (Abins v1 disregards this.)
+}
 
 performance = {
     "optimal_size": 5000000,  # this is used to create optimal size of chunk energies for which S is calculated

--- a/scripts/abins/scalculatorfactory.py
+++ b/scripts/abins/scalculatorfactory.py
@@ -27,7 +27,7 @@ class SCalculatorFactory(object):
         abins_data: abins.AbinsData,
         instrument: Instrument,
         quantum_order_num: int,
-        autoconvolution: bool = False
+        autoconvolution_max: int = 0
     ):
         """
         :param filename: name of input DFT file (CASTEP: foo.phonon)
@@ -36,7 +36,7 @@ class SCalculatorFactory(object):
         :param abins_data: object of type AbinsData with data from phonon file
         :param instrument: object of type Instrument for which simulation should be performed
         :param quantum_order_num: number of quantum order events taken into account during the simulation
-        :param autoconvolution: Convolve results with fundamentals to obtain approximate spectra up to this order
+        :param autoconvolution_max: Convolve results with fundamentals to obtain approximate spectra up to this order
         """
         if sample_form in ALL_SAMPLE_FORMS:
             if sample_form == "Powder":
@@ -47,11 +47,9 @@ class SCalculatorFactory(object):
                     abins_data=abins_data,
                     instrument=instrument,
                     quantum_order_num=quantum_order_num,
-                    autoconvolution=autoconvolution,
+                    autoconvolution_max=autoconvolution_max,
                 )
-                # TODO: implement numerical powder averaging
 
-            # elif sample == "SingleCrystal":  #TODO implement single crystal scenario
             else:
                 raise ValueError("Only implementation for sample in the form of powder is available.")
         else:

--- a/scripts/abins/sdata.py
+++ b/scripts/abins/sdata.py
@@ -11,10 +11,10 @@ import numpy as np
 from numbers import Real
 from scipy.signal import convolve
 
-from mantid.kernel import logger as mantid_logger
 import abins
 from abins.constants import ALL_KEYWORDS_ATOMS_S_DATA, ALL_SAMPLE_FORMS, ATOM_LABEL, FLOAT_TYPE, S_LABEL
 from abins.instruments.directinstrument import DirectInstrument
+from abins.logging import get_logger, Logger
 import abins.parameters
 
 # Type annotation for atom items e.g. data['atom_1']
@@ -378,7 +378,7 @@ class SData(collections.abc.Sequence):
                 spectrum = convolve(atom_data["s"][f"order_{order_index}"], fundamental_spectrum, mode="full")[: fundamental_spectrum.size]
                 self._data[atom_key]["s"][f"order_{order_index + 1}"] = spectrum
 
-    def check_thresholds(self, return_cases: bool = False, logger=None, logging_level: str = "warning"):
+    def check_thresholds(self, return_cases: bool = False, logger: Optional[Logger] = None, logging_level: str = "warning"):
         """
         Compare the S data values to minimum thresholds and warn if the threshold appears large relative to the data
 
@@ -396,8 +396,7 @@ class SData(collections.abc.Sequence):
 
         """
 
-        if logger is None:
-            logger = mantid_logger
+        logger = get_logger(logger=logger)
         logger_call = getattr(logger, logging_level)
 
         warning_cases = []
@@ -508,8 +507,7 @@ class SData(collections.abc.Sequence):
         return len(self._data)
 
     @overload  # F811
-    def __getitem__(self, item: int) -> OneAtomSData:
-        ...
+    def __getitem__(self, item: int) -> OneAtomSData: ...
 
     @overload  # F811
     def __getitem__(self, item: slice) -> List[OneAtomSData]:  # F811
@@ -586,8 +584,7 @@ class SDataByAngle(collections.abc.Sequence):
         return len(self.angles)
 
     @overload  # F811
-    def __getitem__(self, item: int) -> SData:
-        ...
+    def __getitem__(self, item: int) -> SData: ...
 
     @overload  # F811
     def __getitem__(self: SDBA, item: slice) -> SDBA:  # F811

--- a/scripts/abins/test_helpers.py
+++ b/scripts/abins/test_helpers.py
@@ -14,6 +14,7 @@ from numpy.testing import assert_allclose
 
 from abins.atomsdata import _AtomData
 from abins.kpointsdata import KpointData
+import abins.io
 
 
 # Module with helper functions used to create tests.
@@ -61,7 +62,7 @@ def remove_output_files(list_of_names=None):
     for filename in all_files:
         for name in list_of_names:
             if name in filename:
-                full_path = os.path.join(save_dir_path, filename)
+                full_path = os.path.join(abins.io.IO.get_save_dir_path(), filename)
                 if os.path.isfile(full_path):
                     os.remove(full_path)
                 break

--- a/scripts/test/Abins/AbinsCalculateSPowderTest.py
+++ b/scripts/test/Abins/AbinsCalculateSPowderTest.py
@@ -32,7 +32,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
     _instruments_defaults = {}
 
     default_calculator_kwargs = dict(
-        temperature=_temperature, instrument=_instrument, sample_form=_sample_form, quantum_order_num=_order_event, autoconvolution=False
+        temperature=_temperature, instrument=_instrument, sample_form=_sample_form, quantum_order_num=_order_event, autoconvolution_max=10
     )
 
     def setUp(self):
@@ -113,7 +113,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
         self._good_case(test_name=self._si2 + "_1d_o2", abinsdata_name=self._si2, quantum_order_num=2)
 
     def test_1d_order10(self):
-        self._good_case(test_name=self._si2 + "_1d_o10", abinsdata_name=self._si2, quantum_order_num=2, autoconvolution=True)
+        self._good_case(test_name=self._si2 + "_1d_o10", abinsdata_name=self._si2, quantum_order_num=2, autoconvolution_max=10)
 
     def test_2d_order1_mari(self):
         abins.parameters.instruments["MARI"].update({"q_size": 10, "n_energy_bins": 100})


### PR DESCRIPTION
### Description of work

#### Summary of work
Create a work-in-progress Abins-v2 algorithm, which may be subscribed to the Algorithm Factory by calling a `subscribe()` classmethod

#### Purpose of work
Several API-breaking features are intended for Abins; these should be collected into a version 2 of the Algorithm.

Rather than attempt a complete API design before implementing features, this should be developed progressively and reviewed in small pieces before the collected changes are released for general use.

One way to manage this would be a feature branch. However, @robertapplin suggested an alternative that seems even better: implement the algorithm and merge into master, but leave it unsubscribed until ready. This approach:
- avoids a long-lived feature branch and related merge conflicts
- streamlines user testing, as scientists can be directed to use a Nightly build and run a line or two of Python to subscribe the algorithm and test it


#### Further detail of work
- In this PR we avoid implementing any complex features and focus on the instantiation/testing issues. A few deprecated parameters/properties are removed from the Algorithm.
- In order to avoid a race condition between the caching systems of duplicated tests, unittest.mock.patch is used to redirect the cache files to a temporary directory when running the Abins-v2 tests

### To test:

Unit tests have been added which call the Abins-v2 algorithm and verify its properties.

Note that the tests all set Version=2 explicitly: it should be possible to avoid that by using `importlib.reload(mantid.simpleapi)`. However, this would likely break all the Abins tests that require Version 1, so perhaps that is the lesser evil for now.

To test manually, from a Mantid python environment:
```python
import abins.abins2
abins.abins2.Abins.subscribe()
```

This subscribes the Algorithm to the Algorithm Factory: v2 can be found in the GUI under "Simulation". To call from a Python script/shell it is necessary to explicitly set version with `Abins(Version=2, ...)` or to `importlib.reload(mantid.simpleapi)` to update the default version.

Release notes are not required as this is not (yet) a user-facing change. *Perhaps it will be worth compiling draft release notes somewhere...*

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
