### PR TITLE
Fix casting warnings in core team code

### DIFF
--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -999,7 +999,7 @@ void LoadRawHelper::calculateWorkspacesizes(const std::vector<specnum_t> &monito
     if (m_interval) {
       const auto msize = std::count_if(monitorSpecList.cbegin(), monitorSpecList.cend(),
                                        [&](const auto &spec) { return (spec >= m_spec_min && spec < m_spec_max); });
-      monitorwsSpecs = msize;
+      monitorwsSpecs = static_cast<specnum_t>(msize);
       normalwsSpecs = m_total_specs - monitorwsSpecs;
       g_log.debug() << "normalwsSpecs when  m_interval true is  " << normalwsSpecs << "  monitorwsSpecs is "
                     << monitorwsSpecs << '\n';

--- a/Framework/DataHandling/src/SaveISISNexus.cpp
+++ b/Framework/DataHandling/src/SaveISISNexus.cpp
@@ -313,9 +313,10 @@ int SaveISISNexus::saveStringVectorOpen(const char *name, const std::vector<std:
   }
   int buff_size = max_str_size;
   if (buff_size <= 0) {
-    buff_size = std::max_element(str_vec.cbegin(), str_vec.cend(), [](const auto &a, const auto &b) {
-                  return a.size() < b.size();
-                })->size();
+    const auto max_size = std::max_element(str_vec.cbegin(), str_vec.cend(), [](const auto &a, const auto &b) {
+                            return a.size() < b.size();
+                          })->size();
+    buff_size = boost::numeric_cast<int>(max_size);
   }
   if (buff_size <= 0)
     buff_size = 1;

--- a/Framework/DataHandling/src/SaveISISNexus.cpp
+++ b/Framework/DataHandling/src/SaveISISNexus.cpp
@@ -694,12 +694,13 @@ void SaveISISNexus::sample() {
   saveString("id", " ");
   float tmp(0.0);
   saveFloat("distance", &tmp, 1);
-  std::string shape[] = {"cylinder", "flat plate", "HRPD slab", "unknown"};
+  const std::string shape[] = {"cylinder", "flat plate", "HRPD slab", "unknown"};
   int i = m_isisRaw->spb.e_geom - 1;
   if (i < 0 || i > 3)
     i = 3;
   saveString("shape", shape[i]);
-  std::string type[] = {"sample+can", "empty can", "vanadium", "absorber", "nothing", "sample, no can", "unknown"};
+  const std::string type[] = {"sample+can", "empty can",      "vanadium", "absorber",
+                              "nothing",    "sample, no can", "unknown"};
   i = m_isisRaw->spb.e_type - 1;
   if (i < 0 || i > 6)
     i = 6;

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -706,13 +706,11 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNexus
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNexusProcessed.cpp:1179
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNexusProcessed.cpp:1965
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNexusProcessed.cpp:425
-shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveISISNexus.cpp:389
 shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveISISNexus.cpp:390
-shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveISISNexus.cpp:599
-shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveISISNexus.cpp:610
+shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveISISNexus.cpp:391
+shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveISISNexus.cpp:600
 shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveISISNexus.cpp:611
-constVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveISISNexus.cpp:696
-constVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveISISNexus.cpp:701
+shadowVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveISISNexus.cpp:612
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCanSAS1D.cpp:32
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCanSAS1D.cpp:397
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCanSAS1D2.cpp:24


### PR DESCRIPTION
### Description of work

Fix a couple warnings that have slipped through:

```
10:12:37 /Users/mantidbuilder/Jenkins/workspace/pull_requests-conda-osx/Framework/DataHandling/src/LoadRawHelper.cpp:1002:24: warning: implicit conversion loses integer precision: 'const typename iterator_traits<__wrap_iter<const int *>>::difference_type' (aka 'const long') to 'Mantid::specnum_t' (aka 'int') [-Wshorten-64-to-32]
10:12:37       monitorwsSpecs = msize;
10:12:37                      ~ ^~~~~
10:12:37 1 warning generated.
```

```
10:14:19 /Users/mantidbuilder/Jenkins/workspace/pull_requests-conda-osx/Framework/DataHandling/src/SaveISISNexus.cpp:318:21: warning: implicit conversion loses integer precision: 'std::basic_string<char>::size_type' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]
10:14:19                 })->size();
10:14:19                 ~~~~^~~~~~
10:14:19 1 warning generated.
```

*There is no associated issue.*

### To test:

- Tests pass
- Check for warnings in the builds of these files

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
