### PR TITLE
Specify input workspace flipper configuration order

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrectionWildes.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrectionWildes.h
@@ -60,13 +60,10 @@ private:
   WorkspaceMap threeInputCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   WorkspaceMap fullCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   API::WorkspaceGroup_sptr groupOutput(const WorkspaceMap &outputs);
-  WorkspaceMap mapInputsToDirections(const std::string &flippers);
+  WorkspaceMap mapInputsToDirections(const std::vector<std::string> &flippers);
   void threeInputsSolve01(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   void threeInputsSolve10(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   void twoInputsSolve01And10(WorkspaceMap &fullInputs, const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
-  API::MatrixWorkspace_sptr workspaceForGivenFlipper(const std::vector<std::string> &flipperOptions,
-                                                     const std::string &flipperInput,
-                                                     const std::vector<std::string> &wsNameList);
 };
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrectionWildes.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrectionWildes.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidAlgorithms/DllConfig.h"
 
@@ -59,10 +60,13 @@ private:
   WorkspaceMap threeInputCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   WorkspaceMap fullCorrections(const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   API::WorkspaceGroup_sptr groupOutput(const WorkspaceMap &outputs);
-  WorkspaceMap mapInputsToDirections(const std::vector<std::string> &flippers);
+  WorkspaceMap mapInputsToDirections(const std::string &flippers);
   void threeInputsSolve01(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   void threeInputsSolve10(WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
   void twoInputsSolve01And10(WorkspaceMap &fullInputs, const WorkspaceMap &inputs, const EfficiencyMap &efficiencies);
+  API::MatrixWorkspace_sptr workspaceForGivenFlipper(const std::vector<std::string> &flipperOptions,
+                                                     const std::string &flipperInput,
+                                                     const std::vector<std::string> &wsNameList);
 };
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
@@ -19,6 +19,5 @@ MANTID_ALGORITHMS_DLL API::MatrixWorkspace_sptr workspaceForSpinState(API::Works
 MANTID_ALGORITHMS_DLL size_t indexOfWorkspaceForSpinState(const std::string &spinStateOrder,
                                                           const std::string &targetSpinState);
 MANTID_ALGORITHMS_DLL std::vector<std::string> splitSpinStateString(const std::string &spinStates);
-MANTID_ALGORITHMS_DLL bool hasSingleSpinStates(const std::string &spinStates);
 } // namespace PolarizationCorrectionsHelpers
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
@@ -19,5 +19,6 @@ MANTID_ALGORITHMS_DLL API::MatrixWorkspace_sptr workspaceForSpinState(API::Works
 MANTID_ALGORITHMS_DLL size_t indexOfWorkspaceForSpinState(const std::string &spinStateOrder,
                                                           const std::string &targetSpinState);
 MANTID_ALGORITHMS_DLL std::vector<std::string> splitSpinStateString(const std::string &spinStates);
+MANTID_ALGORITHMS_DLL bool hasSingleSpinStates(const std::string &spinStates);
 } // namespace PolarizationCorrectionsHelpers
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/SpinStateValidator.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/SpinStateValidator.h
@@ -24,7 +24,7 @@ particular ordering.
 */
 class MANTID_ALGORITHMS_DLL SpinStateValidator : public Kernel::TypedValidator<std::string> {
 public:
-  SpinStateValidator(std::unordered_set<int> allowedNumbersOfSpins, bool acceptSingleStates = false);
+  SpinStateValidator(std::unordered_set<int> allowedNumbersOfSpins, const bool acceptSingleStates = false);
   Kernel::IValidator_sptr clone() const override;
 
   static const std::string ZERO_ONE;

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/SpinStateValidator.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/SpinStateValidator.h
@@ -24,16 +24,24 @@ particular ordering.
 */
 class MANTID_ALGORITHMS_DLL SpinStateValidator : public Kernel::TypedValidator<std::string> {
 public:
-  SpinStateValidator(std::unordered_set<int> allowedNumbersOfSpins);
+  SpinStateValidator(std::unordered_set<int> allowedNumbersOfSpins, bool acceptSingleStates = false);
   Kernel::IValidator_sptr clone() const override;
 
   static const std::string ZERO_ONE;
   static const std::string ONE_ZERO;
   static const std::string ZERO_ZERO;
   static const std::string ONE_ONE;
+  static const std::string ZERO;
+  static const std::string ONE;
+
+  static bool anyOfIsInSet(const std::vector<std::string> &anyOf, const std::unordered_set<std::string> &set);
+  static bool setContains(const std::unordered_set<std::string> &set, const std::string &s) {
+    return set.find(s) != set.cend();
+  }
 
 private:
   std::string checkValidity(const std::string &input) const override;
   std::unordered_set<int> m_allowedNumbersOfSpins = {1, 2, 3, 4};
+  bool m_acceptSingleStates = false;
 };
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
@@ -784,8 +784,8 @@ PolarizationCorrectionWildes::workspaceForGivenFlipper(const std::vector<std::st
                                                        const std::string &flipperInput,
                                                        const std::vector<std::string> &wsNameList) {
   for (const auto &f : flipperOptions) {
-    const auto index = PolarizationCorrectionsHelpers::indexOfWorkspaceForSpinState(nullptr, flipperInput, f);
-    if (index >= 0 && index < wsNameList.size()) {
+    const auto index = PolarizationCorrectionsHelpers::indexOfWorkspaceForSpinState(flipperInput, f);
+    if (index < wsNameList.size()) {
       auto ws = (API::AnalysisDataService::Instance().retrieveWS<API::MatrixWorkspace>(wsNameList[index]));
       if (!ws) {
         throw std::runtime_error("One of the input workspaces doesn't seem to be a MatrixWorkspace.");

--- a/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
@@ -348,7 +348,6 @@ void PolarizationCorrectionWildes::init() {
  */
 void PolarizationCorrectionWildes::exec() {
   const std::string flipperProperty = getProperty(Prop::FLIPPERS);
-  const bool analyzer = !PolarizationCorrectionsHelpers::hasSingleSpinStates(flipperProperty);
   const auto flippers = PolarizationCorrectionsHelpers::splitSpinStateString(flipperProperty);
   const auto inputs = mapInputsToDirections(flippers);
   checkConsistentNumberHistograms(inputs);
@@ -360,7 +359,8 @@ void PolarizationCorrectionWildes::exec() {
     outputs = directBeamCorrections(inputs, efficiencies);
     break;
   case 2:
-    if (analyzer) {
+    // Check if the input flipper configuration includes an analyser
+    if (flippers.front().size() > 1) {
       outputs = twoInputCorrections(inputs, efficiencies);
     } else {
       outputs = analyzerlessCorrections(inputs, efficiencies);

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizationCorrectionsHelpers.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizationCorrectionsHelpers.cpp
@@ -53,6 +53,6 @@ True if there is a spin state in the input string specified with one character, 
 */
 bool hasSingleSpinStates(const std::string &spinStates) {
   const auto splitString = splitSpinStateString(spinStates);
-  return std::any_of(splitString.cbegin(), splitString.cend(), [](std::string s) { return s.size() == 1; });
+  return std::any_of(splitString.cbegin(), splitString.cend(), [](const std::string &s) { return s.size() == 1; });
 }
 } // namespace Mantid::Algorithms::PolarizationCorrectionsHelpers

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizationCorrectionsHelpers.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizationCorrectionsHelpers.cpp
@@ -47,12 +47,4 @@ std::vector<std::string> splitSpinStateString(const std::string &spinStates) {
   StringTokenizer tokens{spinStates, ",", StringTokenizer::TOK_TRIM};
   return std::vector<std::string>{tokens.begin(), tokens.end()};
 }
-
-/*
-True if there is a spin state in the input string specified with one character, e.g. 0 (instead of 00 or 10)
-*/
-bool hasSingleSpinStates(const std::string &spinStates) {
-  const auto splitString = splitSpinStateString(spinStates);
-  return std::any_of(splitString.cbegin(), splitString.cend(), [](const std::string &s) { return s.size() == 1; });
-}
 } // namespace Mantid::Algorithms::PolarizationCorrectionsHelpers

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizationCorrectionsHelpers.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizationCorrectionsHelpers.cpp
@@ -6,7 +6,9 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h"
+#include "MantidKernel/StringTokenizer.h"
 
+#include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <vector>
@@ -41,11 +43,16 @@ into a vector of individual spin states. This will also trim any leading/trailin
 whitespace in the individual spin states.
 */
 std::vector<std::string> splitSpinStateString(const std::string &spinStates) {
-  std::vector<std::string> spinStateVector;
-  boost::split(spinStateVector, spinStates, boost::is_any_of(","));
-  for (auto &spinState : spinStateVector) {
-    boost::trim(spinState);
-  }
-  return spinStateVector;
+  using Mantid::Kernel::StringTokenizer;
+  StringTokenizer tokens{spinStates, ",", StringTokenizer::TOK_TRIM};
+  return std::vector<std::string>{tokens.begin(), tokens.end()};
+}
+
+/*
+True if there is a spin state in the input string specified with one character, e.g. 0 (instead of 00 or 10)
+*/
+bool hasSingleSpinStates(const std::string &spinStates) {
+  const auto splitString = splitSpinStateString(spinStates);
+  return std::any_of(splitString.cbegin(), splitString.cend(), [](std::string s) { return s.size() == 1; });
 }
 } // namespace Mantid::Algorithms::PolarizationCorrectionsHelpers

--- a/Framework/Algorithms/src/PolarizationCorrections/SpinStateValidator.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/SpinStateValidator.cpp
@@ -78,6 +78,6 @@ std::string SpinStateValidator::checkValidity(const std::string &input) const {
 
 bool SpinStateValidator::anyOfIsInSet(const std::vector<std::string> &anyOf,
                                       const std::unordered_set<std::string> &set) {
-  return std::any_of(anyOf.cbegin(), anyOf.cend(), [&set](std::string s) { return setContains(set, s); });
+  return std::any_of(anyOf.cbegin(), anyOf.cend(), [&set](const std::string &s) { return setContains(set, s); });
 }
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/PolarizationCorrections/SpinStateValidator.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/SpinStateValidator.cpp
@@ -15,23 +15,28 @@ const std::string SpinStateValidator::ZERO_ONE = "01";
 const std::string SpinStateValidator::ONE_ZERO = "10";
 const std::string SpinStateValidator::ZERO_ZERO = "00";
 const std::string SpinStateValidator::ONE_ONE = "11";
+const std::string SpinStateValidator::ZERO = "0";
+const std::string SpinStateValidator::ONE = "1";
 
 namespace SpinStateStrings {
-static const std::unordered_set<std::string> ALLOWED_SPIN_STATES{
+static const std::unordered_set<std::string> ALLOWED_PAIR_SPIN_STATES{
     SpinStateValidator::ZERO_ZERO, SpinStateValidator::ZERO_ONE, SpinStateValidator::ONE_ZERO,
     SpinStateValidator::ONE_ONE};
+static const std::unordered_set<std::string> ALLOWED_SINGLE_SPIN_STATES{SpinStateValidator::ZERO,
+                                                                        SpinStateValidator::ONE};
 } // namespace SpinStateStrings
 
-SpinStateValidator::SpinStateValidator(std::unordered_set<int> allowedNumbersOfSpins)
-    : TypedValidator<std::string>(), m_allowedNumbersOfSpins(std::move(allowedNumbersOfSpins)) {}
+SpinStateValidator::SpinStateValidator(std::unordered_set<int> allowedNumbersOfSpins, bool acceptSingleStates)
+    : TypedValidator<std::string>(), m_allowedNumbersOfSpins(std::move(allowedNumbersOfSpins)),
+      m_acceptSingleStates(acceptSingleStates) {}
 
 Kernel::IValidator_sptr SpinStateValidator::clone() const {
-  return std::make_shared<SpinStateValidator>(m_allowedNumbersOfSpins);
+  return std::make_shared<SpinStateValidator>(m_allowedNumbersOfSpins, m_acceptSingleStates);
 }
 
 std::string SpinStateValidator::checkValidity(const std::string &input) const {
   if (input.empty())
-    return "Enter a spin state string, it should be a comma-separated list of spin states, e.g. 01, 11";
+    return "Enter a spin state string, it should be a comma-separated list of spin states, e.g. 01, 11, 10, 00";
 
   std::vector<std::string> spinStates = PolarizationCorrectionsHelpers::splitSpinStateString(input);
 
@@ -39,10 +44,26 @@ std::string SpinStateValidator::checkValidity(const std::string &input) const {
   if (m_allowedNumbersOfSpins.find(numberSpinStates) == m_allowedNumbersOfSpins.cend())
     return "The number of spin states specified is not an allowed value";
 
-  if (std::any_of(spinStates.cbegin(), spinStates.cend(), [](std::string s) {
-        return SpinStateStrings::ALLOWED_SPIN_STATES.find(s) == SpinStateStrings::ALLOWED_SPIN_STATES.cend();
+  // First check that the spin states are valid entries
+  if (std::any_of(spinStates.cbegin(), spinStates.cend(), [this](std::string s) {
+        const bool isPair = setContains(SpinStateStrings::ALLOWED_PAIR_SPIN_STATES, s);
+        const bool isSingle = m_acceptSingleStates && setContains(SpinStateStrings::ALLOWED_SINGLE_SPIN_STATES, s);
+        return !isPair && !isSingle;
       })) {
-    return "The spin states must consist of two digits, either a zero or a one.";
+    return m_acceptSingleStates
+               ? "The spin states must either be one or two digits, with each being either a zero or one"
+               : "The spin states must consist of two digits, either a zero or a one.";
+  }
+
+  // Single digits can't mix with pairs
+  if (m_acceptSingleStates) {
+    bool containsAnySingles =
+        SpinStateValidator::anyOfIsInSet(spinStates, SpinStateStrings::ALLOWED_SINGLE_SPIN_STATES);
+
+    bool containsAnyPairs = SpinStateValidator::anyOfIsInSet(spinStates, SpinStateStrings::ALLOWED_PAIR_SPIN_STATES);
+    if (!(containsAnyPairs ^ containsAnySingles)) {
+      return "Single and paired spin states cannot be mixed";
+    }
   }
 
   // Check that each spin state only appears once
@@ -53,5 +74,10 @@ std::string SpinStateValidator::checkValidity(const std::string &input) const {
     return "Each spin state must only appear once";
 
   return "";
+}
+
+bool SpinStateValidator::anyOfIsInSet(const std::vector<std::string> &anyOf,
+                                      const std::unordered_set<std::string> &set) {
+  return std::any_of(anyOf.cbegin(), anyOf.cend(), [&set](std::string s) { return setContains(set, s); });
 }
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/PolarizationCorrections/SpinStateValidator.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/SpinStateValidator.cpp
@@ -26,7 +26,7 @@ static const std::unordered_set<std::string> ALLOWED_SINGLE_SPIN_STATES{SpinStat
                                                                         SpinStateValidator::ONE};
 } // namespace SpinStateStrings
 
-SpinStateValidator::SpinStateValidator(std::unordered_set<int> allowedNumbersOfSpins, bool acceptSingleStates)
+SpinStateValidator::SpinStateValidator(std::unordered_set<int> allowedNumbersOfSpins, const bool acceptSingleStates)
     : TypedValidator<std::string>(), m_allowedNumbersOfSpins(std::move(allowedNumbersOfSpins)),
       m_acceptSingleStates(acceptSingleStates) {}
 

--- a/Framework/Algorithms/test/PolarizationCorrectionWildesTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrectionWildesTest.h
@@ -9,6 +9,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAlgorithms/PolarizationCorrectionWildes.h"
+#include "MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h"
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
@@ -19,6 +20,7 @@
 #include "MantidDataObjects/WorkspaceCreation.h"
 
 #include <Eigen/Dense>
+#include <algorithm>
 
 using Mantid::Algorithms::PolarizationCorrectionWildes;
 
@@ -40,18 +42,31 @@ public:
     TS_ASSERT(alg.isInitialized())
   }
 
-  void test_IdealCaseFullCorrections() {
+  void test_IdealCaseFullCorrections() { runIdealCaseFullCorrections("00,01,10,11", {"++", "+-", "-+", "--"}); }
+
+  void test_IdealCaseFullCorrectionsReorderedInputs() {
+    runIdealCaseFullCorrections("11,00,10,01", {"++", "+-", "-+", "--"});
+  }
+
+  void runIdealCaseFullCorrections(const std::string &flipperConfig, const std::array<std::string, 4> &outputOrder) {
     using namespace Mantid::HistogramData;
 
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     auto effWS = idealEfficiencies(edges);
-    const std::array<std::string, 4> POL_DIRS{{"++", "+-", "-+", "--"}};
-    idealCaseFullCorrectionsTest(edges, effWS, POL_DIRS);
+    idealCaseFullCorrectionsTest(edges, effWS, outputOrder, flipperConfig);
   }
 
-  void test_IdealCaseThreeInputs10Missing() { idealThreeInputsTest("10"); }
+  void test_IdealCaseThreeInputs10Missing() { idealThreeInputsTest("10", "00,01,11", {"++", "+-", "-+", "--"}); }
 
-  void test_IdealCaseThreeInputs01Missing() { idealThreeInputsTest("01"); }
+  void test_IdealCaseThreeInputs10MissingReorderedInput() {
+    idealThreeInputsTest("10", "01,00,11", {"++", "+-", "-+", "--"});
+  }
+
+  void test_IdealCaseThreeInputs01Missing() { idealThreeInputsTest("01", "00,10,11", {"++", "+-", "-+", "--"}); }
+
+  void test_IdealCaseThreeInputs01MissingReorderedInput() {
+    idealThreeInputsTest("01", "11,00,10", {"++", "+-", "-+", "--"});
+  }
 
   void test_IdealCaseTwoInputsWithAnalyzer() {
     using namespace Mantid::API;
@@ -735,7 +750,8 @@ private:
 
   void idealCaseFullCorrectionsTest(const Mantid::HistogramData::BinEdges &edges,
                                     const Mantid::API::MatrixWorkspace_sptr &effWS,
-                                    const std::array<std::string, 4> &outputSpinStates) {
+                                    const std::array<std::string, 4> &outputSpinStates,
+                                    const std::string &flipperConfig = "00,01,10,11") {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
     using namespace Mantid::HistogramData;
@@ -747,15 +763,23 @@ private:
     MatrixWorkspace_sptr ws01 = ws00->clone();
     MatrixWorkspace_sptr ws10 = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    const std::vector<std::string> wsNames{{"ws00", "ws01", "ws10", "ws11"}};
-    const std::array<MatrixWorkspace_sptr, 4> wsList{{ws00, ws01, ws10, ws11}};
+    const std::vector<std::string> originalFlipperConfig{"00", "01", "10", "11"};
+    std::array<MatrixWorkspace_sptr, 4> wsList{{ws00, ws01, ws10, ws11}};
     for (size_t i = 0; i != 4; ++i) {
       for (size_t j = 0; j != nHist; ++j) {
         wsList[i]->mutableY(j) *= static_cast<double>(i + 1);
         wsList[i]->mutableE(j) *= static_cast<double>(i + 1);
       }
-      AnalysisDataService::Instance().addOrReplace(wsNames[i], wsList[i]);
+      AnalysisDataService::Instance().addOrReplace("ws" + originalFlipperConfig[i], wsList[i]);
     }
+    using namespace Mantid::Algorithms::PolarizationCorrectionsHelpers;
+    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, "00")] = ws00;
+    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, "01")] = ws01;
+    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, "10")] = ws10;
+    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, "11")] = ws11;
+    std::vector<std ::string> wsNames{wsList.size()};
+    std::transform(wsList.cbegin(), wsList.cend(), wsNames.begin(),
+                   [](MatrixWorkspace_sptr w) { return w->getName(); });
     PolarizationCorrectionWildes alg;
     alg.setChild(true);
     alg.setRethrows(true);
@@ -763,6 +787,7 @@ private:
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Flippers", flipperConfig))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     TS_ASSERT(alg.isExecuted())
@@ -789,7 +814,8 @@ private:
     }
   }
 
-  void idealThreeInputsTest(const std::string &missingFlipperConf) {
+  void idealThreeInputsTest(const std::string &missingFlipperConf, const std::string &flipperConfig,
+                            const std::vector<std::string> &ouputWsOrder) {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
     using namespace Mantid::HistogramData;
@@ -802,15 +828,23 @@ private:
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr wsXX = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
-    const std::vector<std::string> wsNames{{"ws00", "wsXX", "ws11"}};
-    const std::array<MatrixWorkspace_sptr, 3> wsList{{ws00, wsXX, ws11}};
+    const std::string presentFlipperConf = missingFlipperConf == "01" ? "10" : "01";
+    const std::vector<std::string> originalFlipperConfig{"ws00", "ws" + presentFlipperConf, "ws11"};
+    std::array<MatrixWorkspace_sptr, 3> wsList{{ws00, wsXX, ws11}};
     for (size_t i = 0; i != 3; ++i) {
       for (size_t j = 0; j != nHist; ++j) {
         wsList[i]->mutableY(j) *= static_cast<double>(i + 1);
         wsList[i]->mutableE(j) *= static_cast<double>(i + 1);
       }
-      AnalysisDataService::Instance().addOrReplace(wsNames[i], wsList[i]);
+      AnalysisDataService::Instance().addOrReplace("ws" + originalFlipperConfig[i], wsList[i]);
     }
+    using namespace Mantid::Algorithms::PolarizationCorrectionsHelpers;
+    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, "00")] = ws00;
+    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, presentFlipperConf)] = wsXX;
+    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, "11")] = ws11;
+    std::vector<std ::string> wsNames{wsList.size()};
+    std::transform(wsList.cbegin(), wsList.cend(), wsNames.begin(),
+                   [](MatrixWorkspace_sptr w) { return w->getName(); });
     auto effWS = idealEfficiencies(edges);
     PolarizationCorrectionWildes alg;
     alg.setChild(true);
@@ -820,17 +854,14 @@ private:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", wsNames))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", m_outputWSName))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Efficiencies", effWS))
-    const std::string presentFlipperConf = missingFlipperConf == "01" ? "10" : "01";
-    const std::string flipperConf = "00, " + presentFlipperConf + ", 11";
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", flipperConf))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Flippers", flipperConfig))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     TS_ASSERT(alg.isExecuted())
     WorkspaceGroup_sptr outputWS = alg.getProperty("OutputWorkspace");
     TS_ASSERT(outputWS)
     TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), 4)
