### PR TITLE
Add grouping options for HB3A

### DIFF
--- a/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
+++ b/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
@@ -168,21 +168,8 @@ void ConvertHFIRSCDtoMDE::exec() {
   std::string instrument = expInfo.getInstrument()->getName();
 
   std::vector<double> twotheta, azimuthal;
-  if (instrument == "HB3A") {
-    const auto &di = expInfo.detectorInfo();
-    for (size_t x = 0; x < 512; x++) {
-      for (size_t y = 0; y < 512 * 3; y++) {
-        size_t n = x + y * 512;
-        if (!di.isMonitor(n)) {
-          twotheta.push_back(di.twoTheta(n));
-          azimuthal.push_back(di.azimuthal(n));
-        }
-      }
-    }
-  } else { // HB2C
-    azimuthal = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("azimuthal"))))();
-    twotheta = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("twotheta"))))();
-  }
+  azimuthal = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("azimuthal"))))();
+  twotheta = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("twotheta"))))();
 
   auto outputWS = DataObjects::MDEventFactory::CreateMDWorkspace(3, "MDEvent");
   Mantid::Geometry::QSample frame;

--- a/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
+++ b/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
@@ -168,8 +168,21 @@ void ConvertHFIRSCDtoMDE::exec() {
   std::string instrument = expInfo.getInstrument()->getName();
 
   std::vector<double> twotheta, azimuthal;
-  azimuthal = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("azimuthal"))))();
-  twotheta = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("twotheta"))))();
+  if (instrument == "HB3A" && !expInfo.run().hasProperty("azimuthal")) { // HB3A Load MD
+    const auto &di = expInfo.detectorInfo();
+    for (size_t x = 0; x < 512; x++) {
+      for (size_t y = 0; y < 512 * 3; y++) {
+        size_t n = x + y * 512;
+        if (!di.isMonitor(n)) {
+          twotheta.push_back(di.twoTheta(n));
+          azimuthal.push_back(di.azimuthal(n));
+        }
+      }
+    }
+  } else { // HB2C LoadWAND or HB3A HB3AAdjustSampleNorm
+    azimuthal = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("azimuthal"))))();
+    twotheta = (*(dynamic_cast<Kernel::PropertyWithValue<std::vector<double>> *>(expInfo.getLog("twotheta"))))();
+  }
 
   auto outputWS = DataObjects::MDEventFactory::CreateMDWorkspace(3, "MDEvent");
   Mantid::Geometry::QSample frame;

--- a/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
+++ b/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
@@ -245,7 +245,7 @@ void ConvertHFIRSCDtoMDE::exec() {
         if (lorentz) {
           factor = lorentz_pre[m];
         }
-        inserter.insertMDEvent(signal * factor, signal * factor, 0, goniometerIndex, 0, q_sample.data());
+        inserter.insertMDEvent(signal * factor, signal * factor * factor, 0, goniometerIndex, 0, q_sample.data());
       }
     }
   }

--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -372,21 +372,8 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
             k = 2 * np.pi / self.getProperty("Wavelength").value
 
         progress.report("Calculating Qlab for each pixel")
-        if inWS.getExperimentInfo(0).run().hasProperty("twotheta"):
-            polar = np.array(inWS.getExperimentInfo(0).run().getProperty("twotheta").value)
-        else:
-            di = inWS.getExperimentInfo(0).detectorInfo()
-            polar = np.array([di.twoTheta(i) for i in range(di.size()) if not di.isMonitor(i)])
-            if inWS.getExperimentInfo(0).getInstrument().getName() == "HB3A":
-                polar = polar.reshape(512 * 3, 512).T.flatten()
-
-        if inWS.getExperimentInfo(0).run().hasProperty("azimuthal"):
-            azim = np.array(inWS.getExperimentInfo(0).run().getProperty("azimuthal").value)
-        else:
-            di = inWS.getExperimentInfo(0).detectorInfo()
-            azim = np.array([di.azimuthal(i) for i in range(di.size()) if not di.isMonitor(i)])
-            if inWS.getExperimentInfo(0).getInstrument().getName() == "HB3A":
-                azim = azim.reshape(512 * 3, 512).T.flatten()
+        polar = np.array(inWS.getExperimentInfo(0).run().getProperty("twotheta").value)
+        azim = np.array(inWS.getExperimentInfo(0).run().getProperty("azimuthal").value)
 
         # check convention to determine the sign
         if config["Q.convention"] == "Crystallography":

