### PR TITLE
Add option to build mantidworkbench without depending on mantiddocs for ornl-* branches

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -20,7 +20,6 @@ PUBLISH_TO_GITHUB_DEFAULT = PUBLISH_PACKAGES_DEFAULT
 // If required, switch off the mantiddocs conda package build. This is deliberately not listed in the
 // pipeline parameters because it's only switched off for ornl-next anaconda publishing.
 BUILD_MANTIDDOCS_PACKAGE = true
-WORKBENCH_INCLUDE_DOCS = true
 
 switch(GIT_BRANCH) {
   case ['main', 'release-next']:
@@ -36,7 +35,6 @@ switch(GIT_BRANCH) {
     PUBLISH_TO_ANACONDA_DEFAULT = true
     ANACONDA_CHANNEL_DEFAULT = 'mantid-ornl'
     BUILD_MANTIDDOCS_PACKAGE = false
-    WORKBENCH_INCLUDE_DOCS = false
     break
   default:
     PACKAGE_SUFFIX_DEFAULT = 'Unstable'
@@ -504,10 +502,10 @@ def package_conda_options(platform, base_or_workbench) {
     package_flags = "--build-mantid --build-qt ${docs_flags}"
   }
   else if(base_or_workbench == 'workbench') {
-    if(WORKBENCH_INCLUDE_DOCS) {
+    if(BUILD_MANTIDDOCS_PACKAGE) {
       package_flags = "--build-workbench"
     } else {
-      package_flags = "--build-workbench --build-workbench-without-docs"
+      package_flags = "--build-workbench-without-docs"
     }
   }
 

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -20,6 +20,7 @@ PUBLISH_TO_GITHUB_DEFAULT = PUBLISH_PACKAGES_DEFAULT
 // If required, switch off the mantiddocs conda package build. This is deliberately not listed in the
 // pipeline parameters because it's only switched off for ornl-next anaconda publishing.
 BUILD_MANTIDDOCS_PACKAGE = true
+WORKBENCH_INCLUDE_DOCS = true
 
 switch(GIT_BRANCH) {
   case ['main', 'release-next']:
@@ -35,6 +36,7 @@ switch(GIT_BRANCH) {
     PUBLISH_TO_ANACONDA_DEFAULT = true
     ANACONDA_CHANNEL_DEFAULT = 'mantid-ornl'
     BUILD_MANTIDDOCS_PACKAGE = false
+    WORKBENCH_INCLUDE_DOCS = false
     break
   default:
     PACKAGE_SUFFIX_DEFAULT = 'Unstable'
@@ -502,7 +504,11 @@ def package_conda_options(platform, base_or_workbench) {
     package_flags = "--build-mantid --build-qt ${docs_flags}"
   }
   else if(base_or_workbench == 'workbench') {
-    package_flags = "--build-workbench"
+    if(WORKBENCH_INCLUDE_DOCS) {
+      package_flags = "--build-workbench"
+    } else {
+      package_flags = "--build-workbench --build-workbench-without-docs"
+    }
   }
 
   package_options = "${package_flags} --git-tag ${generate_git_tag()}"

--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -55,6 +55,7 @@ ENABLE_BUILD_MANTID=false
 ENABLE_BUILD_QT=false
 ENABLE_BUILD_WORKBENCH=false
 ENABLE_BUILD_DOCS=false
+BUILD_WORKBENCH_WITH_DOCS=true
 
 # Handle flag inputs
 while [ ! $# -eq 0 ]
@@ -64,6 +65,7 @@ do
         --build-qt) ENABLE_BUILD_QT=true ;;
         --build-workbench) ENABLE_BUILD_WORKBENCH=true ;;
         --build-docs) ENABLE_BUILD_DOCS=true ;;
+        --build-workbench-without-docs) BUILD_WORKBENCH_WITH_DOCS=false ;;
         --git-tag)
             GIT_TAG="$2"
             shift ;;
@@ -107,7 +109,7 @@ export LC_ALL=C
 # copy the source to a working folder
 export CONDA_BLD_PATH=$WORKSPACE/conda-bld
 if [[ -d $CONDA_BLD_PATH ]]; then
-    conda index $CONDA_BLD_PATH
+    python -m conda_index $CONDA_BLD_PATH
 fi
 cd $RECIPES_DIR
 
@@ -131,6 +133,9 @@ if [[ $ENABLE_BUILD_DOCS == true ]]; then
     conda mambabuild ./mantiddocs/ $EXTRA_BUILD_OPTIONS
 fi
 if [[ $ENABLE_BUILD_WORKBENCH == true ]]; then
+    if [[ $BUILD_WORKBENCH_WITH_DOCS == false ]]; then
+	export INCLUDE_MANTIDDOCS=False
+    fi
     conda mambabuild ./mantidworkbench/ $EXTRA_BUILD_OPTIONS
 fi
 

--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -65,7 +65,10 @@ do
         --build-qt) ENABLE_BUILD_QT=true ;;
         --build-workbench) ENABLE_BUILD_WORKBENCH=true ;;
         --build-docs) ENABLE_BUILD_DOCS=true ;;
-        --build-workbench-without-docs) BUILD_WORKBENCH_WITH_DOCS=false ;;
+        --build-workbench-without-docs)
+            ENABLE_BUILD_WORKBENCH=true
+            BUILD_WORKBENCH_WITH_DOCS=false
+            ;;
         --git-tag)
             GIT_TAG="$2"
             shift ;;

--- a/conda/recipes/mantidworkbench/meta.yaml
+++ b/conda/recipes/mantidworkbench/meta.yaml
@@ -44,7 +44,9 @@ requirements:
     - python.app  # [osx]
     - qtconsole {{ qtconsole }}
     - {{ pin_compatible("setuptools", max_pin="x.x") }}
+    {% if environ.get('INCLUDE_MANTIDDOCS', 'True') != 'False' %}
     - mantiddocs {{ version }}
+    {% endif %}
 
 test:
   imports:

--- a/dev-docs/source/Packaging.rst
+++ b/dev-docs/source/Packaging.rst
@@ -63,6 +63,13 @@ directory relative to the current working directory
    # wait quite a while ...
    # packages will appear in a conda-bld directory
 
+You can build the workbench without the documentation by:
+
+.. code:: sh
+
+   mantid-conda-build/buildconfig/Jenkins/Conda/package-conda $PWD \
+     --build-mantid --build-qt --build-workbench-without-docs 2>&1 | tee package.log
+
 To create a new test environment with packages from the local build:
 
 .. code:: sh


### PR DESCRIPTION
The ornl builds don't build the `mantiddocs` package, so this will make it so that the `mantidworkbench` package for the ornl builds to not depend on `mantiddocs`.

I ran these pipelines to test the output result

First by adding this branch to [the list with ornl](https://github.com/mantidproject/mantid/blob/3434908516c5379c2de00bda455313fcdcf9cc92/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile#L30) which has built `mantidworkbench` without depending on `mantiddocs`. https://builds.mantidproject.org/job/Core_Team_test_pipeline/103/

Then the non-ornl branch build which should build `mantidworkbench` which does depend on `mantiddocs`. https://builds.mantidproject.org/job/Core_Team_test_pipeline/105/



### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [EWM4210](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4210)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
