### PR TITLE
Add option to build mantidworkbench without depending on mantiddocs for ornl-* branches - ornl-next

### DIFF
--- a/buildconfig/Jenkins/Conda/generate-version-number
+++ b/buildconfig/Jenkins/Conda/generate-version-number
@@ -8,6 +8,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # where for these commands.
 cd ${SCRIPT_DIR}
 
+# Remove any local tags that are not published
+git fetch -p -P
+
 # Find the latest version tag. Anything that starts with v is considered
 # The '-' prefixing version:refname sorts in descending order
 LATEST_VERSION_TAG=$(git tag --list  --sort -version:refname 'v*' | head -n 1)

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -107,6 +107,20 @@ pipeline {
         }
       }
     }
+    // Generate the git tag only once to avoid issues where tags are not up to date on
+    // certain agents. In particular, this can be a problem when the branch being built
+    // is on a fork.
+    stage('Generate git tag') {
+      agent { label 'linux-64' }
+      steps {
+        checkoutSource("${GIT_SHA}")
+        script {
+          env.GIT_TAG = generate_git_tag()
+        }
+        echo "${env.GIT_TAG}"
+      }
+    }
+
     // Verify developer environment build/test while also building conda packages
     // in parallel. Running both steps in parallel reduces the overall pipeline
     // time, however if either part breaks then no publishing occurs.
@@ -417,7 +431,7 @@ pipeline {
         sh 'tar -cvf conda-packages.tar ${WORKSPACE}/conda-packages/'
         // Publish to github. Single quotes are required for token variables to avoid them leaking
         sh "${CISCRIPT_DIR}/publish-to-github ${WORKSPACE}" + ' ${GITHUB_TOKEN} ' +\
-          "${GITHUB_RELEASES_REPO} ${generate_git_tag()} ${GIT_SHA} ${prerelease_option()} " +\
+          "${GITHUB_RELEASES_REPO} ${GIT_TAG} ${GIT_SHA} ${prerelease_option()} " +\
           "${WORKSPACE}/standalone-packages/* ${WORKSPACE}/conda-packages.tar"
       }
     }
@@ -502,10 +516,14 @@ def package_conda_options(platform, base_or_workbench) {
     package_flags = "--build-mantid --build-qt ${docs_flags}"
   }
   else if(base_or_workbench == 'workbench') {
-    package_flags = "--build-workbench"
+    if(BUILD_MANTIDDOCS_PACKAGE) {
+      package_flags = "--build-workbench"
+    } else {
+      package_flags = "--build-workbench-without-docs"
+    }
   }
 
-  package_options = "${package_flags} --git-tag ${generate_git_tag()}"
+  package_options = "${package_flags} --git-tag ${GIT_TAG}"
   return package_options.trim()
 }
 

--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -55,6 +55,7 @@ ENABLE_BUILD_MANTID=false
 ENABLE_BUILD_QT=false
 ENABLE_BUILD_WORKBENCH=false
 ENABLE_BUILD_DOCS=false
+BUILD_WORKBENCH_WITH_DOCS=true
 
 # Handle flag inputs
 while [ ! $# -eq 0 ]
@@ -64,6 +65,10 @@ do
         --build-qt) ENABLE_BUILD_QT=true ;;
         --build-workbench) ENABLE_BUILD_WORKBENCH=true ;;
         --build-docs) ENABLE_BUILD_DOCS=true ;;
+        --build-workbench-without-docs)
+            ENABLE_BUILD_WORKBENCH=true
+            BUILD_WORKBENCH_WITH_DOCS=false
+            ;;
         --git-tag)
             GIT_TAG="$2"
             shift ;;
@@ -107,7 +112,7 @@ export LC_ALL=C
 # copy the source to a working folder
 export CONDA_BLD_PATH=$WORKSPACE/conda-bld
 if [[ -d $CONDA_BLD_PATH ]]; then
