### PR TITLE
Fix crash when setting invalid spectra indices in workspace dialogs

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -178,7 +178,7 @@ template <typename T> inline void appendValue(const std::string &strvalue, std::
   auto stop = boost::lexical_cast<T>(strvalue.substr(pos + 1, numChar));
   if (start > stop) {
     std::swap(start, stop);
-    std::abs(std::make_signed_t<T>(step));
+    step = std::abs(std::make_signed_t<T>(step));
   }
 
   if (start + step < start)

--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -154,8 +154,11 @@ template <typename T> inline void appendValue(const std::string &strvalue, std::
   std::size_t pos = strvalue.find(':');
   std::size_t numChar = std::string::npos; // go to the end of the string
   T step{1};
+  bool dashSeparator = false;
   if (pos == std::string::npos) {
     pos = strvalue.find('-', 1);
+    if (pos != std::string::npos)
+      dashSeparator = true;
   } else {
     const auto posStep = strvalue.find(':', pos + 1);
     if (posStep != std::string::npos) {
@@ -176,19 +179,29 @@ template <typename T> inline void appendValue(const std::string &strvalue, std::
   // convert the input string into boundaries and run through a list
   auto start = boost::lexical_cast<T>(strvalue.substr(0, pos));
   auto stop = boost::lexical_cast<T>(strvalue.substr(pos + 1, numChar));
-  if (start > stop) {
+
+  if ((start > stop) && (dashSeparator)) {
     std::swap(start, stop);
-    step = std::abs(std::make_signed_t<T>(step));
   }
 
-  if (start + step < start)
-    throw std::logic_error("Step size is negative with increasing limits");
-
-  for (auto i = start; i <= stop;) {
-    value.emplace_back(i);
-    // done inside the loop because gcc7 doesn't like i+=step for short
-    // unsigned int
-    i = static_cast<T>(i + step);
+  if (start <= stop) {
+    if (start + step < start)
+      throw std::logic_error("Step size is negative with increasing limits");
+    for (auto i = start; i <= stop;) {
+      value.emplace_back(i);
+      // done inside the loop because gcc7 doesn't like i+=step for short
+      // unsigned int
+      i = static_cast<T>(i + step);
+    }
+  } else {
+    if (start + step >= start)
+      throw std::logic_error("Step size is positive with decreasing limits");
+    for (auto i = start; i >= stop;) {
+      value.emplace_back(i);
+      // done inside the loop because gcc7 doesn't like i+=step for short
+      // unsigned int
+      i = static_cast<T>(i + step);
+    }
   }
 }
 

--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -174,26 +174,21 @@ template <typename T> inline void appendValue(const std::string &strvalue, std::
     throw std::logic_error("Step size must be non-zero");
 
   // convert the input string into boundaries and run through a list
-  const auto start = boost::lexical_cast<T>(strvalue.substr(0, pos));
-  const auto stop = boost::lexical_cast<T>(strvalue.substr(pos + 1, numChar));
-  if (start <= stop) {
-    if (start + step < start)
-      throw std::logic_error("Step size is negative with increasing limits");
-    for (auto i = start; i <= stop;) {
-      value.emplace_back(i);
-      // done inside the loop because gcc7 doesn't like i+=step for short
-      // unsigned int
-      i = static_cast<T>(i + step);
-    }
-  } else {
-    if (start + step >= start)
-      throw std::logic_error("Step size is positive with decreasing limits");
-    for (auto i = start; i >= stop;) {
-      value.emplace_back(i);
-      // done inside the loop because gcc7 doesn't like i+=step for short
-      // unsigned int
-      i = static_cast<T>(i + step);
-    }
+  auto start = boost::lexical_cast<T>(strvalue.substr(0, pos));
+  auto stop = boost::lexical_cast<T>(strvalue.substr(pos + 1, numChar));
+  if (start > stop) {
+    std::swap(start, stop);
+    std::abs(std::make_signed_t<T>(step));
+  }
+
+  if (start + step < start)
+    throw std::logic_error("Step size is negative with increasing limits");
+
+  for (auto i = start; i <= stop;) {
+    value.emplace_back(i);
+    // done inside the loop because gcc7 doesn't like i+=step for short
+    // unsigned int
+    i = static_cast<T>(i + step);
   }
 }
 

--- a/docs/source/release/v6.10.0/Inelastic/New_features/37008.rst
+++ b/docs/source/release/v6.10.0/Inelastic/New_features/37008.rst
@@ -1,0 +1,1 @@
+- Fix a crash happening when setting spectra limits on workspace dialogs using an string format of the sort: "SpectraStart-SpectraEnd" where Spectra Start is larger than Spectra End.


### PR DESCRIPTION
### Description of work
It is possible to slice a set of spectra in the input workspaces of the `AddWorkspace` dialogs of several indirect/inelastic interfaces. The format for slicing indices is an input string which uses dashes or commas as separators: `0-5`, `1,2,4-6`,`20-30`. However, if a slice is taken with a dash separator in numerical decreasing order: `5-0` instead of `0-5` (which should take all spectra from index 0 to 5) Mantid crashes. `FunctionModelSpectra` is the custom class that takes the input string and converts it into an array of workspace indexes. The constructor of the class makes uses of the `ArrayProperty` classes of the `Kernel` libraries of Mantid. In particular, the helper templated function `appendValue` defined  in `PropertyHelper.h` is used to parse the string and convert it appropriately. The case for a string of the sort `5-0` is not considered in the function and causes a throw. To avoid interfering much with this function, I have added a new condition that it is only meet when the string is of the format `StartIndex-StopIndex` when `StartIndex>StopIndex`, swapping the start and stop values.
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37008. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
 - Follow instructions described in #37008. See that the crash doesn't happen.
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
