### PR TITLE
IqtFit - Stretched Exp option is now in a combobox

### DIFF
--- a/docs/source/release/v6.10.0/Inelastic/New_features/36498.rst
+++ b/docs/source/release/v6.10.0/Inelastic/New_features/36498.rst
@@ -1,0 +1,1 @@
+- The IqtFit tab of :ref:`Inelastic QENS Fitting <interface-inelastic-qens-fitting>` now has a 'Fit Type' box for selecting a Stretched Exponential function. This allows further fit functions to be added in the future.

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTabConstants.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTabConstants.h
@@ -70,9 +70,9 @@ static const auto HIDDEN_PROPS =
                               "OutputCompositeMembers", "OutputWorkspace", "Output", "PeakRadius", "PlotParameter"});
 
 inline auto templateSubTypes() {
-  return packTemplateSubTypes(
-      std::make_unique<IqtTypes::ExponentialSubType>(), std::make_unique<IqtTypes::StretchExpSubType>(),
-      std::make_unique<IqtTypes::BackgroundSubType>(), std::make_unique<IqtTypes::TieIntensitiesSubType>());
+  return packTemplateSubTypes(std::make_unique<IqtTypes::ExponentialSubType>(),
+                              std::make_unique<IqtTypes::FitSubType>(), std::make_unique<IqtTypes::BackgroundSubType>(),
+                              std::make_unique<IqtTypes::TieIntensitiesSubType>());
 }
 
 } // namespace IqtFit

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.cpp
@@ -21,9 +21,9 @@ std::map<IqtTypes::ExponentialType, TemplateSubTypeDescriptor>
     };
 
 template <>
