### PR TITLE
Fix crash due to subscribing observer twice to notification center

### DIFF
--- a/docs/source/release/v6.9.1/index.rst
+++ b/docs/source/release/v6.9.1/index.rst
@@ -15,6 +15,7 @@ The changes are:
  - Removed slit lookup that was specific to OFFSPEC in :ref:`algm-ReflectometryReductionOneLiveData` as it is no longer required and was causing regular crashes when running live data on OFFSPEC.
  - Fixed a bug in :ref:`Elwin Tab <elwin>` of :ref:`Data Manipulation Interface <interface-inelastic-data-manipulation>` where changing integration range with the sliders did not change default integration range.
  - Add sample log values to the live data workspace before the instrument is loaded in :ref:`algm-ReflectometryReductionOneLiveData` to ensure log values are available when setting the detector positions.
+ - Fixed a crash when using multiple Indirect or Inelastic interfaces. This crash was present on the :ref:`Bayes Fitting <interface-inelastic-bayes-fitting>` interface, but could also be replicated elsewhere.
 
 Citation
 --------
@@ -36,6 +37,7 @@ Changes in this version
 * `37053 <https://github.com/mantidproject/mantid/pull/37053>`_ Load instrument after loading sample logs in ReflectometryReductionOneLiveData
 * `37016 <https://github.com/mantidproject/mantid/pull/37016>`_ Fix sliders not changing integration limits in Elwin tab
 * `36935 <https://github.com/mantidproject/mantid/pull/36935>`_ Fix regular live data crashes on OFFSPEC
+* `37074 <https://github.com/mantidproject/mantid/pull/37074>`_ Fix crash on Indirect/Inelastic interfaces.
 
 .. _download page: http://download.mantidproject.org
 

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -43,6 +43,16 @@ constexpr auto LOG_SCALE = "Log";
 constexpr auto SQUARE_SCALE = "Square";
 constexpr auto SHOWALLERRORS = "Show all errors";
 constexpr auto HIDEALLERRORS = "Hide all errors";
+
+template <typename Observer> void modifyObserver(Observer &observer, bool const turnOn) {
+  auto &notificationCenter = AnalysisDataService::Instance().notificationCenter;
+  if (turnOn && !notificationCenter.hasObserver(observer)) {
+    notificationCenter.addObserver(observer);
+  } else if (!turnOn && notificationCenter.hasObserver(observer)) {
+    notificationCenter.removeObserver(observer);
+  }
+}
+
 } // namespace
 
 namespace MantidQt::MantidWidgets {
@@ -77,14 +87,8 @@ PreviewPlot::~PreviewPlot() { watchADS(false); }
  * @param on If true ADS observers are enabled else they are disabled
  */
 void PreviewPlot::watchADS(bool on) {
-  auto &notificationCenter = AnalysisDataService::Instance().notificationCenter;
-  if (on) {
-    notificationCenter.addObserver(m_wsRemovedObserver);
-    notificationCenter.addObserver(m_wsReplacedObserver);
-  } else {
-    notificationCenter.removeObserver(m_wsReplacedObserver);
-    notificationCenter.removeObserver(m_wsRemovedObserver);
-  }
+  modifyObserver(m_wsReplacedObserver, on);
+  modifyObserver(m_wsRemovedObserver, on);
 }
 
 /**


### PR DESCRIPTION
**Report to:** Franz Demmel

### Description of work
This PR fixes a consistent crash when using multiple of the Indirect and Inelastic interfaces. It is possible to cause this crash in multiple different ways, from multiple different interfaces. It is caused by adding the same observer to the notification center more than once, and the solution was easy - not to add the observer if it is already subscribed to the notification center.

Fixes #37071


### To test:
1. Go to 'Inelastic'->`Data Manipulations`
2. Load data into the Symmetrise Tab
3. Click `Preview`, then click `Run`
4. Close the interface
5. Open the `Data Analysis` interface
6. On MSD Fit load data
7. Select `Gaus` function
8. Click `Run`. There should be no crash
### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
