### PR TITLE
35710 added AllPeaksNSigma peak finding stratergy to FindSXPeaks algo…

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/FindSXPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/FindSXPeaks.h
@@ -56,6 +56,7 @@ public:
 
   static const std::string strongestPeakStrategy;
   static const std::string allPeaksStrategy;
+  static const std::string allPeaksNSigmaStrategy;
   static const std::string relativeResolutionStrategy;
   static const std::string absoluteResolutionPeaksStrategy;
 

--- a/Framework/Crystal/inc/MantidCrystal/FindSXPeaksHelper.h
+++ b/Framework/Crystal/inc/MantidCrystal/FindSXPeaksHelper.h
@@ -110,6 +110,7 @@ public:
   void record(yIt item);
   size_t getNumberOfPointsInPeak() const;
   yIt getMaxIterator() const;
+  double getStartingSignal() const;
 
 private:
   const HistogramData::HistogramY &m_y;

--- a/Framework/Crystal/inc/MantidCrystal/FindSXPeaksHelper.h
+++ b/Framework/Crystal/inc/MantidCrystal/FindSXPeaksHelper.h
@@ -201,6 +201,8 @@ private:
               const Mantid::Crystal::FindSXPeaksHelper::BackgroundStrategy *backgroundStrategy) const;
 };
 
