### PR TITLE
Add polarizer efficiency algorithm

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -240,6 +240,7 @@ set(SRC_FILES
     src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
     src/PolarizationCorrections/PolarizationCorrectionsHelpers.cpp
     src/PolarizationCorrections/SpinStateValidator.cpp
+    src/PolarizationCorrections/PolarizerEfficiency.cpp
     src/PolarizationCorrectionFredrikze.cpp
     src/PolarizationCorrectionWildes.cpp
     src/PolarizationEfficiencyCor.cpp
@@ -598,6 +599,7 @@ set(INC_FILES
     inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
     inc/MantidAlgorithms/PolarizationCorrections/SpinStateValidator.h
     inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
+    inc/MantidAlgorithms/PolarizationCorrections/PolarizerEfficiency.h
     inc/MantidAlgorithms/PolarizationCorrectionFredrikze.h
     inc/MantidAlgorithms/PolarizationCorrectionWildes.h
     inc/MantidAlgorithms/PolarizationEfficiencyCor.h
@@ -949,6 +951,7 @@ set(TEST_FILES
     PolarizationCorrections/PolarizationCorrectionsHelpersTest.h
     PolarizationCorrections/SpinStateValidatorTest.h
     PolarizationCorrections/FlipperEfficiencyTest.h
+    PolarizationCorrections/PolarizerEfficiencyTest.h
     PolarizationCorrectionFredrikzeTest.h
     PolarizationCorrectionWildesTest.h
     PolarizationEfficiencyCorTest.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizerEfficiency.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizerEfficiency.h
@@ -12,6 +12,7 @@
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAlgorithms/DllConfig.h"
 #include <map>
+#include <string>
 
 namespace Mantid {
 namespace Algorithms {
@@ -37,12 +38,26 @@ private:
   bool processGroups() override;
   void validateGroupInput();
   void calculatePolarizerEfficiency();
-  MatrixWorkspace_sptr workspaceForSpinConfig(WorkspaceGroup_sptr group,
-                                              const std::vector<std::string> &spinConfigOrder,
-                                              const std::string &spinConfig);
-  void scaleWorkspace(MatrixWorkspace_sptr ws, const double factor) { runScaleAlgorithm(ws, factor, true); }
-  void addOffsetToWorkspace(MatrixWorkspace_sptr ws, const double offset) { runScaleAlgorithm(ws, offset, false); }
-  void runScaleAlgorithm(MatrixWorkspace_sptr ws, const double factor, const bool isMultiply);
+  void scaleWorkspace(MatrixWorkspace_sptr ws, const double factor);
+  MatrixWorkspace_sptr addTwoWorkspaces(MatrixWorkspace_sptr a, MatrixWorkspace_sptr b,
+                                        MatrixWorkspace_sptr output = nullptr) {
+    return runMathsAlgorithm("Plus", a, b, output);
+  }
+  MatrixWorkspace_sptr subtractTwoWorkspaces(MatrixWorkspace_sptr lhs, MatrixWorkspace_sptr rhs,
+                                             MatrixWorkspace_sptr output = nullptr) {
+    return runMathsAlgorithm("Minus", lhs, rhs, output);
+  }
+  MatrixWorkspace_sptr multiplyWorkspaces(MatrixWorkspace_sptr a, MatrixWorkspace_sptr b,
+                                          MatrixWorkspace_sptr output = nullptr) {
+    return runMathsAlgorithm("Multiply", a, b, output);
+  }
+  MatrixWorkspace_sptr divideWorkspaces(MatrixWorkspace_sptr numerator, MatrixWorkspace_sptr denominator,
+                                        MatrixWorkspace_sptr output = nullptr) {
+    return runMathsAlgorithm("Divide", numerator, denominator, output);
+  }
+  MatrixWorkspace_sptr runMathsAlgorithm(std::string algName, MatrixWorkspace_sptr lhs, MatrixWorkspace_sptr rhs,
+                                         MatrixWorkspace_sptr output);
+  MatrixWorkspace_sptr convertToHistIfNecessary(const MatrixWorkspace_sptr ws);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizerEfficiency.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizerEfficiency.h
@@ -1,0 +1,49 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAlgorithms/DllConfig.h"
+#include <map>
+
+namespace Mantid {
+namespace Algorithms {
+using namespace API;
+
+class MANTID_ALGORITHMS_DLL PolarizerEfficiency final : public API::Algorithm {
+public:
+  /// Algorithm's name for identification overriding a virtual method
+  const std::string name() const override { return "PolarizerEfficiency"; }
+  /// Summary of algorithms purpose
+  const std::string summary() const override { return "Calculates the efficiency of a polarizer."; }
+  /// Algorithm's version for identification overriding a virtual method
+  int version() const override { return 1; }
+  /// Algorithm's category for identification overriding a virtual method
+  const std::string category() const override { return "SANS\\PolarizationCorrections"; }
+  /// Check that input params are valid
+  std::map<std::string, std::string> validateInputs() override;
+
+private:
+  // Implement abstract Algorithm methods
+  void init() override;
+  void exec() override;
+  bool processGroups() override;
+  void validateGroupInput();
+  void calculatePolarizerEfficiency();
+  MatrixWorkspace_sptr workspaceForSpinConfig(WorkspaceGroup_sptr group,
+                                              const std::vector<std::string> &spinConfigOrder,
+                                              const std::string &spinConfig);
+  void scaleWorkspace(MatrixWorkspace_sptr ws, const double factor) { runScaleAlgorithm(ws, factor, true); }
+  void addOffsetToWorkspace(MatrixWorkspace_sptr ws, const double offset) { runScaleAlgorithm(ws, offset, false); }
+  void runScaleAlgorithm(MatrixWorkspace_sptr ws, const double factor, const bool isMultiply);
+};
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizerEfficiency.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizerEfficiency.h
@@ -39,6 +39,7 @@ private:
   void validateGroupInput();
   void calculatePolarizerEfficiency();
   MatrixWorkspace_sptr convertToHistIfNecessary(const MatrixWorkspace_sptr ws);
+  void saveToFile(MatrixWorkspace_sptr const &workspace, std::string const &filePathStr);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizerEfficiency.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizerEfficiency.h
@@ -38,25 +38,6 @@ private:
   bool processGroups() override;
   void validateGroupInput();
   void calculatePolarizerEfficiency();
-  void scaleWorkspace(MatrixWorkspace_sptr ws, const double factor);
-  MatrixWorkspace_sptr addTwoWorkspaces(MatrixWorkspace_sptr a, MatrixWorkspace_sptr b,
-                                        MatrixWorkspace_sptr output = nullptr) {
-    return runMathsAlgorithm("Plus", a, b, output);
-  }
-  MatrixWorkspace_sptr subtractTwoWorkspaces(MatrixWorkspace_sptr lhs, MatrixWorkspace_sptr rhs,
-                                             MatrixWorkspace_sptr output = nullptr) {
-    return runMathsAlgorithm("Minus", lhs, rhs, output);
-  }
-  MatrixWorkspace_sptr multiplyWorkspaces(MatrixWorkspace_sptr a, MatrixWorkspace_sptr b,
-                                          MatrixWorkspace_sptr output = nullptr) {
-    return runMathsAlgorithm("Multiply", a, b, output);
-  }
-  MatrixWorkspace_sptr divideWorkspaces(MatrixWorkspace_sptr numerator, MatrixWorkspace_sptr denominator,
-                                        MatrixWorkspace_sptr output = nullptr) {
-    return runMathsAlgorithm("Divide", numerator, denominator, output);
-  }
-  MatrixWorkspace_sptr runMathsAlgorithm(std::string algName, MatrixWorkspace_sptr lhs, MatrixWorkspace_sptr rhs,
-                                         MatrixWorkspace_sptr output);
   MatrixWorkspace_sptr convertToHistIfNecessary(const MatrixWorkspace_sptr ws);
 };
 

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
@@ -38,6 +38,10 @@ static const std::string OUTPUT_WORKSPACE = "OutputWorkspace";
 static const std::string OUTPUT_FILE_PATH = "OutputFilePath";
 } // namespace PropertyNames
 
+namespace {
+static const std::string FILE_EXTENSION = ".nxs";
+} // unnamed namespace
+
 void PolarizerEfficiency::init() {
   declareProperty(
       std::make_unique<WorkspaceProperty<WorkspaceGroup>>(PropertyNames::INPUT_WORKSPACE, "", Direction::Input),
@@ -74,13 +78,13 @@ std::map<std::string, std::string> PolarizerEfficiency::validateInputs() {
   if (inputWorkspace->size() != 4) {
     errorList[PropertyNames::INPUT_WORKSPACE] =
         "The input group workspace must have four periods corresponding to the four spin configurations.";
-  }
-
-  for (size_t i = 0; i < inputWorkspace->size(); ++i) {
-    const MatrixWorkspace_sptr stateWs = std::dynamic_pointer_cast<MatrixWorkspace>(inputWorkspace->getItem(i));
-    Unit_const_sptr unit = stateWs->getAxis(0)->unit();
-    if (unit->unitID() != "Wavelength") {
-      errorList[PropertyNames::INPUT_WORKSPACE] = "All input workspaces must be in units of Wavelength.";
+  } else {
+    for (size_t i = 0; i < inputWorkspace->size(); ++i) {
+      const MatrixWorkspace_sptr stateWs = std::dynamic_pointer_cast<MatrixWorkspace>(inputWorkspace->getItem(i));
+      Unit_const_sptr unit = stateWs->getAxis(0)->unit();
+      if (unit->unitID() != "Wavelength") {
+        errorList[PropertyNames::INPUT_WORKSPACE] = "All input workspaces must be in units of Wavelength.";
+      }
     }
   }
 
@@ -153,9 +157,8 @@ void PolarizerEfficiency::calculatePolarizerEfficiency() {
 void PolarizerEfficiency::saveToFile(MatrixWorkspace_sptr const &workspace, std::string const &filePathStr) {
   std::filesystem::path filePath = filePathStr;
   // Add the nexus extension if it's not been applied already.
-  const std::string fileExtension = ".nxs";
-  if (filePath.extension() != fileExtension) {
-    filePath.replace_extension(fileExtension);
+  if (filePath.extension() != FILE_EXTENSION) {
+    filePath.replace_extension(FILE_EXTENSION);
   }
   auto saveAlg = createChildAlgorithm("SaveNexus");
   saveAlg->initialize();

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
@@ -1,0 +1,186 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidAlgorithms/PolarizationCorrections/PolarizerEfficiency.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/HistogramValidator.h"
+#include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidKernel/BoundedValidator.h"
+#include "MantidKernel/CompositeValidator.h"
+#include "MantidKernel/ListValidator.h"
+
+#include <boost/algorithm/string/join.hpp>
+
+namespace Mantid::Algorithms {
+// Register the algorithm into the algorithm factory
+DECLARE_ALGORITHM(PolarizerEfficiency)
+
+using namespace Kernel;
+using namespace API;
+
+namespace SpinConfigurations {
+static const std::string UP_UP = "11";
+static const std::string UP_DOWN = "10";
+static const std::string DOWN_UP = "01";
+static const std::string DOWN_DOWN = "00";
+} // namespace SpinConfigurations
+
+namespace PropertyNames {
+static const std::string INPUT_WORKSPACE = "InputWorkspace";
+static const std::string ANALYSER_EFFICIENCY = "AnalyserEfficiency";
+static const std::string SPIN_STATES = "SpinStates";
+static const std::string OUTPUT_WORKSPACE = "OutputWorkspace";
+} // namespace PropertyNames
+
+void PolarizerEfficiency::init() {
+  // Declare required input parameters for algorithm and do some validation here
+  auto validator = std::make_shared<CompositeValidator>();
+  validator->add<WorkspaceUnitValidator>("Wavelength");
+  validator->add<HistogramValidator>();
+  declareProperty(
+      std::make_unique<WorkspaceProperty<>>(PropertyNames::INPUT_WORKSPACE, "", Direction::Input, validator),
+      "Input group workspace to use for polarization calculation");
+  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropertyNames::ANALYSER_EFFICIENCY, "",
+                                                                       Direction::Input, validator),
+                  "Analyser efficiency as a function of wavelength");
+  declareProperty(
+      std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropertyNames::OUTPUT_WORKSPACE, "", Direction::Output),
+      "Polarizer efficiency as a function of wavelength");
+
+  std::vector<std::string> initialSpinConfig{{SpinConfigurations::UP_UP, SpinConfigurations::UP_DOWN,
+                                              SpinConfigurations::DOWN_UP, SpinConfigurations::DOWN_DOWN}};
+  std::sort(initialSpinConfig.begin(), initialSpinConfig.end());
+  std::vector<std::string> allowedSpinConfigs;
+  allowedSpinConfigs.push_back(boost::algorithm::join(initialSpinConfig, ","));
+  while (std::next_permutation(initialSpinConfig.begin(), initialSpinConfig.end())) {
+    allowedSpinConfigs.push_back(boost::algorithm::join(initialSpinConfig, ","));
+  }
+  // "Order of individual spin states in the input group workspace, e.g. \"01,11,00,10\""
+  declareProperty(
+      PropertyNames::SPIN_STATES,
+      boost::algorithm::join(std::vector<std::string>{{SpinConfigurations::UP_UP, SpinConfigurations::DOWN_UP,
+                                                       SpinConfigurations::DOWN_DOWN, SpinConfigurations::UP_DOWN}},
+                             ","),
+      std::make_shared<ListValidator<std::string>>(allowedSpinConfigs));
+}
+
+/**
+ * Tests that the inputs are all valid
+ * @return A map containing the incorrect workspace
+ * properties and an error message
+ */
+std::map<std::string, std::string> PolarizerEfficiency::validateInputs() {
+  std::map<std::string, std::string> errorList;
+  const std::string inputWorkspaceName = getProperty(PropertyNames::INPUT_WORKSPACE);
+  if (!AnalysisDataService::Instance().doesExist(inputWorkspaceName)) {
+    errorList[PropertyNames::INPUT_WORKSPACE] = "The workspace " + inputWorkspaceName + " does not exist in the ADS.";
+    return errorList;
+  }
+
+  const auto ws = AnalysisDataService::Instance().retrieve(inputWorkspaceName);
+  if (!ws->isGroup()) {
+    errorList[PropertyNames::INPUT_WORKSPACE] = "The input workspace is not a group workspace.";
+  } else {
+    const auto wsGroup = std::dynamic_pointer_cast<WorkspaceGroup>(ws);
+    if (wsGroup->size() != 4) {
+      errorList[PropertyNames::INPUT_WORKSPACE] =
+          "The input group workspace must have four periods corresponding to the four spin configurations.";
+    }
+  }
+
+  return errorList;
+}
+
+/**
+ * Explicitly calls validateInputs and throws runtime error in case
+ * of issues in the input properties.
+ */
+void PolarizerEfficiency::validateGroupInput() {
+  const auto results = validateInputs();
+  for (const auto &result : results) {
+    throw std::runtime_error("Issue in " + result.first + " property: " + result.second);
+  }
+}
+
+bool PolarizerEfficiency::processGroups() {
+  validateGroupInput();
+  calculatePolarizerEfficiency();
+  return true;
+}
+
+void PolarizerEfficiency::exec() { calculatePolarizerEfficiency(); }
+
+void PolarizerEfficiency::calculatePolarizerEfficiency() {
+  // First we extract the individual workspaces corresponding to each spin configuration from the group workspace
+  const auto groupWorkspace =
+      AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(getProperty(PropertyNames::INPUT_WORKSPACE));
+  std::string spinConfigurationInput = getProperty(PropertyNames::SPIN_STATES);
+  std::vector<std::string> spinConfigurations;
+  boost::split(spinConfigurations, spinConfigurationInput, boost::is_any_of(","));
+
+  const auto t01Ws = workspaceForSpinConfig(groupWorkspace, spinConfigurations, SpinConfigurations::DOWN_UP);
+  const auto t00Ws = workspaceForSpinConfig(groupWorkspace, spinConfigurations, SpinConfigurations::DOWN_DOWN);
+
+  const MatrixWorkspace_sptr effCell =
+      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(getProperty(PropertyNames::ANALYSER_EFFICIENCY));
+
+  // The efficiency is given by 0.5 + (T_00 - T_01) / (8 * e_cell - 4)
+
+  auto minus = createChildAlgorithm("Minus");
+  minus->initialize();
+  minus->setProperty("LHSWorkspace", t00Ws);
+  minus->setProperty("RHSWorkspace", t01Ws);
+  minus->setProperty("OutputWorkspace", "numerator");
+  minus->execute();
+  MatrixWorkspace_sptr numerator = minus->getProperty("OutputWorkspace");
+
+  // To divide workspaces they need to have matching bins
+  auto rebinToWorkspace = createChildAlgorithm("RebinToWorkspace");
+  rebinToWorkspace->initialize();
+  rebinToWorkspace->setProperty("WorkspaceToRebin", effCell);
+  rebinToWorkspace->setProperty("WorkspaceToMatch", numerator);
+  rebinToWorkspace->setProperty("OutputWorkspace", "effCellRebinned");
+  rebinToWorkspace->execute();
+  MatrixWorkspace_sptr denominator = rebinToWorkspace->getProperty("OutputWorkspace");
+
+  scaleWorkspace(denominator, 8);
+  addOffsetToWorkspace(denominator, -4);
+
+  auto divide = createChildAlgorithm("Divide");
+  divide->initialize();
+  divide->setProperty("LHSWorkspace", numerator);
+  divide->setProperty("RHSWorkspace", denominator);
+  divide->setProperty("OutputWorkspace", "effPolarizer");
+  divide->execute();
+  MatrixWorkspace_sptr effPolarizer = divide->getProperty("OutputWorkspace");
+
+  addOffsetToWorkspace(effPolarizer, 0.5);
+
+  setProperty(PropertyNames::OUTPUT_WORKSPACE, effPolarizer);
+}
+
+void PolarizerEfficiency::runScaleAlgorithm(MatrixWorkspace_sptr ws, const double factor, const bool isMultiply) {
+  auto scale = createChildAlgorithm("Scale");
+  scale->initialize();
+  scale->setProperty("InputWorkspace", ws);
+  scale->setProperty("OutputWorkspace", ws);
+  scale->setProperty("Factor", factor);
+  const std::string operation = isMultiply ? "Multiply" : "Add";
+  scale->setProperty("Operation", operation);
+  scale->execute();
+}
+
+MatrixWorkspace_sptr PolarizerEfficiency::workspaceForSpinConfig(WorkspaceGroup_sptr group,
+                                                                 const std::vector<std::string> &spinConfigOrder,
+                                                                 const std::string &spinConfig) {
+  const auto wsIndex =
+      std::find(spinConfigOrder.cbegin(), spinConfigOrder.cend(), spinConfig) - spinConfigOrder.cbegin();
+  return std::dynamic_pointer_cast<MatrixWorkspace>(group->getItem(wsIndex));
+}
+} // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
@@ -35,7 +35,7 @@ static const std::string OUTPUT_WORKSPACE = "OutputWorkspace";
 
 void PolarizerEfficiency::init() {
   // Declare required input parameters for algorithm and do some validation here
-  auto &validator = std::make_shared<CompositeValidator>();
+  auto validator = std::make_shared<CompositeValidator>();
   validator->add<WorkspaceUnitValidator>("Wavelength");
   validator->add<HistogramValidator>();
   declareProperty(
@@ -112,10 +112,10 @@ void PolarizerEfficiency::calculatePolarizerEfficiency() {
   const auto &t00Ws = PolarizationCorrectionsHelpers::workspaceForSpinState(groupWorkspace, spinConfigurationInput,
                                                                             SpinStateValidator::ZERO_ZERO);
 
-  auto &effCell = convertToHistIfNecessary(
+  auto effCell = convertToHistIfNecessary(
       AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(getProperty(PropertyNames::ANALYSER_EFFICIENCY)));
 
-  auto &rebin = createChildAlgorithm("RebinToWorkspace");
+  auto rebin = createChildAlgorithm("RebinToWorkspace");
   rebin->initialize();
   rebin->setProperty("WorkspaceToRebin", effCell);
   rebin->setProperty("WorkspaceToMatch", t00Ws);
@@ -137,7 +137,7 @@ MatrixWorkspace_sptr PolarizerEfficiency::convertToHistIfNecessary(const MatrixW
   if (wsClone->isHistogramData())
     return wsClone;
 
-  auto &convertToHistogram = createChildAlgorithm("ConvertToHistogram");
+  auto convertToHistogram = createChildAlgorithm("ConvertToHistogram");
   convertToHistogram->initialize();
   convertToHistogram->setProperty("InputWorkspace", wsClone);
   convertToHistogram->setProperty("OutputWorkspace", wsClone);

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
@@ -42,7 +42,7 @@ void PolarizerEfficiency::init() {
   validator->add<WorkspaceUnitValidator>("Wavelength");
   validator->add<HistogramValidator>();
   declareProperty(
-      std::make_unique<WorkspaceProperty<>>(PropertyNames::INPUT_WORKSPACE, "", Direction::Input, validator),
+      std::make_unique<WorkspaceProperty<WorkspaceGroup>>(PropertyNames::INPUT_WORKSPACE, "", Direction::Input, validator),
       "Input group workspace to use for polarization calculation");
   const auto &wavelengthValidator = std::make_shared<WorkspaceUnitValidator>("Wavelength");
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropertyNames::ANALYSER_EFFICIENCY, "",

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
@@ -67,9 +67,9 @@ void PolarizerEfficiency::init() {
  */
 std::map<std::string, std::string> PolarizerEfficiency::validateInputs() {
   std::map<std::string, std::string> errorList;
-  const std::string inputWorkspaceName = getProperty(PropertyNames::INPUT_WORKSPACE);
-  if (!AnalysisDataService::Instance().doesExist(inputWorkspaceName)) {
-    errorList[PropertyNames::INPUT_WORKSPACE] = "The workspace " + inputWorkspaceName + " does not exist in the ADS.";
+  const WorkspaceGroup_sptr inputWorkspace = getProperty(PropertyNames::INPUT_WORKSPACE);
+  if (inputWorkspace == nullptr) {
+    errorList[PropertyNames::INPUT_WORKSPACE] = "The input workspace  is not a workspace group."
     return errorList;
   }
 

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
@@ -123,14 +123,7 @@ void PolarizerEfficiency::calculatePolarizerEfficiency() {
   rebin->execute();
   effCell = rebin->getProperty("OutputWorkspace");
 
-  // The efficiency is given by (e_cell * (T00 + T01) - T01) / ((2 * e_cell - 1) * (T00 + T01))
-
-  const auto &sumT = t00Ws + t01Ws;
-  auto &eCellTimesSum = effCell * sumT;
-  const auto &numerator = eCellTimesSum - t01Ws;
-  eCellTimesSum *= 2;
-  const auto &denominator = eCellTimesSum - sumT;
-  const auto &effPolarizer = numerator / denominator;
+  const auto &effPolarizer = (t00Ws - t01Ws) / (4 * (2 * effCell - 1) * (t00Ws + t01Ws)) + 0.5;
   setProperty(PropertyNames::OUTPUT_WORKSPACE, effPolarizer);
 }
 

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
@@ -50,8 +50,7 @@ void PolarizerEfficiency::init() {
       "Polarizer efficiency as a function of wavelength");
 
   auto spinValidator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{4});
-  std::string initialSpinConfig = "11,10,01,00";
-  declareProperty(PropertyNames::SPIN_STATES, initialSpinConfig, spinValidator,
+  declareProperty(PropertyNames::SPIN_STATES, "11,10,01,00", spinValidator,
                   "Order of individual spin states in the input group workspace, e.g. \"01,11,00,10\"");
 }
 
@@ -88,8 +87,9 @@ std::map<std::string, std::string> PolarizerEfficiency::validateInputs() {
  */
 void PolarizerEfficiency::validateGroupInput() {
   const auto results = validateInputs();
-  for (const auto &result : results) {
-    throw std::runtime_error("Issue in " + result.first + " property: " + result.second);
+  if (results.size() > 0) {
+    const auto result = results.cbegin();
+    throw std::runtime_error("Issue in " + result->first + " property: " + result->second);
   }
 }
 
@@ -130,7 +130,7 @@ void PolarizerEfficiency::calculatePolarizerEfficiency() {
   auto numerator = subtractTwoWorkspaces(eCellTimesSum, t01Ws);
   scaleWorkspace(eCellTimesSum, 2);
   auto denominator = subtractTwoWorkspaces(eCellTimesSum, sumT);
-  auto effPolarizer = divideWorkspaces(numerator, denominator);
+  auto effPolarizer = divideWorkspaces(std::move(numerator), std::move(denominator));
   setProperty(PropertyNames::OUTPUT_WORKSPACE, effPolarizer);
 }
 

--- a/Framework/Algorithms/test/PolarizationCorrections/PolarizerEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/PolarizerEfficiencyTest.h
@@ -44,7 +44,7 @@ public:
 
     MatrixWorkspace_sptr ws1 = generateWorkspace("ws1", x, y);
 
-    auto &polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
+    auto polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
     polariserEfficiency->initialize();
     polariserEfficiency->setProperty("InputWorkspace", ws1->getName());
     TS_ASSERT_THROWS(polariserEfficiency->execute(), const std::runtime_error &);
@@ -58,12 +58,12 @@ public:
     MatrixWorkspace_sptr ws1 = generateWorkspace("ws1", x, y);
     MatrixWorkspace_sptr ws2 = generateWorkspace("ws2", x, y);
     WorkspaceGroup_sptr groupWs = groupWorkspaces("grp", std::vector<MatrixWorkspace_sptr>{ws1, ws2});
-    auto &polariserEfficiency = createPolarizerEfficiencyAlgorithm(groupWs);
+    auto polariserEfficiency = createPolarizerEfficiencyAlgorithm(groupWs);
     TS_ASSERT_THROWS(polariserEfficiency->execute(), const std::runtime_error &);
   }
 
   void testOutput() {
-    auto &polariserEfficiency = createPolarizerEfficiencyAlgorithm();
+    auto polariserEfficiency = createPolarizerEfficiencyAlgorithm();
     polariserEfficiency->execute();
 
     const auto &workspaces = AnalysisDataService::Instance().getObjectNames();
@@ -71,7 +71,7 @@ public:
   }
 
   void testSpinConfigurations() {
-    auto &polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
+    auto polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
     TS_ASSERT_THROWS(polariserEfficiency->setProperty("SpinStates", "bad"), std::invalid_argument &);
     TS_ASSERT_THROWS(polariserEfficiency->setProperty("SpinStates", "10,01"), std::invalid_argument &);
     TS_ASSERT_THROWS(polariserEfficiency->setProperty("SpinStates", "00,00,11,11"), std::invalid_argument &);
@@ -80,21 +80,21 @@ public:
 
   void testNonWavelengthInput() {
     // The units of the input workspace should be wavelength
-    auto &wsGrp = createExampleGroupWorkspace("wsGrp", "TOF");
-    auto &polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
+    auto wsGrp = createExampleGroupWorkspace("wsGrp", "TOF");
+    auto polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
     polariserEfficiency->initialize();
     TS_ASSERT_THROWS(polariserEfficiency->setProperty("InputWorkspace", wsGrp->getName()), std::invalid_argument &);
   }
 
   void testExampleCalculation() {
-    auto &tPara = generateFunctionDefinedWorkspace("T_para", "4 + x*0");
-    auto &tPara1 = generateFunctionDefinedWorkspace("T_para1", "4 + x*0");
-    auto &tAnti = generateFunctionDefinedWorkspace("T_anti", "2 + x*0");
-    auto &tAnti1 = generateFunctionDefinedWorkspace("T_anti1", "2 + x*0");
+    auto tPara = generateFunctionDefinedWorkspace("T_para", "4 + x*0");
+    auto tPara1 = generateFunctionDefinedWorkspace("T_para1", "4 + x*0");
+    auto tAnti = generateFunctionDefinedWorkspace("T_anti", "2 + x*0");
+    auto tAnti1 = generateFunctionDefinedWorkspace("T_anti1", "2 + x*0");
 
-    auto &grpWs = groupWorkspaces("grpWs", {tPara, tAnti, tAnti1, tPara1});
+    auto grpWs = groupWorkspaces("grpWs", {tPara, tAnti, tAnti1, tPara1});
 
-    auto &polariserEfficiency = createPolarizerEfficiencyAlgorithm(grpWs);
+    auto polariserEfficiency = createPolarizerEfficiencyAlgorithm(grpWs);
     polariserEfficiency->execute();
     MatrixWorkspace_sptr calculatedPolariserEfficiency = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
         polariserEfficiency->getProperty("OutputWorkspace"));
@@ -107,7 +107,7 @@ public:
   }
 
   void testErrors() {
-    auto &polarizerEfficiency = createPolarizerEfficiencyAlgorithm();
+    auto polarizerEfficiency = createPolarizerEfficiencyAlgorithm();
     polarizerEfficiency->execute();
     MatrixWorkspace_sptr eff = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
         polarizerEfficiency->getProperty("OutputWorkspace"));
@@ -142,7 +142,7 @@ private:
 
   MatrixWorkspace_sptr generateWorkspace(const std::string &name, const std::vector<double> &x,
                                          const std::vector<double> &y, const std::string &xUnit = "Wavelength") {
-    auto &e = std::vector<double>(x.size());
+    auto e = std::vector<double>(x.size());
     for (size_t i = 0; i < e.size(); ++i) {
       e[i] = 0;
     }
@@ -152,7 +152,7 @@ private:
   MatrixWorkspace_sptr generateWorkspace(const std::string &name, const std::vector<double> &x,
                                          const std::vector<double> &y, const std::vector<double> &e,
                                          const std::string &xUnit = "Wavelength") {
-    auto &createWorkspace = AlgorithmManager::Instance().create("CreateWorkspace");
+    auto createWorkspace = AlgorithmManager::Instance().create("CreateWorkspace");
     createWorkspace->initialize();
     createWorkspace->setProperty("DataX", x);
     createWorkspace->setProperty("DataY", y);
@@ -162,7 +162,7 @@ private:
     createWorkspace->setProperty("Distribution", true);
     createWorkspace->execute();
 
-    auto &convertToHistogram = AlgorithmManager::Instance().create("ConvertToHistogram");
+    auto convertToHistogram = AlgorithmManager::Instance().create("ConvertToHistogram");
     convertToHistogram->initialize();
     convertToHistogram->setProperty("InputWorkspace", name);
     convertToHistogram->setProperty("OutputWorkspace", name);
@@ -173,7 +173,7 @@ private:
   }
 
   WorkspaceGroup_sptr groupWorkspaces(const std::string &name, const std::vector<MatrixWorkspace_sptr> &wsToGroup) {
-    auto &groupWorkspace = AlgorithmManager::Instance().create("GroupWorkspaces");
+    auto groupWorkspace = AlgorithmManager::Instance().create("GroupWorkspaces");
     groupWorkspace->initialize();
     std::vector<std::string> wsToGroupNames(wsToGroup.size());
     std::transform(wsToGroup.cbegin(), wsToGroup.cend(), wsToGroupNames.begin(),
@@ -186,7 +186,7 @@ private:
   }
 
   MatrixWorkspace_sptr generateFunctionDefinedWorkspace(const std::string &name, const std::string &func) {
-    auto &createSampleWorkspace = AlgorithmManager::Instance().create("CreateSampleWorkspace");
+    auto createSampleWorkspace = AlgorithmManager::Instance().create("CreateSampleWorkspace");
     createSampleWorkspace->initialize();
     createSampleWorkspace->setProperty("WorkspaceType", "Histogram");
     createSampleWorkspace->setProperty("OutputWorkspace", name);
@@ -210,7 +210,7 @@ private:
     if (inputGrp == nullptr) {
       inputGrp = createExampleGroupWorkspace("wsGrp");
     }
-    auto &polarizerEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
+    auto polarizerEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
     polarizerEfficiency->initialize();
     polarizerEfficiency->setProperty("InputWorkspace", inputGrp->getName());
     polarizerEfficiency->setProperty("AnalyserEfficiency", ANALYSER_EFFICIENCY_WS_NAME);

--- a/Framework/Algorithms/test/PolarizationCorrections/PolarizerEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/PolarizerEfficiencyTest.h
@@ -52,8 +52,7 @@ public:
 
     auto polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
     polariserEfficiency->initialize();
-    polariserEfficiency->setProperty("InputWorkspace", ws1->getName());
-    TS_ASSERT_THROWS(polariserEfficiency->execute(), const std::runtime_error &);
+    TS_ASSERT_THROWS(polariserEfficiency->setProperty("InputWorkspace", ws1), const std::invalid_argument &);
   }
 
   void testGroupWorkspaceWithWrongSize() {
@@ -89,7 +88,8 @@ public:
     auto wsGrp = createExampleGroupWorkspace("wsGrp", "TOF");
     auto polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
     polariserEfficiency->initialize();
-    TS_ASSERT_THROWS(polariserEfficiency->setProperty("InputWorkspace", wsGrp->getName()), std::invalid_argument &);
+    polariserEfficiency->setProperty("InputWorkspace", wsGrp);
+    TS_ASSERT_THROWS(polariserEfficiency->execute(), const std::runtime_error &);
   }
 
   void testExampleCalculation() {

--- a/Framework/Algorithms/test/PolarizationCorrections/PolarizerEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/PolarizerEfficiencyTest.h
@@ -1,0 +1,215 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#pragma once
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAlgorithms/PolarizationCorrections/PolarizerEfficiency.h"
+
+#include <cxxtest/TestSuite.h>
+
+using namespace Mantid;
+using namespace Mantid::Algorithms;
+using namespace Mantid::API;
+
+class PolarizerEfficiencyTest : public CxxTest::TestSuite {
+public:
+  void setUp() override {
+    // Use an analyser efficiency of 1 to make test calculations simpler
+    generateFunctionDefinedWorkspace(ANALYSER_EFFICIENCY_WS_NAME, "1 + x*0");
+  }
+
+  void tearDown() override { AnalysisDataService::Instance().clear(); }
+
+  void testName() {
+    PolarizerEfficiency alg;
+    TS_ASSERT_EQUALS(alg.name(), "PolarizerEfficiency");
+  }
+
+  void testInit() {
+    PolarizerEfficiency alg;
+    alg.initialize();
+    TS_ASSERT(alg.isInitialized());
+  }
+
+  void testNonGroupWorkspaceInput() {
+    // Should accept a group workspace containing four workspaces, corresponding to the four spin configurations
+    std::vector<double> x{1, 2, 3, 4, 5};
+    std::vector<double> y{1, 4, 9, 16, 25};
+
+    MatrixWorkspace_sptr ws1 = generateWorkspace("ws1", x, y);
+
+    auto polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
+    polariserEfficiency->initialize();
+    polariserEfficiency->setProperty("InputWorkspace", ws1->getName());
+    TS_ASSERT_THROWS(polariserEfficiency->execute(), const std::runtime_error &);
+  }
+
+  void testGroupWorkspaceWithWrongSize() {
+    // Should accept a group workspace containing four workspaces, corresponding to the four spin configurations
+    std::vector<double> x{1, 2, 3, 4, 5};
+    std::vector<double> y{1, 4, 9, 16, 25};
+
+    MatrixWorkspace_sptr ws1 = generateWorkspace("ws1", x, y);
+    MatrixWorkspace_sptr ws2 = generateWorkspace("ws2", x, y);
+    WorkspaceGroup_sptr groupWs = groupWorkspaces("grp", std::vector<MatrixWorkspace_sptr>{ws1, ws2});
+    auto polariserEfficiency = createPolarizerEfficiencyAlgorithm(groupWs);
+    TS_ASSERT_THROWS(polariserEfficiency->execute(), const std::runtime_error &);
+  }
+
+  void testOutput() {
+    auto polariserEfficiency = createPolarizerEfficiencyAlgorithm();
+    polariserEfficiency->execute();
+
+    const auto workspaces = AnalysisDataService::Instance().getObjectNames();
+    ASSERT_TRUE(std::find(workspaces.cbegin(), workspaces.cend(), "psm") != workspaces.cend());
+  }
+
+  void testSpinConfigurations() {
+    auto polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
+    TS_ASSERT_THROWS(polariserEfficiency->setProperty("SpinStates", "bad"), std::invalid_argument &);
+    TS_ASSERT_THROWS(polariserEfficiency->setProperty("SpinStates", "10,01"), std::invalid_argument &);
+    TS_ASSERT_THROWS(polariserEfficiency->setProperty("SpinStates", "00,00,11,11"), std::invalid_argument &);
+    TS_ASSERT_THROWS(polariserEfficiency->setProperty("SpinStates", "02,20,22,00"), std::invalid_argument &);
+  }
+
+  void testNonWavelengthInput() {
+    // The units of the input workspace should be wavelength
+    auto wsGrp = createExampleGroupWorkspace("wsGrp", "TOF");
+    auto polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
+    polariserEfficiency->initialize();
+    TS_ASSERT_THROWS(polariserEfficiency->setProperty("InputWorkspace", wsGrp->getName()), std::invalid_argument &);
+  }
+
+  void testExampleCalculation() {
+    auto tPara = generateFunctionDefinedWorkspace("T_para", "4 + x*0");
+    auto tPara1 = generateFunctionDefinedWorkspace("T_para1", "4 + x*0");
+    auto tAnti = generateFunctionDefinedWorkspace("T_anti", "2 + x*0");
+    auto tAnti1 = generateFunctionDefinedWorkspace("T_anti1", "2 * x*0");
+
+    auto grpWs = groupWorkspaces("grpWs", {tPara, tAnti, tPara1, tAnti1});
+
+    auto polariserEfficiency = createPolarizerEfficiencyAlgorithm(grpWs);
+    polariserEfficiency->execute();
+    MatrixWorkspace_sptr calculatedPolariserEfficiency = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+        polariserEfficiency->getProperty("OutputWorkspace"));
+
+    // The T_para and T_anti curves are 4 and 2 (constant wrt wavelength) respectively, and the analyser
+    // efficiency is 1 for all wavelengths, which should give us a polarizer efficiency of 1
+    for (const double &y : calculatedPolariserEfficiency->dataY(0)) {
+      TS_ASSERT_DELTA(1, y, 1e-8);
+    }
+  }
+
+  void testErrors() {
+    auto polarizerEfficiency = createPolarizerEfficiencyAlgorithm();
+    polarizerEfficiency->execute();
+    MatrixWorkspace_sptr eff = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+        polarizerEfficiency->getProperty("OutputWorkspace"));
+    const auto errors = eff->dataE(0);
+    // Skip the first error because with this toy data it'll be NaN
+    for (size_t i = 1; i < errors.size(); ++i) {
+      TS_ASSERT_DELTA(353.55339059327378, errors[i], 1e-8);
+    }
+  }
+
+private:
+  const std::string ANALYSER_EFFICIENCY_WS_NAME = "effAnalyser";
+
+  WorkspaceGroup_sptr createExampleGroupWorkspace(const std::string &name, const std::string &xUnit = "Wavelength",
+                                                  const size_t numBins = 5) {
+    std::vector<double> x(numBins);
+    std::vector<double> y(numBins);
+    std::vector<double> e(numBins);
+    for (size_t i = 0; i < numBins; ++i) {
+      x[i] = static_cast<double>(i) + 1.0;
+      y[i] = x[i] * x[i];
+      e[i] = 1000;
+    }
+    std::vector<MatrixWorkspace_sptr> wsVec(4);
+    for (size_t i = 0; i < 4; ++i) {
+      wsVec[i] = generateWorkspace("ws" + std::to_string(i), x, y, e, xUnit);
+    }
+    return groupWorkspaces(name, wsVec);
+  }
+
+  MatrixWorkspace_sptr generateWorkspace(const std::string &name, const std::vector<double> &x,
+                                         const std::vector<double> &y, const std::string &xUnit = "Wavelength") {
+    auto e = std::vector<double>(x.size());
+    for (size_t i = 0; i < e.size(); ++i) {
+      e[i] = 0;
+    }
+    return generateWorkspace(name, x, y, e, xUnit);
+  }
+
+  MatrixWorkspace_sptr generateWorkspace(const std::string &name, const std::vector<double> &x,
+                                         const std::vector<double> &y, const std::vector<double> &e,
+                                         const std::string &xUnit = "Wavelength") {
+    auto createWorkspace = AlgorithmManager::Instance().create("CreateWorkspace");
+    createWorkspace->initialize();
+    createWorkspace->setProperty("DataX", x);
+    createWorkspace->setProperty("DataY", y);
+    createWorkspace->setProperty("DataE", e);
+    createWorkspace->setProperty("UnitX", xUnit);
+    createWorkspace->setProperty("OutputWorkspace", name);
+    createWorkspace->execute();
+
+    auto convertToHistogram = AlgorithmManager::Instance().create("ConvertToHistogram");
+    convertToHistogram->initialize();
+    convertToHistogram->setProperty("InputWorkspace", name);
+    convertToHistogram->setProperty("OutputWorkspace", name);
+    convertToHistogram->execute();
+
+    MatrixWorkspace_sptr ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
+    return ws;
+  }
+
+  WorkspaceGroup_sptr groupWorkspaces(const std::string &name, const std::vector<MatrixWorkspace_sptr> &wsToGroup) {
+    auto groupWorkspace = AlgorithmManager::Instance().create("GroupWorkspaces");
+    groupWorkspace->initialize();
+    std::vector<std::string> wsToGroupNames(wsToGroup.size());
+    std::transform(wsToGroup.cbegin(), wsToGroup.cend(), wsToGroupNames.begin(),
+                   [](MatrixWorkspace_sptr w) { return w->getName(); });
+    groupWorkspace->setProperty("InputWorkspaces", wsToGroupNames);
+    groupWorkspace->setProperty("OutputWorkspace", name);
+    groupWorkspace->execute();
+    WorkspaceGroup_sptr group = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(name);
+    return group;
+  }
+
+  MatrixWorkspace_sptr generateFunctionDefinedWorkspace(const std::string &name, const std::string &func) {
+    auto createSampleWorkspace = AlgorithmManager::Instance().create("CreateSampleWorkspace");
+    createSampleWorkspace->initialize();
+    createSampleWorkspace->setProperty("WorkspaceType", "Histogram");
+    createSampleWorkspace->setProperty("OutputWorkspace", name);
+    createSampleWorkspace->setProperty("Function", "User Defined");
+    createSampleWorkspace->setProperty("UserDefinedFunction", "name=UserFunction,Formula=" + func);
+    createSampleWorkspace->setProperty("XUnit", "Wavelength");
+    createSampleWorkspace->setProperty("XMin", "1");
+    createSampleWorkspace->setProperty("XMax", "8");
+    createSampleWorkspace->setProperty("BinWidth", "1");
+    createSampleWorkspace->setProperty("NumBanks", 1);
+    createSampleWorkspace->setProperty("BankPixelWidth", 1);
+    createSampleWorkspace->execute();
+
+    MatrixWorkspace_sptr result = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
+    return result;
+  }
+
+  IAlgorithm_sptr createPolarizerEfficiencyAlgorithm(WorkspaceGroup_sptr inputGrp = nullptr) {
+    if (inputGrp == nullptr) {
+      inputGrp = createExampleGroupWorkspace("wsGrp");
+    }
+    auto polarizerEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
+    polarizerEfficiency->initialize();
+    polarizerEfficiency->setProperty("InputWorkspace", inputGrp->getName());
+    polarizerEfficiency->setProperty("AnalyserEfficiency", ANALYSER_EFFICIENCY_WS_NAME);
+    polarizerEfficiency->setProperty("OutputWorkspace", "psm");
+    return polarizerEfficiency;
+  }
+};

--- a/Framework/Algorithms/test/PolarizationCorrections/PolarizerEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/PolarizerEfficiencyTest.h
@@ -44,7 +44,7 @@ public:
 
     MatrixWorkspace_sptr ws1 = generateWorkspace("ws1", x, y);
 
-    auto polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
+    auto &polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
     polariserEfficiency->initialize();
     polariserEfficiency->setProperty("InputWorkspace", ws1->getName());
     TS_ASSERT_THROWS(polariserEfficiency->execute(), const std::runtime_error &);
@@ -58,20 +58,20 @@ public:
     MatrixWorkspace_sptr ws1 = generateWorkspace("ws1", x, y);
     MatrixWorkspace_sptr ws2 = generateWorkspace("ws2", x, y);
     WorkspaceGroup_sptr groupWs = groupWorkspaces("grp", std::vector<MatrixWorkspace_sptr>{ws1, ws2});
-    auto polariserEfficiency = createPolarizerEfficiencyAlgorithm(groupWs);
+    auto &polariserEfficiency = createPolarizerEfficiencyAlgorithm(groupWs);
     TS_ASSERT_THROWS(polariserEfficiency->execute(), const std::runtime_error &);
   }
 
   void testOutput() {
-    auto polariserEfficiency = createPolarizerEfficiencyAlgorithm();
+    auto &polariserEfficiency = createPolarizerEfficiencyAlgorithm();
     polariserEfficiency->execute();
 
-    const auto workspaces = AnalysisDataService::Instance().getObjectNames();
+    const auto &workspaces = AnalysisDataService::Instance().getObjectNames();
     ASSERT_TRUE(std::find(workspaces.cbegin(), workspaces.cend(), "psm") != workspaces.cend());
   }
 
   void testSpinConfigurations() {
-    auto polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
+    auto &polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
     TS_ASSERT_THROWS(polariserEfficiency->setProperty("SpinStates", "bad"), std::invalid_argument &);
     TS_ASSERT_THROWS(polariserEfficiency->setProperty("SpinStates", "10,01"), std::invalid_argument &);
     TS_ASSERT_THROWS(polariserEfficiency->setProperty("SpinStates", "00,00,11,11"), std::invalid_argument &);
@@ -80,41 +80,41 @@ public:
 
   void testNonWavelengthInput() {
     // The units of the input workspace should be wavelength
-    auto wsGrp = createExampleGroupWorkspace("wsGrp", "TOF");
-    auto polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
+    auto &wsGrp = createExampleGroupWorkspace("wsGrp", "TOF");
+    auto &polariserEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
     polariserEfficiency->initialize();
     TS_ASSERT_THROWS(polariserEfficiency->setProperty("InputWorkspace", wsGrp->getName()), std::invalid_argument &);
   }
 
   void testExampleCalculation() {
-    auto tPara = generateFunctionDefinedWorkspace("T_para", "4 + x*0");
-    auto tPara1 = generateFunctionDefinedWorkspace("T_para1", "4 + x*0");
-    auto tAnti = generateFunctionDefinedWorkspace("T_anti", "2 + x*0");
-    auto tAnti1 = generateFunctionDefinedWorkspace("T_anti1", "2 + x*0");
+    auto &tPara = generateFunctionDefinedWorkspace("T_para", "4 + x*0");
+    auto &tPara1 = generateFunctionDefinedWorkspace("T_para1", "4 + x*0");
+    auto &tAnti = generateFunctionDefinedWorkspace("T_anti", "2 + x*0");
+    auto &tAnti1 = generateFunctionDefinedWorkspace("T_anti1", "2 + x*0");
 
-    auto grpWs = groupWorkspaces("grpWs", {tPara, tAnti, tAnti1, tPara1});
+    auto &grpWs = groupWorkspaces("grpWs", {tPara, tAnti, tAnti1, tPara1});
 
-    auto polariserEfficiency = createPolarizerEfficiencyAlgorithm(grpWs);
+    auto &polariserEfficiency = createPolarizerEfficiencyAlgorithm(grpWs);
     polariserEfficiency->execute();
     MatrixWorkspace_sptr calculatedPolariserEfficiency = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
         polariserEfficiency->getProperty("OutputWorkspace"));
 
     // The T_para and T_anti curves are 4 and 2 (constant wrt wavelength) respectively, and the analyser
-    // efficiency is 1 for all wavelengths, which should give us a polarizer efficiency of 2/3
+    // efficiency is 1 for all wavelengths, which should give us a polarizer efficiency of 7/12
     for (const double &y : calculatedPolariserEfficiency->dataY(0)) {
-      TS_ASSERT_DELTA(2.0 / 3.0, y, 1e-8);
+      TS_ASSERT_DELTA(7.0 / 12.0, y, 1e-8);
     }
   }
 
   void testErrors() {
-    auto polarizerEfficiency = createPolarizerEfficiencyAlgorithm();
+    auto &polarizerEfficiency = createPolarizerEfficiencyAlgorithm();
     polarizerEfficiency->execute();
     MatrixWorkspace_sptr eff = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
         polarizerEfficiency->getProperty("OutputWorkspace"));
-    const auto errors = eff->dataE(0);
+    const auto &errors = eff->dataE(0);
     // Skip the first error because with this toy data it'll be NaN
-    const std::vector<double> expectedErrors{293.15439618057928, 130.29700166149377, 73.301389823113183,
-                                             46.925472826600263};
+    const std::vector<double> expectedErrors{44.194173824159222, 19.641855032959654, 11.048543456039805,
+                                             7.0710678118654755};
     for (size_t i = 0; i < expectedErrors.size(); ++i) {
       TS_ASSERT_DELTA(expectedErrors[i], errors[i + 1], 1e-7);
     }
@@ -142,7 +142,7 @@ private:
 
   MatrixWorkspace_sptr generateWorkspace(const std::string &name, const std::vector<double> &x,
                                          const std::vector<double> &y, const std::string &xUnit = "Wavelength") {
-    auto e = std::vector<double>(x.size());
+    auto &e = std::vector<double>(x.size());
     for (size_t i = 0; i < e.size(); ++i) {
       e[i] = 0;
     }
@@ -152,7 +152,7 @@ private:
   MatrixWorkspace_sptr generateWorkspace(const std::string &name, const std::vector<double> &x,
                                          const std::vector<double> &y, const std::vector<double> &e,
                                          const std::string &xUnit = "Wavelength") {
-    auto createWorkspace = AlgorithmManager::Instance().create("CreateWorkspace");
+    auto &createWorkspace = AlgorithmManager::Instance().create("CreateWorkspace");
     createWorkspace->initialize();
     createWorkspace->setProperty("DataX", x);
     createWorkspace->setProperty("DataY", y);
@@ -162,7 +162,7 @@ private:
     createWorkspace->setProperty("Distribution", true);
     createWorkspace->execute();
 
-    auto convertToHistogram = AlgorithmManager::Instance().create("ConvertToHistogram");
+    auto &convertToHistogram = AlgorithmManager::Instance().create("ConvertToHistogram");
     convertToHistogram->initialize();
     convertToHistogram->setProperty("InputWorkspace", name);
     convertToHistogram->setProperty("OutputWorkspace", name);
@@ -173,7 +173,7 @@ private:
   }
 
   WorkspaceGroup_sptr groupWorkspaces(const std::string &name, const std::vector<MatrixWorkspace_sptr> &wsToGroup) {
-    auto groupWorkspace = AlgorithmManager::Instance().create("GroupWorkspaces");
+    auto &groupWorkspace = AlgorithmManager::Instance().create("GroupWorkspaces");
     groupWorkspace->initialize();
     std::vector<std::string> wsToGroupNames(wsToGroup.size());
     std::transform(wsToGroup.cbegin(), wsToGroup.cend(), wsToGroupNames.begin(),
@@ -186,7 +186,7 @@ private:
   }
 
   MatrixWorkspace_sptr generateFunctionDefinedWorkspace(const std::string &name, const std::string &func) {
-    auto createSampleWorkspace = AlgorithmManager::Instance().create("CreateSampleWorkspace");
+    auto &createSampleWorkspace = AlgorithmManager::Instance().create("CreateSampleWorkspace");
     createSampleWorkspace->initialize();
     createSampleWorkspace->setProperty("WorkspaceType", "Histogram");
     createSampleWorkspace->setProperty("OutputWorkspace", name);
@@ -210,7 +210,7 @@ private:
     if (inputGrp == nullptr) {
       inputGrp = createExampleGroupWorkspace("wsGrp");
     }
-    auto polarizerEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
+    auto &polarizerEfficiency = AlgorithmManager::Instance().create("PolarizerEfficiency");
     polarizerEfficiency->initialize();
     polarizerEfficiency->setProperty("InputWorkspace", inputGrp->getName());
     polarizerEfficiency->setProperty("AnalyserEfficiency", ANALYSER_EFFICIENCY_WS_NAME);

--- a/docs/source/algorithms/PolarizerEfficiency-v1.rst
+++ b/docs/source/algorithms/PolarizerEfficiency-v1.rst
@@ -14,7 +14,8 @@ Calculates how the efficiency of a polarizer varies with wavelength. The
 ordering of the workspaces in ``InputWorkspace`` is taken from the ``SpinStates`` parameter, and the analyser
 efficiency, :math:`\epsilon_{cell}`, is given by ``AnalyserEfficiency``.
 
-The polarization of the polarizer, :math:`P_{SM}`, is given by
+First the ``AnalyserEfficiency`` workspace is rebinned to match the binning of the input workspace that corresponds to the "00" spin state.
+Having done this, the polarization of the polarizer, :math:`P_{SM}`, is given by
 
 .. math::
     P_{SM} = \frac{T_{00} - T_{01}}{2P_{cell}(T_{00} + T_{01})}

--- a/docs/source/algorithms/PolarizerEfficiency-v1.rst
+++ b/docs/source/algorithms/PolarizerEfficiency-v1.rst
@@ -47,7 +47,7 @@ Output:
 .. testoutput:: PolarizerEfficiencyExample
     :options: +ELLIPSIS +NORMALIZE_WHITESPACE
 
-    Polarizer efficiency at a wavelength of 4.5 Å is ...
+    Polarizer efficiency at a wavelength of 4.0 Å is ...
 
 .. categories::
 

--- a/docs/source/algorithms/PolarizerEfficiency-v1.rst
+++ b/docs/source/algorithms/PolarizerEfficiency-v1.rst
@@ -1,0 +1,54 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+Calculates how the efficiency of a polarizer varies with wavelength. The
+ordering of the workspaces in ``InputWorkspace`` is taken from the ``SpinStates`` parameter, and the analyser
+efficiency, :math:`\epsilon_{cell}`, is given by ``AnalyserEfficiency``.
+
+The polarization of the polarizer, :math:`P_{SM}`, is given by
+
+.. math::
+    P_{SM} = \frac{T_{00} - T_{01}}{2P_{cell}}
+
+Since the efficiency, :math:`\epsilon_{SM}`, is given by :math:`\frac{1 + P_{SM}}{2}`, we have that
+
+.. math::
+    \epsilon_{SM} = \frac{1}{2} + \frac{T_{00} - T_{01}}{8\epsilon_{cell} - 4}
+
+Usage
+-----
+
+**Example - Calculate Polarizer Efficiency**
+
+.. testcode:: PolarizerEfficiencyExample
+
+    wsPara = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=0.5*exp(-0.0733*12*x*(1-0.9))',XUnit='Wavelength', xMin='1',XMax='8', BinWidth='1')
+    wsPara1 = CloneWorkspace(wsPara)
+    wsAnti = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=0.5*exp(-0.0733*12*x*(1+0.9))',XUnit='Wavelength', xMin='1',XMax='8', BinWidth='1')
+    wsAnti1 = CloneWorkspace(wsAnti)
+
+    grp = GroupWorkspaces([wsPara,wsAnti,wsPara1,wsAnti1])
+    eCell = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=(1 + tanh(0.0733 * 12 * x * 0.2))/2',XUnit='Wavelength', xMin='1',XMax='16', BinWidth='1')
+
+    psm = PolarizerEfficiency(grp, eCell)
+    print("Polarizer efficiency at a wavelength of " + str(mtd['psm'].dataX(0)[3]) + " Å is " + str(mtd['psm'].dataY(0)[3]))
+
+Output:
+
+.. testoutput:: PolarizerEfficiencyExample
+    :options: +ELLIPSIS +NORMALIZE_WHITESPACE
+
+    Polarizer efficiency at a wavelength of 4.5 Å is ...
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/PolarizerEfficiency-v1.rst
+++ b/docs/source/algorithms/PolarizerEfficiency-v1.rst
@@ -17,12 +17,12 @@ efficiency, :math:`\epsilon_{cell}`, is given by ``AnalyserEfficiency``.
 The polarization of the polarizer, :math:`P_{SM}`, is given by
 
 .. math::
-    P_{SM} = \frac{T_{00} - T_{01}}{P_{cell}(T_{00} + T_{01})}
+    P_{SM} = \frac{T_{00} - T_{01}}{2P_{cell}(T_{00} + T_{01})}
 
 Since the efficiency, :math:`\epsilon_{SM}`, is given by :math:`\frac{1 + P_{SM}}{2}`, we have that
 
 .. math::
-    \epsilon_{SM} = \frac{\epsilon_{cell}(T_{00} + T_{01}) - T_{01}}{(2\epsilon_{cell} - 1)(T_{00} + T_{01})}
+    \epsilon_{SM} = \frac{1}{2} + \frac{T_{00} - T_{01}}{4(2\epsilon_{cell} - 1)(T_{00} + T_{01})}
 
 Usage
 -----

--- a/docs/source/algorithms/PolarizerEfficiency-v1.rst
+++ b/docs/source/algorithms/PolarizerEfficiency-v1.rst
@@ -17,12 +17,12 @@ efficiency, :math:`\epsilon_{cell}`, is given by ``AnalyserEfficiency``.
 The polarization of the polarizer, :math:`P_{SM}`, is given by
 
 .. math::
-    P_{SM} = \frac{T_{00} - T_{01}}{2P_{cell}}
+    P_{SM} = \frac{T_{00} - T_{01}}{P_{cell}(T_{00} + T_{01})}
 
 Since the efficiency, :math:`\epsilon_{SM}`, is given by :math:`\frac{1 + P_{SM}}{2}`, we have that
 
 .. math::
-    \epsilon_{SM} = \frac{1}{2} + \frac{T_{00} - T_{01}}{8\epsilon_{cell} - 4}
+    \epsilon_{SM} = \frac{\epsilon_{cell}(T_{00} + T_{01}) - T_{01}}{(2\epsilon_{cell} - 1)(T_{00} + T_{01})}
 
 Usage
 -----
@@ -31,9 +31,9 @@ Usage
 
 .. testcode:: PolarizerEfficiencyExample
 
-    wsPara = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=0.5*exp(-0.0733*12*x*(1-0.9))',XUnit='Wavelength', xMin='1',XMax='8', BinWidth='1')
+    wsPara = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=0.5*exp(-0.0733*12*x*(1-0.1))',XUnit='Wavelength', xMin='1',XMax='8', BinWidth='1')
     wsPara1 = CloneWorkspace(wsPara)
-    wsAnti = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=0.5*exp(-0.0733*12*x*(1+0.9))',XUnit='Wavelength', xMin='1',XMax='8', BinWidth='1')
+    wsAnti = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=0.5*exp(-0.0733*12*x*(1+0.1))',XUnit='Wavelength', xMin='1',XMax='8', BinWidth='1')
     wsAnti1 = CloneWorkspace(wsAnti)
 
     grp = GroupWorkspaces([wsPara,wsAnti,wsPara1,wsAnti1])

--- a/docs/source/release/v6.10.0/SANS/New_features/36139.rst
+++ b/docs/source/release/v6.10.0/SANS/New_features/36139.rst
@@ -1,0 +1,1 @@
+- Added algorithm for calculating the efficiency of a polariser.


### PR DESCRIPTION
New algorithm to calculate the supermirror polarizer efficiency using a group workspace with 4 runs for the 4 spin combinations, plus the efficiency of the analyser cell, calculated previously. This is part of the polarized SANS epic.

Output can either be to a workspace, a file, or both.

Fixes #36139

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
- Added algorithm
- Added tests
- Added doc page

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
Calculates how the efficiency of a polarizer varies with wavelength. The ordering of the workspaces in ``InputWorkspace`` is taken from the ``SpinStates`` parameter, and the analyser efficiency, e_cell, is given by ``AnalyserEfficiency``.

The polarization of the polarizer, P_SM, is given by

![image](https://github.com/mantidproject/mantid/assets/139879523/695c219e-f5d6-41e4-a0bc-1a5a6d4f32c2)

Since the efficiency, e_SM , is given by (1 + P_SM)/2, we have that

![image](https://github.com/mantidproject/mantid/assets/139879523/2ef7f8f2-b461-48f2-bfa3-26d564101f28)

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
This will generate a simple example:
``` Python
wsPara = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=0.5*exp(-0.0733*12*x*(1-0.9))',XUnit='Wavelength', xMin='1',XMax='8', BinWidth='1', NumBanks='1', BankPixelWidth='1')
wsPara1 = CloneWorkspace(wsPara)
wsAnti = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=0.5*exp(-0.0733*12*x*(1+0.9))',XUnit='Wavelength', xMin='1',XMax='8', BinWidth='1', NumBanks='1', BankPixelWidth='1')
wsAnti1 = CloneWorkspace(wsAnti)

grp = GroupWorkspaces([wsPara,wsAnti,wsPara1,wsAnti1])
eCell = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=(1 + tanh(0.0733 * 12 * x * 0.2))/2',XUnit='Wavelength', xMin='1',XMax='16', BinWidth='1', NumBanks='1', BankPixelWidth='1')

psm = PolarizerEfficiency(grp, eCell)
print("Polarizer efficiency at a wavelength of " + str(mtd['psm'].dataX(0)[3]) + " Å is " + str(mtd['psm'].dataY(0)[3]))
```

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
