### PR TITLE
Add Algorithm For Calculating SANS Flipper Efficiency

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -948,6 +948,7 @@ set(TEST_FILES
     PolarizationCorrections/HeliumAnalyserEfficiencyTest.h
     PolarizationCorrections/PolarizationCorrectionsHelpersTest.h
     PolarizationCorrections/SpinStateValidatorTest.h
+    PolarizationCorrections/FlipperEfficiencyTest.h
     PolarizationCorrectionFredrikzeTest.h
     PolarizationCorrectionWildesTest.h
     PolarizationEfficiencyCorTest.h

--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -244,6 +244,7 @@ set(SRC_FILES
     src/PolarizationCorrectionWildes.cpp
     src/PolarizationEfficiencyCor.cpp
     src/PolarizationCorrections/DepolarizedAnalyserTransmission.cpp
+    src/PolarizationCorrections/FlipperEfficiency.cpp
     src/PolynomialCorrection.cpp
     src/Power.cpp
     src/PowerLawCorrection.cpp
@@ -596,6 +597,7 @@ set(INC_FILES
     inc/MantidAlgorithms/PolarizationCorrections/HeliumAnalyserEfficiency.h
     inc/MantidAlgorithms/PolarizationCorrections/PolarizationCorrectionsHelpers.h
     inc/MantidAlgorithms/PolarizationCorrections/SpinStateValidator.h
+    inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
     inc/MantidAlgorithms/PolarizationCorrectionFredrikze.h
     inc/MantidAlgorithms/PolarizationCorrectionWildes.h
     inc/MantidAlgorithms/PolarizationEfficiencyCor.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
@@ -33,8 +33,11 @@ private:
   /// Execute the algorithm with the provided properties.
   void exec() override;
 
+  /// Check that the inputs to the algorithm are valid.
   std::map<std::string, std::string> validateInputs() override;
 
-  void saveToFile(API::MatrixWorkspace_sptr const &workspace);
+  void saveToFile(API::MatrixWorkspace_sptr const &workspace, std::string const &filePathStr);
+
+  API::MatrixWorkspace_sptr calculateEfficiency(API::WorkspaceGroup_sptr const &groupWs);
 };
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
@@ -33,6 +33,8 @@ private:
   /// Execute the algorithm with the provided properties.
   void exec() override;
 
-  void saveToFile(API::MatrixWorkspace_sptr const &workspace, std::string const &filepath);
+  std::map<std::string, std::string> validateInputs() override;
+
+  void saveToFile(API::MatrixWorkspace_sptr const &workspace);
 };
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAlgorithms/DllConfig.h"
 
 namespace Mantid::Algorithms {
@@ -31,5 +32,7 @@ private:
 
   /// Execute the algorithm with the provided properties.
   void exec() override;
+
+  void saveToFile(API::MatrixWorkspace_sptr const &workspace, std::string const &filepath);
 };
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
@@ -1,0 +1,35 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAlgorithms/DllConfig.h"
+
+namespace Mantid::Algorithms {
+
+class MANTID_ALGORITHMS_DLL FlipperEfficiency : public API::Algorithm {
+public:
+  /// The string identifier for the algorithm. @see Algorithm::name
+  std::string const name() const override { return "FlipperEfficiency"; }
+
+  /// A summary of the algorithm's purpose. @see Algorithm::summary
+  std::string const summary() const override;
+
+  /// The category of the algorithm. @see Algorithm::category
+  std::string const category() const override { return "SANS\\PolarizationCorrections"; }
+
+  /// The version number of the algorithm. @see Algorithm::version
+  int version() const override { return 1; }
+
+private:
+  /// Setup the algorithm's properties and prepare constants.
+  void init() override;
+
+  /// Execute the algorithm with the provided properties.
+  void exec() override;
+};
+} // namespace Mantid::Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h
@@ -36,8 +36,10 @@ private:
   /// Check that the inputs to the algorithm are valid.
   std::map<std::string, std::string> validateInputs() override;
 
+  /// Save the given workspace to a given path as Nexus, applying the relevant extension if necessary.
   void saveToFile(API::MatrixWorkspace_sptr const &workspace, std::string const &filePathStr);
 
+  /// Perform the main calculation for determining the efficiency on the given group.
   API::MatrixWorkspace_sptr calculateEfficiency(API::WorkspaceGroup_sptr const &groupWs);
 };
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -1,0 +1,28 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h"
+
+namespace {
+/// Property Names
+namespace PropNames {} // namespace PropNames
+} // namespace
+
+namespace Mantid::Algorithms {
+
+using namespace API;
+using namespace Kernel;
+
+// Register the algorithm in the AlgorithmFactory
+DECLARE_ALGORITHM(FlipperEfficiency)
+
+std::string const FlipperEfficiency::summary() const {}
+
+void FlipperEfficiency::init() {}
+
+void FlipperEfficiency::exec() {}
+
+} // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -63,12 +63,13 @@ std::map<std::string, std::string> FlipperEfficiency::validateInputs() {
   }
   if (groupWs->size() != 4) {
     problems[PropNames::INPUT_WS] = "The input group must contain a workspace for all four spin states.";
-  }
-  for (size_t i = 0; i < groupWs->size(); ++i) {
-    MatrixWorkspace_sptr const stateWs = std::dynamic_pointer_cast<MatrixWorkspace>(groupWs->getItem(i));
-    Unit_const_sptr unit = stateWs->getAxis(0)->unit();
-    if (unit->unitID() != "Wavelength") {
-      problems[PropNames::INPUT_WS] = "All input workspaces must be in units of Wavelength.";
+  } else {
+    for (size_t i = 0; i < groupWs->size(); ++i) {
+      MatrixWorkspace_sptr const stateWs = std::dynamic_pointer_cast<MatrixWorkspace>(groupWs->getItem(i));
+      Unit_const_sptr unit = stateWs->getAxis(0)->unit();
+      if (unit->unitID() != "Wavelength") {
+        problems[PropNames::INPUT_WS] = "All input workspaces must be in units of Wavelength.";
+      }
     }
   }
 

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -4,17 +4,21 @@
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
-#include "MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h"
+#include <filesystem>
+
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h"
 
 namespace {
 /// Property Names
 namespace PropNames {
-std::string const &INPUT_WS{"InputWorkspace"};
-std::string const &OUTPUT_WS{"OutputWorkspace"};
-std::string const &OUTPUT_FILE{"OutputFilePath"};
+std::string const INPUT_WS{"InputWorkspace"};
+std::string const OUTPUT_WS{"OutputWorkspace"};
+std::string const OUTPUT_FILE{"OutputFilePath"};
 } // namespace PropNames
+
+std::string const FILE_EXTENSION{".nxs"};
 } // namespace
 
 namespace Mantid::Algorithms {
@@ -33,21 +37,36 @@ void FlipperEfficiency::init() {
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropNames::OUTPUT_WS, "", Direction::Output,
                                                                        PropertyMode::Optional),
                   "Workspace containing the wavelength-dependent efficiency for the flipper.");
-  declareProperty(std::make_unique<FileProperty>(PropNames::OUTPUT_FILE, "", FileProperty::OptionalSave, ".nxs"),
+  declareProperty(std::make_unique<FileProperty>(PropNames::OUTPUT_FILE, "", FileProperty::OptionalSave),
                   "File name or path for the output to be saved to.");
+}
+
+std::map<std::string, std::string> FlipperEfficiency::validateInputs() {
+  std::map<std::string, std::string> problems;
+  auto const &outputWs = getPropertyValue(PropNames::OUTPUT_WS);
+  auto const &outputFile = getPropertyValue(PropNames::OUTPUT_FILE);
+  if (outputWs.empty() && outputFile.empty()) {
+    problems[PropNames::OUTPUT_FILE] = "Either an output workspace or output file must be provided.";
+    problems[PropNames::OUTPUT_WS] = "Either an output workspace or output file must be provided.";
+  }
+  return problems;
 }
 
 void FlipperEfficiency::exec() {
   WorkspaceGroup_sptr const groupWs = getProperty(PropNames::INPUT_WS);
   MatrixWorkspace_sptr const firstWs = std::dynamic_pointer_cast<MatrixWorkspace>(groupWs->getItem(0));
-  auto const filePath = getPropertyValue(PropNames::OUTPUT_FILE);
-  saveToFile(firstWs, filePath);
+  saveToFile(firstWs);
 }
 
-void FlipperEfficiency::saveToFile(MatrixWorkspace_sptr const &workspace, std::string const &filePath) {
+void FlipperEfficiency::saveToFile(MatrixWorkspace_sptr const &workspace) {
+  std::filesystem::path filePath = getPropertyValue(PropNames::OUTPUT_FILE);
+  // Add the nexus extension if it's not been applied already.
+  if (filePath.extension() != FILE_EXTENSION) {
+    filePath += FILE_EXTENSION;
+  }
   auto saveAlg = createChildAlgorithm("SaveNexus");
   saveAlg->initialize();
-  saveAlg->setProperty("Filename", filePath);
+  saveAlg->setProperty("Filename", filePath.string());
   saveAlg->setProperty("InputWorkspace", workspace);
   saveAlg->execute();
 }

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -15,15 +15,14 @@
 namespace {
 /// Property Names
 namespace PropNames {
-std::string const INPUT_WS{"InputWorkspace"};
-std::string const OUTPUT_WS{"OutputWorkspace"};
-std::string const OUTPUT_FILE{"OutputFilePath"};
-std::string const SPIN_STATES{"SpinStates"};
-
+constexpr char const *INPUT_WS{"InputWorkspace"};
+constexpr char const *OUTPUT_WS{"OutputWorkspace"};
+constexpr char const *OUTPUT_FILE{"OutputFilePath"};
+constexpr char const *SPIN_STATES{"SpinStates"};
 } // namespace PropNames
 
-std::string const FILE_EXTENSION{".nxs"};
-std::string const INITIAL_SPIN = "11,10,01,00";
+constexpr char const *FILE_EXTENSION{".nxs"};
+constexpr char const *INITIAL_SPIN{"11,10,01,00"};
 } // namespace
 
 namespace Mantid::Algorithms {

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h"
+#include "MantidAlgorithms/PolarizationCorrections/SpinStateValidator.h"
 
 namespace {
 /// Property Names
@@ -16,9 +17,12 @@ namespace PropNames {
 std::string const INPUT_WS{"InputWorkspace"};
 std::string const OUTPUT_WS{"OutputWorkspace"};
 std::string const OUTPUT_FILE{"OutputFilePath"};
+std::string const SPIN_STATES{"SpinStates"};
+
 } // namespace PropNames
 
 std::string const FILE_EXTENSION{".nxs"};
+std::string const INITIAL_SPIN = "11,10,01,00";
 } // namespace
 
 namespace Mantid::Algorithms {
@@ -39,10 +43,20 @@ void FlipperEfficiency::init() {
                   "Workspace containing the wavelength-dependent efficiency for the flipper.");
   declareProperty(std::make_unique<FileProperty>(PropNames::OUTPUT_FILE, "", FileProperty::OptionalSave),
                   "File name or path for the output to be saved to.");
+  auto spinValidator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{4});
+  declareProperty(PropNames::SPIN_STATES, INITIAL_SPIN, spinValidator,
+                  "Order of individual spin states in the input group workspace, e.g. \"01,11,00,10\"");
 }
 
 std::map<std::string, std::string> FlipperEfficiency::validateInputs() {
   std::map<std::string, std::string> problems;
+  // Check input.
+  WorkspaceGroup_sptr const groupWs = getProperty(PropNames::INPUT_WS);
+  if (groupWs->size() != 4) {
+    problems[PropNames::INPUT_WS] = "The input group must contain a workspace for all four spin states.";
+  }
+
+  // Check outputs.
   auto const &outputWs = getPropertyValue(PropNames::OUTPUT_WS);
   auto const &outputFile = getPropertyValue(PropNames::OUTPUT_FILE);
   if (outputWs.empty() && outputFile.empty()) {

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -8,7 +8,11 @@
 
 namespace {
 /// Property Names
-namespace PropNames {} // namespace PropNames
+namespace PropNames {
+std::string const &INPUT_WS{"InputWorkspace"};
+std::string const &OUTPUT_WS{"OutputWorkspace"};
+std::string const &OUTPUT_FILE{"OutputFilePath"};
+} // namespace PropNames
 } // namespace
 
 namespace Mantid::Algorithms {
@@ -21,7 +25,13 @@ DECLARE_ALGORITHM(FlipperEfficiency)
 
 std::string const FlipperEfficiency::summary() const { return "Calculate the efficiency of the polarization flipper."; }
 
-void FlipperEfficiency::init() {}
+void FlipperEfficiency::init() {
+  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropNames::INPUT_WS, "", Direction::Input),
+                  "Group workspace containing the 4 polarisation periods.");
+  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropNames::OUTPUT_WS, "", Direction::Output),
+                  "Workspace containing the wavelength-dependent efficiency for the flipper.");
+  declareProperty(PropNames::OUTPUT_FILE, "", "File name or path for the output to be saved to.");
+}
 
 void FlipperEfficiency::exec() {}
 

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -41,7 +41,7 @@ std::string const FlipperEfficiency::summary() const { return "Calculate the eff
 
 void FlipperEfficiency::init() {
   declareProperty(std::make_unique<WorkspaceProperty<WorkspaceGroup>>(PropNames::INPUT_WS, "", Direction::Input),
-                  "Group workspace containing flipper transmissions for all 4 polarisation states.");
+                  "Group workspace containing flipper transmissions for all 4 polarization states.");
   auto const spinValidator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{4});
   declareProperty(PropNames::SPIN_STATES, INITIAL_SPIN, spinValidator,
                   "Order of individual spin states in the input group workspace, e.g. \"01,11,00,10\"");

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -19,7 +19,7 @@ using namespace Kernel;
 // Register the algorithm in the AlgorithmFactory
 DECLARE_ALGORITHM(FlipperEfficiency)
 
-std::string const FlipperEfficiency::summary() const {}
+std::string const FlipperEfficiency::summary() const { return "Calculate the efficiency of the polarization flipper."; }
 
 void FlipperEfficiency::init() {}
 

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -30,12 +30,26 @@ std::string const FlipperEfficiency::summary() const { return "Calculate the eff
 void FlipperEfficiency::init() {
   declareProperty(std::make_unique<WorkspaceProperty<WorkspaceGroup>>(PropNames::INPUT_WS, "", Direction::Input),
                   "Group workspace containing the 4 polarisation periods.");
-  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropNames::OUTPUT_WS, "", Direction::Output),
+  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropNames::OUTPUT_WS, "", Direction::Output,
+                                                                       PropertyMode::Optional),
                   "Workspace containing the wavelength-dependent efficiency for the flipper.");
   declareProperty(std::make_unique<FileProperty>(PropNames::OUTPUT_FILE, "", FileProperty::OptionalSave, ".nxs"),
                   "File name or path for the output to be saved to.");
 }
 
