### PR TITLE
Make Muon Analysis fitting code safer

### DIFF
--- a/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/37255.rst
+++ b/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/37255.rst
@@ -1,0 +1,1 @@
+- Fixed an error that would occur during simultaneous fitting on the :ref:`Muon Analysis interface <Muon_Analysis-ref>`.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -49,6 +49,8 @@ DEFAULT_START_X = 0.0
 
 def get_function_name_for_composite(composite: CompositeFunction) -> str:
     """Gets the function name to associate with a composite function when saving fit results."""
+    assert isinstance(composite, CompositeFunction), "Expected to get function name of a CompositeFunction."
+
     function_names = [composite.getFunction(i).name() for i in range(composite.nFunctions())]
 
     if len(function_names) > 3:
@@ -818,10 +820,9 @@ class BasicFittingModel:
         if function.getNumberDomains() > 1:
             function = function.getFunction(0)
 
-        try:
+        if isinstance(function, CompositeFunction):
             return get_function_name_for_composite(function)
-        except AttributeError:
-            return function.name()
+        return function.name()
 
     def _evaluate_plot_guess(self, plot_guess: bool) -> str:
         """Evaluate the plot guess fit function and returns the name of the resulting guess workspace."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -197,10 +197,10 @@ class GeneralFittingModel(BasicFittingModel):
         simultaneous_function = self.fitting_context.simultaneous_fit_function
 
         if len(dataset_names) == len(new_dataset_names) and simultaneous_function is not None:
-            if len(dataset_names) == 1:
-                return [simultaneous_function.clone()]
-            else:
+            if isinstance(simultaneous_function, MultiDomainFunction):
                 return [simultaneous_function.getFunction(i).clone() for i in range(simultaneous_function.nFunctions())]
+            else:
+                return [simultaneous_function.clone()]
         elif len(dataset_names) <= 1:
             return [self._clone_function(simultaneous_function) for _ in range(len(new_dataset_names))]
         else:
@@ -211,7 +211,7 @@ class GeneralFittingModel(BasicFittingModel):
         dataset_names = self.fitting_context.dataset_names
         simultaneous_function = self.fitting_context.simultaneous_fit_function
 
-        if new_dataset_name in dataset_names and simultaneous_function is not None:
+        if new_dataset_name in dataset_names and isinstance(simultaneous_function, MultiDomainFunction):
             return self._clone_function(simultaneous_function.getFunction(dataset_names.index(new_dataset_name)))
         else:
             return self._clone_function(self.current_domain_fit_function())

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid import AlgorithmManager, logger
-from mantid.api import IFunction
+from mantid.api import IFunction, MultiDomainFunction
 from mantid.simpleapi import CopyLogs, ConvertFitFunctionForMuonTFAsymmetry
 
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.workspace_naming import (
@@ -94,7 +94,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         """Updates the TF Asymmetry and normal simultaneous fit function based on the function from a TFA fit."""
         self.fitting_context.tf_asymmetry_simultaneous_function = tf_asymmetry_simultaneous_function
 
-        if self.fitting_context.number_of_datasets > 1:
+        if isinstance(tf_asymmetry_simultaneous_function, MultiDomainFunction):
             self._update_parameters_of_multi_domain_simultaneous_function_from(tf_asymmetry_simultaneous_function)
         else:
             self.fitting_context.simultaneous_fit_function = self._get_normal_fit_function_from(tf_asymmetry_simultaneous_function)
@@ -112,7 +112,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
 
     def get_domain_tf_asymmetry_fit_function(self, tf_simultaneous_function: IFunction, dataset_index: int) -> IFunction:
         """Returns the fit function in the TF Asymmetry simultaneous function corresponding to the specified index."""
-        if self.fitting_context.number_of_datasets < 2 or tf_simultaneous_function is None:
+        if self.fitting_context.number_of_datasets < 2 or not isinstance(tf_simultaneous_function, MultiDomainFunction):
             return tf_simultaneous_function
 
         index = dataset_index if dataset_index is not None else 0

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -94,14 +94,18 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         """Updates the TF Asymmetry and normal simultaneous fit function based on the function from a TFA fit."""
         self.fitting_context.tf_asymmetry_simultaneous_function = tf_asymmetry_simultaneous_function
 
-        if isinstance(tf_asymmetry_simultaneous_function, MultiDomainFunction):
+        if isinstance(self.fitting_context.simultaneous_fit_function, MultiDomainFunction) and isinstance(
+            tf_asymmetry_simultaneous_function, MultiDomainFunction
+        ):
             self._update_parameters_of_multi_domain_simultaneous_function_from(tf_asymmetry_simultaneous_function)
         else:
             self.fitting_context.simultaneous_fit_function = self._get_normal_fit_function_from(tf_asymmetry_simultaneous_function)
 
     def _update_parameters_of_multi_domain_simultaneous_function_from(self, tf_asymmetry_simultaneous_function: IFunction) -> None:
         """Updates the parameters in the normal simultaneous function based on a TF Asymmetry simultaneous function."""
-        for domain_index in range(tf_asymmetry_simultaneous_function.nFunctions()):
+        for domain_index in range(
+            min([tf_asymmetry_simultaneous_function.nFunctions(), self.fitting_context.simultaneous_fit_function.nFunctions()])
+        ):
             tf_asymmetry_domain_function = tf_asymmetry_simultaneous_function.getFunction(domain_index)
             parameter_values, errors = self.get_fit_function_parameter_values(
                 self._get_normal_fit_function_from(tf_asymmetry_domain_function)

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -620,6 +620,18 @@ class GeneralFittingModelTest(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "This method assumes the simultaneous fit function is not None."):
             self.model._add_global_ties_to_simultaneous_function()
 
+    def test_get_new_domain_function_for_does_not_error_if_the_simultaneous_function_is_not_a_composite(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.fit_function
+
+        self.model._get_new_domain_function_for(self.dataset_names[0])
+
+    def test_get_new_domain_functions_using_existing_datasets_does_not_error_if_the_simultaneous_function_is_not_a_composite(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.fit_function
+
+        self.model._get_new_domain_functions_using_existing_datasets(self.dataset_names)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataModel.cpp
@@ -62,7 +62,7 @@ FunctionModelSpectra FitDataModel::getSpectra(WorkspaceID workspaceID) const {
 }
 
 FunctionModelDataset FitDataModel::getDataset(WorkspaceID workspaceID) const {
-  auto const name = getWorkspace(workspaceID)->getName();
+  auto const &name = getWorkspace(workspaceID)->getName();
   return FunctionModelDataset(name, getSpectra(workspaceID));
 }
 

--- a/qt/widgets/common/src/AlgorithmRunner.cpp
+++ b/qt/widgets/common/src/AlgorithmRunner.cpp
@@ -26,13 +26,13 @@ void AlgorithmRunner::execute(std::deque<IConfiguredAlgorithm_sptr> algorithmQue
   m_jobRunner->executeAlgorithmQueue();
 }
 
-void AlgorithmRunner::notifyBatchComplete(bool error) { m_subscriber->notifyBatchComplete(m_lastAlgorithm, error); };
+void AlgorithmRunner::notifyBatchComplete(bool error) { m_subscriber->notifyBatchComplete(m_lastAlgorithm, error); }
 
 void AlgorithmRunner::notifyBatchCancelled() { m_subscriber->notifyBatchCancelled(); }
 
 void AlgorithmRunner::notifyAlgorithmStarted(IConfiguredAlgorithm_sptr &algorithm) {
   m_subscriber->notifyAlgorithmStarted(algorithm);
-};
+}
 
 void AlgorithmRunner::notifyAlgorithmComplete(IConfiguredAlgorithm_sptr &algorithm) {
   m_subscriber->notifyAlgorithmComplete(algorithm);

--- a/qt/widgets/common/src/AlgorithmRunner.cpp
+++ b/qt/widgets/common/src/AlgorithmRunner.cpp
@@ -22,7 +22,7 @@ void AlgorithmRunner::execute(IConfiguredAlgorithm_sptr algorithm) {
 }
 
 void AlgorithmRunner::execute(std::deque<IConfiguredAlgorithm_sptr> algorithmQueue) {
-  m_jobRunner->setAlgorithmQueue(algorithmQueue);
+  m_jobRunner->setAlgorithmQueue(std::move(algorithmQueue));
   m_jobRunner->executeAlgorithmQueue();
 }
 

--- a/qt/widgets/common/src/QtAlgorithmRunner.cpp
+++ b/qt/widgets/common/src/QtAlgorithmRunner.cpp
@@ -75,7 +75,7 @@ void QtAlgorithmRunner::startAlgorithm(Mantid::API::IAlgorithm_sptr alg) {
   alg->addObserver(m_errorObserver);
   alg->addObserver(m_progressObserver);
   // Start asynchronous execution
-  m_asyncAlg = alg;
+  m_asyncAlg = std::move(alg);
   m_asyncResult = new Poco::ActiveResult<bool>(m_asyncAlg->executeAsync());
 }
 

--- a/qt/widgets/common/src/QtJobRunner.cpp
+++ b/qt/widgets/common/src/QtJobRunner.cpp
@@ -26,7 +26,7 @@ void QtJobRunner::subscribe(JobRunnerSubscriber *notifyee) { m_notifyee = notify
 void QtJobRunner::clearAlgorithmQueue() { m_batchAlgoRunner.clearQueue(); }
 
 void QtJobRunner::setAlgorithmQueue(std::deque<IConfiguredAlgorithm_sptr> algorithms) {
-  m_batchAlgoRunner.setQueue(algorithms);
+  m_batchAlgoRunner.setQueue(std::move(algorithms));
 }
 
 void QtJobRunner::executeAlgorithmQueue() { m_batchAlgoRunner.executeBatchAsync(); }


### PR DESCRIPTION
### Description of work
This PR makes some of the Muon Analysis fitting interface code safer by only calling `getFunction` if we know the function provided is at least a CompositeFunction. This is in response to several error reports submitted with errors such as:
```
File "C:\MantidInstall\bin\lib\site-packages\mantidqtinterfaces\Muon\GUI\Common\fitting_widgets\general_fitting\general_fitting_model.py", line 207, in _get_new_domain_functions_using_existing_datasets
    return [self._get_new_domain_function_for(name) for name in new_dataset_names]
  File "C:\MantidInstall\bin\lib\site-packages\mantidqtinterfaces\Muon\GUI\Common\fitting_widgets\general_fitting\general_fitting_model.py", line 207, in <listcomp>
    return [self._get_new_domain_function_for(name) for name in new_dataset_names]
  File "C:\MantidInstall\bin\lib\site-packages\mantidqtinterfaces\Muon\GUI\Common\fitting_widgets\general_fitting\general_fitting_model.py", line 215, in _get_new_domain_function_for
    return self._clone_function(simultaneous_function.getFunction(dataset_names.index(new_dataset_name)))
RuntimeError: Function StandardSC doesn't have children.
```

The PR also fixes a coverity scan warning in the FitDataModel and AlgorithmRunner. It was very small so I decided to sneak it into this PR. Also removes some extra colons spotted by Tom.

*There is no associated issue.*

### To test:

1. Go to Muon->Muon Analysis interface
2. Load EMU 62260
3. Go to the Fitting tab
4. Tick Simultaneous over, and choose `Group/Pair`
5. Add the `StandardSC` function to the function browser
7. Load EMU 62260-1. There should be no issues

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
