### PR TITLE
Add safety net around reading in file contents to open in an editor tab

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/Bugfixes/37127.rst
+++ b/docs/source/release/v6.10.0/Workbench/Bugfixes/37127.rst
@@ -1,0 +1,1 @@
+- Fixed potential crash when opening a file to edit where that file / directory had been deleted.

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -19,6 +19,7 @@ from qtpy.QtWidgets import QVBoxLayout, QWidget, QMessageBox
 from mantidqt.widgets.codeeditor.interpreter import PythonFileInterpreter
 from mantidqt.widgets.codeeditor.scriptcompatibility import add_mantid_api_import, mantid_api_import_needed
 from mantidqt.widgets.codeeditor.tab_widget.codeeditor_tab_view import CodeEditorTabWidget
+from mantid.kernel import logger
 
 
 NEW_TAB_TITLE = "New"
@@ -338,8 +339,12 @@ class MultiPythonFileInterpreter(QWidget):
         :param filepath: A path to an existing file
         :param startup: Flag for if function is being called on startup
         """
-        with open(filepath, "r", encoding="utf_8") as code_file:
-            content = code_file.read()
+        try:
+            with open(filepath, "r", encoding="utf_8") as code_file:
+                content = code_file.read()
+        except FileNotFoundError:
+            logger.warning(f"Failed to find {filepath}, path does not exist.")
+            return
 
         matching_index = self.find_matching_tab(filepath)
 

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -145,6 +145,13 @@ class MultiPythonFileInterpreterTest(unittest.TestCase, QtWidgetFinder):
                 widget.open_file_in_new_tab(filename)
             self.assertEqual(2, widget.editor_count, msg="Should be the original tab, plus one (not two) tabs for the file")
 
+    def test_open_file_in_new_tab_handles_missing_file(self):
+        widget = MultiPythonFileInterpreter()
+        missing_file = "fake/file/path.txt"
+        # Should catch the filenotfound and return early
+        widget.open_file_in_new_tab(missing_file)
+        self.assertEqual(1, widget.editor_count, msg="No new file should have been opened")
+
     def test_cancelled_save_does_not_add_file_to_watcher(self):
         widget = MultiPythonFileInterpreter()
         widget.current_editor = mock.MagicMock(autospec=True)


### PR DESCRIPTION
### Description of work

We recieved an error report where `MultiPythonFileInterpreter.open_file_in_new_tab` has raised a `FileNotFoundError`. Support issur [here](https://github.com/ISISNeutronMuon/mantid-isis-support/issues/185). I am not sure how this happened, I've tried a couple of different things, I'm thinking maybe it was just some very bad timing with the file getting deleted by another process.

Either way, there's now a try block around the open statement to catch the error if it happens again.

Fixes https://github.com/ISISNeutronMuon/mantid-isis-support/issues/185

### To test:

 - Unit test

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