-void FlipperEfficiency::exec() {}
+void FlipperEfficiency::exec() {
+  WorkspaceGroup_sptr const groupWs = getProperty(PropNames::INPUT_WS);
+  MatrixWorkspace_sptr const firstWs = std::dynamic_pointer_cast<MatrixWorkspace>(groupWs->getItem(0));
+  auto const filePath = getPropertyValue(PropNames::OUTPUT_FILE);
+  saveToFile(firstWs, filePath);
+}
+
+void FlipperEfficiency::saveToFile(MatrixWorkspace_sptr const &workspace, std::string const &filePath) {
+  auto saveAlg = createChildAlgorithm("SaveNexus");
+  saveAlg->initialize();
+  saveAlg->setProperty("Filename", filePath);
+  saveAlg->setProperty("InputWorkspace", workspace);
+  saveAlg->execute();
+}
 
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -5,6 +5,8 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h"
+#include "MantidAPI/FileProperty.h"
+#include "MantidAPI/WorkspaceGroup.h"
 
 namespace {
 /// Property Names
@@ -26,11 +28,12 @@ DECLARE_ALGORITHM(FlipperEfficiency)
 std::string const FlipperEfficiency::summary() const { return "Calculate the efficiency of the polarization flipper."; }
 
 void FlipperEfficiency::init() {
-  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropNames::INPUT_WS, "", Direction::Input),
+  declareProperty(std::make_unique<WorkspaceProperty<WorkspaceGroup>>(PropNames::INPUT_WS, "", Direction::Input),
                   "Group workspace containing the 4 polarisation periods.");
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropNames::OUTPUT_WS, "", Direction::Output),
                   "Workspace containing the wavelength-dependent efficiency for the flipper.");
