### PR TITLE
Fix mismatch in doctest output

### DIFF
--- a/docs/source/algorithms/GenerateGroupingPowder-v1.rst
+++ b/docs/source/algorithms/GenerateGroupingPowder-v1.rst
@@ -120,7 +120,7 @@ Output:
 
 .. testoutput:: GenerateGroupingPowder_GroupingWorkspace
 
-    The grouped workspace has 51200 histograms
+    The grouping workspace has 51200 histograms
 
 
 


### PR DESCRIPTION
### Description of work
This PR fixes a doctest warning which crept into the nightly
```
**********************************************************************
File "algorithms/GenerateGroupingPowder-v1.rst", line 197, in GenerateGroupingPowder_GroupingWorkspace
Failed example:
    #load some file
    ws=Load("CNCS_7860")
    gws_name= "a_nice_name_for_grouping_workspace"

    #generate the files
    GenerateGroupingPowder(ws,10, GroupingWorkspace=gws_name)

    #check that it works
    gws = mtd[gws_name]
    print("The grouping workspace has {} histograms".format(gws.getNumberHistograms()))
Expected:
    The grouped workspace has 51200 histograms
Got:
    The grouping workspace has 51200 histograms
```

### To test:
Code review and check tests pass

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
