### PR TITLE
Fix workspace not opening if a recovery file has been corrupted

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/Bugfixes/37175.rst
+++ b/docs/source/release/v6.10.0/Workbench/Bugfixes/37175.rst
@@ -1,0 +1,1 @@
+- Fixed bug where a corrupted recovery file could stop workbench from opening.

--- a/qt/applications/workbench/workbench/projectrecovery/recoverygui/projectrecoverymodel.py
+++ b/qt/applications/workbench/workbench/projectrecovery/recoverygui/projectrecoverymodel.py
@@ -45,7 +45,14 @@ class ProjectRecoveryModel(QObject):
         if os.path.exists(rec_file):
             rec_file_dict = {}
             with open(rec_file) as reader:
-                rec_file_dict = json.load(reader)
+                try:
+                    rec_file_dict = json.load(reader)
+                except json.decoder.JSONDecodeError:
+                    logger.warning(
+                        f"Project Recovery Model: Recovery file {rec_file} is corrupted, open plots and interfaces will "
+                        "fail to recover, but workspaces may reload."
+                    )
+                    return 0
 
             return len(rec_file_dict.get("workspaces", 0))
         else:


### PR DESCRIPTION
### Description of work

If a recovery file (`.recfile` file which holds a JSON object detailing workspace names, plot parameters, and open interfaces) is somehow corrupted, workbench was crashing as it set up the project recovery widget. I'm not sure how to recreate the corruption naturally, but I did have it happen to me where it was only half written out, maybe from a very badly timed force quit?

#### Summary of work
I've just added a try except around the read to catch a decode error and print a warning. The `load_workspaces.py` could still be perfectly usable, so the user can try and run this recovery regardless.

Fixes #37175

### To test:

- Follow the steps I wrote in the issue
- The recovery checkpoint will appear in the widget as having 0 workspaces to recovery and a warning will be output
- Running the recovery will still run the `ordered_recovery.py` script to recreate any lost workspaces

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
