### PR TITLE
Allow specifiable number of system test threads per machine

### DIFF
--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -18,9 +18,13 @@ ENABLE_DOCS=$4
 ENABLE_DOC_TESTS=$5
 BUILD_THREADS=$6
 
-# Run only 3 tests at a time because of memory constraints in the system tests
-BUILD_THREADS_SYSTEM_TESTS=3
 XVFB_SERVER_NUM=101
+
+# If this isn't specified for a Jenkins agent, revert to default value
+if [[ -z "BUILD_THREADS_SYSTEM_TESTS" ]]; then
+    # Default to 3 system tests running in parallel, assuming builders have >= 32GB RAM
+    BUILD_THREADS_SYSTEM_TESTS=3
+fi
 
 function run_with_xvfb {
     if [ $(command -v xvfb-run) ]; then

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -21,7 +21,7 @@ BUILD_THREADS=$6
 XVFB_SERVER_NUM=101
 
 # If this isn't specified for a Jenkins agent, revert to default value
-if [[ -z "BUILD_THREADS_SYSTEM_TESTS" ]]; then
+if [[ -z "$BUILD_THREADS_SYSTEM_TESTS" ]]; then
     # Default to 3 system tests running in parallel, assuming builders have >= 32GB RAM
     BUILD_THREADS_SYSTEM_TESTS=3
 fi


### PR DESCRIPTION
### Description of work
This was previously hard-coded to 3 threads. Now that most of our Linux builders have 120GB+ RAM, we can add the `BUILD_THREADS_SYSTEM_TESTS` to individual Jenkins agent settings to speed up the system test jobs.

Fixes #37057

### To test:
Both of the following jobs ran on `isis-cloud-linux-6`. 
old job:
https://builds.mantidproject.org/job/pull_requests-conda-linux/6667/consoleFull
new job:
https://builds.mantidproject.org/job/build_packages_from_branch/762/execution/node/133/log/?consoleFull

- In the logs, search for `run_with_xvfb /jenkins_workdir/workspace/pull_requests-conda-linux/build/systemtest` and verify the number of cores by looking at the `-j` argument. The new job should run on 6 cores.
- Verify the time taken to run the system tests has improved by comparing time stamps at the start and end of system tests. The old job takes 1hr6min, the new job takes 37min, despite skipping fewer tests.


*This does not require release notes* because **it's a change to a CI build script**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
