### PR TITLE
Cache Load algorithm once found when setting filename property

### DIFF
--- a/Framework/DataHandling/src/Load.cpp
+++ b/Framework/DataHandling/src/Load.cpp
@@ -209,9 +209,9 @@ void Load::findFilenameProperty(const API::IAlgorithm_sptr &loader) {
   } else {
     // Use the first file property as the main Filename
     const auto &props = loader->getProperties();
-    for (auto prop : props) {
-      auto *multiprop = dynamic_cast<API::MultipleFileProperty *>(prop);
-      auto *singleprop = dynamic_cast<API::FileProperty *>(prop);
+    for (auto const &prop : props) {
+      auto const *multiprop = dynamic_cast<API::MultipleFileProperty *>(prop);
+      auto const *singleprop = dynamic_cast<API::FileProperty *>(prop);
       if (multiprop) {
         m_filenamePropName = multiprop->name();
         break;
@@ -256,7 +256,7 @@ void Load::declareLoaderProperties(const API::IAlgorithm_sptr &loader) {
   const std::vector<Property *> &loaderProps = loader->getProperties();
   size_t numProps(loaderProps.size());
   for (size_t i = 0; i < numProps; ++i) {
-    Property *loadProp = loaderProps[i];
+    Property const *loadProp = loaderProps[i];
     if (loadProp->name() == m_filenamePropName)
       continue;
     try {

--- a/Framework/DataHandling/src/Load.cpp
+++ b/Framework/DataHandling/src/Load.cpp
@@ -118,6 +118,7 @@ void Load::setPropertyValue(const std::string &name, const std::string &value) {
       auto loader = getFileLoader(getPropertyValue(name));
       assert(loader); // (getFileLoader should throw if no loader is found.)
       declareLoaderProperties(loader);
+      m_loader = loader;
     }
     // Else we've got multiple files, and must enforce the rule that only one
     // type of loader is allowed.
@@ -323,9 +324,10 @@ void Load::exec() {
   std::vector<std::vector<std::string>> fileNames = getProperty("Filename");
 
   // Test for loading as a single file
-  auto loader = getFileLoader(fileNames[0][0]);
-  auto ifl = std::dynamic_pointer_cast<IFileLoader<Kernel::FileDescriptor>>(loader);
-  auto iflNexus = std::dynamic_pointer_cast<IFileLoader<Kernel::NexusDescriptor>>(loader);
+  if (!m_loader)
+    m_loader = getFileLoader(fileNames[0][0]);
+  auto ifl = std::dynamic_pointer_cast<IFileLoader<Kernel::FileDescriptor>>(m_loader);
+  auto iflNexus = std::dynamic_pointer_cast<IFileLoader<Kernel::NexusDescriptor>>(m_loader);
 
   if (isSingleFile(fileNames) || (ifl && ifl->loadMutipleAsOne()) || (iflNexus && iflNexus->loadMutipleAsOne())) {
     // This is essentially just the same code that was called before multiple
@@ -341,15 +343,11 @@ void Load::exec() {
 }
 
 void Load::loadSingleFile() {
-  std::string loaderName = getPropertyValue("LoaderName");
-  if (loaderName.empty()) {
+  if (!m_loader) {
     m_loader = getFileLoader(getPropertyValue("Filename"));
-    loaderName = m_loader->name();
-  } else {
-    m_loader = createLoader(0, 1);
-    findFilenameProperty(m_loader);
   }
-  g_log.information() << "Using " << loaderName << " version " << m_loader->version() << ".\n";
+
+  g_log.information() << "Using " << m_loader->name() << " version " << m_loader->version() << ".\n";
   /// get the list properties for the concrete loader load algorithm
   const std::vector<Kernel::Property *> &loader_props = m_loader->getProperties();
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -605,9 +605,6 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHa
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/EventWorkspaceCollection.cpp:118
 duplicateConditionalAssign:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/FindDetectorsPar.cpp:484
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/FindDetectorsPar.cpp:632
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/Load.cpp:212
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/Load.cpp:213
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/Load.cpp:258
 comparisonOfFuncReturningBoolError:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/BoundedValidator.h:148
 comparisonOfFuncReturningBoolError:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/BoundedValidator.h:156
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadDNSEvent.h:44

--- a/docs/source/release/v6.10.0/Framework/Algorithms/Bugfixes/37126.rst
+++ b/docs/source/release/v6.10.0/Framework/Algorithms/Bugfixes/37126.rst
@@ -1,0 +1,1 @@
+- A performance improvement when using the :ref:`Load <algm-Load>` algorithm to load a single file has been achieved.


### PR DESCRIPTION
### Description of work
This PR ensures the load algorithm found when using the main mantid `Load` algorithm is cached, and so the search process is not performed more than is necessary. The search process can be slow for certain load workflows because the `NexusDescriptor` will walk through the entire nexus file to gather info about the file. We therefore want to keep the number of time we do the search process to a minimum. You can see in the below profile that the search process, indicated by "chooseLoader" is currently performed twice. The block marked with an `x` is removed by this PR.


![Screenshot 2024-03-24 201047](https://github.com/mantidproject/mantid/assets/40830825/2a2def1b-e582-4e72-8bb8-c029865330a7)

Fixes #37150 

Part of #36769 

### To test:
1. Open Mantid and run the following script:
```py
from mantid.simpleapi import Load

filepath = "//olympic/Babylon5/Public/RobApplin/loading"
filename = "irs26176_graphite002_red_Conv_seq_2L_0-50__Result.nxs"

Load(
    Filename=f"{filepath}/{filename}",
    OutputWorkspace="output_workspace",
)
```
2. The time to run the entire script used to be approx 60 seconds. It is now approx 40 seconds (roughly 33% improvement).

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
