### PR TITLE
Remove hdf5 pin ornl-next - take 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         # Exclude sphinx / template file
         exclude: test_doctest.py|python_export_maker.py
       - id: mantid-release-note-check
-        files: docs\/source\/release\/v\d\.\d\.\d\/.*\/.*\.rst
+        files: docs\/source\/release\/v\d+\.\d+\.\d+\/.*\/.*\.rst
 
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13
@@ -55,14 +55,14 @@ repos:
           )$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.3.5
     # ruff must appear before black in the list of hooks
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black
-    rev: 24.2.0
+    rev: 24.3.0
     hooks:
       - id: black
         exclude: scripts/templates/reference/|Testing/Tools/cxxtest

--- a/Framework/DataHandling/src/H5Util.cpp
+++ b/Framework/DataHandling/src/H5Util.cpp
@@ -197,6 +197,13 @@ std::string readString(H5::Group &group, const std::string &name) {
 std::string readString(H5::DataSet &dataset) {
   std::string value;
   dataset.read(value, dataset.getDataType(), dataset.getSpace());
+
+#if H5_VERSION_GE(1, 14, 0)
+  // hdf5 >=1.14 puts the null terminator in the string
+  // this strips that out
+  value.erase(std::find(value.begin(), value.end(), '\0'), value.end());
+#endif
+
   return value;
 }
 

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -21,16 +21,19 @@ python:
 boost:
   - 1.78
 
+hdf5: # this is to move to libcurl>=8.4
+  - '>1.14.0,<1.15'
+
 # We follow conda-forge and build with the lowest supported version of numpy for forward compatibility.
 numpy:
-  - 1.22.*
+  - 1.24.*
 
 matplotlib:
   - 3.7.*
 
-# mantidqt host environment cannot resolve with openssl 3.2.0, there appears to be a conflict with qt-main 5.15.8
-openssl:
-  - 3.1.4
+# Fix the version to avoid updates being pulled in automatically, which might change the Reflectometry ORSO file content or layout and cause tests to fail.
+orsopy:
+  - 1.2.0
 
 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning.
 # It's resolved on their devel branch but not yet included in a release, as of 1.12.5.
@@ -44,9 +47,8 @@ pycifrw:
 sphinx_bootstrap_theme:
   - 0.8.1
 
-# Some unit test failures present in 1.12.0 from tanh not being found.
 scipy:
-  - '>=1.10.0,!=1.12.0'
+  - '>=1.10.0'
 
 pyqt:
   - 5.15
@@ -65,15 +67,12 @@ qscintilla2:
 tbb:
   - 2021
 
-hdf5:
-  - 1.12.*
-
 gsl:
   - 2.7
 
-# v0.3.23 causes a hang on osx for some systemtests, v0.3.24 causes a unit test failure that needs investigation, v0.3.25/26 causes a system test failure on linux
+# v0.3.23 causes a hang on osx for some systemtests, v0.3.24 causes a unit test failure that needs investigation, v0.3.25 causes a system test failure on linux
 libopenblas:
-  - '!=0.3.23,!=0.3.24,!=0.3.25,!=0.3.26'
+  - '!=0.3.23,!=0.3.24,!=0.3.25'
 
 euphonic:
   - '>=1.2.1,<2.0'

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -33,8 +33,6 @@ requirements:
     - libcxx                                 # [osx]
 
   host:
-    - icu=72.1
-    - libxml2=2.10.4
     - boost {{ boost }}
     - eigen
     - gsl {{ gsl }}
@@ -54,7 +52,6 @@ requirements:
     - setuptools
     - tbb-devel {{ tbb }}
     - pip
-    - openssl {{ openssl }}
     - versioningit
     - libglu  # [linux]
   run:
@@ -64,19 +61,18 @@ requirements:
     - {{ pin_compatible("hdf5", max_pin="x.x") }}
     - lib3mf  # [win]
     - nexus
-    - {{ pin_compatible("numpy", upper_bound="1.25") }}
+    - {{ pin_compatible("numpy", upper_bound="1.27") }}
     - {{ pin_compatible("occt", max_pin="x.x.x") }}
     - pycifrw {{ pycifrw }}
     - python
     - python-dateutil
     - pyyaml
     - scipy {{ scipy }}
-    - openssl
     - euphonic {{ euphonic }}
     - toml
     - libglu  # [linux]
     - joblib
-    - orsopy
+    - orsopy {{ orsopy }}
 
 about:
   home: https://github.com/mantidproject/mantid

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -14,7 +14,7 @@ dependencies:
   - graphviz>=2.47.0
   - gsl=2.7 # Keep gsl a specific version to reduce changes in our fitting
   - h5py
-  - hdf5>=1.12,<1.13
+  - hdf5>1.14.0,<1.15 # gets libcurl>=8.4
   - jemalloc=5.2.0 # We have noticed 5.2.1 can cause a hang on older glibc versions (Cent OS 7, Ubuntu 18.04). Observed with import CaChannel and also our MeierTest.
   - jsoncpp>=1.9.4,<2
   - libopenblas!=0.3.23,!=0.3.24,!=0.3.25 # v0.3.25 causing system test failures on linux. Others are for macOS consistency.
@@ -23,7 +23,7 @@ dependencies:
   - muparser>=2.3.2
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy>=1.23,<1.26
+  - numpy>=1.24,<1.27
   - occt
   - pip>=21.0.1
   - poco=1.12.1|>=1.12.6 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch but not yet included in a release, as of 1.12.5.

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -13,7 +13,7 @@ dependencies:
   - graphviz>=2.47.0
   - gsl=2.7 # Keep gsl a specific version to reduce changes in our fitting
   - h5py
-  - hdf5>=1.12,<1.13
+  - hdf5>1.14.0,<1.15 # gets libcurl>=8.4
   - jemalloc>=5.2.1
   - jsoncpp>=1.9.4,<2
   - libopenblas!=0.3.23,!=0.3.24,!=0.3.25 # v0.3.23 causes a hang for the system tests on OSX, v0.3.24 causing unit test failure - investigation needed, v0.3.25 causing a system test failure.
@@ -22,7 +22,7 @@ dependencies:
   - matplotlib=3.7.*
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy>=1.23,<1.26
+  - numpy>=1.24,<1.27
   - occt
   - pip>=21.0.1
   - poco=1.12.1|>=1.12.6 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch but not yet included in a release, as of 1.12.5.

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -14,7 +14,7 @@ dependencies:
   - graphviz>=2.47.0
   - gsl=2.7 # Keep gsl a specific version to reduce changes in our fitting
   - h5py
-  - hdf5>=1.12,<1.13
+  - hdf5>1.14.0,<1.15 # gets libcurl>=8.4
   - jsoncpp>=1.9.4,<2
   - librdkafka>=1.6.0
   - lib3mf # windows only
@@ -22,7 +22,7 @@ dependencies:
   - matplotlib=3.7.*
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy>=1.23,<1.26
+  - numpy>=1.24,<1.27
   - occt
   - conda-wrappers
   - pip>=21.0.1


### PR DESCRIPTION
This is a version of #36975 into ornl-next. It also includes updating pre-commit.