### PR TITLE
Improve the disable usage reporting dialogue 

### DIFF
--- a/qt/applications/workbench/workbench/widgets/about/usage_verification_view.py
+++ b/qt/applications/workbench/workbench/widgets/about/usage_verification_view.py
@@ -14,7 +14,7 @@ class UsageReportingVerificationView(QDialog):
         super(UsageReportingVerificationView, self).__init__(parent)
         self.presenter = presenter
 
-        self.setWindowTitle("Mantid: Report Usage Data ")
+        self.setWindowTitle("Mantid: Disable Usage Data Reporting")
         parentLayout = QHBoxLayout()
 
         # left side
@@ -46,11 +46,9 @@ class UsageReportingVerificationView(QDialog):
         labelInformation = QLabel(self)
         labelInformation.setText(
             "All usage data is anonymous and untraceable.\n"
-            + "We use the usage data to inform the future development of Mantid.\n"
-            + 'If you click "Yes" aspects you need risk being deprecated in \n'
-            + "future versions if we think they are not used.\n\n"
-            + "Are you sure you still want to disable reporting usage data?\n"
-            + 'Please click "No".'
+            "We use the usage data to inform the future development of Mantid.\n\n"
+            "Disabling usage reporting means features you need risk being deprecated in\n"
+            "future versions if we think they are not used."
         )
         textLayout.addWidget(labelInformation)
 


### PR DESCRIPTION
### Description of work

Updated the title and body text of this dialogue to make it less confusing. Now hopefully it should look like one questions, with a bit of context on why we'd like the user to keep the service turned on. No more `Please click "No"`.

Fixes #35573

### To test:

- On the 'about mantidworkbench' page, disable the usage reporting check box. 
- Read the dialogue and make sure it makes sense

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
