### PR TITLE
Ability to set load algorithm properties in DataSelector widget

### DIFF
--- a/docs/source/release/v6.10.0/Inelastic/Bugfixes/37095.rst
+++ b/docs/source/release/v6.10.0/Inelastic/Bugfixes/37095.rst
@@ -1,0 +1,1 @@
+- It is now approximately 30% faster to load data into the F(Q)Fit tab in the :ref:`QENS Fitting interface <interface-inelastic-qens-fitting>`.

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FqFitAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FqFitAddWorkspaceDialog.cpp
@@ -14,6 +14,7 @@ namespace MantidQt::CustomInterfaces::Inelastic {
 
 FqFitAddWorkspaceDialog::FqFitAddWorkspaceDialog(QWidget *parent) : QDialog(parent) {
   m_uiForm.setupUi(this);
+  m_uiForm.dsWorkspace->setLoadProperty("LoadHistory", false);
 
   connect(m_uiForm.dsWorkspace, SIGNAL(dataReady(const QString &)), this, SLOT(emitWorkspaceChanged(const QString &)));
   connect(m_uiForm.cbParameterType, SIGNAL(currentIndexChanged(const QString &)), this,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
@@ -366,6 +366,8 @@ private slots:
 private:
   /// Attempt to automatically load a file
   void autoLoadFile(const QString &filenames);
+  /// Execute load algorithm
+  void executeLoadAlgorithm(std::string const &filename, std::string const &outputWorkspace);
   /// Member containing the widgets child widgets.
   Ui::DataSelector m_uiForm;
   /// Extra load properties to set on the load algorithm before execution

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
@@ -9,6 +9,7 @@
 #include "DllOption.h"
 #include "ui_DataSelector.h"
 
+#include "MantidAPI/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/AlgorithmRunner.h"
 #include "MantidQtWidgets/Common/MantidWidget.h"
 
@@ -109,6 +110,8 @@ public:
   void setLoadBtnText(const QString & /*text*/);
   /// Sets the DataSelector to always load data inside a WorkspaceGroup
   void setAlwaysLoadAsGroup(bool const loadAsGroup);
+  /// Set an extra property on the load algorithm before execution
+  void setLoadProperty(std::string const &propertyName, bool const value);
 
   // These are accessors/modifiers of the child FileFinderWidget
   /**
@@ -365,6 +368,8 @@ private:
   void autoLoadFile(const QString &filenames);
   /// Member containing the widgets child widgets.
   Ui::DataSelector m_uiForm;
+  /// Extra load properties to set on the load algorithm before execution
+  Mantid::API::AlgorithmRuntimeProps m_loadProperties;
   /// Algorithm Runner used to run the load algorithm
   MantidQt::API::AlgorithmRunner m_algRunner;
   /// Flag to enable auto loading. By default this is set to true.

--- a/qt/widgets/common/src/DataSelector.cpp
+++ b/qt/widgets/common/src/DataSelector.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/DataSelector.h"
 #include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AlgorithmProperties.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FileFinder.h"
 #include "MantidAPI/Workspace.h"
@@ -72,7 +73,8 @@ void makeGroup(std::string const &workspaceName) {
 namespace MantidQt::MantidWidgets {
 
 DataSelector::DataSelector(QWidget *parent)
-    : API::MantidWidget(parent), m_algRunner(), m_autoLoad(true), m_showLoad(true), m_alwaysLoadAsGroup(false) {
+    : API::MantidWidget(parent), m_loadProperties(), m_algRunner(), m_autoLoad(true), m_showLoad(true),
+      m_alwaysLoadAsGroup(false) {
   m_uiForm.setupUi(this);
   connect(m_uiForm.cbInputType, SIGNAL(currentIndexChanged(int)), this, SLOT(handleViewChanged(int)));
   connect(m_uiForm.pbLoadFile, SIGNAL(clicked()), this, SIGNAL(loadClicked()));
@@ -229,8 +231,19 @@ void DataSelector::autoLoadFile(const QString &filepath) {
   loadAlg->initialize();
   loadAlg->setProperty("Filename", filepath.toStdString());
   loadAlg->setProperty("OutputWorkspace", baseName);
+  loadAlg->updatePropertyValues(m_loadProperties);
 
   m_algRunner.startAlgorithm(loadAlg);
+}
+
+/**
+ * Set an extra property on the load algorithm before execution
+ *
+ * @param propertyName :: The name of the Load algorithm property to be set
+ * @param value :: The value of the Load algorithm property to be set
+ */
+void DataSelector::setLoadProperty(std::string const &propertyName, bool const value) {
+  Mantid::API::AlgorithmProperties::update(propertyName, value, m_loadProperties);
 }
 
 /**


### PR DESCRIPTION
### Description of work
This PR speeds up the loading on the FqFit tab of Inelastic Data Analysis by approximately 30% by not loading the workspace history which is often unused.

This only partly fixes 36769. I have identified that the algorithm search process can be sped up - giving an additional speed improvement of approximately 60%. I will do this in separate PRs.

Part of #36769

### To test:
1. Open `Inelastic`->`QENS Fitting`
2. Open the FqFit tab
3. Click `Add Workspace`. Browse for the following dataset

```
//olympic/Babylon5/Public/RobApplin/loading/irs26176_graphite002_red_Conv_seq_2L_0-50__Result.nxs
```

5. Loading the workspace into the dialog will still take a long time, but it should be approximately 30% faster when compared to `main`

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
