### PR TITLE
Add tests for the presenter of elwin interface

### DIFF
--- a/qt/scientific_interfaces/Inelastic/Manipulation/ElwinModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ElwinModel.h
@@ -19,30 +19,54 @@ using namespace MantidQt::MantidWidgets;
 namespace MantidQt {
 namespace CustomInterfaces {
 
-class MANTIDQT_INELASTIC_DLL ElwinModel {
-
+class MANTIDQT_INELASTIC_DLL IElwinModel {
 public:
-  ElwinModel();
-  virtual ~ElwinModel() = default;
+  virtual ~IElwinModel() = default;
   virtual void setupLoadAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::string const &filepath,
-                                  std::string const &outputName);
-  virtual std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra const &spectra);
+                                  std::string const &outputName) = 0;
+  virtual std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra const &spectra) = 0;
   virtual void setupGroupAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
-                                   std::string const &inputWorkspacesString, std::string const &inputGroupWsName);
+                                   std::string const &inputWorkspacesString, std::string const &inputGroupWsName) = 0;
   virtual void setupElasticWindowMultiple(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
                                           std::string const &workspaceBaseName, std::string const &inputGroupWsName,
                                           std::string const &sampleEnvironmentLogName,
-                                          std::string const &sampleEnvironmentLogValue);
-  virtual void ungroupAlgorithm(std::string const &inputWorkspace) const;
-  virtual void groupAlgorithm(std::string const &inputWorkspaces, std::string const &outputWorkspace) const;
-  virtual void setIntegrationStart(double integrationStart);
-  virtual void setIntegrationEnd(double integrationEnd);
-  virtual void setBackgroundStart(double backgroundStart);
-  virtual void setBackgroundEnd(double backgroundEnd);
-  virtual void setBackgroundSubtraction(bool backgroundSubtraction);
-  virtual void setNormalise(bool normalise);
-  virtual void setOutputWorkspaceNames(std::string const &workspaceBaseName);
-  virtual std::string getOutputWorkspaceNames() const;
+                                          std::string const &sampleEnvironmentLogValue) = 0;
+  virtual void ungroupAlgorithm(std::string const &inputWorkspace) const = 0;
+  virtual void groupAlgorithm(std::string const &inputWorkspaces, std::string const &outputWorkspace) const = 0;
+  virtual void setIntegrationStart(double integrationStart) = 0;
+  virtual void setIntegrationEnd(double integrationEnd) = 0;
+  virtual void setBackgroundStart(double backgroundStart) = 0;
+  virtual void setBackgroundEnd(double backgroundEnd) = 0;
+  virtual void setBackgroundSubtraction(bool backgroundSubtraction) = 0;
+  virtual void setNormalise(bool normalise) = 0;
+  virtual void setOutputWorkspaceNames(std::string const &workspaceBaseName) = 0;
+  virtual std::string getOutputWorkspaceNames() const = 0;
+};
+
+class MANTIDQT_INELASTIC_DLL ElwinModel : public IElwinModel {
+
+public:
+  ElwinModel();
+  ~ElwinModel() = default;
+  void setupLoadAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::string const &filepath,
+                          std::string const &outputName) override;
+  std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra const &spectra);
+  void setupGroupAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
+                           std::string const &inputWorkspacesString, std::string const &inputGroupWsName) override;
+  void setupElasticWindowMultiple(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
+                                  std::string const &workspaceBaseName, std::string const &inputGroupWsName,
+                                  std::string const &sampleEnvironmentLogName,
+                                  std::string const &sampleEnvironmentLogValue) override;
+  void ungroupAlgorithm(std::string const &inputWorkspace) const override;
+  void groupAlgorithm(std::string const &inputWorkspaces, std::string const &outputWorkspace) const override;
+  void setIntegrationStart(double integrationStart) override;
+  void setIntegrationEnd(double integrationEnd) override;
+  void setBackgroundStart(double backgroundStart) override;
+  void setBackgroundEnd(double backgroundEnd) override;
+  void setBackgroundSubtraction(bool backgroundSubtraction) override;
+  void setNormalise(bool normalise) override;
+  void setOutputWorkspaceNames(std::string const &workspaceBaseName) override;
+  std::string getOutputWorkspaceNames() const override;
 
 private:
   double m_integrationStart;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ElwinModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ElwinModel.h
