### PR TITLE
Add information about run numbers for multiple file reduction in Indirect Energy Transfer algorithm

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReductionTest.py
@@ -92,14 +92,14 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), "Result workspace should be a workspace group.")
         self.assertEqual(len(wks), 1)
-        self.assertEqual(wks.getNames()[0], "iris26173_multi_diffspec_red")
+        self.assertEqual(wks.getNames()[0], "iris26173-26176_multi_diffspec_red")
 
         red_ws = wks[0]
         self.assertEqual(red_ws.getAxis(0).getUnit().unitID(), "dSpacing")
         self.assertEqual(red_ws.getNumberHistograms(), 1)
 
-        self.assertTrue("multi_run_numbers" in red_ws.getRun())
-        self.assertEqual(red_ws.getRun().get("multi_run_numbers").value, "26173,26174,26175,26176")
+        self.assertTrue("multi_run_reduction" in red_ws.getRun())
+        self.assertEqual(red_ws.getRun().get("run_number").value, "26173,26174,26175,26176")
 
     def test_reduction_with_container_completes(self):
         """

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferTest.py
@@ -287,11 +287,11 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), "Result workspace should be a workspace group.")
         self.assertEqual(len(wks), 1)
-        self.assertEqual(wks.getNames()[0], "iris26176_multi_graphite002_red")
+        self.assertEqual(wks.getNames()[0], "iris26173-26176_multi_graphite002_red")
 
         red_ws = wks[0]
-        self.assertTrue("multi_run_numbers" in red_ws.getRun())
-        self.assertEqual(red_ws.getRun().get("multi_run_numbers").value, "26176,26173")
+        self.assertTrue("multi_run_reduction" in red_ws.getRun())
+        self.assertEqual(red_ws.getRun().get("run_number").value, "26176,26173")
 
     def test_instrument_validation_failure(self):
         """

--- a/docs/source/release/v6.10.0/Indirect/New_features/36850.rst
+++ b/docs/source/release/v6.10.0/Indirect/New_features/36850.rst
@@ -1,0 +1,2 @@
+- Added sample logs for multiple run reductions in :ref:`ISISIndirectEnergyTransfer <algm-ISISIndirectEnergyTransfer>`. `run_number` log stores the run numbers used in the reduction, separated by commas. `multi_run_reduction` log informs about the reduction done on chopped runs or regular runs.
+- Added string with first and last run numbers in the reduced output workspace used with multiple runs in :ref:`ISISIndirectEnergyTransfer <algm-ISISIndirectEnergyTransfer>`.

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -82,11 +82,13 @@ def load_file_ranges(file_ranges, ipf_filename, spec_min, spec_max, sum_files=Tr
 
     @return List of loaded workspace names and flag indicating chopped data
     """
+
     instrument = os.path.splitext(os.path.basename(ipf_filename))[0]
     instrument = instrument.split("_")[0]
     parse_file_range = create_file_range_parser(instrument)
     file_ranges = [file_range for range_str in file_ranges for file_range in range_str.split(",")]
     file_groups = [file_group for file_range in file_ranges for file_group in parse_file_range(file_range)]
+    file_groups = flatten_groups(file_groups)
 
     workspace_names = []
     chopped_data = False
@@ -96,6 +98,23 @@ def load_file_ranges(file_ranges, ipf_filename, spec_min, spec_max, sum_files=Tr
         workspace_names.extend(created_workspaces)
 
     return workspace_names, chopped_data
+
+
+def flatten_groups(file_groups):
+    """
+    If the list of groups to reduce is a list of list with one element per list, it can miss the sum file algorithm unless the list
+    is flattened to a single group
+
+    @param file_groups list of groups to reduce separately
+
+    @return Individual list with one group or list of lists if the groups have more than one member
+    """
+    sum_individual_workspaces = sum([len(group) for group in file_groups])
+    if len(file_groups) != sum_individual_workspaces:
+        return file_groups
+
+    file_groups = [ws[0] for ws in file_groups]
+    return [file_groups]
 
 
 def load_files(data_files, ipf_filename, spec_min, spec_max, sum_files=False, load_logs=True, load_opts=None, find_masked_detectors=False):


### PR DESCRIPTION
### Description of work
This PR adds information about the run numbers used in the reduction of multiple files when passing the Indirect Energy Transfer algorithm either from the Indirect Data Reduction interface or from a direct call to the ISISIndirectEnergyTransfer algorithm. This feature was requested by scientists.
Additionally, the output workspace name was not giving useful information about multiple run numbers. In this PR, the output workspace name contains a string just after the instrument name with the first and last runs used in the reduction separated by a dash.





Fixes #36850. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work

In #36850, it is explained that in most cases there is a log called 'multi_run_numbers' which stores the run numbers used in the reduction, but not when performing reduction with 'TOSCA' data. Also, in some cases, reduction is performed by combining chopped workspaces instead of separated runs. To add more context valid information, I have added the information about multiple runs in two sample logs:
- `run_number` log stores all the runs used in the multiple file reduction separated by commas. 
- `multi_run_reduction` log informs whether the reduction was done with chopped runs or regular runs. 

### To test:
- Set access to Search Data Archive from Mantid `Manage User Directories` setting. 
- Open `Indirect` -> `Data Reduction` interface. 
- Select `IRIS` instrument and on run numbers type `26184,26185,26186`
- Run the algorithm. Check ADS
- Output workspace name starts with `irs26184-26186`.
- Open `show sample logs` in the output workspace. 
- `run_number` sample log shows: `26184,26185,26186`.
- `multi_run_reduction` sample log shows: `regular_runs`
---------------
- Back to the `Data Reduction` interface. 
- Select `OSIRIS` as the instrument now and on run numbers type `97944-97945`.
- Run the algorithm. Check ADS
- Output workspace name starts with `osiris97944-97945`.
-  Open `show sample logs` in the output workspace. 
- `run_number` sample log shows: `97944,97945`.
- `multi_run_reduction` sample log shows: `regular_runs`
---------------
- Back to the `Data Reduction` interface. 
- Select `TOSCA` as the instrument now and on run numbers type `22797-22798`.
- Run the algorithm. Check ADS
- Output workspace name starts with `tosca22797-22798`.
-  Open `show sample logs` in the output workspace. 
- `run_number` sample log shows: `22797,22798`.
- `multi_run_reduction` sample log shows: `chopped_runs`
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

**Added release notes**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
