### PR TITLE
Connect grouping options for OSIRIS Diffonly Diffraction reduction

### DIFF
--- a/docs/source/interfaces/indirect/Indirect Diffraction.rst
+++ b/docs/source/interfaces/indirect/Indirect Diffraction.rst
@@ -65,6 +65,10 @@ Spectra Min & Spectra Max
   options will be disabled when using OSIRIS in diffonly mode, in which case the
   entire spectra range will be used.
 
+Detector Grouping
+  Specify the method to be used for grouping the detectors when performing the reduction.
+  The options include 'All', 'File', 'Groups' and 'Custom'.
+
 Run
   Runs the processing configured on the current tab.
 

--- a/docs/source/release/v6.10.0/Indirect/New_features/36932.rst
+++ b/docs/source/release/v6.10.0/Indirect/New_features/36932.rst
@@ -1,3 +1,3 @@
-- Added the ability to use `File` detector grouping from the :ref:`Indirect Diffraction interface <interface-indirect-diffraction>` for all instruments, except for OSIRIS in diffonly mode.
-- Added the ability to use `Custom` detector grouping from the :ref:`Indirect Diffraction interface <interface-indirect-diffraction>` for all instruments, except for OSIRIS in diffonly mode.
-- Added the ability to use `Groups` detector grouping from the :ref:`Indirect Diffraction interface <interface-indirect-diffraction>` for all instruments, except for OSIRIS in diffonly mode.
+- Added the ability to use `File` detector grouping from the :ref:`Indirect Diffraction interface <interface-indirect-diffraction>` for all instruments.
+- Added the ability to use `Custom` detector grouping from the :ref:`Indirect Diffraction interface <interface-indirect-diffraction>` for all instruments.
+- Added the ability to use `Groups` detector grouping from the :ref:`Indirect Diffraction interface <interface-indirect-diffraction>` for all instruments.

--- a/qt/scientific_interfaces/Indirect/Diffraction/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Diffraction/IndirectDiffractionReduction.cpp
@@ -421,7 +421,8 @@ void IndirectDiffractionReduction::runOSIRISdiffonlyReduction() {
       osirisDiffReduction->setProperty("ContainerScaleFactor", m_uiForm.spCanScale->value());
   }
 
-  m_batchAlgoRunner->addAlgorithm(osirisDiffReduction);
+  auto groupingProps = m_groupingWidget->groupingProperties();
+  m_batchAlgoRunner->addAlgorithm(osirisDiffReduction, std::move(groupingProps));
 
   auto inputFromReductionProps = std::make_unique<Mantid::API::AlgorithmRuntimeProps>();
   inputFromReductionProps->setPropertyValue("InputWorkspace", drangeWsName.toStdString());
@@ -539,11 +540,6 @@ void IndirectDiffractionReduction::instrumentSelected(const QString &instrumentN
 
   // Hide rebin options for OSIRIS diffonly
   m_uiForm.gbDspaceRebinCalibOnly->setVisible(!(instrumentName == "OSIRIS" && reflectionName == "diffonly"));
-
-  auto allowDetectorGrouping = !(instrumentName == "OSIRIS" && reflectionName == "diffonly");
-  m_uiForm.fDetectorGrouping->setEnabled(allowDetectorGrouping);
-  m_uiForm.fDetectorGrouping->setToolTip(!allowDetectorGrouping ? "OSIRIS cannot group detectors in diffonly mode."
-                                                                : "");
 
   if (instrumentName == "OSIRIS" && reflectionName == "diffonly") {
     // Disable sum files

--- a/qt/scientific_interfaces/Indirect/Diffraction/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Diffraction/IndirectDiffractionReduction.cpp
@@ -535,6 +535,8 @@ void IndirectDiffractionReduction::instrumentSelected(const QString &instrumentN
   m_uiForm.ckUseCalib->setVisible(calibrationOptional);
   m_uiForm.rfCalFile->setVisible(calibrationOptional);
   m_uiForm.rfCalFile->isOptional(!calibrationMandatory);
+  m_uiForm.rfCalFile->setToolTip("Note: The calibration file will not be used for detector grouping unless explicitly "
+                                 "selected in the 'File' grouping option below.");
   m_uiForm.ckUseCalib->setChecked(calibrationMandatory);
   m_uiForm.ckUseCalib->setDisabled(calibrationMandatory);
 


### PR DESCRIPTION
### Description of work
This PR connects the Grouping detector options widget to the OSIRISDiffractionReduction algorithm on the Indirect Diffraction interface.

Fixes #37026 

### To test:
1. Open `Indirect`->`Diffraction` interface
2. Set Instrument to OSIRIS
3. Set Analyser to Diffonly
4. Load 89813 as sample
5. Load 89757 as vanadium
6. Select 'All' detector grouping. Run. The output workspaces should have 1 spectra
6. Select 'Groups' detector grouping, and 5 groups. Run. The output workspaces should have 5 spectra
6. Select 'Custom' detector grouping, and `3-500,501-962`. Run. The output workspaces should have 2 spectra

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
