### PR TITLE
Fix Function Browsers going out of sync

### DIFF
--- a/docs/source/release/v6.10.0/Inelastic/Bugfixes/37199.rst
+++ b/docs/source/release/v6.10.0/Inelastic/Bugfixes/37199.rst
@@ -1,0 +1,1 @@
+- Fixed a bug causing the Full Function Browser and Template Function Browser from going out of sync on the :ref:`QENS Fitting <interface-inelastic-qens-fitting>` interface.

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
@@ -129,6 +129,8 @@ void InelasticFitPropertyBrowser::syncFullBrowserWithTemplate() {
     m_functionBrowser->updateMultiDatasetParameters(*m_templatePresenter->getGlobalFunction());
     m_functionBrowser->setGlobalParameters(m_templatePresenter->getGlobalParameters());
     m_functionBrowser->setCurrentDataset(m_templatePresenter->getCurrentDataset());
+  } else {
+    m_functionBrowser->clear();
   }
   m_functionBrowser->blockSignals(false);
 }
@@ -141,6 +143,8 @@ void InelasticFitPropertyBrowser::syncTemplateBrowserWithFull() {
     m_templatePresenter->updateMultiDatasetParameters(*fun);
     m_templatePresenter->setGlobalParameters(m_functionBrowser->getGlobalParameters());
     m_templatePresenter->setCurrentDataset(m_functionBrowser->getCurrentDataset());
+  } else {
+    m_templatePresenter->setFunction("");
   }
   m_templatePresenter->browser()->blockSignals(false);
 }


### PR DESCRIPTION
### Description of work
This PR fixes a bug where the Full FunctionBrowser and Template FunctionBrowser on the QENS Fitting interface could go out of sync when all functions are removed from either one, before switching to a different view.

Fixes #37199

### To test:

Open Inelastic->QENS Fitting
Go to IqtFit tab
Select Stretched Exp as Fit type
Tick See full function, it should have the stretched exp
Untick See full function
Select None as Fit type
Tick See full function, it should be empty.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
