### PR TITLE
Muon field orientation make case-insensitive

### DIFF
--- a/Framework/DataHandling/src/LoadMuonNexusV2NexusHelper.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2NexusHelper.cpp
@@ -13,6 +13,7 @@
 #include "MantidDataObjects/Workspace2D.h"
 
 #include <algorithm>
+#include <cctype>
 
 namespace {
 template <typename type> std::string convertVectorToString(const std::vector<type> &vector) {
@@ -120,7 +121,7 @@ std::string LoadMuonNexusV2NexusHelper::loadMainFieldDirectionFromNexus() {
     NXChar orientation = m_entry.openNXChar(NeXusEntry::ORIENTATON);
     // some files have no data there
     orientation.load();
-    if (orientation[0] == 't') {
+    if (std::tolower(orientation[0]) == 't') {
       mainFieldDirection = "Transverse";
     }
   } catch (std::runtime_error &) {


### PR DESCRIPTION
### Description of work
This PR fixes an issue which has appeared since MUSR has changed control system to IBEX. The field orientation might now be stored as an upper-case "T", whereas it was previously only a lower case "t". The solution is that we no longer want to do a case-sensitive check.

Fixes #37256

### To test:
1. Open `Muon`->`Muon Analysis`
2. Select MUSR
3. Load 92729
4. Right click any of the loaded workspaces and `Show sample logs`
5. The `main_field_direction` log should be `Transverse`

*This does not require release notes* because **it is not a problem in the previous Mantid version, rather it is a change to the runs which are now generated for MUSR**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
