### PR TITLE
Fix syntax error in check_for_changes

### DIFF
--- a/buildconfig/Jenkins/check_for_changes
+++ b/buildconfig/Jenkins/check_for_changes
@@ -42,7 +42,7 @@ case "$TYPE" in
         fi
     ;;
     docs-gui-only)
-        if git diff --name-only ${BRANCH_TIP} ${BRANCH_BASE} -- | grep -q -E -v '^docs/|^dev-docs/|^qt/; then
+        if git diff --name-only ${BRANCH_TIP} ${BRANCH_BASE} -- | grep -q -E -v '^docs/|^dev-docs/|^qt/'; then
             exit $FOUND
         else
             exit $NOTFOUND


### PR DESCRIPTION
### Description of work
A syntax error was introduced [here](https://github.com/mantidproject/mantid/pull/35082) that broke the `check_for_changes` script. For more than a year, our PR logs have contained several of these errors:

```
jenkins_workdir/workspace/pull_requests-conda-linux/buildconfig/Jenkins/Conda/../check_for_changes: line 45: unexpected EOF while looking for matching `''
```

This means that **all** PR jobs are running all checks, instead of the intended behaviour (e.g. cppcheck should only run when cpp files have change, unit/system tests should not run when only docs have changed).

*There is no associated issue.*

### To test:
e.g. verify that cppcheck isn't run for this PR.

*This does not require release notes* because **it's a fix to a build script**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