@@ -50,7 +50,7 @@ public:
   ~ElwinModel() = default;
   void setupLoadAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::string const &filepath,
                           std::string const &outputName) override;
-  std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra const &spectra);
+  std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra const &spectra) override;
   void setupGroupAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
                            std::string const &inputWorkspacesString, std::string const &inputGroupWsName) override;
   void setupElasticWindowMultiple(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ElwinModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ElwinModel.h
@@ -23,26 +23,26 @@ class MANTIDQT_INELASTIC_DLL ElwinModel {
 
 public:
   ElwinModel();
-  ~ElwinModel() = default;
-  void setupLoadAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::string const &filepath,
-                          std::string const &outputName);
-  std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra const &spectra);
-  void setupGroupAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
-                           std::string const &inputWorkspacesString, std::string const &inputGroupWsName);
-  void setupElasticWindowMultiple(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
-                                  std::string const &workspaceBaseName, std::string const &inputGroupWsName,
-                                  std::string const &sampleEnvironmentLogName,
-                                  std::string const &sampleEnvironmentLogValue);
-  void ungroupAlgorithm(std::string const &inputWorkspace) const;
-  void groupAlgorithm(std::string const &inputWorkspaces, std::string const &outputWorkspace) const;
-  void setIntegrationStart(double integrationStart);
-  void setIntegrationEnd(double integrationEnd);
-  void setBackgroundStart(double backgroundStart);
-  void setBackgroundEnd(double backgroundEnd);
-  void setBackgroundSubtraction(bool backgroundSubtraction);
-  void setNormalise(bool normalise);
-  void setOutputWorkspaceNames(std::string const &workspaceBaseName);
-  std::string getOutputWorkspaceNames() const;
+  virtual ~ElwinModel() = default;
+  virtual void setupLoadAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::string const &filepath,
+                                  std::string const &outputName);
+  virtual std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra const &spectra);
+  virtual void setupGroupAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
+                                   std::string const &inputWorkspacesString, std::string const &inputGroupWsName);
+  virtual void setupElasticWindowMultiple(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
+                                          std::string const &workspaceBaseName, std::string const &inputGroupWsName,
+                                          std::string const &sampleEnvironmentLogName,
+                                          std::string const &sampleEnvironmentLogValue);
+  virtual void ungroupAlgorithm(std::string const &inputWorkspace) const;
+  virtual void groupAlgorithm(std::string const &inputWorkspaces, std::string const &outputWorkspace) const;
+  virtual void setIntegrationStart(double integrationStart);
+  virtual void setIntegrationEnd(double integrationEnd);
+  virtual void setBackgroundStart(double backgroundStart);
+  virtual void setBackgroundEnd(double backgroundEnd);
+  virtual void setBackgroundSubtraction(bool backgroundSubtraction);
+  virtual void setNormalise(bool normalise);
+  virtual void setOutputWorkspaceNames(std::string const &workspaceBaseName);
+  virtual std::string getOutputWorkspaceNames() const;
 
 private:
   double m_integrationStart;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ElwinPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ElwinPresenter.cpp
@@ -49,7 +49,7 @@ ElwinPresenter::ElwinPresenter(QWidget *parent, IElwinView *view)
       std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::Spectra));
 }
 
-ElwinPresenter::ElwinPresenter(QWidget *parent, IElwinView *view, std::unique_ptr<ElwinModel> model,
+ElwinPresenter::ElwinPresenter(QWidget *parent, IElwinView *view, std::unique_ptr<IElwinModel> model,
                                std::unique_ptr<IFitDataModel> dataModel)
     : DataManipulation(parent), m_view(view), m_model(std::move(model)), m_dataModel(std::move(dataModel)),
       m_selectedSpectrum(0) {

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ElwinPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ElwinPresenter.cpp
@@ -49,6 +49,15 @@ ElwinPresenter::ElwinPresenter(QWidget *parent, IElwinView *view)
       std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::Spectra));
 }
 