--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -372,8 +372,21 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
             k = 2 * np.pi / self.getProperty("Wavelength").value
 
         progress.report("Calculating Qlab for each pixel")
-        polar = np.array(inWS.getExperimentInfo(0).run().getProperty("twotheta").value)
-        azim = np.array(inWS.getExperimentInfo(0).run().getProperty("azimuthal").value)
+        if inWS.getExperimentInfo(0).run().hasProperty("twotheta"):
+            polar = np.array(inWS.getExperimentInfo(0).run().getProperty("twotheta").value)
+        else:
+            di = inWS.getExperimentInfo(0).detectorInfo()
+            polar = np.array([di.twoTheta(i) for i in range(di.size()) if not di.isMonitor(i)])
+            if inWS.getExperimentInfo(0).getInstrument().getName() == "HB3A":
+                polar = polar.reshape(512 * 3, 512).T.flatten()
+
+        if inWS.getExperimentInfo(0).run().hasProperty("azimuthal"):
+            azim = np.array(inWS.getExperimentInfo(0).run().getProperty("azimuthal").value)
+        else:
+            di = inWS.getExperimentInfo(0).detectorInfo()
+            azim = np.array([di.azimuthal(i) for i in range(di.size()) if not di.isMonitor(i)])
+            if inWS.getExperimentInfo(0).getInstrument().getName() == "HB3A":
+                azim = azim.reshape(512 * 3, 512).T.flatten()
 
         # check convention to determine the sign
         if config["Q.convention"] == "Crystallography":

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -386,7 +386,7 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
             )
 
         y_dim, x_dim, number_of_runs = array.shape
-        array = array.T.flatten()
+        array = np.swapaxes(array.T, 1, 2).flatten()
 
         run = mtd[ws].getExperimentInfo(0).run()
         det_trans = run.getProperty("det_trans").timeAverageValue()
@@ -396,7 +396,7 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
         _tmp_ws = CreateSimulationWorkspace(Instrument="HB3A", BinParams="0,1,2", UnitX="TOF", SetErrors=True)
         AddSampleLog(Workspace=_tmp_ws, LogName="det_trans", LogText=str(det_trans), LogType="Number Series", NumberType="Double")
         AddSampleLog(Workspace=_tmp_ws, LogName="2theta", LogText=str(two_theta), LogType="Number Series", NumberType="Double")
-        LoadInstrument(Workspace=_tmp_ws, RewriteSpectraMap=True, InstrumentName="HB3A")
+        LoadInstrument(Workspace=_tmp_ws, RewriteSpectraMap=False, InstrumentName="HB3A")
         self.__move_components(_tmp_ws, height, distance)
 
         CreateMDHistoWorkspace(
@@ -433,10 +433,8 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
         CopySample(scan, "__scan_grouped", CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False)
 
-        twotheta = mtd["_PreprocessedDetectorsWS"].column(2)
-        azimuthal = mtd["_PreprocessedDetectorsWS"].column(3)
-        run["azimuthal"] = azimuthal
-        run["twotheta"] = twotheta
+        run["twotheta"] = mtd["_PreprocessedDetectorsWS"].column(2)
+        run["azimuthal"] = mtd["_PreprocessedDetectorsWS"].column(3)
 
         DeleteWorkspace(_tmp_ws, EnableLogging=False)
         DeleteWorkspace("_PreprocessedDetectorsWS", EnableLogging=False)

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -336,11 +336,10 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
                     BinningDim2=bin2,
                     OutputWorkspace=out_ws_name,
                 )
-                if load_files:
-                    DeleteWorkspace(scan)
             else:
                 norm_data = self.__normalization(scan, vanws, load_files)
                 RenameWorkspace(norm_data, OutputWorkspace=out_ws_name)
+            DeleteWorkspace(scan)
 
         if has_multiple:
             out_ws_name = out_ws
@@ -350,7 +349,7 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
             else:
                 GroupWorkspaces(InputWorkspaces=wslist, OutputWorkspace=out_ws_name)
 