-  declareProperty(PropNames::OUTPUT_FILE, "", "File name or path for the output to be saved to.");
+  declareProperty(std::make_unique<FileProperty>(PropNames::OUTPUT_FILE, "", FileProperty::OptionalSave, ".nxs"),
+                  "File name or path for the output to be saved to.");
 }
 
 void FlipperEfficiency::exec() {}

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -42,14 +42,14 @@ std::string const FlipperEfficiency::summary() const { return "Calculate the eff
 void FlipperEfficiency::init() {
   declareProperty(std::make_unique<WorkspaceProperty<WorkspaceGroup>>(PropNames::INPUT_WS, "", Direction::Input),
                   "Group workspace containing flipper transmissions for all 4 polarisation states.");
+  auto const spinValidator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{4});
+  declareProperty(PropNames::SPIN_STATES, INITIAL_SPIN, spinValidator,
+                  "Order of individual spin states in the input group workspace, e.g. \"01,11,00,10\"");
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropNames::OUTPUT_WS, "", Direction::Output,
                                                                        PropertyMode::Optional),
                   "Workspace containing the wavelength-dependent efficiency for the flipper.");
   declareProperty(std::make_unique<FileProperty>(PropNames::OUTPUT_FILE, "", FileProperty::OptionalSave),
                   "File name or path for the output to be saved to.");
