### PR TITLE
32679 fixed FindPeaks crash when the number of bins are not sufficient

### DIFF
--- a/Framework/Algorithms/src/FindPeaks.cpp
+++ b/Framework/Algorithms/src/FindPeaks.cpp
@@ -403,6 +403,13 @@ void FindPeaks::findPeaksUsingMariscotti() {
   if (!(w % 2))
     ++w;
 
+  if (!m_dataWS->isRaggedWorkspace() && m_dataWS->blocksize() <= w) {
+    std::stringstream errss;
+    errss << "Block size of the workspace should be greater than:" << w;
+    g_log.warning(errss.str());
+    throw std::runtime_error(errss.str());
+  }
+
   smoothData(smoothedData, w, g_z);
 
   // Now calculate the errors on the smoothed data

--- a/Framework/Algorithms/src/FindPeaks.cpp
+++ b/Framework/Algorithms/src/FindPeaks.cpp
@@ -403,7 +403,7 @@ void FindPeaks::findPeaksUsingMariscotti() {
   if (!(w % 2))
     ++w;
 
-  if (!m_dataWS->isRaggedWorkspace() && m_dataWS->blocksize() <= w) {
+  if (!m_dataWS->isRaggedWorkspace() && (m_dataWS->blocksize() <= static_cast<size_t>(w))) {
     std::stringstream errss;
     errss << "Block size of the workspace should be greater than:" << w;
     g_log.warning(errss.str());

--- a/Framework/Algorithms/src/FindPeaks.cpp
+++ b/Framework/Algorithms/src/FindPeaks.cpp
@@ -406,7 +406,6 @@ void FindPeaks::findPeaksUsingMariscotti() {
   if (!m_dataWS->isRaggedWorkspace() && (m_dataWS->blocksize() <= static_cast<size_t>(w))) {
     std::stringstream errss;
     errss << "Block size of the workspace should be greater than:" << w;
-    g_log.warning(errss.str());
     throw std::runtime_error(errss.str());
   }
 

--- a/Framework/Algorithms/test/FindPeaksTest.h
+++ b/Framework/Algorithms/test/FindPeaksTest.h
@@ -302,6 +302,20 @@ public:
     AnalysisDataService::Instance().remove(WKSP_NAME_OUTPUT);
   }
 
+  void testWhenSingleBinWs() {
+    MatrixWorkspace_sptr dataws = WorkspaceCreationHelper::create2DWorkspace(10, 1);
+    std::string wsName("SingleBinTestData");
+    AnalysisDataService::Instance().addOrReplace(wsName, dataws);
+    FindPeaks finder;
+    finder.setRethrows(true);
+
+    if (!finder.isInitialized())
+      finder.initialize();
+    TS_ASSERT_THROWS_NOTHING(finder.setPropertyValue("InputWorkspace", wsName));
+    TS_ASSERT_THROWS_NOTHING(finder.setPropertyValue("PeaksList", "peakslist"));
+    TSM_ASSERT_THROWS("Block size is not sufficient to run FindSXPeaks", finder.execute(), std::runtime_error &);
+  }
+
   //----------------------------------------------------------------------------------------------
   /** Parse a row in output parameter tableworkspace to a string/double
    * parameter name/value map

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -208,8 +208,8 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetEiMonDet
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FilterEvents.cpp:620
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FilterEvents.cpp:304
 shadowVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetDetectorOffsets.cpp:148
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FindPeaks.cpp:886
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FindPeaks.cpp:993
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FindPeaks.cpp:892
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FindPeaks.cpp:1000
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetEi2.cpp:213
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/MaskBinsIf.cpp:107
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GeneratePeaks.cpp:662

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -208,7 +208,7 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetEiMonDet
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FilterEvents.cpp:620
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FilterEvents.cpp:304
 shadowVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetDetectorOffsets.cpp:148
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FindPeaks.cpp:892
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FindPeaks.cpp:893
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FindPeaks.cpp:1000
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetEi2.cpp:213
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/MaskBinsIf.cpp:107

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -208,8 +208,8 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetEiMonDet
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FilterEvents.cpp:620
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FilterEvents.cpp:304
 shadowVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetDetectorOffsets.cpp:148
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FindPeaks.cpp:893
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FindPeaks.cpp:1000
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FindPeaks.cpp:892
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FindPeaks.cpp:999
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetEi2.cpp:213
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/MaskBinsIf.cpp:107
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GeneratePeaks.cpp:662

--- a/docs/source/release/v6.10.0/Framework/Algorithms/Bugfixes/32679.rst
+++ b/docs/source/release/v6.10.0/Framework/Algorithms/Bugfixes/32679.rst
@@ -1,0 +1,1 @@
+- Fixed a crash in :ref:`FindPeaks <algm-FindPeaks>` when the number of bins in the workspace are not sufficient to run SmoothData:ref:`algm-SmoothData` algorithm and raise the error instead.


### PR DESCRIPTION
### Description of work
Fixed a crash on `FindPeaks` algorithm when run on histograms containing a single bin by raising an error message on this condition.

Fixes #32679. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1. Run the below code and the algorithm should not crash instead should throw a meaningful error
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws = CreateWorkspace(OutputWorkspace='test', DataX='1', DataY='0,0,0,2,5,2,0,0,0,0', NSpec=10)

peaks_ws = FindPeaks(ws)
```

2. Errors should be raised even when the `FindPeaks` algorithm is run from Algorithms window on a similar workspace without crashing the workbench.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
