### PR TITLE
Add new fitting function for Teixeira model

### DIFF
--- a/Framework/PythonInterface/plugins/CMakeLists.txt
+++ b/Framework/PythonInterface/plugins/CMakeLists.txt
@@ -386,6 +386,7 @@ set(PYTHON_PLUGINS
     functions/StretchedKT.py
     functions/TFMuonium.py
     functions/TeixeiraWater.py
+    functions/TeixeiraWaterIqt.py
     functions/ZFMuonium.py
     functions/ZFdipole.py
     functions/ZFelectronDipole.py

--- a/Framework/PythonInterface/plugins/functions/TeixeiraWaterIqt.py
+++ b/Framework/PythonInterface/plugins/functions/TeixeiraWaterIqt.py
@@ -14,49 +14,63 @@
 import numpy as np
 
 from mantid.api import IFunction1D, FunctionFactory
-
-from scipy import constants
 from scipy.special import spherical_jn  # bessel
 
 
 class TeixeiraWaterIqt(IFunction1D):
-    planck_constant = constants.Planck / constants.e * 1e15  # meV*psec
-    hbar = planck_constant / (2 * np.pi)  # meV * ps  = ueV * ns
 
     def category(self):
         return "QuasiElastic"
 
     def init(self):
-        # Active fitting parameters
+        # Fitting parameters
         self.declareParameter("Amp", 1.00, "Amplitude")
-        self.declareParameter("Tau0", 1.25, "Residence time")
         self.declareParameter("Tau1", 0.05, "Relaxation time")
-        self.declareParameter("a", 1.3, "Radius rotation")
-        self.declareParameter("Diff", 2.3, "Diffusion coefficient")
+        self.declareParameter("Gamma", 1.2, "Line Width")
+        self.addConstraints("Tau1 > 0")
+        # Non-fitting parameters
         self.declareAttribute("Q", 0.4)
+        self.declareAttribute("a", 0.98)
 
     def setAttributeValue(self, name, value):
         if name == "Q":
             self.Q = value
+        if name == "a":
+            self.radius = value
 
     def function1D(self, xvals):
         amp = self.getParameterValue("Amp")
-        tau0 = self.getParameterValue("Tau0")
         tau1 = self.getParameterValue("Tau1")
-        radius = self.getParameterValue("a")
-        diff = self.getParameterValue("Diff")
+        gamma = self.getParameterValue("Gamma")
         xvals = np.array(xvals)
 
-        qr = np.array(self.Q * radius)
+        qr = np.array(self.Q * self.radius)
         j0 = spherical_jn(0, qr)
         j1 = spherical_jn(1, qr)
         j2 = spherical_jn(2, qr)
         with np.errstate(divide="ignore"):
             rotational = j0 * j0 + 3 * j1 * j1 * np.exp(-xvals / (3 * tau1)) + 5 * j2 * j2 * np.exp(-xvals / tau1)
-            gamma = diff * self.Q * self.Q / (1 + diff * self.Q * self.Q * tau0)
             translational = np.exp(-gamma * xvals)
             iqt = amp * rotational * translational
         return iqt
+
+    def functionDeriv1D(self, xvals, jacobian):
+        amp = self.getParameterValue("Amp")
+        tau1 = self.getParameterValue("Tau1")
+        gamma = self.getParameterValue("Gamma")
+
+        qr = np.array(self.Q * self.radius)
+        j0 = spherical_jn(0, qr)
+        j1 = spherical_jn(1, qr)
+        j2 = spherical_jn(2, qr)
+        with np.errstate(divide="ignore"):
+            for i, x in enumerate(xvals, start=0):
+                rotational = j0 * j0 + 3 * j1 * j1 * np.exp(-x / (3 * tau1)) + 5 * j2 * j2 * np.exp(-x / tau1)
+                translational = np.exp(-gamma * x)
+                partial_tau = (x / np.square(tau1)) * (j1 * j1 * np.exp(-x / (3 * tau1)) + 5 * j2 * j2 * np.exp(-x / tau1))
+                jacobian.set(i, 0, rotational * translational)
+                jacobian.set(i, 1, amp * rotational * partial_tau)
+                jacobian.set(i, 2, -x * amp * rotational * translational)
 
 
 # Required to have Mantid recognise the new function

--- a/Framework/PythonInterface/plugins/functions/TeixeiraWaterIqt.py
+++ b/Framework/PythonInterface/plugins/functions/TeixeiraWaterIqt.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2007 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +

--- a/Framework/PythonInterface/plugins/functions/TeixeiraWaterIqt.py
+++ b/Framework/PythonInterface/plugins/functions/TeixeiraWaterIqt.py
@@ -1,0 +1,63 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2007 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+# pylint: disable=no-init,invalid-name
+
+"""
+@author Spencer Howells, ISIS
+@date December 05, 2013
+"""
+
+import numpy as np
+
+from mantid.api import IFunction1D, FunctionFactory
+
+from scipy import constants
+from scipy.special import spherical_jn  # bessel
+
+
+class TeixeiraWaterIqt(IFunction1D):
+    planck_constant = constants.Planck / constants.e * 1e15  # meV*psec
+    hbar = planck_constant / (2 * np.pi)  # meV * ps  = ueV * ns
+
+    def category(self):
+        return "QuasiElastic"
+
+    def init(self):
+        # Active fitting parameters
+        self.declareParameter("Amp", 1.00, "Amplitude")
+        self.declareParameter("Tau0", 1.25, "Residence time")
+        self.declareParameter("Tau1", 0.05, "Relaxation time")
+        self.declareParameter("a", 1.3, "Radius rotation")
+        self.declareParameter("Diff", 2.3, "Diffusion coefficient")
+        self.declareAttribute("Q", 0.4)
+
+    def setAttributeValue(self, name, value):
+        if name == "Q":
+            self.Q = value
+
+    def function1D(self, xvals):
+        amp = self.getParameterValue("Amp")
+        tau0 = self.getParameterValue("Tau0")
+        tau1 = self.getParameterValue("Tau1")
+        radius = self.getParameterValue("a")
+        diff = self.getParameterValue("Diff")
+        xvals = np.array(xvals)
+
+        qr = np.array(self.Q * radius)
+        j0 = spherical_jn(0, qr)
+        j1 = spherical_jn(1, qr)
+        j2 = spherical_jn(2, qr)
+        with np.errstate(divide="ignore"):
+            rotational = j0 * j0 + 3 * j1 * j1 * np.exp(-xvals / (3 * tau1)) + 5 * j2 * j2 * np.exp(-xvals / tau1)
+            gamma = diff * self.Q * self.Q / (1 + diff * self.Q * self.Q * tau0)
+            translational = np.exp(-gamma * xvals)
+            iqt = amp * rotational * translational
+        return iqt
+
+
+# Required to have Mantid recognise the new function
+FunctionFactory.subscribe(TeixeiraWaterIqt)

--- a/Framework/PythonInterface/test/python/plugins/functions/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/functions/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TEST_PY_FILES
     StretchedExpFTTest.py
     StretchedKTTest.py
     TeixeiraWaterTest.py
+    TeixeiraWaterIqtTest.py
     TFMuoniumTest.py
     ZFprotonDipoleTest.py
     ZFdipoleTest.py

--- a/Framework/PythonInterface/test/python/plugins/functions/TeixeiraWaterIqtTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/TeixeiraWaterIqtTest.py
@@ -1,0 +1,39 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+import numpy as np
+
+from MsdTestHelper import is_registered, check_output, do_a_fit
+
+
+class TeixeiraWaterTest(unittest.TestCase):
+    def test_function_has_been_registered(self):
+        status, msg = is_registered("TeixeiraWaterIqt")
+        if not status:
+            self.fail(msg)
+
+    def test_function_output(self):
+        input = [0.01, 0.1, 1.0, 10.0]
+        expected = [9.89878890e-01, 9.03317815e-01, 3.62579771e-01, 4.32020532e-05]
+        tolerance = 1.0e-05
+        status, output = check_output("TeixeiraWaterIqt", input, expected, tolerance, Q=0.4, a=0.98, Amp=1.0, Tau1=1.0, Gamma=1)
+        if not status:
+            msg = "Computed output {} from input {} unequal to expected: {}"
+            self.fail(msg.format(*[str(a) for a in (output, input, expected)]))
+
+    def test_do_fit(self):
+        do_a_fit(
+            np.arange(0.1, 2.2, 0.2),
+            "TeixeiraWaterIqt",
+            guess=dict(Q=0.4, a=0.98, Amp=10, Tau1=1.2, Gamma=1.2),
+            target=dict(Q=0.4, a=0.98, Amp=1.0, Tau1=1.0, Gamma=1),
+            atol=0.01,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/functions/TeixeiraWaterIqtTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/TeixeiraWaterIqtTest.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +

--- a/docs/source/fitting/fitfunctions/TeixeiraWaterIqt.rst
+++ b/docs/source/fitting/fitfunctions/TeixeiraWaterIqt.rst
@@ -22,7 +22,7 @@ where:
 - :math:`A` is the amplitude.
 - :math:`\Gamma` is the spectrum linewidth.
 - :math:`\tau_{1}` is the relaxation time associated with rotation diffusion.
-- :math:`Q` is the elastic momentum transfer, :math:`0.4\AA_{-1}` by default, but should be set to a correct value prior to fitting.
+- :math:`Q` is the elastic momentum transfer, :math:`0.4\AA^{-1}` by default, but should be set to a correct value prior to fitting.
 - :math:`a` is the molecular radius of rotation, set by default to :math:`0.98\AA`.
 
 Units of :math:`a` are inverse units of :math:`Q`.

--- a/docs/source/fitting/fitfunctions/TeixeiraWaterIqt.rst
+++ b/docs/source/fitting/fitfunctions/TeixeiraWaterIqt.rst
@@ -1,0 +1,45 @@
+.. _func-TeixeiraWaterIqt:
+
+================
+TeixeiraWaterIqt
+================
+
+.. index:: TeixeiraWaterIqt
+
+Description
+-----------
+
+It models the intermediate scattering function for the inelastic spectra of water molecules, based on Teixeira's model [1]_.
+
+.. math::
+    F_s(Q,t) &= A  R(Q,t)  T(Q,t) \\
+    T(Q,t) &= e^{- \Gamma t} \\
+    R(Q,t) &= j_{0}^{2}(Qa)+3j_{1}^{2}(Qa) e^{-t/{3\tau_1}}+5j_{2}^{2}(Qa) e^{-t/\tau_1}
+
+where:
+
+- :math:`j_{n}(x)` are the spherical bessel functions of order *n*.
+- :math:`A` is the amplitude.
+- :math:`\Gamma` is the spectrum linewidth.
+- :math:`\tau_{1}` is the relaxation time associated with rotation diffusion.
+- :math:`Q` is the elastic momentum transfer, :math:`0.4\AA_{-1}` by default, but should be set to a correct value prior to fitting.
+- :math:`a` is the molecular radius of rotation, set by default to :math:`0.98\AA`.
+
+Units of :math:`a` are inverse units of :math:`Q`.
+
+Units of :math:`\Gamma` inverse units of :math:`t`. After fitting, if scaled by correct :math:`\hbar`, units are :math:`meV` if units of :math:`\tau_1` are *ps*.
+Alternatively, units of :math:`\Gamma` are :math:`\mu eV` if units of
+:math:`\tau_{1}` are *ns*.
+
+.. attributes::
+
+.. properties::
+
+References
+----------
+
+.. [1] J. Teixeira, M.-C. Bellissent-Funel, S. H. Chen, and A. J. Dianoux. `Phys. Rev. A, 31:1913–1917 <http://dx.doi.org/10.1103/PhysRevA.31.1913>`__
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.10.0/Inelastic/New_features/36502.rst
+++ b/docs/source/release/v6.10.0/Inelastic/New_features/36502.rst
@@ -1,0 +1,1 @@
+- Added new `TeixeiraWaterIqt` fitting function, to fit linewidth and molecular residence time in intermediate scattering functions with Teixeira's model for water.


### PR DESCRIPTION
### Description of work
This PR adds a fitting function for the intermediary scattering function of quasielastic spectra by using the Teixeira formalism for water. Relevant links can be found in #36502 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
A new fitting function has been added, along with test and documentation. 
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Part of #36502 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Build the docs, you should find new fitting function `TeixeiraWaterIqt` on `Fit Functions` list section of documentation.
- Make sure function is recognized by Mantid, you can check the overall fitting by using the following script: 
```# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

#input workspace
iw=Load("iris26176_graphite002_iqt")

# Specify the fitting interval
startX=0.002
endX=0.15

#spectrum number
dec=CreateDetectorTable(iw)
spec_number=0

#initial parameters and attributes
q = dec.row(spec_number)['Q elastic']
amp=1
tau1=0.05
gamma=10

fit_out = Fit(InputWorkspace='iw', WorkspaceIndex=spec_number, \
           StartX = startX, EndX=endX, Output='fit_out', \
           Function="name=TeixeiraWaterIqt,Q="+str(q)+",a=0.98,"+\
                    "Amp="+str(amp)+",Tau1="+str(tau1)+",Gamma="+str(gamma) \
                    +";name=LinearBackground,A0=0,A1=-0.154131",
           Minimizer="Levenberg-Marquardt,Damping=0,Verbose=0,AbsError=0.0001,RelError=0.0001")
       
        
costFuncVal=fit_out.OutputChi2overDoF
print("Current cost function is", costFuncVal)
amp=fit_out.OutputParameters.row(0)['Value'] 
tau1=fit_out.OutputParameters.row(1)['Value']
gamma=fit_out.OutputParameters.row(2)['Value']
print('Amplitude: ',amp,' Tau1: ',tau1,' Gamma: ',gamma)
        
fig, axes = plt.subplots(edgecolor='#ffffff', figsize=[8, 8], num='test', subplot_kw={'projection': 'mantid'})
axes.plot(fit_out.OutputWorkspace, color='#1f77b4', label='fit_out_Workspace: Data', wkspIndex=0)
axes.plot(fit_out.OutputWorkspace, color='#ff7f0e', label='fit_out_Workspace: Calc', wkspIndex=1)
axes.plot(fit_out.OutputWorkspace, color='#2ca02c', label='fit_out_Workspace: Diff', wkspIndex=2)
axes.set_title('Fitting results on iris26176_graphite002_iqt')
axes.set_xlabel('Time ($ns$)')
axes.set_ylabel('Fs(Q,t)')
legend = axes.legend(fontsize=8.0).set_draggable(True).legend

fig.show()
# Use plt.show() if running the script outside of Workbench
#plt.show()
# Scripting Plots in Mantid:
# https://docs.mantidproject.org/tutorials/python_in_mantid/plotting/02_scripting_plots.html
```


*Added release notes*

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
