### PR TITLE
Use NexusHDF5Descriptor for LoadNexusProcessed algorithms

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
@@ -12,9 +12,9 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidAPI/NexusFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidHistogramData/BinEdges.h"
-#include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/cow_ptr.h"
 #include "MantidNexus/NexusClasses.h"
 #include <map>
@@ -40,7 +40,7 @@ Required Properties:
 <LI> InputWorkspace - The name of the workspace to put the data </LI>
 </UL>
 */
-class MANTID_DATAHANDLING_DLL LoadNexusProcessed : public API::IFileLoader<Kernel::NexusDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadNexusProcessed : public API::NexusFileLoader {
 
 public:
   /// Default constructor
@@ -64,7 +64,7 @@ public:
   const std::string category() const override { return "DataHandling\\Nexus"; }
 
   /// Returns a confidence value that this algorithm can load a file
-  int confidence(Kernel::NexusDescriptor &descriptor) const override;
+  int confidence(Kernel::NexusHDF5Descriptor &descriptor) const override;
 
 protected:
   /// Read the spectra
@@ -78,7 +78,7 @@ private:
   /// Overwrites Algorithm method.
   void init() override;
   /// Overwrites Algorithm method
-  void exec() override;
+  void execLoader() override;
 
   /// Create the workspace name if it's part of a group workspace
   std::string buildWorkspaceName(const std::string &name, const std::string &baseName, size_t wsIndex);

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed2.h
@@ -37,7 +37,7 @@ class MANTID_DATAHANDLING_DLL LoadNexusProcessed2 : public LoadNexusProcessed {
 public:
   const std::string name() const override;
   int version() const override;
-  int confidence(Kernel::NexusDescriptor &descriptor) const override;
+  int confidence(Kernel::NexusHDF5Descriptor &descriptor) const override;
 
 private:
   void readSpectraToDetectorMapping(Mantid::NeXus::NXEntry &mtd_entry, Mantid::API::MatrixWorkspace &ws) override;

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -48,7 +48,7 @@
 namespace Mantid::DataHandling {
 
 // Register the algorithm into the algorithm factory
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadNexusProcessed)
+DECLARE_NEXUS_HDF5_FILELOADER_ALGORITHM(LoadNexusProcessed)
 
 using namespace Mantid::NeXus;
 using namespace DataObjects;
@@ -190,8 +190,8 @@ LoadNexusProcessed::~LoadNexusProcessed() = default;
  * @returns An integer specifying the confidence level. 0 indicates it will not
  * be used
  */
-int LoadNexusProcessed::confidence(Kernel::NexusDescriptor &descriptor) const {
-  if (descriptor.pathExists("/mantid_workspace_1"))
+int LoadNexusProcessed::confidence(Kernel::NexusHDF5Descriptor &descriptor) const {
+  if (descriptor.isEntry("/mantid_workspace_1"))
     return 80;
   else
     return 0;
@@ -370,7 +370,7 @@ Workspace_sptr LoadNexusProcessed::doAccelleratedMultiPeriodLoading(NXRoot &root
  *
  *  @throw runtime_error Thrown if algorithm cannot execute
  */
-void LoadNexusProcessed::exec() {
+void LoadNexusProcessed::execLoader() {
 
   API::Workspace_sptr tempWS;
   int nWorkspaceEntries = 0;

--- a/Framework/DataHandling/src/LoadNexusProcessed2.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed2.cpp
@@ -24,7 +24,7 @@ using Mantid::API::WorkspaceProperty;
 using Mantid::Kernel::Direction;
 
 // Register the algorithm into the AlgorithmFactory
-DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadNexusProcessed2)
+DECLARE_NEXUS_HDF5_FILELOADER_ALGORITHM(LoadNexusProcessed2)
 //----------------------------------------------------------------------------------------------
 
 namespace {
@@ -215,8 +215,8 @@ bool LoadNexusProcessed2::loadNexusGeometry(API::Workspace &ws, const int nWorks
   return false;
 }
 
-int LoadNexusProcessed2::confidence(Kernel::NexusDescriptor &descriptor) const {
-  if (descriptor.pathExists("/mantid_workspace_1"))
+int LoadNexusProcessed2::confidence(Kernel::NexusHDF5Descriptor &descriptor) const {
+  if (descriptor.isEntry("/mantid_workspace_1"))
     return LoadNexusProcessed::confidence(descriptor) + 1; // incrementally better than v1.
   else
     return 0;

--- a/docs/source/release/v6.10.0/Framework/Algorithms/Bugfixes/37164.rst
+++ b/docs/source/release/v6.10.0/Framework/Algorithms/Bugfixes/37164.rst
@@ -1,0 +1,1 @@
+- A performance improvement when using the :ref:`LoadNexusProcessed <algm-LoadNexusProcessed>` algorithm to load a NeXus file has been achieved.

--- a/scripts/test/corelli/calibration/test_database.py
+++ b/scripts/test/corelli/calibration/test_database.py
@@ -441,12 +441,12 @@ class TestCorelliDatabase(unittest.TestCase):
             assert list(load_calibration_set(workspace, database_path)) == [None, None]
 
             set_daystamp(workspace, 20200601)
-            with self.assertRaises(RuntimeError) as ar:
+            with self.assertRaises(ValueError) as ar:
                 load_calibration_set(workspace, database_path)  # should pick calibration 20200601
             self.assertEqual("20200601" in str(ar.exception), True)
 
             set_daystamp(workspace, 20201201)
-            with self.assertRaises(RuntimeError) as ar:
+            with self.assertRaises(ValueError) as ar:
                 load_calibration_set(workspace, database_path)
             self.assertEqual("calibration_corelli_20200601.nxs.h5" in str(ar.exception), True)
 
@@ -456,22 +456,22 @@ class TestCorelliDatabase(unittest.TestCase):
             assert list(load_calibration_set(workspace, database_path)) == [None, None]
 
             set_daystamp(workspace, "20200401")
-            with self.assertRaises(RuntimeError) as ar:
+            with self.assertRaises(ValueError) as ar:
                 load_calibration_set(workspace, database_path)
             self.assertEqual("calibration_corelli_20200401.nxs.h5" in str(ar.exception), True)
 
             set_daystamp(workspace, "20200601")
-            with self.assertRaises(RuntimeError) as ar:
+            with self.assertRaises(ValueError) as ar:
                 load_calibration_set(workspace, database_path)
             self.assertEqual("calibration_corelli_20200401.nxs.h5" in str(ar.exception), True)
 
             set_daystamp(workspace, "20200801")
-            with self.assertRaises(RuntimeError) as ar:
+            with self.assertRaises(ValueError) as ar:
                 load_calibration_set(workspace, database_path)
             self.assertEqual("calibration_corelli_20200801.nxs.h5" in str(ar.exception), True)
 
             set_daystamp(workspace, "20201201")
-            with self.assertRaises(RuntimeError) as ar:
+            with self.assertRaises(ValueError) as ar:
                 load_calibration_set(workspace, database_path)
             self.assertEqual("calibration_corelli_20200801.nxs.h5" in str(ar.exception), True)
         workspace.delete()


### PR DESCRIPTION
### Description of work
This PR makes sure the `LoadNexusProcessed` and `LoadNexusProcessed2` algorithms use the `NexusHDF5Descriptor` rather than the `NexusDescriptor`. These loaders can use `NexusHDF5Descriptor` because they are only ever used to load nexus files which are in the HDF5 format. We know this because Mantid writes out all files which can then be reloaded by LoadNexusProcessed.

Using the `NexusHDF5Descriptor` rather than the `NexusDescriptor` gives us a speed up for the algorithm search process of approximately a factor of 80. For the below workflow, it shows an overall performance improvement of about 30% for the full load workflow. This PR removes (almost all of) the time block indicated by the blue cross. The block with the red cross was removed in a previous PR.

![Screenshot 2024-03-24 201047](https://github.com/mantidproject/mantid/assets/40830825/062f0321-24aa-4f28-811c-7e9fc6949ccf)


Part of #37164

### To test:
1. Open Mantid
2. Run the below python script on `main`. It will take approximately 30 seconds
3. Run the same python script on this branch. It will take approximately 1 or 2 seconds.
```py
from mantid.simpleapi import Load

filepath = "//olympic/Babylon5/Public/RobApplin/loading"
filename = "irs26176_graphite002_red_Conv_seq_2L_0-50__Result.nxs"

Load(
    Filename=f"{filepath}/{filename}",
    LoadHistory=False,
    OutputWorkspace="output_workspace",
)
```

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