-std::map<IqtTypes::StretchExpType, TemplateSubTypeDescriptor> TemplateSubTypeImpl<IqtTypes::StretchExpType>::g_typeMap{
-    {IqtTypes::StretchExpType::None, {"None", "", {ParamID::NONE, ParamID::NONE}}},
-    {IqtTypes::StretchExpType::StretchExponential,
+std::map<IqtTypes::FitType, TemplateSubTypeDescriptor> TemplateSubTypeImpl<IqtTypes::FitType>::g_typeMap{
+    {IqtTypes::FitType::None, {"None", "", {ParamID::NONE, ParamID::NONE}}},
+    {IqtTypes::FitType::StretchExponential,
      {"Stretch Exponential", "StretchExp", {ParamID::STRETCH_HEIGHT, ParamID::STRETCH_STRETCHING}}},
 };
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.h
@@ -23,7 +23,7 @@ enum class ExponentialType {
   TwoExponentials,
 };
 
-enum class StretchExpType { None, StretchExponential };
+enum class FitType { None, StretchExponential };
 
 enum class BackgroundType { None, Flat };
 
@@ -31,7 +31,7 @@ enum class TieIntensitiesType { False, True };
 
 enum SubTypeIndex {
   Exponential = 0,
-  StretchExponential = 1,
+  Fit = 1,
   Background = 2,
   TieIntensities = 3,
 };
@@ -41,9 +41,8 @@ struct ExponentialSubType : public TemplateSubTypeImpl<ExponentialType> {
   bool isType(const std::type_info &type) const override { return type == typeid(int); }
 };
 
-struct StretchExpSubType : public TemplateSubTypeImpl<StretchExpType> {
-  std::string name() const override { return "Stretch Exponential"; }
-  bool isType(const std::type_info &type) const override { return type == typeid(bool); }
+struct FitSubType : public TemplateSubTypeImpl<FitType> {
+  std::string name() const override { return "Fit Type"; }
 };
 
 struct BackgroundSubType : public TemplateSubTypeImpl<BackgroundType> {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/IqtFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/IqtFunctionTemplateModel.cpp
@@ -57,7 +57,7 @@ IqtFunctionTemplateModel::IqtFunctionTemplateModel()
 
 void IqtFunctionTemplateModel::clearData() {
   m_exponentialType = ExponentialType::None;
-  m_stretchExpType = StretchExpType::None;
+  m_fitType = FitType::None;
   m_backgroundType = BackgroundType::None;
 
   m_model->clear();
@@ -81,7 +81,7 @@ void IqtFunctionTemplateModel::setFunction(IFunction_sptr fun) {
     if (name == "ExpDecay") {
       m_exponentialType = ExponentialType::OneExponential;
     } else if (name == "StretchExp") {
-      m_stretchExpType = StretchExpType::StretchExponential;
+      m_fitType = FitType::StretchExponential;
     } else if (name == "FlatBackground") {
       m_backgroundType = BackgroundType::Flat;
     } else {
@@ -110,7 +110,7 @@ void IqtFunctionTemplateModel::setFunction(IFunction_sptr fun) {
       if (isStretchSet) {
         throw std::runtime_error("Function has wrong structure.");
       }
-      m_stretchExpType = StretchExpType::StretchExponential;
+      m_fitType = FitType::StretchExponential;
       areExponentialsSet = true;
       isStretchSet = true;
     } else if (name == "FlatBackground") {
@@ -148,7 +148,7 @@ void IqtFunctionTemplateModel::addFunction(std::string const &prefix, std::strin
   } else if (name == "StretchExp") {
     if (hasStretchExponential())
       throw std::runtime_error("Cannot add more stretched exponentials.");
-    m_stretchExpType = StretchExpType::StretchExponential;
+    m_fitType = FitType::StretchExponential;
     newPrefix = *getStretchPrefix();
   } else if (name == "FlatBackground") {
     if (hasBackground())
@@ -172,8 +172,8 @@ void IqtFunctionTemplateModel::setSubType(std::size_t subTypeIndex, int typeInde
   case IqtTypes::SubTypeIndex::Exponential:
     m_exponentialType = static_cast<IqtTypes::ExponentialType>(typeIndex);
     break;
-  case IqtTypes::SubTypeIndex::StretchExponential:
-    m_stretchExpType = static_cast<IqtTypes::StretchExpType>(typeIndex);
+  case IqtTypes::SubTypeIndex::Fit:
+    m_fitType = static_cast<IqtTypes::FitType>(typeIndex);
     break;
   case IqtTypes::SubTypeIndex::Background:
     m_backgroundType = static_cast<IqtTypes::BackgroundType>(typeIndex);
@@ -192,7 +192,7 @@ void IqtFunctionTemplateModel::setSubType(std::size_t subTypeIndex, int typeInde
 std::map<std::size_t, int> IqtFunctionTemplateModel::getSubTypes() const {
   std::map<std::size_t, int> subTypes;
   subTypes[IqtTypes::SubTypeIndex::Exponential] = static_cast<int>(m_exponentialType);
-  subTypes[IqtTypes::SubTypeIndex::StretchExponential] = static_cast<int>(m_stretchExpType);
+  subTypes[IqtTypes::SubTypeIndex::Fit] = static_cast<int>(m_fitType);
   subTypes[IqtTypes::SubTypeIndex::Background] = static_cast<int>(m_backgroundType);
   subTypes[IqtTypes::SubTypeIndex::TieIntensities] = static_cast<int>(m_tieIntensitiesType);
   return subTypes;
@@ -215,7 +215,7 @@ void IqtFunctionTemplateModel::removeFunction(std::string const &prefix) {
   }
   prefix1 = getStretchPrefix();
   if (prefix1 && *prefix1 == prefix) {
-    m_stretchExpType = StretchExpType::None;
+    m_fitType = FitType::None;
     return;
   }
   prefix1 = getBackgroundPrefix();
@@ -230,7 +230,7 @@ int IqtFunctionTemplateModel::numberOfExponentials() const { return static_cast<
 
 bool IqtFunctionTemplateModel::hasExponential() const { return m_exponentialType != ExponentialType::None; }
 
-bool IqtFunctionTemplateModel::hasStretchExponential() const { return m_stretchExpType != StretchExpType::None; }
+bool IqtFunctionTemplateModel::hasStretchExponential() const { return m_fitType == FitType::StretchExponential; }
 
 void IqtFunctionTemplateModel::removeBackground() {
   auto oldValues = getCurrentValues();

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/IqtFunctionTemplateModel.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/IqtFunctionTemplateModel.h
@@ -67,7 +67,7 @@ private:
   std::string buildBackgroundFunctionString() const;
 
   IqtTypes::ExponentialType m_exponentialType = IqtTypes::ExponentialType::None;
-  IqtTypes::StretchExpType m_stretchExpType = IqtTypes::StretchExpType::None;
+  IqtTypes::FitType m_fitType = IqtTypes::FitType::None;
   IqtTypes::BackgroundType m_backgroundType = IqtTypes::BackgroundType::None;
   IqtTypes::TieIntensitiesType m_tieIntensitiesType = IqtTypes::TieIntensitiesType::False;
 };


### PR DESCRIPTION
### Description of work
This PR changes the "Stretched Exp" fit function option in the IqtFit tab of Inelastic QENS Fitting, from a checkbox to a combobox. This makes IqtFit more consistent with ConvFit, and also allows us to add more fit function options in the future. For example, we might want to add the `TeixeiraWaterIqt` fit function.

Fixes #36498

### To test:
1. Open `Inelastic`->`QENS Fitting`
2. Go to the IqtFit tab
3. Load the below data
[irs26176_graphite002_iqt.zip](https://github.com/mantidproject/mantid/files/14907709/irs26176_graphite002_iqt.zip)

5. There should be a "Fit type" option in the Function browser
6. Choose the Stretched Exponential option
7. Click `Run`
8. The fit should be successful

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
