### PR TITLE
Try using pydantic to cut down on type validation boilerplate

### DIFF
--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -75,6 +75,8 @@ requirements:
     - joblib
     - orsopy {{ orsopy }}
     - quasielasticbayes
+    - pydantic
+
   run_constrained:
     - matplotlib {{ matplotlib }}
 

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -51,6 +51,7 @@ dependencies:
   - versioningit>=2.1
   - joblib
   - orsopy==1.2.1 # Fix the version to avoid updates being pulled in automatically, which might change the Reflectometry ORSO file content or layout and cause tests to fail.
+  - pydantic
 
   # Not Windows, OpenGL implementation:
   - mesa-libgl-devel-cos7-x86_64>=18.3.4

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -49,6 +49,7 @@ dependencies:
   - versioningit>=2.1
   - joblib
   - orsopy==1.2.1 # Fix the version to avoid updates being pulled in automatically, which might change the Reflectometry ORSO file content or layout and cause tests to fail.
+  - pydantic
 
   # Needed only for development
   - black  # may be out of sync with pre-commit

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -48,7 +48,10 @@ dependencies:
   - versioningit>=2.1
   - joblib
   - orsopy==1.2.1 # Fix the version to avoid updates being pulled in automatically, which might change the Reflectometry ORSO file content or layout and cause tests to fail.
+  - pydantic
+
   # Needed only for development
   - black  # may be out of sync with pre-commit
   - cppcheck==2.14.2
   - pre-commit>=2.12.0
+

--- a/scripts/abins/abinsdata.py
+++ b/scripts/abins/abinsdata.py
@@ -6,6 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from typing import Any, Dict, Type, TypedDict, TypeVar
 
+from pydantic import validate_call
+
 import mantid
 from abins.kpointsdata import KpointsData
 from abins.atomsdata import AtomsData