-        # Don't delete workspaces if they were passed in
+        # Delete workspaces
         if load_van:
             DeleteWorkspace(vanws)
 

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -417,7 +417,7 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
                     spectra_list = []
                     for i in range(grouping):
                         for j in range(grouping):
-                            spectra_list.append(x + j + (y + i) * 512)
+                            spectra_list.append(str(x + j + (y + i) * 512))
                     detector_list += "," + "+".join(spectra_list)
             _tmp_ws = GroupDetectors(InputWorkspace=_tmp_ws, GroupingPattern=detector_list, EnableLogging=False)
 

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -412,14 +412,13 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
         if grouping > 1:
             detector_list = ""
-            for b in range(3):
-                for x in range(0, 512, grouping):
-                    for y in range(0, 512, grouping):
-                        spectra_list = []
+            for x in range(0, 512, grouping):
+                for y in range(0, 512 * 3, grouping):
+                    spectra_list = []
+                    for i in range(grouping):
                         for j in range(grouping):
-                            for i in range(grouping):
-                                spectra_list.append(str(b + (y + i + (x + j) * 512) * 3))
-                        detector_list += "," + "+".join(spectra_list)
+                            spectra_list.append(x + j + (y + i) * 512)
+                    detector_list += "," + "+".join(spectra_list)
             _tmp_ws = GroupDetectors(InputWorkspace=_tmp_ws, GroupingPattern=detector_list, EnableLogging=False)
 
         _tmp_ws = Rebin(InputWorkspace=_tmp_ws, Params="0,1,2", EnableLogging=False)

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -361,7 +361,7 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
         ws = scan.name()
 
-        array = mtd[ws].getSignalArray()
+        array = mtd[ws].getSignalArray().copy()
 
         if grouping == 2:
             array = array[0::2, 0::2] + array[1::2, 0::2] + array[0::2, 1::2] + array[1::2, 1::2]
@@ -412,12 +412,12 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
         if grouping > 1:
             detector_list = ""
-            for x in range(0, 512, grouping):
-                for y in range(0, 512 * 3, grouping):
+            for y in range(0, 512 * 3, grouping):
+                for x in range(0, 512, grouping):
                     spectra_list = []
-                    for i in range(grouping):
-                        for j in range(grouping):
-                            spectra_list.append(str(x + j + (y + i) * 512))
+                    for j in range(grouping):
+                        for i in range(grouping):
+                            spectra_list.append(str(x + i + (y + j) * 512))
                     detector_list += "," + "+".join(spectra_list)
             _tmp_ws = GroupDetectors(InputWorkspace=_tmp_ws, GroupingPattern=detector_list, EnableLogging=False)
 
@@ -440,8 +440,8 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
         DeleteWorkspace(_tmp_ws, EnableLogging=False)
         DeleteWorkspace("_PreprocessedDetectorsWS", EnableLogging=False)
-        DeleteWorkspace(scan)
 
+        DeleteWorkspace(scan)
         RenameWorkspace("__scan_grouped", OutputWorkspace=ws)
 
         return mtd[ws]

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -269,7 +269,7 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
         out_ws_name = out_ws
 
         if load_van:
-            vanws = LoadMD(vanadiumfile, StoreInADS=False)
+            vanws = LoadMD(vanadiumfile, StoreInADS=True)
             vanws = self.__regroup_and_move(vanws, grouping, height, distance)
 
         has_multiple = len(datafiles) > 1

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -415,8 +415,8 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
             for x in range(0, 512, grouping):
                 for y in range(0, 512 * 3, grouping):
                     spectra_list = []
