### PR TITLE
Add x and y limits to the main view of sliceviewer

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/SliceViewer/New_features/37152.rst
+++ b/docs/source/release/v6.10.0/Workbench/SliceViewer/New_features/37152.rst
@@ -1,0 +1,1 @@
+- Added controls for the x and y limits to the main view of Sliceviewer.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
@@ -108,6 +108,7 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
             # incompatible with drag zooming/panning as they both require drag selection
             data_view.deactivate_and_disable_tool(ToolItemText.ZOOM)
             data_view.deactivate_and_disable_tool(ToolItemText.PAN)
+            data_view.extents_set_enabled(False)
             tool = RectangleSelectionLinePlot
             if data_view.line_plots_active:
                 data_view.switch_line_plots_tool(RectangleSelectionLinePlot, self)
@@ -116,6 +117,7 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
         else:
             data_view.enable_tool_button(ToolItemText.ZOOM)
             data_view.enable_tool_button(ToolItemText.PAN)
+            data_view.extents_set_enabled(True)
             data_view.switch_line_plots_tool(PixelLinePlot, self)
 
     @abc.abstractmethod

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
@@ -7,10 +7,12 @@
 import unittest
 from typing import Dict
 from unittest import mock
+import numpy as np
 
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.sliceviewer.views.toolbar import ToolItemText
 from mantidqt.widgets.sliceviewer.views.view import SliceViewerDataView
+from mantidqt.widgets.sliceviewer.models.transform import NonOrthogonalTransform
 
 
 @start_qapplication
@@ -308,7 +310,9 @@ class SliceviewerDataViewTest(unittest.TestCase):
         self.view.grid_helper = mock.Mock()
         self.patched_objs["CurveLinearSubPlot"].return_value = self.view.fig.add_subplot(111)
 
-        self.view.create_axes_nonorthogonal(None)
+        transform = NonOrthogonalTransform(np.radians(30))
+
+        self.view.create_axes_nonorthogonal(transform)
 
         self.assertEqual(self.view.x_min.value(), 0.0)
         self.assertEqual(self.view.x_max.value(), 0.0)
@@ -320,10 +324,12 @@ class SliceviewerDataViewTest(unittest.TestCase):
 
         self.assertEqual(self.view.x_min.value(), -1.0)
         self.assertEqual(self.view.x_max.value(), 1.0)
-        self.assertEqual(self.view.y_min.value(), -2.0)
-        self.assertEqual(self.view.y_max.value(), 2.0)
 
-    def test_extents_update_from_spinbox(self):
+        # y should be double because y / sin(angle) = y/0.5 for 30 degrees
+        self.assertEqual(self.view.y_min.value(), -4.0)
+        self.assertEqual(self.view.y_max.value(), 4.0)
+
+    def test_extents_update_from_spinbox_orthogonal(self):
         self.view.set_integer_axes_ticks = mock.Mock()
 
         self.view.create_axes_orthogonal()
@@ -347,6 +353,36 @@ class SliceviewerDataViewTest(unittest.TestCase):
         self.assertEqual(x_max, 2.0)
         self.assertEqual(y_min, -3.0)
         self.assertEqual(y_max, 4.0)
+
+    def test_extents_update_from_spinbox_nonorthogonal(self):
+        self.view.grid_helper = mock.Mock()
+        self.patched_objs["CurveLinearSubPlot"].return_value = self.view.fig.add_subplot(111)
+
+        transform = NonOrthogonalTransform(np.radians(30))
+
+        self.view.create_axes_nonorthogonal(transform)
+
+        x_min, x_max = self.view.ax.get_xlim()
+        y_min, y_max = self.view.ax.get_ylim()
+        self.assertEqual(x_min, 0.0)
+        self.assertEqual(x_max, 1.0)
+        self.assertEqual(y_min, 0.0)
+        self.assertEqual(y_max, 1.0)
+
+        self.view.x_min.setValue(-1.0)
+        self.view.x_max.setValue(2.0)
+        self.view.y_min.setValue(-3.0)
+        self.view.y_max.setValue(4.0)
+
+        x_min, x_max = self.view.ax.get_xlim()
+        y_min, y_max = self.view.ax.get_ylim()
+
+        self.assertEqual(x_min, -1.0)
+        self.assertEqual(x_max, 2.0)
+
+        # y should be halved because y * sin(angle) = y * 0.5 for 30 degrees
+        self.assertAlmostEqual(y_min, -1.5, 9)
+        self.assertAlmostEqual(y_max, 2.0, 9)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
@@ -286,6 +286,68 @@ class SliceviewerDataViewTest(unittest.TestCase):
         scale = self.view.get_default_scale_norm()
         self.assertEqual(scale, "SymmetricLog10")
 
