### PR TITLE
Add table view for group peak workspace

### DIFF
--- a/Framework/API/inc/MantidAPI/WorkspaceGroup.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceGroup.h
@@ -69,8 +69,10 @@ public:
   /// This method returns true if the group is empty (no member workspace)
   bool isEmpty() const;
   bool areNamesSimilar() const;
-  /// Inidicates that the workspace group can be treated as multiperiod.
+  /// Indicates that the workspace group can be treated as multiperiod.
   bool isMultiperiod() const;
+  /// Check if the workspace group contains just peak workspaces
+  bool isGroupPeaksWorkspaces() const;
   /// Check if a workspace is included in this group or any nested groups.
   bool isInGroup(const Workspace &workspaceToCheck, size_t level = 0) const;
   /// Prints the group to the screen using the logger at debug

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidKernel/IPropertyManager.h"
@@ -456,6 +457,14 @@ bool WorkspaceGroup::isMultiperiod() const {
 }
 
 /**
+ * @return :: True if all of the workspaces in the group are peak workspaces
+ */
+bool WorkspaceGroup::isGroupPeaksWorkspaces() const {
+  return std::all_of(m_workspaces.begin(), m_workspaces.end(),
+                     [](auto ws) { return dynamic_cast<IPeaksWorkspace *>(ws.get()) != nullptr; });
+}
+
+/**
  * @param workspaceToCheck :: A workspace to check.
  * @param level :: The current nesting level. Intended for internal use only
  * by WorkspaceGroup.
@@ -471,7 +480,7 @@ bool WorkspaceGroup::isInGroup(const Workspace &workspaceToCheck, size_t level) 
   for (const auto &workspace : m_workspaces) {
     if (workspace.get() == &workspaceToCheck)
       return true;
-    auto *group = dynamic_cast<WorkspaceGroup *>(workspace.get());
+    const auto *group = dynamic_cast<WorkspaceGroup *>(workspace.get());
     if (group) {
       if (group->isInGroup(workspaceToCheck, level + 1))
         return true;
@@ -503,7 +512,7 @@ namespace Mantid::Kernel {
 template <>
 MANTID_API_DLL Mantid::API::WorkspaceGroup_sptr
 IPropertyManager::getValue<Mantid::API::WorkspaceGroup_sptr>(const std::string &name) const {
-  auto *prop = dynamic_cast<PropertyWithValue<Mantid::API::WorkspaceGroup_sptr> *>(getPointerToProperty(name));
+  const auto *prop = dynamic_cast<PropertyWithValue<Mantid::API::WorkspaceGroup_sptr> *>(getPointerToProperty(name));
   if (prop) {
     return *prop;
   } else {
@@ -516,7 +525,7 @@ IPropertyManager::getValue<Mantid::API::WorkspaceGroup_sptr>(const std::string &
 template <>
 MANTID_API_DLL Mantid::API::WorkspaceGroup_const_sptr
 IPropertyManager::getValue<Mantid::API::WorkspaceGroup_const_sptr>(const std::string &name) const {
-  auto *prop = dynamic_cast<PropertyWithValue<Mantid::API::WorkspaceGroup_sptr> *>(getPointerToProperty(name));
+  const auto *prop = dynamic_cast<PropertyWithValue<Mantid::API::WorkspaceGroup_sptr> *>(getPointerToProperty(name));
   if (prop) {
     return prop->operator()();
   } else {

--- a/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
@@ -74,17 +74,13 @@ list retrieveGroupPeaksWorkspaces(AnalysisDataServiceImpl const *const self, con
 
   auto wsSharedPtrs = self->retrieveWorkspaces(Converters::PySequenceToVector<std::string>(names)(), false);
 
-  auto isGroupPeakWorkspace = [](const Workspace_sptr &wksp) {
+  auto isNotGroupPeakWorkspace = [](const Workspace_sptr &wksp) {
     if (auto gws = dynamic_cast<WorkspaceGroup *>(wksp.get())) {
-      for (auto it = gws->begin(); it != gws->end(); it++) {
-        if (auto ws = dynamic_cast<IPeaksWorkspace *>(it->get())) {
-          return false;
-        }
-      }
+      return !gws->isGroupPeaksWorkspaces();
     }
     return true;
   };
-  auto end = std::remove_if(wsSharedPtrs.begin(), wsSharedPtrs.end(), isGroupPeakWorkspace);
+  auto end = std::remove_if(wsSharedPtrs.begin(), wsSharedPtrs.end(), isNotGroupPeakWorkspace);
   wsSharedPtrs.erase(end, wsSharedPtrs.end());
 
   std::vector<WeakPtr> wsWeakPtrs;

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -400,12 +400,10 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorke
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:261
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:268
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/CalculateUMatrix.cpp:65
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/WorkspaceGroup.cpp:78
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/WorkspaceGroup.cpp:437
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/WorkspaceGroup.cpp:474
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/WorkspaceGroup.cpp:519
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/API/src/WorkspaceGroup.cpp:125
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/API/src/WorkspaceGroup.cpp:406
+constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/WorkspaceGroup.cpp:79
+constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/WorkspaceGroup.cpp:438
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/API/src/WorkspaceGroup.cpp:126
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/API/src/WorkspaceGroup.cpp:407
 shadowFunction:${CMAKE_SOURCE_DIR}/Framework/API/src/IFunction.cpp:263
 shadowFunction:${CMAKE_SOURCE_DIR}/Framework/API/src/IFunction.cpp:313
 shadowFunction:${CMAKE_SOURCE_DIR}/Framework/API/src/IFunction.cpp:325

--- a/docs/source/release/v6.12.0/Diffraction/Single_Crystal/New_features/37166.rst
+++ b/docs/source/release/v6.12.0/Diffraction/Single_Crystal/New_features/37166.rst
@@ -1,0 +1,1 @@
+- Added table view for group peaks workspaces, displaying group indices alongside standard peak data, with all the capabilities of a standard table view.

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -295,6 +295,19 @@ class WorkspaceWidget(PluginWidget):
         import matplotlib.pyplot
 
         parent, flags = get_window_config()
+        # Process group peak workspaces first and remove them from the list
+        for ws in self._ads.retrieveGroupPeaksWorkspaces(names):
+            try:
+                TableWorkspaceDisplay.supports(ws)
+                presenter = TableWorkspaceDisplay(ws, plot=matplotlib.pyplot, parent=parent, window_flags=flags, group=True)
+                presenter.show_view()
+                names.remove(ws.name())
+            except ValueError as e:
+                logger.error(str(e))
+                logger.error(
+                    "Could not open workspace: {0} with neither " "MatrixWorkspaceDisplay nor TableWorkspaceDisplay." "".format(ws.name())
+                )
+
         for ws in self._ads.retrieveWorkspaces(names, unrollGroups=True):
             try:
                 MatrixWorkspaceDisplay.supports(ws)

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -170,6 +170,7 @@ set(PYTHON_WIDGET_QT5_ONLY_TESTS
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_error_column.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_group_model.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_group_table_model.py
+    mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_group_presenter.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_marked_columns.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_tableworkspace_item.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -169,6 +169,7 @@ set(PYTHON_WIDGET_QT5_ONLY_TESTS
     mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_io.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_error_column.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_group_model.py
+    mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_group_table_model.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_marked_columns.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_tableworkspace_item.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -168,6 +168,7 @@ set(PYTHON_WIDGET_QT5_ONLY_TESTS
     mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_view.py
     mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_io.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_error_column.py
+    mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_group_model.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_marked_columns.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_tableworkspace_item.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py

--- a/qt/python/mantidqt/mantidqt/widgets/observers/ads_observer.py
+++ b/qt/python/mantidqt/mantidqt/widgets/observers/ads_observer.py
@@ -31,7 +31,7 @@ def _catch_exceptions(func):
 
 
 class WorkspaceDisplayADSObserver(AnalysisDataServiceObserver):
-    def __init__(self, presenter, observe_replace=True):
+    def __init__(self, presenter, observe_replace=True, observe_group_update=False):
         super(WorkspaceDisplayADSObserver, self).__init__()
         self.presenter = presenter
 
@@ -39,6 +39,7 @@ class WorkspaceDisplayADSObserver(AnalysisDataServiceObserver):
         self.observeDelete(True)
         self.observeReplace(observe_replace)
         self.observeRename(True)
+        self.observeGroupUpdate(observe_group_update)
 
     @_catch_exceptions
     def clearHandle(self):
@@ -72,3 +73,7 @@ class WorkspaceDisplayADSObserver(AnalysisDataServiceObserver):
     @_catch_exceptions
     def renameHandle(self, old_name, new_name):
         self.presenter.rename_workspace(old_name, new_name)
+
+    @_catch_exceptions
+    def groupUpdateHandle(self, ws_name, workspace):
+        self.presenter.group_update(ws_name, workspace)

--- a/qt/python/mantidqt/mantidqt/widgets/observers/observing_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/observers/observing_presenter.py
@@ -56,3 +56,6 @@ class ObservingPresenter(object):
     def rename_workspace(self, old_name, new_name):
         if self.model.workspace_equals(old_name):
             self.container.emit_rename(new_name)
+
+    def group_update(self, ws_name, workspace):
+        return

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/group_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/group_model.py
@@ -75,6 +75,9 @@ class GroupTableWorkspaceDisplayModel:
                 if err_for_column >= 0:
                     self.marked_columns.add_y_err(ErrorColumn(col, err_for_column + 2))
 
+    def original_column_headers(self):
+        return self._original_column_headers[:]
+
     def build_current_labels(self):
         return self.marked_columns.build_labels()
 
@@ -137,6 +140,15 @@ class GroupTableWorkspaceDisplayModel:
         elif col_name == "l":
             p.setL(data)
 
+    def get_number_of_rows(self):
+        return self.ws_num_rows
+
+    def get_number_of_columns(self):
+        return self.ws_num_cols
+
+    def workspace_equals(self, workspace_name):
+        return self.ws.name() == workspace_name
+
     def delete_rows(self, selected_rows):
         from mantid.simpleapi import DeleteTableRows
 
@@ -155,6 +167,9 @@ class GroupTableWorkspaceDisplayModel:
 
     def sort(self, column_index, sort_ascending):
         from mantid.simpleapi import SortPeaksWorkspace
+
+        if column_index in [0, 1]:
+            return
 
         column_name = self.get_column_header(column_index)
 

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/group_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/group_model.py
@@ -9,11 +9,11 @@
 from mantid.api import WorkspaceGroup
 from mantidqt.widgets.workspacedisplay.table.error_column import ErrorColumn
 from mantidqt.widgets.workspacedisplay.table.marked_columns import MarkedColumns
-from mantidqt.widgets.workspacedisplay.table.model import TableWorkspaceColumnTypeMapping, TableWorkspaceDisplayModel
+from mantidqt.widgets.workspacedisplay.table.model import TableWorkspaceColumnTypeMapping
 from collections import defaultdict
 
 
-class GroupTableWorkspaceDisplayModel(TableWorkspaceDisplayModel):
+class GroupTableWorkspaceDisplayModel:
     EDITABLE_COLUMN_NAMES = ["h", "k", "l"]
 
     ALLOWED_WORKSPACE_TYPES = [WorkspaceGroup]
@@ -88,6 +88,9 @@ class GroupTableWorkspaceDisplayModel(TableWorkspaceDisplayModel):
         if self.ws.size() != 0:
             return ["WS Index", "Group Index"] + self.ws[0].getColumnNames()
         return []
+
+    def get_column_header(self, index):
+        return self.get_column_headers()[index]
 
     def get_column(self, index):
         column_data = []

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/group_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/group_model.py
@@ -1,0 +1,171 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+# coding=utf-8
+#  This file is part of the mantidqt package.
+from mantid.api import WorkspaceGroup
+from mantidqt.widgets.workspacedisplay.table.error_column import ErrorColumn
+from mantidqt.widgets.workspacedisplay.table.marked_columns import MarkedColumns
+from mantidqt.widgets.workspacedisplay.table.model import TableWorkspaceColumnTypeMapping
+from collections import defaultdict
+
+
+class GroupTableWorkspaceDisplayModel:
+    SPECTRUM_PLOT_LEGEND_STRING = "{}-{}"
+    BIN_PLOT_LEGEND_STRING = "{}-bin-{}"
+    EDITABLE_COLUMN_NAMES = ["h", "k", "l"]
+
+    ALLOWED_WORKSPACE_TYPES = [WorkspaceGroup]
+
+    @classmethod
+    def supports(cls, ws: WorkspaceGroup):
+        """
+        Checks that the provided workspace is supported by this display.
+        :param ws: Workspace to be checked for support
+        :raises ValueError: if the workspace is not supported
+        """
+        if not any(isinstance(ws, allowed_type) for allowed_type in cls.ALLOWED_WORKSPACE_TYPES):
+            raise ValueError("The workspace type is not supported: {0}".format(ws))
+
+    def __init__(self, ws: WorkspaceGroup):
+        """
+        Initialise the model with the workspace
+        :param ws: Workspace to be used for providing data
+        :raises ValueError: if the workspace is not supported
+        """
+        self.supports(ws)
+
+        self.ws: WorkspaceGroup = ws
+        self.ws_num_rows = sum(peakWs.rowCount() for peakWs in ws)
+        self.ws_num_cols = self.ws[0].columnCount() + 1
+        self.marked_columns = MarkedColumns()
+        self._original_column_headers = self.get_column_headers()
+        self.block_model_replace = False
+        # loads the types of the columns
+        for col in range(1, len(self._original_column_headers)):
+            plot_type = self.ws[0].getPlotType(col - 1)
+            if plot_type == TableWorkspaceColumnTypeMapping.X:
+                self.marked_columns.add_x(col)
+            elif plot_type == TableWorkspaceColumnTypeMapping.Y:
+                self.marked_columns.add_y(col)
+            elif plot_type == TableWorkspaceColumnTypeMapping.YERR:
+                err_for_column = self.ws[0].getLinkedYCol(col - 1)
+                if err_for_column >= 0:
+                    self.marked_columns.add_y_err(ErrorColumn(col, err_for_column))
+
+    def _get_group_and_workspace_indcies(self, row_indicies):
+        cumulative_size = 0
+        ws_range_limits = []
+        for peaksWs in self.ws:
+            ws_range_limits.append((cumulative_size, cumulative_size + len(peaksWs)))
+            cumulative_size += len(peaksWs)
+
+        row_to_ws_index = defaultdict(list)
+
+        for row_index in list(map(int, row_indicies.split(","))):
+            for group_index, ws_range_limit in enumerate(ws_range_limits):
+                if row_index >= ws_range_limit[0] and row_index < ws_range_limit[1]:
+                    row_to_ws_index[group_index].append(row_index - ws_range_limit[0])
+                    break
+
+        return row_to_ws_index
+
+    def original_column_headers(self):
+        return self._original_column_headers[:]
+
+    def build_current_labels(self):
+        return self.marked_columns.build_labels()
+
+    def get_name(self):
+        return self.ws.name()
+
+    def get_column_headers(self):
+        return ["Group Index"] + self.ws[0].getColumnNames()
+
+    def get_column(self, index):
+        column_data = []
+
+        for i, ws_item in enumerate(self.ws):
+            if index == 0:
+                column_data.extend([i] * ws_item.rowCount())
+            else:
+                column_data.extend(ws_item.column(index - 1))
+
+        return column_data
+
+    def get_number_of_rows(self):
+        return self.ws_num_rows
+
+    def get_number_of_columns(self):
+        return self.ws_num_cols
+
+    def get_column_header(self, index):
+        return self.get_column_headers()[index]
+
+    def is_editable_column(self, icol):
+        return self.get_column_headers()[icol] in self.EDITABLE_COLUMN_NAMES
+
+    def workspace_equals(self, workspace_name):
+        return self.ws.name() == workspace_name
+
+    def set_column_type(self, col, type, linked_col_index=-1):
+        for peaksWs in self.ws:
+            peaksWs.setPlotType(col, type, linked_col_index)
+
+    def get_cell(self, row, column):
+        row_to_ws_index = self._get_group_and_workspace_indcies(f"{row}")
+
+        group_index, ws_index = next(iter(row_to_ws_index.items()))
+
+        return self.ws[group_index][ws_index]
+
+    def set_cell_data(self, row, col, data, is_v3d):
+        cumulative_size = 0
+        col = col - 1
+        for peaksWs in self.ws:
+            if cumulative_size + len(peaksWs) > row:
+                local_index = row - cumulative_size
+
+                p = peaksWs[local_index]
+                if self.ws.getColumnNames()[col] == "h":
+                    p.setH(data)
+                elif self.ws.getColumnNames()[col] == "k":
+                    p.setK(data)
+                elif self.ws.getColumnNames()[col] == "l":
+                    p.setL(data)
+
+            cumulative_size += len(peaksWs)
+
+    def delete_rows(self, selected_rows):
+        from mantid.simpleapi import DeleteTableRows
+
+        row_to_ws_index = self._get_group_and_workspace_indcies(selected_rows)
+
+        for group_index in row_to_ws_index:
+            DeleteTableRows(self.ws[group_index], ",".join(map(str, row_to_ws_index[group_index])))
+
+    def get_statistics(self, selected_columns):
+
+        from mantid.simpleapi import StatisticsOfTableWorkspace
+
+        stats = StatisticsOfTableWorkspace(self.ws, selected_columns)
+        return stats
+
+    def sort(self, column_index, sort_ascending):
+        from mantid.simpleapi import SortPeaksWorkspace
+
+        if column_index == 0:
+            return
+
+        column_name = self.get_column_headers()[column_index]
+
+        for peakWs in self.ws:
+            SortPeaksWorkspace(
+                InputWorkspace=peakWs,
+                OutputWorkspace=peakWs,
+                ColumnNameToSortBy=column_name,
+                SortAscending=sort_ascending,
+            )

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/group_table_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/group_table_model.py
@@ -1,0 +1,49 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package.
+
+from qtpy.QtCore import Qt
+
+from mantidqt.widgets.workspacedisplay.table.table_model import TableModel
+
+from mantid.kernel import V3D
+from numpy import ndarray
+
+
+class GroupTableModel(TableModel):
+    def __init__(self, data_model, parent=None):
+        super().__init__(data_model, parent=parent)
+
+    def setData(self, index, value, role):
+        if index.isValid() and role == Qt.EditRole:
+            model = index.model()
+            group_index = int(model.data(model.index(index.row(), 0)))
+            ws_index = int(model.data(model.index(index.row(), 1)))
+            row = (group_index, ws_index)
+
+            try:
+                self._data_model.set_cell_data(row, index.column(), value, False)
+            except ValueError:
+                print(self.ITEM_CHANGED_INVALID_DATA_MESSAGE)
+                return False
+            except Exception as x:
+                print(self.ITEM_CHANGED_UNKNOWN_ERROR_MESSAGE.format(x))
+                return False
+            self.dataChanged.emit(index, index)
+            return True
+        else:
+            return False
+
+    def data(self, index, role=Qt.DisplayRole):
+        if not index.isValid():
+            return None
+        if index.row() >= self.max_rows() or index.row() < 0:
+            return None
+        if role in (Qt.DisplayRole, Qt.EditRole):
+            data = self._data_model.get_cell(index.row(), index.column())
+            return str(data) if isinstance(data, (V3D, ndarray)) else data
+        return None

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/group_table_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/group_table_model.py
@@ -21,8 +21,8 @@ class GroupTableModel(TableModel):
     def setData(self, index, value, role):
         if index.isValid() and role == Qt.EditRole:
             model = index.model()
-            group_index = int(model.data(model.index(index.row(), 0)))
-            ws_index = int(model.data(model.index(index.row(), 1)))
+            ws_index = int(model.data(model.index(index.row(), 0)))
+            group_index = int(model.data(model.index(index.row(), 1)))
             row = (group_index, ws_index)
 
             try:

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/group_view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/group_view.py
@@ -1,0 +1,39 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package.
+
+from qtpy.QtCore import Qt, QSortFilterProxyModel
+from mantidqt.widgets.workspacedisplay.table.view import TableWorkspaceDisplayView
+
+
+class GroupTableWorkspaceDisplayView(TableWorkspaceDisplayView):
+    """Specialization of a table view to display peaks
+    Designed specifically to be used by PeaksViewerView
+    """
+
+    def __init__(self, *args, **kwargs):
+        TableWorkspaceDisplayView.__init__(self, *args, **kwargs)
+        self.source_model = TableWorkspaceDisplayView.model(self)
+        self.proxy_model = QSortFilterProxyModel()
+        self.proxy_model.setSourceModel(self.table_model)
+        self.setModel(self.proxy_model)
+
+        # Always hide the ws index column, this column is just used for indexing in different models operations
+        super().hideColumn(0)
+
+    def model(self):
+        return self.source_model
+
+    def sortBySelectedColumn(self, selected_column, sort_ascending):
+        self.sortByColumn(selected_column, Qt.AscendingOrder if sort_ascending else Qt.DescendingOrder)
+
+    def showColumn(self, column_index):
+        # Never show the ws index column, this column is just used for indexing in different models operations
+        if column_index == 0:
+            return
+
+        super().showColumn(column_index)

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/presenter_group.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/presenter_group.py
@@ -32,11 +32,12 @@ class TableWorkspaceDataPresenterGroup(TableWorkspaceDataPresenterBase):
         group_ws_rows = []
         model = self.view.model()
         for row in selected_rows:
-            group_index = int(model.data(model.index(row, 0)))
-            ws_index = int(model.data(model.index(row, 1)))
+            ws_index = int(model.data(model.index(row, 0)))
+            group_index = int(model.data(model.index(row, 1)))
             group_ws_rows.append((group_index, ws_index))
         self.model.delete_rows(group_ws_rows)
 
     def sort(self, selected_column, sort_ascending):
         self.view.sortBySelectedColumn(selected_column, sort_ascending)
         self.sort_data = (selected_column, sort_ascending)
+        self.view.hideColumn(0)

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/presenter_group.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/presenter_group.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
@@ -8,20 +8,35 @@
 from mantidqt.widgets.workspacedisplay.table.presenter_base import TableWorkspaceDataPresenterBase
 
 
-class TableWorkspaceDataPresenterBatch(TableWorkspaceDataPresenterBase):
+class TableWorkspaceDataPresenterGroup(TableWorkspaceDataPresenterBase):
     def __init__(self, view, model):
         super().__init__(view, model)
+        self.sort_data = None
 
     def load_data(self, table):
         table.model().load_data(self.model)
+        if self.sort_data is not None:
+            self.sort(*self.sort_data)
 
     def update_column_headers(self):
         # deep copy the original headers so that they are not changed by the appending of the label
         column_headers = self.model.original_column_headers()
-        table_item_model = self.view.model()
         extra_labels = self.model.build_current_labels()
         if len(extra_labels) > 0:
             for index, label in extra_labels:
                 column_headers[index] += str(label)
 
-        table_item_model.setHorizontalHeaderLabels(column_headers)
+        self.view.model().setHorizontalHeaderLabels(column_headers)
+
+    def delete_rows(self, selected_rows):
+        group_ws_rows = []
+        model = self.view.model()
+        for row in selected_rows:
+            group_index = int(model.data(model.index(row, 0)))
+            ws_index = int(model.data(model.index(row, 1)))
+            group_ws_rows.append((group_index, ws_index))
+        self.model.delete_rows(group_ws_rows)
+
+    def sort(self, selected_column, sort_ascending):
+        self.view.sortBySelectedColumn(selected_column, sort_ascending)
+        self.sort_data = (selected_column, sort_ascending)

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_group_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_group_model.py
@@ -1,0 +1,310 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+import functools
+import unittest
+import sys
+
+from mantid.dataobjects import PeaksWorkspace
+from unittest.mock import Mock
+from mantidqt.utils.testing.mocks.mock_mantid import MockWorkspaceGroup
+from mantidqt.utils.testing.strict_mock import StrictMock
+from mantidqt.widgets.workspacedisplay.table.group_model import (
+    GroupTableWorkspaceDisplayModel,
+)
+from mantidqt.widgets.workspacedisplay.table.model import TableWorkspaceColumnTypeMapping
+
+
+def with_mock_workspace(func):
+    @functools.wraps(func)
+    def wrapper(self):
+        group_ws = MockWorkspaceGroup("group_ws")
+        model = GroupTableWorkspaceDisplayModel(group_ws)
+        return func(self, model)
+
+    return wrapper
+
+
+class GroupTableWorkspaceDisplayModelTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        GroupTableWorkspaceDisplayModel.ALLOWED_WORKSPACE_TYPES.append(MockWorkspaceGroup)
+
+    def test_get_name(self):
+        ws = MockWorkspaceGroup()
+        expected_name = "TEST_WORKSPACE"
+        ws.name = Mock(return_value=expected_name)
+        model = GroupTableWorkspaceDisplayModel(ws)
+
+        self.assertEqual(expected_name, model.get_name())
+
+    def test_raises_with_unsupported_workspace(self):
+        self.assertRaises(ValueError, lambda: GroupTableWorkspaceDisplayModel([]))
+        self.assertRaises(ValueError, lambda: GroupTableWorkspaceDisplayModel(1))
+        self.assertRaises(ValueError, lambda: GroupTableWorkspaceDisplayModel("test_string"))
+
+    @with_mock_workspace
+    def test_set_cell_data_hkl(self, model):
+        peak_ws = Mock(spec=PeaksWorkspace)
+        peak_ws.rowCount.return_value = 10
+        peak_ws.columnCount.read_return = 3
+        peak_ws.getColumnNames.return_value = ["h", "k", "l"]
+        mock_peak = Mock()
+        peak_ws.getPeak.return_value = mock_peak
+        model.ws.append(peak_ws)
+
+        row = (0, 0)
+        HKL = [5, 10, 15]
+        for col in range(0, len(HKL)):
+            model.set_cell_data(row, col + 2, HKL[col], False)
+
+        mock_peak.setH.assert_called_once_with(HKL[0])
+        mock_peak.setK.assert_called_once_with(HKL[1])
+        mock_peak.setL.assert_called_once_with(HKL[2])
+
+    def test_no_raise_with_supported_workspace(self):
+        from mantid.simpleapi import CreateEmptyTableWorkspace, GroupWorkspaces, mtd
+
+        ws = MockWorkspaceGroup()
+        expected_name = "TEST_WORKSPACE"
+        ws.name = Mock(return_value=expected_name)
+
+        # no need to assert anything - if the constructor raises the test will fail
+        GroupTableWorkspaceDisplayModel(ws)
+
+        ws = CreateEmptyTableWorkspace()
+        GroupWorkspaces([ws], OutputWorkspace="group_ws")
+        group_ws = mtd["group_ws"]
+
+        GroupTableWorkspaceDisplayModel(group_ws)
+
+    def test_initialise_marked_columns_one_of_each_type(self):
+        num_of_repeated_columns = 10
+
+        ws = MockWorkspaceGroup()
+        peak_ws = Mock(spec=PeaksWorkspace)
+        peak_ws.rowCount = StrictMock(return_value=10)
+        peak_ws.columnCount = StrictMock(return_value=num_of_repeated_columns * 3)
+        peak_ws.getColumnNames = StrictMock(return_value=["col"] * (num_of_repeated_columns * 3))
+        peak_ws.__len__ = StrictMock(return_value=10)
+
+        mock_column_types = [
+            TableWorkspaceColumnTypeMapping.X,
+            TableWorkspaceColumnTypeMapping.Y,
+            TableWorkspaceColumnTypeMapping.YERR,
+        ] * num_of_repeated_columns
+
+        peak_ws.getPlotType = lambda i: mock_column_types[i]
+        peak_ws.getLinkedYCol = lambda i: i - 1
+        ws.append(peak_ws)
+        model = GroupTableWorkspaceDisplayModel(ws)
+
+        self.assertEqual(num_of_repeated_columns, len(model.marked_columns.as_x))
+        self.assertEqual(num_of_repeated_columns, len(model.marked_columns.as_y))
+        self.assertEqual(num_of_repeated_columns, len(model.marked_columns.as_y_err))
+
+        for i, col in enumerate(range(4, 30, 3)):
+            self.assertEqual(col - 1, model.marked_columns.as_y_err[i].related_y_column)
+
+    def test_initialise_marked_columns_multiple_y_before_yerr(self):
+        ws = MockWorkspaceGroup()
+
+        mock_column_types = [
+            TableWorkspaceColumnTypeMapping.X,
+            TableWorkspaceColumnTypeMapping.Y,
+            TableWorkspaceColumnTypeMapping.YERR,
+            TableWorkspaceColumnTypeMapping.Y,
+            TableWorkspaceColumnTypeMapping.Y,
+            TableWorkspaceColumnTypeMapping.YERR,
+            TableWorkspaceColumnTypeMapping.YERR,
+            TableWorkspaceColumnTypeMapping.X,
+        ]
+
+        peak_ws = Mock(spec=PeaksWorkspace)
+        peak_ws.rowCount = StrictMock(return_value=10)
+        peak_ws.columnCount = StrictMock(return_value=len(mock_column_types))
+        peak_ws.getColumnNames = StrictMock(return_value=["col"] * len(mock_column_types))
+        peak_ws.__len__ = StrictMock(return_value=10)
+        peak_ws.getPlotType = lambda i: mock_column_types[i]
+        peak_ws.getLinkedYCol = StrictMock(side_effect=[1, 3, 4])
+        ws.append(peak_ws)
+
+        model = GroupTableWorkspaceDisplayModel(ws)
+
+        self.assertEqual(2, len(model.marked_columns.as_x))
+        self.assertEqual(3, len(model.marked_columns.as_y))
+        self.assertEqual(3, len(model.marked_columns.as_y_err))
+
+        self.assertEqual(3, model.marked_columns.as_y_err[0].related_y_column)
+        self.assertEqual(5, model.marked_columns.as_y_err[1].related_y_column)
+        self.assertEqual(6, model.marked_columns.as_y_err[2].related_y_column)
+
+    def test_is_editable_column(self):
+        group_ws = MockWorkspaceGroup()
+
+        cols = ["h", "k", "l"]
+        peak_ws = Mock(spec=PeaksWorkspace)
+        peak_ws.rowCount = StrictMock(return_value=10)
+        peak_ws.columnCount = StrictMock(return_value=len(cols))
+        peak_ws.__len__ = StrictMock(return_value=10)
+        peak_ws.getColumnNames = StrictMock(return_value=cols)
+        group_ws.append(peak_ws)
+
+        self.assertTrue(group_ws.size() == 1)
+
+        model = GroupTableWorkspaceDisplayModel(group_ws)
+
+        self.assertListEqual([False, False, True, True, True], [model.is_editable_column(i) for i in range(len(cols) + 2)])
+
+    def test_get_cell(self):
+        group_ws = MockWorkspaceGroup()
+
+        cols = ["h", "k", "l"]
+        peak_ws = Mock(spec=PeaksWorkspace)
+        peak_ws.rowCount = StrictMock(return_value=10)
+        peak_ws.columnCount = StrictMock(return_value=len(cols))
+        peak_ws.__len__ = StrictMock(return_value=10)
+        peak_ws.getColumnNames = StrictMock(return_value=cols)
+        peak_ws.cell = Mock()
+        group_ws.append(peak_ws)
+
+        peak_ws2 = Mock(spec=PeaksWorkspace)
+        peak_ws2.rowCount = StrictMock(return_value=10)
+        peak_ws2.columnCount = StrictMock(return_value=len(cols))
+        peak_ws2.__len__ = StrictMock(return_value=10)
+        peak_ws2.getColumnNames = StrictMock(return_value=cols)
+        peak_ws2.cell = Mock()
+        group_ws.append(peak_ws2)
+
+        model = GroupTableWorkspaceDisplayModel(group_ws)
+
+        model.get_cell(0, 1)
+        peak_ws.cell.assert_not_called()
+
+        model.get_cell(0, 0)
+        peak_ws.cell.assert_not_called()
+
+        model.get_cell(0, 2)
+        peak_ws.cell.assert_called_once_with(0, 0)
+
+        model.get_cell(12, 6)
+        peak_ws2.cell.assert_called_once_with(2, 4)
+
+    def test_set_column_type(self):
+        group_ws = MockWorkspaceGroup()
+
+        cols = ["h", "k", "l"]
+        peak_ws = Mock(spec=PeaksWorkspace)
+        peak_ws.rowCount = StrictMock(return_value=10)
+        peak_ws.columnCount = StrictMock(return_value=len(cols))
+        peak_ws.__len__ = StrictMock(return_value=10)
+        peak_ws.getColumnNames = StrictMock(return_value=cols)
+        peak_ws.setPlotType = Mock()
+        group_ws.append(peak_ws)
+
+        model = GroupTableWorkspaceDisplayModel(group_ws)
+
+        model.set_column_type(2, 0)
+        peak_ws.setPlotType.assert_called_with(0, 0, -1)
+
+        model.set_column_type(2, 1, 2)
+        peak_ws.setPlotType.assert_called_with(0, 1, 0)
+
+    def test_get_column(self):
+        group_ws = MockWorkspaceGroup()
+
+        cols = ["h", "k", "l"]
+        peak_ws = Mock(spec=PeaksWorkspace)
+        peak_ws.rowCount = StrictMock(return_value=10)
+        peak_ws.columnCount = StrictMock(return_value=len(cols))
+        peak_ws.__len__ = StrictMock(return_value=10)
+        peak_ws.getColumnNames = StrictMock(return_value=cols)
+        peak_ws.setPlotType = Mock()
+        peak_ws.column = StrictMock(return_value=[])
+        group_ws.append(peak_ws)
+
+        model = GroupTableWorkspaceDisplayModel(group_ws)
+
+        self.assertListEqual(model.get_column(0), [0] * peak_ws.rowCount())
+        self.assertListEqual(model.get_column(1), [i for i in range(peak_ws.rowCount())])
+
+        model.get_column(2)
+        peak_ws.column.assert_called_once_with(0)
+
+    def test_get_statistics(self):
+        group_ws = MockWorkspaceGroup()
+
+        cols = ["h", "k", "l"]
+        peak_ws = Mock(spec=PeaksWorkspace)
+        peak_ws.rowCount = StrictMock(return_value=10)
+        peak_ws.columnCount = StrictMock(return_value=len(cols))
+        peak_ws.__len__ = StrictMock(return_value=10)
+        peak_ws.getColumnNames = StrictMock(return_value=cols)
+        group_ws.append(peak_ws)
+
+        model = GroupTableWorkspaceDisplayModel(group_ws)
+
+        mock_simpleapi = Mock()
+        mock_simpleapi.StatisticsOfTableWorkspace = Mock()
+        sys.modules["mantid.simpleapi"] = mock_simpleapi
+
+        model.get_statistics([0, 1, 2])
+        mock_simpleapi.StatisticsOfTableWorkspace.assert_called_once_with(group_ws, [0, 1, 2])
+
+        del sys.modules["mantid.simpleapi"]
+
+    def test_sort(self):
+        group_ws = MockWorkspaceGroup()
+
+        cols = ["h", "k", "l"]
+        peak_ws = Mock(spec=PeaksWorkspace)
+        peak_ws.rowCount = StrictMock(return_value=10)
+        peak_ws.columnCount = StrictMock(return_value=len(cols))
+        peak_ws.__len__ = StrictMock(return_value=10)
+        peak_ws.getColumnNames = StrictMock(return_value=cols)
+        group_ws.append(peak_ws)
+
+        model = GroupTableWorkspaceDisplayModel(group_ws)
+
+        mock_simpleapi = Mock()
+        mock_simpleapi.SortPeaksWorkspace = Mock()
+        sys.modules["mantid.simpleapi"] = mock_simpleapi
+
+        model.sort(2, True)
+        mock_simpleapi.SortPeaksWorkspace.assert_called_once_with(
+            InputWorkspace=group_ws, OutputWorkspace=group_ws, ColumnNameToSortBy="h", SortAscending=True
+        )
+
+        del sys.modules["mantid.simpleapi"]
+
+    def test_delete_rows(self):
+        group_ws = MockWorkspaceGroup()
+
+        cols = ["h", "k", "l"]
+        peak_ws = Mock(spec=PeaksWorkspace)
+        peak_ws.rowCount = StrictMock(return_value=10)
+        peak_ws.columnCount = StrictMock(return_value=len(cols))
+        peak_ws.__len__ = StrictMock(return_value=10)
+        peak_ws.getColumnNames = StrictMock(return_value=cols)
+        group_ws.append(peak_ws)
+
+        model = GroupTableWorkspaceDisplayModel(group_ws)
+
+        mock_simpleapi = Mock()
+        mock_simpleapi.DeleteTableRows = Mock()
+        sys.modules["mantid.simpleapi"] = mock_simpleapi
+
+        model.delete_rows([(0, 1), (0, 2), (0, 3), (0, 4)])
+        mock_simpleapi.DeleteTableRows.assert_called_once_with(peak_ws, "1,2,3,4")
+
+        del sys.modules["mantid.simpleapi"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_group_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_group_presenter.py
@@ -1,0 +1,96 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+
+import functools
+import unittest
+from unittest.mock import Mock
+
+from mantidqt.utils.testing.mocks.mock_mantid import MockWorkspaceGroup
+from mantidqt.widgets.workspacedisplay.table.presenter_group import TableWorkspaceDataPresenterGroup
+from mantidqt.widgets.workspacedisplay.table.group_model import GroupTableWorkspaceDisplayModel
+from mantidqt.widgets.workspacedisplay.table.view import TableWorkspaceDisplayView
+
+
+def with_mock_presenter(func):
+    @functools.wraps(func)
+    def wrapper(self):
+        view = Mock(spec=TableWorkspaceDisplayView)
+        model = Mock(spec=GroupTableWorkspaceDisplayModel)
+        presenter = TableWorkspaceDataPresenterGroup(view=view, model=model)
+        return func(self, presenter)
+
+    return wrapper
+
+
+class TableWorkspaceDisplayTableModelTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        GroupTableWorkspaceDisplayModel.ALLOWED_WORKSPACE_TYPES.append(MockWorkspaceGroup)
+
+    @with_mock_presenter
+    def test_load_data(self, presenter):
+        model = Mock()
+        table = Mock()
+        table.model = Mock(return_value=model)
+        model.load_data = Mock(return_value=None)
+
+        presenter.load_data(table)
+        model.load_data.assert_called_with(presenter.model)
+
+        presenter.sort_data = (0, True)
+        presenter.view.sortBySelectedColumn = Mock()
+        presenter.view.hideColumn = Mock()
+        presenter.load_data(table)
+        model.load_data.assert_called_with(presenter.model)
+        presenter.view.sortBySelectedColumn.assert_called_once_with(0, True)
+        presenter.view.hideColumn.assert_called_once_with(0)
+
+    @with_mock_presenter
+    def test_update_column_headers(self, presenter):
+        model = Mock()
+        presenter.view.model = Mock(return_value=model)
+
+        col_headers = ["h", "k", "l"]
+        presenter.model.original_column_headers = Mock(return_value=col_headers)
+        presenter.model.build_current_labels = Mock(return_value=[])
+
+        presenter.update_column_headers()
+        model.setHorizontalHeaderLabels.assert_called_with(col_headers)
+
+        presenter.model.build_current_labels = Mock(return_value=[(0, "-m")])
+        col_headers[0] += "-m"
+        model.setHorizontalHeaderLabels.assert_called_with(col_headers)
+
+    @with_mock_presenter
+    def test_delete_rows(self, presenter):
+        model = Mock()
+        model.index = Mock(return_value=0)
+        model.data = Mock(return_value=0)
+        presenter.view.model = Mock(return_value=model)
+        presenter.model.delete_rows = Mock()
+
+        presenter.delete_rows([0])
+        presenter.model.delete_rows.assert_called_once_with([(0, 0)])
+
+    @with_mock_presenter
+    def test_sort(self, presenter):
+        presenter.view.sortBySelectedColumn = Mock()
+        presenter.view.hideColumn = Mock()
+
+        selected_col = 0
+        sort_ascending = True
+        presenter.sort(selected_col, sort_ascending)
+        presenter.view.sortBySelectedColumn.assert_called_once()
+        presenter.view.hideColumn.assert_called_once()
+        self.assertEqual(presenter.sort_data, (selected_col, sort_ascending))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_group_table_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_group_table_model.py
@@ -1,0 +1,107 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+import functools
+import unittest
+from unittest.mock import Mock
+
+from mantid.dataobjects import PeaksWorkspace
+
+from mantidqt.utils.testing.mocks.mock_mantid import MockWorkspaceGroup
+from mantidqt.widgets.workspacedisplay.table.group_table_model import GroupTableModel
+from mantidqt.widgets.workspacedisplay.table.group_model import GroupTableWorkspaceDisplayModel
+
+
+def with_mock_workspace(func):
+    @functools.wraps(func)
+    def wrapper(self):
+        group_ws = MockWorkspaceGroup("group_ws")
+        model = GroupTableWorkspaceDisplayModel(group_ws)
+        return func(self, model)
+
+    return wrapper
+
+
+class TableWorkspaceDisplayTableModelTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        GroupTableWorkspaceDisplayModel.ALLOWED_WORKSPACE_TYPES.append(MockWorkspaceGroup)
+
+    @with_mock_workspace
+    def setUp(self, model):
+        self.model = GroupTableModel(data_model=model)
+        self.model.beginResetModel = Mock()
+        self.model.endResetModel = Mock()
+
+    @with_mock_workspace
+    def test_load_data(self, model):
+        model.get_column_headers = Mock(return_value=["header1", "header2"])
+        self.model._update_row_batch_size = Mock()
+        self.model.load_data(model)
+        self.assertEqual(["header1", "header2"], self.model._headers)
+        self.assertEqual(0, self.model._row_count)
+        self.model._update_row_batch_size.assert_called_once_with()
+
+    def test_data(self):
+        group_ws = MockWorkspaceGroup()
+
+        cols = ["h", "k", "l"]
+        peak_ws = Mock(spec=PeaksWorkspace)
+        peak_ws.rowCount = Mock(return_value=10)
+        peak_ws.columnCount = Mock(return_value=len(cols))
+        peak_ws.__len__ = Mock(return_value=10)
+        peak_ws.getColumnNames = Mock(return_value=cols)
+        group_ws.append(peak_ws)
+
+        data_model = GroupTableWorkspaceDisplayModel(group_ws)
+        data_model.get_number_of_rows = Mock(return_value=10)
+        data_model.get_cell = Mock(return_value=0)
+        table_model = GroupTableModel(data_model=data_model)
+
+        index = Mock()
+        index.isValid = Mock(return_value=False)
+        self.assertEqual(table_model.data(index), None)
+
+        index.isValid = Mock(return_value=True)
+        index.row = Mock(return_value=10)
+        index.max_rows = Mock(return_value=5)
+        self.assertEqual(table_model.data(index), None)
+
+        index.isValid = Mock(return_value=True)
+        index.row = Mock(return_value=0)
+        index.column = Mock(return_value=10)
+        table_model.data(index)
+        data_model.get_cell.assert_called_once_with(0, 10)
+
+    def test_setData(self):
+        group_ws = MockWorkspaceGroup()
+
+        cols = ["h", "k", "l"]
+        peak_ws = Mock(spec=PeaksWorkspace)
+        peak_ws.rowCount = Mock(return_value=10)
+        peak_ws.columnCount = Mock(return_value=len(cols))
+        peak_ws.__len__ = Mock(return_value=10)
+        peak_ws.getColumnNames = Mock(return_value=cols)
+        group_ws.append(peak_ws)
+
+        data_model = GroupTableWorkspaceDisplayModel(group_ws)
+        data_model.get_number_of_rows = Mock(return_value=10)
+        data_model.set_cell = Mock(return_value=0)
+        table_model = GroupTableModel(data_model=data_model)
+
+        index = Mock()
+        index.model = Mock(return_value=table_model)
+        table_model.index = Mock(return_value=0)
+        table_model.data = Mock(return_value=0)
+
+        self.assertEqual(table_model.setData(index, 1, None), False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/view.py
@@ -37,6 +37,7 @@ class TableWorkspaceDisplayView(QTableView):
     def __init__(self, presenter=None, parent=None, window_flags=Qt.Window, table_model=None):
         super().__init__(parent)
         self.table_model = table_model if table_model else QStandardItemModel(parent)
+
         self.setModel(self.table_model)
 
         self.presenter = presenter

--- a/qt/widgets/common/src/MantidTreeWidget.cpp
+++ b/qt/widgets/common/src/MantidTreeWidget.cpp
@@ -127,7 +127,7 @@ void MantidTreeWidget::mouseDoubleClickEvent(QMouseEvent *e) {
     auto wsName = wsNames.front();
     Mantid::API::WorkspaceGroup_sptr grpWSPstr;
     grpWSPstr = std::dynamic_pointer_cast<WorkspaceGroup>(m_ads.retrieve(wsName.toStdString()));
-    if (!grpWSPstr) {
+    if (!grpWSPstr || grpWSPstr->isGroupPeaksWorkspaces()) {
       if (!wsName.isEmpty()) {
         m_doubleClickAction(wsName);
         return;

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -334,9 +334,6 @@ void WorkspaceTreeWidgetSimple::addWorkspaceGroupActions(QMenu *menu, const Mant
   if (containsMatrixWorkspace) {
     menu->addMenu(createMatrixWorkspacePlotMenu(menu, true));
     menu->addSeparator();
-  }
-
-  if (containsMatrixWorkspace) {
     menu->addAction(m_showDetectors);
   }
 

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -336,7 +336,12 @@ void WorkspaceTreeWidgetSimple::addWorkspaceGroupActions(QMenu *menu, const Mant
     menu->addSeparator();
   }
 
-  if (containsMatrixWorkspace || containsPeaksWorkspace) {
+  if (containsMatrixWorkspace) {
+    menu->addAction(m_showDetectors);
+  }
+
+  if (containsPeaksWorkspace) {
+    menu->addAction(m_showData);
     menu->addAction(m_showDetectors);
   }
 }


### PR DESCRIPTION
### Description of work
This pull request introduces a new table view for group peaks workspaces. The new group table view will display the same data as the table view for single peak workspaces but with additional columns for the index of the peak workspace in the group and the index of the spectrum in the peak workspace. Moreover, it has the same features as the single peak workspace table view like sorting, deleting, copying, and plotting. 

Fixes #36592. 
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
The work is implemented without adding a new data structure for the group peak workspace as it is not needed and all of the table view operations can be done with the existing data structure. The new view has been implemented by extending the existing table display MVP classes with new presenters and models for the group workspace.

### To test:
Load and Group Workspaces:
- Load multiple peak workspaces and verify they appear in the workspace tree.
- Use the "GroupWorkspace" algorithm to group them.

Verify Group Data View:
- Right-click the group in ADS and select "Show Data."
- Verify the new table view has the same data of all the workspaces in the group.
- The table should include "Group Index" indicating workspace position in the group and "WS Index" showing the workspace index in the corresponding peak workspace.

Interact with the Table View:
- Test copying data (single/multiple rows, single/multiple columns) to the clipboard and paste it in another file.
- Test deleting rows (single/multiple) and confirm successful removal.
- Sort data by column (ascending/descending) and ensure correct sorting.
- Select "Statistics on Columns" and verify the output includes tables with different statistics (e.g., Mean, Std Dev, Min/Max) for each column in each peak workspace
- Select columns for 'X', 'Y', and 'Y Error'. Choose various plot types and check the data is visualized correctly.
- Test hiding/unhiding columns 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
