### PR TITLE
Muon Spin Diffusion fit function

### DIFF
--- a/Framework/PythonInterface/plugins/CMakeLists.txt
+++ b/Framework/PythonInterface/plugins/CMakeLists.txt
@@ -379,6 +379,7 @@ set(PYTHON_PLUGINS
     functions/RFresonance.py
     functions/Redfield.py
     functions/SCgapSwave.py
+    functions/SpinDiffusion.py
     functions/SpinGlass.py
     functions/StandardSC.py
     functions/StaticLorentzianKT.py

--- a/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
+++ b/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
@@ -10,6 +10,7 @@ from functools import cache
 from numpy import float64
 from numpy.typing import NDArray
 from mantid.api import IFunction1D, FunctionFactory
+from mantid.kernel import IntBoundedValidator
 from scipy.integrate import quad
 from scipy.special import i0e
 from typing import Tuple
@@ -64,7 +65,7 @@ class SpinDiffusion(IFunction1D):
         self.declareParameter("D2", 1e-2, "Dipolar term 2 (MHz)")
         self.declareParameter("D3", 1e-2, "Dipolar term 3 (MHz)")
         # Non-fitting parameters
-        self.declareAttribute("NDimensions", 1)
+        self.declareAttribute("NDimensions", 1, IntBoundedValidator(lower=1, upper=3))
 
     def function1D(self, xvals):
         A = self.getParameterValue("A")

--- a/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
+++ b/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
@@ -11,9 +11,12 @@ from numpy import float64
 from numpy.typing import NDArray
 from mantid.api import IFunction1D, FunctionFactory
 from mantid.kernel import IntBoundedValidator
+from scipy.constants import elementary_charge, physical_constants
 from scipy.integrate import quad
 from scipy.special import i0e
 from typing import Tuple
+
+MAGNETOGYRIC_RATIO = physical_constants["muon g factor"][0] * -elementary_charge / (2 * physical_constants["muon mass"][0] * 1e6)  # MHz / T
 
 
 @cache
@@ -89,10 +92,11 @@ class SpinDiffusion(IFunction1D):
         n_dimensions = self.getAttributeValue("NDimensions")
 
         d_i_terms = d_rates(n_dimensions, d_par, d_perp)
+        w_values = MAGNETOGYRIC_RATIO * np.array(xvals)
         if n_dimensions == 1:
-            spectral_density_results = spectral_density_approximation_1d(*d_i_terms, np.array(xvals))
+            spectral_density_results = spectral_density_approximation_1d(*d_i_terms, w_values)
         else:
-            spectral_density_results = np.array([spectral_density(*d_i_terms, w, len(xvals) / 4) for w in xvals])
+            spectral_density_results = np.array([spectral_density(*d_i_terms, w, len(w_values) / 4) for w in w_values])
 
         return np.square(A) / 4 * spectral_density_results
 

--- a/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
+++ b/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
@@ -10,64 +10,63 @@ from functools import cache
 from numpy import float64
 from numpy.typing import NDArray
 from mantid.api import IFunction1D, FunctionFactory
+from scipy.integrate import quad
 from scipy.special import i0e
 from typing import Tuple
 
 
 @cache
 def cached_i0e(d_i: float, t: Tuple[float]) -> NDArray[float64]:
+    """Calculate the zeroth order modified Bessel function, scaled by an exponential term."""
     return i0e(2 * d_i * np.array(t))
 
 
 def autocorrelation_st(d_1: float, d_2: float, d_3: float, t: Tuple[float]) -> float:
+    """Calculate S(t), the autocorrelation function represented by an anisotropic random walk."""
     return cached_i0e(d_1, t) * cached_i0e(d_2, t) * cached_i0e(d_3, t)
 
 
 def spectral_density_approximation_1d(d_1: float, d_2: float, w: NDArray[float64]) -> NDArray[float64]:
+    """Calculate J(w) approximation for a 1D system."""
     return (1 / np.sqrt(4 * d_1 * d_2)) * np.sqrt((1 + np.sqrt(1 + np.power(w / (2 * d_2), 2))) / (1 + np.power(w / (2 * d_2), 2)))
 
 
+def integrand(t: Tuple[float], d_1: float, d_2: float, d_3: float, w: float) -> float:
+    "Integrand used to calculate J(w)."
+    return autocorrelation_st(d_1, d_2, d_3, t) * np.cos(w * t)
+
+
 def spectral_density(d_1: float, d_2: float, d_3: float, w: float) -> float:
-    raise NotImplementedError("This is not implemented yet")
+    """Calculate J(w) for 2D and 3D systems."""
+    integral, _ = quad(
+        integrand,
+        0,
+        300,
+        args=(
+            d_1,
+            d_2,
+            d_3,
+            w,
+        ),
+    )  # Change integration range so it tends towards infinity
+    return 2.0 * integral
 
 
 class SpinDiffusion(IFunction1D):
-
-    # For integration over all directions of vector Q
-    n_theta = 128
-    d_theta = (np.pi / 2.0) / n_theta
-    theta = d_theta * np.arange(1, n_theta)
-    sin_theta = np.sin(theta)
-    cos_theta = np.cos(theta)
 
     def category(self):
         return "Muon\\MuonSpecific"
 
     def init(self):
-        # Active fitting parameters
+        # Fitting parameters
         self.declareParameter("A", 1.0, "Amplitude, or Scaling factor")
         self.declareParameter("D1", 1e3, "Dipolar term 1 (MHz)")
         self.declareParameter("D2", 1e-2, "Dipolar term 2 (MHz)")
         self.declareParameter("D3", 1e-2, "Dipolar term 3 (MHz)")
         # Non-fitting parameters
-        self.declareAttribute("NDimensions", 1)
+        self.declareAttribute("NDimensions", 1, "The number of dimensions (1, 2 or 3)")
 
     def function1D(self, xvals):
-        r"""Calculate the intensities
-
-        Parameters
-        ----------
-        xvals : sequence of floats
-          The domain where to evaluate the function
-        jacobian: 2D array
-          partial derivative of the function with respect to the fitting
-          parameters evaluated at the domain.
-
-        Returns
-        -------
-        numpy.ndarray
-            Function values
-        """
         A = self.getParameterValue("A")
         d_1 = self.getParameterValue("D1")
         d_2 = self.getParameterValue("D2")
@@ -75,9 +74,16 @@ class SpinDiffusion(IFunction1D):
 
         n_dimensions = int(self.getAttributeValue("NDimensions"))
         if n_dimensions == 1:
+            d_3 = d_2
             spectral_density_results = spectral_density_approximation_1d(d_1 / d_1, d_2 / d_1, np.array(xvals))
+        elif n_dimensions == 2:
+            d_2 = d_1
+            spectral_density_results = np.array([spectral_density(d_1 / d_1, d_2 / d_1, d_3 / d_1, w) for w in xvals])
+        elif n_dimensions == 3:
+            d_3 = d_2 = d_1
+            spectral_density_results = np.array([spectral_density(d_1 / d_1, d_2 / d_1, d_3 / d_1, w) for w in xvals])
         else:
-            spectral_density_results = spectral_density(d_1 / d_1, d_2 / d_1, d_3 / d_1, "Not implemented")
+            raise NotImplementedError("Not implemented for more than 3 dimensions")
 
         return np.square(A) / 4 * spectral_density_results
 

--- a/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
+++ b/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
@@ -7,12 +7,12 @@
 # pylint: disable=no-init,invalid-name
 import numpy as np
 from functools import cache
-from numpy import float64
+from numpy import complex64, float64
 from numpy.typing import NDArray
 from mantid.api import IFunction1D, FunctionFactory
-from mantid.kernel import FloatBoundedValidator, IntBoundedValidator
+from mantid.kernel import IntBoundedValidator
 from scipy.constants import elementary_charge, physical_constants
-from scipy.integrate import quad
+from scipy.fft import fft, fftshift
 from scipy.special import i0e
 from typing import Tuple
 
@@ -30,43 +30,21 @@ def autocorrelation_st(d_1: float, d_2: float, d_3: float, t: Tuple[float]) -> f
     return cached_i0e(d_1, t) * cached_i0e(d_2, t) * cached_i0e(d_3, t)
 
 
-def spectral_density_approximation_1d(d_parallel: float, d_perpendicular: float, w: NDArray[float64]) -> NDArray[float64]:
-    """Calculate J(w) approximation for a 1D system."""
-    return (1 / np.sqrt(4 * d_parallel * d_perpendicular)) * np.sqrt(
-        (1 + np.sqrt(1 + np.power(w / (2 * d_perpendicular), 2))) / (1 + np.power(w / (2 * d_perpendicular), 2))
-    )
-
-
-def integrand(t: Tuple[float], d_1: float, d_2: float, d_3: float, w: float) -> float:
-    "Integrand used to calculate J(w)."
-    return autocorrelation_st(d_1, d_2, d_3, t) * np.cos(w * t)
-
-
-def spectral_density(d_1: float, d_2: float, d_3: float, w: float, integration_upper: float) -> float:
-    """Calculate J(w) for 2D and 3D systems."""
-    integral, _ = quad(
-        integrand,
-        0,
-        integration_upper,
-        args=(
-            d_1,
-            d_2,
-            d_3,
-            w,
-        ),
-    )  # Note the integration range in the paper tends towards infinity
-    return 2.0 * integral
+def perform_fft(d_1: float, d_2: float, d_3: float, t: Tuple[float]) -> NDArray[complex64]:
+    """Calculate the discrete Fast Fourier Transform of S(t)."""
+    g = autocorrelation_st(d_1, d_2, d_3, t)
+    return fftshift(fft(g))
 
 
 def d_rates(n_dimensions: int, d_par: float, d_perp: float) -> Tuple[float]:
     """Tie dipolar rates based on the dimensionality of the system."""
     match n_dimensions:
         case 1:  # D1 = D||           D2, D3 = D_|_
-            return d_par, d_perp
+            return d_par / d_par, d_perp / d_par, d_perp / d_par
         case 2:  # D1, D2 = D||       D3 = D_|_
-            return d_par, d_par, d_perp
+            return d_par / d_par, d_par / d_par, d_perp / d_par
         case 3:  # D1, D2, D3 = D||
-            return d_par, d_par, d_par
+            return d_par / d_par, d_par / d_par, d_par / d_par
         case _:
             raise RuntimeError("The number of dimensions has an upper bound of 3.")
 
@@ -83,24 +61,22 @@ class SpinDiffusion(IFunction1D):
         self.declareParameter("DPerpendicular", 1e-2, "Dipolar perpendicular, the slow rate dipolar term (MHz)")
         # Non-fitting parameters
         self.declareAttribute("NDimensions", 1, IntBoundedValidator(lower=1, upper=3))
-        self.declareAttribute("IntegrationUpperLimit", 1.0, FloatBoundedValidator(lower=0.0))
 
     def function1D(self, xvals):
-        A = self.getParameterValue("A")
+        # A = self.getParameterValue("A")
         d_par = self.getParameterValue("DParallel")
         d_perp = self.getParameterValue("DPerpendicular")
 
         n_dimensions = self.getAttributeValue("NDimensions")
-        integration_upper_limit = self.getAttributeValue("IntegrationUpperLimit")
 
         d_i_terms = d_rates(n_dimensions, d_par, d_perp)
-        w_values = MAGNETOGYRIC_RATIO * np.array(xvals)
-        if n_dimensions == 1:
-            spectral_density_results = spectral_density_approximation_1d(*d_i_terms, w_values)
-        else:
-            spectral_density_results = np.array([spectral_density(*d_i_terms, w, integration_upper_limit) for w in w_values])
+        # w_values = MAGNETOGYRIC_RATIO * np.array(xvals)
+        spectral_density_complex = perform_fft(*d_i_terms, tuple(xvals))
 
-        return np.square(A) / 4 * spectral_density_results
+        # Convert from an NDArray(complex64) to a NDArray(float64)
+        spectral_density_real = np.array(np.real(spectral_density_complex))
+
+        return spectral_density_real  # np.square(A) / 4 * spectral_density_results
 
 
 FunctionFactory.subscribe(SpinDiffusion)

--- a/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
+++ b/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
@@ -17,7 +17,7 @@ from scipy.special import i0e
 from typing import Tuple
 
 MUON_MAGNETOGYRIC_RATIO = (
-    physical_constants["muon g factor"][0] * -elementary_charge / (2 * physical_constants["muon mass"][0] * 1e6)
+    physical_constants["muon g factor"][0] * -elementary_charge / (2 * physical_constants["muon mass"][0] * 1e6) / (2 * np.pi)
 )  # MHz / T
 
 

--- a/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
+++ b/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
@@ -65,7 +65,6 @@ class SpinDiffusion(IFunction1D):
         self.declareAttribute("NDimensions", 1, IntBoundedValidator(lower=1, upper=3))
 
     def function1D(self, xvals):
-        # xvals is assumed to be B(LF)
         A = self.getParameterValue("A")
         d_parallel = self.getParameterValue("DParallel")
         d_perpendicular = self.getParameterValue("DPerpendicular")
@@ -73,8 +72,11 @@ class SpinDiffusion(IFunction1D):
         n_dimensions = self.getAttributeValue("NDimensions")
 
         d_rates = d_rates_from_dimensionality(n_dimensions, d_parallel, d_perpendicular)
-        # w_values = MUON_MAGNETOGYRIC_RATIO * np.array(xvals)
-        spectral_density_complex = perform_fft(*d_rates, tuple(xvals))
+
+        # xvals is assumed to be B(LF), in units of Tesla. We need to convert to inverse MHz
+        t_values = 1 / (MUON_MAGNETOGYRIC_RATIO * np.array(xvals))
+
+        spectral_density_complex = perform_fft(*d_rates, tuple(t_values))
 
         # Convert from an NDArray(complex64) to a NDArray(float64)
         spectral_density_real = np.array(np.real(spectral_density_complex))

--- a/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
+++ b/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
@@ -62,11 +62,11 @@ def d_rates(n_dimensions: int, d_par: float, d_perp: float) -> Tuple[float]:
     """Tie dipolar rates based on the dimensionality of the system."""
     match n_dimensions:
         case 1:  # D1 = D||           D2, D3 = D_|_
-            return d_par / d_par, d_perp / d_par
+            return d_par, d_perp
         case 2:  # D1, D2 = D||       D3 = D_|_
-            return d_par / d_par, d_par / d_par, d_perp / d_par
+            return d_par, d_par, d_perp
         case 3:  # D1, D2, D3 = D||
-            return d_par / d_par, d_par / d_par, d_par / d_par
+            return d_par, d_par, d_par
         case _:
             raise RuntimeError("The number of dimensions has an upper bound of 3.")
 

--- a/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
+++ b/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
@@ -1,0 +1,85 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+# pylint: disable=no-init,invalid-name
+import numpy as np
+from functools import cache
+from numpy import float64
+from numpy.typing import NDArray
+from mantid.api import IFunction1D, FunctionFactory
+from scipy.special import i0e
+from typing import Tuple
+
+
+@cache
+def cached_i0e(d_i: float, t: Tuple[float]) -> NDArray[float64]:
+    return i0e(2 * d_i * np.array(t))
+
+
+def autocorrelation_st(d_1: float, d_2: float, d_3: float, t: Tuple[float]) -> float:
+    return cached_i0e(d_1, t) * cached_i0e(d_2, t) * cached_i0e(d_3, t)
+
+
+def spectral_density_approximation_1d(d_1: float, d_2: float, w: NDArray[float64]) -> NDArray[float64]:
+    return (1 / np.sqrt(4 * d_1 * d_2)) * np.sqrt((1 + np.sqrt(1 + np.power(w / (2 * d_2), 2))) / (1 + np.power(w / (2 * d_2), 2)))
+
+
+def spectral_density(d_1: float, d_2: float, d_3: float, w: float) -> float:
+    raise NotImplementedError("This is not implemented yet")
+
+
+class SpinDiffusion(IFunction1D):
+
+    # For integration over all directions of vector Q
+    n_theta = 128
+    d_theta = (np.pi / 2.0) / n_theta
+    theta = d_theta * np.arange(1, n_theta)
+    sin_theta = np.sin(theta)
+    cos_theta = np.cos(theta)
+
+    def category(self):
+        return "Muon\\MuonSpecific"
+
+    def init(self):
+        # Active fitting parameters
+        self.declareParameter("A", 1.0, "Amplitude, or Scaling factor")
+        self.declareParameter("D1", 1e3, "Dipolar term 1 (MHz)")
+        self.declareParameter("D2", 1e-2, "Dipolar term 2 (MHz)")
+        self.declareParameter("D3", 1e-2, "Dipolar term 3 (MHz)")
+        # Non-fitting parameters
+        self.declareAttribute("NDimensions", 1)
+
+    def function1D(self, xvals):
+        r"""Calculate the intensities
+
+        Parameters
+        ----------
+        xvals : sequence of floats
+          The domain where to evaluate the function
+        jacobian: 2D array
+          partial derivative of the function with respect to the fitting
+          parameters evaluated at the domain.
+
+        Returns
+        -------
+        numpy.ndarray
+            Function values
+        """
+        A = self.getParameterValue("A")
+        d_1 = self.getParameterValue("D1")
+        d_2 = self.getParameterValue("D2")
+        d_3 = self.getParameterValue("D3")
+
+        n_dimensions = int(self.getAttributeValue("NDimensions"))
+        if n_dimensions == 1:
+            spectral_density_results = spectral_density_approximation_1d(d_1 / d_1, d_2 / d_1, np.array(xvals))
+        else:
+            spectral_density_results = spectral_density(d_1 / d_1, d_2 / d_1, d_3 / d_1, "Not implemented")
+
+        return np.square(A) / 4 * spectral_density_results
+
+
+FunctionFactory.subscribe(SpinDiffusion)

--- a/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
+++ b/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
@@ -11,14 +11,12 @@ from numpy import float64
 from numpy.typing import NDArray
 from mantid.api import IFunction1D, FunctionFactory
 from mantid.kernel import IntBoundedValidator
-from scipy.constants import elementary_charge, physical_constants
+from mantid.kernel import PhysicalConstants
 from scipy.integrate import quad
 from scipy.special import i0e
 from typing import Tuple
 
-MUON_MAGNETOGYRIC_RATIO = (
-    physical_constants["muon g factor"][0] * -elementary_charge / (2 * physical_constants["muon mass"][0] * 1e6)
-)  # MHz / T
+MUON_MAGNETOGYRIC_RATIO = 2 * np.pi * PhysicalConstants.MuonGyromagneticRatio  # MHz / G
 
 
 @cache
@@ -37,7 +35,7 @@ def integrand(t, d_1, d_2, d_3, w):
 
 
 def jw(d_1, d_2, d_3, w):
-    integral, error = quad(
+    integral, _ = quad(
         integrand,
         0,
         np.inf,  # Integration upper bound
@@ -88,7 +86,7 @@ class SpinDiffusion(IFunction1D):
 
         d_rates = d_rates_from_dimensionality(n_dimensions, d_parallel, d_perpendicular)
 
-        # xvals is assumed to be B(LF), in units of Tesla. We need to convert to inverse MHz
+        # xvals is assumed to be B(LF), in units of Gauss. We need to convert to inverse MHz
         w_values = MUON_MAGNETOGYRIC_RATIO * np.array(xvals)
 
         spectral_density = [jw(*d_rates, w) for w in w_values]

--- a/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
+++ b/Framework/PythonInterface/plugins/functions/SpinDiffusion.py
@@ -27,9 +27,11 @@ def autocorrelation_st(d_1: float, d_2: float, d_3: float, t: Tuple[float]) -> f
     return cached_i0e(d_1, t) * cached_i0e(d_2, t) * cached_i0e(d_3, t)
 
 
-def spectral_density_approximation_1d(d_1: float, d_2: float, w: NDArray[float64]) -> NDArray[float64]:
+def spectral_density_approximation_1d(d_parallel: float, d_perpendicular: float, w: NDArray[float64]) -> NDArray[float64]:
     """Calculate J(w) approximation for a 1D system."""
-    return (1 / np.sqrt(4 * d_1 * d_2)) * np.sqrt((1 + np.sqrt(1 + np.power(w / (2 * d_2), 2))) / (1 + np.power(w / (2 * d_2), 2)))
+    return (1 / np.sqrt(4 * d_parallel * d_perpendicular)) * np.sqrt(
+        (1 + np.sqrt(1 + np.power(w / (2 * d_perpendicular), 2))) / (1 + np.power(w / (2 * d_perpendicular), 2))
+    )
 
 
 def integrand(t: Tuple[float], d_1: float, d_2: float, d_3: float, w: float) -> float:
@@ -37,20 +39,33 @@ def integrand(t: Tuple[float], d_1: float, d_2: float, d_3: float, w: float) -> 
     return autocorrelation_st(d_1, d_2, d_3, t) * np.cos(w * t)
 
 
-def spectral_density(d_1: float, d_2: float, d_3: float, w: float, n_points: int) -> float:
+def spectral_density(d_1: float, d_2: float, d_3: float, w: float, integration_upper: float) -> float:
     """Calculate J(w) for 2D and 3D systems."""
     integral, _ = quad(
         integrand,
         0,
-        n_points / 4,
+        integration_upper,
         args=(
             d_1,
             d_2,
             d_3,
             w,
         ),
-    )  # Change integration range so it tends towards infinity
+    )  # Note the integration range in the paper tends towards infinity
     return 2.0 * integral
+
+
+def d_rates(n_dimensions: int, d_par: float, d_perp: float) -> Tuple[float]:
+    """Tie dipolar rates based on the dimensionality of the system."""
+    match n_dimensions:
+        case 1:  # D1 = D||           D2, D3 = D_|_
+            return d_par / d_par, d_perp / d_par
+        case 2:  # D1, D2 = D||       D3 = D_|_
+            return d_par / d_par, d_par / d_par, d_perp / d_par
+        case 3:  # D1, D2, D3 = D||
+            return d_par / d_par, d_par / d_par, d_par / d_par
+        case _:
+            raise RuntimeError("The number of dimensions has an upper bound of 3.")
 
 
 class SpinDiffusion(IFunction1D):
@@ -61,30 +76,23 @@ class SpinDiffusion(IFunction1D):
     def init(self):
         # Fitting parameters
         self.declareParameter("A", 1.0, "Amplitude, or Scaling factor")
-        self.declareParameter("D1", 1e3, "Dipolar term 1 (MHz)")
-        self.declareParameter("D2", 1e-2, "Dipolar term 2 (MHz)")
-        self.declareParameter("D3", 1e-2, "Dipolar term 3 (MHz)")
+        self.declareParameter("DParallel", 1e3, "Dipolar parallel, the fast rate dipolar term (MHz)")
+        self.declareParameter("DPerpendicular", 1e-2, "Dipolar perpendicular, the slow rate dipolar term (MHz)")
         # Non-fitting parameters
         self.declareAttribute("NDimensions", 1, IntBoundedValidator(lower=1, upper=3))
 
     def function1D(self, xvals):
         A = self.getParameterValue("A")
-        d_1 = self.getParameterValue("D1")
-        d_2 = self.getParameterValue("D2")
-        d_3 = self.getParameterValue("D3")
+        d_par = self.getParameterValue("DParallel")
+        d_perp = self.getParameterValue("DPerpendicular")
 
-        n_dimensions = int(self.getAttributeValue("NDimensions"))
-        n_points = len(xvals)
-        match n_dimensions:
-            case 1:
-                d_3 = d_2
-                spectral_density_results = spectral_density_approximation_1d(d_1 / d_1, d_2 / d_1, np.array(xvals))
-            case 2:
-                d_2 = d_1
-                spectral_density_results = np.array([spectral_density(d_1 / d_1, d_2 / d_1, d_3 / d_1, w, n_points) for w in xvals])
-            case 3:
-                d_3 = d_2 = d_1
-                spectral_density_results = np.array([spectral_density(d_1 / d_1, d_2 / d_1, d_3 / d_1, w, n_points) for w in xvals])
+        n_dimensions = self.getAttributeValue("NDimensions")
+
+        d_i_terms = d_rates(n_dimensions, d_par, d_perp)
+        if n_dimensions == 1:
+            spectral_density_results = spectral_density_approximation_1d(*d_i_terms, np.array(xvals))
+        else:
+            spectral_density_results = np.array([spectral_density(*d_i_terms, w, len(xvals) / 4) for w in xvals])
 
         return np.square(A) / 4 * spectral_density_results
 

--- a/Framework/PythonInterface/test/python/plugins/functions/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/functions/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TEST_PY_FILES
     PrimStretchedExpFTTest.py
     RedfieldTest.py
     RFresonanceTest.py
+    SpinDiffusionTest.py
     SpinGlassTest.py
     StandardSCTest.py
     StaticLorentzianKTTest.py

--- a/Framework/PythonInterface/test/python/plugins/functions/SpinDiffusionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/SpinDiffusionTest.py
@@ -18,7 +18,7 @@ class SpinDiffusionTest(unittest.TestCase):
 
     def test_function_output(self):
         input = [0.01, 0.1, 1.0, 10.0]
-        expected = [3.19722414e-04, 2.49714580e-04, 1.35235417e-04, 3.03475905e-05]
+        expected = [0.00058769, 0.00056914, 0.00050933, 0.00041845]
         tolerance = 1.0e-05
         status, output = check_output("SpinDiffusion", input, expected, tolerance, A=1.0, DParallel=1e3, DPerpendicular=1e-2, NDimensions=2)
         if not status:

--- a/Framework/PythonInterface/test/python/plugins/functions/SpinDiffusionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/SpinDiffusionTest.py
@@ -1,0 +1,30 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+import numpy as np
+
+from MsdTestHelper import is_registered, check_output
+
+
+class SpinDiffusionTest(unittest.TestCase):
+    def test_function_has_been_registered(self):
+        status, msg = is_registered("SpinDiffusion")
+        if not status:
+            self.fail(msg)
+
+    def test_function_output(self):
+        input = [0.01, 0.1, 1.0, 10.0]
+        expected = [3.19722414e-04, 2.49714580e-04, 1.35235417e-04, 3.03475905e-05]
+        tolerance = 1.0e-05
+        status, output = check_output("SpinDiffusion", input, expected, tolerance, A=1.0, DParallel=1e3, DPerpendicular=1e-2, NDimensions=2)
+        if not status:
+            msg = "Computed output {} from input {} unequal to expected: {}"
+            self.fail(msg.format(*[str(a) for a in (output, input, expected)]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/source/fitting/fitfunctions/SpinDiffusion.rst
+++ b/docs/source/fitting/fitfunctions/SpinDiffusion.rst
@@ -9,7 +9,7 @@ SpinDiffusion
 Description
 -----------
 
-[Get description from Adam] [1]_.
+[Get description from Adam] [1]_. The data fitted using this fit function is assumed to be in units of Gauss.
 
 .. math::
     \lambda(B) &= \frac{A^2}{4} J(\omega) \\
@@ -21,7 +21,7 @@ where:
 
 - :math:`I_{0}(x)` is the zeroth order modified Bessel function.
 - :math:`\omega` is the angular momentum (:math:`MHz`).
-- :math:`\gamma_{\mu}` is the Muon gyromagnetic ratio (:math:`2 \pi \times 135.5 MHz/T`).
+- :math:`\gamma_{\mu}` is the Muon gyromagnetic ratio (:math:`2 \pi \times 0.001356 MHz/G`).
 - :math:`S(t)` is the autocorrelation function, represented by an anisotropic random walk.
 - :math:`J(\omega)` is the spectral density (:math:`MHz^{-1}`). It is the Fourier Transform of :math:`S(t)`.
 - :math:`A` is a parameter to be fitted.

--- a/docs/source/fitting/fitfunctions/SpinDiffusion.rst
+++ b/docs/source/fitting/fitfunctions/SpinDiffusion.rst
@@ -1,0 +1,48 @@
+.. _func-SpinDiffusion:
+
+=============
+SpinDiffusion
+=============
+
+.. index:: SpinDiffusion
+
+Description
+-----------
+
+[Get description from Adam] [1]_.
+
+.. math::
+    \lambda(B) &= \frac{A^2}{4} J(\omega) \\
+    J(\omega) &= 2 \int_{0}^{+\infty} S(t)\cos(\omega t) \\
+    S(t) &= \prod_{i=1}^{3} \exp(-2 D_{i} t) I_{0}(2 D_{i} t) \\
+    \omega &= 2 \pi f = \gamma_{\mu} B
+
+where:
+
+- :math:`I_{0}(x)` is the zeroth order modified Bessel function.
+- :math:`\omega` is the angular momentum (:math:`MHz`).
+- :math:`\gamma_{\mu}` is the Muon gyromagnetic ratio (:math:`2 \pi \times 135.5 MHz/T`).
+- :math:`S(t)` is the autocorrelation function, represented by an anisotropic random walk.
+- :math:`J(\omega)` is the spectral density (:math:`MHz^{-1}`). It is the Fourier Transform of :math:`S(t)`.
+- :math:`A` is a parameter to be fitted.
+- :math:`D_{i}` are the fast and slow rate dipolar terms. These are also fitting parameters.
+
+Systems of different dimensionality :math:`d` can simply be represented in terms of fast and slow rates :math:`D_{\parallel}` and :math:`D_{\perp}`:
+
+.. math::
+    D_{1} = D_{\parallel},                D_{2}, D_{3} = D_{\perp}   (d=1)
+    D_{1}, D_{2} = D_{\parallel},         D_{3} = D_{\perp}          (d=2)
+    D_{1}, D_{2}, D_{3} = D_{\parallel}                              (d=3)
+
+.. attributes::
+
+.. properties::
+
+References
+----------
+
+.. [1] Blundell, Stephen J., and others (eds), Muon Spectroscopy: An Introduction (Oxford, 2021; online edn, Oxford Academic, 23 June 2022), https://doi.org/10.1093/oso/9780198858959.001.0001, accessed 17 Apr. 2024.
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/fitting/fitfunctions/SpinDiffusion.rst
+++ b/docs/source/fitting/fitfunctions/SpinDiffusion.rst
@@ -9,7 +9,7 @@ SpinDiffusion
 Description
 -----------
 
-[Get description from Adam] [1]_. The data fitted using this fit function is assumed to be in units of Gauss.
+The Spin diffusion fitting function, models the diffusion of isotropic muonium as a function of applied field for 1D, 2D and 3D behaviour [1]_. The data fitted using this fit function is assumed to be in units of Gauss.
 
 .. math::
     \lambda(B) &= \frac{A^2}{4} J(\omega) \\
@@ -41,7 +41,7 @@ Systems of different dimensionality :math:`d` can simply be represented in terms
 References
 ----------
 
-.. [1] Blundell, Stephen J., and others (eds), Muon Spectroscopy: An Introduction (Oxford, 2021; online edn, Oxford Academic, 23 June 2022), https://doi.org/10.1093/oso/9780198858959.001.0001, accessed 17 Apr. 2024.
+.. [1] Blundell, Stephen J., and others (eds), Muon Spectroscopy: An Introduction (Oxford, 2021; online edn, Oxford Academic, 23 June 2022), pp. 117-119, https://doi.org/10.1093/oso/9780198858959.001.0001, accessed 17 Apr. 2024.
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/SpinDiffusion.rst
+++ b/docs/source/fitting/fitfunctions/SpinDiffusion.rst
@@ -34,6 +34,8 @@ Systems of different dimensionality :math:`d` can simply be represented in terms
     D_{1}, D_{2} = D_{\parallel},         D_{3} = D_{\perp}          (d=2)
     D_{1}, D_{2}, D_{3} = D_{\parallel}                              (d=3)
 
+For the :math:`d=3` case, the :math:`D_{\perp}` parameter has no significance. It may be a good idea to fix this parameter to prevent the minimizer from performing unnecessary optimization steps in this case.
+
 .. attributes::
 
 .. properties::

--- a/docs/source/release/v6.11.0/Framework/Fit_Functions/New_features/37194.rst
+++ b/docs/source/release/v6.11.0/Framework/Fit_Functions/New_features/37194.rst
@@ -1,0 +1,1 @@
+- Added the :ref:`SpinDiffusion <func-SpinDiffusion>` fit function in the Muon category.


### PR DESCRIPTION
### Description of work
This PR adds a new fit function for the Muon category called SpinDiffusion. Its implementation is outlined in the following pages
[scan_lvr68513_2024-04-11-12-36-56 (2).zip](https://github.com/user-attachments/files/16125796/scan_lvr68513_2024-04-11-12-36-56.2.zip)

It has three distinct forms, for the 1D, 2D and 3D cases. To test this function, I have checked that evaluating the function for these three cases match the expected relationship. They should follow a relationship y = x^(-d/2) where d=1,2 or 3 depending on the dimensionality.

Fixes #37176

**Report to:** 
Adam Berlie

### To test:
1. Load the following data set into Mantid
[CuSSZ13D_LF_12K.zip](https://github.com/user-attachments/files/16126064/CuSSZ13D_LF_12K.zip)

3. Run this script to generate a plot
```
import matplotlib.pyplot as plt
from mantid.plots.utility import MantidAxType
from matplotlib.ticker import NullFormatter, ScalarFormatter, LogFormatterSciNotation
from mantid.api import AnalysisDataService as ADS

CuSSZ13D_LF_12K = ADS.retrieve('CuSSZ13D_LF_12K')

fig, axes = plt.subplots(edgecolor='#ffffff', num='CuSSZ13D_LF_12K-2', subplot_kw={'projection': 'mantid'})
axes.errorbar(CuSSZ13D_LF_12K, capsize=2.0, color='#1f77b4', elinewidth=1.0, label='CuSSZ13D_LF_12K: spec 1', linestyle='None', marker='.', wkspIndex=0)
axes.tick_params(axis='x', which='major', **{'gridOn': False, 'tick1On': True, 'tick2On': False, 'label1On': True, 'label2On': False, 'size': 6, 'tickdir': 'out', 'width': 1})
axes.tick_params(axis='y', which='major', **{'gridOn': False, 'tick1On': True, 'tick2On': False, 'label1On': True, 'label2On': False, 'size': 6, 'tickdir': 'out', 'width': 1})
axes.set_title('CuSSZ13D_LF_12K')
axes.set_xlabel('Energy ($meV$)')
axes.set_ylabel('($meV$)$^{-1}$')
axes.set_xlim([10.168, 4197.6])
axes.set_ylim([0.19624, 0.44328])
axes.set_xscale('log')
axes.set_yscale('log')
axes.yaxis.set_major_formatter(ScalarFormatter(useOffset=True))
legend = axes.legend(fontsize=8.0).set_draggable(True).legend

fig.show()
```
3. Click `Fit` on the plot
4. Set StartX to 20.0 and EndX to 3998.207
5. Go to `Setup`->`Manage Setup`->`Load from String`
6. Paste the following string and click Ok
```
name=SpinDiffusion,NDimensions=2,A=8.96897,DParallel=137.868,DPerpendicular=0.00193379,constraints=(0<A,0<DParallel,0<DPerpendicular);name=FlatBackground,A0=0.211545
```
7. Click `Fit`->`Fit`
8. Wait. You should get a fit similar to this:
![image](https://github.com/mantidproject/mantid/assets/40830825/5d6b7d08-bb5b-4c14-a5cd-a9155afdcf04)

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