-  auto const spinValidator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{4});
-  declareProperty(PropNames::SPIN_STATES, INITIAL_SPIN, spinValidator,
-                  "Order of individual spin states in the input group workspace, e.g. \"01,11,00,10\"");
 }
 
 std::map<std::string, std::string> FlipperEfficiency::validateInputs() {

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -18,14 +18,14 @@
 namespace {
 /// Property Names
 namespace PropNames {
-constexpr char const *INPUT_WS{"InputWorkspace"};
-constexpr char const *OUTPUT_WS{"OutputWorkspace"};
-constexpr char const *OUTPUT_FILE{"OutputFilePath"};
-constexpr char const *SPIN_STATES{"SpinStates"};
+auto constexpr INPUT_WS{"InputWorkspace"};
+auto constexpr OUTPUT_WS{"OutputWorkspace"};
+auto constexpr OUTPUT_FILE{"OutputFilePath"};
+auto constexpr SPIN_STATES{"SpinStates"};
 } // namespace PropNames
 
-constexpr char const *FILE_EXTENSION{".nxs"};
-constexpr char const *INITIAL_SPIN{"11,10,01,00"};
+auto constexpr FILE_EXTENSION{".nxs"};
+auto constexpr INITIAL_SPIN{"11,10,01,00"};
 } // namespace
 
 namespace Mantid::Algorithms {

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -45,7 +45,7 @@ void FlipperEfficiency::init() {
                   "Workspace containing the wavelength-dependent efficiency for the flipper.");
   declareProperty(std::make_unique<FileProperty>(PropNames::OUTPUT_FILE, "", FileProperty::OptionalSave),
                   "File name or path for the output to be saved to.");
-  auto spinValidator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{4});
+  auto const spinValidator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{4});
   declareProperty(PropNames::SPIN_STATES, INITIAL_SPIN, spinValidator,
                   "Order of individual spin states in the input group workspace, e.g. \"01,11,00,10\"");
 }

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -62,7 +62,7 @@ void FlipperEfficiency::saveToFile(MatrixWorkspace_sptr const &workspace) {
   std::filesystem::path filePath = getPropertyValue(PropNames::OUTPUT_FILE);
   // Add the nexus extension if it's not been applied already.
   if (filePath.extension() != FILE_EXTENSION) {
-    filePath += FILE_EXTENSION;
+    filePath.replace_extension(FILE_EXTENSION);
   }
   auto saveAlg = createChildAlgorithm("SaveNexus");
   saveAlg->initialize();

--- a/Framework/Algorithms/test/PolarizationCorrections/DepolarizedAnalyserTransmissionTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/DepolarizedAnalyserTransmissionTest.h
@@ -143,6 +143,7 @@ public:
     TS_ASSERT_THROWS_EQUALS(alg->execute(), std::runtime_error const &e, std::string(e.what()),
                             "Failed to fit to transmission workspace, : Fit quality (chi-squared) is too poor "
                             "(0.000000. Should be 0 < x < 1). You may want to check that the correct spectrum "
+
                             "and starting fitting values were provided.");
     TS_ASSERT(!alg->isExecuted());
   }

