### PR TITLE
Updates error reporter manual testing instructions

### DIFF
--- a/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ErrorReporterTesting.rst
+++ b/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ErrorReporterTesting.rst
@@ -32,16 +32,17 @@ Error Reporter test
 - Cause a crash by running the ``Segfault`` algorithm, Workbench should close
 - This should cause an error reporter dialog saying Mantid has thrown an unexpected exception
 - Make sure the hyperlink to the privacy policy works
-- Click the `Show More Details` button to open the Show More Details dialog. This should show user details such as OS.
+- Click the ``Show More Details`` button to open the Show More Details dialog. This should show user details such as OS.
   The python stacktrace should be empty as the Workbench unhandled exception occurred in C++. Close this dialog.
-- Enter some text in the `Name` box; make sure the `Share non-identifiable information` button gets greyed out
-- In the `Name` box enter `Private` and in the `Email` box enter `private`
+- Test that the ``Yes, share information`` is disabled and the ``Email`` box is outlined in red until a valid email
+  (``something@something.somthing``) is entered in the ``Email`` box.
+- In the ``Name`` box enter ``Private`` and in the ``Email`` box enter ``private@private.com``
 - Input some additional information into the main textbox. Check that the character count label updates as you type, copy paste etc.
-- Check that the character count label changes to red and the buttons to send the report are disabled if you exceed the character limit.
+- Check that the character count label changes to red and the button to send the report are disabled if you exceed the character limit.
 - Check that these changes revert when brining the number of characters back within the limit.
 - Input some additional information into the main textbox. Try to include characters that need to be escaped such as ``"``
-- Tick the `Remember Me` checkbox
-- Click the `Don't share any information` button
+- Tick the ``Remember Me`` checkbox
+- Click the ``Don't share any information`` button
 - Check with the database admin that an error report was **not** sent.
 
 ---------------
@@ -50,11 +51,11 @@ Error Reporter test
 
 - Cause a crash by running the ``Segfault`` algorithm, Workbench should close
 - This should cause an error reporter dialog saying Mantid has thrown an unexpected exception
-- The `Private` contact details from Test 1 should **NOT** be displayed and the `Remember Me` checkbox should **NOT** be ticked
-- In the `Name` box enter `Public` and in the `Email` box enter `public`
+- The private contact details from Test 1 should **NOT** be displayed and the ``Remember Me`` checkbox should **NOT** be ticked
+- In the ``Name`` box enter ``Public`` and in the ``Email`` box enter ``public@public.com``
 - Input some additional information into the main textbox. Try to include characters that need to be escaped such as ``"``
-- Tick the `Remember Me` checkbox
-- Click the `Yes, share information` button
+- Tick the ``Remember Me`` checkbox
+- Click the ``Yes, share information`` button
 - Check with the database admin that an error report was sent **WITH** the correct name, email and textbox.
 
 ---------------
@@ -64,13 +65,12 @@ Error Reporter test
 - Load the file ``Training_Exercise3a_SNS.nxs``
 - Run the ``NormaliseToMonitor`` algorithm
 - This should cause an error reporter dialog saying Mantid has thrown an unexpected exception
-- The `Public` contact details from Test 2 should be displayed and the `Remember Me` checkbox ticked
+- The shared contact details from test 2 should be displayed and the ``Remember Me`` checkbox ticked
 - Make sure the hyperlink to the privacy policy works
-- Enter some text in the `Name` box; make sure the `Share non-identifiable information` button gets greyed out
-- In the `Name` box enter `Private2` and in the `Email` box enter `private2`
+- In the ``Name`` box enter ``Private2`` and in the ``Email`` box enter ``private2@private.com``
 - Input some additional information into the main textbox. Try to include characters that need to be escaped such as ``"``
-- Make sure the `Continue` radio button is checked
-- Click the `Don't share any information` button
+- Make sure the ``Continue`` radio button is checked
+- Click the ``Don't share any information`` button
 - You should be returned to the main Mantid window
 - Check with the database admin that an error report was **not** sent.
 
@@ -81,15 +81,15 @@ Error Reporter test
 - Load the file ``Training_Exercise3a_SNS.nxs``
 - Run the ``NormaliseToMonitor`` algorithm
 - This should cause an error reporter dialog saying Mantid has thrown an unexpected exception
-- The `Public` contact details from Test 2 should be displayed and the `Remember Me` checkbox ticked
-- Click the `Show More Details` button to open the Show More Details dialog. This should show user details such as OS.
-  There should be a python stacktrace as this unhandled exception occurred in Python. Close this dialog.
+- The shared contact details from test 2 should be displayed and the ``Remember Me`` checkbox ticked
+- Click the ``Show More Details`` button to open the Show More Details dialog. This should show user details such as OS.
 - Input some additional information into the main textbox. Try to include characters that need to be escaped such as ``"``
