### PR TITLE
Add alias for SaveAscii v1

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/SaveAscii.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveAscii.h
@@ -28,6 +28,7 @@ public:
   SaveAscii();
   /// Algorithm's name for identification overriding a virtual method
   const std::string name() const override { return "SaveAscii"; }
+  const std::string alias() const override { return "SaveAsciiTOSCA"; }
   /// Summary of algorithms purpose
   const std::string summary() const override { return "Saves a 2D workspace to a ascii file."; }
 

--- a/docs/source/release/v6.10.0/Indirect/Algorithms/New_features/37097.rst
+++ b/docs/source/release/v6.10.0/Indirect/Algorithms/New_features/37097.rst
@@ -1,0 +1,1 @@
+- The :ref:`algm-SaveAscii-v1` algorithm can now be found in the algorithm list using the ``SaveAsciiTOSCA`` alias.


### PR DESCRIPTION
### Description of work
The TOSCA scientists have mentioned that they have had problems with the SaveAscii algorithm they use. They still use the SaveAscii v1 algorithm, however they sometimes get a data file saved out which is identical to the file saved using the SaveAscii v2 algorithm. This PR adds an alias to the SaveAscii v1 algorithm which will make it easier to find and select the correct algorithm for TOSCA.

Fixes #37080 

### To test:
Search for the "SaveAsciiTOSCA" algorithm in the algorithm list. 
Run the following script
```py
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

# Do data reduction
ISISIndirectEnergyTransfer(InputFiles=r'\\isis.cclrc.ac.uk\inst$\ndxtosca\instrument\data\cycle_23_5\TSC29406.nxs', Instrument='TOSCA', Analyser='graphite', Reflection='002', SpectraRange='1,140', RebinString='-2.5,0.015,3,-0.005,1000', UnitX='DeltaE_inWavenumber', OutputWorkspace='TOSCA29406_graphite_002_Reduced')
UnGroupWorkspace(InputWorkspace='TOSCA29406_graphite_002_Reduced')
```
Execute "SaveAsciiTOSCA" algorithm on the output workspace
The resulting data file should have 7 columns

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
