### PR TITLE
Add integration range info to the sample logs of output workspaces for Elastic Window algorithm 

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
@@ -138,6 +138,8 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
         # Lists of input and output workspaces
         q_workspaces = list()
         q2_workspaces = list()
+        elf_workspace = None  # initializing for logs
+        elt_workspace = None
         run_numbers = list()
         sample_param = list()
 
@@ -236,7 +238,8 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
             _normalize_by_index(elt_workspace, 0)
 
             self.setProperty("OutputELT", elt_workspace)
-
+        # Add sample logs
+        self._add_sample_logs_to_output_workspaces([q_workspace, q2_workspace, elf_workspace, elt_workspace])
         # Set the output workspace
         self.setProperty("OutputInQ", q_workspace)
         self.setProperty("OutputInQSquared", q2_workspace)
@@ -286,6 +289,21 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
             unit = ""
 
         return sample, unit
+
+    def _add_sample_logs_to_output_workspaces(self, out_ws):
+        names = ["integration_range_start", "integration_range_end"]
+        values = [self._integration_range_start, self._integration_range_end]
+        for ws in out_ws:
+            if ws is not None:
+                self._add_sample_log(ws, names, values)
+
+    def _add_sample_log(self, workspace, names, values):
+        add_log = self.createChildAlgorithm("AddSampleLogMultiple", enableLogging=False)
+        add_log.setProperty("Workspace", workspace)
+        add_log.setProperty("LogNames", names)
+        add_log.setProperty("LogValues", values)
+        add_log.setProperty("ParseType", True)
+        add_log.execute()
 
 
 def _extract_temperature_from_log(workspace, sample_log_name, log_filename, run_name):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultipleTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultipleTest.py
@@ -116,6 +116,19 @@ class ElasticWindowMultipleTest(unittest.TestCase):
         self.assertEqual(elf_y.unitID(), "MomentumTransfer")
         self.assertEqual(str(elf_y.symbol()), "Angstrom^-1")
 
+    def test_ElasticWindowMultiple_returns_integration_sample_logs(self):
+        run_q = self.q.getRun()
+        run_q2 = self.q2.getRun()
+        run_elf = self.elf.getRun()
+
+        self.assertEqual(run_q.getLogData("integration_range_start").value, -0.1)
+        self.assertEqual(run_q2.getLogData("integration_range_start").value, -0.1)
+        self.assertEqual(run_elf.getLogData("integration_range_start").value, -0.1)
+
+        self.assertEqual(run_q.getLogData("integration_range_end").value, 0.1)
+        self.assertEqual(run_q2.getLogData("integration_range_end").value, 0.1)
+        self.assertEqual(run_elf.getLogData("integration_range_end").value, 0.1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/release/v6.10.0/Inelastic/New_features/37015.rst
+++ b/docs/source/release/v6.10.0/Inelastic/New_features/37015.rst
@@ -1,0 +1,1 @@
+- The :ref:`ElasticWindowMultiple <algm-ElasticWindowMultiple>` algorithm will add the integration range to the output workspaces sample logs, calling it either from script or from the :ref:`Elwin Tab <elwin>` of :ref:`Data Manipulation Interface <interface-inelastic-data-manipulation>`.


### PR DESCRIPTION
### Description of work
This PR adds the info of the integration range used in the elastic window algorithm to the output workspaces. 



Fixes #37015 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->


### To test:
- Go to `Inelastic -> Data Manipulation->Elwin tab`. 
- In `Add Workspaces` add from file the `irs26174_graphite002_red.nxs` sample data from the ISIS sample data files.
- Check numeric value of integration range on the `Fit Property Browser`
- Run the algorithm 
- On the ADS, right-click on workspaces ending on `_q`,` _q2` and `_elf` and select `Show sample logs` 
- You should find two sample logs called `integration_range_start` and `integration_range_end` whose value is the selected integration ranges on the fit property browser.

*Added release notes*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