+ElwinPresenter::ElwinPresenter(QWidget *parent, IElwinView *view, std::unique_ptr<ElwinModel> model,
+                               std::unique_ptr<IFitDataModel> dataModel)
+    : DataManipulation(parent), m_view(view), m_model(std::move(model)), m_dataModel(std::move(dataModel)),
+      m_selectedSpectrum(0) {
+  m_view->subscribePresenter(this);
+  setOutputPlotOptionsPresenter(
+      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::Spectra));
+}
+
 ElwinPresenter::~ElwinPresenter() {}
 
 void ElwinPresenter::setup() {

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ElwinPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ElwinPresenter.h
@@ -43,6 +43,8 @@ public:
 class MANTIDQT_INELASTIC_DLL ElwinPresenter : public DataManipulation, public IElwinPresenter {
 public:
   ElwinPresenter(QWidget *parent, IElwinView *view);
+  ElwinPresenter(QWidget *parent, IElwinView *view, std::unique_ptr<ElwinModel> model,
+                 std::unique_ptr<IFitDataModel> dataModel);
   ~ElwinPresenter();
 
   // base Manipulation tab methods
@@ -63,6 +65,13 @@ public:
   void handleRowModeChanged() override;
   void updateAvailableSpectra() override;
 
+  void setInputWorkspace(MatrixWorkspace_sptr inputWorkspace);
+  virtual void setSelectedSpectrum(int spectrum);
+  int getSelectedSpectrum() const;
+  MatrixWorkspace_sptr getInputWorkspace() const;
+  MatrixWorkspace_sptr getPreviewPlotWorkspace();
+  void setPreviewPlotWorkspace(const MatrixWorkspace_sptr &previewPlotWorkspace);
+
 protected:
   void runComplete(bool error) override;
   void newInputDataFromDialog();
@@ -72,23 +81,16 @@ private:
   void updateTableFromModel();
   void updateIntegrationRange();
 
-  int getSelectedSpectrum() const;
-  virtual void setSelectedSpectrum(int spectrum);
-
   std::vector<std::string> getOutputWorkspaceNames();
   std::string getOutputBasename();
-  MatrixWorkspace_sptr getInputWorkspace() const;
-  MatrixWorkspace_sptr getPreviewPlotWorkspace();
   bool checkForELTWorkspace();
-  void setInputWorkspace(MatrixWorkspace_sptr inputWorkspace);
-  void setPreviewPlotWorkspace(const MatrixWorkspace_sptr &previewPlotWorkspace);
   void newPreviewFileSelected(const std::string &workspaceName, const std::string &filename);
   void newPreviewWorkspaceSelected(const std::string &workspaceName);
   size_t findWorkspaceID();
 
   IElwinView *m_view;
   std::unique_ptr<ElwinModel> m_model;
-  std::unique_ptr<FitDataModel> m_dataModel;
+  std::unique_ptr<IFitDataModel> m_dataModel;
   int m_selectedSpectrum;
   std::weak_ptr<MatrixWorkspace> m_previewPlotWorkspace;
   MatrixWorkspace_sptr m_inputWorkspace;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ElwinPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ElwinPresenter.h
@@ -43,7 +43,7 @@ public:
 class MANTIDQT_INELASTIC_DLL ElwinPresenter : public DataManipulation, public IElwinPresenter {
 public:
   ElwinPresenter(QWidget *parent, IElwinView *view);
-  ElwinPresenter(QWidget *parent, IElwinView *view, std::unique_ptr<ElwinModel> model,
+  ElwinPresenter(QWidget *parent, IElwinView *view, std::unique_ptr<IElwinModel> model,
                  std::unique_ptr<IFitDataModel> dataModel);
   ~ElwinPresenter();
 
@@ -89,7 +89,7 @@ private:
   size_t findWorkspaceID();
 
   IElwinView *m_view;
-  std::unique_ptr<ElwinModel> m_model;
+  std::unique_ptr<IElwinModel> m_model;
   std::unique_ptr<IFitDataModel> m_dataModel;
   int m_selectedSpectrum;
   std::weak_ptr<MatrixWorkspace> m_previewPlotWorkspace;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ElwinView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ElwinView.cpp
@@ -212,7 +212,7 @@ void ElwinView::addData(MantidWidgets::IAddWorkspaceDialog const *dialog) {
   }
 }
 
-OutputPlotOptionsView *ElwinView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
+IOutputPlotOptionsView *ElwinView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
 
 void ElwinView::setHorizontalHeaders() {
   QStringList headers;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ElwinView.h
@@ -31,7 +31,7 @@ public:
   void subscribePresenter(IElwinPresenter *presenter) override;
   void setup() override;
 
-  OutputPlotOptionsView *getPlotOptions() const override;
+  IOutputPlotOptionsView *getPlotOptions() const override;
 
   void setAvailableSpectra(WorkspaceIndex minimum, WorkspaceIndex maximum) override;
   void setAvailableSpectra(const std::vector<WorkspaceIndex>::const_iterator &from,

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
@@ -23,7 +23,7 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-class OutputPlotOptionsView;
+class IOutputPlotOptionsView;
 class IElwinPresenter;
 
 class MANTIDQT_INELASTIC_DLL IElwinView {
@@ -31,7 +31,7 @@ class MANTIDQT_INELASTIC_DLL IElwinView {
 public:
   virtual void subscribePresenter(IElwinPresenter *presenter) = 0;
   virtual void setup() = 0;
-  virtual OutputPlotOptionsView *getPlotOptions() const = 0;
+  virtual IOutputPlotOptionsView *getPlotOptions() const = 0;
 
   virtual void setAvailableSpectra(MantidWidgets::WorkspaceIndex minimum, MantidWidgets::WorkspaceIndex maximum) = 0;
   virtual void setAvailableSpectra(const std::vector<MantidWidgets::WorkspaceIndex>::const_iterator &from,

--- a/qt/scientific_interfaces/Inelastic/test/Manipulation/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/test/Manipulation/CMakeLists.txt
@@ -1,6 +1,8 @@
 get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
 
-set(TEST_FILES ElwinModelTest.h IqtModelTest.h MomentsModelTest.h SqwModelTest.h SymmetriseModelTest.h)
+set(TEST_FILES ElwinModelTest.h ElwinPresenterTest.h IqtModelTest.h MomentsModelTest.h SqwModelTest.h
+               SymmetriseModelTest.h
+)
 
 list(TRANSFORM TEST_FILES PREPEND ${SUB_DIRECTORY}/)
 

--- a/qt/scientific_interfaces/Inelastic/test/Manipulation/ElwinPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Manipulation/ElwinPresenterTest.h
@@ -1,0 +1,141 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+#include "Manipulation/ElwinModel.h"
+#include "Manipulation/ElwinPresenter.h"
+#include "Manipulation/ElwinView.h"
+#include "MantidQtWidgets/Common/AddWorkspaceDialog.h"
+
+#include "../Common/MockObjects.h"
+#include "../QENSFitting/MockObjects.h"
+
+#include "MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h"
+#include "MantidKernel/WarningSuppressions.h"
+
+using namespace Mantid::API;
+using namespace Mantid::IndirectFitDataCreationHelper;
+using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::Inelastic;
+using namespace testing;
+
+class ElwinPresenterTest : public CxxTest::TestSuite {
+public:
+  static ElwinPresenterTest *createSuite() { return new ElwinPresenterTest(); }
+
+  static void destroySuite(ElwinPresenterTest *suite) { delete suite; }
+
+  void setUp() override {
+    m_view = std::make_unique<NiceMock<MockElwinView>>();
+    m_outputPlotView = std::make_unique<NiceMock<MockOutputPlotOptionsView>>();
+
+    auto model = std::make_unique<NiceMock<MockElwinModel>>();
+    auto dataModel = std::make_unique<NiceMock<MockFitDataModel>>();
+    m_model = model.get();
+    m_dataModel = dataModel.get();
+
+    ON_CALL(*m_view, getPlotOptions()).WillByDefault(Return((m_outputPlotView.get())));
+    m_presenter = std::make_unique<ElwinPresenter>(nullptr, m_view.get(), std::move(model), std::move(dataModel));
+
+    m_workspace = createWorkspace(5);
+    m_ads = std::make_unique<SetUpADSWithWorkspace>("workspace_test", m_workspace);
+  }
+
+  void tearDown() override {
+    AnalysisDataService::Instance().clear();
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_view.get()));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&m_model));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&m_dataModel));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_outputPlotView.get()));
+
+    m_presenter.reset();
+    m_view.reset();
+    m_outputPlotView.reset();
+  }
+
+  ///----------------------------------------------------------------------
+  /// Unit Tests that test the signals, methods and slots of the presenter
+  ///----------------------------------------------------------------------
+
+  void test_handleValueChanged_sets_correct_bool_property() {
+
+    EXPECT_CALL(*m_model, setNormalise(true)).Times((Exactly(1)));
+    m_presenter->handleValueChanged("Normalise", true);
+
+    EXPECT_CALL(*m_model, setBackgroundSubtraction(true)).Times((Exactly(1)));
+    m_presenter->handleValueChanged("BackgroundSubtraction", true);
+  }
+
+  void test_handleValueChanged_sets_correct_double_property() {
+    double value = 0.1;
+
+    EXPECT_CALL(*m_model, setIntegrationStart(value)).Times((Exactly(1)));
+    m_presenter->handleValueChanged("IntegrationStart", value);
+    EXPECT_CALL(*m_model, setIntegrationEnd(value)).Times((Exactly(1)));
+    m_presenter->handleValueChanged("IntegrationEnd", value);
+    EXPECT_CALL(*m_model, setBackgroundStart(value)).Times((Exactly(1)));
+    m_presenter->handleValueChanged("BackgroundStart", value);
+    EXPECT_CALL(*m_model, setBackgroundEnd(value)).Times((Exactly(1)));
+    m_presenter->handleValueChanged("BackgroundEnd", value);
+  }
+
+  void test_handleRunClicked_doesnt_run_with_invalid_ranges() {
+    EXPECT_CALL(*m_outputPlotView, clearWorkspaces()).Times(1);
+    EXPECT_CALL(*m_view, isTableEmpty()).Times(1);
+    m_presenter->handleRunClicked();
+  }
+
+  void test_handlePlotPreviewClicked_calls_warning_when_no_workspace() {
+    EXPECT_CALL(*m_view, showMessageBox("Workspace not found - data may not be loaded.")).Times(Exactly(1));
+    m_presenter->handlePlotPreviewClicked();
+  }
+
+  void test_handlePreviewSpectrumChanged_calls_correct_spectrum() {
+    m_presenter->setInputWorkspace(m_workspace);
+    auto spectrum = 1;
+    EXPECT_CALL(*m_view, getPreviewSpec()).Times(Exactly(1)).WillOnce(Return(1));
+    EXPECT_CALL(*m_view, plotInput(m_workspace, spectrum)).Times(Exactly(1));
+    m_presenter->handlePreviewSpectrumChanged(spectrum);
+  }
+
+  void test_handleAddData_sets_preview_workspace_and_spectrum() {
+    auto dialog = new MantidQt::MantidWidgets::AddWorkspaceDialog(nullptr);
+    m_presenter->setSelectedSpectrum(0);
+
+    ON_CALL(*m_view, getPreviewWorkspaceName(0)).WillByDefault(Return("workspace_test"));
+    EXPECT_CALL(*m_view, clearPreviewFile()).Times(Exactly(1));
+    EXPECT_CALL(*m_view, newInputDataFromDialog(m_dataModel->getWorkspaceNames())).Times(Exactly(1));
+    EXPECT_CALL(*m_view, plotInput(m_workspace, 0)).Times(Exactly(1));
+    m_presenter->handleAddData(dialog);
+  }
+
+  void test_handleRowModeChanged_gets_domains_when_rows_are_not_collapsed() {
+    EXPECT_CALL(*m_view, isRowCollapsed()).WillOnce(Return(false));
+    EXPECT_CALL(*m_dataModel, getNumberOfDomains()).Times(Exactly(1));
+    m_presenter->handleRowModeChanged();
+  }
+
+  void test_handleRowModeChanged_gets_workspaces_when_rows_are_collapsed() {
+    EXPECT_CALL(*m_view, isRowCollapsed()).WillOnce(Return(true));
+    EXPECT_CALL(*m_dataModel, getNumberOfWorkspaces()).Times(Exactly(1));
+    m_presenter->handleRowModeChanged();
+  }
+
+private:
+  NiceMock<MockFitDataModel> *m_dataModel;
+  NiceMock<MockElwinModel> *m_model;
+  std::unique_ptr<NiceMock<MockOutputPlotOptionsView>> m_outputPlotView;
+  std::unique_ptr<NiceMock<MockElwinView>> m_view;
+  std::unique_ptr<ElwinPresenter> m_presenter;
+
+  MatrixWorkspace_sptr m_workspace;
+  std::unique_ptr<SetUpADSWithWorkspace> m_ads;
+};

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -9,6 +9,11 @@
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 
+#include "Manipulation/DataManipulation.h"
+#include "Manipulation/ElwinModel.h"
+#include "Manipulation/ElwinPresenter.h"
+#include "Manipulation/ElwinView.h"
+#include "Manipulation/IElwinView.h"
 #include "QENSFitting/FitTab.h"
 #include "QENSFitting/FunctionBrowser/FunctionTemplateView.h"
 #include "QENSFitting/FunctionBrowser/ITemplatePresenter.h"
