### PR TITLE
Fix a bug in the pairings table of the Muon Analysis interface

### DIFF
--- a/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/37254.rst
+++ b/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/37254.rst
@@ -1,0 +1,1 @@
+- Fixed a bug that can crashed Mantid  in the groupings or difference tables of the groupings tab. The crashed occurred when you deleted any rows other than the last one from the table and then clicked on the interactive widgets of the remainings rows of the table.

--- a/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/37254.rst
+++ b/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/37254.rst
@@ -1,1 +1,1 @@
-- Fixed a bug that can crashed Mantid  in the groupings or difference tables of the groupings tab. The crashed occurred when you deleted any rows other than the last one from the table and then clicked on the interactive widgets of the remainings rows of the table.
+- Fixed a bug affecting the pairing and the difference tables of the groupings tab in the Muon Analysis Interface. The bug can crash Mantid if after deleting any rows other than the last one from the table, the `Alpha Guess` button or the `Group 1`, `Group 2` combo boxes are clicked.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/difference_table_widget/difference_table_widget_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/difference_table_widget/difference_table_widget_view.py
@@ -207,7 +207,7 @@ class DifferenceTableView(QtWidgets.QWidget):
 
     def on_cell_changed(self, row, column):
         if not self._updating:
-            if not isinstance(self.sender(), QtWidgets.QTableWidget):
+            if not (isinstance(self.sender(), QtWidgets.QTableWidget) or self.sender().pos().isNull()):
                 pos_index = self.diff_table.indexAt(self.sender().pos())
                 row = pos_index.row()
                 column = pos_index.column()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/difference_table_widget/difference_table_widget_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/difference_table_widget/difference_table_widget_view.py
@@ -33,7 +33,7 @@ class DifferenceTableView(QtWidgets.QWidget):
         # Table entry validation
         self._validate_diff_name_entry = lambda text: True
 
-        self._on_table_data_changed = lambda: 0
+        self._on_table_data_changed = lambda row, column: 0
 
         # The active groups that can be selected from the group combo box
         self._group_selections = []
@@ -205,9 +205,13 @@ class DifferenceTableView(QtWidgets.QWidget):
         if not self._updating:
             pass
 
-    def on_cell_changed(self, _row, _col):
+    def on_cell_changed(self, row, column):
         if not self._updating:
-            self._on_table_data_changed(_row, _col)
+            if not isinstance(self.sender(), QtWidgets.QTableWidget):
+                pos_index = self.diff_table.indexAt(self.sender().pos())
+                row = pos_index.row()
+                column = pos_index.column()
+            self._on_table_data_changed(row, column)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Context Menu

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
@@ -34,7 +34,7 @@ class PairingTableView(QtWidgets.QWidget):
         self._validate_pair_name_entry = lambda text: True
         self._validate_alpha = lambda text: True
 
-        self._on_table_data_changed = lambda: 0
+        self._on_table_data_changed = lambda row, column: 0
         self._on_guess_alpha_clicked = lambda row: 0
 
         # The active groups that can be selected from the group combo box
@@ -183,7 +183,7 @@ class PairingTableView(QtWidgets.QWidget):
             self.pairing_table.setItem(row_position, i, item)
         # guess alpha button
         guess_alpha_widget = self._guess_alpha_button()
-        guess_alpha_widget.clicked.connect(lambda: self.guess_alpha_clicked_from_row(row_position))
+        guess_alpha_widget.clicked.connect(self.guess_alpha_clicked_from_row)
         self.pairing_table.setCellWidget(row_position, 5, guess_alpha_widget)
 
     def _group_selection_cell_widget(self):
@@ -200,8 +200,8 @@ class PairingTableView(QtWidgets.QWidget):
         guess_alpha.setText("Guess")
         return guess_alpha
 
