### PR TITLE
Fix multiple of same functions not showing in QENS Fitting

### DIFF
--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
@@ -334,10 +334,10 @@ std::optional<std::string> ConvFunctionTemplateModel::getPrefix(ParamID name) co
     return model()->fitTypePrefix();
   } else {
     auto const prefixes = model()->peakPrefixes();
-    if (!prefixes)
-      return std::optional<std::string>();
     auto const index = name > ParamID::LOR1_FWHM && name <= ParamID::LOR2_FWHM ? 1 : 0;
-    return prefixes->at(index).toStdString();
+    if (!prefixes || index >= prefixes->size())
+      return std::optional<std::string>();
+    return (*prefixes)[index];
   }
 }
 
@@ -519,11 +519,17 @@ std::string ConvFunctionTemplateModel::buildBackgroundFunctionString() const {
 }
 
 std::optional<std::string> ConvFunctionTemplateModel::getLor1Prefix() const {
-  return model()->peakPrefixes()->at(0).toStdString();
+  auto const prefixes = model()->peakPrefixes();
+  if (!prefixes || prefixes->size() < 1)
+    return std::optional<std::string>();
+  return (*prefixes)[0];
 }
 
 std::optional<std::string> ConvFunctionTemplateModel::getLor2Prefix() const {
-  return model()->peakPrefixes()->at(1).toStdString();
+  auto const prefixes = model()->peakPrefixes();
+  if (!prefixes || prefixes->size() < 2)
+    return std::optional<std::string>();
+  return (*prefixes)[1];
 }
 
 std::optional<std::string> ConvFunctionTemplateModel::getFitTypePrefix() const { return model()->fitTypePrefix(); }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/MultiFunctionTemplateView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/MultiFunctionTemplateView.h
@@ -45,8 +45,7 @@ private:
   std::optional<std::size_t> propertySubTypeIndex(QtProperty *prop);
 
   std::vector<std::unique_ptr<TemplateSubType>> m_templateSubTypes;
-  // Map fit type to a list of function parameters (QtProperties for those parameters)
-  std::vector<std::map<int, std::vector<QtProperty *>>> m_subTypeParameters;
+  std::vector<std::map<int, std::vector<ParamID>>> m_subTypeParamIDs;
   std::vector<std::vector<QtProperty *>> m_currentSubTypeParameters;
   std::vector<QtProperty *> m_subTypeProperties;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ConvolutionFunctionModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ConvolutionFunctionModel.h
@@ -30,7 +30,7 @@ public:
   std::optional<std::string> convolutionPrefix() const { return m_convolutionPrefix; }
   std::optional<std::string> deltaFunctionPrefix() const { return m_deltaFunctionPrefix; }
   std::optional<std::string> tempFunctionPrefix() const { return m_tempFunctionPrefix; }
-  std::optional<QStringList> peakPrefixes() const { return m_peakPrefixes; }
+  std::optional<std::vector<std::string>> peakPrefixes() const { return m_peakPrefixes; }
   std::optional<std::string> fitTypePrefix() const { return m_fitTypePrefix; }
 
   std::string resolutionWorkspace() const { return m_resolutionWorkspace; }
@@ -55,7 +55,7 @@ private:
   std::optional<std::string> m_deltaFunctionPrefix;
   std::optional<std::string> m_tempFunctionPrefix;
   std::optional<std::string> m_fitTypePrefix;
-  std::optional<QStringList> m_peakPrefixes;
+  std::optional<std::vector<std::string>> m_peakPrefixes;
   std::string m_resolutionWorkspace;
   int m_resolutionWorkspaceIndex;
 };

--- a/qt/widgets/common/src/ConvolutionFunctionModel.cpp
+++ b/qt/widgets/common/src/ConvolutionFunctionModel.cpp
@@ -196,7 +196,7 @@ void ConvolutionFunctionModel::findComponentPrefixes() {
   m_deltaFunctionPrefix.reset();
   m_tempFunctionPrefix.reset();
   m_fitTypePrefix.reset();
-  m_peakPrefixes = QStringList();
+  m_peakPrefixes = std::vector<std::string>{};
   m_resolutionWorkspace.clear();
   m_resolutionWorkspaceIndex = 0;
 
@@ -205,7 +205,7 @@ void ConvolutionFunctionModel::findComponentPrefixes() {
     return;
   iterateThroughFunction(function.get(), "");
 
-  if (m_peakPrefixes->isEmpty()) {
+  if (m_peakPrefixes->empty()) {
     m_peakPrefixes.reset();
   }
   if (!m_convolutionPrefix) {
@@ -249,7 +249,7 @@ void ConvolutionFunctionModel::setPrefix(IFunction *func, std::string const &pre
     m_resolutionWorkspace = func->getAttribute("Workspace").asString();
     m_resolutionWorkspaceIndex = func->getAttribute("WorkspaceIndex").asInt();
   } else if (isLorentzianFunction(func)) {
-    m_peakPrefixes->append(QString::fromStdString(prefix));
+    m_peakPrefixes->emplace_back(prefix);
   } else if (isfitTypeFunction(func)) {
     m_fitTypePrefix = prefix;
   }


### PR DESCRIPTION
### Description of work
A recent change in the QENS Fitting interface has caused a bug where selecting 2 Exponentials in IqtFit, or selecting 2 Lorentzians in ConvFit, will not show both of the functions. Only one of these functions is shown.

*There is no associated issue.*

### To test:
1. Open `Inelastic` ->`QENS Fitting` interface
2. Go to the `IqtFit` tab
5. Select 1 exponential fit function
6. There should be a Height and Lifetime parameter
7. Select 2 exponentials
8. There should be two Heights and two lifetime parameters.
9. Repeat the same on ConvFit, but for the Lorentzians (each lorentzian should have three parameters)

*This does not require release notes* because **it is a regression since the last stable release**


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
