### PR TITLE
Remove build warnings in tablet widget validator class

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/TableWidgetValidators.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/TableWidgetValidators.h
@@ -39,7 +39,7 @@ public:
   void setEditorData(QWidget *editor, const QModelIndex &index) const override;
 
 private:
-  double m_precision;
+  int m_precision;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/src/TableWidgetValidators.cpp
+++ b/qt/widgets/common/src/TableWidgetValidators.cpp
@@ -52,7 +52,7 @@ std::string getRegexValidatorString(const RegexValidatorStrings &validatorMask) 
 QString makeQStringNumber(double value, int precision) { return QString::number(value, 'f', precision); }
 
 RegexInputDelegate::RegexInputDelegate(QWidget *parent, const std::string &validator)
-    : QStyledItemDelegate(parent), m_validator(QRegExp(QString::fromStdString(validator))){};
+    : QStyledItemDelegate(parent), m_validator(QRegExp(QString::fromStdString(validator))) {}
 
 QWidget *RegexInputDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem & /*option*/,
                                           const QModelIndex & /*index*/) const {
@@ -63,7 +63,7 @@ QWidget *RegexInputDelegate::createEditor(QWidget *parent, const QStyleOptionVie
 }
 
 NumericInputDelegate::NumericInputDelegate(QWidget *parent, double precision)
-    : QStyledItemDelegate(parent), m_precision(precision){};
+    : QStyledItemDelegate(parent), m_precision(precision) {}
 
 QWidget *NumericInputDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem &, const QModelIndex &) const {
 


### PR DESCRIPTION
### Description of work
Some build warnings were found on jenkins when building the table widget validator class. This PR fixes the warnings.

```
15:25:13 /jenkins_workdir/workspace/STAGING_pull_requests-doc-tests/qt/widgets/common/src/TableWidgetValidators.cpp:55:93: warning: extra ';' [-Wpedantic]
15:25:13    55 |     : QStyledItemDelegate(parent), m_validator(QRegExp(QString::fromStdString(validator))){};
15:25:13       |                                                                                             ^
15:25:13 /jenkins_workdir/workspace/STAGING_pull_requests-doc-tests/qt/widgets/common/src/TableWidgetValidators.cpp:66:60: warning: extra ';' [-Wpedantic]
15:25:13    66 |     : QStyledItemDelegate(parent), m_precision(precision){};
15:25:13       |                                                            ^
15:25:13 /jenkins_workdir/workspace/STAGING_pull_requests-doc-tests/qt/widgets/common/src/TableWidgetValidators.cpp: In member function 'virtual QWidget* MantidQt::MantidWidgets::NumericInputDelegate::createEditor(QWidget*, const QStyleOptionViewItem&, const QModelIndex&) const':
15:25:13 /jenkins_workdir/workspace/STAGING_pull_requests-doc-tests/qt/widgets/common/src/TableWidgetValidators.cpp:73:26: warning: conversion from 'double' to 'int' may change value [-Wfloat-conversion]
15:25:13    73 |   validator->setDecimals(m_precision);
15:25:13       |                          ^~~~~~~~~~~
15:25:13 /jenkins_workdir/workspace/STAGING_pull_requests-doc-tests/qt/widgets/common/src/TableWidgetValidators.cpp: In member function 'virtual void MantidQt::MantidWidgets::NumericInputDelegate::setEditorData(QWidget*, const QModelIndex&) const':
15:25:13 /jenkins_workdir/workspace/STAGING_pull_requests-doc-tests/qt/widgets/common/src/TableWidgetValidators.cpp:81:70: warning: conversion from 'double' to 'int' may change value [-Wfloat-conversion]
15:25:13    81 |   static_cast<QLineEdit *>(editor)->setText(makeQStringNumber(value, m_precision));
15:25:13       |
```


#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->


*There is no associated issue.*


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Code review
- Build shows no warnings. 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