-- This time, UNTick the `Remember Me` checkbox
-- Make sure the `Continue` radio button is checked
-- Click the `Share non-identifiable information` button
+- Leave the ``Name`` box EMPTY and in the ``Email`` box enter ``public2@public.com``
+- Tick the ``Remember Me`` checkbox
+- Make sure the ``Continue`` radio button is checked
+- Click the ``Yes, share information`` button
 - You should be returned to the main Mantid window
-- Check with the database admin that an error report was sent **without** a name, email or stacktrace, BUT **WITH** a textbox.
+- Check with the database admin that an error report was sent **WITH** a name, email, stacktrace and a textbox.
 
 ---------------
 
@@ -98,56 +98,40 @@ Error Reporter test
 - Load the file ``Training_Exercise3a_SNS.nxs``
 - Run the ``NormaliseToMonitor`` algorithm
 - This should cause an error reporter dialog saying Mantid has thrown an unexpected exception
-- Contact details from before should **NOT** be displayed and the `Remember Me` checkbox should **NOT** be ticked
-- Enter some text in the `Name` box; make sure the `Share non-identifiable information` button gets greyed out
+- Only the ``public2@public.com`` email from test 4 should be displayed in the email box and the ``Remember Me`` checkbox ticked.
+- In the `Name` box enter ``Public3`` and in the ``Email`` box enter ``public3@public.com``
 - Input some additional information into the main textbox. Try to include characters that need to be escaped such as ``"``
-- Leave the `Name` box EMPTY and in the `Email` box enter `public2`
-- Tick the `Remember Me` checkbox
-- Make sure the `Continue` radio button is checked
-- Click the `Yes, share information` button
-- You should be returned to the main Mantid window
-- Check with the database admin that an error report was sent **WITH** a name, email, stacktrace and a textbox.
-
----------------
-
-6. MantidWorkbench is still open
-
-- Load the file ``Training_Exercise3a_SNS.nxs``
-- Run the ``NormaliseToMonitor`` algorithm
-- This should cause an error reporter dialog saying Mantid has thrown an unexpected exception
-- Only the `public2` email from Test 5 should be displayed in the email box and the `Remember Me` checkbox ticked.
-  Make sure the `Share non-identifiable information` button is currently enabled (not greyed out)
-- Enter some text in the `Name` box; make sure the `Share non-identifiable information` button gets greyed out
-- In the `Name` box enter `Public3` and in the `Email` box enter `public3`
-- Input some additional information into the main textbox. Try to include characters that need to be escaped such as ``"``
-- Tick the `Remember Me` checkbox
-- Make sure the `Terminate` radio button is checked
-- Click the `Yes, share information` button
+- Tick the ``Remember Me`` checkbox
+- Make sure the ``Terminate`` radio button is checked
+- Click the ``Yes, share information`` button
 - Mantid should shut down
 - Check with the database admin that an error report was sent **WITH** a name, email, stacktrace and a textbox.
 
 --------------
 
-7. Open MantidWorkbench
+6. Open MantidWorkbench
 
 - Load the file ``Training_Exercise3a_SNS.nxs``
 - Run the ``NormaliseToMonitor`` algorithm
 - This should cause an error reporter dialog saying Mantid has thrown an unexpected exception
-- The `Public3` contact details from Test 6 should be displayed and the `Remember Me` checkbox ticked
+- The shared contact details from test 5 should be displayed and the ``Remember Me`` checkbox ticked
 - Close the error reporter and MantidWorkbench
 
 --------------
 
-8. Open your ``Mantid.user.properties`` file
+7. Open your ``Mantid.user.properties`` file
 
-- Add the incorrect rooturl ``errorreports.rooturl = https://error.mantidproject.org`` anywhere in the file (correct url is ``https://errorreports.mantidproject.org``)
+- Add the incorrect rooturl ``errorreports.rooturl = https://fake.mantidproject.org`` anywhere in the file (correct url is ``https://errorreports.mantidproject.org``)
 - This will cause the error reporter to fail to send the report
 - Open MantidWorkbench
 - Cause a crash using either of the previous methods
+- Enter a fake email address into the ``Email`` box
 - Click the ``Yes, share information`` button to send the report
 - A message box should appear informing you that the error report has failed to send
 - Close the message box and the error reporter should stay open
 - Check you can still access the additional information
+- Click the ``Don't share any information`` button and close MantidWorkbench
+- Remove the line added to the ``Mantid.user.properties`` file
 
 Test the error reporter with any weird and wonderful ideas.
 Note any problems with Workbench or these testing instructions.


### PR DESCRIPTION
### Description of work

Recently, the "Share non-idntifiable information" button was removed from the error reporter. This was part of work to force the inclusion of a contact email in all error reports. This pr updates the manual testing instructions to reflect that change.

Fixes #36729 

### To test:

- Build `dev-docs-html` and open `Testing/ErrorReporter-ProjectRecovery/ErrorReporterTesting.html`
- Follow the instructions and make sure they make sense.


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
