### PR TITLE
Fix for bug with the algorithm name alias

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmFactory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmFactory.h
@@ -14,6 +14,7 @@
 #include "MantidKernel/SingletonHolder.h"
 #include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
@@ -113,7 +114,7 @@ public:
   const std::vector<std::string> getKeys(bool includeHidden) const;
 
   /// Get an algorithms name and version from the alias map
-  boost::optional<std::pair<std::string, int>> getRealNameFromAlias(const std::string &alias) const noexcept;
+  std::optional<std::pair<std::string, int>> getRealNameFromAlias(const std::string &alias) const noexcept;
 
   /// Returns the highest version of the algorithm currently registered
   int highestVersion(const std::string &algorithmName) const;

--- a/Framework/API/inc/MantidAPI/AlgorithmFactory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmFactory.h
@@ -96,11 +96,12 @@ public:
     } else {
       throw std::invalid_argument("Cannot register empty algorithm name");
     }
+    auto nameAndVersion = std::make_pair(className, version);
 
     if (!alias.empty())
-      m_amap[alias] = className;
+      m_amap[alias] = nameAndVersion;
 
-    return std::make_pair(className, version);
+    return nameAndVersion;
   }
   /// Unsubscribe the given algorithm
   void unsubscribe(const std::string &algorithmName, const int version);
@@ -111,8 +112,8 @@ public:
   const std::vector<std::string> getKeys() const override;
   const std::vector<std::string> getKeys(bool includeHidden) const;
 
-  /// Get an algorithms name from the alias map
-  boost::optional<std::string> getRealNameFromAlias(const std::string &alias) const noexcept;
+  /// Get an algorithms name and version from the alias map
+  boost::optional<std::pair<std::string, int>> getRealNameFromAlias(const std::string &alias) const noexcept;
 
   /// Returns the highest version of the algorithm currently registered
   int highestVersion(const std::string &algorithmName) const;
@@ -156,7 +157,7 @@ private:
   /// The map holding the registered class names and their highest versions
   VersionMap m_vmap;
   /// A typedef for the map of algorithm aliases
-  using AliasMap = std::unordered_map<std::string, std::string>;
+  using AliasMap = std::unordered_map<std::string, std::pair<std::string, int>>;
   /// The map holding the alias names of registered algorithms
   AliasMap m_amap;
 };