-    const std::array<std::string, 4> POL_DIRS{{"++", "+-", "-+", "--"}};
     for (size_t i = 0; i != 4; ++i) {
-      const auto &dir = POL_DIRS[i];
+      const auto &dir = ouputWsOrder[i];
       const std::string wsName = m_outputWSName + std::string("_") + dir;
       MatrixWorkspace_sptr ws = std::dynamic_pointer_cast<MatrixWorkspace>(outputWS->getItem(wsName));
       TS_ASSERT(ws)

--- a/Framework/Algorithms/test/PolarizationCorrectionWildesTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrectionWildesTest.h
@@ -48,14 +48,6 @@ public:
     runIdealCaseFullCorrections("11,00,10,01", {"++", "+-", "-+", "--"});
   }
 
-  void runIdealCaseFullCorrections(const std::string &flipperConfig, const std::array<std::string, 4> &outputOrder) {
-    using namespace Mantid::HistogramData;
-
-    BinEdges edges{0.3, 0.6, 0.9, 1.2};
-    auto effWS = idealEfficiencies(edges);
-    idealCaseFullCorrectionsTest(edges, effWS, outputOrder, flipperConfig);
-  }
-
   void test_IdealCaseThreeInputs10Missing() { idealThreeInputsTest("10", "00,01,11", {"++", "+-", "-+", "--"}); }
 
   void test_IdealCaseThreeInputs10MissingReorderedInput() {
@@ -763,6 +755,14 @@ private:
     MatrixWorkspace_sptr ws01 = ws00->clone();
     MatrixWorkspace_sptr ws10 = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
+    /*
+    We're going to set up the test numbers in the workspaces in the order given by
+    the originalFlipperConfig vector. They are named 'ws' followed by the flipper
+    string in the ADS.
+    Following that we reorder these workspaces into the order specified by the input
+    flipperConfig argument to this method. From that we generate vector of the
+    names of the workspaces to pass to the PolarizationCorrectionWildes algorithm.
+    */
     const std::vector<std::string> originalFlipperConfig{"00", "01", "10", "11"};
     std::array<MatrixWorkspace_sptr, 4> wsList{{ws00, ws01, ws10, ws11}};
     for (size_t i = 0; i != 4; ++i) {
@@ -828,6 +828,14 @@ private:
     MatrixWorkspace_sptr ws00 = create<Workspace2D>(nHist, Histogram(edges, counts));
     MatrixWorkspace_sptr wsXX = ws00->clone();
     MatrixWorkspace_sptr ws11 = ws00->clone();
+    /*
+    We're going to set up the test numbers in the workspaces in the order given by
+    the originalFlipperConfig vector. They are named 'ws' followed by the flipper
+    string in the ADS.
+    Following that we reorder these workspaces into the order specified by the input
+    flipperConfig argument to this method. From that we generate vector of the
+    names of the workspaces to pass to the PolarizationCorrectionWildes algorithm.
+    */
     const std::string presentFlipperConf = missingFlipperConf == "01" ? "10" : "01";
     const std::vector<std::string> originalFlipperConfig{"ws00", "ws" + presentFlipperConf, "ws11"};
     std::array<MatrixWorkspace_sptr, 3> wsList{{ws00, wsXX, ws11}};
@@ -1619,6 +1627,14 @@ private:
         }
       }
     }
