### PR TITLE
37107 findsxpeaks peak size validation

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/FindSXPeaksHelper.h
+++ b/Framework/Crystal/inc/MantidCrystal/FindSXPeaksHelper.h
@@ -159,7 +159,7 @@ public:
   virtual ~PeakFindingStrategy() = default;
   PeakList findSXPeaks(const HistogramData::HistogramX &x, const HistogramData::HistogramY &y,
                        const HistogramData::HistogramE &e, const int workspaceIndex) const;
-  void setMinBinsForAPeak(int minBinsForAPeak);
+  void setMinNBinsPerPeak(int minBinsPerPeak);
 
 protected:
   void filterPeaksForMinBins(std::vector<std::unique_ptr<PeakContainer>> &inputPeakList) const;
@@ -179,7 +179,7 @@ protected:
   const double m_maxValue = EMPTY_DBL();
   const API::SpectrumInfo &m_spectrumInfo;
   const XAxisUnit m_units;
-  int m_minBinsForPeak = EMPTY_INT();
+  int m_minNBinsPerPeak = EMPTY_INT();
 };
 
 class MANTID_CRYSTAL_DLL StrongestPeaksStrategy : public PeakFindingStrategy {
@@ -269,13 +269,13 @@ public:
   virtual std::vector<SXPeak> reduce(const std::vector<SXPeak> &peaks,
                                      Mantid::Kernel::ProgressBase &progress) const = 0;
 
-  void setMinSpectrasForPeak(int minSpectrasForPeak);
-  void setMaxSpectrasForPeak(int maxSpectrasForPeak);
+  void setMinNSpectraPerPeak(int minSpectrasForPeak);
+  void setMaxNSpectraPerPeak(int maxSpectrasForPeak);
 
 protected:
   const CompareStrategy *m_compareStrategy;
-  int m_minSpectrasForPeak = EMPTY_INT();
-  int m_maxSpectrasForPeak = EMPTY_INT();
+  int m_minNSpectraPerPeak = EMPTY_INT();
+  int m_maxNSpectraPerPeak = EMPTY_INT();
 };
 
 class MANTID_CRYSTAL_DLL SimpleReduceStrategy : public ReducePeakListStrategy {

--- a/Framework/Crystal/inc/MantidCrystal/FindSXPeaksHelper.h
+++ b/Framework/Crystal/inc/MantidCrystal/FindSXPeaksHelper.h
@@ -157,8 +157,11 @@ public:
   virtual ~PeakFindingStrategy() = default;
   PeakList findSXPeaks(const HistogramData::HistogramX &x, const HistogramData::HistogramY &y,
                        const HistogramData::HistogramE &e, const int workspaceIndex) const;
+  void setMinBinsForAPeak(int minBinsForAPeak);
 
 protected:
+  void filterPeaksForMinBins(std::vector<std::unique_ptr<PeakContainer>> &inputPeakList) const;
+
   BoundsIterator getBounds(const HistogramData::HistogramX &x) const;
   double calculatePhi(size_t workspaceIndex) const;
   double getXValue(const HistogramData::HistogramX &x, const size_t peakLocation) const;
@@ -174,6 +177,7 @@ protected:
   const double m_maxValue = EMPTY_DBL();
   const API::SpectrumInfo &m_spectrumInfo;
   const XAxisUnit m_units;
+  int m_minBinsForPeak = EMPTY_INT();
 };
 
 class MANTID_CRYSTAL_DLL StrongestPeaksStrategy : public PeakFindingStrategy {

--- a/Framework/Crystal/inc/MantidCrystal/FindSXPeaksHelper.h
+++ b/Framework/Crystal/inc/MantidCrystal/FindSXPeaksHelper.h
@@ -70,6 +70,8 @@ public:
 
   detid_t getDetectorId() const;
 
+  const std::vector<int> &getPeakSpectras() const;
+
 private:
   /// TOF for the peak centre
   double m_tof;
@@ -267,14 +269,22 @@ public:
   virtual std::vector<SXPeak> reduce(const std::vector<SXPeak> &peaks,
                                      Mantid::Kernel::ProgressBase &progress) const = 0;
 
+  void setMinSpectrasForPeak(int minSpectrasForPeak);
+  void setMaxSpectrasForPeak(int maxSpectrasForPeak);
+
 protected:
   const CompareStrategy *m_compareStrategy;
+  int m_minSpectrasForPeak = EMPTY_INT();
+  int m_maxSpectrasForPeak = EMPTY_INT();
 };
 
 class MANTID_CRYSTAL_DLL SimpleReduceStrategy : public ReducePeakListStrategy {
 public:
   SimpleReduceStrategy(const CompareStrategy *compareStrategy);
   std::vector<SXPeak> reduce(const std::vector<SXPeak> &peaks, Mantid::Kernel::ProgressBase &progress) const override;
+
+private:
+  void reducePeaksFromNumberOfSpectras(std::vector<SXPeak> &inputPeaks) const;
 };
 
 class MANTID_CRYSTAL_DLL FindMaxReduceStrategy : public ReducePeakListStrategy {

--- a/Framework/Crystal/src/FindSXPeaks.cpp
+++ b/Framework/Crystal/src/FindSXPeaks.cpp
@@ -297,9 +297,9 @@ void FindSXPeaks::exec() {
   entries.reserve(m_MaxWsIndex - m_MinWsIndex);
   // Count the peaks so that we can resize the peak vector at the end.
 
-  // PARALLEL_FOR_IF(Kernel::threadSafe(*localworkspace))
+  PARALLEL_FOR_IF(Kernel::threadSafe(*localworkspace))
   for (auto wsIndex = static_cast<int>(m_MinWsIndex); wsIndex <= static_cast<int>(m_MaxWsIndex); ++wsIndex) {
-    // PARALLEL_START_INTERRUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // If no detector found / monitor, skip onto the next spectrum
     const auto wsIndexSize_t = static_cast<size_t>(wsIndex);
@@ -318,12 +318,11 @@ void FindSXPeaks::exec() {
       continue;
     }
 
-    // PARALLEL_CRITICAL(entries) { std::copy(foundPeaks->cbegin(), foundPeaks->cend(), std::back_inserter(entries)); }
-    { std::copy(foundPeaks->cbegin(), foundPeaks->cend(), std::back_inserter(entries)); }
+    PARALLEL_CRITICAL(entries) { std::copy(foundPeaks->cbegin(), foundPeaks->cend(), std::back_inserter(entries)); }
     progress.report();
-    // PARALLEL_END_INTERRUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  // PARALLEL_CHECK_INTERRUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Now reduce the list with duplicate entries
   reducePeakList(entries, progress);

--- a/Framework/Crystal/src/FindSXPeaks.cpp
+++ b/Framework/Crystal/src/FindSXPeaks.cpp
@@ -228,8 +228,8 @@ std::map<std::string, std::string> FindSXPeaks::validateInputs() {
     validationOutput["XResolution"] = "XResolution must be set to a value greater than 0";
   }
 
-  const int minNSpectraPerPeak = static_cast<int>(getProperty("MinNSpectraPerPeak"));
-  const int maxNSpectraPerPeak = static_cast<int>(getProperty("MaxNSpectraPerPeak"));
+  const int minNSpectraPerPeak = getProperty("MinNSpectraPerPeak");
+  const int maxNSpectraPerPeak = getProperty("MaxNSpectraPerPeak");
   if (!isEmpty(minNSpectraPerPeak) && !isEmpty(maxNSpectraPerPeak)) {
     if (maxNSpectraPerPeak < minNSpectraPerPeak) {
       validationOutput["MaxNSpectraPerPeak"] = "MaxNSpectraPerPeak must be greater than MinNSpectraPerPeak";
@@ -239,8 +239,8 @@ std::map<std::string, std::string> FindSXPeaks::validateInputs() {
 
   MatrixWorkspace_const_sptr inputWorkspace = getProperty("InputWorkspace");
   if (inputWorkspace) {
-    int minWsIndex = static_cast<int>(getProperty("StartWorkspaceIndex"));
-    int maxWsIndex = static_cast<int>(getProperty("EndWorkspaceIndex"));
+    const int minWsIndex = getProperty("StartWorkspaceIndex");
+    const int maxWsIndex = getProperty("EndWorkspaceIndex");
     size_t numberOfSpectraToConsider =
         !isEmpty(minWsIndex) ? (!isEmpty(maxWsIndex) ? (maxWsIndex - minWsIndex + 1)
                                                      : (inputWorkspace->getNumberHistograms() - minWsIndex))
@@ -260,7 +260,7 @@ std::map<std::string, std::string> FindSXPeaks::validateInputs() {
       }
     }
 
-    const int minNBinsPerPeak = static_cast<int>(getProperty("MinNBinsPerPeak"));
+    const int minNBinsPerPeak = getProperty("MinNBinsPerPeak");
     if (!isEmpty(minNBinsPerPeak)) {
       if (minNBinsPerPeak > inputWorkspace->getMaxNumberBins()) {
         validationOutput["MinNBinsPerPeak"] =
@@ -327,7 +327,7 @@ void FindSXPeaks::exec() {
   auto peakFindingStrategy =
       getPeakFindingStrategy(backgroundStrategy.get(), spectrumInfo, m_MinRange, m_MaxRange, xUnit);
 
-  const int minNBinsPerPeak = static_cast<int>(getProperty("MinNBinsPerPeak"));
+  const int minNBinsPerPeak = getProperty("MinNBinsPerPeak");
   if (!isEmpty(minNBinsPerPeak)) {
     peakFindingStrategy->setMinNBinsPerPeak(minNBinsPerPeak);
   }
@@ -382,12 +382,12 @@ void FindSXPeaks::reducePeakList(const peakvector &pcv, Progress &progress) {
   auto compareStrategy = getCompareStrategy();
   auto reductionStrategy = getReducePeakListStrategy(compareStrategy.get());
 
-  const int minNSpectraPerPeak = static_cast<int>(getProperty("MinNSpectraPerPeak"));
+  const int minNSpectraPerPeak = getProperty("MinNSpectraPerPeak");
   if (!isEmpty(minNSpectraPerPeak)) {
     reductionStrategy->setMinNSpectraPerPeak(minNSpectraPerPeak);
   }
 
-  const int maxNSpectraPerPeak = static_cast<int>(getProperty("MaxNSpectraPerPeak"));
+  const int maxNSpectraPerPeak = getProperty("MaxNSpectraPerPeak");
   if (!isEmpty(maxNSpectraPerPeak)) {
     reductionStrategy->setMaxNSpectraPerPeak(maxNSpectraPerPeak);
   }

--- a/Framework/Crystal/src/FindSXPeaksHelper.cpp
+++ b/Framework/Crystal/src/FindSXPeaksHelper.cpp
@@ -665,6 +665,10 @@ std::vector<SXPeak> SimpleReduceStrategy::reduce(const std::vector<SXPeak> &peak
 }
 
 void SimpleReduceStrategy::reducePeaksFromNumberOfSpectras(std::vector<SXPeak> &inputPeaks) const {
+  if (m_minNSpectraPerPeak == EMPTY_INT() && m_maxNSpectraPerPeak == EMPTY_INT()) {
+    return;
+  }
+
   for (auto peakIt = inputPeaks.begin(); peakIt != inputPeaks.end();) {
     if (((m_minNSpectraPerPeak != EMPTY_INT()) && ((*peakIt).getPeakSpectras().size() < m_minNSpectraPerPeak)) ||
         ((m_maxNSpectraPerPeak != EMPTY_INT()) && ((*peakIt).getPeakSpectras().size() > m_maxNSpectraPerPeak))) {

--- a/Framework/Crystal/src/FindSXPeaksHelper.cpp
+++ b/Framework/Crystal/src/FindSXPeaksHelper.cpp
@@ -239,7 +239,7 @@ size_t PeakContainer::getNumberOfPointsInPeak() const {
     return 0;
   }
   if (m_stopIndex >= m_startIndex) {
-    return m_stopIndex - m_startIndex;
+    return m_stopIndex - m_startIndex + 1;
   }
   return 0;
 }

--- a/Framework/Crystal/test/FindSXPeaksHelperTest.h
+++ b/Framework/Crystal/test/FindSXPeaksHelperTest.h
@@ -160,7 +160,7 @@ public:
     // WHEN
     auto peakFindingStrategy = std::make_unique<AllPeaksStrategy>(backgroundStrategy.get(), spectrumInfo);
     if (minBinWidth != Mantid::EMPTY_INT())
-      peakFindingStrategy->setMinBinsForAPeak(minBinWidth);
+      peakFindingStrategy->setMinNBinsPerPeak(minBinWidth);
     return peakFindingStrategy->findSXPeaks(x, y, e, workspaceIndex);
   }
 
@@ -239,7 +239,7 @@ public:
     // WHEN
     auto peakFindingStrategy = std::make_unique<NSigmaPeaksStrategy>(spectrumInfo, nsigma);
     if (minBinWidth != Mantid::EMPTY_INT()) {
-      peakFindingStrategy->setMinBinsForAPeak(minBinWidth);
+      peakFindingStrategy->setMinNBinsPerPeak(minBinWidth);
     }
 
     auto peaks = peakFindingStrategy->findSXPeaks(x, y, e, workspaceIndex);

--- a/Framework/Crystal/test/FindSXPeaksHelperTest.h
+++ b/Framework/Crystal/test/FindSXPeaksHelperTest.h
@@ -143,11 +143,45 @@ public:
     TSM_ASSERT("The second peak should have a signal value of 11.", peaks.get()[1].getIntensity() == 11.);
   }
 
-  void testThatFindAllPeaksNSigmaFindPeaks_1() {
+  PeakList runFindAllPeaksWithMinBinWidth(const std::unique_ptr<BackgroundStrategy> backgroundStrategy,
+                                          int minBinWidth = Mantid::EMPTY_INT()) {
+    // GIVEN
+    // auto backgroundStrategy = std::make_unique<AbsoluteBackgroundStrategy>(3.);
+    auto workspace = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(2 /*nhist*/, 15 /*nbins*/);
+    const int workspaceIndex = 1;
+    auto &mutableY = workspace->mutableY(workspaceIndex);
+    doAddDoublePeakToData(mutableY);
+
+    const auto &x = workspace->x(workspaceIndex);
+    const auto &y = workspace->y(workspaceIndex);
+    const auto &e = workspace->e(workspaceIndex);
+    const auto &spectrumInfo = workspace->spectrumInfo();
+
+    // WHEN
+    auto peakFindingStrategy = std::make_unique<AllPeaksStrategy>(backgroundStrategy.get(), spectrumInfo);
+    if (minBinWidth != Mantid::EMPTY_INT())
+      peakFindingStrategy->setMinBinsForAPeak(minBinWidth);
+    return peakFindingStrategy->findSXPeaks(x, y, e, workspaceIndex);
+  }
+
+  void testWhenFindsAllPeaksWithMinimumBinWidthSpecified() {
+    auto peaks = runFindAllPeaksWithMinBinWidth(std::make_unique<AbsoluteBackgroundStrategy>(3.0), 4);
+
+    TSM_ASSERT("There should be only one peak found.", peaks.get().size() == 1);
+    TSM_ASSERT("The only peak should have a signal value of 7.", peaks.get()[0].getIntensity() == 7.);
+  }
+
+  void testAllPeaksWithMinimumBinWidthSpecifiedFindsNoPeaks() {
+    auto peaks = runFindAllPeaksWithMinBinWidth(std::make_unique<AbsoluteBackgroundStrategy>(3.0), 5);
+
+    ETS_ASSERT_EQUALS(peaks.is_initialized(), false);
+  }
+
+  void testThatFindAllPeaksNSigmaFindPeaks() {
     // GIVEN
     std::vector<double> newYValues = {1.5, 2.0, 10.0, 11.0, 14.0, 9.0, 1.5, 1.5, 1.5, 6.0, 9.0, 19.0, 21.5, 1.5, 1.5};
     std::vector<double> newErrorValues = {1.5, 2.0, 2.0, 5.0, 7.0, 1.5, 1.5, 1.5, 1.5, 3.0, 4.0, 3.0, 2.5, 2.5, 1.5};
-    auto peaks = AllPeaksNSigma(newYValues, newErrorValues, 3.0);
+    auto peaks = runAllPeaksNSigma(newYValues, newErrorValues, 3.0);
 
     // THEN
     TSM_ASSERT("There should be two peaks that are found.", peaks.get().size() == 2);
@@ -155,27 +189,40 @@ public:
     TSM_ASSERT("The second peak should have a signal value of 21.5", peaks.get()[1].getIntensity() == 21.5);
   }
 
-  void testThatFindAllPeaksNSigmaFindPeaksAtEnd() {
+  void testThatFindAllPeaksNSigmaFindPeaksWithMinBinWidthRequired() {
+    // GIVEN
+    std::vector<double> newYValues = {1.5, 2.0, 10.0, 11.0, 14.0, 11.0, 9.5, 1.5,
+                                      1.5, 6.0, 9.0,  19.0, 21.5, 20.5, 19.5};
+    std::vector<double> newErrorValues = {1.5, 2.0, 2.0, 5.0, 7.0, 5.5, 6.5, 1.5, 1.5, 3.0, 4.0, 3.0, 12.5, 7.5, 8.5};
+
+    auto peaks = runAllPeaksNSigma(newYValues, newErrorValues, 3.0, 4);
+
+    // THEN
+    TSM_ASSERT("There should be two peaks that are found.", peaks.get().size() == 1);
+    TSM_ASSERT("The first peak should have a signal value of 14.", peaks.get()[0].getIntensity() == 14.);
+  }
+
+  void testThatFindAllPeaksNSigmaFindPeaksAtBoundary() {
     // GIVEN
     std::vector<double> newYValues = {1.5, 2.0, 10.0, 11.0, 14.0, 9.0, 1.5, 1.5, 1.5, 6.0, 9.0, 19.0, 21.5, 22.5, 23.5};
     std::vector<double> newErrorValues = {1.5, 2.0, 5.0, 5.0, 7.0, 1.5, 1.5, 1.5, 1.5, 3.0, 4.0, 3.0, 2.5, 2.5, 1.5};
-    auto peaks = AllPeaksNSigma(newYValues, newErrorValues, 3.0);
+    auto peaks = runAllPeaksNSigma(newYValues, newErrorValues, 3.0);
 
     // THEN
     TSM_ASSERT("There should be two peaks that are found.", peaks.get().size() == 1);
     TSM_ASSERT("The second peak should have a signal value of 21.5", peaks.get()[0].getIntensity() == 23.5);
   }
 
-  void testThatFindAllPeaksNSigmaFindNoPeaks() {
+  void testWhenAllPeaksNSigmaFindsNoPeaks() {
     std::vector<double> newYValues = {1.5, 2.0, 10.0, 11.0, 14.0, 9.0, 1.5, 1.5, 1.5, 6.0, 9.0, 19.0, 21.5, 1.5, 1.5};
     std::vector<double> newErrorValues = {1.5, 2.0, 5.0, 5.0, 7.0, 1.5, 1.5, 1.5, 1.5, 3.0, 2.0, 4.0, 6.5, 2.5, 1.5};
-    auto peaks = AllPeaksNSigma(newYValues, newErrorValues, 3.0);
+    auto peaks = runAllPeaksNSigma(newYValues, newErrorValues, 3.0);
 
     ETS_ASSERT_EQUALS(peaks.is_initialized(), false);
   }
 
-  PeakList AllPeaksNSigma(const std::vector<double> &newYValues, const std::vector<double> &newEValues,
-                          const double nsigma) {
+  PeakList runAllPeaksNSigma(const std::vector<double> &newYValues, const std::vector<double> &newEValues,
+                             const double nsigma, int minBinWidth = Mantid::EMPTY_INT()) {
     // GIVEN
     auto workspace = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(2 /*nhist*/, 15 /*nbins*/);
     const int workspaceIndex = 1;
@@ -191,6 +238,10 @@ public:
 
     // WHEN
     auto peakFindingStrategy = std::make_unique<NSigmaPeaksStrategy>(spectrumInfo, nsigma);
+    if (minBinWidth != Mantid::EMPTY_INT()) {
+      peakFindingStrategy->setMinBinsForAPeak(minBinWidth);
+    }
+
     auto peaks = peakFindingStrategy->findSXPeaks(x, y, e, workspaceIndex);
     return peaks;
   }

--- a/Framework/Crystal/test/FindSXPeaksTest.h
+++ b/Framework/Crystal/test/FindSXPeaksTest.h
@@ -181,7 +181,7 @@ public:
     makeOnePeak(3, 45, 2, workspace);
 
     auto alg = createFindSXPeaks(workspace);
-    alg->setProperty("MinSpectrumsForAPeak", 2);
+    alg->setProperty("MinNSpectraPerPeak", 2);
     alg->execute();
     TSM_ASSERT("FindSXPeak should have been executed.", alg->isExecuted());
 
@@ -199,7 +199,7 @@ public:
     makeOnePeak(3, 45, 2, workspace);
 
     auto alg = createFindSXPeaks(workspace);
-    alg->setProperty("MaxSpectrumsForAPeak", 3);
+    alg->setProperty("maxNSpectraPerPeak", 3);
     alg->execute();
     TSM_ASSERT("FindSXPeak should have been executed.", alg->isExecuted());
 

--- a/Framework/Crystal/test/FindSXPeaksTest.h
+++ b/Framework/Crystal/test/FindSXPeaksTest.h
@@ -172,6 +172,56 @@ public:
     TSM_ASSERT_EQUALS("Wrong peak intensity matched on found peak", 60, results[2]);
   }
 
+  void testWhenMinSpectrasNotFound() {
+    // creates a workspace where all y-values are 2
+    Workspace2D_sptr workspace = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(10, 10);
+    // Stick three peaks in different histograms.
+    makeOnePeak(1, 40, 2, workspace);
+    makeOnePeak(2, 60, 2, workspace);
+    makeOnePeak(3, 45, 2, workspace);
+
+    auto alg = createFindSXPeaks(workspace);
+    alg->setProperty("MinSpectrumsForAPeak", 2);
+    alg->execute();
+    TSM_ASSERT("FindSXPeak should have been executed.", alg->isExecuted());
+
+    IPeaksWorkspace_sptr result = std::dynamic_pointer_cast<IPeaksWorkspace>(
+        Mantid::API::AnalysisDataService::Instance().retrieve("found_peaks"));
+    TSM_ASSERT_EQUALS("Should have found no peaks!", 0, result->rowCount());
+  }
+
+  void testWhenMaxSpectraSpecified() {
+    // creates a workspace where all y-values are 2
+    Workspace2D_sptr workspace = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(10, 10);
+    // Stick three peaks in different histograms.
+    makeOnePeak(1, 40, 2, workspace);
+    makeOnePeak(2, 60, 2, workspace);
+    makeOnePeak(3, 45, 2, workspace);
+
+    auto alg = createFindSXPeaks(workspace);
+    alg->setProperty("MaxSpectrumsForAPeak", 3);
+    alg->execute();
+    TSM_ASSERT("FindSXPeak should have been executed.", alg->isExecuted());
+
+    IPeaksWorkspace_sptr result = std::dynamic_pointer_cast<IPeaksWorkspace>(
+        Mantid::API::AnalysisDataService::Instance().retrieve("found_peaks"));
+    TSM_ASSERT_EQUALS("Should have found three peaks!", 3, result->rowCount());
+  }
+
+  void updateYAndEData(Mantid::HistogramData::HistogramY &y, const std::vector<double> &newYValues,
+                       Mantid::HistogramData::HistogramE &e, const std::vector<double> &newErrorValues) {
+
+    if (y.size() != newYValues.size() || e.size() != newErrorValues.size()) {
+      throw std::runtime_error("The data sizes don't match. This is a test setup issue. "
+                               "Make sure there is one fake data point per entry in the histogram.");
+    }
+
+    for (size_t index = 0; index < y.size(); ++index) {
+      y[index] = newYValues[index];
+      e[index] = newErrorValues[index];
+    }
+  }
+
   void testSpectrumWithoutUniqueDetectorsDoesNotThrow() {
     const int nHist = 10;
     Workspace2D_sptr workspace = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(nHist, 10);

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -442,7 +442,7 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/CentroidPeaks.c
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/GoniometerAnglesFromPhiRotation.cpp:306
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/LoadIsawSpectrum.cpp:190
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/LoadIsawSpectrum.cpp:191
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/FindSXPeaks.cpp:206
+constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/FindSXPeaks.cpp:216
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp:286
 nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.cpp:95
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.cpp:331

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -442,7 +442,7 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/CentroidPeaks.c
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/GoniometerAnglesFromPhiRotation.cpp:306
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/LoadIsawSpectrum.cpp:190
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/LoadIsawSpectrum.cpp:191
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/FindSXPeaks.cpp:216
+constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/FindSXPeaks.cpp:223
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp:286
 nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.cpp:95
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.cpp:331

--- a/docs/source/release/v6.10.0/Framework/Algorithms/New_features/37107.rst
+++ b/docs/source/release/v6.10.0/Framework/Algorithms/New_features/37107.rst
@@ -1,0 +1,3 @@
+- Validation rules added to FindSXPeaks :ref:`FindSXPeaks <algm-FindSXPeaks-v1>` algorithm to remove spurious peaks due to noise by allowing user to provide additional arguements as below
+- `MinBinsForAPeak`, the Minimum number of bins contributing to a peak in an individual spectrum
+- `MinSpectrumsForAPeak`, `MaxSpectrumsForAPeak` Minimum & Maximum number of spectra contributing to a peak after they are grouped

--- a/docs/source/release/v6.10.0/Framework/Algorithms/New_features/37107.rst
+++ b/docs/source/release/v6.10.0/Framework/Algorithms/New_features/37107.rst
@@ -1,3 +1,3 @@
 - Validation rules added to FindSXPeaks :ref:`FindSXPeaks <algm-FindSXPeaks-v1>` algorithm to remove spurious peaks due to noise by allowing user to provide additional arguements as below
-- `MinBinsForAPeak`, the Minimum number of bins contributing to a peak in an individual spectrum
-- `MinSpectrumsForAPeak`, `MaxSpectrumsForAPeak` Minimum & Maximum number of spectra contributing to a peak after they are grouped
+- `MinNBinsPerPeak`, the Minimum number of bins contributing to a peak in an individual spectrum
+- `MinNSpectraPerPeak`, `MaxNSpectraPerPeak` Minimum & Maximum number of spectra contributing to a peak after they are grouped


### PR DESCRIPTION
### Description of work
`FindSXPeaks` returns spurious peaks due to noise and peaks with a large number of contributing pixels due to powder lines. A set of new parameters were introduced to the algorithm to validate peaks as below.
- `MinBinsForAPeak`, the Minimum number of bins contributing to a peak in an individual spectrum
- `MinSpectrumsForAPeak`, `MaxSpectrumsForAPeak` Minimum & Maximum number of spectra contributing to a peak after they are grouped

Fixes #37107. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->

### To test:

1. Load a workspace (ex: SXD23767)
2. Select FindSXPeaks algorithm from the algorithm pane
3. Select the above workspase as InputWorkspace
4. Pick a `PeakFindingStratergy` of interest, ex:-`AllPeaksNSigma` 
5. Provide values for the new parameters `MinBinsForAPeak`, `MinSpectrumsForAPeak`, and `MaxSpectrumsForAPeak` values for which are independent (other than the validation `MinSpectrumsForAPeak` < `MaxSpectrumsForAPeak`)
6. Enter a name for `OutputWorkspace`
7. Check the results in OutputWorkspace when those parameters are varied, the number of peaks detected should be filtered accordingly. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
