### PR TITLE
Fix coverity scan warnings in QENS Fitting interface

### DIFF
--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvFitDataPresenter.cpp
@@ -26,7 +26,7 @@ bool ConvFitDataPresenter::addWorkspaceFromDialog(IAddWorkspaceDialog const *dia
 void ConvFitDataPresenter::addTableEntry(FitDomainIndex row) {
   const auto &name = m_model->getWorkspace(row)->getName();
   auto resolutionVector = m_model->getResolutionsForFit();
-  const auto resolution = resolutionVector.at(row.value).first;
+  const auto &resolution = resolutionVector.at(row.value).first;
   const auto workspaceIndex = m_model->getSpectrum(row);
   const auto range = m_model->getFittingRange(row);
   const auto exclude = m_model->getExcludeRegion(row);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataModel.cpp
@@ -125,7 +125,7 @@ bool FitDataModel::setResolution(const std::string &name, WorkspaceID workspaceI
   bool hasValidValues = true;
   if (!name.empty() && m_adsInstance.doesExist(name)) {
     const auto resolution = m_adsInstance.retrieveWS<Mantid::API::MatrixWorkspace>(name);
-    auto y = resolution->readY(workspaceID.value);
+    const auto &y = resolution->readY(workspaceID.value);
     hasValidValues = std::all_of(y.cbegin(), y.cend(), [](double value) { return value == value; });
 
     if (m_resolutions->size() > workspaceID.value) {
@@ -303,7 +303,7 @@ void FitDataModel::removeDataByIndex(FitDomainIndex fitDomainIndex) {
 }
 
 std::vector<double> FitDataModel::getExcludeRegionVector(WorkspaceID workspaceID, WorkspaceIndex spectrum) const {
-  auto fitData = m_fittingData->at(workspaceID.value);
+  auto const &fitData = m_fittingData->at(workspaceID.value);
   return fitData.excludeRegionsVector(spectrum);
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotModel.cpp
@@ -83,7 +83,8 @@ namespace MantidQt::CustomInterfaces::Inelastic {
 
 using namespace Mantid::API;
 
-FitPlotModel::FitPlotModel() : m_activeWorkspaceID{0}, m_activeWorkspaceIndex{0} {}
+FitPlotModel::FitPlotModel()
+    : m_fittingData(), m_fitOutput(), m_activeWorkspaceID{0}, m_activeWorkspaceIndex{0}, m_activeFunction() {}
 
 FitPlotModel::~FitPlotModel() {}
 
@@ -120,12 +121,12 @@ std::pair<double, double> FitPlotModel::getRange() const {
 }
 
 std::pair<double, double> FitPlotModel::getWorkspaceRange() const {
-  const auto xValues = getWorkspace()->x(0);
+  const auto &xValues = getWorkspace()->x(0);
   return {xValues.front(), xValues.back()};
 }
 
 std::pair<double, double> FitPlotModel::getResultRange() const {
-  const auto xValues = getResultWorkspace()->x(0);
+  const auto &xValues = getResultWorkspace()->x(0);
   return {xValues.front(), xValues.back()};
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotPresenter.cpp
@@ -92,7 +92,7 @@ void FitPlotPresenter::handleHWHMMinimumChanged(double maximum) {
   m_view->setHWHMMinimum(m_model->calculateHWHMMinimum(maximum));
 }
 
-void FitPlotPresenter::appendLastDataToSelection(std::vector<std::string> displayNames) {
+void FitPlotPresenter::appendLastDataToSelection(std::vector<std::string> const &displayNames) {
   const auto workspaceCount = displayNames.size();
   if (m_view->dataSelectionSize() == workspaceCount) {
     // if adding a spectra to an existing workspace, update all the combo box
@@ -104,7 +104,7 @@ void FitPlotPresenter::appendLastDataToSelection(std::vector<std::string> displa
     m_view->appendToDataSelection(displayNames.back());
 }
 
-void FitPlotPresenter::updateDataSelection(std::vector<std::string> displayNames) {
+void FitPlotPresenter::updateDataSelection(std::vector<std::string> const &displayNames) {
   m_view->clearDataSelection();
   const auto workspaceCount = displayNames.size();
   for (size_t i = 0; i < workspaceCount; ++i) {
@@ -142,7 +142,7 @@ void FitPlotPresenter::enableAllDataSelection() {
 }
 
 void FitPlotPresenter::setFitFunction(Mantid::API::MultiDomainFunction_sptr function) {
-  m_model->setFitFunction(function);
+  m_model->setFitFunction(std::move(function));
 }
 
 void FitPlotPresenter::setFitSingleSpectrumIsFitting(bool fitting) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotPresenter.h
@@ -61,8 +61,8 @@ public:
 
   void setStartX(double value);
   void setEndX(double value);
-  void appendLastDataToSelection(std::vector<std::string> displayNames);
-  void updateDataSelection(std::vector<std::string> displayNames);
+  void appendLastDataToSelection(std::vector<std::string> const &displayNames);
+  void updateDataSelection(std::vector<std::string> const &displayNames);
   void updateAvailableSpectra();
   void updatePlots();
   void updateFit();

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
@@ -588,16 +588,14 @@ void FitTab::handleDataAdded(IAddWorkspaceDialog const *dialog) {
     m_fittingModel->addDefaultParameters();
   }
   updateDataReferences();
-  auto displayNames = m_dataPresenter->createDisplayNames();
-  m_plotPresenter->appendLastDataToSelection(displayNames);
+  m_plotPresenter->appendLastDataToSelection(m_dataPresenter->createDisplayNames());
   updateParameterEstimationData();
 }
 
 void FitTab::handleDataRemoved() {
   m_fittingModel->removeDefaultParameters();
   updateDataReferences();
-  auto displayNames = m_dataPresenter->createDisplayNames();
-  m_plotPresenter->updateDataSelection(displayNames);
+  m_plotPresenter->updateDataSelection(m_dataPresenter->createDisplayNames());
   updateParameterEstimationData();
 }
 
@@ -634,7 +632,7 @@ std::string FitTab::getFitTypeString() const {
   }
 
   std::string fitType{""};
-  for (auto fitFunctionName : FUNCTION_STRINGS) {
+  for (auto const &fitFunctionName : FUNCTION_STRINGS) {
     auto occurances = getNumberOfCustomFunctions(fitFunctionName.first);
     if (occurances > 0) {
       fitType += std::to_string(occurances) + fitFunctionName.second;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FqFitDataPresenter.cpp
@@ -376,9 +376,12 @@ void FqFitDataPresenter::setActiveEISF(std::size_t eisfIndex, WorkspaceID worksp
 void FqFitDataPresenter::addTableEntry(FitDomainIndex row) {
   const auto &name = m_model->getWorkspace(row)->getName();
 
-  auto subIndices = m_model->getSubIndices(row);
+  const auto subIndices = m_model->getSubIndices(row);
   const auto workspace = m_model->getWorkspace(subIndices.first);
   const auto axis = dynamic_cast<Mantid::API::TextAxis const *>(workspace->getAxis(1));
+  if (!axis) {
+    return;
+  }
   const auto parameter = axis->label(subIndices.second.value);
 
   const auto workspaceIndex = m_model->getSpectrum(row);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FunctionTemplateView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FunctionTemplateView.cpp
@@ -32,7 +32,9 @@
 
 namespace MantidQt::CustomInterfaces::Inelastic {
 
-FunctionTemplateView::FunctionTemplateView() : QWidget(), m_parameterNames(), m_decimals(6) {}
+FunctionTemplateView::FunctionTemplateView()
+    : QWidget(), m_boolManager(), m_intManager(), m_doubleManager(), m_stringManager(), m_enumManager(),
+      m_groupManager(), m_parameterManager(), m_parameterNames(), m_browser(), m_presenter() {}
 
 FunctionTemplateView::~FunctionTemplateView() {
   m_browser->unsetFactoryForManager(m_stringManager);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FunctionTemplateView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FunctionTemplateView.h
@@ -124,9 +124,6 @@ protected:
   /// Qt property browser which displays properties
   QtTreePropertyBrowser *m_browser;
 
-  /// Precision of doubles in m_doubleManager
-  const int m_decimals;
-
   /// The corresponding template presenter
   ITemplatePresenter *m_presenter;
 };

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/MultiFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/MultiFunctionTemplateModel.cpp
@@ -255,7 +255,7 @@ std::optional<ParamID> MultiFunctionTemplateModel::getParameterId(std::string co
     if (paramNameFromID && parameterName == *paramNameFromID)
       result = pid;
   };
-  applyParameterFunction(getter);
+  applyParameterFunction(std::move(getter));
   return result;
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/MultiFunctionTemplateView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/MultiFunctionTemplateView.cpp
@@ -82,7 +82,7 @@ void MultiFunctionTemplateView::createFunctionParameterProperties() {
         m_parameterMap[prop] = id;
         m_parameterReverseMap[id] = prop;
       }
-      parameters[index] = props;
+      parameters[index] = std::move(props);
     }
     QtProperty *subTypeProp;
     if (subType->isType(typeid(int))) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/SingleFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/SingleFunctionTemplateModel.cpp
@@ -47,7 +47,7 @@ void SingleFunctionTemplateModel::updateAvailableFunctions(
   m_fitTypeToFunctionStore.clear();
   m_globalParameterStore.clear();
   m_fitTypeList.clear();
-  for (auto functionInfo : functionInitialisationStrings) {
+  for (auto const &functionInfo : functionInitialisationStrings) {
     IFunction_sptr function;
     try {
       function = FunctionFactory::Instance().createInitialized(functionInfo.second);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/TemplateSubType.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/TemplateSubType.h
@@ -83,7 +83,7 @@ template <class Type> struct TemplateSubTypeImpl : public TemplateSubType {
   QList<std::string> getParameterDescriptions(int typeIndex) const override {
     auto const type = static_cast<Type>(typeIndex);
     QList<std::string> descriptions;
-    auto const function = g_typeMap[type].function;
+    auto const &function = g_typeMap[type].function;
     if (!function.empty()) {
       Mantid::API::IFunction_sptr fun = Mantid::API::FunctionFactory::Instance().createFunction(function);
       auto fillDescriptions = [&descriptions, &fun](ParamID id) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
@@ -53,7 +53,8 @@ struct ScopedSignalBlocker {
  * @param mantidui :: The UI form for MantidPlot
  */
 InelasticFitPropertyBrowser::InelasticFitPropertyBrowser(QWidget *parent)
-    : QDockWidget(parent), m_templatePresenter(nullptr), m_functionWidget(nullptr) {
+    : QDockWidget(parent), m_mainLayout(), m_functionBrowser(), m_fitOptionsBrowser(), m_templatePresenter(),
+      m_fitStatusWidget(), m_functionWidget(), m_browserSwitcher(), m_fitStatus(), m_fitChiSquared() {
   setFeatures(QDockWidget::DockWidgetFloatable);
   setWindowTitle("Fit Function");
 }
@@ -99,7 +100,7 @@ MultiDomainFunction_sptr InelasticFitPropertyBrowser::getGlobalFunction() const 
     return temp;
   } else if (fun) {
     MultiDomainFunction_sptr multiFunction = std::make_shared<MultiDomainFunction>();
-    multiFunction->addFunction(fun);
+    multiFunction->addFunction(std::move(fun));
     multiFunction->setDomainIndex(0, 0);
     return multiFunction;
   } else {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ParameterEstimation.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ParameterEstimation.cpp
@@ -46,8 +46,8 @@ parameterEstimateSetter(FunctionParameterEstimation::ParameterEstimator estimato
   };
 }
 
-FunctionParameterEstimation::FunctionParameterEstimation(
-    std::unordered_map<std::string, ParameterEstimator> estimators) {
+FunctionParameterEstimation::FunctionParameterEstimation(std::unordered_map<std::string, ParameterEstimator> estimators)
+    : m_funcMap() {
   for (auto it = estimators.cbegin(); it != estimators.cend(); ++it) {
     addParameterEstimationFunction(it->first, parameterEstimateSetter(it->second));
   }


### PR DESCRIPTION
### Description of work
This PR fixes several coverity scan warnings after renaming many of the QENSFitting files.

### To test:
Code review and make sure the tests are passing

*This does not require release notes* because **it is fixing internal coverity warnings**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
