### PR TITLE
Add wall-clock filtering via pulse information to LoadEventNexus - ornl-next

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
@@ -47,6 +47,15 @@ public:
   /// The wall clock time of the pulse
   const Mantid::Types::Core::DateAndTime &pulseTime(const size_t index) const;
 
+  /**
+   * Return a vector of [include,exclude) indices into the pulse vectors that are between the start and stop times. This
+   * is very similar to the behavior of Mantid::Kernel::TimeROI.
+   *
+   * This will return an empty vector if all pulse indices are between the start and stop.
+   */
+  std::vector<size_t> getPulseIndices(const Mantid::Types::Core::DateAndTime &start,
+                                      const Mantid::Types::Core::DateAndTime &stop) const;
+
   /// Equals
   bool equals(size_t otherNumPulse, const std::string &otherStartTime);
 

--- a/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
@@ -23,7 +23,9 @@ namespace Mantid::DataHandling {
 class MANTID_DATAHANDLING_DLL BankPulseTimes {
 public:
   /// Starting number for assigning periods.
-  static const unsigned int FirstPeriod;
+  static const int FIRST_PERIOD;
+  /// Unix epoch used as default epoch when the file does not specify one
+  static const std::string DEFAULT_START_TIME;
 
   /// Constructor with NeXus::File
   BankPulseTimes(::NeXus::File &file, const std::vector<int> &periodNumbers);
@@ -54,6 +56,9 @@ public:
 private:
   template <typename ValueType>
   void readData(::NeXus::File &file, int64_t numValues, Mantid::Types::Core::DateAndTime &start);
+
+  /// This is not needed
+  void updateStartTime();
 
   /// Ensure that we always have a consistency between nPulses and periodNumbers containers
   void finalizePeriodNumbers();

--- a/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
@@ -66,7 +66,7 @@ private:
   template <typename ValueType>
   void readData(::NeXus::File &file, int64_t numValues, Mantid::Types::Core::DateAndTime &start);
 
-  /// This is not needed
+  /// This determines the start time by finding the minimum value in the array
   void updateStartTime();
 
   /// Ensure that we always have a consistency between nPulses and periodNumbers containers

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -159,6 +159,8 @@ public:
   Mantid::Types::Core::DateAndTime filter_time_start;
   /// Filter by stop time
   Mantid::Types::Core::DateAndTime filter_time_stop;
+  /// if wall-clock filtering was requested
+  bool m_is_time_filtered{false};
 
   /// Mutex protecting tof limits
   std::mutex m_tofMutex;

--- a/Framework/DataHandling/inc/MantidDataHandling/PulseIndexer.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/PulseIndexer.h
@@ -33,7 +33,7 @@ namespace DataHandling {
 class MANTID_DATAHANDLING_DLL PulseIndexer {
 public:
   PulseIndexer(std::shared_ptr<std::vector<uint64_t>> event_index, const std::size_t firstEventIndex,
-               const std::size_t numEvents, const std::string &entry_name);
+               const std::size_t numEvents, const std::string &entry_name, const std::vector<size_t> &pulse_roi);
 
   /// Which element in the event_index array is the first one to use
   size_t getFirstPulseIndex() const;
@@ -47,8 +47,9 @@ public:
    */
   size_t getStartEventIndex(const size_t pulseIndex) const;
   /**
-   * The one past the last event(tof,detid) index to read for this pulse. When this is before the event indices to use,
-   * it returns the value of getStartEventIndex. This is only public for testing.
+   * The one past the last event(tof,detid) index to read for this pulse. When this is not a pulse index to use,
+   * it returns the value of getStartEventIndex. When the pulseIndex is past the end of the use regions, it returns the
+   * m_numEvents. This is only public for testing.
    */
   size_t getStopEventIndex(const size_t pulseIndex) const;
 
@@ -57,6 +58,8 @@ private:
 
   size_t determineFirstPulseIndex() const;
   size_t determineLastPulseIndex() const;
+  /// returns true when the roi says the pulse should be used
+  bool includedPulse(const size_t pulseIndex) const;
 
   /// vector of indices (length of # of pulses) into the event arrays
   const std::shared_ptr<std::vector<uint64_t>> m_event_index;
@@ -83,6 +86,8 @@ private:
    * neighboring values.
    */
   std::vector<std::size_t> m_roi;
+  /// true when there is more to check than the pulse being between the ends
+  bool m_roi_complex;
 
   /// Total number of pulsetime/pulseindex
   std::size_t m_numPulses;

--- a/Framework/DataHandling/src/BankPulseTimes.cpp
+++ b/Framework/DataHandling/src/BankPulseTimes.cpp
@@ -214,7 +214,7 @@ std::vector<size_t> BankPulseTimes::getPulseIndices(const Mantid::Types::Core::D
         // do a linear search with the assumption that the index will be near the beginning
         for (size_t index = this->pulseTimes.size() - 1; index > start_index; --index) {
           if (this->pulseTime(index) <= stop) {
-            roi.push_back(index);
+            roi.push_back(index + 1); // include this pulse
             break;
           }
         }

--- a/Framework/DataHandling/src/LoadErrorEventsNexus.cpp
+++ b/Framework/DataHandling/src/LoadErrorEventsNexus.cpp
@@ -113,7 +113,8 @@ void LoadErrorEventsNexus::exec() {
   auto min_tof = std::numeric_limits<double>::max();
   auto max_tof = std::numeric_limits<double>::lowest();
 
-  const PulseIndexer pulseIndexer(event_index, event_index->at(0), numEvents, "bank_error_events");
+  const PulseIndexer pulseIndexer(event_index, event_index->at(0), numEvents, "bank_error_events",
+                                  std::vector<size_t>());
   const auto firstPulseIndex = pulseIndexer.getFirstPulseIndex();
   const auto lastPulseIndex = pulseIndexer.getLastPulseIndex();
 

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -359,7 +359,6 @@ void LoadEventNexus::filterDuringPause<EventWorkspaceCollection_sptr>(EventWorks
 template <typename T>
 T LoadEventNexus::filterEventsByTime(T workspace, Mantid::Types::Core::DateAndTime &startTime,
                                      Mantid::Types::Core::DateAndTime &stopTime) {
-
   auto filterByTime = createChildAlgorithm("FilterByTime");
   g_log.information("Filtering events by time...");
   filterByTime->setProperty("InputWorkspace", workspace);
@@ -1038,7 +1037,6 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
   filter_time_stop_sec = getProperty("FilterByTimeStop");
 
   // Default to ALL pulse times
-  bool is_time_filtered = false;
   filter_time_start = Types::Core::DateAndTime::minimum();
   filter_time_stop = Types::Core::DateAndTime::maximum();
 
@@ -1047,12 +1045,12 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
     // seconds to absolute PulseTime
     if (filter_time_start_sec != EMPTY_DBL()) {
       filter_time_start = run_start + filter_time_start_sec;
-      is_time_filtered = true;
+      m_is_time_filtered = true;
     }
 
     if (filter_time_stop_sec != EMPTY_DBL()) {
       filter_time_stop = run_start + filter_time_stop_sec;
-      is_time_filtered = true;
+      m_is_time_filtered = true;
     }
 
     // Silly values?
@@ -1161,6 +1159,7 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
     safeOpenFile(m_filename);
   }
   if (!loaded) {
+    loaderType = LoaderType::DEFAULT; // to be used later
     bool precount = getProperty("Precount");
     int chunk = getProperty("ChunkNumber");
     int totalChunks = getProperty("TotalChunks");
@@ -1223,10 +1222,18 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
   // if there is time_of_flight load it
   adjustTimeOfFlightISISLegacy(*m_file, m_ws, m_top_entry_name, classType, descriptor.get());
 
-  if (is_time_filtered) {
-    // Now filter out the run and events, using the DateAndTime type.
-    // This will sort both by pulse time
-    filterEventsByTime(m_ws, filter_time_start, filter_time_stop);
+  if (m_is_time_filtered) {
+    if (loaderType == LoaderType::MULTIPROCESS) {
+      // Now filter out the run and events, using the DateAndTime type.
+      // This will sort both by pulse time
+      filterEventsByTime(m_ws, filter_time_start, filter_time_stop);
+    } else {
+      // events were filtered during read
+      // filter the logs the same way FilterByTime does
+      TimeROI timeroi(filter_time_start, filter_time_stop);
+      m_ws->mutableRun().setTimeROI(timeroi);
+      m_ws->mutableRun().removeDataOutsideTimeROI();
+    }
   }
 }
 

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -572,7 +572,7 @@ LoadEventNexus::runLoadNexusLogs(const std::string &nexusfilename, T localWorksp
     }
     // Get the period log. Map of DateAndTime to Period int values.
     if (run.hasProperty("period_log")) {
-      auto *temp = run.getProperty("period_log");
+      const auto *temp = run.getProperty("period_log");
       // Check for corrupted period logs
       std::string status = "";
       std::unique_ptr<TimeSeriesProperty<int>> tempPeriodLog(dynamic_cast<TimeSeriesProperty<int> *>(temp->clone()));
@@ -1361,7 +1361,7 @@ void LoadEventNexus::deleteBanks(const EventWorkspaceCollection_sptr &workspace,
   for (auto &det : detList) {
     bool keep = false;
     std::string det_name = det->getName();
-    for (auto &bankName : bankNames) {
+    for (const auto &bankName : bankNames) {
       size_t pos = bankName.find("_events");
       if (det_name == bankName.substr(0, pos))
         keep = true;

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -111,10 +111,17 @@ void ProcessBankData::run() {
   const double TOF_MAX = alg->filter_tof_max;
   const bool NO_TOF_FILTERING = !(alg->filter_tof_range);
 
-  // TODO don't bother with pulse filtering...yet
-  const PulseIndexer pulseIndexer(event_index, startAt, numEvents, entry_name, std::vector<size_t>());
+  // set up wall-clock filtering if it was requested
+  std::vector<size_t> pulseROI;
+  if (alg->m_is_time_filtered) {
+    pulseROI = thisBankPulseTimes->getPulseIndices(alg->filter_time_start, alg->filter_time_stop);
+  }
+
+  const PulseIndexer pulseIndexer(event_index, startAt, numEvents, entry_name, pulseROI);
   const auto firstPulseIndex = pulseIndexer.getFirstPulseIndex(); // for whole file reading is 0
   const auto lastPulseIndex = pulseIndexer.getLastPulseIndex();   // for whole file reading is event_index->size()
+
+  // loop over all pulses
   for (std::size_t pulseIndex = firstPulseIndex; pulseIndex < lastPulseIndex; pulseIndex++) {
     // determine range of events for the pulse
     const auto eventIndexRange = pulseIndexer.getEventIndexRange(pulseIndex);

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -111,15 +111,16 @@ void ProcessBankData::run() {
   const double TOF_MAX = alg->filter_tof_max;
   const bool NO_TOF_FILTERING = !(alg->filter_tof_range);
 
-  const PulseIndexer pulseIndexer(event_index, startAt, numEvents, entry_name);
+  // TODO don't bother with pulse filtering...yet
+  const PulseIndexer pulseIndexer(event_index, startAt, numEvents, entry_name, std::vector<size_t>());
   const auto firstPulseIndex = pulseIndexer.getFirstPulseIndex(); // for whole file reading is 0
   const auto lastPulseIndex = pulseIndexer.getLastPulseIndex();   // for whole file reading is event_index->size()
   for (std::size_t pulseIndex = firstPulseIndex; pulseIndex < lastPulseIndex; pulseIndex++) {
     // determine range of events for the pulse
     const auto eventIndexRange = pulseIndexer.getEventIndexRange(pulseIndex);
-    if (eventIndexRange.first > numEvents)
+    if (eventIndexRange.first >= numEvents) // already process all the events that were requested
       break;
-    else if (eventIndexRange.first == eventIndexRange.second)
+    else if (eventIndexRange.first == eventIndexRange.second) // empty range
       continue;
 
     // Save the pulse time at this index for creating those events

--- a/Framework/DataHandling/src/PulseIndexer.cpp
+++ b/Framework/DataHandling/src/PulseIndexer.cpp
@@ -114,8 +114,8 @@ std::pair<size_t, size_t> PulseIndexer::getEventIndexRange(const size_t pulseInd
   const auto stop = this->getStopEventIndex(pulseIndex);
   if (start > stop) {
     std::stringstream msg;
-    msg << "Something went really wrong: " << start << " > " << stop << "| " << m_entry_name
-        << " startAt=" << m_firstEventIndex << " numEvents=" << m_event_index->size() << " RAWINDICES=["
+    msg << "Something went really wrong with pulseIndex=" << pulseIndex << ": " << start << " > " << stop << "| "
+        << m_entry_name << " startAt=" << m_firstEventIndex << " numEvents=" << m_event_index->size() << " RAWINDICES=["
         << start + m_firstEventIndex << ",?)"
         << " pulseIndex=" << pulseIndex << " of " << m_event_index->size();
     throw std::runtime_error(msg.str());
@@ -174,7 +174,13 @@ size_t PulseIndexer::getStopEventIndex(const size_t pulseIndex) const {
   const auto pulseIndexEnd = pulseIndex + 1;
 
   // check if the requests have gone past the end - order of if/else matters
-  const size_t eventIndex = (pulseIndexEnd >= m_roi.back()) ? m_numEvents : m_event_index->operator[](pulseIndexEnd);
+  // const size_t eventIndex = (pulseIndexEnd >= m_roi.back()) ? m_numEvents : m_event_index->operator[](pulseIndexEnd);
+  size_t eventIndex = m_event_index->operator[](pulseIndexEnd);
+  if (pulseIndexEnd == m_roi.back()) {
+    eventIndex = std::min(m_numEvents, eventIndex);
+    if (pulseIndexEnd == m_event_index->size())
+      eventIndex = m_numEvents;
+  }
 
   if (eventIndex > m_firstEventIndex)
     return eventIndex - m_firstEventIndex;

--- a/Framework/DataHandling/src/PulseIndexer.cpp
+++ b/Framework/DataHandling/src/PulseIndexer.cpp
@@ -29,7 +29,7 @@ PulseIndexer::PulseIndexer(std::shared_ptr<std::vector<uint64_t>> event_index, c
     if (pulse_roi.size() % 2 != 0)
       throw std::runtime_error("Invalid size for pulsetime roi, must be even or empty");
 
-    auto roi_combined = Mantid::Kernel::calculate_intersection(m_roi, pulse_roi);
+    auto roi_combined = Mantid::Kernel::ROI::calculate_intersection(m_roi, pulse_roi);
     m_roi.clear();
     m_roi.assign(roi_combined.cbegin(), roi_combined.cend());
     m_roi_complex = bool(m_roi.size() > 2);

--- a/Framework/DataHandling/src/PulseIndexer.cpp
+++ b/Framework/DataHandling/src/PulseIndexer.cpp
@@ -6,14 +6,16 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidDataHandling/PulseIndexer.h"
+#include "MantidKernel/TimeROI.h"
 #include <sstream>
 #include <utility>
 
 namespace Mantid::DataHandling {
 PulseIndexer::PulseIndexer(std::shared_ptr<std::vector<uint64_t>> event_index, const std::size_t firstEventIndex,
-                           const std::size_t numEvents, const std::string &entry_name)
+                           const std::size_t numEvents, const std::string &entry_name,
+                           const std::vector<size_t> &pulse_roi)
     : m_event_index(std::move(event_index)), m_firstEventIndex(firstEventIndex), m_numEvents(numEvents),
-      m_entry_name(entry_name) {
+      m_roi_complex(false), m_entry_name(entry_name) {
   // cache the number of pulses
   m_numPulses = m_event_index->size();
 
@@ -21,6 +23,17 @@ PulseIndexer::PulseIndexer(std::shared_ptr<std::vector<uint64_t>> event_index, c
   m_roi.push_back(this->determineFirstPulseIndex());
   // for now, use all pulses up to the end
   m_roi.push_back(this->determineLastPulseIndex());
+
+  // update based on the information in the pulse_roi
+  if (!pulse_roi.empty()) {
+    if (pulse_roi.size() % 2 != 0)
+      throw std::runtime_error("Invalid size for pulsetime roi, must be even or empty");
+
+    auto roi_combined = Mantid::Kernel::calculate_intersection(m_roi, pulse_roi);
+    m_roi.clear();
+    m_roi.assign(roi_combined.cbegin(), roi_combined.cend());
+    m_roi_complex = bool(m_roi.size() > 2);
+  }
 }
 
 /**
@@ -132,19 +145,36 @@ size_t PulseIndexer::getStartEventIndex(const size_t pulseIndex) const {
   }
 }
 
+bool PulseIndexer::includedPulse(const size_t pulseIndex) const {
+  if (pulseIndex >= m_roi.back()) {
+    return false; // case is already handled in getStopEventIndex and shouldn't be called
+  } else if (pulseIndex < m_roi.front()) {
+    return false;
+  } else {
+    if (m_roi_complex) {
+      // get the first ROI time boundary greater than the input time. Note that an ROI is a series of alternating
+      // ROI_USE and ROI_IGNORE values.
+      const auto iterUpper = std::upper_bound(m_roi.cbegin(), m_roi.cend(), pulseIndex);
+
+      return (std::distance(m_roi.cbegin(), iterUpper) % 2 != 0);
+    } else {
+      return true; // value is past m_roi.front()
+    }
+  }
+}
+
 size_t PulseIndexer::getStopEventIndex(const size_t pulseIndex) const {
+  if (pulseIndex >= m_roi.back()) // indicates everything has already been read
+    return m_numEvents;
+
   // return the start index to signify not using
-  if (pulseIndex < m_roi.front())
+  if (!includedPulse(pulseIndex))
     return this->getStartEventIndex(pulseIndex);
 
   const auto pulseIndexEnd = pulseIndex + 1;
 
   // check if the requests have gone past the end - order of if/else matters
-  size_t eventIndex = m_event_index->operator[](pulseIndexEnd);
-  if (pulseIndexEnd >= m_numPulses) // last pulse should read to the last event
-    eventIndex = m_numEvents;
-  else if (pulseIndexEnd >= m_roi.back()) // this can be equal to the number of pulses
-    eventIndex = m_numEvents;
+  const size_t eventIndex = (pulseIndexEnd >= m_roi.back()) ? m_numEvents : m_event_index->operator[](pulseIndexEnd);
 
   if (eventIndex > m_firstEventIndex)
     return eventIndex - m_firstEventIndex;

--- a/Framework/DataHandling/test/BankPulseTimesTest.h
+++ b/Framework/DataHandling/test/BankPulseTimesTest.h
@@ -12,10 +12,13 @@
 
 using Mantid::DataHandling::BankPulseTimes;
 
+namespace {
+const static Mantid::Types::Core::DateAndTime START_TIME(0., 0.);
+}
+
 class BankPulseTimesTest : public CxxTest::TestSuite {
 private:
   std::vector<Mantid::Types::Core::DateAndTime> createPulseTimes(const size_t length) {
-    const static Mantid::Types::Core::DateAndTime START_TIME(0., 0.);
     constexpr double SECONDS_DELTA{30.};
 
     std::vector<Mantid::Types::Core::DateAndTime> pulse_times;
@@ -45,11 +48,12 @@ public:
 
     BankPulseTimes bank_pulse_times(pulse_times);
 
+    TS_ASSERT_EQUALS(bank_pulse_times.startTime, pulse_times[0].toISO8601String());
     TS_ASSERT_EQUALS(bank_pulse_times.numberOfPulses(), pulse_times.size());
 
     for (std::size_t i = 0; i < pulse_times.size(); ++i) {
       TS_ASSERT_EQUALS(bank_pulse_times.pulseTime(i), pulse_times[i]);
-      TS_ASSERT_EQUALS(bank_pulse_times.periodNumber(i), BankPulseTimes::FirstPeriod);
+      TS_ASSERT_EQUALS(bank_pulse_times.periodNumber(i), BankPulseTimes::FIRST_PERIOD);
     }
   }
 
@@ -59,6 +63,7 @@ public:
 
     BankPulseTimes bank_pulse_times(pulse_times, period_indices);
 
+    TS_ASSERT_EQUALS(bank_pulse_times.startTime, pulse_times[0].toISO8601String());
     TS_ASSERT_EQUALS(bank_pulse_times.numberOfPulses(), pulse_times.size());
 
     for (std::size_t i = 0; i < pulse_times.size(); ++i) {
@@ -78,6 +83,8 @@ public:
 
     // should be zero length
     TS_ASSERT_EQUALS(bank_pulse_times.numberOfPulses(), NUM_PULSES);
+    // default is unix epoch
+    TS_ASSERT_EQUALS(bank_pulse_times.startTime, BankPulseTimes::DEFAULT_START_TIME);
   }
 
   void test_periods_not_parallel() {
@@ -86,11 +93,12 @@ public:
 
     BankPulseTimes bank_pulse_times(pulse_times, period_indices);
 
+    TS_ASSERT_EQUALS(bank_pulse_times.startTime, pulse_times[0].toISO8601String());
     TS_ASSERT_EQUALS(bank_pulse_times.numberOfPulses(), pulse_times.size());
 
     for (std::size_t i = 0; i < pulse_times.size(); ++i) {
       TS_ASSERT_EQUALS(bank_pulse_times.pulseTime(i), pulse_times[i]);
-      TS_ASSERT_EQUALS(bank_pulse_times.periodNumber(i), BankPulseTimes::FirstPeriod);
+      TS_ASSERT_EQUALS(bank_pulse_times.periodNumber(i), BankPulseTimes::FIRST_PERIOD);
     }
   }
 };

--- a/Framework/DataHandling/test/BankPulseTimesTest.h
+++ b/Framework/DataHandling/test/BankPulseTimesTest.h
@@ -111,7 +111,7 @@ public:
       std::vector<DateAndTime> starting({start, pulse_times.front()});
       std::vector<DateAndTime> stopping({stop, stop + .5 * SECONDS_DELTA});
 
-      const std::vector<size_t> roi_exp({0, pulse_times.size() - 3});
+      const std::vector<size_t> roi_exp({0, pulse_times.size() - 2});
 
       doROITest(bank_pulse_times, starting, stopping, roi_exp);
     }

--- a/Framework/DataHandling/test/BankPulseTimesTest.h
+++ b/Framework/DataHandling/test/BankPulseTimesTest.h
@@ -11,11 +11,12 @@
 #include "MantidDataHandling/BankPulseTimes.h"
 
 using Mantid::DataHandling::BankPulseTimes;
-typedef std::vector<Mantid::Types::Core::DateAndTime> PulseTimeVec;
+using Mantid::Types::Core::DateAndTime;
+typedef std::vector<DateAndTime> PulseTimeVec;
 
 namespace {
 constexpr double SECONDS_DELTA{30.};
-const static Mantid::Types::Core::DateAndTime START_TIME(0., 0.);
+const static DateAndTime START_TIME(0., 0.);
 } // namespace
 
 class BankPulseTimesTest : public CxxTest::TestSuite {
@@ -37,13 +38,13 @@ private:
     return period_indices;
   }
 
-  void doROITest(BankPulseTimes &bank_pulse_times, const std::vector<Mantid::Types::Core::DateAndTime> &starting,
-                 const std::vector<Mantid::Types::Core::DateAndTime> &stopping, const std::vector<size_t> &roi_exp) {
+  void doROITest(BankPulseTimes &bank_pulse_times, const std::vector<DateAndTime> &starting,
+                 const std::vector<DateAndTime> &stopping, const std::vector<size_t> &roi_exp) {
 
     for (const auto &startVal : starting) {
       for (const auto &stopVal : stopping) {
         auto roi = bank_pulse_times.getPulseIndices(startVal, stopVal);
-        TS_ASSERT_EQUALS(roi.size(), 2);
+        TS_ASSERT_EQUALS(roi.size(), roi_exp.size());
         TS_ASSERT_EQUALS(roi, roi_exp);
       }
     }
@@ -93,8 +94,8 @@ public:
       const auto stop = pulse_times.back() + SECONDS_DELTA;
 
       // parameterize values to check - all have the same roi result
-      std::vector<Mantid::Types::Core::DateAndTime> starting({start, start - .5 * SECONDS_DELTA});
-      std::vector<Mantid::Types::Core::DateAndTime> stopping({stop, pulse_times.back()});
+      std::vector<DateAndTime> starting({start, start - .5 * SECONDS_DELTA});
+      std::vector<DateAndTime> stopping({stop, pulse_times.back()});
 
       const std::vector<size_t> roi_exp({2, pulse_times.size()});
 
@@ -107,8 +108,8 @@ public:
       const auto stop = pulse_times.back() - 2. * SECONDS_DELTA;
 
       // parameterize values to check - all have the same roi result
-      std::vector<Mantid::Types::Core::DateAndTime> starting({start, pulse_times.front()});
-      std::vector<Mantid::Types::Core::DateAndTime> stopping({stop, stop + .5 * SECONDS_DELTA});
+      std::vector<DateAndTime> starting({start, pulse_times.front()});
+      std::vector<DateAndTime> stopping({stop, stop + .5 * SECONDS_DELTA});
 
       const std::vector<size_t> roi_exp({0, pulse_times.size() - 3});
 
@@ -124,7 +125,7 @@ public:
         pulse_times.emplace_back(START_TIME + static_cast<double>(offset) + (static_cast<double>(i) * SECONDS_DELTA));
 
     // cache the minimum value
-    const auto startTimeObj = std::min(pulse_times.cbegin(), pulse_times.cend());
+    const auto [startTimeObj, stopTimeObj] = std::minmax_element(pulse_times.cbegin(), pulse_times.cend());
 
     BankPulseTimes bank_pulse_times(pulse_times);
 
@@ -134,6 +135,54 @@ public:
     for (std::size_t i = 0; i < pulse_times.size(); ++i) {
       TS_ASSERT_EQUALS(bank_pulse_times.pulseTime(i), pulse_times[i]);
       TS_ASSERT_EQUALS(bank_pulse_times.periodNumber(i), BankPulseTimes::FIRST_PERIOD);
+    }
+
+    // roi - include everything
+    {
+      const DateAndTime start = (*startTimeObj) - SECONDS_DELTA;
+      const DateAndTime stop = (*stopTimeObj) + SECONDS_DELTA;
+
+      // past both ends
+      auto roi = bank_pulse_times.getPulseIndices(start, stop);
+      TS_ASSERT(roi.empty());
+
+      // at the front and past the end
+      roi = bank_pulse_times.getPulseIndices(*startTimeObj, stop);
+      TS_ASSERT(roi.empty());
+
+      // before the front and at the end
+      roi = bank_pulse_times.getPulseIndices(start, *stopTimeObj);
+      TS_ASSERT(roi.empty());
+    }
+
+    // roi - trim from the front
+    {
+      const auto start = (*startTimeObj) + 2. * SECONDS_DELTA;
+      const auto stop = (*stopTimeObj) + SECONDS_DELTA;
+
+      // parameterize values to check - all have the same roi result
+      std::vector<Mantid::Types::Core::DateAndTime> starting({start, start - .25 * SECONDS_DELTA});
+      std::vector<Mantid::Types::Core::DateAndTime> stopping({stop, stop + 0.5 * SECONDS_DELTA});
+
+      // these values were determined by inspecting the values by hand
+      // roi is [2, 33), [35, 66), [69, size)
+      const std::vector<size_t> roi_exp({2, 33, 35, 66, 68, pulse_times.size()});
+
+      doROITest(bank_pulse_times, starting, stopping, roi_exp);
+    }
+
+    // roi - trim from the back
+    {
+      const auto start = (*startTimeObj) - SECONDS_DELTA;
+      const auto stop = (*stopTimeObj) - 2. * SECONDS_DELTA;
+
+      // parameterize values to check - all have the same roi result
+      std::vector<Mantid::Types::Core::DateAndTime> starting({start, start + .25 * SECONDS_DELTA});
+      std::vector<Mantid::Types::Core::DateAndTime> stopping({stop, stop + .25 * SECONDS_DELTA});
+
+      const std::vector<size_t> roi_exp({0, 31, 33, 64, 66, 97});
+
+      doROITest(bank_pulse_times, starting, stopping, roi_exp);
     }
   }
 

--- a/Framework/DataHandling/test/BankPulseTimesTest.h
+++ b/Framework/DataHandling/test/BankPulseTimesTest.h
@@ -37,6 +37,18 @@ private:
     return period_indices;
   }
 
+  void doROITest(BankPulseTimes &bank_pulse_times, const std::vector<Mantid::Types::Core::DateAndTime> &starting,
+                 const std::vector<Mantid::Types::Core::DateAndTime> &stopping, const std::vector<size_t> &roi_exp) {
+
+    for (const auto &startVal : starting) {
+      for (const auto &stopVal : stopping) {
+        auto roi = bank_pulse_times.getPulseIndices(startVal, stopVal);
+        TS_ASSERT_EQUALS(roi.size(), 2);
+        TS_ASSERT_EQUALS(roi, roi_exp);
+      }
+    }
+  }
+
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
@@ -84,19 +96,9 @@ public:
       std::vector<Mantid::Types::Core::DateAndTime> starting({start, start - .5 * SECONDS_DELTA});
       std::vector<Mantid::Types::Core::DateAndTime> stopping({stop, pulse_times.back()});
 
-      const size_t start_index_exp = 2;
-      const size_t stop_index_exp = pulse_times.size();
+      const std::vector<size_t> roi_exp({2, pulse_times.size()});
 
-      for (const auto &startVal : starting) {
-        for (const auto &stopVal : stopping) {
-          auto roi = bank_pulse_times.getPulseIndices(startVal, stopVal);
-          TS_ASSERT_EQUALS(roi.size(), 2);
-          if (!roi.empty()) {
-            TS_ASSERT_EQUALS(roi.front(), start_index_exp);
-            TS_ASSERT_EQUALS(roi.back(), stop_index_exp);
-          }
-        }
-      }
+      doROITest(bank_pulse_times, starting, stopping, roi_exp);
     }
 
     // roi - trim from the back
@@ -108,19 +110,9 @@ public:
       std::vector<Mantid::Types::Core::DateAndTime> starting({start, pulse_times.front()});
       std::vector<Mantid::Types::Core::DateAndTime> stopping({stop, stop + .5 * SECONDS_DELTA});
 
-      const size_t start_index_exp = 0;
-      const size_t stop_index_exp = pulse_times.size() - 3;
+      const std::vector<size_t> roi_exp({0, pulse_times.size() - 3});
 
-      for (const auto &startVal : starting) {
-        for (const auto &stopVal : stopping) {
-          auto roi = bank_pulse_times.getPulseIndices(startVal, stopVal);
-          TS_ASSERT_EQUALS(roi.size(), 2);
-          if (!roi.empty()) {
-            TS_ASSERT_EQUALS(roi.front(), start_index_exp);
-            TS_ASSERT_EQUALS(roi.back(), stop_index_exp);
-          }
-        }
-      }
+      doROITest(bank_pulse_times, starting, stopping, roi_exp);
     }
   }
 

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -442,6 +442,51 @@ public:
     AnalysisDataService::Instance().remove(wsName);
   }
 
+  // FilteredLoadvsLoadThenFilter system test and algorithm usage example
+  void test_CNCS_7860_filtering() {
+    const std::string filename("CNCS_7860_event.nxs");
+    const std::string wsName("CNCS_7860");
+    constexpr double filterStart{60};
+    constexpr double filterEnd{120};
+    constexpr size_t NUM_HIST{8 * 128 * 50};
+    constexpr size_t NUM_EVENTS{29753};
+
+    LoadEventNexus alg;
+    alg.initialize();
+    alg.setPropertyValue("Filename", filename);
+    alg.setPropertyValue("OutputWorkspace", wsName);
+    alg.setProperty("FilterByTimeStart", filterStart);
+    alg.setProperty("FilterByTimeStop", filterEnd);
+    alg.setProperty("NumberOfBins", 1); // only one bin to make validation easier
+    TS_ASSERT(alg.execute());
+
+    // get the workspace
+    auto outWS = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(wsName);
+    TS_ASSERT(outWS);
+
+    TS_ASSERT_EQUALS(outWS->getNumberHistograms(), NUM_HIST);
+    TS_ASSERT_EQUALS(outWS->getNumberEvents(), NUM_EVENTS);
+
+    // number of empty spectra should match
+    size_t numEmpty{0};
+    for (std::size_t wi = 0; wi < outWS->getNumberHistograms(); ++wi)
+      if (outWS->getSpectrum(wi).empty())
+        numEmpty++;
+    TS_ASSERT_EQUALS(numEmpty, 31411); // observed from running LoadEventNexus + FilterByTime
+
+    // these are pixels that were showing the wrong behavior during testing
+    // should have one event [4325, 20673, 27475, 30675, 46869]
+    // near the magic pulse-time of missing events is 2010-Mar-25 16:10:36.997398376 when stoptime is 16:10:37
+    TS_ASSERT_EQUALS(outWS->getSpectrum(4325).getNumberEvents(), 1);
+    TS_ASSERT_EQUALS(outWS->getSpectrum(20673).getNumberEvents(), 1);
+    TS_ASSERT_EQUALS(outWS->getSpectrum(27475).getNumberEvents(), 1);
+    TS_ASSERT_EQUALS(outWS->getSpectrum(30675).getNumberEvents(), 1);
+    TS_ASSERT_EQUALS(outWS->getSpectrum(46869).getNumberEvents(), 1);
+
+    // cleanup assumes this worked
+    AnalysisDataService::Instance().remove(wsName);
+  }
+
   void test_Normal_vs_Precount() {
     Mantid::API::FrameworkManager::Instance();
     LoadEventNexus ld;
@@ -539,10 +584,10 @@ public:
         it2++;
       }
 
-      int pixelID = 2000;
+      constexpr std::size_t pixelID = 2000;
 
-      std::vector<TofEvent> events1 = WS->getSpectrum(pixelID).getEvents();
-      std::vector<TofEvent> events2 = WS2->getSpectrum(pixelID).getEvents();
+      const std::vector<TofEvent> events1 = WS->getSpectrum(pixelID).getEvents();
+      const std::vector<TofEvent> events2 = WS2->getSpectrum(pixelID).getEvents();
 
       // std::cout << events1.size() << '\n';
       TS_ASSERT_EQUALS(events1.size(), events2.size());

--- a/Framework/DataHandling/test/PulseIndexerTest.h
+++ b/Framework/DataHandling/test/PulseIndexerTest.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <cxxtest/TestSuite.h>
-#include <iostream>
 
 #include "MantidDataHandling/PulseIndexer.h"
 
@@ -24,13 +23,14 @@ public:
   static PulseIndexerTest *createSuite() { return new PulseIndexerTest(); }
   static void destroySuite(PulseIndexerTest *suite) { delete suite; }
 
+private:
   void run_test(std::shared_ptr<std::vector<uint64_t>> eventIndices, const size_t start_event_index,
                 const size_t total_events, const size_t firstPulseIndex = 0, const size_t lastPulseIndex = 0) {
     // rather than make all the tests supply a value, calculate it when it isn't specified
     const size_t myLastPulseIndex = (lastPulseIndex == 0) ? eventIndices->size() : lastPulseIndex;
 
     // create the object to test
-    PulseIndexer indexer(eventIndices, start_event_index, total_events, entry_name);
+    PulseIndexer indexer(eventIndices, start_event_index, total_events, entry_name, std::vector<size_t>());
 
     // test locating the range of pulse entirely containing the event indices
     TS_ASSERT_EQUALS(indexer.getFirstPulseIndex(), firstPulseIndex);
@@ -46,36 +46,22 @@ public:
     // test locating the first event index for the pulse
     // how start_event_index affects values is baked in from how code worked pre 2024
     for (size_t i = firstPulseIndex; i < myLastPulseIndex - 1; ++i) {
-      TS_ASSERT_EQUALS(indexer.getStartEventIndex(i), eventIndices->operator[](i) - start_event_index);
-      TS_ASSERT_EQUALS(indexer.getStopEventIndex(i), eventIndices->operator[](i + 1) - start_event_index);
+      assert_indices_equal(indexer, i, eventIndices->operator[](i) - start_event_index,
+                           eventIndices->operator[](i + 1) - start_event_index);
     }
 
     const auto exp_stop_event = (total_events >= start_event_index) ? (total_events - start_event_index) : total_events;
     // last element is a little different
     {
       const size_t i = myLastPulseIndex - 1;
-      TS_ASSERT_EQUALS(indexer.getStartEventIndex(i), eventIndices->operator[](i) - start_event_index);
-      TS_ASSERT_EQUALS(indexer.getStopEventIndex(i), exp_stop_event);
+      assert_indices_equal(indexer, i, eventIndices->operator[](i) - start_event_index, exp_stop_event);
     }
 
     // check past the end
     for (size_t i = myLastPulseIndex; i < eventIndices->size() + 2; ++i) {
       TS_ASSERT_EQUALS(indexer.getStartEventIndex(i), indexer.getStopEventIndex(i));
-      TS_ASSERT_EQUALS(indexer.getStopEventIndex(i), exp_stop_event);
+      TS_ASSERT_EQUALS(indexer.getStopEventIndex(i), total_events);
     }
-  }
-
-  void test_Simple() {
-    auto eventIndices = std::make_shared<std::vector<uint64_t>>();
-    for (uint64_t i = 0; i < 30; i += 10) {
-      eventIndices->push_back(i);
-    }
-
-    TS_ASSERT_EQUALS(eventIndices->size(), 3);
-
-    constexpr size_t total_events{40};
-    constexpr size_t start_event_index{0};
-    run_test(eventIndices, start_event_index, total_events);
   }
 
   std::shared_ptr<std::vector<uint64_t>> generate_nonConstant() {
@@ -88,6 +74,26 @@ public:
     TS_ASSERT_EQUALS(eventIndices->size(), 4);
 
     return eventIndices;
+  }
+
+  void assert_indices_equal(PulseIndexer &indexer, const size_t pulseIndex, const size_t startEventIndex,
+                            const size_t stopEventIndex) {
+    TS_ASSERT_EQUALS(indexer.getStartEventIndex(pulseIndex), startEventIndex);
+    TS_ASSERT_EQUALS(indexer.getStopEventIndex(pulseIndex), stopEventIndex);
+  }
+
+public:
+  void test_Simple() {
+    auto eventIndices = std::make_shared<std::vector<uint64_t>>();
+    for (uint64_t i = 0; i < 30; i += 10) {
+      eventIndices->push_back(i);
+    }
+
+    TS_ASSERT_EQUALS(eventIndices->size(), 3);
+
+    constexpr size_t total_events{40};
+    constexpr size_t start_event_index{0};
+    run_test(eventIndices, start_event_index, total_events);
   }
 
   void test_nonConstant() {
@@ -141,5 +147,101 @@ public:
     constexpr size_t first_pulse_index{1};
 
     run_test(eventIndices, start_event_index, total_events, first_pulse_index);
+  }
+
+  void test_invalidPulseROI() {
+    auto eventIndices = generate_nonConstant();
+
+    std::vector<size_t> roi;
+    roi.push_back(1); // must be even number
+
+    TS_ASSERT_THROWS(PulseIndexer indexer(eventIndices, 0, eventIndices->back() + 10, entry_name, roi),
+                     const std::runtime_error &);
+  }
+
+  // this exercises the functionality of filtering pulse times using BankPulseTimes
+  void test_pulseROI() {
+    // add to an example above
+    auto eventIndices = generate_nonConstant();
+    for (uint64_t i = 50; i < 100; i += 13)
+      eventIndices->push_back(i);
+
+    constexpr size_t first_pulse_index{1};
+    const size_t last_pulse_index{eventIndices->size() - 1};
+    const auto start_event_index = eventIndices->operator[](1);
+    const size_t total_events{eventIndices->back() - eventIndices->operator[](first_pulse_index) - 1};
+    std::vector<size_t> roi;
+
+    // test having the roi being entirely included
+    {
+      roi.clear();
+      roi.push_back(first_pulse_index);
+      roi.push_back(last_pulse_index);
+      PulseIndexer indexer(eventIndices, start_event_index, total_events, entry_name, roi);
+
+      const auto firstPulseIndex = indexer.getFirstPulseIndex();
+
+      TS_ASSERT_EQUALS(firstPulseIndex, roi.front());
+      TS_ASSERT_EQUALS(indexer.getLastPulseIndex(), roi.back());
+
+      TS_ASSERT_EQUALS(indexer.getStartEventIndex(firstPulseIndex),
+                       eventIndices->operator[](firstPulseIndex) - start_event_index);
+      TS_ASSERT_EQUALS(indexer.getStopEventIndex(firstPulseIndex),
+                       eventIndices->operator[](firstPulseIndex + 1) - start_event_index);
+    }
+
+    // test chopping off the front
+    {
+      roi.clear();
+      roi.push_back(first_pulse_index + 1);
+      roi.push_back(eventIndices->size());
+      PulseIndexer indexer(eventIndices, start_event_index, total_events, entry_name, roi);
+
+      const auto firstPulseIndex = indexer.getFirstPulseIndex();
+
+      TS_ASSERT_EQUALS(firstPulseIndex, roi.front());
+      TS_ASSERT_EQUALS(indexer.getLastPulseIndex(), last_pulse_index);
+
+      TS_ASSERT_EQUALS(indexer.getStartEventIndex(firstPulseIndex),
+                       eventIndices->operator[](firstPulseIndex) - start_event_index);
+      TS_ASSERT_EQUALS(indexer.getStopEventIndex(firstPulseIndex),
+                       eventIndices->operator[](firstPulseIndex + 1) - start_event_index);
+    }
+
+    // test a more interesting roi
+    {
+      roi.clear();
+      // one frame after the first pulse index
+      roi.push_back(first_pulse_index + 1);
+      roi.push_back(first_pulse_index + 3);
+      // two frames just before the end
+      roi.push_back(eventIndices->size() - 2);
+      roi.push_back(eventIndices->size());
+
+      PulseIndexer indexer(eventIndices, start_event_index, total_events, entry_name, roi);
+
+      TS_ASSERT_EQUALS(indexer.getFirstPulseIndex(), roi.front());
+      TS_ASSERT_EQUALS(indexer.getLastPulseIndex(), last_pulse_index);
+
+      auto toEventIndex = [eventIndices, start_event_index](const size_t pulseIndex) {
+        return eventIndices->operator[](pulseIndex) - start_event_index;
+      };
+
+      const auto exp_start_event = eventIndices->operator[](indexer.getFirstPulseIndex()) - start_event_index;
+      const auto exp_total_event = total_events - start_event_index;
+
+      // check the individual event indices
+      assert_indices_equal(indexer, 0, exp_start_event, exp_start_event); // exclude before
+      assert_indices_equal(indexer, 1, exp_start_event, exp_start_event); // exclude before
+      assert_indices_equal(indexer, 2, toEventIndex(2), toEventIndex(3)); // include
+      assert_indices_equal(indexer, 3, toEventIndex(3), toEventIndex(4)); // include
+      assert_indices_equal(indexer, 4, toEventIndex(4), toEventIndex(4)); // exclude
+      assert_indices_equal(indexer, 5, toEventIndex(5), toEventIndex(5)); // exclude
+      assert_indices_equal(indexer, 6, toEventIndex(6), exp_total_event); // include
+      assert_indices_equal(indexer, 7, total_events, total_events);       // exclude due to number of events
+      assert_indices_equal(indexer, 8, total_events, total_events);       // exclude after
+      assert_indices_equal(indexer, 9, total_events, total_events);       // exclude after
+      assert_indices_equal(indexer, 10, total_events, total_events);      // exclude out of range
+    }
   }
 };

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -76,5 +76,13 @@ private:
   std::vector<Types::Core::DateAndTime> m_roi;
 };
 
+/**
+ * This calculates the intersection of two sorted vectors that represent regions of interest (ROI).
+ * The ROI are pairs of [[include, exclude), [include,exclude), ...] where an empty vector is interpreted to mean "use
+ * all".
+ */
+template <typename TYPE>
+std::vector<TYPE> calculate_intersection(const std::vector<TYPE> &left, const std::vector<TYPE> &right);
+
 } // namespace Kernel
 } // namespace Mantid

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -76,6 +76,7 @@ private:
   std::vector<Types::Core::DateAndTime> m_roi;
 };
 
+namespace ROI {
 /**
  * This calculates the intersection of two sorted vectors that represent regions of interest (ROI).
  * The ROI are pairs of [[include, exclude), [include,exclude), ...] where an empty vector is interpreted to mean "use
@@ -83,6 +84,7 @@ private:
  */
 template <typename TYPE>
 std::vector<TYPE> calculate_intersection(const std::vector<TYPE> &left, const std::vector<TYPE> &right);
+} // namespace ROI
 
 } // namespace Kernel
 } // namespace Mantid

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -478,7 +478,7 @@ void TimeROI::update_intersection(const TimeROI &other) {
     return;
   }
 
-  auto output = Mantid::Kernel::calculate_intersection(m_roi, other.m_roi);
+  auto output = calculate_intersection(m_roi, other.m_roi);
 
   if (output.empty())
     this->replaceROI(USE_NONE);

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -417,6 +417,48 @@ void TimeROI::replaceROI(const std::vector<Types::Core::DateAndTime> &roi) {
     m_roi.assign(roi.cbegin(), roi.cend());
 }
 
+template <typename TYPE>
+std::vector<TYPE> Mantid::Kernel::calculate_intersection(const std::vector<TYPE> &left,
+                                                         const std::vector<TYPE> &right) {
+  // empty is interpreted to mean use everything
+  // these checks skip putting together temporary variables for the loops
+  if (left == right || right.empty())
+    return left;
+  else if (left.empty())
+    return right;
+
+  // create vector to hold the intersection results
+  std::vector<TYPE> result;
+
+  // iterators are faster access than random access via operator[]
+  auto it1 = left.cbegin();
+  auto it2 = right.cbegin();
+
+  while (it1 != left.cend() && it2 != right.cend()) {
+    // Left bound for intersecting segment
+    const TYPE &leftBound = std::max(*it1, *it2);
+
+    // Right bound for intersecting segment
+    const auto it1_next = std::next(it1);
+    const auto it2_next = std::next(it2);
+    const TYPE &rightBound = std::min(*it1_next, *it2_next);
+
+    // If segment is valid, include it
+    if (leftBound < rightBound) {
+      result.emplace_back(leftBound);
+      result.emplace_back(rightBound);
+    }
+
+    // If it1 right bound is smaller, increment it1; else increment it2
+    if (*it1_next < *it2_next)
+      std::advance(it1, 2);
+    else
+      std::advance(it2, 2);
+  }
+
+  return result;
+}
+
 /**
  * Updates the TimeROI values with the intersection with another TimeROI.
  * See https://en.wikipedia.org/wiki/Intersection for the intersection theory.
@@ -431,40 +473,17 @@ void TimeROI::update_intersection(const TimeROI &other) {
 
   if (other.useAll() || this->useAll()) {
     // empty out this environment
+    // this behavior is required by existing calling code due to not universal use of TimeROI
     m_roi.clear();
     return;
   }
 
-  TimeROI output;
-  auto it1 = m_roi.cbegin();
-  auto it2 = other.m_roi.cbegin();
-
-  while (it1 != m_roi.end() && it2 != other.m_roi.end()) {
-    // Left bound for intersecting segment
-    const DateAndTime &leftBound = std::max(*it1, *it2);
-
-    // Right bound for intersecting segment
-    const auto it1_next = std::next(it1);
-    const auto it2_next = std::next(it2);
-    const DateAndTime &rightBound = std::min(*it1_next, *it2_next);
-
-    // If segment is valid, include it
-    if (leftBound < rightBound) {
-      output.m_roi.emplace_back(leftBound);
-      output.m_roi.emplace_back(rightBound);
-    }
-
-    // If it1 right bound is smaller, increment it1; else increment it2
-    if (*it1_next < *it2_next)
-      std::advance(it1, 2);
-    else
-      std::advance(it2, 2);
-  }
+  auto output = Mantid::Kernel::calculate_intersection(m_roi, other.m_roi);
 
   if (output.empty())
-    output.replaceROI(USE_NONE);
-
-  m_roi = std::move(output.m_roi);
+    this->replaceROI(USE_NONE);
+  else
+    m_roi = std::move(output);
 }
 
 /**
@@ -655,6 +674,13 @@ void TimeROI::saveNexus(::NeXus::File *file) const {
   // save things to to disk
   tsp.saveProperty(file);
 }
+
+// concrete instantiations need to be exported
+template MANTID_KERNEL_DLL std::vector<std::size_t> calculate_intersection(const std::vector<std::size_t> &left,
+                                                                           const std::vector<std::size_t> &right);
+template MANTID_KERNEL_DLL std::vector<Types::Core::DateAndTime>
+calculate_intersection(const std::vector<Types::Core::DateAndTime> &left,
+                       const std::vector<Types::Core::DateAndTime> &right);
 
 } // namespace Kernel
 } // namespace Mantid

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -685,8 +685,6 @@ unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/vms_co
 unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/vms_convert.cpp:230
 unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/vms_convert.cpp:231
 unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/vms_convert.cpp:232
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadEventNexus.cpp:1357
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadEventNexus.cpp:576
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/isisraw.cpp:906
 uninitdata:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/isisraw.cpp:518
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLReflectometry.cpp:485


### PR DESCRIPTION
This is a version of #37059 into ornl-next.