+    def test_extents_set_correctly_orthogonal(self):
+        self.view.set_integer_axes_ticks = mock.Mock()
+
+        self.view.create_axes_orthogonal()
+
+        self.assertEqual(self.view.x_min.value(), 0.0)
+        self.assertEqual(self.view.x_max.value(), 0.0)
+        self.assertEqual(self.view.y_min.value(), 0.0)
+        self.assertEqual(self.view.y_max.value(), 0.0)
+
+        self.view.ax.set_xlim(-1.0, 1.0)
+        self.view.ax.set_ylim(-2.0, 2.0)
+
+        self.assertEqual(self.view.x_min.value(), -1.0)
+        self.assertEqual(self.view.x_max.value(), 1.0)
+        self.assertEqual(self.view.y_min.value(), -2.0)
+        self.assertEqual(self.view.y_max.value(), 2.0)
+
+    def test_extents_set_correctly_nonorthogonal(self):
+        self.view.grid_helper = mock.Mock()
+        self.patched_objs["CurveLinearSubPlot"].return_value = self.view.fig.add_subplot(111)
+
+        self.view.create_axes_nonorthogonal(None)
+
+        self.assertEqual(self.view.x_min.value(), 0.0)
+        self.assertEqual(self.view.x_max.value(), 0.0)
+        self.assertEqual(self.view.y_min.value(), 0.0)
+        self.assertEqual(self.view.y_max.value(), 0.0)
+
+        self.view.ax.set_xlim(-1.0, 1.0)
+        self.view.ax.set_ylim(-2.0, 2.0)
+
+        self.assertEqual(self.view.x_min.value(), -1.0)
+        self.assertEqual(self.view.x_max.value(), 1.0)
+        self.assertEqual(self.view.y_min.value(), -2.0)
+        self.assertEqual(self.view.y_max.value(), 2.0)
+
+    def test_extents_update_from_spinbox(self):
+        self.view.set_integer_axes_ticks = mock.Mock()
+
+        self.view.create_axes_orthogonal()
+
+        x_min, x_max = self.view.ax.get_xlim()
+        y_min, y_max = self.view.ax.get_ylim()
+        self.assertEqual(x_min, 0.0)
+        self.assertEqual(x_max, 1.0)
+        self.assertEqual(y_min, 0.0)
+        self.assertEqual(y_max, 1.0)
+
+        self.view.x_min.setValue(-1.0)
+        self.view.x_max.setValue(2.0)
+        self.view.y_min.setValue(-3.0)
+        self.view.y_max.setValue(4.0)
+
+        x_min, x_max = self.view.ax.get_xlim()
+        y_min, y_max = self.view.ax.get_ylim()
+
+        self.assertEqual(x_min, -1.0)
+        self.assertEqual(x_max, 2.0)
+        self.assertEqual(y_min, -3.0)
+        self.assertEqual(y_max, 4.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -19,6 +19,7 @@ from qtpy.QtWidgets import (
     QStatusBar,
     QToolButton,
     QSizePolicy,
+    QDoubleSpinBox,
 )
 from matplotlib.figure import Figure
 from mpl_toolkits.axisartist import Subplot as CurveLinearSubPlot, GridHelperCurveLinear
@@ -153,6 +154,29 @@ class SliceViewerDataView(QWidget):
         self.status_bar.addWidget(self.help_button)
         self.status_bar.addWidget(self.status_bar_label)
 
+        # min/max extents
+        self.extents = QHBoxLayout()
+        self.x_min = QDoubleSpinBox()
+        self.x_min.setRange(-DBLMAX, DBLMAX)
+        self.x_min.valueChanged.connect(self.update_xlim)
+        self.x_max = QDoubleSpinBox()
+        self.x_max.setRange(-DBLMAX, DBLMAX)
+        self.x_max.valueChanged.connect(self.update_xlim)
+        self.y_min = QDoubleSpinBox()
+        self.y_min.setRange(-DBLMAX, DBLMAX)
+        self.y_min.valueChanged.connect(self.update_ylim)
+        self.y_max = QDoubleSpinBox()
+        self.y_max.setRange(-DBLMAX, DBLMAX)
+        self.y_max.valueChanged.connect(self.update_ylim)
+        self.extents.addWidget(QLabel("X min:"))
+        self.extents.addWidget(self.x_min)
+        self.extents.addWidget(QLabel("X max:"))
+        self.extents.addWidget(self.x_max)
+        self.extents.addWidget(QLabel("Y min:"))
+        self.extents.addWidget(self.y_min)
+        self.extents.addWidget(QLabel("Y max:"))
+        self.extents.addWidget(self.y_max)
+
         # layout
         layout = QGridLayout(self)
         layout.setSpacing(1)
@@ -161,6 +185,7 @@ class SliceViewerDataView(QWidget):
         layout.addLayout(self.colorbar_layout, 1, 1, 3, 1)
         layout.addWidget(self.canvas, 2, 0, 1, 1)
         layout.addWidget(self.status_bar, 3, 0, 1, 1)
+        layout.addLayout(self.extents, 5, 0, 1, 1)
         layout.setRowStretch(2, 1)
 
     def create_dimensions(self, dims_info, custom_image_info=False):
@@ -199,6 +224,9 @@ class SliceViewerDataView(QWidget):
 
         self.plot_MDH = self.plot_MDH_orthogonal
         self.set_integer_axes_ticks()
+
+        self.ax.callbacks.connect("xlim_changed", self.xlim_changed)
+        self.ax.callbacks.connect("ylim_changed", self.ylim_changed)
 
         self.canvas.draw_idle()
 
@@ -520,6 +548,32 @@ class SliceViewerDataView(QWidget):
         """
         self.ax.set_xlim(xlim)
         self.ax.set_ylim(ylim)
+
+    def xlim_changed(self, ax):
+        x_min, x_max = ax.get_xlim()
+        self.x_min.blockSignals(True)
+        self.x_min.setValue(x_min)
+        self.x_min.blockSignals(False)
+        self.x_max.blockSignals(True)
+        self.x_max.setValue(x_max)
+        self.x_max.blockSignals(False)
+
+    def update_xlim(self, _):
+        self.ax.set_xlim(self.x_min.value(), self.x_max.value(), emit=False)
+        self.on_data_limits_changed()
+
+    def ylim_changed(self, ax):
+        y_min, y_max = ax.get_ylim()
+        self.y_min.blockSignals(True)
+        self.y_min.setValue(y_min)
+        self.y_min.blockSignals(False)
+        self.y_max.blockSignals(True)
+        self.y_max.setValue(y_max)
+        self.y_max.blockSignals(False)
+
+    def update_ylim(self, _):
+        self.ax.set_ylim(self.y_min.value(), self.y_max.value(), emit=False)
+        self.on_data_limits_changed()
 
     def set_integer_axes_ticks(self):
         """

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -155,37 +155,17 @@ class SliceViewerDataView(QWidget):
         self.status_bar.addWidget(self.status_bar_label)
 
         # min/max extents
-        self.extents = QHBoxLayout()
-        self.x_min = QDoubleSpinBox()
-        self.x_min.setRange(-DBLMAX, DBLMAX)
-        self.x_min.valueChanged.connect(self.update_xlim)
-        self.x_max = QDoubleSpinBox()
-        self.x_max.setRange(-DBLMAX, DBLMAX)
-        self.x_max.valueChanged.connect(self.update_xlim)
-        self.y_min = QDoubleSpinBox()
-        self.y_min.setRange(-DBLMAX, DBLMAX)
-        self.y_min.valueChanged.connect(self.update_ylim)
-        self.y_max = QDoubleSpinBox()
-        self.y_max.setRange(-DBLMAX, DBLMAX)
-        self.y_max.valueChanged.connect(self.update_ylim)
-        self.extents.addWidget(QLabel("X min:"))
-        self.extents.addWidget(self.x_min)
-        self.extents.addWidget(QLabel("X max:"))
-        self.extents.addWidget(self.x_max)
-        self.extents.addWidget(QLabel("Y min:"))
-        self.extents.addWidget(self.y_min)
-        self.extents.addWidget(QLabel("Y max:"))
-        self.extents.addWidget(self.y_max)
+        self.extents = self.create_extents_layout()
 
         # layout
         layout = QGridLayout(self)
         layout.setSpacing(1)
         layout.addLayout(self.dimensions_layout, 0, 0, 1, 2)
         layout.addLayout(self.toolbar_layout, 1, 0, 1, 1)
-        layout.addLayout(self.colorbar_layout, 1, 1, 3, 1)
+        layout.addLayout(self.colorbar_layout, 1, 1, 4, 1)
         layout.addWidget(self.canvas, 2, 0, 1, 1)
-        layout.addWidget(self.status_bar, 3, 0, 1, 1)
-        layout.addLayout(self.extents, 5, 0, 1, 1)
+        layout.addLayout(self.extents, 3, 0, 1, 1)
+        layout.addWidget(self.status_bar, 4, 0, 1, 1)
         layout.setRowStretch(2, 1)
 
     def create_dimensions(self, dims_info, custom_image_info=False):
@@ -574,6 +554,50 @@ class SliceViewerDataView(QWidget):
     def update_ylim(self, _):
         self.ax.set_ylim(self.y_min.value(), self.y_max.value(), emit=False)
         self.on_data_limits_changed()
+
+    def create_extents_layout(self):
+        self.x_min = QDoubleSpinBox()
+        self.x_min.setRange(-DBLMAX, DBLMAX)
+        self.x_min.setMaximumWidth(100)
+        self.x_min.valueChanged.connect(self.update_xlim)
+
+        self.x_max = QDoubleSpinBox()
+        self.x_max.setRange(-DBLMAX, DBLMAX)
+        self.x_max.setMaximumWidth(100)
+        self.x_max.valueChanged.connect(self.update_xlim)
+
+        self.y_min = QDoubleSpinBox()
+        self.y_min.setRange(-DBLMAX, DBLMAX)
+        self.y_min.setMaximumWidth(100)
+        self.y_min.valueChanged.connect(self.update_ylim)
+
+        self.y_max = QDoubleSpinBox()
+        self.y_max.setRange(-DBLMAX, DBLMAX)
+        self.y_max.setMaximumWidth(100)
+        self.y_max.valueChanged.connect(self.update_ylim)
+
+        extents = QHBoxLayout()
+        extents.addStretch(1)
+        extents.addWidget(QLabel("X min:"))
+        extents.addWidget(self.x_min)
+        extents.addSpacing(10)
+        extents.addWidget(QLabel("X max:"))
+        extents.addWidget(self.x_max)
+        extents.addSpacing(30)
+        extents.addWidget(QLabel("Y min:"))
+        extents.addWidget(self.y_min)
+        extents.addSpacing(10)
+        extents.addWidget(QLabel("Y max:"))
+        extents.addWidget(self.y_max)
+        extents.addStretch(1)
+
+        return extents
+
+    def extents_set_enabled(self, state):
+        self.x_min.setEnabled(state)
+        self.x_max.setEnabled(state)
+        self.y_min.setEnabled(state)
+        self.y_max.setEnabled(state)
 
     def set_integer_axes_ticks(self):
         """

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -547,6 +547,9 @@ class SliceViewerDataView(QWidget):
 
     def ylim_changed(self, ax):
         y_min, y_max = ax.get_ylim()
+        if self.nonorthogonal_mode:
+            y_min = self.nonortho_transform.inv_tr(0, y_min)[1]
+            y_max = self.nonortho_transform.inv_tr(0, y_max)[1]
         self.y_min.blockSignals(True)
         self.y_min.setValue(y_min)
         self.y_min.blockSignals(False)
@@ -555,7 +558,12 @@ class SliceViewerDataView(QWidget):
         self.y_max.blockSignals(False)
 
     def update_ylim(self, _):
-        self.ax.set_ylim(self.y_min.value(), self.y_max.value(), emit=False)
+        y_min = self.y_min.value()
+        y_max = self.y_max.value()
+        if self.nonorthogonal_mode:
+            y_min = self.nonortho_transform.tr(0, y_min)[1]
+            y_max = self.nonortho_transform.tr(0, y_max)[1]
+        self.ax.set_ylim(y_min, y_max, emit=False)
         self.on_data_limits_changed()
 
     def create_extents_layout(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -239,6 +239,9 @@ class SliceViewerDataView(QWidget):
         self.fig.add_subplot(self.ax)
         self.plot_MDH = self.plot_MDH_nonorthogonal
 
+        self.ax.callbacks.connect("xlim_changed", self.xlim_changed)
+        self.ax.callbacks.connect("ylim_changed", self.ylim_changed)
+
         self.canvas.draw_idle()
 
     def enable_zoom_on_mouse_scroll(self, redraw):


### PR DESCRIPTION
This allows you to view and update the x and y limits of the image easily. The value should update if you zoom or pan. Changing a value will update the plot with the new limits. This is to make these more accessible then the previous method of double clicking the axis values.

I have place the new boxes where I thought most appropriate but are open to moving them if someone has a better suggestion.

![sliceviewer_extents](https://github.com/mantidproject/mantid/assets/5595210/69f48cf9-8a19-4240-a6ed-6d25ce078d4e)



### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [EMW977](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=977)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Open any MDHistoWorkspace, MDEventWorkspace or MatrixWorkspace with sliceviewer, pan or zoom and check that the values update, change a x/y min/max and check that the plot limits are updated.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
