### PR TITLE
Add instructions to sync release-next with main at code freeze

### DIFF
--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -388,14 +388,9 @@ Code Freeze
   the next steps.
 * Click ``Build Now`` on `open-release-testing
   <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__,
-  which will perform the following actions:
-
-  * Create or update the ``release-next`` branch.
-  * Enable the job to periodically merge ``release-next`` into ``main``.
-  * Set the value of the Jenkins global property ``BRANCH_TO_PUBLISH`` to ``release-next``.
-    This will turn off publishing for the ``main`` branch pipeline and switch it on for the
-    ``release-next`` pipeline.
-
+  which will perform the following action set the value of the Jenkins global property
+  ``BRANCH_TO_PUBLISH`` to ``release-next``, which will re-enable package publishing for
+  the ``release-next`` nightly pipeline.
 * Check the state of all open pull requests for this milestone and decide which
   should be kept for the release, liaise with the Release Manager on this. Move any
   pull requests not targeted for this release out of the milestone, and then change

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -398,10 +398,9 @@ Code Freeze
 
 * Verify that the latest commit on ``release-next`` is correct before moving to the next step.
 * Click ``Build Now`` on `open-release-testing
-  <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__,
-  which will perform the following action set the value of the Jenkins global property
-  ``BRANCH_TO_PUBLISH`` to ``release-next``, which will re-enable package publishing for
-  the ``release-next`` nightly pipeline.
+  <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__. This will
+  set the value of the Jenkins global property ``BRANCH_TO_PUBLISH`` to ``release-next``,
+  which will re-enable package publishing for the ``release-next`` nightly pipeline.
 * Check the state of all open pull requests for this milestone and decide which
   should be kept for the release, liaise with the Release Manager on this. Move any
   pull requests not targeted for this release out of the milestone, and then change

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -386,6 +386,17 @@ Code Freeze
   <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/>`__
   has passed for all build environments. If it fails, decide if a fix is needed before moving on to
   the next steps.
+* Ask a mantid gatekeeper or administrator to update the ``release-next`` branch so that it's up to
+  date with the ``main`` branch, pushing the changes directly to GitHub:
+
+.. code-block:: bash
+
+    git checkout release-next
+    git fetch origin main
+    git reset --hard origin/main
+    git push origin release-next --force
+
+* Verify that the latest commit on ``release-next`` is correct before moving to the next step.
 * Click ``Build Now`` on `open-release-testing
   <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__,
   which will perform the following action set the value of the Jenkins global property


### PR DESCRIPTION
### Description of work
Since the Docker container for deployment-tools disappeared, the Jenkins job for pointing release-next to the tip of main wasn't working. After discussion, we decided the best plan was to simply add instructions to the release checklist for performing the task manually. Otherwise it is too easy for any developer to click the "run job" button and spoil the `release-next` branch part way through the release period.

Fixes #36918 

### To test:
Check that the instructions are clear and the logic is correct.

*This does not require release notes* because **it's an update to dev docs**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
