### PR TITLE
fix cmake warning

### DIFF
--- a/buildconfig/CMake/FindCppcheck.cmake
+++ b/buildconfig/CMake/FindCppcheck.cmake
@@ -29,7 +29,7 @@ endif()
 find_program(CPPCHECK_EXECUTABLE NAMES cppcheck)
 
 if(MSVC)
-  set(CPPCHECK_TEMPLATE_ARG --template="{file}({line}): warning : ({severity}-{id}) {message}")
+  set(CPPCHECK_TEMPLATE_ARG --template= "{file}({line}): warning : ({severity}-{id}) {message}")
   set(CPPCHECK_FAIL_REGULAR_EXPRESSION "[(]error[)]")
   set(CPPCHECK_WARN_REGULAR_EXPRESSION "[(]style[)]")
 elseif(CMAKE_COMPILER_IS_GNUCXX)


### PR DESCRIPTION
### Description of work
Fixes the following warning:
```
CMake Warning (dev) at buildconfig/CMake/FindCppcheck.cmake:32:
  Syntax Warning in cmake code at column 40

  Argument not separated from preceding token by whitespace.
Call Stack (most recent call first):
  buildconfig/CMake/CppCheckSetup.cmake:1 (find_package)
  buildconfig/CMake/CommonSetup.cmake:155 (include)
  CMakeLists.txt:96 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

*There is no associated issue.*

### To test:
Make sure that cppcheck runs successfully and check that the warning is gone.

*This does not require release notes* because **it's a syntax fix to a cmake file**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