--- a/Framework/Algorithms/test/PolarizationCorrections/DepolarizedAnalyserTransmissionTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/DepolarizedAnalyserTransmissionTest.h
@@ -143,7 +143,6 @@ public:
     TS_ASSERT_THROWS_EQUALS(alg->execute(), std::runtime_error const &e, std::string(e.what()),
                             "Failed to fit to transmission workspace, : Fit quality (chi-squared) is too poor "
                             "(0.000000. Should be 0 < x < 1). You may want to check that the correct spectrum "
-
                             "and starting fitting values were provided.");
     TS_ASSERT(!alg->isExecuted());
   }

--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -7,13 +7,20 @@
 #pragma once
 
 #include <cxxtest/TestSuite.h>
+#include <filesystem>
 
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAlgorithms/CreateSampleWorkspace.h"
+#include "MantidAlgorithms/GroupWorkspaces.h"
 #include "MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h"
 
 namespace {} // namespace
 
+using Mantid::Algorithms::CreateSampleWorkspace;
 using Mantid::Algorithms::FlipperEfficiency;
+using Mantid::Algorithms::GroupWorkspaces;
+using Mantid::API::MatrixWorkspace_sptr;
 
 class FlipperEfficiencyTest : public CxxTest::TestSuite {
 public:
@@ -30,5 +37,66 @@ public:
   void test_category() {
     FlipperEfficiency const alg;
     TS_ASSERT_EQUALS(alg.category(), "SANS\\PolarizationCorrections");
+  }
+
+  void test_saving_absolute() {
+    FlipperEfficiency alg;
+    alg.initialize();
+    auto temp_filename = std::filesystem::temp_directory_path() /= "something.nxs";
+    auto group = createTestingWorkspace("testWs");
+    alg.setProperty("InputWorkspace", group);
+    alg.setPropertyValue("OutputFilePath", temp_filename.string());
+    TS_ASSERT(std::filesystem::exists(temp_filename));
+  }
+
+private:
+  Mantid::API::WorkspaceGroup_sptr createTestingWorkspace(std::string const &outName, int const numSpectra = 1,
+                                                          bool const isMonitor = true, double const binWidth = 0.1) {
+
+    CreateSampleWorkspace makeWsAlg;
+    makeWsAlg.initialize();
+    makeWsAlg.setPropertyValue("Function", "User Defined");
+    makeWsAlg.setPropertyValue("XUnit", "wavelength");
+    if (isMonitor) {
+      makeWsAlg.setProperty("NumBanks", 0);
+      makeWsAlg.setProperty("NumMonitors", numSpectra);
+    } else {
+      makeWsAlg.setProperty("NumBanks", numSpectra);
+    }
+    makeWsAlg.setProperty("BankPixelWidth", 1);
+    makeWsAlg.setProperty("XMin", 1.45);
+    makeWsAlg.setProperty("XMax", 9.50);
+    makeWsAlg.setProperty("BinWidth", binWidth);
+
+    makeWsAlg.setPropertyValue("UserDefinedFunction",
+                               "name=Lorentzian, Amplitude=48797.2, PeakCentre=2.774, FWHM=1.733");
+    makeWsAlg.setPropertyValue("OutputWorkspace", outName + "_00");
+    makeWsAlg.execute();
+
+    makeWsAlg.setPropertyValue("UserDefinedFunction",
+                               "name=Lorentzian, Amplitude=48797.2, PeakCentre=2.734, FWHM=1.733");
+    makeWsAlg.setPropertyValue("OutputWorkspace", outName + "_11");
+    makeWsAlg.execute();
+
+    makeWsAlg.setPropertyValue("UserDefinedFunction",
+                               "name=Lorentzian, Amplitude=21130.1, PeakCentre=2.574, FWHM=0.933");
+    makeWsAlg.setPropertyValue("OutputWorkspace", outName + "_10");
+    makeWsAlg.execute();
+
+    makeWsAlg.setPropertyValue("UserDefinedFunction",
+                               "name=Lorentzian, Amplitude=48797.2, PeakCentre=2.566, FWHM=0.933");
+    makeWsAlg.setPropertyValue("OutputWorkspace", outName + "_01");
+    makeWsAlg.execute();
+
+    GroupWorkspaces groupAlg;
+    groupAlg.initialize();
+    groupAlg.setChild(true);
+    std::vector<std::string> const &input{outName + "_10", outName + "_11", outName + "_01", outName + "_00"};
+    TS_ASSERT_THROWS_NOTHING(groupAlg.setProperty("InputWorkspaces", input));
+    TS_ASSERT_THROWS_NOTHING(groupAlg.setPropertyValue("OutputWorkspace", outName));
+    TS_ASSERT_THROWS_NOTHING(groupAlg.execute());
+    TS_ASSERT(groupAlg.isExecuted());
+
+    return groupAlg.getProperty("OutputWorkspace");
   }
 };