@@ -28,6 +33,7 @@
 #include <vector>
 
 using namespace MantidQt::CustomInterfaces::Inelastic;
+using namespace MantidQt::CustomInterfaces;
 
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
@@ -355,6 +361,85 @@ public:
   virtual ~MockInelasticFitPropertyBrowser() = default;
 
   MOCK_METHOD1(updateFunctionListInBrowser, void(const std::map<std::string, std::string> &functionStrings));
+};
+
+class MockElwinView : public IElwinView {
+public:
+  virtual ~MockElwinView() = default;
+
+  MOCK_METHOD1(subscribePresenter, void(IElwinPresenter *presenter));
+  MOCK_METHOD0(setup, void());
+  MOCK_CONST_METHOD0(getPlotOptions, IOutputPlotOptionsView *());
+
+  MOCK_METHOD2(setAvailableSpectra,
+               void(MantidQt::MantidWidgets::WorkspaceIndex minimum, MantidQt::MantidWidgets::WorkspaceIndex maximum));
+  MOCK_METHOD2(setAvailableSpectra,
+               void(const std::vector<MantidQt::MantidWidgets::WorkspaceIndex>::const_iterator &from,
+                    const std::vector<MantidQt::MantidWidgets::WorkspaceIndex>::const_iterator &to));
+  MOCK_METHOD2(plotInput, void(Mantid::API::MatrixWorkspace_sptr inputWS, int spectrum));
+  MOCK_METHOD1(newInputDataFromDialog, void(std::vector<std::string> const &names));
+  MOCK_METHOD0(clearPreviewFile, void());
+
+  MOCK_METHOD1(setRunIsRunning, void(const bool running));
+  MOCK_METHOD1(setSaveResultEnabled, void(const bool enabled));
+  MOCK_CONST_METHOD0(getPreviewSpec, int());
+
+  MOCK_CONST_METHOD1(getPreviewWorkspaceName, std::string(int index));
+  MOCK_CONST_METHOD1(getPreviewFilename, std::string(int index));
+  MOCK_CONST_METHOD0(getCurrentPreview, std::string());
+
+  MOCK_METHOD0(clearDataTable, void());
+  MOCK_METHOD3(addTableEntry, void(int row, std::string const &name, std::string const &wsIndexes));
+
+  MOCK_METHOD0(getSelectedData, QModelIndexList());
+
+  MOCK_CONST_METHOD0(isGroupInput, bool());
+  MOCK_CONST_METHOD0(isRowCollapsed, bool());
+  MOCK_CONST_METHOD0(isTableEmpty, bool());
+
+  MOCK_METHOD0(getNormalise, bool());
+  MOCK_METHOD0(getBackgroundSubtraction, bool());
+  MOCK_METHOD0(getLogName, std::string());
+  MOCK_METHOD0(getLogValue, std::string());
+
+  MOCK_METHOD1(setIntegrationStart, void(double value));
+  MOCK_METHOD1(setIntegrationEnd, void(double value));
+  MOCK_METHOD1(setBackgroundStart, void(double value));
+  MOCK_METHOD1(setBackgroundEnd, void(double value));
+
+  MOCK_METHOD0(getIntegrationStart, double());
+  MOCK_METHOD0(getIntegrationEnd, double());
+  MOCK_METHOD0(getBackgroundStart, double());
+  MOCK_METHOD0(getBackgroundEnd, double());
+
+  MOCK_CONST_METHOD1(showMessageBox, void(std::string const &message));
+};
+
+class MockElwinModel : public ElwinModel {
+public:
+  virtual ~MockElwinModel() = default;
+
+  MOCK_METHOD3(setupLoadAlgorithm, void(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
+                                        std::string const &filepath, std::string const &outputName));
+  MOCK_METHOD2(createGroupedWorkspaces,
+               std::string(MatrixWorkspace_sptr workspce, FunctionModelSpectra const &spectra));
+  MOCK_METHOD3(setupGroupAlgorithm,
+               void(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::string const &inputWorkspacesString,
+                    std::string const &inputGroupWsName));
+  MOCK_METHOD5(setupElasticWindowMultiple,
+               void(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::string const &workspaceBaseName,
+                    std::string const &inputGroupWsName, std::string const &sampleEnvironmentLogName,
+                    std::string const &sampleEnvironmentLogValue));
+  MOCK_CONST_METHOD1(ungroupAlgorithm, void(std::string const &inputWorkspaces));
+  MOCK_CONST_METHOD2(groupAlgorithm, void(std::string const &inputWorkspaces, std::string const &outputWorkspace));
+  MOCK_METHOD1(setIntegrationStart, void(double integrationStart));
+  MOCK_METHOD1(setIntegrationEnd, void(double integrationEnd));
+  MOCK_METHOD1(setBackgroundStart, void(double backgroundStart));
+  MOCK_METHOD1(setBackgroundEnd, void(double backgroundEnd));
+  MOCK_METHOD1(setBackgroundSubtraction, void(bool backgroundSubstraction));
+  MOCK_METHOD1(setNormalise, void(bool normalise));
+  MOCK_METHOD1(setOutputWorkspaceNames, void(std::string const &workspaceBaseName));
+  MOCK_CONST_METHOD0(getOutputWorkspaceNames, std::string());
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -415,7 +415,7 @@ public:
   MOCK_CONST_METHOD1(showMessageBox, void(std::string const &message));
 };
 
-class MockElwinModel : public ElwinModel {
+class MockElwinModel : public IElwinModel {
 public:
   virtual ~MockElwinModel() = default;
 


### PR DESCRIPTION
### Description of work
This PR follows after refactoring the presenter of the elwin interface and making it non qt-dependent (#36537). Now test are added for most public members of the class.
To make it possible to test by mocking the models and the data model, I had to add a new overloaded constructor to the elwin presenter which is only called from the test. All Data Manipulation presenter classes share the same structure, so maybe we can think of adding an issue in the future for homogenizing the presenters and constructing them by passing directly unique pointers to the model, as it is done on most other presenter of mantid MVP interfaces.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #34928 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Test passes in CI 
- Code review

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->
** does not need release notes**
<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