+  }
+
+  void runIdealCaseFullCorrections(const std::string &flipperConfig, const std::array<std::string, 4> &outputOrder) {
+    using namespace Mantid::HistogramData;
+
+    BinEdges edges{0.3, 0.6, 0.9, 1.2};
+    auto effWS = idealEfficiencies(edges);
+    idealCaseFullCorrectionsTest(edges, effWS, outputOrder, flipperConfig);
   }
 };
 

--- a/Framework/Algorithms/test/PolarizationCorrectionWildesTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrectionWildesTest.h
@@ -773,10 +773,10 @@ private:
       AnalysisDataService::Instance().addOrReplace("ws" + originalFlipperConfig[i], wsList[i]);
     }
     using namespace Mantid::Algorithms::PolarizationCorrectionsHelpers;
-    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, "00")] = ws00;
-    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, "01")] = ws01;
-    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, "10")] = ws10;
-    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, "11")] = ws11;
+    wsList[indexOfWorkspaceForSpinState(flipperConfig, "00")] = ws00;
+    wsList[indexOfWorkspaceForSpinState(flipperConfig, "01")] = ws01;
+    wsList[indexOfWorkspaceForSpinState(flipperConfig, "10")] = ws10;
+    wsList[indexOfWorkspaceForSpinState(flipperConfig, "11")] = ws11;
     std::vector<std ::string> wsNames{wsList.size()};
     std::transform(wsList.cbegin(), wsList.cend(), wsNames.begin(),
                    [](MatrixWorkspace_sptr w) { return w->getName(); });
