### PR TITLE
Fix failing OSIRISDiffractionFocusingWithMultipleScattering Test

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS_PowderOsirisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderOsirisTest.py
@@ -24,7 +24,6 @@ working_folder_name = "ISIS_Powder"
 
 # Relative to working folder
 input_folder_name = "input"
-output_folder_name = "output"
 
 # Relative to input folder
 calibration_folder_name = os.path.join("calibration", inst_name.lower())
@@ -35,70 +34,16 @@ calibration_map_rel_path = os.path.join("yaml_files", "osiris_system_test_mappin
 working_dir = os.path.join(DIRS[0], working_folder_name)
 
 input_dir = os.path.join(working_dir, input_folder_name)
-output_dir = os.path.join(working_dir, output_folder_name)
 
 calibration_map_path = os.path.join(input_dir, calibration_map_rel_path)
 calibration_dir = os.path.join(input_dir, calibration_folder_name)
-
-
-def run_diffraction_focusing(
-    sample_runs,
-    user_name,
-    output_file,
-    merge_drange=False,
-    subtract_empty_can=False,
-    vanadium_normalisation=False,
-    sample_empty_scale=None,
-    absorb_corrections=False,
-    empty_can_subtraction_method="Simple",
-    sample_details=None,
-    paalman_pings_events_per_point=None,
-    simple_events_per_point=None,
-    neutron_paths_multiple=None,
-    neutron_paths_single=None,
-    multiple_scattering=False,
-):
-    sample_runs = sample_runs  # Choose full drange set in the cycle 1_1
-
-    osiris_inst_obj = setup_inst_object(user_name)
-
-    osiris_inst_obj.create_vanadium(
-        run_number=sample_runs,
-        subtract_empty_can=subtract_empty_can,
-    )
-
-    if sample_details:
-        osiris_inst_obj.set_sample_details(sample=sample_details)
-
-    # Run diffraction focusing
-    osiris_inst_obj.focus(
-        run_number=sample_runs,
-        merge_drange=merge_drange,
-        subtract_empty_can=subtract_empty_can,
-        vanadium_normalisation=vanadium_normalisation,
-        sample_empty_scale=sample_empty_scale,
-        absorb_corrections=absorb_corrections,
-        empty_can_subtraction_method=empty_can_subtraction_method,
-        paalman_pings_events_per_point=paalman_pings_events_per_point,
-        simple_events_per_point=simple_events_per_point,
-        neutron_paths_multiple=neutron_paths_multiple,
-        neutron_paths_single=neutron_paths_single,
-        multiple_scattering=multiple_scattering,
-    )
-
-    focussed_rel_path = os.path.join("1_1", user_name, output_file)
-    focused_path = os.path.join(output_dir, focussed_rel_path)
-
-    foccussed_ws = mantid.Load(Filename=focused_path)
-
-    return foccussed_ws
 
 
 def setup_mantid_paths():
     config["datasearch.directories"] += ";" + input_dir
 
 
-def setup_inst_object(user_name, with_container=False):
+def setup_inst_object(user_name, output_dir):
     inst_obj = Osiris(
         user_name=user_name,
         calibration_mapping_file=calibration_map_path,
@@ -132,6 +77,7 @@ class _OSIRISDiffractionFocusingTest(systemtesting.MantidSystemTest):
     existing_config = config["datasearch.directories"]
     refrence_ws_name = None
     required_run_files = []
+    output_dir = None
 
     def skipTests(self):
         # Don't actually run this test, as it is a common interface for other tests tests
@@ -149,7 +95,7 @@ class _OSIRISDiffractionFocusingTest(systemtesting.MantidSystemTest):
 
     def cleanup(self):
         try:
-            _try_delete(output_dir)
+            _try_delete(self.output_dir)
         finally:
             mantid.mtd.clear()
             config["datasearch.directories"] = self.existing_config
@@ -159,6 +105,59 @@ class _OSIRISDiffractionFocusingTest(systemtesting.MantidSystemTest):
         input_files.append(calibration_map_path)
         return input_files
 
+    def run_diffraction_focusing(
+        self,
+        sample_runs,
+        user_name,
+        output_file,
+        merge_drange=False,
+        subtract_empty_can=False,
+        vanadium_normalisation=False,
+        sample_empty_scale=None,
+        absorb_corrections=False,
+        empty_can_subtraction_method="Simple",
+        sample_details=None,
+        paalman_pings_events_per_point=None,
+        simple_events_per_point=None,
+        neutron_paths_multiple=None,
+        neutron_paths_single=None,
+        multiple_scattering=False,
+    ):
+        sample_runs = sample_runs  # Choose full drange set in the cycle 1_1
+
+        osiris_inst_obj = setup_inst_object(user_name, self.output_dir)
+
+        osiris_inst_obj.create_vanadium(
+            run_number=sample_runs,
+            subtract_empty_can=subtract_empty_can,
+        )
+
+        if sample_details:
+            osiris_inst_obj.set_sample_details(sample=sample_details)
+
+        # Run diffraction focusing
+        osiris_inst_obj.focus(
+            run_number=sample_runs,
+            merge_drange=merge_drange,
+            subtract_empty_can=subtract_empty_can,
+            vanadium_normalisation=vanadium_normalisation,
+            sample_empty_scale=sample_empty_scale,
+            absorb_corrections=absorb_corrections,
+            empty_can_subtraction_method=empty_can_subtraction_method,
+            paalman_pings_events_per_point=paalman_pings_events_per_point,
+            simple_events_per_point=simple_events_per_point,
+            neutron_paths_multiple=neutron_paths_multiple,
+            neutron_paths_single=neutron_paths_single,
+            multiple_scattering=multiple_scattering,
+        )
+
+        focussed_rel_path = os.path.join("1_1", user_name, output_file)
+        focused_path = os.path.join(self.output_dir, focussed_rel_path)
+
+        foccussed_ws = mantid.Load(Filename=focused_path)
+
+        return foccussed_ws
+
 
 class OSIRISDiffractionFocusingWithSubtractionTest(_OSIRISDiffractionFocusingTest):
     refrence_ws_name = "OSI119977_d_spacing.nxs"
@@ -167,10 +166,11 @@ class OSIRISDiffractionFocusingWithSubtractionTest(_OSIRISDiffractionFocusingTes
         "OSIRIS00119963.nxs",  # van
         "OSIRIS00119977.nxs",
     ]
+    output_dir = os.path.join(working_dir, "output_with_subtraction")
 
     def runTest(self):
         super().runPreTest()
-        self.results = run_diffraction_focusing(
+        self.results = self.run_diffraction_focusing(
             "119977",
             "Test",
             "OSI119977_d_spacing.nxs",
@@ -191,10 +191,11 @@ class OSIRISDiffractionFocusingWithMergingTest(_OSIRISDiffractionFocusingTest):
         "OSIRIS00119977.nxs",
         "OSIRIS00119978.nxs",
     ]
+    output_dir = os.path.join(working_dir, "output_with_merging")
 
     def runTest(self):
         super().runPreTest()
-        self.results = run_diffraction_focusing(
+        self.results = self.run_diffraction_focusing(
             "119977-119978",
             "Test_Merge",
             "OSI119977-119978_d_spacing.nxs",
@@ -212,12 +213,13 @@ class OSIRISDiffractionFocusingWithSimpleAbsorptionCorrection(_OSIRISDiffraction
         "OSIRIS00119963.nxs",
         "OSIRIS00120032.nxs",  # van
     ]
+    output_dir = os.path.join(working_dir, "output_with_simple")
 
     def runTest(self):
         super().runPreTest()
         sample_details = setup_sample_details()
 
-        self.results = run_diffraction_focusing(
+        self.results = self.run_diffraction_focusing(
             "120032",
             "Test_Simple_Absorb",
             "OSI120032_d_spacing.nxs",
@@ -238,6 +240,7 @@ class OSIRISDiffractionFocusingWithPaalmanPingsAbsorptionCorrection(_OSIRISDiffr
         "OSIRIS00119964.nxs",  # van
         "OSIRIS00120032.nxs",
     ]
+    output_dir = os.path.join(working_dir, "output_with_paalman")
 
     def runTest(self):
         self.tolerance = 1e-8
@@ -245,7 +248,7 @@ class OSIRISDiffractionFocusingWithPaalmanPingsAbsorptionCorrection(_OSIRISDiffr
         super().runPreTest()
         sample_details = setup_sample_details()
 
-        self.results = run_diffraction_focusing(
+        self.results = self.run_diffraction_focusing(
             "120032",
             "Test_PaalmanPings_Absorb",
             "OSI120032_d_spacing.nxs",
@@ -268,12 +271,13 @@ class OSIRISDiffractionFocusingWithMultipleScattering(_OSIRISDiffractionFocusing
         "OSIRIS00119964.nxs",  # van
         "OSIRIS00120032.nxs",
     ]
+    output_dir = os.path.join(working_dir, "output_with_multiple")
 
     def runTest(self):
         super().runPreTest()
         sample_details = setup_sample_details()
 
-        self.results = run_diffraction_focusing(
+        self.results = self.run_diffraction_focusing(
             "120032",
             "Test_Multiple_Scattering",
             "OSI120032_d_spacing.nxs",

--- a/Testing/SystemTests/tests/framework/ISIS_PowderOsirisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderOsirisTest.py
@@ -286,7 +286,5 @@ class OSIRISDiffractionFocusingWithMultipleScattering(_OSIRISDiffractionFocusing
             neutron_paths_multiple=5,
         )
 
-        mantid.SaveNexus(InputWorkspace=self.results, Filename=r"C:\Users\joy22959\Documents\test\multiscatt")
-
     def skipTests(self):
         return False


### PR DESCRIPTION
### Description of work
This PR fixes two problems within the OSIRISDiffractionFocusingWithMultipleScattering  test which were causing unreliable failures:
- There was an accidental `SaveNexus` line with a suspiciously specific path
- The tests in this `ISIS_PowderOsirisTest` all used the same output directory when running the diffraction focus. When running the tests in parallel, this could cause problems because when one test finishes, it would clean up the output directory. This output directory might still be used by another one of the tests on a different thread, hence the "missing file" error we were seeing unreliably. The problem was exposed when we recently increased the number of threads we use for the system testing step.

### To test:
Run the following locally, it should pass. The tests on this PR should pass too

```sh
./systemtest.bat -C DebugWithRelRuntime -R ISIS_PowderOsirisTest
```

*This does not require release notes* because **this is an internal fix**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
