### PR TITLE
QENS Fitting - fix parameters guesses not updating

### DIFF
--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/MultiFunctionTemplateView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/MultiFunctionTemplateView.cpp
@@ -41,7 +41,8 @@ void MultiFunctionTemplateView::createProperties() {
 void MultiFunctionTemplateView::updateParameterNames(const std::map<int, std::string> &parameterNames) {
   m_parameterNames.clear();
   MantidQt::MantidWidgets::ScopedFalse _paramBlock(m_emitParameterValueChange);
-  for (auto const prop : m_parameterMap.keys()) {
+  for (auto const propParam : m_parameterMap) {
+    auto &prop = propParam.first;
     auto const it = parameterNames.find(static_cast<int>(m_parameterMap[prop]));
     if (it != parameterNames.cend()) {
       auto const name = it->second;
@@ -55,7 +56,8 @@ void MultiFunctionTemplateView::updateParameterNames(const std::map<int, std::st
 
 void MultiFunctionTemplateView::setGlobalParametersQuiet(std::vector<std::string> const &globals) {
   MantidQt::MantidWidgets::ScopedFalse _paramBlock(m_emitParameterValueChange);
-  for (auto const prop : m_parameterMap.keys()) {
+  for (auto const propParam : m_parameterMap) {
+    auto &prop = propParam.first;
     auto const parameterName = m_parameterNames[prop];
     auto const findIter = std::find(globals.cbegin(), globals.cend(), parameterName);
     m_parameterManager->setGlobal(prop, findIter != globals.cend());

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/MultiFunctionTemplateView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/MultiFunctionTemplateView.cpp
@@ -41,8 +41,8 @@ void MultiFunctionTemplateView::createProperties() {
 void MultiFunctionTemplateView::updateParameterNames(const std::map<int, std::string> &parameterNames) {
   m_parameterNames.clear();
   MantidQt::MantidWidgets::ScopedFalse _paramBlock(m_emitParameterValueChange);
-  for (auto const propParam : m_parameterMap) {
-    auto &prop = propParam.first;
+  for (auto const &propParam : m_parameterMap) {
+    auto const &prop = propParam.first;
     auto const it = parameterNames.find(static_cast<int>(m_parameterMap[prop]));
     if (it != parameterNames.cend()) {
       auto const name = it->second;
@@ -56,8 +56,8 @@ void MultiFunctionTemplateView::updateParameterNames(const std::map<int, std::st
 
 void MultiFunctionTemplateView::setGlobalParametersQuiet(std::vector<std::string> const &globals) {
   MantidQt::MantidWidgets::ScopedFalse _paramBlock(m_emitParameterValueChange);
-  for (auto const propParam : m_parameterMap) {
-    auto &prop = propParam.first;
+  for (auto const &propParam : m_parameterMap) {
+    auto const &prop = propParam.first;
     auto const parameterName = m_parameterNames[prop];
     auto const findIter = std::find(globals.cbegin(), globals.cend(), parameterName);
     m_parameterManager->setGlobal(prop, findIter != globals.cend());
@@ -76,11 +76,16 @@ void MultiFunctionTemplateView::createFunctionParameterProperties() {
       auto const descriptions = subType->getParameterDescriptions(index);
       std::vector<QtProperty *> props;
       for (auto i = 0u; i < names.size(); ++i) {
+        auto const id = paramIDs[i];
+        if (m_parameterReverseMap.find(id) != m_parameterReverseMap.end()) {
+          // Skip if the parameter has already been defined as part of another sub type
+          continue;
+        }
+
         auto prop = m_parameterManager->addProperty(QString::fromStdString(names[i]));
         m_parameterManager->setDescription(prop, descriptions[i]);
         m_parameterManager->setDecimals(prop, 6);
         props.emplace_back(prop);
-        auto const id = paramIDs[i];
         m_parameterMap[prop] = id;
         m_parameterReverseMap[id] = prop;
       }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/MultiFunctionTemplateView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/MultiFunctionTemplateView.h
@@ -10,11 +10,10 @@
 #include "FitTypes.h"
 #include "FunctionTemplateView.h"
 
+#include <map>
 #include <optional>
 #include <string>
 #include <vector>
-
-#include <QMap>
 
 class QtProperty;
 
@@ -47,12 +46,12 @@ private:
 
   std::vector<std::unique_ptr<TemplateSubType>> m_templateSubTypes;
   // Map fit type to a list of function parameters (QtProperties for those parameters)
-  std::vector<QMap<int, std::vector<QtProperty *>>> m_subTypeParameters;
+  std::vector<std::map<int, std::vector<QtProperty *>>> m_subTypeParameters;
   std::vector<std::vector<QtProperty *>> m_currentSubTypeParameters;
   std::vector<QtProperty *> m_subTypeProperties;
 
-  QMap<QtProperty *, ParamID> m_parameterMap;
-  QMap<ParamID, QtProperty *> m_parameterReverseMap;
+  std::map<QtProperty *, ParamID> m_parameterMap;
+  std::map<ParamID, QtProperty *> m_parameterReverseMap;
 };
 
 } // namespace Inelastic


### PR DESCRIPTION
**Reported by:** Spencer

### Description of work
This PR fixes a bug where a parameter property would be overriden in the template function browser in the QENS Fitting interface if the property has already been defined as part of a different sub type. The solution was not to redefine the property if it already exists.

*There is no associated issue.*

### To test:
1. Open `Inelastic` ->`QENS Fitting` interface
2. Go to the `IqtFit` tab
3. Load the data below
[irs26176_graphite002_iqt.zip](https://github.com/mantidproject/mantid/files/14977698/irs26176_graphite002_iqt.zip)

5. Select 1 exponential fit function
6. The height parameter should be 1.0, and the Lifetime parameter should be non-zero

*This does not require release notes* because **this bug is a regression since the last stable release**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
