### PR TITLE
Fix "Save Other" Widget's Saving in ISIS SANS Interface

### DIFF
--- a/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
+++ b/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
@@ -194,6 +194,24 @@ Processing
 #. Check that your save location contains files for both the background subtracted workspace and the normal reduction
    output.
 
+Save Other
+##########
+
+*Single Workspace*
+
+#. On the ``Runs`` tab, with some workspaces present in the ADS, click the ``Save Other`` button.
+#. Select one of the workspaces from the list.
+#. Provide a path to a new save directory, and provide a file name.
+#. Click ``Save``.
+#. Check the file was saved to the correct location on your system.
+
+*Multiple Workspaces*
+
+#. Select multiple workspaces with Shift or Ctrl/Cmd.
+#. Provide a suffix for the files.
+#. Click ``Save``.
+#. Check that the files were saved with their workspace's names, but with the provided suffix appended.
+
 Beam centre finder
 ##################
 

--- a/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
+++ b/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
@@ -199,7 +199,9 @@ Save Other
 
 *Single Workspace*
 
-#. On the ``Runs`` tab, with some workspaces present in the ADS, click the ``Save Other`` button.
+#. Navigate to the ``Runs`` tab, making sure there are some reduced workspaces present in the ADS. Follow one of the
+   "Processing" instruction sets above if you need to create some.
+#. Click the ``Save Other`` button.
 #. Select one of the workspaces from the list.
 #. Provide a path to a new save directory, and provide a file name.
 #. Click ``Save``.

--- a/docs/source/release/v6.10.0/SANS/Bugfixes/37219.rst
+++ b/docs/source/release/v6.10.0/SANS/Bugfixes/37219.rst
@@ -1,0 +1,1 @@
+- An error is no longer produced when saving from the ``Save Other`` dialog.

--- a/docs/source/release/v6.10.0/SANS/Bugfixes/37219.rst
+++ b/docs/source/release/v6.10.0/SANS/Bugfixes/37219.rst
@@ -1,1 +1,1 @@
-- An error is no longer produced when saving from the ``Save Other`` dialog.
+- An error is no longer produced when saving from the ``Save Other`` dialog in the :ref:`ISIS_SANS_Runs_Tab-ref`.

--- a/scripts/SANS/sans/gui_logic/presenter/save_other_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/save_other_presenter.py
@@ -40,13 +40,14 @@ class SaveOtherPresenter(object):
         selected_workspaces = self.get_workspaces()
         selected_filenames = self.get_filenames(selected_workspaces, self.filename)
         additional_run_numbers = {}
+        additional_metadata = {}
 
         self._view.progress_bar_minimum = 0
         self._view.progress_bar_maximum = len(selected_workspaces)
         self._view.progress_bar_value = 0
         for name_to_save, filename in zip(selected_workspaces, selected_filenames):
             try:
-                save_workspace_to_file(name_to_save, file_formats, filename, additional_run_numbers)
+                save_workspace_to_file(name_to_save, file_formats, filename, additional_run_numbers, additional_metadata)
             except RuntimeError:
                 logger.warning(
                     f"Cannot save {name_to_save} using SANSSave. "

--- a/scripts/test/SANS/gui_logic/save_other_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/save_other_presenter_test.py
@@ -9,6 +9,7 @@ import unittest
 from mantid import ConfigService
 from unittest import mock
 from sans.gui_logic.presenter.save_other_presenter import SaveOtherPresenter
+from os.path import join
 
 
 class SaveOtherPresenterTest(unittest.TestCase):
@@ -74,6 +75,26 @@ class SaveOtherPresenterTest(unittest.TestCase):
         expected_list = ["base_dir/workspace_1"]
 
         self.assertEqual(expected_list, returned_list)
+
+    @mock.patch("sans.gui_logic.presenter.save_other_presenter.AnalysisDataService")
+    def test_on_save_clicked_calls_save_workspace_to_file(self, mock_ads):
+        # This test is to make sure that any positional argument changes are caught.
+        self.mock_view.get_selected_workspaces.return_value = ["a"]
+        self.mock_view.get_filenames.return_value = ["a.nxs"]
+        self.presenter.on_save_clicked()
+
+    @mock.patch("sans.gui_logic.presenter.save_other_presenter.save_workspace_to_file")
+    @mock.patch("sans.gui_logic.presenter.save_other_presenter.AnalysisDataService")
+    def test_on_save_clicked_calls_save_workspace_to_file_with_correct_params(self, _, mock_save):
+        # This one is to ensure on_save is passing the correct params. Split, else the mocking hides bugs.
+        workspace_names = ["aworkspace"]
+        file_name = "afile"
+        file_types = ["Nexus"]
+        self.mock_view.get_selected_workspaces.return_value = workspace_names
+        self.presenter.filename = file_name
+        self.mock_view.get_save_options.return_value = file_types
+        self.presenter.on_save_clicked()
+        mock_save.assert_called_with(workspace_names[0], file_types, join(self.presenter.current_directory, file_name), {}, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of work

#### Summary of work
Add the additional positional argument to the `save_workspace_to_file` method imported from `batch_execution` in the call from the Save Other widget. 


Fixes #37219 <!-- and fix #372 or close #xxxx xor resolves #xxxx. One line per issue fixed. -->

#### Further detail of work
This seems not to have been covered by either our unit or manual testing. So appropriate tests have been added to to the docs and code to remedy this.

The unit tests added test the call two-fold. Once to make sure that any future changes to the `save_workspace_to_file`'s positional arguments will cause a failure, and the other to make sure any unexpected changes to the call of `save_workspace_to_file` will also fail. 

`on_save()` was completely untested. There is probably more that could be added, but that's beyond the scope of this PR. 

### To test:
1. Open the ISIS SANS Interface
2. Load the batch and user files from the `loqdemo` in the training course data.
3. Process one of the rows. 
4. Click `Save Other`.
5. In the widget, select one of the generated output workspaces. 
6. Provide a file name and a save path
7. Click Save. 
8. No errors should appear (note that attempting to save a non-reduced workspace will produce an error, but this is expected and the error message should be reasonably clear to indicate this.)

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