--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -1,0 +1,34 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAlgorithms/CreateSampleWorkspace.h"
+#include "MantidAlgorithms/PolarizationCorrections/FlipperEfficiency.h"
+
+namespace {} // namespace
+
+using Mantid::Algorithms::FlipperEfficiency;
+
+class FlipperEfficiencyTest : public CxxTest::TestSuite {
+public:
+  void test_name() {
+    FlipperEfficiency const alg;
+    TS_ASSERT_EQUALS(alg.name(), "FlipperEfficiency");
+  }
+
+  void test_version() {
+    FlipperEfficiency const alg;
+    TS_ASSERT_EQUALS(alg.version(), 1);
+  }
+
+  void test_category() {
+    FlipperEfficiency const alg;
+    TS_ASSERT_EQUALS(alg.category(), "SANS\\PolarizationCorrections");
+  }
+};

--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -100,6 +100,18 @@ public:
         "provided.\n OutputWorkspace: Either an output workspace or output file must be provided.")
   }
 
+  void test_invalid_group_size_is_captured() {
+    FlipperEfficiency alg;
+    alg.initialize();
+    auto const &group = createTestingWorkspace("testWs");
+    group->removeItem(0);
+    alg.setProperty("InputWorkspace", group);
+    alg.setPropertyValue("OutputWorkspace", "out");
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error const &e, std::string(e.what()),
+                            "Some invalid Properties found: \n InputWorkspace: The input group must contain a "
+                            "workspace for all four spin states.")
+  }
+
 private:
   std::string m_defaultSaveDirectory;
 

--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -45,6 +45,8 @@ public:
     TS_ASSERT_EQUALS(alg.category(), "SANS\\PolarizationCorrections")
   }
 
+  /// Saving Tests
+
   void test_saving_absolute() {
     FlipperEfficiency alg;
     alg.initialize();
@@ -83,6 +85,19 @@ public:
     auto savedPath = temp_filename.string() + ".nxs";
     TS_ASSERT(std::filesystem::exists(savedPath))
     std::filesystem::remove(savedPath);
+  }
+
+  /// Validation Tests
+
+  void test_no_workspaces_or_file_output_fails() {
+    FlipperEfficiency alg;
+    alg.initialize();
+    auto const &group = createTestingWorkspace("testWs");
+    alg.setProperty("InputWorkspace", group);
+    TS_ASSERT_THROWS_EQUALS(
+        alg.execute(), std::runtime_error const &e, std::string(e.what()),
+        "Some invalid Properties found: \n OutputFilePath: Either an output workspace or output file must be "
+        "provided.\n OutputWorkspace: Either an output workspace or output file must be provided.")
   }
 
 private:
@@ -130,9 +145,9 @@ private:
     groupAlg.initialize();
     groupAlg.setChild(true);
     std::vector<std::string> const &input{outName + "_10", outName + "_11", outName + "_01", outName + "_00"};
-    TS_ASSERT_THROWS_NOTHING(groupAlg.setProperty("InputWorkspaces", input));
-    TS_ASSERT_THROWS_NOTHING(groupAlg.setPropertyValue("OutputWorkspace", outName));
-    TS_ASSERT_THROWS_NOTHING(groupAlg.execute());
+    groupAlg.setProperty("InputWorkspaces", input);
+    groupAlg.setPropertyValue("OutputWorkspace", outName);
+    groupAlg.execute();
     TS_ASSERT(groupAlg.isExecuted());
 
     return groupAlg.getProperty("OutputWorkspace");

--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -46,6 +46,7 @@ public:
     auto group = createTestingWorkspace("testWs");
     alg.setProperty("InputWorkspace", group);
     alg.setPropertyValue("OutputFilePath", temp_filename.string());
+    alg.execute();
     TS_ASSERT(std::filesystem::exists(temp_filename));
   }
 

--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -59,7 +59,7 @@ public:
 
   void test_saving_relative() {
     auto tempDir = std::filesystem::temp_directory_path();
-    ConfigService::Instance().setString("defaultsave.directory", tempDir);
+    ConfigService::Instance().setString("defaultsave.directory", tempDir.string());
     std::string const &filename = "something.nxs";
     auto const &group = createTestingWorkspace("testWs");
     auto alg = initialize_alg(group, false);

--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -112,6 +112,10 @@ public:
                             "workspace for all four spin states.")
   }
 
+  /// Calculation Tests
+
+  void test_correct_calculation() {}
+
 private:
   std::string m_defaultSaveDirectory;
 

--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -9,6 +9,7 @@
 #include <cxxtest/TestSuite.h>
 #include <filesystem>
 
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAlgorithms/ConvertUnits.h"
@@ -30,7 +31,10 @@ class FlipperEfficiencyTest : public CxxTest::TestSuite {
 public:
   void setUp() override { m_defaultSaveDirectory = ConfigService::Instance().getString("defaultsave.directory"); }
 
-  void tearDown() override { ConfigService::Instance().setString("defaultsave.directory", m_defaultSaveDirectory); }
+  void tearDown() override {
+    ConfigService::Instance().setString("defaultsave.directory", m_defaultSaveDirectory);
+    Mantid::API::AnalysisDataService::Instance().clear();
+  }
 
   void test_name() {
     FlipperEfficiency const alg;

--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -111,6 +111,13 @@ public:
         "Some invalid Properties found: \n InputWorkspace: All input workspaces must be in units of Wavelength.")
   }
 