--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -54,8 +54,7 @@ std::shared_ptr<Algorithm> AlgorithmFactoryImpl::create(const std::string &name,
 
   // Fallback, name might be an alias
   // Try get real name and create from that instead
-  const auto realNameAndVersion = getRealNameFromAlias(name);
-  if (realNameAndVersion) {
+  if (const auto realNameAndVersion = getRealNameFromAlias(name)) {
     // Try create algorithm again with real name
     try {
       auto alg = this->createAlgorithm(realNameAndVersion->first, local_version);
@@ -214,11 +213,11 @@ const std::vector<std::string> AlgorithmFactoryImpl::getKeys(bool includeHidden)
  * @param alias The name of the algorithm to look up in the alias map
  * @return Real name of algorithm if found
  */
-boost::optional<std::pair<std::string, int>>
+std::optional<std::pair<std::string, int>>
 AlgorithmFactoryImpl::getRealNameFromAlias(const std::string &alias) const noexcept {
   auto a_it = m_amap.find(alias);
   if (a_it == m_amap.end())
-    return boost::none;
+    return std::nullopt;
   else
     return a_it->second;
 }
@@ -235,8 +234,7 @@ int AlgorithmFactoryImpl::highestVersion(const std::string &algorithmName) const
   else {
     // Fall back, algorithmName might be an alias
     // Check alias map, then find version from real name
-    const auto realNameAndVersion = getRealNameFromAlias(algorithmName);
-    if (realNameAndVersion != boost::none) {
+    if (const auto realNameAndVersion = getRealNameFromAlias(algorithmName)) {
       return realNameAndVersion->second;
     } else {
       throw std::runtime_error("AlgorithmFactory::highestVersion() - Unknown algorithm '" + algorithmName + "'");

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -329,4 +329,15 @@ public:
     mangledName = "Cat 1";
     TS_ASSERT_THROWS_ANYTHING(outPair = algFactory.decodeName(mangledName));
   }
+
+  void testAliasPointsToCorrectVersion() {
+    auto &algFactory = AlgorithmFactory::Instance();
+    algFactory.subscribe<CoolAlgorithm1>();
+    algFactory.subscribe<CoolAlgorithm2>();
+
+    const auto nameAndVersion = algFactory.getRealNameFromAlias("TheCoolestAlgorithm");
+
+    TS_ASSERT_EQUALS(nameAndVersion->first, "CoolAlgorithm");
+    TS_ASSERT_EQUALS(nameAndVersion->second, 1);
+  }
 };

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -129,7 +129,7 @@ public:
 
     TS_ASSERT_EQUALS(resultAlias->first, "ToyAlgorithm");
     TS_ASSERT_EQUALS(resultAlias->second, 1);
-    TS_ASSERT_EQUALS(resultFakeAlias, boost::none);
+    TS_ASSERT(!resultFakeAlias);
   }
 
   void test_HighestVersion() {

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -127,7 +127,8 @@ public:
     const auto resultAlias = algFactory.getRealNameFromAlias("Dog");
     const auto resultFakeAlias = algFactory.getRealNameFromAlias("Frog");
 
-    TS_ASSERT_EQUALS(resultAlias.get(), "ToyAlgorithm");
+    TS_ASSERT_EQUALS(resultAlias->first, "ToyAlgorithm");
+    TS_ASSERT_EQUALS(resultAlias->second, 1);
     TS_ASSERT_EQUALS(resultFakeAlias, boost::none);
   }
 
@@ -135,7 +136,6 @@ public:
     auto &algFactory = AlgorithmFactory::Instance();
 
     TS_ASSERT_THROWS(algFactory.highestVersion("ToyAlgorithm"), const std::runtime_error &);
-    TS_ASSERT_THROWS(algFactory.highestVersion("Dog"), const std::runtime_error &);
 
     algFactory.subscribe<ToyAlgorithm>();
     TS_ASSERT_EQUALS(1, algFactory.highestVersion("ToyAlgorithm"));

--- a/Framework/API/test/FakeAlgorithms.h
+++ b/Framework/API/test/FakeAlgorithms.h
@@ -108,3 +108,28 @@ public:
   }
   void exec() override {}
 };
+
+class CoolAlgorithm1 : public Algorithm {
+public:
+  CoolAlgorithm1() : Algorithm() {}
+  ~CoolAlgorithm1() override = default;
+  const std::string name() const override { return "CoolAlgorithm"; }
+  int version() const override { return 1; }
+  const std::string alias() const override { return "TheCoolestAlgorithm"; }
+  const std::string summary() const override { return "Test summary"; }
+
+  void init() override {}
+  void exec() override {}
+};
+
+class CoolAlgorithm2 : public Algorithm {
+public:
+  CoolAlgorithm2() : Algorithm() {}
+  ~CoolAlgorithm2() override = default;
+  const std::string name() const override { return "CoolAlgorithm"; }
+  int version() const override { return 2; }
+  const std::string summary() const override { return "Test summary"; }
+
+  void init() override {}
+  void exec() override {}
+};

--- a/docs/source/release/v6.10.0/Workbench/Bugfixes/37112.rst
+++ b/docs/source/release/v6.10.0/Workbench/Bugfixes/37112.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where an algorithm alias would always get the highest version of the parent algorithm instead of the specific version it was assigned to.


### PR DESCRIPTION
### Description of work

Fixed a bug where if an algorithm.v1 had the alias "hello" and algorithm.v2 did not, executing the algorithm "hello" would give algorithm.v2 (the latest version). The alias will now respect which version of the original algorithm it has been assigned to.

Fixes #37112

### To test:

Follow the example from the issue.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
