### PR TITLE
Skip Bayes system tests on MacOS

### DIFF
--- a/Testing/SystemTests/tests/framework/ISISIndirectBayesTest.py
+++ b/Testing/SystemTests/tests/framework/ISISIndirectBayesTest.py
@@ -10,6 +10,7 @@ import os
 import warnings
 
 from mantid.simpleapi import *
+from sys import platform
 import systemtesting
 
 
@@ -30,6 +31,9 @@ def _cleanup_files(dirname, filenames):
 
 
 class QLresTest(systemtesting.MantidSystemTest):
+    def skipTests(self):
+        return platform == "darwin"
+
     def runTest(self):
         prefix = "rt_"
         sname = "irs26176_graphite002_red"
@@ -78,6 +82,9 @@ class QLresTest(systemtesting.MantidSystemTest):
 
 
 class QuestTest(systemtesting.MantidSystemTest):
+    def skipTests(self):
+        return platform == "darwin"
+
     def runTest(self):
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_res"
@@ -115,6 +122,9 @@ class QuestTest(systemtesting.MantidSystemTest):
 
 
 class QSeTest(systemtesting.MantidSystemTest):
+    def skipTests(self):
+        return platform == "darwin"
+
     def runTest(self):
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_res"
@@ -157,6 +167,9 @@ class QSeTest(systemtesting.MantidSystemTest):
 
 
 class QLDataTest(systemtesting.MantidSystemTest):
+    def skipTests(self):
+        return platform == "darwin"
+
     def runTest(self):
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_red"
@@ -205,6 +218,9 @@ class QLDataTest(systemtesting.MantidSystemTest):
 
 
 class QLResNormTest(systemtesting.MantidSystemTest):
+    def skipTests(self):
+        return platform == "darwin"
+
     def runTest(self):
         sname = "irs26176_graphite002_red"
         rname = "irs26173_graphite002_res"
@@ -257,6 +273,9 @@ class QLResNormTest(systemtesting.MantidSystemTest):
 
 
 class QLWidthTest(systemtesting.MantidSystemTest):
+    def skipTests(self):
+        return platform == "darwin"
+
     def runTest(self):
         prefix = "wt_"
         sname = "irs26176_graphite002_red"


### PR DESCRIPTION
### Description of work
The Bayes system tests which use the quasielasticbayes conda package are failing on MacOS with the following error
```
02:24:16  At line 7 of file quasielasticbayes/Util.f90 (unit = 2)
02:24:16  Fortran runtime error: File already opened in another unit
```

I think this happens because the same file is being opened from different system test threads. I don't think there is an easy fix for this, so I think we should just skip the tests for MacOS as this is the only OS where it seems to be happening. Given that qeb was not previously available on MacOS, I don't think its too important to fix this properly in future. We are also planning on replacing quasielasticbayes with quickBayes, so minimal time should be spent on the qeb package.

*There is no associated issue.*

### To test:
Check that the following build_from_branch passes:
https://builds.mantidproject.org/job/build_packages_from_branch/772/

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