@@ -839,9 +839,9 @@ private:
       AnalysisDataService::Instance().addOrReplace("ws" + originalFlipperConfig[i], wsList[i]);
     }
     using namespace Mantid::Algorithms::PolarizationCorrectionsHelpers;
-    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, "00")] = ws00;
-    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, presentFlipperConf)] = wsXX;
-    wsList[indexOfWorkspaceForSpinState(nullptr, flipperConfig, "11")] = ws11;
+    wsList[indexOfWorkspaceForSpinState(flipperConfig, "00")] = ws00;
+    wsList[indexOfWorkspaceForSpinState(flipperConfig, presentFlipperConf)] = wsXX;
+    wsList[indexOfWorkspaceForSpinState(flipperConfig, "11")] = ws11;
     std::vector<std ::string> wsNames{wsList.size()};
     std::transform(wsList.cbegin(), wsList.cend(), wsNames.begin(),
                    [](MatrixWorkspace_sptr w) { return w->getName(); });

--- a/Framework/Algorithms/test/PolarizationCorrections/SpinStateValidatorTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/SpinStateValidatorTest.h
@@ -16,9 +16,15 @@ using namespace Mantid::Algorithms;
 
 class SpinStateValidatorTest : public CxxTest::TestSuite {
 public:
-  void testSingleCorrectInputs() {
+  void testSinglePairCorrectInputs() {
     auto validator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{1});
     auto correctInputs = std::vector<std::string>{"01", "00", "10", "11", " 01", " 00 ", "11 "};
+    checkAllInputs(validator, correctInputs, true);
+  }
+
+  void testSingleDigitCorrectInputs() {
+    auto validator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{1}, true);
+    auto correctInputs = std::vector<std::string>{"01", "00", "10", "11", " 01", " 00 ", "11 ", "0", "1"};
     checkAllInputs(validator, correctInputs, true);
   }
 
