### PR TITLE
Treat Doxygen warnings as errors

### DIFF
--- a/Framework/API/src/ADSValidator.cpp
+++ b/Framework/API/src/ADSValidator.cpp
@@ -32,6 +32,7 @@ bool ADSValidator::isOptional() const { return m_isOptional; }
 void ADSValidator::setOptional(const bool setOptional) { m_isOptional = setOptional; }
 
 /** Checks if the string passed is in the ADS, or if all members are in the ADS
+ *  @param test_for_warning :: This parameter does not exist, expect warning
  *  @param value :: The value to test
  *  @return "" if the value is on the list, or "The workspace is not in the
  * workspace list"

--- a/Framework/API/src/ADSValidator.cpp
+++ b/Framework/API/src/ADSValidator.cpp
@@ -32,7 +32,6 @@ bool ADSValidator::isOptional() const { return m_isOptional; }
 void ADSValidator::setOptional(const bool setOptional) { m_isOptional = setOptional; }
 
 /** Checks if the string passed is in the ADS, or if all members are in the ADS
- *  @param test_for_warning :: This parameter does not exist, expect warning
  *  @param value :: The value to test
  *  @return "" if the value is on the list, or "The workspace is not in the
  * workspace list"

--- a/Framework/Doxygen/Mantid_template.doxyfile
+++ b/Framework/Doxygen/Mantid_template.doxyfile
@@ -73,6 +73,7 @@ WARN_IF_DOC_ERROR      = YES
 WARN_NO_PARAMDOC       = YES
 WARN_FORMAT            = @DOXY_WARN_FORMAT@
 WARN_LOGFILE           =
+WARN_AS_ERROR          = YES
 #---------------------------------------------------------------------------
 # configuration options related to the input files
 #---------------------------------------------------------------------------


### PR DESCRIPTION
### Description of work

#### Summary of work
Doxygen warnings are now treated as errors after setting the corresponding flag in Framework/Doxygen/Mantid_template.doxyfile.

Fixes #37298.

### To test:

As there are no genuine Doxygen warnings at the moment, I created a temporary commit to trigger a Doxygen warning: [Added temporary modification to trigger warning](https://github.com/mantidproject/mantid/pull/37302/commits/4fdcf70953ba35c40c407110a878e99eb78324c4)

Please check that the Doxygen pipeline failed for this commit, but was successful after removing it in the next (and final) commit for this branch.

*This does not require release notes* because **it is a change to the Doxygen pipeline and not user facing.**


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
