### PR TITLE
Fix for bug in Show Detectors when Efixed not available

### DIFF
--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -119,6 +119,8 @@ ITableWorkspace_sptr createDetectorTableWorkspace(const MatrixWorkspace_sptr &ws
       ws->getEFixed(detector);
     } catch (std::invalid_argument &) {
       calcQ = false;
+    } catch (std::runtime_error &) {
+      calcQ = false;
     }
   } else {
     // No detectors available

--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -117,7 +117,7 @@ ITableWorkspace_sptr createDetectorTableWorkspace(const MatrixWorkspace_sptr &ws
     try {
       std::shared_ptr<const IDetector> detector(&spectrumInfo.detector(0), Mantid::NoDeleting());
       ws->getEFixed(detector);
-    } catch (std::runtime_error &) {
+    } catch (std::invalid_argument &) {
       calcQ = false;
     }
   } else {

--- a/Framework/Algorithms/test/CreateDetectorTableTest.h
+++ b/Framework/Algorithms/test/CreateDetectorTableTest.h
@@ -106,7 +106,9 @@ public:
     TS_ASSERT_THROWS(inputWS->getEFixed(detector), const std::runtime_error &);
     // Check that an invalid efixed value throws an invalid argument error
     auto &run = inputWS->mutableRun();
+    run.addProperty("deltaE-mode", std::string("Direct"), true);
     run.addProperty("Ei", std::string("23423f42"));
+
     TS_ASSERT_THROWS(inputWS->getEFixed(detector), const std::invalid_argument &);
 
     TableWorkspace_sptr ws;

--- a/Framework/Algorithms/test/CreateDetectorTableTest.h
+++ b/Framework/Algorithms/test/CreateDetectorTableTest.h
@@ -100,10 +100,14 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.execute();)
     TS_ASSERT(alg.isExecuted());
 
-    // Check that a missing efixed value throws
+    // Check that a missing efixed value throws a runtime error
     const auto &spectrumInfo = inputWS->spectrumInfo();
     std::shared_ptr<const IDetector> detector(&spectrumInfo.detector(0), Mantid::NoDeleting());
-    TS_ASSERT_THROWS_ANYTHING(inputWS->getEFixed(detector));
+    TS_ASSERT_THROWS(inputWS->getEFixed(detector), const std::runtime_error &);
+    // Check that an invalid efixed value throws an invalid argument error
+    auto &run = inputWS->mutableRun();
+    run.addProperty("Ei", std::string("23423f42"));
+    TS_ASSERT_THROWS(inputWS->getEFixed(detector), const std::invalid_argument &);
 
     TableWorkspace_sptr ws;
     TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<TableWorkspace>(outWSName));

--- a/Framework/Algorithms/test/CreateDetectorTableTest.h
+++ b/Framework/Algorithms/test/CreateDetectorTableTest.h
@@ -11,11 +11,13 @@
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidGeometry/Instrument/Detector.h"
 #include <cxxtest/TestSuite.h>
 
 using namespace Mantid::Algorithms;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
+using namespace Mantid::Geometry;
 
 class CreateDetectorTableTest : public CxxTest::TestSuite {
 public:

--- a/Framework/Algorithms/test/CreateDetectorTableTest.h
+++ b/Framework/Algorithms/test/CreateDetectorTableTest.h
@@ -98,6 +98,11 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.execute();)
     TS_ASSERT(alg.isExecuted());
 
+    // Check that a missing efixed value throws
+    const auto &spectrumInfo = inputWS->spectrumInfo();
+    std::shared_ptr<const IDetector> detector(&spectrumInfo.detector(0), Mantid::NoDeleting());
+    TS_ASSERT_THROWS_ANYTHING(inputWS->getEFixed(detector));
+
     TableWorkspace_sptr ws;
     TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<TableWorkspace>(outWSName));
     TS_ASSERT(ws);

--- a/docs/source/release/v6.10.0/Direct_Geometry/General/Bugfixes/37101.rst
+++ b/docs/source/release/v6.10.0/Direct_Geometry/General/Bugfixes/37101.rst
@@ -1,0 +1,1 @@
+- Fixed a bug that prevented to show detectors for Let data


### PR DESCRIPTION
### Description of work

#### Summary of work

In some cases when the `efixed` value is not available for a detector, an `invalid_argument` exception is thrown instead of a `runtime_error`. Previously only the `runtime_error` exception was caught and the creation of the detector table failed. Now both types of exception are caught and `Show Detectors` works regardless of whether the `efixed` value is available or not.

Fixes #[36988](https://github.com/mantidproject/mantid/issues/36988)

**Report to:** @mducle 

### To test:

Follow the instructions in the original issue: https://github.com/mantidproject/mantid/issues/36988

In addition, load a few old and new data sets from different instruments and check whether `Show Detectors` works as expected.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
