### PR TITLE
35600 avoid overriding blank primary log setting

### DIFF
--- a/docs/source/release/v6.10.0/Diffraction/Engineering/Bugfixes/35600.rst
+++ b/docs/source/release/v6.10.0/Diffraction/Engineering/Bugfixes/35600.rst
@@ -1,0 +1,1 @@
+- Avoid overwriting Blank primary log setting in Engineering diffractions :ref:`Engineering Diffraction interface <Engineering_Diffraction-ref>` fitting tab :ref:`Fitting tab <ui engineering fitting>` when doing a sequential fit.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
@@ -165,7 +165,7 @@ class SettingsPresenter(object):
 
     def save_new_settings(self):
         self._collect_new_settings_from_view()
-        self._save_settings_to_file()
+        self._save_settings_to_file(set_nullables_to_default=False)
 
     def _collect_new_settings_from_view(self):
         self._validate_settings()
@@ -180,7 +180,7 @@ class SettingsPresenter(object):
         self.settings["dSpacing_min"] = self.view.get_dSpacing_min()
 
     def _show_settings_in_view(self):
-        self._validate_settings()
+        self._validate_settings(set_nullables_to_default=False)
         self.view.set_save_location(self.settings["save_location"])
         self.view.set_full_calibration(self.settings["full_calibration"])
         self.view.set_checked_logs(self.settings["logs"])
@@ -198,8 +198,8 @@ class SettingsPresenter(object):
         self.view.find_path_to_gsas2()
         self.validate_gsas2_path()
 
-    def _save_settings_to_file(self):
-        self._validate_settings()
+    def _save_settings_to_file(self, set_nullables_to_default=True):
+        self._validate_settings(set_nullables_to_default)
         self.model.set_settings_dict(self.settings)
         self.savedir_notifier.notify_subscribers(self.settings["save_location"])
 
@@ -216,7 +216,7 @@ class SettingsPresenter(object):
         if name not in self.settings or self.settings[name] == "":
             self.settings[name] = DEFAULT_SETTINGS[name]
 
-    def _validate_settings(self):
+    def _validate_settings(self, set_nullables_to_default=True):
         for key in list(self.settings):
             if key not in DEFAULT_SETTINGS.keys():
                 del self.settings[key]
@@ -229,7 +229,9 @@ class SettingsPresenter(object):
         self.check_and_populate_with_default("save_location")
         self.check_and_populate_with_default("logs")
 
-        self.check_and_populate_with_default("primary_log")
+        if set_nullables_to_default:
+            self.check_and_populate_with_default("primary_log")
+
         # boolean values already checked to be "" or True or False in settings_helper
         self.check_and_populate_with_default("sort_ascending")
         self.check_and_populate_with_default("path_to_gsas2")

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/test/test_settings_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/test/test_settings_presenter.py
@@ -109,6 +109,27 @@ class SettingsPresenterTest(unittest.TestCase):
         self.assertEqual(self.presenter.savedir_notifier.notify_subscribers.call_count, 1)
 
     @patch(dir_path + ".path.isfile")
+    def test_save_blank_primary_log_settings(self, mock_isfile):
+        mock_isfile.return_value = True
+        self.view.get_save_location.return_value = self.settings["save_location"][:]
+        self.view.get_full_calibration.return_value = self.settings["full_calibration"][:]
+        self.view.get_checked_logs.return_value = self.settings["logs"][:]
+        self.view.get_primary_log.return_value = ""
+        self.view.get_ascending_checked.return_value = self.settings["sort_ascending"]
+        self.view.get_peak_function.return_value = self.settings["default_peak"]
+        self.view.get_path_to_gsas2.return_value = self.settings["path_to_gsas2"]
+        self.view.get_timeout.return_value = self.settings["timeout"]
+        self.view.get_dSpacing_min.return_value = self.settings["dSpacing_min"]
+        self.presenter.savedir_notifier = mock.MagicMock()
+
+        self.presenter.save_new_settings()
+
+        self.assertEqual(self.view.close.call_count, 0)
+        self.assertEqual(self.presenter.settings["primary_log"], "")
+        self.model.set_settings_dict.assert_called_with(self.presenter.settings)
+        self.assertEqual(self.presenter.savedir_notifier.notify_subscribers.call_count, 1)
+
+    @patch(dir_path + ".path.isfile")
     def test_show(self, mock_isfile):
         mock_isfile.return_value = True
         self.presenter.settings = self.settings.copy()


### PR DESCRIPTION
### Description of work
Avoid overriding `Blank` `primary log` setting in EngDiff UI. When setting the primary log to blank in settings of fitting tab should mean `Sequential Fit` executes in order the runs were loaded - but the setting is overwritten with the default value on closing and re-opening the settings.

#### Purpose of work
Found during manual testing https://github.com/mantidproject/mantid/issues/35541

Fixes #35600.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
Follow `Test 8` of engineering diffraction's manual testing instructions and should work as instructed when primary log setting is set to Blank at `step 9`
https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html#test-8

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
