### PR TITLE
Prevent warnings when adding data from dialogs in QENS fitting interface

### DIFF
--- a/docs/source/release/v6.10.0/Inelastic/Bugfixes/37185.rst
+++ b/docs/source/release/v6.10.0/Inelastic/Bugfixes/37185.rst
@@ -1,0 +1,1 @@
+- Disable `Add` button and change the button text to *Loading* from workspace dialogs to prevent warnings or crashes if `Add` button is pressed but files are still loading.

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FqFitAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FqFitAddWorkspaceDialog.cpp
@@ -17,6 +17,7 @@ FqFitAddWorkspaceDialog::FqFitAddWorkspaceDialog(QWidget *parent) : QDialog(pare
   m_uiForm.dsWorkspace->setLoadProperty("LoadHistory", false);
 
   connect(m_uiForm.dsWorkspace, SIGNAL(dataReady(const QString &)), this, SLOT(emitWorkspaceChanged(const QString &)));
+  connect(m_uiForm.dsWorkspace, SIGNAL(filesAutoLoaded()), this, SLOT(handleAutoLoaded()));
   connect(m_uiForm.cbParameterType, SIGNAL(currentIndexChanged(const QString &)), this,
           SLOT(emitParameterTypeChanged(const QString &)));
   connect(m_uiForm.pbAdd, SIGNAL(clicked()), this, SLOT(emitAddData()));
@@ -65,11 +66,17 @@ void FqFitAddWorkspaceDialog::setFBSuffices(const QStringList &suffices) {
 }
 
 void FqFitAddWorkspaceDialog::emitWorkspaceChanged(const QString &name) {
+  m_uiForm.pbAdd->setText("Add");
+  m_uiForm.pbAdd->setEnabled(true);
   emit workspaceChanged(this, name.toStdString());
 }
 
 void FqFitAddWorkspaceDialog::emitParameterTypeChanged(const QString &type) {
   emit parameterTypeChanged(this, type.toStdString());
+}
+void FqFitAddWorkspaceDialog::handleAutoLoaded() {
+  m_uiForm.pbAdd->setText("Loading");
+  m_uiForm.pbAdd->setEnabled(false);
 }
 
 void FqFitAddWorkspaceDialog::emitAddData() { emit addData(this); }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FqFitAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FqFitAddWorkspaceDialog.h
@@ -44,6 +44,7 @@ private slots:
   void emitWorkspaceChanged(const QString &name);
   void emitParameterTypeChanged(const QString &index);
   void emitAddData();
+  void handleAutoLoaded();
 
 private:
   Ui::FqFitAddWorkspaceDialog m_uiForm;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceDialog.h
@@ -40,6 +40,7 @@ private slots:
   void selectAllSpectra(int state);
   void workspaceChanged(const QString &workspaceName);
   void emitAddData();
+  void handleAutoLoaded();
 
 private:
   void setWorkspace(const std::string &workspace);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
@@ -346,6 +346,8 @@ signals:
   void dataReady(const QString &wsname);
   /// Signal emitted when the load button is clicked
   void loadClicked();
+  /// Signal emitted when files are found and autoloaded
+  void filesAutoLoaded();
 
 protected:
   // Method for handling drop events

--- a/qt/widgets/common/src/AddWorkspaceDialog.cpp
+++ b/qt/widgets/common/src/AddWorkspaceDialog.cpp
@@ -19,7 +19,7 @@ AddWorkspaceDialog::AddWorkspaceDialog(QWidget *parent) : QDialog(parent) {
   const auto validatorString = QString::fromStdString(getRegexValidatorString(RegexValidatorStrings::SpectraValidator));
   m_uiForm.leWorkspaceIndices->setValidator(new QRegExpValidator(QRegExp(validatorString), this));
   setAllSpectraSelectionEnabled(false);
-
+  connect(m_uiForm.dsWorkspace, SIGNAL(filesAutoLoaded()), this, SLOT(handleAutoLoaded()));
   connect(m_uiForm.dsWorkspace, SIGNAL(dataReady(const QString &)), this, SLOT(workspaceChanged(const QString &)));
   connect(m_uiForm.ckAllSpectra, SIGNAL(stateChanged(int)), this, SLOT(selectAllSpectra(int)));
   connect(m_uiForm.pbAdd, SIGNAL(clicked()), this, SLOT(emitAddData()));
@@ -55,6 +55,9 @@ void AddWorkspaceDialog::selectAllSpectra(int state) {
 void AddWorkspaceDialog::workspaceChanged(const QString &workspaceName) {
   const auto name = workspaceName.toStdString();
   const auto workspace = WorkspaceUtils::getADSWorkspace(name);
+  m_uiForm.pbAdd->setText("Add");
+  m_uiForm.pbAdd->setEnabled(true);
+
   if (workspace)
     setWorkspace(name);
   else
@@ -62,6 +65,11 @@ void AddWorkspaceDialog::workspaceChanged(const QString &workspaceName) {
 }
 
 void AddWorkspaceDialog::emitAddData() { emit addData(this); }
+
+void AddWorkspaceDialog::handleAutoLoaded() {
+  m_uiForm.pbAdd->setText("Loading");
+  m_uiForm.pbAdd->setEnabled(false);
+}
 
 void AddWorkspaceDialog::setWorkspace(const std::string &workspace) {
   setAllSpectraSelectionEnabled(true);

--- a/qt/widgets/common/src/DataSelector.cpp
+++ b/qt/widgets/common/src/DataSelector.cpp
@@ -112,6 +112,7 @@ void DataSelector::handleFileInput() {
 
   // attempt to load the file
   if (m_autoLoad) {
+    emit filesAutoLoaded();
     autoLoadFile(filename);
   } else {
     // files were found


### PR DESCRIPTION
### Description of work
This PR fixes a warning that can appear whenever data is being loaded from dialogs in all tabs of QENS fitting interface. Even if the data is taking a long time to load, it is still possible to click on the `Add` button of the dialog window, which will cause the interface to try to act on the data while is being loaded on the ADS, thus creating warnings or crashes. 
The solution I have adopted to fix this undesired behaviour from the dialogs is to emit a signal from the `Data Selector` widget when it autoloads the data. This signal can then by received by the dialog interface to disable the  `Add`  button (and change its text) until the loading of the data is finished. 
However, there are still problems with the dialogs:
- If the dialog window is closed while the data is being loaded, this will create a crash in Mantid (this is not happening due to the changes on this PR, it's a current issue with the dialogs).
- Interface can still freeze while the data is being loaded if trying to interact with it. 

A more fitting solution would be to implement a manager class for the loading algorithm in a different thread with which we can communicate ([#37184](https://github.com/mantidproject/mantid/issues/37184)).  There are plans to implement that solution for Mantid 6.11. But I still think emitting a signal from the selector widget when it is auto-loading may be a good inclusion. And disabling the button helps the users understand what is happening with the data.
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37185 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Follow instructions on #37185. You shouldn't be able to click on the `Add` button until the data is loaded. 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
