### PR TITLE
Fix a failing doctest - `ornl-next`

### DIFF
--- a/docs/source/algorithms/GenerateGroupingPowder-v1.rst
+++ b/docs/source/algorithms/GenerateGroupingPowder-v1.rst
@@ -72,7 +72,7 @@ Usage
     if(os.path.isfile(mantid.config.getString("defaultsave.directory")+"powder.par")):
         print("Found file powder.par")
     wsg=GroupDetectors(ws,outputFilename)
-    print("The grouped workspace has {} histograms".format(wsg.getNumberHistograms()))
+    print("The grouping workspace has {} histograms".format(wsg.getNumberHistograms()))
 
 .. testcleanup:: GenerateGroupingPowder_default
 
@@ -90,7 +90,7 @@ Output:
 
     Found file powder.xml
     Found file powder.par
-    The grouped workspace has 14 histograms
+    The grouping workspace has 14 histograms
 
 ----
 
@@ -120,7 +120,7 @@ Output:
 
 .. testoutput:: GenerateGroupingPowder_GroupingWorkspace
 
-    The grouped workspace has 51200 histograms
+    The grouping workspace has 51200 histograms
 
 
 

--- a/docs/source/release/v6.10.0/Framework/Algorithms/Bugfixes/37249.rst
+++ b/docs/source/release/v6.10.0/Framework/Algorithms/Bugfixes/37249.rst
@@ -1,0 +1,1 @@
+- Fix doctest strings for :ref:`GenerateGroupingPowder <algm-GenerateGroupingPowder>`


### PR DESCRIPTION
This is a sister of #37215 into `ornl-next`.

It is closely relates to #37224, which merged into main.