-    def guess_alpha_clicked_from_row(self, row):
-        self._on_guess_alpha_clicked(row)
+    def guess_alpha_clicked_from_row(self):
+        self._on_guess_alpha_clicked(self.pairing_table.currentIndex().row())
 
     def get_table_contents(self):
         if self._updating:
@@ -252,14 +252,18 @@ class PairingTableView(QtWidgets.QWidget):
     def on_table_data_changed(self, slot):
         self._on_table_data_changed = slot
 
-    def on_item_changed(self):
+    def on_item_changed(self, item):
         """Not yet implemented."""
         if not self._updating:
             pass
 
-    def on_cell_changed(self, _row, _col):
+    def on_cell_changed(self, row, column):
         if not self._updating:
-            self._on_table_data_changed(_row, _col)
+            if not isinstance(self.sender(), QtWidgets.QTableWidget):
+                pos_index = self.pairing_table.indexAt(self.sender().pos())
+                row = pos_index.row()
+                column = pos_index.column()
+            self._on_table_data_changed(row, column)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Context Menu

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
@@ -259,7 +259,7 @@ class PairingTableView(QtWidgets.QWidget):
 
     def on_cell_changed(self, row, column):
         if not self._updating:
-            if not isinstance(self.sender(), QtWidgets.QTableWidget):
+            if not (isinstance(self.sender(), QtWidgets.QTableWidget) or self.sender().pos().isNull()):
                 pos_index = self.pairing_table.indexAt(self.sender().pos())
                 row = pos_index.row()
                 column = pos_index.column()

--- a/qt/python/mantidqtinterfaces/test/Muon/grouping_tab/difference_table_selector_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/grouping_tab/difference_table_selector_test.py
@@ -190,14 +190,14 @@ class DifferenceTablePresenterTest(unittest.TestCase):
         self.presenter.group_widget.handle_add_diff_button_clicked()
 
         self.assertEqual(2, self.get_group_1_selector_from_diff(0).count())
-        self.assertEqual(2, self.get_group_1_selector_from_diff(0).count())
+        self.assertEqual(2, self.get_group_2_selector_from_diff(0).count())
         self.assertEqual("group_0", self.get_group_1_selector_from_diff(0).currentText())
         self.assertEqual("group_1", self.get_group_2_selector_from_diff(0).currentText())
 
         self.get_group_1_selector_from_diff(0).setCurrentIndex(1)
 
         self.assertEqual(2, self.get_group_1_selector_from_diff(0).count())
-        self.assertEqual(2, self.get_group_1_selector_from_diff(0).count())
+        self.assertEqual(2, self.get_group_2_selector_from_diff(0).count())
         self.assertEqual("group_1", self.get_group_1_selector_from_diff(0).currentText())
         self.assertEqual("group_0", self.get_group_2_selector_from_diff(0).currentText())
 


### PR DESCRIPTION
### Description of work
This PR fixes a bug occurring whenever you remove any row other than the last row from the pairings table of the groupings tab in the Muon Analysis interface and then click on the alpha guess button of the remaining rows.  
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
The bug was more pervasive than just the `Guess Alpha` button, it also affected the `Group 1` and `Group 2` columns where there are combo boxes and equivalent columns (`Pair 1 ` and `Pair 2`) in the differences table, just below the pairings table.  This was ocurring because the lambda connecting the custom widget elements in those columns (either QComboBox or QPushButton) was not really passing correct parameters at runtime, as the signal sent from those buttons does not contain information about the rows and columns (other than when they are created). Therefore, whenever a row is removed, the table indexes that are sent by the signals are wrong. 
I have tried to go for a safer solution. In this case the slot function that responds to the calls from the cells is checking whether the sender is an instance of the table or any other widget, and retrieving the right coordinates in either case. 

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37254  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Follow test instructions in #37254. Check that the problem is also not there with the `Group 1` and `Group 2` columns. 
- Follow test instructions on the difference table with `Pair 1` and `Pair 2` columns (just below the pairing table). 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

_Added release notes_
<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