@@ -23,13 +25,9 @@ class AbinsData:
 
     """
 
+    @validate_call(config=dict(arbitrary_types_allowed=True, strict=True))
     def __init__(self, *, k_points_data: KpointsData, atoms_data: AtomsData) -> None:
-        if not isinstance(k_points_data, KpointsData):
-            raise TypeError("Invalid type of k-points data.: {}".format(type(k_points_data)))
         self._k_points_data = k_points_data
-
-        if not isinstance(atoms_data, AtomsData):
-            raise TypeError("Invalid type of atoms data.")
         self._atoms_data = atoms_data
         self._check_consistent_dimensions()
 

--- a/scripts/abins/atomsdata.py
+++ b/scripts/abins/atomsdata.py
@@ -6,8 +6,9 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import collections.abc
 import numbers
-from typing import Dict, List, Optional, overload, Union, TypedDict
+from typing import Dict, List, Optional, overload, TypedDict, Union
 import re
+
 import numpy as np
 
 import abins
@@ -146,12 +147,10 @@ class AtomsData(collections.abc.Sequence):
         return len(self._data)
 
     @overload
-    def __getitem__(self, item: int) -> _AtomData:
-        ...
+    def __getitem__(self, item: int) -> _AtomData: ...
 
     @overload
-    def __getitem__(self, item: slice) -> List[_AtomData]:
-        ...
+    def __getitem__(self, item: slice) -> List[_AtomData]: ...
 
     def __getitem__(self, item):
         return self._data[item]

--- a/scripts/abins/constants.py
+++ b/scripts/abins/constants.py
@@ -191,6 +191,9 @@ COMPLEX_TYPE = np.dtype(complex)
 INT_ID = np.dtype(np.uint32).num
 INT_TYPE = np.dtype(np.uint32)
 
+# Valid types for hdf5 attr read/write
+HDF5_ATTR_TYPE = np.int64 | int | np.float64 | float | str | bytes | bool
+
 HIGHER_ORDER_QUANTUM_EVENTS = 3  # number of quantum order effects taken into account
 HIGHER_ORDER_QUANTUM_EVENTS_DIM = HIGHER_ORDER_QUANTUM_EVENTS
 

--- a/scripts/abins/constants.py
+++ b/scripts/abins/constants.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import math
+from typing import Literal
 import warnings
 
 import numpy as np
@@ -164,6 +165,7 @@ M_2_HARTREE = constants.value("atomic mass unit-hartree relationship")  # amu * 
 
 # ALL_SAMPLE_FORMS = ["SingleCrystal", "Powder"]  # valid forms of samples
 ALL_SAMPLE_FORMS = ["Powder"]  # valid forms of samples
+ALL_SAMPLE_FORMS_TYPE = Literal["Powder"]
 
 # keywords which define data structure of KpointsData
 ALL_KEYWORDS_K_DATA = ["weights", "k_vectors", "frequencies", "atomic_displacements", "unit_cell"]

--- a/scripts/abins/test_helpers.py
+++ b/scripts/abins/test_helpers.py
@@ -6,11 +6,12 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
 from pathlib import Path
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, List, Mapping
 from unittest import TestCase
 
 import numpy as np
 from numpy.testing import assert_allclose
+from pydantic import validate_call
 
 from abins.atomsdata import _AtomData
 from abins.kpointsdata import KpointData
@@ -39,7 +40,8 @@ def find_file(filename: str, try_upcase_suffix: bool = True) -> str:
         raise ValueError(f"Could not find file '{filename}'")
 
 
-def remove_output_files(list_of_names=None):
+@validate_call
+def remove_output_files(list_of_names: List[str]) -> None:
     """Removes output files created during a test."""
 
     # import ConfigService here to avoid:
@@ -47,11 +49,6 @@ def remove_output_files(list_of_names=None):
     # instances is not enabled (http://www.boost.org/libs/python/doc/v2/pickle.html)
 
     from mantid.kernel import ConfigService
-
-    if not isinstance(list_of_names, list):
-        raise ValueError("List of names is expected.")
-    if not all(isinstance(i, str) for i in list_of_names):
-        raise ValueError("Each name should be a string.")
 
     save_dir_path = ConfigService.getString("defaultsave.directory")
     if save_dir_path != "":  # default save directory set

--- a/scripts/test/Abins/AbinsCalculateSPowderTest.py
+++ b/scripts/test/Abins/AbinsCalculateSPowderTest.py
@@ -53,7 +53,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
             good_data = AbinsData.from_dict(json.load(fp))
 
         # invalid filename
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "Input should be a valid string"):
             abins.SCalculatorFactory.init(
                 filename=1,
                 temperature=self._temperature,
@@ -64,7 +64,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
             )
 
         # invalid temperature
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "Input should be greater than 0"):
             abins.SCalculatorFactory.init(
                 filename=full_path_filename,
                 temperature=-1,
@@ -86,7 +86,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
             )
 
         # invalid abins data: content of abins data instead of object abins_data
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "Input should be an instance of AbinsData"):
             abins.SCalculatorFactory.init(
                 filename=full_path_filename,
                 temperature=self._temperature,
@@ -97,7 +97,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
             )
 
         # invalid instrument
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "Input should be an instance of Instrument"):
             abins.SCalculatorFactory.init(
                 filename=full_path_filename,
                 temperature=self._temperature,

--- a/scripts/test/Abins/AbinsCalculateSPowderTest.py
+++ b/scripts/test/Abins/AbinsCalculateSPowderTest.py
@@ -11,6 +11,7 @@ import unittest
 
 import numpy as np
 from numpy.testing import assert_almost_equal
+from pydantic import ValidationError
 
 import abins
 from abins import AbinsData
@@ -52,7 +53,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
             good_data = AbinsData.from_dict(json.load(fp))
 
         # invalid filename
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValidationError):
             abins.SCalculatorFactory.init(
                 filename=1,
                 temperature=self._temperature,
@@ -63,7 +64,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
             )
 
         # invalid temperature
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValidationError):
             abins.SCalculatorFactory.init(
                 filename=full_path_filename,
                 temperature=-1,
@@ -85,7 +86,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
             )
 
         # invalid abins data: content of abins data instead of object abins_data
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValidationError):
             abins.SCalculatorFactory.init(
                 filename=full_path_filename,
                 temperature=self._temperature,
@@ -96,7 +97,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
             )
 
         # invalid instrument
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValidationError):
             abins.SCalculatorFactory.init(
                 filename=full_path_filename,
                 temperature=self._temperature,

--- a/scripts/test/Abins/AbinsDataTest.py
+++ b/scripts/test/Abins/AbinsDataTest.py
@@ -26,9 +26,9 @@ class TestAbinsData(unittest.TestCase):
         self.mock_kpd = MagicMock(spec=abins.KpointsData)
 
     def test_init_typeerror(self):
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "Input should be an instance of KpointsData"):
             AbinsData(k_points_data=1, atoms_data=self.mock_ad)
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "Input should be an instance of AtomsData"):
             AbinsData(k_points_data=self.mock_kpd, atoms_data={"key": "value"})
 
     def test_init_noloader(self):

--- a/scripts/test/Abins/AbinsDataTest.py
+++ b/scripts/test/Abins/AbinsDataTest.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 from tempfile import TemporaryDirectory
 
 from numpy.testing import assert_allclose
+from pydantic import ValidationError
 
 import abins
 from abins.abinsdata import AbinsData
@@ -25,9 +26,9 @@ class TestAbinsData(unittest.TestCase):
         self.mock_kpd = MagicMock(spec=abins.KpointsData)
 
     def test_init_typeerror(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValidationError):
             AbinsData(k_points_data=1, atoms_data=self.mock_ad)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValidationError):
             AbinsData(k_points_data=self.mock_kpd, atoms_data={"key": "value"})
 
     def test_init_noloader(self):

--- a/scripts/test/Abins/AbinsIOmoduleTest.py
+++ b/scripts/test/Abins/AbinsIOmoduleTest.py
@@ -7,6 +7,7 @@
 import unittest
 
 import numpy as np
+from pydantic import ValidationError
 from abins import IO, test_helpers
 
 
@@ -41,18 +42,22 @@ class IOTest(unittest.TestCase):
         # save attributes and datasets
         saver.save()
 
-    def _save_wrong_attribute(self):
+    def _add_wrong_attribute(self):
         poor_saver = IO(input_filename="BadCars.foo", group_name="Volksvagen")
-        poor_saver.add_attribute("BadPassengers", np.array([4]))
-        self.assertRaises(ValueError, poor_saver.save)
+
+        with self.assertRaises(ValidationError):
+            poor_saver.add_attribute("BadPassengers", np.array([4, 5], dtype=np.int64))
 
     def _save_wrong_dataset(self):
         poor_saver = IO(input_filename="BadCars.foo", group_name="Volksvagen")
         poor_saver.add_data("BadPassengers", 4)
         self.assertRaises(ValueError, poor_saver.save)
 
-    def _wrong_filename(self):
-        self.assertRaises(ValueError, IO, input_filename=1, group_name="goodgroup")
+    def _wrong_filename_type(self):
+        self.assertRaises(ValidationError, IO, input_filename=1, group_name="goodgroup")
+
+    def _empty_filename(self):
+        self.assertRaises(ValueError, IO, input_filename="", group_name="goodgroup")
 
     def _wrong_groupname(self):
         self.assertRaises(ValueError, IO, input_filename="goodfile", group_name=1)
@@ -107,12 +112,13 @@ class IOTest(unittest.TestCase):
 
         self._save_stuff()
 
-        self._save_wrong_attribute()
+        self._add_wrong_attribute()
         self._save_wrong_dataset()
 
         self.loader = IO(input_filename="Cars.foo", group_name="Volksvagen")
 
-        self._wrong_filename()
+        self._wrong_filename_type()
+        self._empty_filename()
         self._wrong_groupname()
         self._wrong_file()
 

--- a/scripts/test/Abins/AbinsIOmoduleTest.py
+++ b/scripts/test/Abins/AbinsIOmoduleTest.py
@@ -51,7 +51,7 @@ class IOTest(unittest.TestCase):
     def _save_wrong_dataset(self):
         poor_saver = IO(input_filename="BadCars.foo", group_name="Volksvagen")
         poor_saver.add_data("BadPassengers", 4)
-        self.assertRaises(ValueError, poor_saver.save)
+        self.assertRaises(TypeError, poor_saver.save)
 
     def _wrong_filename_type(self):
         self.assertRaises(ValidationError, IO, input_filename=1, group_name="goodgroup")

--- a/scripts/test/Abins/AbinsIOmoduleTest.py
+++ b/scripts/test/Abins/AbinsIOmoduleTest.py
@@ -45,7 +45,7 @@ class IOTest(unittest.TestCase):
     def _add_wrong_attribute(self):
         poor_saver = IO(input_filename="BadCars.foo", group_name="Volksvagen")
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "Input should be an instance of int64"):
             poor_saver.add_attribute("BadPassengers", np.array([4, 5], dtype=np.int64))
 
     def _save_wrong_dataset(self):
@@ -54,7 +54,7 @@ class IOTest(unittest.TestCase):
         self.assertRaises(TypeError, poor_saver.save)
 
     def _wrong_filename_type(self):
-        self.assertRaises(ValidationError, IO, input_filename=1, group_name="goodgroup")
+        self.assertRaisesRegex(ValidationError, "Input should be a valid string", IO, input_filename=1, group_name="goodgroup")
 
     def _empty_filename(self):
         self.assertRaises(ValueError, IO, input_filename="", group_name="goodgroup")

--- a/scripts/test/Abins/AbinsLoadCASTEPTest.py
+++ b/scripts/test/Abins/AbinsLoadCASTEPTest.py
@@ -27,7 +27,7 @@ class LoadCastepUsingEuphonicTest(unittest.TestCase):
 
         try:
             reader.read_vibrational_or_phonon_data()
-        except ValueError:
+        except TypeError:
             pass  # Clerk will freak out when passed mocked data to serialise
 
         from_castep.assert_called_with(filename, prefer_non_loto=True)

--- a/scripts/test/Abins/AbinsPowderDataTest.py
+++ b/scripts/test/Abins/AbinsPowderDataTest.py
@@ -5,7 +5,10 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+
+from pydantic import ValidationError
 import numpy as np
+
 from abins import PowderData
 
 
@@ -42,14 +45,14 @@ class AbinsPowderDataTest(unittest.TestCase):
         # wrong items: array instead of dict
         bad_items = self.good_items.copy()
         bad_items["a_tensors"] = bad_items["a_tensors"][0]
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValidationError):
             PowderData(**bad_items, num_atoms=2)
 
         # list instead of np array
         bad_items = self.good_items.copy()
         for key, value in bad_items.items():
             bad_items[key][0] = value[0].tolist()
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValidationError):
             PowderData(**bad_items, num_atoms=2)
 
         # wrong size of items: data only for one atom ; should be for two atoms

--- a/scripts/test/Abins/AbinsPowderDataTest.py
+++ b/scripts/test/Abins/AbinsPowderDataTest.py
@@ -45,14 +45,14 @@ class AbinsPowderDataTest(unittest.TestCase):
         # wrong items: array instead of dict
         bad_items = self.good_items.copy()
         bad_items["a_tensors"] = bad_items["a_tensors"][0]
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "Input should be a valid dictionary"):
             PowderData(**bad_items, num_atoms=2)
 
         # list instead of np array
         bad_items = self.good_items.copy()
         for key, value in bad_items.items():
             bad_items[key][0] = value[0].tolist()
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "Input should be an instance of ndarray"):
             PowderData(**bad_items, num_atoms=2)
 
         # wrong size of items: data only for one atom ; should be for two atoms

--- a/scripts/test/Abins/AbinsSDataTest.py
+++ b/scripts/test/Abins/AbinsSDataTest.py
@@ -190,7 +190,7 @@ class AbinsSDataTest(unittest.TestCase):
     def test_sample_form(self):
         sample_form = "Polycrystalline"
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(ValidationError, "Input should be 'Powder'"):
             _ = SData(sample_form=sample_form, data=self.sample_data, frequencies=self.frequencies)
 
     def test_bin_width(self):
@@ -254,8 +254,12 @@ class AbinsSDataTest(unittest.TestCase):
         s_data_good_temperature = SData(frequencies=self.frequencies, data=self.sample_data, temperature=good_temperature)
         self.assertAlmostEqual(good_temperature, s_data_good_temperature.get_temperature())
 
-        for bad_temperature in (-20.0, 0, "10"):
-            with self.assertRaises(ValidationError):
+        for bad_temperature, regex in (
+            (-20.0, "Input should be greater than 0"),
+            (0, "Input should be greater than 0"),
+            ("10", "Input should be a valid number"),
+        ):
+            with self.assertRaisesRegex(ValidationError, regex):
                 _ = SData(frequencies=self.frequencies, data=self.sample_data, temperature=bad_temperature)
 
 

--- a/scripts/test/Abins/AbinsSDataTest.py
+++ b/scripts/test/Abins/AbinsSDataTest.py
@@ -10,6 +10,7 @@ import unittest
 
 import numpy as np
 from numpy.testing import assert_almost_equal
+from pydantic import ValidationError
 
 import abins
 from abins import SData
@@ -67,7 +68,7 @@ class AbinsSDataTest(unittest.TestCase):
             atom_keys=["atom_2", "atom_3"],
             order_keys=["order_2", "order_3"],
             temperature=101.0,
-            sample_form="etherial",
+            sample_form="Powder",
         )
         with self.assertRaises(IndexError):
             sdata[1]
@@ -78,7 +79,7 @@ class AbinsSDataTest(unittest.TestCase):
             assert_almost_equal(sdata[atom][order], np.zeros(10))
 
         assert_almost_equal(sdata.get_temperature(), 101.0)
-        self.assertEqual(sdata.get_sample_form(), "etherial")
+        self.assertEqual(sdata.get_sample_form(), "Powder")
 
     def test_s_data_update(self):
         # Case 1: add new atom
@@ -189,15 +190,8 @@ class AbinsSDataTest(unittest.TestCase):
     def test_sample_form(self):
         sample_form = "Polycrystalline"
 
-        s_data = SData(sample_form=sample_form, data=self.sample_data, frequencies=self.frequencies)
-        self.assertEqual(sample_form, s_data.get_sample_form())
-
-        with self.assertRaises(ValueError):
-            s_data.check_known_sample_form()
-
-        # Check should pass for 'Powder'
-        powder_data = SData(sample_form="Powder", data=self.sample_data, frequencies=self.frequencies)
-        powder_data.check_known_sample_form()
+        with self.assertRaises(ValidationError):
+            _ = SData(sample_form=sample_form, data=self.sample_data, frequencies=self.frequencies)
 
     def test_bin_width(self):
         s_data = SData(data=self.sample_data, frequencies=self.frequencies)
@@ -258,18 +252,11 @@ class AbinsSDataTest(unittest.TestCase):
         # Good temperature should pass without issue
         good_temperature = 10.5
         s_data_good_temperature = SData(frequencies=self.frequencies, data=self.sample_data, temperature=good_temperature)
-        s_data_good_temperature.check_finite_temperature()
         self.assertAlmostEqual(good_temperature, s_data_good_temperature.get_temperature())
 
-        # Wrong type should get a TypeError at init
-        with self.assertRaises(TypeError):
-            SData(frequencies=self.frequencies, data=self.sample_data, temperature="10")
-
-        # Non-finite values should get a ValueError when explicitly checked
-        for bad_temperature in (-20.0, 0):
-            s_data_bad_temperature = SData(frequencies=self.frequencies, data=self.sample_data, temperature=bad_temperature)
-            with self.assertRaises(ValueError):
-                s_data_bad_temperature.check_finite_temperature()
+        for bad_temperature in (-20.0, 0, "10"):
+            with self.assertRaises(ValidationError):
+                _ = SData(frequencies=self.frequencies, data=self.sample_data, temperature=bad_temperature)
 
 
 class AbinsSDataByAngleTest(unittest.TestCase):
@@ -392,7 +379,7 @@ class AbinsSDataByAngleTest(unittest.TestCase):
         return SDataByAngle(data=self.init_data, angles=self.angles, frequencies=self.frequencies, **kwargs)
 
     def test_s_data_by_angle_indexing(self):
-        temperature, sample_form = (100.0, "powder")
+        temperature, sample_form = (100.0, "Powder")
 
         sdba = self.get_s_data_by_angle(temperature=temperature, sample_form=sample_form)
 
@@ -405,7 +392,7 @@ class AbinsSDataByAngleTest(unittest.TestCase):
             sdba[2]
 
     def test_s_data_by_angle_slicing(self):
-        temperature, sample_form = (101.0, "plasma")
+        temperature, sample_form = (101.0, "Powder")
 
         sdba = self.get_s_data_by_angle(temperature=temperature, sample_form=sample_form)
         sliced_data = sdba[-1:]
@@ -421,7 +408,7 @@ class AbinsSDataByAngleTest(unittest.TestCase):
         self.assertEqual(len(sdba[-1:]), 1)
 
     def test_sdba_from_sdata_series(self):
-        temperature, sample_form = (102.0, "quasicrystal")
+        temperature, sample_form = (102.0, "Powder")
         angle_0_sdata = SData(data=self.list_data[0], frequencies=self.frequencies, temperature=temperature, sample_form=sample_form)
         angle_1_sdata = SData(data=self.list_data[1], frequencies=self.frequencies, temperature=temperature, sample_form=sample_form)
 
@@ -437,17 +424,8 @@ class AbinsSDataByAngleTest(unittest.TestCase):
         bad_data = [  # Inconsistent frequencies
             {
                 "data": [
-                    SData(data=self.list_data[0], frequencies=[1, 2, 3, 4, 5, 6]),
-                    SData(data=self.list_data[1], frequencies=[2, 4, 6, 8, 10, 12]),
-                ],
-                "angles": self.angles,
-                "error": ValueError,
-            },
-            # Inconsistent sample_form
-            {
-                "data": [
-                    SData(data=self.list_data[0], frequencies=self.frequencies),
-                    SData(data=self.list_data[1], frequencies=self.frequencies, sample_form="crystal"),
+                    SData(data=self.list_data[0], frequencies=np.array([1, 2, 3, 4, 5, 6])),
+                    SData(data=self.list_data[1], frequencies=np.array([2, 4, 6, 8, 10, 12])),
                 ],
                 "angles": self.angles,
                 "error": ValueError,
@@ -471,7 +449,7 @@ class AbinsSDataByAngleTest(unittest.TestCase):
             {
                 "data": [SData(data=self.list_data[0], frequencies=self.frequencies, temperature=100.0), "SData (actually just a string)"],
                 "angles": self.angles,
-                "error": TypeError,
+                "error": ValidationError,
             },
         ]
 
@@ -480,7 +458,7 @@ class AbinsSDataByAngleTest(unittest.TestCase):
                 SDataByAngle.from_sdata_series(dataset["data"], angles=dataset["angles"])
 
     def test_s_data_sum_over_angles(self):
-        temperature, sample_form = (100.0, "crunchy powder")
+        temperature, sample_form = (100.0, "Powder")
 
         sdba = self.get_s_data_by_angle(temperature=temperature, sample_form=sample_form)
 


### PR DESCRIPTION
### Description of work

#### Summary of work
As part of refactoring Abins for v2, I noticed a lot of code deals with validating the types and ranges of inputs. As this is spread through the code it makes the "business logic" of the modules hard to read.

The Pydantic library is a popular tool for runtime validation of Python class/function parameters. It uses a Rust backend to get tolerable performance, and gets information from standard Python type annotations.

Of course there are sometimes edge cases that need a bit of extra fiddling, and extra dependencies should not be taken lightly... Rather than debate it in the abstract, here I try applying it to a few files and we can discuss whether this is a good idea.

##### Observations so far
- The error messages from pydantic are pretty verbose; until one is familiar with them, the custom messages are often more helpful
- So far I am not adding validation in new places and do not intend to; this is just a refactor of existing validation. There is a separate question of whether it is actually a good idea to do this much runtime validation: another option is to simply delete these checks and spend more time debugging when it goes wrong...
- Pydantic really encourages you to work with dataclasses. Dataclasses work best with simple public attributes, so this has encouraged me to make some needlessly private attributes public.
- It is possible to pull an initialisation argument into a private attribute with a little extra work: see what happens to "data" in SData.
- Or we can just apply `@validate_call` to `__init__` and ignore the "Model" concept; see abins.abinsdata
- As such, many of the lines of this diff consist of removing underscores or replacing a test for TypeError/ValueError with a test for ValidationError
- In some parts of the modified code, I remove a check from the middle of some data-shuffling or file writing, because the check now happens earlier. Seems healthy.

#### Purpose of work
Improve maintainability with cleaner, more concise runtime checks.

#### Alternatives
[beartype](https://github.com/beartype/beartype) prioritises performance over strictness and the docs are more entertaining than pydantic's

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
