### PR TITLE
Fix title redraw bug

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/Bugfixes/36913.rst
+++ b/docs/source/release/v6.10.0/Workbench/Bugfixes/36913.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where renaming a plot in the plots widget would redraw the plot title regardless of the Show Title setting.

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -24,7 +24,7 @@ from qtpy.QtGui import QImage
 from qtpy.QtWidgets import QApplication, QLabel, QFileDialog, QMessageBox
 
 from mantid.api import AnalysisDataService, AnalysisDataServiceObserver, ITableWorkspace, MatrixWorkspace
-from mantid.kernel import logger
+from mantid.kernel import logger, ConfigService
 from mantid.plots import datafunctions, MantidAxes, axesfunctions
 from mantidqt.io import open_a_file_dialog
 from mantidqt.utils.qt.qappthreadcall import QAppThreadCall, force_method_calls_to_qapp_thread
@@ -465,7 +465,8 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
     def set_axes_title(self, title):
         plot_axes = self._axes_that_are_not_colour_bars()
-        if len(plot_axes) == 1:
+        show_title = "on" == ConfigService.getString("plots.ShowTitle").lower()
+        if len(plot_axes) == 1 and show_title:
             plot_axes[0].set_title(title)
             self.canvas.draw_idle()
 


### PR DESCRIPTION
### Description of work

When I added tracking between the plot name, title and window title [here](https://github.com/mantidproject/mantid/pull/36393) I forgot to respect the `ShowTitle` plot setting when drawing the plot title after its name was changed in the plots widget.

Fixes #36913

### To test:

- Open the settings and go to the plots section
- Untick the Show Title setting
- Load and plot some data (should have no title)
- Go to the plots widget in the bottom left and rename the plot.
- A title should not appear on the plot but the window title should be updated.
- Change the setting back to ticked

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