@@ -28,15 +34,33 @@ public:
     checkAllInputs(validator, incorrectInputs, false);
   }
 
+  void testSinglePairAndDigitIncorrectInputs() {
+    auto validator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{1}, true);
+    auto incorrectInputs = std::vector<std::string>{"0 1", "2", "01,10", "!", "001", "", " ", "01,1", "0,00"};
+    checkAllInputs(validator, incorrectInputs, false);
+  }
+
   void testDuplicateEntry() {
     auto validator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{2, 3});
     auto duplicates = std::vector<std::string>{"01, 01", "11,10,11", "00,00"};
     checkAllInputs(validator, duplicates, false);
   }
 
+  void testDuplicateEntryWithSingleDigit() {
+    auto validator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{2, 3}, true);
+    auto duplicates = std::vector<std::string>{"01, 01", "11,10,11", "00,00", "1,1,0", "0,1,0", "1,1"};
+    checkAllInputs(validator, duplicates, false);
+  }
+
   void testMultipleStatesCorrectInputs() {
     auto validator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{2, 3, 4});
     auto correctInputs = std::vector<std::string>{"01, 11", "00,10,11", "11,10, 00,01", "00, 10 "};
+    checkAllInputs(validator, correctInputs, true);
+  }
+
+  void testTwoSingleDigitCorrectInputs() {
+    auto validator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{2}, true);
+    auto correctInputs = std::vector<std::string>{"0, 1", "1,0"};
     checkAllInputs(validator, correctInputs, true);
   }
 