+  void test_non_group_workspace_is_captured() {
+    auto const &group = createTestingWorkspace("testWs", 1.0);
+    auto alg = initialize_alg(group);
+    TS_ASSERT_THROWS_EQUALS(alg->setProperty("InputWorkspace", group->getItem(0)), std::invalid_argument const &e,
+                            std::string(e.what()), "Enter a name for the Input/InOut workspace")
+  }
+
   /// Calculation Tests
 
   void test_normal_perfect_calculation_occurs() {

--- a/docs/source/algorithms/FlipperEfficiency-v1.rst
+++ b/docs/source/algorithms/FlipperEfficiency-v1.rst
@@ -1,0 +1,58 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+Calculates the efficiency of a single flipper  with regards to wavelength. The input workspace must be a group workspace
+containing four known spin states, which can be given by the ``SpinStates`` parameter. It then uses these four spin
+states to calculate the proportion of neutrons lost to the flipper with regards to wavelength.
+
+The polarisation of the flipper :math:`P_{F}` is given by:
+
+.. math::
+
+   P_F = \frac{T_{11} - T_{10}}{T_{00} - T_{01}}
+
+Since the efficiency :math:`\epsilon_{F}` is equal to :math:`\frac{1 + P_{F}}{2}`, we can calculate the efficiency of
+the flipper directly using:
+
+.. math::
+
+   \epsilon_{F} = \frac{T_{00} - T_{01} + T_{11} - T_{10}}{2(T_{00} - T_{01})}
+
+Usage
+-----
+
+**Example - Calculate Flipper Efficiency**
+
+.. testcode:: FlipperEfficiencyExample
+
+    CreateSampleWorkspace(OutputWorkspace='out_00', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=48000, PeakCentre=2.65, FWHM=1.2', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
+    CreateSampleWorkspace(OutputWorkspace='out_11', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=47000, PeakCentre=2.65, FWHM=1.2', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
+    CreateSampleWorkspace(OutputWorkspace='out_10', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=22685, PeakCentre=2.55, FWHM=0.6', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
+    CreateSampleWorkspace(OutputWorkspace='out_01', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=22685, PeakCentre=2.55, FWHM=0.6', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
+
+    group = GroupWorkspaces(['out_00','out_11','out_10','out_01'])
+
+    group = ConvertUnits(group, "Wavelength")
+
+    out = FlipperEfficiency(group, SpinStates="00, 11, 10, 01")
+
+    print("Flipper efficiency at a wavelength of " + str(mtd['out'].dataX(0)[3]) + " Å is " + str(mtd['out'].dataY(0)[3]))
+
+Output:
+
+.. testoutput:: FlipperEfficiencyExample
+    :options: +ELLIPSIS +NORMALIZE_WHITESPACE
+
+    Flipper efficiency at a wavelength of 4.0 Å is ...
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/FlipperEfficiency-v1.rst
+++ b/docs/source/algorithms/FlipperEfficiency-v1.rst
@@ -51,7 +51,7 @@ Output:
 .. testoutput:: FlipperEfficiencyExample
     :options: +ELLIPSIS +NORMALIZE_WHITESPACE
 
-    Flipper efficiency at a wavelength of 4.0 Å is ...
+    Flipper efficiency at a wavelength of 0.3 Å is ...
 
 .. categories::
 

--- a/docs/source/algorithms/FlipperEfficiency-v1.rst
+++ b/docs/source/algorithms/FlipperEfficiency-v1.rst
@@ -26,6 +26,19 @@ the flipper directly using:
 
    \epsilon_{F} = \frac{T_{00} - T_{01} + T_{11} - T_{10}}{2(T_{00} - T_{01})}
 
+
+Outputs
+=======
+
+If an output file path is provided, a NeXus file containing the output workspace will be saved. If an absolute path is
+provided, the output workspace will be saved to the given path. If only a filename or a relative path is provided, the
+output workspace will be saved with that filename into the location set in the ``Default Save Directory`` field of the
+``File -> Manage User Directories`` window.
+
+A workspace will not be output by the algorithm unless an output workspace name is provided.
+
+An output workspace name, output file path, or both must be given.
+
 Usage
 -----
 

--- a/docs/source/algorithms/FlipperEfficiency-v1.rst
+++ b/docs/source/algorithms/FlipperEfficiency-v1.rst
@@ -13,7 +13,7 @@ Calculates the efficiency of a single flipper  with regards to wavelength. The i
 containing four known spin states, which can be given by the ``SpinStates`` parameter. It then uses these four spin
 states to calculate the proportion of neutrons lost to the flipper with regards to wavelength.
 
-The polarisation of the flipper :math:`P_{F}` is given by:
+The polarization of the flipper :math:`P_{F}` is given by:
 
 .. math::
 

--- a/docs/source/release/v6.10.0/SANS/New_features/36144.rst
+++ b/docs/source/release/v6.10.0/SANS/New_features/36144.rst
@@ -1,0 +1,1 @@
+- A :ref:`algm-FlipperEfficiency` algorithm has been created as part of the Polarised SANS workflow.


### PR DESCRIPTION
### Description of work

#### Summary of work
Implemented an algorithm for calculating the efficiency of the flipper in Polarised SANS experiments. 

Fixes #36144 

#### Further detail of work
Includes tests and makes use of the spin state validation implemented as part of the Analyser Efficiency algorithm. 

### To test:
1. Run the following script:
```python
    CreateSampleWorkspace(OutputWorkspace='out_00', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=48000, PeakCentre=2.65, FWHM=1.2', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
    CreateSampleWorkspace(OutputWorkspace='out_11', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=47000, PeakCentre=2.65, FWHM=1.2', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
    CreateSampleWorkspace(OutputWorkspace='out_10', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=22685, PeakCentre=2.55, FWHM=0.6', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
    CreateSampleWorkspace(OutputWorkspace='out_01', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=22685, PeakCentre=2.55, FWHM=0.6', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)

    group = GroupWorkspaces(['out_00','out_11','out_10','out_01'])

    group = ConvertUnits(group, "Wavelength")

    out = FlipperEfficiency(group, SpinStates="00, 11, 10, 01")

    print("Flipper efficiency at a wavelength of " + str(mtd['out'].dataX(0)[3]) + " Å is " + str(mtd['out'].dataY(0)[3]))
```
2. Check that the validation is working for both the scripted implementation and using the Algorithm Dialog. 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
