### PR TITLE
Add option to find peaks using ratio variance/ mean in FindSXPeaksConvolve

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/FindSXPeaksConvolveTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FindSXPeaksConvolveTest.py
@@ -59,15 +59,13 @@ class FindSXPeaksConvolveTest(unittest.TestCase):
     def tearDownClass(cls):
         AnalysisDataService.clear()
 
-    def _assert_found_correct_peaks(self, peak_ws):
+    def _assert_found_correct_peaks(self, peak_ws, integrated=True):
         self.assertEqual(peak_ws.getNumberPeaks(), 1)
-        peak_ws = SortPeaksWorkspace(
-            InputWorkspace=peak_ws, OutputWorkspace=peak_ws.name(), ColumnNameToSortBy="DetID", SortAscending=False
-        )
         pk = peak_ws.getPeak(0)
         self.assertEqual(pk.getDetectorID(), 74)
-        self.assertAlmostEqual(pk.getTOF(), 5.0, delta=1e-8)
-        self.assertAlmostEqual(pk.getIntensityOverSigma(), 7.4826, delta=1e-4)
+        if integrated:
+            self.assertAlmostEqual(pk.getTOF(), 5.0, delta=1e-8)
+            self.assertAlmostEqual(pk.getIntensityOverSigma(), 7.4826, delta=1e-4)
 
     def test_exec_specify_nbins(self):
         out = FindSXPeaksConvolve(
@@ -93,9 +91,22 @@ class FindSXPeaksConvolveTest(unittest.TestCase):
 
     def test_exec_min_frac_size(self):
         out = FindSXPeaksConvolve(
-            InputWorkspace=self.ws, PeaksWorkspace="peaks1", NRows=3, NCols=3, NBins=5, ThresholdIoverSigma=3.0, MinFracSize=0.5
+            InputWorkspace=self.ws, PeaksWorkspace="peaks4", NRows=3, NCols=3, NBins=5, ThresholdIoverSigma=3.0, MinFracSize=0.5
         )
         self.assertEqual(out.getNumberPeaks(), 0)
+
+    def test_exec_VarOverMean(self):
+        out = FindSXPeaksConvolve(
+            InputWorkspace=self.ws,
+            PeaksWorkspace="peaks5",
+            NRows=5,
+            NCols=5,
+            Nbins=3,
+            PeakFindingStrategy="VarianceOverMean",
+            ThresholdVarianceOverMean=3.0,
+            MinFracSize=0.02,
+        )
+        self._assert_found_correct_peaks(out, integrated=False)
 
 
 if __name__ == "__main__":

--- a/Testing/SystemTests/tests/framework/SXDAnalysis.py
+++ b/Testing/SystemTests/tests/framework/SXDAnalysis.py
@@ -37,7 +37,6 @@ class SXDPeakSearchAndFindUBUsingFFT(systemtesting.MantidSystemTest):
         self.assertAlmostEqual(alpha, latt.alpha(), delta=1e-10)
         self.assertAlmostEqual(alpha, latt.beta(), delta=1e-10)
         self.assertAlmostEqual(alpha, latt.gamma(), delta=1e-10)
-        return self.peaks, "SXD23767_found_peaks.nxs"
 
 
 class SXDDetectorCalibration(systemtesting.MantidSystemTest):

--- a/Testing/SystemTests/tests/framework/SXDAnalysis.py
+++ b/Testing/SystemTests/tests/framework/SXDAnalysis.py
@@ -21,16 +21,16 @@ class SXDPeakSearchAndFindUBUsingFFT(systemtesting.MantidSystemTest):
 
     def runTest(self):
         ws = Load(Filename="SXD23767.raw", LoadMonitors="Exclude")
-        self.peaks = SXD.find_sx_peaks(ws, nstd=6)
+        self.peaks = SXD.find_sx_peaks(ws, ThresholdVarianceOverMean=1.5)
         FindUBUsingFFT(PeaksWorkspace=self.peaks, MinD=1, MaxD=10, Tolerance=0.15)
         SelectCellOfType(PeaksWorkspace=self.peaks, CellType="Cubic", Centering="F", Apply=True)
         OptimizeLatticeForCellType(PeaksWorkspace=self.peaks, CellType="Cubic", Apply=True)
         self.nindexed, *_ = IndexPeaks(PeaksWorkspace=self.peaks, Tolerance=0.1, CommonUBForAll=True)
 
     def validate(self):
-        self.assertEqual(214, self.nindexed)
+        self.assertEqual(171, self.nindexed)
         latt = SXD.retrieve(self.peaks).sample().getOrientedLattice()
-        a, alpha = 5.6541, 90  # published value for NaCl is a=6.6402 but the detector positions haven't been calibrated
+        a, alpha = 5.6533, 90  # published value for NaCl is a=6.6402 but the detector positions haven't been calibrated
         self.assertAlmostEqual(a, latt.a(), delta=1e-5)
         self.assertAlmostEqual(a, latt.b(), delta=1e-5)
         self.assertAlmostEqual(a, latt.c(), delta=1e-5)

--- a/Testing/SystemTests/tests/framework/reference/SXD23767_found_peaks_convolve.nxs.md5
+++ b/Testing/SystemTests/tests/framework/reference/SXD23767_found_peaks_convolve.nxs.md5
@@ -1,0 +1,1 @@
+23bbde7e64f3d3fcb00984fd91e89e62

--- a/docs/source/algorithms/FindSXPeaksConvolve-v1.rst
+++ b/docs/source/algorithms/FindSXPeaksConvolve-v1.rst
@@ -12,7 +12,7 @@ Description
 This is an algorithm to find single-crystal Bragg peaks in a :ref:`MatrixWorkspace <MatrixWorkspace>` with detector
 banks of type :ref:`RectangularDetector <RectangularDetector>` (e.g. SXD, TOPAZ).
 
-There are two peak finding stratgeyies set by ``PeakFindingStrategy``:
+There are two peak finding strategies set by ``PeakFindingStrategy``:
 
 a. ``PeakFindingStrategy="IOverSigma"`` - by integrating the data by convolution with a shoebox kernel and looking for
    regions with statistically significant I/sigma (larger than ``ThresholdIoverSigma``). Note a valid peak would be

--- a/docs/source/algorithms/FindSXPeaksConvolve-v1.rst
+++ b/docs/source/algorithms/FindSXPeaksConvolve-v1.rst
@@ -10,8 +10,18 @@ Description
 -----------
 
 This is an algorithm to find single-crystal Bragg peaks in a :ref:`MatrixWorkspace <MatrixWorkspace>` with detector
-banks of type :ref:`RectangularDetector <RectangularDetector>` (e.g. SXD, TOPAZ) by integrating the data using a
-convolution with a shoebox kernel.
+banks of type :ref:`RectangularDetector <RectangularDetector>` (e.g. SXD, TOPAZ).
+
+There are two peak finding stratgeyies set by ``PeakFindingStrategy``:
+
+a. ``PeakFindingStrategy="IOverSigma"`` - by integrating the data by convolution with a shoebox kernel and looking for
+   regions with statistically significant I/sigma (larger than ``ThresholdIoverSigma``). Note a valid peak would be
+   expected to have intensity/sigma > 3 and stronger peaks will have a larger intensity/sigma.
+
+b. ``PeakFindingStrategy="VarianceOverMean"`` - by looking for regions with ratio of variance/mean larger than
+   ``ThresholdVarianceOverMean`` - note for a poisson distributed counts with a constant count-rate the ratio is
+   expected to be 1. This peak finding criterion taken from DIALS [1]_.
+
 
 The size of the kernel is defined in the input to the algorithm and should match the approximate extent of a typical peak.
 The size on the detector is governed by ``NRows`` and ``NCols`` which are in units of pixels.
@@ -26,15 +36,14 @@ The size of the kernel along the TOF dimension can be specified in one of two wa
 Note to use method 2, back-to-back exponential coefficients must be defined in the Parameters.xml file for the
 instrument.
 
-The integration requires a background shell with negative weights, such that the total kernel size is increased by a
-factor 1.25 along each dimension (such that there are approximately the same number of elements in the kernel and the
-background shell). The integral of the kernel and background shell together is zero.
+The shoebox integration (for ``PeakFindingStrategy="IOverSigma"``) requires a background shell with negative weights,
+such that the total kernel size is increased by a factor 1.25 along each dimension (such that there are approximately
+the same number of elements in the kernel and the background shell). The integral of the kernel and background shell
+together is zero.
 
 The integrated intensity is evaluated by convolution of the signal array with the kernel and the square of the error on
 the integrated intensity is determined by convolution of the squared error array with the squared value of the kernel.
 
-The threshold for peak detection is given by ``ThresholdIoverSigma`` which is the cutoff ratio of intensity/sigma (i.e.
-a valid peak would be expected to have intensity/sigma > 3). Stronger peaks will have a larger intensity/sigma.
 
 Usage
 -----
@@ -56,6 +65,10 @@ Usage
 
     Found 261 peaks
 
+References
+----------
+
+.. [1]  Winter, G., et al.  Acta Crystallographica Section D: Structural Biology 74.2 (2018): 85-97.
 
 .. categories::
 

--- a/docs/source/release/v6.10.0/Diffraction/Single_Crystal/New_features/37171.rst
+++ b/docs/source/release/v6.10.0/Diffraction/Single_Crystal/New_features/37171.rst
@@ -1,0 +1,2 @@
+- Add option to find peaks using the ratio of variance/ mean in :ref:`FindSXPeaksConvolve <algm-FindSXPeaksConvolve>` - this is a peak finding criterion used in DIALS software Winter, G., et al.  Acta Crystallographica Section D: Structural Biology 74.2 (2018): 85-97.
+- :ref:`FindSXPeaksConvolve <algm-FindSXPeaksConvolve>` is the default peak finding algorithm in the SXD reduction class.

--- a/docs/source/techniques/ISIS_SingleCrystalDiffraction_Workflow.rst
+++ b/docs/source/techniques/ISIS_SingleCrystalDiffraction_Workflow.rst
@@ -37,7 +37,7 @@ Here is an example using the ``SXD`` class that finds peaks and then removes dup
 
   # find peaks using SXD static method - determines peak threshold from
   # the standard deviation of the intensity distribution
-  peaks_ws = SXD.find_sx_peaks(ws, nstd=6)
+  peaks_ws = SXD.find_sx_peaks(ws, ThresholdVarianceOverMean=2.0)
   SXD.remove_duplicate_peaks_by_qlab(peaks_ws, q_tol=0.05)
 
   # find a UB

--- a/docs/source/techniques/ISIS_SingleCrystalDiffraction_Workflow.rst
+++ b/docs/source/techniques/ISIS_SingleCrystalDiffraction_Workflow.rst
@@ -36,7 +36,7 @@ Here is an example using the ``SXD`` class that finds peaks and then removes dup
   ws = Load(Filename='SXD33335.nxs', OutputWorkspace='SXD33335')
 
   # find peaks using SXD static method - determines peak threshold from
-  # the standard deviation of the intensity distribution
+  # the ratio of local variance over mean
   peaks_ws = SXD.find_sx_peaks(ws, ThresholdVarianceOverMean=2.0)
   SXD.remove_duplicate_peaks_by_qlab(peaks_ws, q_tol=0.05)
 

--- a/scripts/Diffraction/single_crystal/sxd.py
+++ b/scripts/Diffraction/single_crystal/sxd.py
@@ -336,16 +336,20 @@ class SXD(BaseSX):
             mantid.DeleteTableRows(TableWorkspace=peaks, Rows=iremove, EnableLogging=False)
 
     @staticmethod
-    def find_sx_peaks(ws, bg=None, nstd=None, lambda_min=0.45, lambda_max=3, nbunch=3, out_peaks=None, **kwargs):
+    def find_sx_peaks(ws, out_peaks=None, **kwargs):
         wsname = SXD.retrieve(ws).name()
-        ws_rb = wsname + "_rb"
-        mantid.Rebunch(InputWorkspace=ws, OutputWorkspace=ws_rb, NBunch=nbunch, EnableLogging=False)
-        SXD.mask_detector_edges(ws_rb)
-        SXD.crop_ws(ws_rb, lambda_min, lambda_max, xunit="Wavelength")
         if out_peaks is None:
-            out_peaks = wsname + "_peaks"  # need to do this so not "_rb_peaks"
-        BaseSX.find_sx_peaks(ws_rb, bg, nstd, out_peaks, **kwargs)
-        mantid.DeleteWorkspace(ws_rb, EnableLogging=False)
+            out_peaks = wsname + "_peaks"
+        default_kwargs = {
+            "NRows": 7,
+            "NCols": 7,
+            "GetNBinsFromBackToBackParams": True,
+            "NFWHM": 6,
+            "PeakFindingStrategy": "VarianceOverMean",
+            "ThresholdVarianceOverMean": 2,
+        }
+        kwargs = {**default_kwargs, **kwargs}  # will overwrite default with provided if duplicate keys
+        mantid.FindSXPeaksConvolve(InputWorkspace=wsname, PeaksWorkspace=out_peaks, **kwargs)
         return out_peaks
 
     @staticmethod


### PR DESCRIPTION
### Description of work

Add option to find peaks using ratio variance/ mean in FindSXPeaksConvolve - this is a peak finding criterion used in DIALS, Winter (2018) 
https://doi.org/10.1107/S2059798317017235 

Here it is performed by doing 2 convolutions to evaluate `E[y]` and `E[y^2]` after scaling to ensure the data are in raw counts.

This work was started because it was noticed while benchmarking peak finding algorithms as part of testing #37123 that `FindSXPeaksConvolve` using ratio of I/sigma, was picking up lots of spurious noisy peaks in bank 1 of SXD  (higher gain as upgraded detector bank recently) unless quite a high value of I/sigma chosen.

Here is a comparison of the two methods for an SXD run with lower stats

![image](https://github.com/mantidproject/mantid/assets/55979119/1b5349d4-5f4d-42bb-9b84-30453a6a75e7)

It can be seen that the new method (variance/mean) find ~15-20% more peaks that can be indexed with 90% accuracy with a hkl tolerance of 0.1 (note detector positions were calibrated prior to this benchmark). it also out performs the older `FindSXPeaks` algorithm with `AllPEaks` strategy (see comments in #37123).

*There is no associated issue.*

### To test:

To-Do

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
