### PR TITLE
Fix for bug when overplotting onto a regular mpl axis

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/Bugfixes/37083.rst
+++ b/docs/source/release/v6.10.0/Workbench/Bugfixes/37083.rst
@@ -1,0 +1,1 @@
+- Fixed bug where overplotting workspaces onto a regular Matplotlib plot could cause an error.

--- a/qt/python/mantidqt/mantidqt/plotting/figuretype.py
+++ b/qt/python/mantidqt/mantidqt/plotting/figuretype.py
@@ -95,12 +95,14 @@ def figure_type(fig, ax=None):
     """
     if len(fig.get_axes()) == 0:
         return FigureType.Empty
-    else:
-        if ax:
-            # If ax is a colorbar then find a non-colorbar axes on the figure so the plot type can be determined.
-            if type(ax) == Axes:
-                ax = next(axes for axes in fig.get_axes() if not type(axes) == Axes)
 
-            return axes_type(ax)
-        else:
-            return axes_type(fig.axes[0])
+    if ax:
+        # ax could be a colorbar, if so then find a non-colorbar axes on the figure so the plot type can be determined.
+        if type(ax) == Axes:
+            other_axes = [axes for axes in fig.get_axes() if not type(axes) == Axes]
+            if other_axes:
+                ax = other_axes[0]
+
+        return axes_type(ax)
+
+    return axes_type(fig.axes[0])

--- a/qt/python/mantidqt/mantidqt/plotting/figuretype.py
+++ b/qt/python/mantidqt/mantidqt/plotting/figuretype.py
@@ -98,8 +98,8 @@ def figure_type(fig, ax=None):
 
     if ax:
         # ax could be a colorbar, if so then find a non-colorbar axes on the figure so the plot type can be determined.
-        if type(ax) == Axes:
-            other_axes = [axes for axes in fig.get_axes() if not type(axes) == Axes]
+        if isinstance(ax, Axes):
+            other_axes = [axes for axes in fig.get_axes() if not isinstance(axes, Axes)]
             if other_axes:
                 ax = other_axes[0]
 

--- a/qt/python/mantidqt/mantidqt/plotting/test/test_figuretype.py
+++ b/qt/python/mantidqt/mantidqt/plotting/test/test_figuretype.py
@@ -37,6 +37,11 @@ class FigureTypeTest(TestCase):
         ax.plot([1])
         self.assertEqual(FigureType.Line, figure_type(ax.figure))
 
+    def test_line_plot_returns_line_when_ax_specified(self):
+        ax = plt.subplot(111)
+        ax.plot(range(3))
+        self.assertEqual(FigureType.Line, figure_type(ax.figure, ax))
+
     def test_error_plot_returns_error(self):
         ax = plt.subplot(111)
         ax.errorbar([1], [1], yerr=[0.01])


### PR DESCRIPTION
### Description of work

Small change to the `figure_type` function to a fix a bug where if a mpl axis was given as the `ax` argument, a `StopIteration` exception would occur. This would happen when overplotting onto a mpl axis.

Fixes #37083

### To test:

 - Recreate using issue instructions
 - Try some different overplotting scenarios (different workspace typs etc.) to have a quick check for any introduced problems.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
