### PR TITLE
Use ADSObserver for PreviewPlot widget

### DIFF
--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/AnalysisDataServiceObserver.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/MplCpp/Line2D.h"
 #include "MantidQtWidgets/MplCpp/PanZoomTool.h"
@@ -14,8 +15,6 @@
 #include "MantidQtWidgets/Plotting/DllOption.h"
 #include "MantidQtWidgets/Plotting/RangeSelector.h"
 #include "MantidQtWidgets/Plotting/SingleSelector.h"
-
-#include <Poco/NObserver.h>
 
 #include <QHash>
 #include <QPair>
@@ -38,7 +37,7 @@ namespace MantidWidgets {
 /**
  * Displays several workpaces on a matplotlib figure
  */
-class EXPORT_OPT_MANTIDQT_PLOTTING PreviewPlot : public QWidget {
+class EXPORT_OPT_MANTIDQT_PLOTTING PreviewPlot : public QWidget, public AnalysisDataServiceObserver {
   Q_OBJECT
 
   Q_PROPERTY(QColor canvasColour READ canvasColour WRITE setCanvasColour)
@@ -47,7 +46,6 @@ class EXPORT_OPT_MANTIDQT_PLOTTING PreviewPlot : public QWidget {
 
 public:
   PreviewPlot(QWidget *parent = nullptr, bool observeADS = true);
-  ~PreviewPlot();
 
   void watchADS(bool on);
 
@@ -122,8 +120,8 @@ private:
   void createLayout();
   void createActions();
 
-  void onWorkspaceRemoved(Mantid::API::WorkspacePreDeleteNotification_ptr nf);
-  void onWorkspaceReplaced(Mantid::API::WorkspaceBeforeReplaceNotification_ptr nf);
+  void replaceHandle(const std::string &wsName, const Workspace_sptr &ws) override;
+  void deleteHandle(const std::string &wsName, const Workspace_sptr &ws) override;
 
   void regenerateLegend();
   void removeLegend();
@@ -173,10 +171,6 @@ private:
 
   // Canvas tools
   Widgets::MplCpp::PanZoomTool m_panZoomTool;
-
-  // Observers for ADS Notifications
-  Poco::NObserver<PreviewPlot, Mantid::API::WorkspacePreDeleteNotification> m_wsRemovedObserver;
-  Poco::NObserver<PreviewPlot, Mantid::API::WorkspaceBeforeReplaceNotification> m_wsReplacedObserver;
 
   // Tick label style
   char *m_axis;

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -43,16 +43,6 @@ constexpr auto LOG_SCALE = "Log";
 constexpr auto SQUARE_SCALE = "Square";
 constexpr auto SHOWALLERRORS = "Show all errors";
 constexpr auto HIDEALLERRORS = "Hide all errors";
-
-template <typename Observer> void modifyObserver(Observer &observer, bool const turnOn) {
-  auto &notificationCenter = AnalysisDataService::Instance().notificationCenter;
-  if (turnOn && !notificationCenter.hasObserver(observer)) {
-    notificationCenter.addObserver(observer);
-  } else if (!turnOn && notificationCenter.hasObserver(observer)) {
-    notificationCenter.removeObserver(observer);
-  }
-}
-
 } // namespace
 
 namespace MantidQt::MantidWidgets {
@@ -64,9 +54,8 @@ namespace MantidQt::MantidWidgets {
  */
 PreviewPlot::PreviewPlot(QWidget *parent, bool observeADS)
     : QWidget(parent), m_canvas{new FigureCanvasQt(111, MANTID_PROJECTION, parent)}, m_panZoomTool(m_canvas),
-      m_wsRemovedObserver(*this, &PreviewPlot::onWorkspaceRemoved),
-      m_wsReplacedObserver(*this, &PreviewPlot::onWorkspaceReplaced), m_axis("both"), m_style("sci"), m_useOffset(true),
-      m_xAxisScale("linear"), m_yAxisScale("linear"), m_redrawOnPaint(false) {
+      m_axis("both"), m_style("sci"), m_useOffset(true), m_xAxisScale("linear"), m_yAxisScale("linear"),
+      m_redrawOnPaint(false) {
   createLayout();
   createActions();
 
@@ -77,18 +66,12 @@ PreviewPlot::PreviewPlot(QWidget *parent, bool observeADS)
 }
 
 /**
- * Destructor.
- * Removes ADS observers
- */
-PreviewPlot::~PreviewPlot() { watchADS(false); }
-
-/**
  * Enable/disable the ADS observers
  * @param on If true ADS observers are enabled else they are disabled
  */
 void PreviewPlot::watchADS(bool on) {
-  modifyObserver(m_wsReplacedObserver, on);
-  modifyObserver(m_wsRemovedObserver, on);
+  this->observeReplace(on);
+  this->observeDelete(on);
 }
 
 /**
@@ -603,17 +586,17 @@ QStringList PreviewPlot::linesWithErrors() const {
  * Observer method called when a workspace is removed from the ADS
  * @param nf A pointer to the notification object
  */
-void PreviewPlot::onWorkspaceRemoved(Mantid::API::WorkspacePreDeleteNotification_ptr nf) {
+void PreviewPlot::deleteHandle(const std::string &wsName, const Workspace_sptr &ws) {
   if (m_lines.isEmpty()) {
     return;
   }
   // Ignore non matrix workspaces
-  if (auto ws = std::dynamic_pointer_cast<MatrixWorkspace>(nf->object())) {
+  if (auto deletedWs = std::dynamic_pointer_cast<MatrixWorkspace>(ws)) {
     // the artist may have already been removed. ignore the event is that is the
     // case
     bool removed = false;
     try {
-      removed = m_canvas->gca<MantidAxes>().removeWorkspaceArtists(ws);
+      removed = m_canvas->gca<MantidAxes>().removeWorkspaceArtists(deletedWs);
     } catch (Mantid::PythonInterface::PythonException &) {
     }
     if (removed) {
@@ -626,16 +609,14 @@ void PreviewPlot::onWorkspaceRemoved(Mantid::API::WorkspacePreDeleteNotification
  * Observer method called when a workspace is replaced in the ADS
  * @param nf A pointer to the notification object
  */
-void PreviewPlot::onWorkspaceReplaced(Mantid::API::WorkspaceBeforeReplaceNotification_ptr nf) {
+void PreviewPlot::replaceHandle(const std::string &wsName, const Workspace_sptr &ws) {
   if (m_lines.isEmpty()) {
     return;
   }
   // Ignore non matrix workspaces
-  if (std::dynamic_pointer_cast<MatrixWorkspace>(nf->oldObject())) {
-    if (auto newWS = std::dynamic_pointer_cast<MatrixWorkspace>(nf->newObject())) {
-      if (m_canvas->gca<MantidAxes>().replaceWorkspaceArtists(newWS)) {
-        this->replot();
-      }
+  if (auto newWS = std::dynamic_pointer_cast<MatrixWorkspace>(ws)) {
+    if (m_canvas->gca<MantidAxes>().replaceWorkspaceArtists(newWS)) {
+      this->replot();
     }
   }
 }

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -584,9 +584,12 @@ QStringList PreviewPlot::linesWithErrors() const {
 
 /**
  * Observer method called when a workspace is removed from the ADS
- * @param nf A pointer to the notification object
+ * @param wsName The name of the workspace which has been removed.
+ * @param ws The workspace which has been removed.
  */
 void PreviewPlot::deleteHandle(const std::string &wsName, const Workspace_sptr &ws) {
+  (void)wsName;
+
   if (m_lines.isEmpty()) {
     return;
   }
@@ -607,9 +610,12 @@ void PreviewPlot::deleteHandle(const std::string &wsName, const Workspace_sptr &
 
 /**
  * Observer method called when a workspace is replaced in the ADS
- * @param nf A pointer to the notification object
+ * @param wsName The name of the workspace which has been replaced.
+ * @param ws The new workspace.
  */
 void PreviewPlot::replaceHandle(const std::string &wsName, const Workspace_sptr &ws) {
+  (void)wsName;
+
   if (m_lines.isEmpty()) {
     return;
   }


### PR DESCRIPTION
### Description of work
This PR ensures the `PreviewPlot` widget uses the `AnalysisDataServiceObserver` to keep a track of events happening in the ADS. It is better to use this observer than re-implement the Poco observers. There was a bug, fixed by #37074 , which would not have happened if we had used `AnalysisDataServiceObserver`.

### To test:

1. Go to 'Inelastic'->`Data Manipulations`
2. Load data into the Symmetrise Tab
3. Click `Preview`, then click `Run`
4. Close the interface
5. Open the `Data Analysis` interface
6. On MSD Fit load data
7. Select `Gaus` function
8. Click `Run`. There should be no crash

*This does not require release notes* because **it is internal maintenance**


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
