### PR TITLE
Add Logarithmic event grouping to CompressEvents

### DIFF
--- a/Framework/DataHandling/test/CompressEventsTest.h
+++ b/Framework/DataHandling/test/CompressEventsTest.h
@@ -20,6 +20,7 @@ using namespace Mantid::DataHandling;
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
 using namespace Mantid::DataObjects;
+using namespace Mantid::Types::Core;
 
 class CompressEventsTest : public CxxTest::TestSuite {
 public:
@@ -178,17 +179,18 @@ public:
     }
 
     if (wallClockTolerance > 0.) {
-      int64_t firstTime = 631152000000000000;
-      TS_ASSERT_EQUALS(el.getEvent(0).pulseTime().totalNanoseconds(), firstTime);
-      TS_ASSERT_EQUALS(el.getEvent(1).pulseTime().totalNanoseconds(), firstTime + 1000000000);
-      TS_ASSERT_EQUALS(el.getEvent(2).pulseTime().totalNanoseconds(), firstTime + 2500000000);
-      TS_ASSERT_EQUALS(el.getEvent(3).pulseTime().totalNanoseconds(), firstTime + 5500000000);
-      TS_ASSERT_EQUALS(el.getEvent(4).pulseTime().totalNanoseconds(), firstTime + 11500000000);
-      TS_ASSERT_EQUALS(el.getEvent(5).pulseTime().totalNanoseconds(), firstTime + 23500000000);
-      TS_ASSERT_EQUALS(el.getEvent(6).pulseTime().totalNanoseconds(), firstTime + 47500000000);
+      const auto startTime = DateAndTime("2010-01-01T00:00:00");
+      TS_ASSERT_EQUALS(el.getEvent(0).pulseTime(), startTime);
+      TS_ASSERT_EQUALS(el.getEvent(1).pulseTime(), startTime + 1.0);
+      TS_ASSERT_EQUALS(el.getEvent(2).pulseTime(), startTime + 2.5);
+      TS_ASSERT_EQUALS(el.getEvent(3).pulseTime(), startTime + 5.5);
+      TS_ASSERT_EQUALS(el.getEvent(4).pulseTime(), startTime + 11.5);
+      TS_ASSERT_EQUALS(el.getEvent(5).pulseTime(), startTime + 23.5);
+      TS_ASSERT_EQUALS(el.getEvent(6).pulseTime(), startTime + 47.5);
     } else {
+      const auto timeZero = DateAndTime{0};
       for (int i = 0; i < 7; i++) {
-        TS_ASSERT_EQUALS(el.getEvent(i).pulseTime().totalNanoseconds(), 0);
+        TS_ASSERT_EQUALS(el.getEvent(i).pulseTime(), timeZero);
       }
     }
   }

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1476,6 +1476,12 @@ inline void EventList::compressEventsHelper(const std::vector<T> &events, std::v
   std::function<double(const double, double)> next_bin;
 
   if (tolerance < 0) { // log
+    if (lastTof < 0)
+      throw std::runtime_error("compressEvents with log binning doesn't work with negative TOF");
+
+    if (lastTof == 0)
+      bin_end = fabs(tolerance);
+
     // for log we do "less than" so that is matches the log binning of the Rebin algorithm
     compareTof = [](const double lhs, const double rhs) { return lhs < rhs; };
     next_bin = [tolerance](const double lastTof, double bin_end) {
@@ -1602,6 +1608,13 @@ inline void EventList::compressFatEventsHelper(const std::vector<T> &events, std
     const auto event_min = std::min_element(
         events.cbegin(), events.cend(), [](const auto &left, const auto &right) { return left.tof() < right.tof(); });
     bin_end = tof_min = event_min->tof();
+
+    if (tof_min < 0)
+      throw std::runtime_error("compressEvents with log binning doesn't work with negative TOF");
+
+    if (tof_min == 0)
+      bin_end = fabs(tolerance);
+
   } else { // linear
     // for linear we do "less than or equals" because that is how it was originally implemented
     compareTof = [](const double lhs, const double rhs) { return lhs <= rhs; };

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1462,7 +1462,7 @@ inline void EventList::compressEventsHelper(const std::vector<T> &events, std::v
   out.reserve(events.size() / 20);
 
   // The last TOF to which we are comparing.
-  double lastTof = std::numeric_limits<double>::lowest();
+  double lastTof = events.front().m_tof;
   // For getting an accurate average TOF
   double totalTof = 0;
   int num = 0;
@@ -1471,74 +1471,58 @@ inline void EventList::compressEventsHelper(const std::vector<T> &events, std::v
   double errorSquared = 0;
   double normalization = 0.;
 
-  if (tolerance < 0) {
-    lastTof = events.front().m_tof;
-    double bin_end = lastTof * (1 - tolerance);
+  double bin_end = lastTof;
+  std::function<bool(const double, const double)> compareTof;
+  std::function<double(const double, double)> next_bin;
 
-    for (auto it = events.cbegin(); it != events.cend(); it++) {
-      if (it->m_tof < bin_end) {
-        // Carry the error and weight
-        weight += it->weight();
-        errorSquared += it->errorSquared();
-        // Track the average tof
-        num++;
-        const double norm = calcNorm(it->errorSquared());
-        normalization += norm;
-        totalTof += it->m_tof * norm;
-      } else {
-        // We exceeded the tolerance
-        // Create a new event with the average TOF and summed weights and
-        // squared errors.
-        if (num == 1) {
-          // last time-of-flight is the only one contributing
-          out.emplace_back(lastTof, weight, errorSquared);
-        } else if (num > 1) {
-          out.emplace_back(totalTof / normalization, weight, errorSquared);
-        }
-        // Start a new combined object
-        num = 1;
-        const double norm = calcNorm(it->errorSquared());
-        normalization = norm;
-        totalTof = it->m_tof * norm;
-        weight = it->weight();
-        errorSquared = it->errorSquared();
-        lastTof = it->m_tof;
+  if (tolerance < 0) { // log
+    // for log we do "less than" so that is matches the log binning of the Rebin algorithm
+    compareTof = [](const double lhs, const double rhs) { return lhs < rhs; };
+    next_bin = [tolerance](const double lastTof, double bin_end) {
+      // advance the bin_end until we find the one that this next event falls into
+      while (lastTof >= bin_end)
+        bin_end = bin_end * (1 - tolerance);
+      return bin_end;
+    };
+  } else { // linear
+    // for linear we do "less than or equals" because that is how it was originally implemented
+    compareTof = [](const double lhs, const double rhs) { return lhs <= rhs; };
+    next_bin = [tolerance](const double lastTof, double) { return lastTof + tolerance; };
+  }
 
-        // advance the bin_end until we find the one that this next event falls into
-        while (lastTof >= bin_end)
-          bin_end = bin_end * (1 - tolerance);
+  // get first bin_end
+  bin_end = next_bin(lastTof, bin_end);
+
+  for (auto it = events.cbegin(); it != events.cend(); it++) {
+    if (compareTof(it->m_tof, bin_end)) {
+      // Carry the error and weight
+      weight += it->weight();
+      errorSquared += it->errorSquared();
+      // Track the average tof
+      num++;
+      const double norm = calcNorm(it->errorSquared());
+      normalization += norm;
+      totalTof += it->m_tof * norm;
+    } else {
+      // We exceeded the tolerance
+      // Create a new event with the average TOF and summed weights and
+      // squared errors.
+      if (num == 1) {
+        // last time-of-flight is the only one contributing
+        out.emplace_back(lastTof, weight, errorSquared);
+      } else if (num > 1) {
+        out.emplace_back(totalTof / normalization, weight, errorSquared);
       }
-    }
-  } else {
-    for (auto it = events.cbegin(); it != events.cend(); it++) {
-      if ((it->m_tof - lastTof) <= tolerance) {
-        // Carry the error and weight
-        weight += it->weight();
-        errorSquared += it->errorSquared();
-        // Track the average tof
-        num++;
-        const double norm = calcNorm(it->errorSquared());
-        normalization += norm;
-        totalTof += it->m_tof * norm;
-      } else {
-        // We exceeded the tolerance
-        // Create a new event with the average TOF and summed weights and
-        // squared errors.
-        if (num == 1) {
-          // last time-of-flight is the only one contributing
-          out.emplace_back(lastTof, weight, errorSquared);
-        } else if (num > 1) {
-          out.emplace_back(totalTof / normalization, weight, errorSquared);
-        }
-        // Start a new combined object
-        num = 1;
-        const double norm = calcNorm(it->errorSquared());
-        normalization = norm;
-        totalTof = it->m_tof * norm;
-        weight = it->weight();
-        errorSquared = it->errorSquared();
-        lastTof = it->m_tof;
-      }
+      // Start a new combined object
+      num = 1;
+      const double norm = calcNorm(it->errorSquared());
+      normalization = norm;
+      totalTof = it->m_tof * norm;
+      weight = it->weight();
+      errorSquared = it->errorSquared();
+      lastTof = it->m_tof;
+
+      bin_end = next_bin(lastTof, bin_end);
     }
   }
 
@@ -1568,7 +1552,7 @@ inline void EventList::compressFatEventsHelper(const std::vector<T> &events, std
   out.reserve(events.size() / 20);
 
   // The last TOF to which we are comparing.
-  double lastTof = std::numeric_limits<double>::lowest();
+  double lastTof = events.front().m_tof;
   // For getting an accurate average TOF
   double totalTof = 0;
 
@@ -1599,103 +1583,79 @@ inline void EventList::compressFatEventsHelper(const std::vector<T> &events, std
   // bin if the pulses are histogrammed
   int64_t lastPulseBin = (it->m_pulsetime.totalNanoseconds() - pulsetimeStart) / pulsetimeDelta;
 
-  if (tolerance < 0) {
+  double bin_end = lastTof;
+  double tof_min{0};
+  std::function<bool(const double, const double)> compareTof;
+  std::function<double(const double, double)> next_bin;
+
+  if (tolerance < 0) { // log
+    // for log we do "less than" so that is matches the log binning of the Rebin algorithm
+    compareTof = [](const double lhs, const double rhs) { return lhs < rhs; };
+    next_bin = [tolerance](const double lastTof, double bin_end) {
+      // advance the bin_end until we find the one that this next event falls into
+      while (lastTof >= bin_end)
+        bin_end = bin_end * (1 - tolerance);
+      return bin_end;
+    };
+
     // get minimum Tof so that binning is consistent across all pulses
     const auto event_min = std::min_element(
         events.cbegin(), events.cend(), [](const auto &left, const auto &right) { return left.tof() < right.tof(); });
-    const auto tof_min = event_min->tof();
+    bin_end = tof_min = event_min->tof();
+  } else { // linear
+    // for linear we do "less than or equals" because that is how it was originally implemented
+    compareTof = [](const double lhs, const double rhs) { return lhs <= rhs; };
+    next_bin = [tolerance](const double lastTof, double) { return lastTof + tolerance; };
+  }
 
-    lastTof = events.front().m_tof;
-    double bin_end = tof_min * (1 - tolerance);
+  // get first bin_end
+  bin_end = next_bin(lastTof, bin_end);
 
-    // loop through events and accumulate weight
-    for (; it != events.cend(); ++it) {
-      const int64_t eventPulseBin = (it->m_pulsetime.totalNanoseconds() - pulsetimeStart) / pulsetimeDelta;
-      if ((eventPulseBin <= lastPulseBin) && (it->m_tof < bin_end)) {
-        // Carry the error and weight
-        weight += it->weight();
-        errorSquared += it->errorSquared();
-        double norm = calcNorm(it->errorSquared());
-        tofNormalization += norm;
-        // Track the average tof
-        totalTof += it->m_tof * norm;
-        // Accumulate the pulse times
-        pulsetimes.emplace_back(it->m_pulsetime);
-        pulsetimeWeights.emplace_back(norm);
-      } else {
-        // We exceeded the tolerance
-        if (!pulsetimes.empty()) {
-          // Create a new event with the average TOF and summed weights and
-          // squared errors. 1 event used doesn't need to average
-          if (pulsetimes.size() == 1) {
-            out.emplace_back(lastTof, pulsetimes.front(), weight, errorSquared);
-          } else {
-            out.emplace_back(totalTof / tofNormalization,
-                             Kernel::DateAndTimeHelpers::averageSorted(pulsetimes, pulsetimeWeights), weight,
-                             errorSquared);
-          }
+  // loop through events and accumulate weight
+  for (; it != events.cend(); ++it) {
+    const int64_t eventPulseBin = (it->m_pulsetime.totalNanoseconds() - pulsetimeStart) / pulsetimeDelta;
+    if ((eventPulseBin <= lastPulseBin) && compareTof(it->m_tof, bin_end)) {
+      // Carry the error and weight
+      weight += it->weight();
+      errorSquared += it->errorSquared();
+      double norm = calcNorm(it->errorSquared());
+      tofNormalization += norm;
+      // Track the average tof
+      totalTof += it->m_tof * norm;
+      // Accumulate the pulse times
+      pulsetimes.emplace_back(it->m_pulsetime);
+      pulsetimeWeights.emplace_back(norm);
+    } else {
+      // We exceeded the tolerance
+      if (!pulsetimes.empty()) {
+        // Create a new event with the average TOF and summed weights and
+        // squared errors. 1 event used doesn't need to average
+        if (pulsetimes.size() == 1) {
+          out.emplace_back(lastTof, pulsetimes.front(), weight, errorSquared);
+        } else {
+          out.emplace_back(totalTof / tofNormalization,
+                           Kernel::DateAndTimeHelpers::averageSorted(pulsetimes, pulsetimeWeights), weight,
+                           errorSquared);
         }
-        // Start a new combined object
-        double norm = calcNorm(it->errorSquared());
-        totalTof = it->m_tof * norm;
-        weight = it->weight();
-        errorSquared = it->errorSquared();
-        tofNormalization = norm;
-        lastTof = it->m_tof;
-        if (eventPulseBin != lastPulseBin)
-          bin_end = tof_min * (1 - tolerance);
-        lastPulseBin = eventPulseBin;
-        pulsetimes.clear();
-        pulsetimes.emplace_back(it->m_pulsetime);
-        pulsetimeWeights.clear();
-        pulsetimeWeights.emplace_back(norm);
+      }
+      if (tolerance < 0 && eventPulseBin != lastPulseBin)
+        // reset the bin_end for the new pulse bin
+        bin_end = tof_min;
 
-        // advance the bin_end until we find the one that this next event falls into
-        while (lastTof >= bin_end)
-          bin_end = bin_end * (1 - tolerance);
-      }
-    }
-  } else {
-    // loop through events and accumulate weight
-    for (; it != events.cend(); ++it) {
-      const int64_t eventPulseBin = (it->m_pulsetime.totalNanoseconds() - pulsetimeStart) / pulsetimeDelta;
-      if ((eventPulseBin <= lastPulseBin) && (std::fabs(it->m_tof - lastTof) <= tolerance)) {
-        // Carry the error and weight
-        weight += it->weight();
-        errorSquared += it->errorSquared();
-        double norm = calcNorm(it->errorSquared());
-        tofNormalization += norm;
-        // Track the average tof
-        totalTof += it->m_tof * norm;
-        // Accumulate the pulse times
-        pulsetimes.emplace_back(it->m_pulsetime);
-        pulsetimeWeights.emplace_back(norm);
-      } else {
-        // We exceeded the tolerance
-        if (!pulsetimes.empty()) {
-          // Create a new event with the average TOF and summed weights and
-          // squared errors. 1 event used doesn't need to average
-          if (pulsetimes.size() == 1) {
-            out.emplace_back(lastTof, pulsetimes.front(), weight, errorSquared);
-          } else {
-            out.emplace_back(totalTof / tofNormalization,
-                             Kernel::DateAndTimeHelpers::averageSorted(pulsetimes, pulsetimeWeights), weight,
-                             errorSquared);
-          }
-        }
-        // Start a new combined object
-        double norm = calcNorm(it->errorSquared());
-        totalTof = it->m_tof * norm;
-        weight = it->weight();
-        errorSquared = it->errorSquared();
-        tofNormalization = norm;
-        lastTof = it->m_tof;
-        lastPulseBin = eventPulseBin;
-        pulsetimes.clear();
-        pulsetimes.emplace_back(it->m_pulsetime);
-        pulsetimeWeights.clear();
-        pulsetimeWeights.emplace_back(norm);
-      }
+      // Start a new combined object
+      double norm = calcNorm(it->errorSquared());
+      totalTof = it->m_tof * norm;
+      weight = it->weight();
+      errorSquared = it->errorSquared();
+      tofNormalization = norm;
+      lastTof = it->m_tof;
+      lastPulseBin = eventPulseBin;
+      pulsetimes.clear();
+      pulsetimes.emplace_back(it->m_pulsetime);
+      pulsetimeWeights.clear();
+      pulsetimeWeights.emplace_back(norm);
+
+      bin_end = next_bin(lastTof, bin_end);
     }
   }
 

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -2226,6 +2226,34 @@ public:
     TS_ASSERT_DELTA(el_output.getEvent(2).tof(), 100000, 1e-5)
   }
 
+  void test_compressEvents_log3() {
+    // check the behavior when TOF is zero or negative
+    el = EventList();
+    el += TofEvent(0, 0);
+    el += TofEvent(0.5, 0);
+    el += TofEvent(1, 0);
+
+    // Do compress events with log binning
+    // Since there is a tof==0 then the first bin_end should be 1
+    EventList el_output;
+    TS_ASSERT_THROWS_NOTHING(el.compressEvents(-1, &el_output))
+
+    // now check individual events
+    TS_ASSERT_EQUALS(el_output.getNumberEvents(), 2)
+
+    TS_ASSERT_EQUALS(el_output.getEvent(0).weight(), 2)
+    TS_ASSERT_EQUALS(el_output.getEvent(0).errorSquared(), 2)
+    TS_ASSERT_DELTA(el_output.getEvent(0).tof(), 0.25, 1e-5)
+
+    TS_ASSERT_EQUALS(el_output.getEvent(1).weight(), 1)
+    TS_ASSERT_EQUALS(el_output.getEvent(1).errorSquared(), 1)
+    TS_ASSERT_DELTA(el_output.getEvent(1).tof(), 1, 1e-5)
+
+    // now add a negative TOF and it should throw
+    el += TofEvent(-1, 0);
+    TS_ASSERT_THROWS(el.compressEvents(-1, &el_output), const std::runtime_error &)
+  }
+
   void test_compressFatEvents_log() {
     el = EventList();
     for (int pulseTime = 0; pulseTime < 5; pulseTime++)
@@ -2348,6 +2376,34 @@ public:
     TS_ASSERT_EQUALS(el_output.getEvent(3).errorSquared(), 2)
     TS_ASSERT_DELTA(el_output.getEvent(3).tof(), 1000.5, 1e-5)
     TS_ASSERT_DELTA(el_output.getEvent(3).pulseTime().totalNanoseconds(), 6000000000, 1e-5)
+  }
+
+  void test_compressFatEvents_log3() {
+    // check the behavior when TOF is zero or negative
+    el = EventList();
+    el += TofEvent(0.5, 1);
+    el += TofEvent(1, 2);
+    el += TofEvent(0, 3);
+
+    // Do compress events with log binning
+    // Since there is a tof==0 then the first bin_end should be 1
+    EventList el_output;
+    TS_ASSERT_THROWS_NOTHING(el.compressFatEvents(-1, DateAndTime{0}, 10, &el_output))
+
+    // now check individual events
+    TS_ASSERT_EQUALS(el_output.getNumberEvents(), 2)
+
+    TS_ASSERT_EQUALS(el_output.getEvent(0).weight(), 2)
+    TS_ASSERT_EQUALS(el_output.getEvent(0).errorSquared(), 2)
+    TS_ASSERT_DELTA(el_output.getEvent(0).tof(), 0.25, 1e-5)
+
+    TS_ASSERT_EQUALS(el_output.getEvent(1).weight(), 1)
+    TS_ASSERT_EQUALS(el_output.getEvent(1).errorSquared(), 1)
+    TS_ASSERT_DELTA(el_output.getEvent(1).tof(), 1, 1e-5)
+
+    // now add a negative TOF and it should throw
+    el += TofEvent(-1, 0);
+    TS_ASSERT_THROWS(el.compressFatEvents(-1, DateAndTime{0}, 10, &el_output), const std::runtime_error &)
   }
 
   //==================================================================================

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -814,11 +814,11 @@ virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDat
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:999
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1095
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h:199
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:3989
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4136
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4263
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4264
-derefInvalidIterator:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1600
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:3949
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4096
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4223
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4224
+derefInvalidIterator:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1584
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TableWorkspace.cpp:253
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TableWorkspace.cpp:318
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/LeanElasticPeaksWorkspace.cpp:620

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -814,11 +814,11 @@ virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDat
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:999
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1095
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h:199
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:3949
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4096
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4223
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4224
-derefInvalidIterator:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1584
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:3962
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4109
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4236
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4237
+derefInvalidIterator:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1590
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TableWorkspace.cpp:253
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TableWorkspace.cpp:318
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/LeanElasticPeaksWorkspace.cpp:620

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -814,11 +814,11 @@ virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDat
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:999
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1095
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h:199
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:3890
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4037
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4164
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4165
-derefInvalidIterator:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1560
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:3989
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4136
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4263
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4264
+derefInvalidIterator:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1600
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TableWorkspace.cpp:253
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TableWorkspace.cpp:318
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/LeanElasticPeaksWorkspace.cpp:620

--- a/docs/source/algorithms/CompressEvents-v1.rst
+++ b/docs/source/algorithms/CompressEvents-v1.rst
@@ -71,7 +71,7 @@ parameter can be left unset.
 Logarithmic binning
 ###################
 
-If you provide a negative tolerance or select ``Logarithmic`` as the ``BinningMode`` then the events will be combined together in increase large tolerances starting from the smallest TOF value. This follows the same method as the logarithmic binning of :ref:`algm-Rebin`.
+If you provide a negative tolerance or select ``Logarithmic`` as the ``BinningMode`` then the events will be combined together in increase large tolerances starting from the smallest TOF value. This follows the same method as the logarithmic binning of :ref:`algm-Rebin`. This mode will fail if any of the TOF values are negative.
 
 Usage
 -----

--- a/docs/source/algorithms/CompressEvents-v1.rst
+++ b/docs/source/algorithms/CompressEvents-v1.rst
@@ -68,6 +68,11 @@ appear in the ``OutputWorkspace``. If it is not specified, then the
 format for the ``StartTime`` is ``2010-09-14T04:20:12``. Normally this
 parameter can be left unset.
 
+Logarithmic binning
+###################
+
+If you provide a negative tolerance or select ``Logarithmic`` as the ``BinningMode`` then the events will be combined together in increase large tolerances starting from the smallest TOF value. This follows the same method as the logarithmic binning of :ref:`algm-Rebin`.
+
 Usage
 -----
 

--- a/docs/source/release/v6.10.0/Framework/Algorithms/New_features/37203.rst
+++ b/docs/source/release/v6.10.0/Framework/Algorithms/New_features/37203.rst
@@ -1,0 +1,1 @@
+- Add the ability for :ref:`algm-CompressEvents` to combine events together in a logarithmic increasing size groups.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

SNAPRed would like to intelligently use `CompressEvents` where the criteria for Time-of-flight compression follows the logarithmic mode used for histogramming TOF/d-spacing. This allows the retention of progressively finer compression tolerance at low times-of-flight, where Bragg peaks are sharper. This should be done in a way that is consistent with the existing output of the histogram representation of the output of `Rebin`. When possible, parameters should mimic the analogous versions in Rebin. This requires one additional parameter "BinningMode" with the possible values of "Linear" (the default) and "Logarithmic" (the new mode).

For a single spectrum with a minimum TOF=TOFmin, the following two workspaces are expected to give the same y-values in the histogram representation

```python
CreateSampleWorkspace(OutputWorkspace="eventWS", WorkspaceType="Event", Xmin=300, XMax=20000)
ExtractSpectra(InputWorkspace="eventWS", OutputWorkspace="eventWS", StartWorkspaceIndex=0, EndworkspaceIndex=0) # get first spectrum
# create histogram
Rebin(InputWorkspace="eventWS", OutputWorkspace="histoWS", Params=(300,-0.001,2000), PreserveEvents=False)
# compress events
CompressEvents(InputWorkspace="eventWS", OutputWorkspace="eventWS", tolerance=0.001, BinningMode="Logarithmic")
Rebin(InputWorkspace="eventWS", OutputWorkspace="eventWS", Params=(300,-0.001,2000))
# compare
np.all(mtd["eventWS"].readY(0) == mtd["histoWS"].readY(0))
```

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [EWM3030](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3030)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
