### PR TITLE
Add sphinx fresh environment flag

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -11,6 +11,7 @@ set_property(CACHE DOCS_MATH_EXT PROPERTY STRINGS "sphinx.ext.imgmath" "sphinx.e
 option(DOCS_PLOTDIRECTIVE "If enabled include plots generated with the plot directive. " OFF)
 option(DOCS_QTHELP "If enabled add a target to build the qthelp documentation" ON)
 option(SPHINX_WARNINGS_AS_ERRORS "non-zero exit if there are sphinx warnings" ON)
+option(SPHINX_FRESH_ENV "Don't use a saved environment, but rebuild it completely" ON)
 
 # Build layout
 set(SPHINX_CONF_DIR ${CMAKE_CURRENT_SOURCE_DIR}/source)
@@ -40,6 +41,11 @@ if(SPHINX_WARNINGS_AS_ERRORS)
 else()
   set(SPHINX_WARNINGS_AS_ERRORS_FLAG "")
 endif()
+if(SPHINX_FRESH_ENV)
+  set(SPHINX_FRESH_ENV_FLAG "-E")
+else()
+  set(SPHINX_FRESH_ENV_FLAG "")
+endif()
 
 # Add a sphinx build target to build documentation builder - Name of the sphinx builder: html, qthelp etc target_name -
 # Optional target name. Default=docs-${builder}
@@ -61,6 +67,7 @@ function(add_sphinx_build_target builder math_renderer)
       ${SPHINX_NOCOLOR}
       ${SPHINX_KEEPGOING}
       ${SPHINX_WARNINGS_AS_ERRORS_FLAG}
+      ${SPHINX_FRESH_ENV_FLAG}
       -b
       ${builder}
       -d


### PR DESCRIPTION
### Description of work
This PR adds the sphinx fresh environment flag `-E` to our document builds. https://www.sphinx-doc.org/en/master/man/sphinx-build.html

This is necessary because when you do not use a fresh environment, if you push two commits in a row, containing the same doctest failure, the second push will not run the failing doctest because the document hasn't changed in the cached environment. Therefore the tests will pass, even when there is a doctest that fails. This assumes both commits run on the same node. This PR will hopefully stop doctest warnings creeping into `main`!

The only problem with using `-E`, is it does a rebuild each time, so the doctests will take longer to run. This shouldn't be a problem when we separate the doctests into its own pipeline, and run it on the linux nodes.

*There is no associated issue.*

### To test:
Check that the doctests job passes

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
