### PR TITLE
Reset loader name and version at end of algorithm

### DIFF
--- a/Framework/DataHandling/src/Load.cpp
+++ b/Framework/DataHandling/src/Load.cpp
@@ -340,6 +340,9 @@ void Load::exec() {
 
   // Set the remaining properties of the loader
   setOutputProperties(m_loader);
+  // Set the loader and version from correct loader
+  setPropertyValue("LoaderName", m_loader->name());
+  setProperty("LoaderVersion", m_loader->version());
 }
 
 void Load::loadSingleFile() {

--- a/Framework/DataHandling/src/Load.cpp
+++ b/Framework/DataHandling/src/Load.cpp
@@ -340,9 +340,17 @@ void Load::exec() {
 
   // Set the remaining properties of the loader
   setOutputProperties(m_loader);
-  // Set the loader and version from correct loader
-  setPropertyValue("LoaderName", m_loader->name());
-  setProperty("LoaderVersion", m_loader->version());
+
+  /**
+   * Set the loader and version from correct loader IF one has been found,
+   * so that caller can reuse these variables for later calls.
+   * Though these are set in call to getFileLoader, they can be errantly
+   * changed by the init process .
+   */
+  if (m_loader) {
+    setPropertyValue("LoaderName", m_loader->name());
+    setProperty("LoaderVersion", m_loader->version());
+  }
 }
 
 void Load::loadSingleFile() {

--- a/Framework/DataHandling/test/LoadTest.h
+++ b/Framework/DataHandling/test/LoadTest.h
@@ -318,8 +318,8 @@ public:
     // verify that at the end, it is correctly set back according to the output
     loader.initialize();
     TS_ASSERT_THROWS_NOTHING(loader.setPropertyValue("Filename", "CNCS_7860_event.nxs"));
-    std::string correctLoader = loader.getPropertyValue("LoaderName");
-    std::string incorrectLoader = "NotALoader";
+    std::string const correctLoader = loader.getPropertyValue("LoaderName");
+    std::string const incorrectLoader = "NotALoader";
     TS_ASSERT_DIFFERS(correctLoader, incorrectLoader);
     TS_ASSERT_THROWS_NOTHING(loader.setPropertyValue("LoaderName", incorrectLoader));
     TS_ASSERT_THROWS_NOTHING(loader.execute());

--- a/Framework/DataHandling/test/LoadTest.h
+++ b/Framework/DataHandling/test/LoadTest.h
@@ -256,7 +256,7 @@ public:
     loader.initialize();
     loader.setPropertyValue("Filename", "084446+084447.nxs");
 
-    std::string outputWS = "LoadTest_out";
+    std::string outputWS = AnalysisDataService::Instance().uniqueName();
     loader.setPropertyValue("OutputWorkspace", outputWS);
     TS_ASSERT_THROWS_NOTHING(loader.execute());
 
@@ -279,7 +279,7 @@ public:
     loader.initialize();
     loader.setPropertyValue("Filename", "084446-084447");
 
-    std::string outputWS = "LoadTest_out";
+    std::string outputWS = AnalysisDataService::Instance().uniqueName();
     loader.setPropertyValue("OutputWorkspace", outputWS);
     TS_ASSERT_THROWS_NOTHING(loader.execute());
 
@@ -313,18 +313,30 @@ public:
   }
 
   void test_must_set_loadername() {
+    std::string const outputWS = AnalysisDataService::Instance().uniqueName();
+    std::string const incorrectLoader = "NotALoader";
+    int const incorrectVersion = -2;
+
     Load loader;
     // run Load with the LoaderName set to something
     // verify that at the end, it is correctly set back according to the output
     loader.initialize();
+    TS_ASSERT_THROWS_NOTHING(loader.setProperty("OutputWorkspace", outputWS))
     TS_ASSERT_THROWS_NOTHING(loader.setPropertyValue("Filename", "CNCS_7860_event.nxs"));
+    // the loader namer will be set: grab it an ensure it is not the bad cvalue
     std::string const correctLoader = loader.getPropertyValue("LoaderName");
-    std::string const incorrectLoader = "NotALoader";
+    int const correctVersion = loader.getProperty("LoaderVersion");
     TS_ASSERT_DIFFERS(correctLoader, incorrectLoader);
+    TS_ASSERT_DIFFERS(correctVersion, incorrectVersion);
+    // now SET the loader to a bad value, and execute
     TS_ASSERT_THROWS_NOTHING(loader.setPropertyValue("LoaderName", incorrectLoader));
+    TS_ASSERT_THROWS_NOTHING(loader.setProperty("LoaderVersion", incorrectVersion));
+    TS_ASSERT_EQUALS(loader.getPropertyValue("LoaderName"), incorrectLoader);
+    TS_ASSERT_EQUALS(loader.getProperty("LoaderVersion"), incorrectVersion);
     TS_ASSERT_THROWS_NOTHING(loader.execute());
     // make sure the loader name has been correctly set
     TS_ASSERT_EQUALS(loader.getPropertyValue("LoaderName"), correctLoader);
+    TS_ASSERT_EQUALS(loader.getProperty("LoaderVersion"), correctVersion);
   }
 };
 

--- a/Framework/DataHandling/test/LoadTest.h
+++ b/Framework/DataHandling/test/LoadTest.h
@@ -332,11 +332,11 @@ public:
     TS_ASSERT_THROWS_NOTHING(loader.setPropertyValue("LoaderName", incorrectLoader));
     TS_ASSERT_THROWS_NOTHING(loader.setProperty("LoaderVersion", incorrectVersion));
     TS_ASSERT_EQUALS(loader.getPropertyValue("LoaderName"), incorrectLoader);
