### PR TITLE
Remove unused code and explicitly cast to double

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideInt.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideInt.h
@@ -22,10 +22,12 @@
  * without express or implied warranty.
  */
 
+#include <charconv>
 #include <climits> // CHAR_BIT
 #include <cmath>
 #include <cstdint>
 #include <iomanip>
+#include <ios>
 #include <limits>
 #include <ostream>
 #include <random>

--- a/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideInt.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideInt.h
@@ -22,12 +22,10 @@
  * without express or implied warranty.
  */
 
-#include <charconv>
 #include <climits> // CHAR_BIT
 #include <cmath>
 #include <cstdint>
 #include <iomanip>
-#include <ios>
 #include <limits>
 #include <ostream>
 #include <random>
@@ -262,24 +260,6 @@ std::wostream &operator<<(std::wostream &out, const wide_integer<Bits, Signed> &
 template <size_t Bits, typename Signed> std::istream &operator>>(std::istream &in, wide_integer<Bits, Signed> &n);
 
 template <size_t Bits, typename Signed> std::wistream &operator>>(std::wistream &in, wide_integer<Bits, Signed> &n);
-
-//// Must be defined in another header
-struct to_chars_result {
-  char *ptr;
-  std::error_code ec;
-};
-
-struct from_chars_result {
-  const char *ptr;
-  std::error_code ec;
-};
-////
-
-template <size_t Bits, typename Signed>
-to_chars_result to_chars(char *first, char *last, const wide_integer<Bits, Signed> &value, int base = 10);
-
-template <size_t Bits, typename Signed>
-from_chars_result from_chars(const char *first, const char *last, wide_integer<Bits, Signed> &value, int base = 10);
 
 inline namespace literals {
 inline namespace wide_integer_literals {

--- a/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideIntImpl.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideIntImpl.h
@@ -10,7 +10,9 @@
 
 #include <algorithm>
 #include <array>
+#include <charconv>
 #include <cstring>
+#include <ios>
 #include <iterator>
 #include <numeric>
 
@@ -180,8 +182,8 @@ template <size_t Bits, typename Signed> struct wide_integer<Bits, Signed>::_impl
   }
 
   constexpr static void wide_integer_from_bultin(wide_integer<Bits, Signed> &self, double rhs) noexcept {
-    if ((rhs > 0 && rhs < std::numeric_limits<uint64_t>::max()) ||
-        (rhs < 0 && rhs > std::numeric_limits<int64_t>::min())) {
+    if ((rhs > 0 && rhs < static_cast<double>(std::numeric_limits<uint64_t>::max())) ||
+        (rhs < 0 && rhs > static_cast<double>(std::numeric_limits<int64_t>::min()))) {
       self = to_Integral(rhs);
       return;
     }

--- a/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideIntImpl.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideIntImpl.h
@@ -10,9 +10,7 @@
 
 #include <algorithm>
 #include <array>
-#include <charconv>
 #include <cstring>
-#include <ios>
 #include <iterator>
 #include <numeric>
 
@@ -1308,49 +1306,6 @@ template <size_t Bits, typename Signed> std::wistream &operator>>(std::wistream 
   return in;
 }
 
-template <size_t Bits, typename Signed>
-to_chars_result to_chars(char *first, char *last, const wide_integer<Bits, Signed> &value, int base) {
-  if (base < 2 || base > 36) {
-    return {last, std::make_error_code(std::errc::invalid_argument)};
-  }
-  if (first >= last) {
-    return {last, std::make_error_code(std::errc::invalid_argument)};
-  }
-
-  if (value == 0) {
-    *first = '0';
-    *(++first) = '\0';
-    return {++first, {}};
-  }
-
-  wide_integer<Bits, Signed> v = value;
-  if (v < 0) {
-    v = -v;
-    *(first++) = '-';
-  }
-
-  char *cur = last;
-
-  while (v != 0 && --cur >= first) {
-    static const char ALPHA[] = "0123456789abcdefghijklmnopqrstuvwxyz";
-    *cur = ALPHA[v % base];
-    v /= base;
-  }
-
-  if (v && cur + 1 == first) {
-    return {nullptr, std::make_error_code(std::errc::value_too_large)};
-  }
-
-  while (cur < last) {
-    *(first++) = *(cur++);
-  }
-  if (first < last) {
-    *first = '\0';
-  }
-
-  return {first, {}};
-}
-
 std::array<char, 256> inline genReverseAlpha() noexcept {
   static const char ALPHA[] = "0123456789abcdefghijklmnopqrstuvwxyz";
   std::array<char, 256> res;
@@ -1359,48 +1314,6 @@ std::array<char, 256> inline genReverseAlpha() noexcept {
     res[ALPHA[i]] = static_cast<char>(i);
   }
   return res;
-}
-
-template <size_t Bits, typename Signed>
-from_chars_result from_chars(const char *first, const char *last, wide_integer<Bits, Signed> &value, int base) {
-  if (base < 2 || base > 36) {
-    return {first, std::make_error_code(std::errc::invalid_argument)};
-  }
-  if (first >= last) {
-    return {first, std::make_error_code(std::errc::invalid_argument)};
-  }
-
-  bool is_negative = *first == '-';
-  if (is_negative) {
-    if (!is_same<Signed, signed>::value) {
-      return {first, std::make_error_code(std::errc::result_out_of_range)};
-    }
-    if (++first >= last) {
-      return {first, std::make_error_code(std::errc::invalid_argument)};
-    }
-  }
-
-  wide_integer<Bits, Signed> v = 0;
-  const char *cur = first;
-
-  do {
-    static const std::array<char, 256> ALPHA = genReverseAlpha();
-    char cv = ALPHA[*cur];
-    if (cv >= base || cv == -1) {
-      if (cur == first) {
-        return {cur, std::make_error_code(std::errc::result_out_of_range)};
-      } else {
-        value = v;
-        return {cur, {}};
-      }
-    }
-
-    v *= base;
-    v += cv;
-  } while (++cur < last);
-
-  value = is_negative ? -v : v;
-  return {cur, {}};
 }
 
 constexpr int128_t operator"" _cppi128(const char *n) { return int128_t::_impl::from_str(n); }

--- a/Framework/DataObjects/test/MDLeanEventTest.h
+++ b/Framework/DataObjects/test/MDLeanEventTest.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "MantidDataObjects/MDLeanEvent.h"
-#include "MantidDataObjects/MortonIndex/WideInt.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/Timer.h"
 #include <cxxtest/TestSuite.h>

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -51,7 +51,7 @@ dependencies:
   - black  # may be out of sync with pre-commit
   - cppcheck==2.13.1
   - pre-commit>=2.12.0
-  - libcxx<17 #Had to pin as there is an issue with 'to_chars_result'
+  - libcxx
   - joblib
   - orsopy==1.2.0 # Fix the version to avoid updates being pulled in automatically, which might change the Reflectometry ORSO file content or layout and cause tests to fail.
 

--- a/qt/widgets/common/test/AlgorithmRunnerTest.h
+++ b/qt/widgets/common/test/AlgorithmRunnerTest.h
@@ -29,6 +29,8 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm() {
   return configuredAlg;
 }
 
+} // namespace
+
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockAlgorithmRunnerSubscriber : public IAlgorithmRunnerSubscriber {
@@ -48,8 +50,6 @@ MATCHER(CheckAlgorithmNull, "Check the algorithm is a nullptr") { return !arg; }
 MATCHER_P(CheckQueueSize, size, "Check the size of a std::deque") { return arg.size() == size; }
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-
-} // namespace
 
 class AlgorithmRunnerTest : public CxxTest::TestSuite {
 public:


### PR DESCRIPTION
### Description of work
This PR attempts to fix the warnings here
https://builds.mantidproject.org/job/pull_requests-conda-osx/5801/console

*There is no associated issue.*
Fixes #37281
### To test:
Check this passes the OSX job
Code review

*This does not require release notes* because **its an internal change**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