+#define NSIGMA_COMPARISON_THRESHOLD 1e-10
+
 class MANTID_CRYSTAL_DLL NSigmaPeaksStrategy : public PeakFindingStrategy {
 public:
   NSigmaPeaksStrategy(const API::SpectrumInfo &spectrumInfo, const double nsigma = EMPTY_DBL(),

--- a/Framework/Crystal/src/FindSXPeaks.cpp
+++ b/Framework/Crystal/src/FindSXPeaks.cpp
@@ -101,7 +101,7 @@ void FindSXPeaks::init() {
                   "Background thresholds which are too low will mistake noise for peaks.");
 
   declareProperty(
-      "NSigma", 10.0, mustBePositiveDouble,
+      "NSigma", 5.0, mustBePositiveDouble,
       "Multiplication factor on error used to compare the difference in intensity between consecutive bins.");
 
   // Enable

--- a/Framework/Crystal/src/FindSXPeaks.cpp
+++ b/Framework/Crystal/src/FindSXPeaks.cpp
@@ -28,6 +28,7 @@ namespace Mantid::Crystal {
 
 const std::string FindSXPeaks::strongestPeakStrategy = "StrongestPeakOnly";
 const std::string FindSXPeaks::allPeaksStrategy = "AllPeaks";
+const std::string FindSXPeaks::allPeaksNSigmaStrategy = "AllPeaksNSigma";
 
 const std::string FindSXPeaks::relativeResolutionStrategy = "RelativeResolution";
 const std::string FindSXPeaks::absoluteResolutionPeaksStrategy = "AbsoluteResolution";
@@ -71,7 +72,7 @@ void FindSXPeaks::init() {
   auto mustBePositiveDouble = std::make_shared<BoundedValidator<double>>();
   mustBePositiveDouble->setLower(0.0);
 
-  std::vector<std::string> peakFindingStrategy = {strongestPeakStrategy, allPeaksStrategy};
+  std::vector<std::string> peakFindingStrategy = {strongestPeakStrategy, allPeaksStrategy, allPeaksNSigmaStrategy};
   declareProperty("PeakFindingStrategy", strongestPeakStrategy,
                   std::make_shared<StringListValidator>(peakFindingStrategy),
                   "Different options for peak finding."
@@ -80,7 +81,9 @@ void FindSXPeaks::init() {
                   "one). This options is more performant than the AllPeaks option.\n"
                   "2. AllPeaks: This strategy will find all peaks in each "
                   "spectrum. This is slower than StrongestPeakOnly. Note that the "
-                  "recommended ResolutionStrategy in this mode is AbsoluteResolution.\n");
+                  "recommended ResolutionStrategy in this mode is AbsoluteResolution.\n"
+                  "3. AllPeaksNSigma: This stratergy will look for peaks by bins that are"
+                  " more than nsigma different in intensity.");
 
   // Declare
   declareProperty("SignalBackground", 10.0, mustBePositiveDouble,
@@ -97,6 +100,10 @@ void FindSXPeaks::init() {
                   "threshold.\n"
                   "Background thresholds which are too low will mistake noise for peaks.");
 
+  declareProperty(
+      "NSigma", 10.0, mustBePositiveDouble,
+      "Multiplication factor on error used to compare the difference in intensity between consecutive bins.");
+
   // Enable
   setPropertySettings("SignalBackground", std::make_unique<EnabledWhenProperty>(
                                               "PeakFindingStrategy", Mantid::Kernel::ePropertyCriterion::IS_EQUAL_TO,
@@ -106,11 +113,16 @@ void FindSXPeaks::init() {
                       std::make_unique<EnabledWhenProperty>(
                           "PeakFindingStrategy", Mantid::Kernel::ePropertyCriterion::IS_EQUAL_TO, allPeaksStrategy));
 
+  setPropertySettings("NSigma", std::make_unique<EnabledWhenProperty>("PeakFindingStrategy",
+                                                                      Mantid::Kernel::ePropertyCriterion::IS_EQUAL_TO,
+                                                                      allPeaksNSigmaStrategy));
+
   // Group
   const std::string peakGroup = "Peak Finding Settings";
   setPropertyGroup("PeakFindingStrategy", peakGroup);
   setPropertyGroup("SignalBackground", peakGroup);
   setPropertyGroup("AbsoluteBackground", peakGroup);
+  setPropertyGroup("NSigma", peakGroup);
 
   // ---------------------------------------------------------------
   // Resolution
@@ -260,6 +272,7 @@ void FindSXPeaks::exec() {
   peakvector entries;
   entries.reserve(m_MaxWsIndex - m_MinWsIndex);
   // Count the peaks so that we can resize the peak vector at the end.
+
   PARALLEL_FOR_IF(Kernel::threadSafe(*localworkspace))
   for (auto wsIndex = static_cast<int>(m_MinWsIndex); wsIndex <= static_cast<int>(m_MaxWsIndex); ++wsIndex) {
     PARALLEL_START_INTERRUPT_REGION
@@ -273,9 +286,10 @@ void FindSXPeaks::exec() {
     // Retrieve the spectrum into a vector
     const auto &x = localworkspace->x(wsIndex);
     const auto &y = localworkspace->y(wsIndex);
+    const auto &e = localworkspace->e(wsIndex);
 
     // Run the peak finding strategy
-    auto foundPeaks = peakFindingStrategy->findSXPeaks(x, y, wsIndex);
+    auto foundPeaks = peakFindingStrategy->findSXPeaks(x, y, e, wsIndex);
     if (!foundPeaks) {
       continue;
     }
@@ -351,6 +365,8 @@ std::unique_ptr<BackgroundStrategy> FindSXPeaks::getBackgroundStrategy() const {
   } else if (peakFindingStrategy == allPeaksStrategy) {
     const double background = getProperty("AbsoluteBackground");
     return std::make_unique<AbsoluteBackgroundStrategy>(background);
+  } else if (peakFindingStrategy == allPeaksNSigmaStrategy) {
+    return nullptr; // AllPeaksNSigma stratergy does not require a background stratergy
   } else {
     throw std::invalid_argument("The selected background strategy has not been implemented yet.");
   }
@@ -365,6 +381,9 @@ FindSXPeaks::getPeakFindingStrategy(const BackgroundStrategy *backgroundStrategy
     return std::make_unique<StrongestPeaksStrategy>(backgroundStrategy, spectrumInfo, minValue, maxValue, tofUnits);
   } else if (peakFindingStrategy == allPeaksStrategy) {
     return std::make_unique<AllPeaksStrategy>(backgroundStrategy, spectrumInfo, minValue, maxValue, tofUnits);
+  } else if (peakFindingStrategy == allPeaksNSigmaStrategy) {
+    const double nsigma = getProperty("NSigma");
+    return std::make_unique<NSigmaPeaksStrategy>(spectrumInfo, nsigma, minValue, maxValue, tofUnits);
   } else {
     throw std::invalid_argument("The selected peak finding strategy has not been implemented yet.");
   }

--- a/Framework/Crystal/src/FindSXPeaksHelper.cpp
+++ b/Framework/Crystal/src/FindSXPeaksHelper.cpp
@@ -549,8 +549,8 @@ std::vector<std::unique_ptr<PeakContainer>> NSigmaPeaksStrategy::getAllNSigmaPea
 
   for (; yIt != highY && eIt != highE; ++yIt, ++eIt) {
     const auto signalDiff = *yIt - *(yIt - 1);
-    const auto isStartPeak = signalDiff > m_nsigma * (*eIt);
-    const auto isSigDropSignificant = signalDiff * (-1.) > m_nsigma * (*eIt);
+    const auto isStartPeak = signalDiff > (m_nsigma * (*eIt)) + NSIGMA_COMPARISON_THRESHOLD;
+    const auto isSigDropSignificant = (signalDiff * (-1.)) > (m_nsigma * (*eIt)) + NSIGMA_COMPARISON_THRESHOLD;
     const auto isEndPeak = (currentPeak != nullptr ? (isSigDropSignificant || currentPeak->getStartingSignal() > *yIt)
                                                    : isSigDropSignificant);
 
@@ -558,7 +558,7 @@ std::vector<std::unique_ptr<PeakContainer>> NSigmaPeaksStrategy::getAllNSigmaPea
     1. isRecording is False and isStartPeak True(== isEndPeak is False) => start recording
     2. isRecording is True and isEndPeak False - continue recording
     3. isRecording is True and isEndpeak is True(== isStartpeak is False) - end peak
-    4. isRecording is False and isStartPeak is False or isEndPeak is False - continue
+    4. else - continue
     */
     if (!isRecording && isStartPeak) {
       currentPeak = std::make_unique<PeakContainer>(y);

--- a/Framework/Crystal/test/FindSXPeaksHelperTest.h
+++ b/Framework/Crystal/test/FindSXPeaksHelperTest.h
@@ -130,16 +130,69 @@ public:
 
     const auto &x = workspace->x(workspaceIndex);
     const auto &y = workspace->y(workspaceIndex);
+    const auto &e = workspace->e(workspaceIndex);
     const auto &spectrumInfo = workspace->spectrumInfo();
 
     // WHEN
     auto peakFindingStrategy = std::make_unique<AllPeaksStrategy>(backgroundStrategy.get(), spectrumInfo);
-    auto peaks = peakFindingStrategy->findSXPeaks(x, y, workspaceIndex);
+    auto peaks = peakFindingStrategy->findSXPeaks(x, y, e, workspaceIndex);
 
     // THEN
     TSM_ASSERT("There should be two peaks that are found.", peaks.get().size() == 2);
     TSM_ASSERT("The first peak should have a signal value of 7.", peaks.get()[0].getIntensity() == 7.);
     TSM_ASSERT("The second peak should have a signal value of 11.", peaks.get()[1].getIntensity() == 11.);
+  }
+
+  void testThatFindAllPeaksNSigmaFindPeaks_1() {
+    // GIVEN
+    std::vector<double> newYValues = {1.5, 2.0, 10.0, 11.0, 14.0, 9.0, 1.5, 1.5, 1.5, 6.0, 9.0, 19.0, 21.5, 1.5, 1.5};
+    std::vector<double> newErrorValues = {1.5, 2.0, 2.0, 5.0, 7.0, 1.5, 1.5, 1.5, 1.5, 3.0, 4.0, 3.0, 2.5, 2.5, 1.5};
+    auto peaks = AllPeaksNSigma(newYValues, newErrorValues, 3.0);
+
+    // THEN
+    TSM_ASSERT("There should be two peaks that are found.", peaks.get().size() == 2);
+    TSM_ASSERT("The first peak should have a signal value of 14.", peaks.get()[0].getIntensity() == 14.);
+    TSM_ASSERT("The second peak should have a signal value of 21.5", peaks.get()[1].getIntensity() == 21.5);
+  }
+
+  void testThatFindAllPeaksNSigmaFindPeaksAtEnd() {
+    // GIVEN
+    std::vector<double> newYValues = {1.5, 2.0, 10.0, 11.0, 14.0, 9.0, 1.5, 1.5, 1.5, 6.0, 9.0, 19.0, 21.5, 22.5, 23.5};
+    std::vector<double> newErrorValues = {1.5, 2.0, 5.0, 5.0, 7.0, 1.5, 1.5, 1.5, 1.5, 3.0, 4.0, 3.0, 2.5, 2.5, 1.5};
+    auto peaks = AllPeaksNSigma(newYValues, newErrorValues, 3.0);
+
+    // THEN
+    TSM_ASSERT("There should be two peaks that are found.", peaks.get().size() == 1);
+    TSM_ASSERT("The second peak should have a signal value of 21.5", peaks.get()[0].getIntensity() == 23.5);
+  }
+
+  void testThatFindAllPeaksNSigmaFindNoPeaks() {
+    std::vector<double> newYValues = {1.5, 2.0, 10.0, 11.0, 14.0, 9.0, 1.5, 1.5, 1.5, 6.0, 9.0, 19.0, 21.5, 1.5, 1.5};
+    std::vector<double> newErrorValues = {1.5, 2.0, 5.0, 5.0, 7.0, 1.5, 1.5, 1.5, 1.5, 3.0, 2.0, 4.0, 6.5, 2.5, 1.5};
+    auto peaks = AllPeaksNSigma(newYValues, newErrorValues, 3.0);
+
+    ETS_ASSERT_EQUALS(peaks.is_initialized(), false);
+  }
+
+  PeakList AllPeaksNSigma(const std::vector<double> &newYValues, const std::vector<double> &newEValues,
+                          const double nsigma) {
+    // GIVEN
+    auto workspace = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(2 /*nhist*/, 15 /*nbins*/);
+    const int workspaceIndex = 1;
+    auto &mutableY = workspace->mutableY(workspaceIndex);
+    auto &mutableE = workspace->mutableE(workspaceIndex);
+
+    doAddNSigmaPeakToData(mutableY, newYValues, mutableE, newEValues);
+
+    const auto &x = workspace->x(workspaceIndex);
+    const auto &y = workspace->y(workspaceIndex);
+    const auto &e = workspace->e(workspaceIndex);
+    const auto &spectrumInfo = workspace->spectrumInfo();
+
+    // WHEN
+    auto peakFindingStrategy = std::make_unique<NSigmaPeaksStrategy>(spectrumInfo, nsigma);
+    auto peaks = peakFindingStrategy->findSXPeaks(x, y, e, workspaceIndex);
+    return peaks;
   }
 
   void testThatThrowsWhenBackgroundStrategyIsNotAbsoluteBackgroundStrategyWhenUsingAllPeaksStrategy() {
@@ -333,11 +386,12 @@ private:
 
     const auto &x = workspace->x(workspaceIndex);
     const auto &y = workspace->y(workspaceIndex);
+    const auto &e = workspace->e(workspaceIndex);
     const auto &spectrumInfo = workspace->spectrumInfo();
 
     // WHEN
     auto peakFindingStrategy = std::make_unique<StrongestPeaksStrategy>(backgroundStrategy, spectrumInfo);
-    auto peaks = peakFindingStrategy->findSXPeaks(x, y, workspaceIndex);
+    auto peaks = peakFindingStrategy->findSXPeaks(x, y, e, workspaceIndex);
 
     // THEN
     TSM_ASSERT("There should only be one peak that is found.", peaks.get().size() == 1);
@@ -353,6 +407,20 @@ private:
 
     for (size_t index = 0; index < y.size(); ++index) {
       y[index] = newDataValues[index];
+    }
+  }
+
+  void doAddNSigmaPeakToData(Mantid::HistogramData::HistogramY &y, const std::vector<double> &newYValues,
+                             Mantid::HistogramData::HistogramE &e, const std::vector<double> &newErrorValues) {
+
+    if (y.size() != newYValues.size() || e.size() != newErrorValues.size()) {
+      throw std::runtime_error("The data sizes don't match. This is a test setup issue. "
+                               "Make sure there is one fake data point per entry in the histogram.");
+    }
+
+    for (size_t index = 0; index < y.size(); ++index) {
+      y[index] = newYValues[index];
+      e[index] = newErrorValues[index];
     }
   }
 };

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -442,7 +442,7 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/CentroidPeaks.c
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/GoniometerAnglesFromPhiRotation.cpp:306
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/LoadIsawSpectrum.cpp:190
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/LoadIsawSpectrum.cpp:191
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/FindSXPeaks.cpp:194
+constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/FindSXPeaks.cpp:206
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp:286
 nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.cpp:95
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.cpp:331

--- a/docs/source/release/v6.10.0/Framework/Algorithms/New_features/35710.rst
+++ b/docs/source/release/v6.10.0/Framework/Algorithms/New_features/35710.rst
@@ -1,1 +1,2 @@
-- Added a new peak finding strategy named AllPeaksNSigma to FindSXPeaks :ref:`FindSXPeaks <algm-FindSXPeaks-v1>` algorithm.
+- Added a new peak finding strategy named AllPeaksNSigma to FindSXPeaks :ref:`FindSXPeaks <algm-FindSXPeaks-v1>` algorithm. Credits to the author of SXD2001 for the idea of using NSigma as a threshold (albeit in SXD2001 the peak finding is done in 3D).
+  Gutmann, M. J. (2005). SXD2001. ISIS Facility, Rutherford Appleton Laboratory, Oxfordshire, England.

--- a/docs/source/release/v6.10.0/Framework/Algorithms/New_features/35710.rst
+++ b/docs/source/release/v6.10.0/Framework/Algorithms/New_features/35710.rst
@@ -1,0 +1,1 @@
+- Added a new peak finding strategy named AllPeaksNSigma to FindSXPeaks :ref:`FindSXPeaks <algm-FindSXPeaks-v1>` algorithm.


### PR DESCRIPTION
### Description of work
Added AllPeaksNSigma peak finding strategy to FindSXPeaks algorithm; Instead of using a threshold, this will look for peaks by bins that are more than `NSigma*error` different in intensity.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #35710. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1. Load a workspace (ex: `SXD23767`)
2. Select `FindSXPeaks` algorithm from the algorithm pane
3. Select the above input workspase as `InputWorkspace` 
4. Select `AllPeaksNSigma` as the `PeakFindingStratergy`
5. Input `NSigma`=10.0
![image](https://github.com/mantidproject/mantid/assets/142818102/665908da-d951-4705-ad21-b2040af9ae10)

7. Enter a name for `OutputWorkspace` ex: AllPeaksNsigmaPeaks
8. Hit Run and observe the results of the above output peaks Workspase and cross check whether the values in `DetID`, `TOF`, and `Intens` columns represent corresponding peaks present in the input workspace's `Y` and `E` values.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