-                    for j in range(grouping):
-                        for i in range(grouping):
+                    for i in range(grouping):
+                        for j in range(grouping):
                             spectra_list.append(str(y + i + (x + j) * 512 * 3))
                     detector_list += "," + "+".join(spectra_list)
             _tmp_ws = GroupDetectors(InputWorkspace=_tmp_ws, GroupingPattern=detector_list, EnableLogging=False)

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -23,7 +23,6 @@ from mantid.kernel import (
     FloatArrayProperty,
     FloatArrayLengthValidator,
     FloatPropertyWithValue,
-    V3D,
     StringListValidator,
 )
 from mantid.simpleapi import (
@@ -40,6 +39,14 @@ from mantid.simpleapi import (
     mtd,
     GroupWorkspaces,
     RenameWorkspace,
+    ConvertToMD,
+    PreprocessDetectorsToMD,
+    LoadInstrument,
+    CreateMDHistoWorkspace,
+    CreateSimulationWorkspace,
+    MoveInstrumentComponent,
+    AddSampleLog,
+    Rebin,
 )
 import os
 import numpy as np
@@ -182,6 +189,11 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
         self.setPropertySettings("BinningDim1", histo_settings)
         self.setPropertySettings("BinningDim2", histo_settings)
 
+        # Grouping info
+        self.declareProperty(
+            "Grouping", "None", StringListValidator(["None", "2x2", "4x4"]), "Group pixels (shared by input and normalization)"
+        )
+
         self.declareProperty(
             WorkspaceProperty("OutputWorkspace", "", optional=PropertyMode.Mandatory, direction=Direction.Output),
             doc="Output MDWorkspace in Q-space, name is prefix if multiple input files were provided.",
@@ -246,11 +258,18 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
         wslist = []
 
+        grouping = self.getProperty("Grouping").value
+        if grouping == "None":
+            grouping = 1
+        else:
+            grouping = 2 if grouping == "2x2" else 4
+
         out_ws = self.getPropertyValue("OutputWorkspace")
         out_ws_name = out_ws
 
         if load_van:
             vanws = LoadMD(vanadiumfile, StoreInADS=False)
+            vanws = self.__regrouping_and_move(vanws, grouping, height, distance)
 
         has_multiple = len(datafiles) > 1
 
@@ -264,6 +283,8 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
             if scan.getNumExperimentInfo() == 0:
                 raise RuntimeError("No experiment info was found in '{}'".format(in_file))
 
+            scan = self.__regrouping_and_move(scan, grouping, height, distance)
+
             prog.report()
             self.log().information("Processing '{}'".format(in_file))
 
@@ -276,10 +297,8 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
                     out_ws_name = out_ws + "_" + in_file
                 wslist.append(out_ws_name)
 
-            exp_info = scan.getExperimentInfo(0)
-            self.__move_components(exp_info, height, distance)
-
             # Get the wavelength from experiment info if it exists, or fallback on property value
+            exp_info = scan.getExperimentInfo(0)
             wavelength = self.__get_wavelength(exp_info)
 
             # set the run number to be the same as scan number, this will be used for peaks
@@ -336,6 +355,92 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
         self.setProperty("OutputWorkspace", out_ws_name)
 
+    def __regrouping_and_move(self, scan, grouping, height, distance):
+
+        ws = scan.name()
+
+        array = mtd[ws].getSignalArray()
+
+        if grouping == 2:
+            array = array[0::2, 0::2] + array[1::2, 0::2] + array[0::2, 1::2] + array[1::2, 1::2]
+        elif grouping == 4:
+            array = (
+                array[0::4, 0::4]
+                + array[1::4, 0::4]
+                + array[2::4, 0::4]
+                + array[3::4, 0::4]
+                + array[0::4, 1::4]
+                + array[1::4, 1::4]
+                + array[2::4, 1::4]
+                + array[3::4, 1::4]
+                + array[0::4, 2::4]
+                + array[1::4, 2::4]
+                + array[2::4, 2::4]
+                + array[3::4, 2::4]
+                + array[0::4, 3::4]
+                + array[1::4, 3::4]
+                + array[2::4, 3::4]
+                + array[3::4, 3::4]
+            )
+
+        y_dim, x_dim, number_of_runs = array.shape
+
+        run = mtd[ws].getExperimentInfo(0).run()
+        det_trans = run.getProperty("det_trans").value[0]
+        two_theta = run.getProperty("2theta").value[0]
+        logs = run.getLogData()
+
+        _tmp_ws = CreateSimulationWorkspace(Instrument="HB3A", BinParams="0,1,2", UnitX="TOF", SetErrors=True)
+        AddSampleLog(Workspace=_tmp_ws, LogName="det_trans", LogText=str(det_trans), LogType="Number Series", NumberType="Double")
+        AddSampleLog(Workspace=_tmp_ws, LogName="2theta", LogText=str(two_theta), LogType="Number Series", NumberType="Double")
+        LoadInstrument(Workspace=_tmp_ws, RewriteSpectraMap=True, InstrumentName="HB3A")
+        self.__move_components(_tmp_ws, height, distance)
+
+        CreateMDHistoWorkspace(
+            SignalInput=array.flatten().tolist(),
+            ErrorInput=np.sqrt(array).flatten().tolist(),
+            Dimensionality=3,
+            Extents="0.5,{},0.5,{},0.5,{}".format(y_dim + 0.5, x_dim + 0.5, number_of_runs + 0.5),
+            NumberOfBins="{},{},{}".format(y_dim, x_dim, number_of_runs),
+            Names="y,x,scanIndex",
+            Units="bin,bin,number",
+            OutputWorkspace="__scan_grouped",
+        )
+
+        if grouping > 1:
+            detector_list = ""
+            for x in range(0, 512 * 3, grouping):
+                for y in range(0, 512, grouping):
+                    spectra_list = []
+                    for j in range(grouping):
+                        for i in range(grouping):
+                            spectra_list.append(str(y + i + (x + j) * 512))
+                    detector_list += "," + "+".join(spectra_list)
+            _tmp_ws = GroupDetectors(InputWorkspace=_tmp_ws, GroupingPattern=detector_list, EnableLogging=False)
+
+        PreprocessDetectorsToMD(InputWorkspace=_tmp_ws, OutputWorkspace="_PreprocessedDetectorsWS")
+        _tmp_ws = Rebin(InputWorkspace=_tmp_ws, Params="0,1,2", EnableLogging=False)
+        _tmp_ws = ConvertToMD(
+            InputWorkspace=_tmp_ws, dEAnalysisMode="Elastic", EnableLogging=False, PreprocDetectorsWS="_PreprocessedDetectorsWS"
+        )
+
+        mtd["__scan_grouped"].copyExperimentInfos(_tmp_ws)
+        run = mtd["__scan_grouped"].getExperimentInfo(0).run()
+        for log in logs:
+            run[log.name] = log
+
+        twotheta = mtd["_PreprocessedDetectorsWS"].column(2)
+        azimuthal = mtd["_PreprocessedDetectorsWS"].column(3)
+        run["azimuthal"] = azimuthal
+        run["twotheta"] = twotheta
+
+        DeleteWorkspace(_tmp_ws, EnableLogging=False)
+        DeleteWorkspace("_PreprocessedDetectorsWS", EnableLogging=False)
+
+        RenameWorkspace("__scan_grouped", OutputWorkspace=ws)
+
+        return mtd[ws]
+
     def __normalization(self, data, vanadium, load_files):
         if vanadium:
             norm_data = ReplicateMD(ShapeWorkspace=data, DataWorkspace=vanadium)
@@ -378,35 +483,29 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
         return norm_data
 
-    def __move_components(self, exp_info, height, distance):
+    def __move_components(self, ws, height, distance):
         """
         Moves all instrument banks by a given height (y) and distance (x-z) in meters,
         relative to the current instrument position.
-        :param exp_info: experiment info of the run, used to get the instrument components
+        :param ws: Workspace2d with instrument definition
         :param height: Distance to move the instrument along y axis
         :param distance: Distance to move the instrument in the x-z plane
         """
         # Adjust detector height and distance with new offsets
-        component = exp_info.componentInfo()
+        instrument = ws.getInstrument()
         for bank in range(1, 4):
             # Set height offset (y) first on bank?
-            index = component.indexOfAny("bank{}".format(bank))
-
+            panel_name = "bank{}".format(bank)
             if height != 0.0:
-                offset = V3D(0, height, 0)
-                pos = component.position(index)
-                offset += pos
-                component.setPosition(index, offset)
+                MoveInstrumentComponent(Workspace=ws, ComponentName=panel_name, Y=height)
 
-            # Set distance offset to detector (x,z) on bank?/panel
+            # Set distance offset to detector (x,z) on bank/panel
             if distance != 0.0:
-                panel_index = int(component.children(index)[0])  # should only have one child
-                panel_pos = component.position(panel_index)
-                panel_rel_pos = component.relativePosition(panel_index)
+                component = instrument.getComponentByName(panel_name)
+                panel_rel_pos = component.getRelativePos()
                 # need to move detector in direction in x-z plane
                 panel_offset = panel_rel_pos * (distance / panel_rel_pos.norm())
-                panel_offset += panel_pos
-                component.setPosition(panel_index, panel_offset)
+                MoveInstrumentComponent(Workspace=ws, ComponentName=panel_name, X=panel_offset[0], Z=panel_offset[2])
 
     def __get_wavelength(self, exp_info):
         """

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -386,7 +386,7 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
             )
 
         y_dim, x_dim, number_of_runs = array.shape
-        array = np.swapaxes(array.T, 1, 2).flatten()
+        array = array.flatten(order="F")
 
         run = mtd[ws].getExperimentInfo(0).run()
         det_trans = run.getProperty("det_trans").timeAverageValue()

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -412,11 +412,11 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
         if grouping > 1:
             detector_list = ""
-            for x in range(0, 512, grouping):
-                for y in range(0, 512 * 3, grouping):
+            for y in range(0, 512 * 3, grouping):
+                for x in range(0, 512, grouping):
                     spectra_list = []
-                    for i in range(grouping):
-                        for j in range(grouping):
+                    for j in range(grouping):
+                        for i in range(grouping):
                             spectra_list.append(str(y + i + (x + j) * 512 * 3))
                     detector_list += "," + "+".join(spectra_list)
             _tmp_ws = GroupDetectors(InputWorkspace=_tmp_ws, GroupingPattern=detector_list, EnableLogging=False)

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -412,12 +412,12 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
         if grouping > 1:
             detector_list = ""
-            for y in range(0, 512 * 3, grouping):
-                for x in range(0, 512, grouping):
+            for x in range(0, 512 * 3, grouping):
+                for y in range(0, 512, grouping):
                     spectra_list = []
                     for j in range(grouping):
                         for i in range(grouping):
-                            spectra_list.append(str(y + i + (x + j) * 512 * 3))
+                            spectra_list.append(str(y + i + (x + j) * 512))
                     detector_list += "," + "+".join(spectra_list)
             _tmp_ws = GroupDetectors(InputWorkspace=_tmp_ws, GroupingPattern=detector_list, EnableLogging=False)
 

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -412,13 +412,14 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
 
         if grouping > 1:
             detector_list = ""
-            for x in range(0, 512 * 3, grouping):
-                for y in range(0, 512, grouping):
-                    spectra_list = []
-                    for j in range(grouping):
-                        for i in range(grouping):
-                            spectra_list.append(str(y + i + (x + j) * 512))
-                    detector_list += "," + "+".join(spectra_list)
+            for b in range(3):
+                for x in range(0, 512, grouping):
+                    for y in range(0, 512, grouping):
+                        spectra_list = []
+                        for j in range(grouping):
+                            for i in range(grouping):
+                                spectra_list.append(str(b + (y + i + (x + j) * 512) * 3))
+                        detector_list += "," + "+".join(spectra_list)
             _tmp_ws = GroupDetectors(InputWorkspace=_tmp_ws, GroupingPattern=detector_list, EnableLogging=False)
 
         _tmp_ws = Rebin(InputWorkspace=_tmp_ws, Params="0,1,2", EnableLogging=False)

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -46,6 +46,7 @@ from mantid.simpleapi import (
     CreateSimulationWorkspace,
     MoveInstrumentComponent,
     AddSampleLog,
+    CopySample,
     Rebin,
 )
 import os
@@ -428,6 +429,8 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
         run = mtd["__scan_grouped"].getExperimentInfo(0).run()
         for log in logs:
             run[log.name] = log
+
+        CopySample(scan, "__scan_grouped", CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False)
 
         twotheta = mtd["_PreprocessedDetectorsWS"].column(2)
         azimuthal = mtd["_PreprocessedDetectorsWS"].column(3)

--- a/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AAdjustSampleNorm.py
@@ -40,6 +40,7 @@ from mantid.simpleapi import (
     GroupWorkspaces,
     RenameWorkspace,
     ConvertToMD,
+    GroupDetectors,
     LoadInstrument,
     CreateMDHistoWorkspace,
     CreateSimulationWorkspace,
@@ -336,10 +337,10 @@ class HB3AAdjustSampleNorm(PythonAlgorithm):
                     BinningDim2=bin2,
                     OutputWorkspace=out_ws_name,
                 )
+                DeleteWorkspace(scan)
             else:
                 norm_data = self.__normalization(scan, vanws, load_files)
                 RenameWorkspace(norm_data, OutputWorkspace=out_ws_name)
-            DeleteWorkspace(scan)
 
         if has_multiple:
             out_ws_name = out_ws

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
@@ -111,6 +111,19 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
         self.assertAlmostEqual(data3.getSignalArray().max(), 16 / 25 * 420 / 621)
         self.assertAlmostEqual(data3.getErrorSquaredArray().max(), (16 / 25) ** 2 * (1 / 16 + 1 / 25) * (420 / 621) ** 2)
 
+    def testDetectorGrouping(self):
+        data = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", Grouping="None")
+        data_2x2 = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", Grouping="2x2")
+        data_4x4 = HB3AAdjustSampleNorm("HB3A_data.nxs", OutputType="Detector", NormaliseBy="None", Grouping="4x4")
+
+        ref_sum = data.getSignalArray().sum()
+        self.assertAlmostEqual(ref_sum, data_2x2.getSignalArray().sum())
+        self.assertAlmostEqual(ref_sum, data_4x4.getSignalArray().sum())
+
+        ref_shape = data.getSignalArray().shape
+        self.assertEqual(ref_shape, tuple([2 * val if i < 2 else val for i, val in enumerate(data_2x2.getSignalArray().shape)]))
+        self.assertEqual(ref_shape, tuple([4 * val if i < 2 else val for i, val in enumerate(data_4x4.getSignalArray().shape)]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/algorithms/HB3AAdjustSampleNorm-v1.rst
+++ b/docs/source/algorithms/HB3AAdjustSampleNorm-v1.rst
@@ -40,6 +40,12 @@ intensities found with :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>`
 to be directly compared between scans measured with different step
 sizes.
 
+Grouping
+--------
+
+A grouping option is available group pixels by either 2x2 or 4x4 which reduces memory
+usage and improves the performance of subsequent reduction steps. The default is the original detetor pixelation.
+
 See :ref:`HB3AIntegratePeaks <algm-HB3AIntegratePeaks>` for complete examples of the HB3A workflow.
 
 .. categories::

--- a/docs/source/release/v6.10.0/Diffraction/Single_Crystal/New_features/37233.rst
+++ b/docs/source/release/v6.10.0/Diffraction/Single_Crystal/New_features/37233.rst
@@ -1,0 +1,1 @@
+- New grouping options using ``HB3AAdjustSampleNorm`` for DEMAND data.


### PR DESCRIPTION
### Description of work

DEMAND currently does not have a grouping option like WAND^2 that helps reduce memory usage and improves performance. 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

The algorithm `HB3AAdjustSampleNorm` has been modified to accept grouping options similar to `LoadWANDSCD`.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Two axis and four-circle scans can consume a lot of computing time and resources.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Run this script:

```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

### experiment data info ###
IPTS = 9884
exp = 817
scan = 1
### -------------------- ###

### sample info ###
a = 6.02
b = 10.35
c = 4.70
alpha = 90
beta = 90
gamma = 90
centering = 'P'
### ----------- ###

### incident wavelength ###
wavelength = 1.003
### ------------------- ###

wavelength_band = [0.98*wavelength, 1.02*wavelength]

filename = '/HFIR/HB3A/IPTS-{}/shared/autoreduce/HB3A_exp{:04}_scan{:04}.nxs'.format(IPTS, exp, scan)

HB3AAdjustSampleNorm(Filename=filename,
                     OutputType='Detector',
                     NormaliseBy='None',
                     Grouping='4x4',
                     OutputWorkspace='data')

two_theta = mtd['data'].getExperimentInfo(0).run().getProperty('TwoTheta').value
Q_max = 4*np.pi/wavelength*np.sin(0.5*max(two_theta))

ConvertHFIRSCDtoMDE(InputWorkspace='data',
                    Wavelength=wavelength,
                    LorentzCorrection=True,
                    MinValues=[-Q_max,-Q_max,-Q_max],
                    MaxValues=[+Q_max,+Q_max,+Q_max],
                    OutputWorkspace='md')
```


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
