### PR TITLE
Only add new extents on SliceViewerDataView if requested

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
@@ -15,10 +15,10 @@ from mantidqt.widgets.sliceviewer.views.dataview import SliceViewerDataView
 class RegionSelectorView(QWidget):
     """The view for the data portion of the sliceviewer"""
 
-    def __init__(self, presenter, parent=None, dims_info=None, image_info_widget=None):
+    def __init__(self, presenter, parent=None, dims_info=None, image_info_widget=None, add_extents=False):
         super().__init__(parent)
         self.setWindowFlags(Qt.Window)
-        self._data_view = SliceViewerDataView(presenter, dims_info, None, self, None, image_info_widget)
+        self._data_view = SliceViewerDataView(presenter, dims_info, None, self, None, image_info_widget, add_extents)
         self._data_view.help_button.hide()
 
         layout = QHBoxLayout(self)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
@@ -384,6 +384,10 @@ class SliceviewerDataViewTest(unittest.TestCase):
         self.assertAlmostEqual(y_min, -1.5, 9)
         self.assertAlmostEqual(y_max, 2.0, 9)
 
+    def test_extents_not_created_if_not_requested(self):
+        view = SliceViewerDataView(presenter=self.presenter, dims_info=mock.MagicMock(), can_normalise=mock.Mock(), add_extents=False)
+        self.assertIsNone(view.extents)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Makes the new extents added to the `SliceViewerDataView` in PR #37152 optional (although added by default) so that they can be excluded when being added to the ISIS Reflectometry Reduction Preview tab.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37300. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
I haven't exposed the option to exclude the extents all the way up to the ISIS Reflectometry preview tab code, as the `RegionSelector` is only being used in that tab at the moment. Instead I've just set it to exclude the extents by default and we can expose the option in the future if others want to use the widget and override the default behaviour.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
1) Load any INTER run into the workspace list.
1) Repeat the tests on the PR for the original change to ensure the main sliceviewer functionality hasn't been broken.
1) Go to the ISIS Reflectometry GUI and click on the Reduction Preview tab.
1) Follow the first few steps of the [Preview tab manual testing instructions](https://developer.mantidproject.org/Testing/ReflectometryGUI/ReflectometryGUITests.html#preview-tab) and check the slice viewer renders OK and the min/max x/y limit combo boxes do not display.

*This does not require release notes* because **it is an amendment to a change introduced since the last release.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