-    TS_ASSERT_EQUALS(loader.getProperty("LoaderVersion"), incorrectVersion);
+    TS_ASSERT_EQUALS((int)loader.getProperty("LoaderVersion"), incorrectVersion);
     TS_ASSERT_THROWS_NOTHING(loader.execute());
     // make sure the loader name has been correctly set
     TS_ASSERT_EQUALS(loader.getPropertyValue("LoaderName"), correctLoader);
-    TS_ASSERT_EQUALS(loader.getProperty("LoaderVersion"), correctVersion);
+    TS_ASSERT_EQUALS((int)loader.getProperty("LoaderVersion"), correctVersion);
   }
 };
 

--- a/Framework/DataHandling/test/LoadTest.h
+++ b/Framework/DataHandling/test/LoadTest.h
@@ -311,6 +311,21 @@ public:
     loader.setPropertyValue("Filename", "argus0026287.nxs");
     TS_ASSERT_EQUALS(loader.getPropertyValue("LoaderName"), "LoadMuonNexus");
   }
+
+  void test_must_set_loadername() {
+    Load loader;
+    // run Load with the LoaderName set to something
+    // verify that at the end, it is correctly set back according to the output
+    loader.initialize();
+    TS_ASSERT_THROWS_NOTHING(loader.setPropertyValue("Filename", "CNCS_7860_event.nxs"));
+    std::string correctLoader = loader.getPropertyValue("LoaderName");
+    std::string incorrectLoader = "NotALoader";
+    TS_ASSERT_DIFFERS(correctLoader, incorrectLoader);
+    TS_ASSERT_THROWS_NOTHING(loader.setPropertyValue("LoaderName", incorrectLoader));
+    TS_ASSERT_THROWS_NOTHING(loader.execute());
+    // make sure the loader name has been correctly set
+    TS_ASSERT_EQUALS(loader.getPropertyValue("LoaderName"), correctLoader);
+  }
 };
 
 //-------------------------------------------------------------------------------------------------

--- a/Framework/DataHandling/test/LoadTest.h
+++ b/Framework/DataHandling/test/LoadTest.h
@@ -256,7 +256,7 @@ public:
     loader.initialize();
     loader.setPropertyValue("Filename", "084446+084447.nxs");
 
-    std::string outputWS = AnalysisDataService::Instance().uniqueName();
+    std::string outputWS = AnalysisDataService::Instance().uniqueName(5, "LoadTest_");
     loader.setPropertyValue("OutputWorkspace", outputWS);
     TS_ASSERT_THROWS_NOTHING(loader.execute());
 
@@ -279,7 +279,7 @@ public:
     loader.initialize();
     loader.setPropertyValue("Filename", "084446-084447");
 
-    std::string outputWS = AnalysisDataService::Instance().uniqueName();
+    std::string outputWS = AnalysisDataService::Instance().uniqueName(5, "LoadTest_");
     loader.setPropertyValue("OutputWorkspace", outputWS);
     TS_ASSERT_THROWS_NOTHING(loader.execute());
 
@@ -313,7 +313,7 @@ public:
   }
 
   void test_must_set_loadername() {
-    std::string const outputWS = AnalysisDataService::Instance().uniqueName();
+    std::string const outputWS = AnalysisDataService::Instance().uniqueName(5, "LoadTest_");
     std::string const incorrectLoader = "NotALoader";
     int const incorrectVersion = -2;
 

--- a/docs/source/release/v6.10.0/Framework/Data_Handling/Bugfixes/37236.rst
+++ b/docs/source/release/v6.10.0/Framework/Data_Handling/Bugfixes/37236.rst
@@ -1,0 +1,1 @@
+- The properties ``LoaderName`` and ``LoaderVersion`` of :ref:`Load <algm-Load>` are now guaranteed to be set by end of algorithm.


### PR DESCRIPTION
### Description of work

#### Summary of work

The `Load` algorithm searches for the best loading algorithm to use to load a file, then returns the loaded workspace, the name of the loader used, and the version of the loader used.

A minor issue allowed a user to overwrite the name and version of the loader, resulting in invalid returns on those outputs.

This makes sure the loader name and version are correctly set at the end of the algorithm.

Fixes #37236 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->

#### Further detail of work
The `Load` algorithm terminates with a call to set the child loader, then sets the output workspace property.

At this point, the other two output properties can be set.

### To test:

I added a unit test which will make sure the loader and version are always set by the end of a program.

Run this script from within workbench.

``` python
from mantid.simpleapi import (
    AlgorithmManager,
    CreateSampleWorkspace,
    SaveNexus,
    Load,
    mtd,
)

inputWS = mtd.unique_name(prefix="loadTest_")
outputWS = mtd.unique_name(prefix="loadTest_")
filename = os.path.expanduser("~/test_file.nxs")

# create an easily readable event file
CreateSampleWorkspace(
    OutputWorkspace=inputWS,
    Random=True,
)
SaveNexus(
    Filename=filename,
    InputWorkspace=inputWS,
)

load = AlgorithmManager.create("Load")
load.setProperty("Filename", filename)
load.setProperty("OutputWorkspace", outputWS)
load.setProperty("LoaderName", "")
load.execute()

assert mtd[inputWS].getNumberHistograms() == mtd[outputWS].getNumberHistograms()
for i in range(mtd[inputWS].getNumberHistograms()):
    assert list(mtd[inputWS].readX(i)) == list(mtd[outputWS].readX(i))
    assert list(mtd[inputWS].readY(i)) == list(mtd[outputWS].readY(i))
print(load.getPropertyValue("LoaderName"))
assert load.getPropertyValue("LoaderName") == "LoadNexusProcessed"
```

If run out of an older version of mantid, this will pass.  If run out of a build from `main`, the very last line will fail.

Pull this branch and build, then launch workbench.  The script should run with no issues.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