--- a/docs/source/release/v6.10.0/Framework/Algorithms/New_features/35067.rst
+++ b/docs/source/release/v6.10.0/Framework/Algorithms/New_features/35067.rst
@@ -1,0 +1,1 @@
+- Add ability to specify input workspace order in `PolarizationCorrectionWildes` algorithm.


### PR DESCRIPTION
Fixes #36146.
First part of #35067. When calling `PolarizationCorrectionWildes`, one can now specify any order of the input workspaces, they do not have to be in one of the hard-coded orders in the algorithm.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
The `PolarizationCorrectionWildes` algorithm takes in various numbers of workspaces, depending on the analysis being conducted and whether or not an analyser is present. The flipper configuration is specified by a string, validated using the existing `SpinStateValidator` class. The main change I've made is where the input workspaces are processed and assigned to the four workspaces on the input `WorkspaceMap` object.

I've added the ability to `SpinStateValidator` to take single spin states, e.g. `0,1`, which is what you get if no analyser is present.

To clarify the difference between spin state and flipper configuration, a neutron can either be up or down spin. A flipper will change the spin of the neutron from one spin state to the other. Hence in this case the output workspaces appear with `+,-` in their names, signifying the neutron spin. A `0,1` tells you if the flipper is on or off, so to go from that to a neutron spin you need to know the spin of the incoming neutron beam, in this case assumed up (`+`) I think. I didn't change any of that logic though, so this is just for info.

### To test:
Should be completely backwards compatible so all old tests and scripts should work. I've added some tests that reorder the input workspaces, change the corresponding `Flippers` input string, and check that all the results are still the same.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