-    conda index $CONDA_BLD_PATH
+    python -m conda_index $CONDA_BLD_PATH
 fi
 cd $RECIPES_DIR
 
@@ -131,6 +136,9 @@ if [[ $ENABLE_BUILD_DOCS == true ]]; then
     conda mambabuild ./mantiddocs/ $EXTRA_BUILD_OPTIONS
 fi
 if [[ $ENABLE_BUILD_WORKBENCH == true ]]; then
+    if [[ $BUILD_WORKBENCH_WITH_DOCS == false ]]; then
+	export INCLUDE_MANTIDDOCS=False
+    fi
     conda mambabuild ./mantidworkbench/ $EXTRA_BUILD_OPTIONS
 fi
 

--- a/buildconfig/Jenkins/Conda/package-standalone
+++ b/buildconfig/Jenkins/Conda/package-standalone
@@ -60,13 +60,13 @@ done
 
 # Mamba
 setup_mamba $WORKSPACE/mambaforge "package-standalone"
-mamba install --yes mamba conda-build=3.28.4
+mamba install --yes mamba conda-build
 
 # Build packages
 # Setup a local conda channel to find our locally built packages package. It is
 # assumed the raw .bz2 artefacts have been copied into the directory below
 LOCAL_CHANNEL_PATH=$WORKSPACE/conda-bld
-conda index $LOCAL_CHANNEL_PATH
+python -m conda_index $LOCAL_CHANNEL_PATH
 
 # Jenkins Pipeline expects packages in the root workspace directory
 cd $WORKSPACE

--- a/buildconfig/Jenkins/Conda/publish-to-anaconda
+++ b/buildconfig/Jenkins/Conda/publish-to-anaconda
@@ -23,7 +23,7 @@ shift 4
 
 # Setup Mamba
 setup_mamba $WORKSPACE/mambaforge "publish-anaconda"
-mamba install --yes anaconda-client "python<3.12"
+mamba install --yes anaconda-client
 
 for package in "$@"
 do

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -18,9 +18,13 @@ ENABLE_DOCS=$4
 ENABLE_DOC_TESTS=$5
 BUILD_THREADS=$6
 
-# Run only 3 tests at a time because of memory constraints in the system tests
-BUILD_THREADS_SYSTEM_TESTS=3
 XVFB_SERVER_NUM=101
+
+# If this isn't specified for a Jenkins agent, revert to default value
+if [[ -z "$BUILD_THREADS_SYSTEM_TESTS" ]]; then
+    # Default to 3 system tests running in parallel, assuming builders have >= 32GB RAM
+    BUILD_THREADS_SYSTEM_TESTS=3
+fi
 
 function run_with_xvfb {
     if [ $(command -v xvfb-run) ]; then

--- a/conda/recipes/mantidworkbench/meta.yaml
+++ b/conda/recipes/mantidworkbench/meta.yaml
@@ -44,7 +44,9 @@ requirements:
     - python.app  # [osx]
     - qtconsole {{ qtconsole }}
     - {{ pin_compatible("setuptools", max_pin="x.x") }}
+    {% if environ.get('INCLUDE_MANTIDDOCS', 'True') != 'False' %}
     - mantiddocs {{ version }}
+    {% endif %}
 
 test:
   imports:

--- a/dev-docs/source/Packaging.rst
+++ b/dev-docs/source/Packaging.rst
@@ -63,6 +63,13 @@ directory relative to the current working directory
    # wait quite a while ...
    # packages will appear in a conda-bld directory
 
+You can build the workbench without the documentation by:
+
+.. code:: sh
+
+   mantid-conda-build/buildconfig/Jenkins/Conda/package-conda $PWD \
+     --build-mantid --build-qt --build-workbench-without-docs 2>&1 | tee package.log
+
 To create a new test environment with packages from the local build:
 
 .. code:: sh


### PR DESCRIPTION
Pull in changes from #37118 and other conda build improvements
