### PR TITLE
Fix bugs when exporting MD Histo cuts workspaces in sliceviewer

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/SliceViewer/Bugfixes/36084.rst
+++ b/docs/source/release/v6.10.0/Workbench/SliceViewer/Bugfixes/36084.rst
@@ -1,0 +1,1 @@
+- Fixed a bug that happens when exporting ROI cuts in MDHisto workspace.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -676,14 +676,16 @@ def _dimension_limits(
     :param limits: An optional Sequence of length 2 containing limits for plotting dimensions. If
                     not provided the full extent of each dimension is used.
     """
-    dims = [workspace.getDimension(i) for i in range(workspace.getNumDims())]
-    dim_limits = [(dim.getMinimum(), dim.getMaximum()) for dim in dims]
-    dim_width = [dim.getBinWidth() for dim in dims]
-    for idim, (dim_min, dim_max) in enumerate(dim_limits):
+    dim_limits = []
+
+    for idim in range(workspace.getNumDims()):
+        dim = workspace.getDimension(idim)
+        dim_min = dim.getMinimum()
+        dim_max = dim.getMaximum()
         slice_pt = slicepoint[idim]
         if slice_pt is not None:
             # replace extents with integration limits (calc from bin width in bin_params)
-            half_bin_width = bin_params[idim] / 2 if bin_params is not None else dim_width[idim] / 2
+            half_bin_width = bin_params[idim] / 2 if bin_params is not None else dim.getBinWidth() / 2
             dim_min, dim_max = (slice_pt - half_bin_width, slice_pt + half_bin_width)
         elif limits is not None and dimension_indices[idim] is not None:
             # replace min/max of non-integrated dims with limits from ROI if specified
@@ -692,7 +694,8 @@ def _dimension_limits(
         # check all limits are over minimum width
         if dim_max - dim_min < MIN_WIDTH:
             dim_max = dim_min + MIN_WIDTH
-        dim_limits[idim] = (dim_min, dim_max)
+        dim_limits.append((dim_min, dim_max))
+
     return dim_limits
 
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -676,12 +676,14 @@ def _dimension_limits(
     :param limits: An optional Sequence of length 2 containing limits for plotting dimensions. If
                     not provided the full extent of each dimension is used.
     """
-    dim_limits = [(dim.getMinimum(), dim.getMaximum()) for dim in [workspace.getDimension(i) for i in range(workspace.getNumDims())]]
+    dims = [workspace.getDimension(i) for i in range(workspace.getNumDims())]
+    dim_limits = [(dim.getMinimum(), dim.getMaximum()) for dim in dims]
+    dim_width = [dim.getBinWidth() for dim in dims]
     for idim, (dim_min, dim_max) in enumerate(dim_limits):
         slice_pt = slicepoint[idim]
         if slice_pt is not None:
             # replace extents with integration limits (calc from bin width in bin_params)
-            half_bin_width = bin_params[idim] / 2
+            half_bin_width = bin_params[idim] / 2 if bin_params is not None else dim_width[idim] / 2
             dim_min, dim_max = (slice_pt - half_bin_width, slice_pt + half_bin_width)
         elif limits is not None and dimension_indices[idim] is not None:
             # replace min/max of non-integrated dims with limits from ROI if specified

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -685,7 +685,7 @@ class SliceViewerModelTest(unittest.TestCase):
         dimension_indices = [0, 1, None]  # Value at index i is the index of the axis that dimension i is displayed on
         transposed_dimension_indices = [1, 0, None]
 
-        def assert_call_as_expected(transpose, dimension_indices, export_type):
+        def assert_call_as_expected(transpose, dimension_indices, export_type, bin_params):
             model = SliceViewerModel(self.ws_MD_3D)
 
             if export_type == "r":
@@ -722,6 +722,9 @@ class SliceViewerModelTest(unittest.TestCase):
                     out_name = "ws_MD_3D_roi"
                     transpose_axes = [1, 0] if transpose else None
 
+                dim = self.ws_MD_3D.getDimension(2)
+                half_bin_width = bin_params[2] / 2 if bin_params is not None else dim.getBinWidth() / 2
+
                 # check call to IntegrateMDHistoWorkspace
                 mock_intMD.assert_has_calls(
                     [
@@ -729,7 +732,7 @@ class SliceViewerModelTest(unittest.TestCase):
                             InputWorkspace=self.ws_MD_3D,
                             P1Bin=p1_bin,
                             P2Bin=p2_bin,
-                            P3Bin=[slicepoint[2] - bin_params[2] / 2, slicepoint[2] + bin_params[2] / 2],
+                            P3Bin=[slicepoint[2] - half_bin_width, slicepoint[2] + half_bin_width],
                             OutputWorkspace=out_name,
                         )
                     ],
@@ -746,8 +749,14 @@ class SliceViewerModelTest(unittest.TestCase):
             mock_transposemd.reset_mock()
 
         for export_type in ("r", "x", "y", "c"):
-            assert_call_as_expected(transpose=False, dimension_indices=dimension_indices, export_type=export_type)
-            assert_call_as_expected(transpose=True, dimension_indices=transposed_dimension_indices, export_type=export_type)
+            assert_call_as_expected(transpose=False, dimension_indices=dimension_indices, export_type=export_type, bin_params=bin_params)
+            assert_call_as_expected(transpose=False, dimension_indices=dimension_indices, export_type=export_type, bin_params=None)
+            assert_call_as_expected(
+                transpose=True, dimension_indices=transposed_dimension_indices, export_type=export_type, bin_params=bin_params
+            )
+            assert_call_as_expected(
+                transpose=True, dimension_indices=transposed_dimension_indices, export_type=export_type, bin_params=None
+            )
 
     @patch("mantidqt.widgets.sliceviewer.models.model.TransposeMD")
     @patch("mantidqt.widgets.sliceviewer.models.model.BinMD")


### PR DESCRIPTION
### Description of work
This PR fixes several bugs that happen when exporting 3D MD Histo workspaces in sliceviewer. For more details check #36084

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a GitHub issue is referenced below
-->
Fixes part of #36084. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
The issue was that `bin_params` is None when the workspace is MD Histo workspace. I handled this case by setting the bin width to the dim bin width when the `bin_params` is None. 
### To test:
Follow #36084
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
