### PR TITLE
New FindGoniometerAngles algorithm

### DIFF
--- a/Framework/Crystal/CMakeLists.txt
+++ b/Framework/Crystal/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SRC_FILES
     src/DisjointElement.cpp
     src/FilterPeaks.cpp
     src/FindClusterFaces.cpp
+    src/FindGoniometerAngles.cpp
     src/FindSXPeaks.cpp
     src/FindSXPeaksHelper.cpp
     src/FindUBUsingFFT.cpp
@@ -94,6 +95,7 @@ set(INC_FILES
     inc/MantidCrystal/DisjointElement.h
     inc/MantidCrystal/FilterPeaks.h
     inc/MantidCrystal/FindClusterFaces.h
+    inc/MantidCrystal/FindGoniometerAngles.h
     inc/MantidCrystal/FindSXPeaks.h
     inc/MantidCrystal/FindSXPeaksHelper.h
     inc/MantidCrystal/FindUBUsingFFT.h
@@ -171,6 +173,7 @@ set(TEST_FILES
     DisjointElementTest.h
     FilterPeaksTest.h
     FindClusterFacesTest.h
+    FindGoniometerAnglesTest.h
     FindSXPeaksHelperTest.h
     FindSXPeaksTest.h
     FindUBUsingFFTTest.h

--- a/Framework/Crystal/inc/MantidCrystal/FindGoniometerAngles.h
+++ b/Framework/Crystal/inc/MantidCrystal/FindGoniometerAngles.h
@@ -1,0 +1,31 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidCrystal/DllConfig.h"
+
+namespace Mantid {
+namespace Crystal {
+
+/** FindGoniometerAngles : TODO: DESCRIPTION
+ */
+class MANTID_CRYSTAL_DLL FindGoniometerAngles : public API::Algorithm {
+public:
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
+  const std::vector<std::string> seeAlso() const override { return {"OptimizeCrystalPlacement"}; }
+
+private:
+  void init() override;
+  void exec() override;
+};
+
+} // namespace Crystal
+} // namespace Mantid

--- a/Framework/Crystal/src/FindGoniometerAngles.cpp
+++ b/Framework/Crystal/src/FindGoniometerAngles.cpp
@@ -1,0 +1,193 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidCrystal/FindGoniometerAngles.h"
+
+#include "MantidAPI/IPeaksWorkspace.h"
+#include "MantidAPI/Run.h"
+#include "MantidAPI/Sample.h"
+#include "MantidGeometry/Crystal/IPeak.h"
+#include "MantidGeometry/Crystal/IndexingUtils.h"
+#include "MantidGeometry/Crystal/OrientedLattice.h"
+#include "MantidGeometry/Instrument/Goniometer.h"
+
+namespace Mantid {
+namespace Crystal {
+using Mantid::API::IPeaksWorkspace;
+using Mantid::API::IPeaksWorkspace_sptr;
+using Mantid::API::WorkspaceProperty;
+using Mantid::Geometry::Goniometer;
+using Mantid::Geometry::IndexingUtils;
+using Mantid::Kernel::DblMatrix;
+using Mantid::Kernel::Direction;
+using Mantid::Kernel::V3D;
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(FindGoniometerAngles)
+
+namespace {
+
+DblMatrix createRotationMatrix(const double phi, const double chi, const double omega) {
+  Goniometer g;
+  g.pushAxis("omega", 0., 1., 0., omega);
+  g.pushAxis("chi", 0., 0., 1., chi);
+  g.pushAxis("phi", 0., 1., 0., phi);
+  return g.getR();
+}
+
+std::pair<int, double> NumIndexed(const DblMatrix &UB, const IPeaksWorkspace_sptr peakWS, const double tolerance,
+                                  const double phi, const double chi, const double omega) {
+  DblMatrix UBinv = UB;
+  UBinv.Invert();
+
+  auto Rinv = createRotationMatrix(phi, chi, omega);
+  Rinv.Invert();
+
+  int n_indexed{0};
+  double sum_sq_err{0};
+
+  for (int i{0}; i < peakWS->getNumberPeaks(); i++) {
+    const auto &peak = peakWS->getPeak(i);
+    const auto q_lab = peak.getQLabFrame();
+    const auto q_sample = Rinv * q_lab;
+    const auto hkl = UBinv * q_sample / (2 * M_PI);
+
+    if (IndexingUtils::ValidIndex(hkl, tolerance)) {
+      n_indexed++;
+      V3D HKL = hkl;
+      HKL.round();
+      V3D q_error = UB * HKL;
+      q_error *= 2 * M_PI;
+      q_error -= q_sample;
+      sum_sq_err += q_error.norm2();
+    }
+  }
+
+  return std::make_pair(n_indexed, sum_sq_err);
+}
+} // namespace
+
+//----------------------------------------------------------------------------------------------
+
+/// Algorithms name for identification. @see Algorithm::name
+const std::string FindGoniometerAngles::name() const { return "FindGoniometerAngles"; }
+
+/// Algorithm's version for identification. @see Algorithm::version
+int FindGoniometerAngles::version() const { return 1; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string FindGoniometerAngles::category() const { return "Crystal\\Corrections"; }
+
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string FindGoniometerAngles::summary() const { return "TODO: FILL IN A SUMMARY"; }
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void FindGoniometerAngles::init() {
+  declareProperty(std::make_unique<WorkspaceProperty<IPeaksWorkspace>>("PeaksWorkspace", "", Direction::Input),
+                  "Workspace of Peaks with UB loaded");
+  declareProperty("MaxAngle", 5.0, "chi squared over dof", Direction::Input);
+  declareProperty("Tolerance", 0.15, "chi squared over dof", Direction::Input);
+  declareProperty("Apply", false, "Update goniometer in peaks workspace");
+  declareProperty("Phi", 0.0, "Phi found", Direction::Output);
+  declareProperty("Chi", 0.0, "Chi found", Direction::Output);
+  declareProperty("Omega", 0.0, "Omega found", Direction::Output);
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void FindGoniometerAngles::exec() {
+
+  const double tolerance = getProperty("Tolerance");
+  const double max_angle = getProperty("MaxAngle");
+  IPeaksWorkspace_sptr peakWS = getProperty("PeaksWorkspace");
+
+  const auto UB = peakWS->sample().getOrientedLattice().getUB();
+
+  auto g = peakWS->run().getGoniometer();
+  const std::vector<double> YZY = g.getEulerAngles("YZY");
+
+  double omega = YZY[0];
+  double chi = YZY[1];
+  double phi = YZY[2];
+
+  auto results = NumIndexed(UB, peakWS, tolerance, phi, chi, omega);
+  g_log.information() << "Starting          Max Indexed = " << results.first << " Err = " << results.second
+                      << " Phi: " << phi << " Chi: " << chi << " Omega: " << omega << "\n";
+
+  const int N_TRIES = 5;
+
+  double phi_offset{phi};
+  double chi_offset{chi};
+  double omega_offset{omega};
+  double best_phi{0};
+  double best_chi{0};
+  double best_omega{0};
+
+  for (int range{1}; range <= N_TRIES; range++) {
+    double max_quality{0};
+    double max_error{0};
+    int max_indexed{0};
+
+    double step = max_angle / range;
+
+    while (step > sqrt(1e-5)) {
+      for (int i{-range}; i <= range; i++)
+        for (int j{-range}; j <= range; j++)
+          for (int k{-range}; k <= range; k++) {
+            phi = phi_offset + i * step;
+            chi = chi_offset + j * step;
+            omega = omega_offset + k * step;
+            results = NumIndexed(UB, peakWS, tolerance, phi, chi, omega);
+            const double quality = results.first - 0.1 * results.second / results.first;
+
+            if (quality > max_quality) {
+              max_quality = quality;
+              max_indexed = results.first;
+              max_error = results.second;
+
+              best_phi = phi;
+              best_chi = chi;
+              best_omega = omega;
+            }
+          }
+
+      phi_offset = best_phi;
+      chi_offset = best_chi;
+      omega_offset = best_omega;
+
+      step *= M_SQRT1_2;
+    }
+
+    g_log.information() << "Range Factor = " << range << "  "
+                        << "Max Indexed = " << max_indexed << " Err = " << max_error << " Phi: " << best_phi
+                        << " Chi: " << best_chi << " Omega: " << best_omega << "\n";
+  }
+
+  setProperty("Phi", best_phi);
+  setProperty("Chi", best_chi);
+  setProperty("Omega", best_omega);
+
+  if (getProperty("Apply")) {
+    const auto R = createRotationMatrix(best_phi, best_chi, best_omega);
+    // set the goniometer on the workspace
+    peakWS->mutableRun().setGoniometer(R, false);
+
+    // set the goniometer on the peaks and reset the q_lab so that the q_sample is recalculated
+    for (int i{0}; i < peakWS->getNumberPeaks(); i++) {
+      auto &peak = peakWS->getPeak(i);
+      const auto q_lab = peak.getQLabFrame();
+      peak.setGoniometerMatrix(R);
+      peak.setQLabFrame(q_lab, boost::none);
+    }
+  }
+}
+
+} // namespace Crystal
+} // namespace Mantid

--- a/Framework/Crystal/test/FindGoniometerAnglesTest.h
+++ b/Framework/Crystal/test/FindGoniometerAnglesTest.h
@@ -8,7 +8,17 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "MantidAPI/AlgorithmFactory.h"
+#include "MantidAPI/IPeaksWorkspace.h"
+#include "MantidAPI/Sample.h"
 #include "MantidCrystal/FindGoniometerAngles.h"
+#include "MantidDataObjects/Peak.h"
+#include "MantidDataObjects/PeaksWorkspace.h"
+#include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidGeometry/Crystal/OrientedLattice.h"
+#include "MantidGeometry/Instrument/Goniometer.h"
+#include "MantidKernel/V3D.h"
 
 using Mantid::Crystal::FindGoniometerAngles;
 
@@ -19,34 +29,142 @@ public:
   static FindGoniometerAnglesTest *createSuite() { return new FindGoniometerAnglesTest(); }
   static void destroySuite(FindGoniometerAnglesTest *suite) { delete suite; }
 
+  auto create_goniometer(const double phi, const double chi, const double omega) {
+    Mantid::Geometry::Goniometer g;
+    g.pushAxis("omega", 0., 1., 0., omega);
+    g.pushAxis("chi", 0., 0., 1., chi);
+    g.pushAxis("phi", 0., 1., 0., phi);
+    return g;
+  }
+
+  auto get_ws_angles(const Mantid::DataObjects::PeaksWorkspace_sptr ws) {
+    auto g = ws->run().getGoniometer();
+    return g.getEulerAngles("YZY");
+  }
+
+  auto get_peak_angles(const Mantid::DataObjects::Peak p) {
+    return Mantid::Kernel::Quat(p.getGoniometerMatrix()).getEulerAngles("YZY");
+  }
   void test_Init() {
     FindGoniometerAngles alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
   }
 
-  void test_exec() {
-    // Create test input if necessary
-    MatrixWorkspace_sptr
-        inputWS = //-- Fill in appropriate code. Consider using MantidFrameworkTestHelpers/WorkspaceCreationHelper.h --
+  void runTest(double delta_phi, double delta_chi, double delta_omega, double max_angle = 5., bool apply = false,
+               bool expect_failure = false) {
+    /* This test works by using PredictPeaks to create a peaks workspace using the goniometer and lattice provided.
+     * After which a new peaks workspace with everything the same except the goniometer is created. The q_lab value from
+     * the first "correct" peaks workspace is copied to the new "wrong" one. FindGoniometerAngles is then use to get
+     * back the correct goniometer.
+     */
 
-        FindGoniometerAngles alg;
-    // Don't put output in ADS by default
+    // first create a workspace with a particular goniometer and lattice
+    const double phi{15.};
+    const double chi{30.};
+    const double omega{45.};
+
+    Mantid::API::MatrixWorkspace_sptr inWS = WorkspaceCreationHelper::create2DWorkspace(1, 1);
+    Mantid::Geometry::Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentRectangular(1, 200);
+    inWS->setInstrument(inst);
+    inWS->mutableSample().setOrientedLattice(
+        std::make_unique<Mantid::Geometry::OrientedLattice>(14.1526, 19.2903, 8.5813, 90, 105.074, 90));
+
+    inWS->mutableRun().setGoniometer(create_goniometer(phi, chi, omega), false);
+
+    // create peakworkspace using predict peaks
+    auto predictPeaks = Mantid::API::AlgorithmFactory::Instance().create("PredictPeaks", 1);
+    predictPeaks->initialize();
+    predictPeaks->setProperty("InputWorkspace", inWS);
+    predictPeaks->setProperty("OutputWorkspace", "FindGoniometerAnglesTestPeaks");
+    predictPeaks->execute();
+
+    auto peaksWS = std::dynamic_pointer_cast<Mantid::DataObjects::PeaksWorkspace>(
+        Mantid::API::AnalysisDataService::Instance().retrieve("FindGoniometerAnglesTestPeaks"));
+
+    // now create new peaks workspace with same q-lab but slightly wrong goniometer
+    auto pw = std::make_shared<Mantid::DataObjects::PeaksWorkspace>();
+    pw->setInstrument(inst);
+    pw->mutableSample().setOrientedLattice(
+        std::make_unique<Mantid::Geometry::OrientedLattice>(14.1526, 19.2903, 8.5813, 90, 105.074, 90));
+
+    pw->mutableRun().setGoniometer(create_goniometer(phi + delta_phi, chi + delta_chi, omega + delta_omega), false);
+
+    // copy peaks by their QLab so that a new q_sample is calculated with the different goniometer
+    for (int i{0}; i < peaksWS->getNumberPeaks(); i++) {
+      pw->addPeak(peaksWS->getPeak(i).getQLabFrame(), Mantid::Kernel::QLab);
+    }
+
+    // check that the goniometer angles are set correctly on the workspace and the peaks
+    auto angles = get_ws_angles(pw);
+    TS_ASSERT_DELTA(phi + delta_phi, angles[2], 5e-3)
+    TS_ASSERT_DELTA(chi + delta_chi, angles[1], 5e-3)
+    TS_ASSERT_DELTA(omega + delta_omega, angles[0], 5e-3)
+
+    auto peak_angles = get_peak_angles(pw->getPeak(0));
+    TS_ASSERT_DELTA(phi + delta_phi, peak_angles[2], 5e-3)
+    TS_ASSERT_DELTA(chi + delta_chi, peak_angles[1], 5e-3)
+    TS_ASSERT_DELTA(omega + delta_omega, peak_angles[0], 5e-3)
+
+    // see if FindGoniometerAngles can get the origonal goniometer back
+    FindGoniometerAngles alg;
     alg.setChild(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("PeaksWorkspace", pw));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Apply", apply));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaxAngle", max_angle));
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
 
-    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
-    // be the type using in declareProperty for the "OutputWorkspace" type.
-    // We can't use auto as it's an implicit conversion.
-    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
-    TS_ASSERT(outputWS);
-    TS_FAIL("TODO: Check the results and remove this line");
+    // check that we got back what we expected
+    if (expect_failure) {
+      TS_ASSERT(abs(phi - static_cast<double>(alg.getProperty("Phi"))) > 1)
+      TS_ASSERT(abs(chi - static_cast<double>(alg.getProperty("Chi"))) > 1)
+      TS_ASSERT(abs(omega - static_cast<double>(alg.getProperty("Omega"))) > 1)
+    } else {
+      TS_ASSERT_DELTA(phi, static_cast<double>(alg.getProperty("Phi")), 5e-3)
+      TS_ASSERT_DELTA(chi, static_cast<double>(alg.getProperty("Chi")), 5e-3)
+      TS_ASSERT_DELTA(omega, static_cast<double>(alg.getProperty("Omega")), 5e-3)
+    }
+
+    // check goniometer angles after running
+    if (apply) {
+      // we expect the goniometer to be updated on the peaks workspace and the peaks
+      auto angles = get_ws_angles(pw);
+      TS_ASSERT_DELTA(phi, angles[2], 5e-3)
+      TS_ASSERT_DELTA(chi, angles[1], 5e-3)
+      TS_ASSERT_DELTA(omega, angles[0], 5e-3)
+
+      auto peak_angles = get_peak_angles(pw->getPeak(0));
+      TS_ASSERT_DELTA(phi, peak_angles[2], 5e-3)
+      TS_ASSERT_DELTA(chi, peak_angles[1], 5e-3)
+      TS_ASSERT_DELTA(omega, peak_angles[0], 5e-3)
+    } else {
+      // we expect the goniometer to NOT be updated on the peaks workspace and the peaks
+      auto angles = get_ws_angles(pw);
+      TS_ASSERT_DELTA(phi + delta_phi, angles[2], 5e-3)
+      TS_ASSERT_DELTA(chi + delta_chi, angles[1], 5e-3)
+      TS_ASSERT_DELTA(omega + delta_omega, angles[0], 5e-3)
+
+      auto peak_angles = get_peak_angles(pw->getPeak(0));
+      TS_ASSERT_DELTA(phi + delta_phi, peak_angles[2], 5e-3)
+      TS_ASSERT_DELTA(chi + delta_chi, peak_angles[1], 5e-3)
+      TS_ASSERT_DELTA(omega + delta_omega, peak_angles[0], 5e-3)
+    }
   }
 
-  void test_Something() { TS_FAIL("You forgot to write a test!"); }
+  void test_phi() { runTest(4., 0., 0.); }
+  void test_phi_apply() { runTest(4., 0., 0., 5., true); }
+  void test_chi() { runTest(0., 4., 0.); }
+  void test_chi_apply() { runTest(0., 4., 0., 5., true); }
+  void test_omega() { runTest(0., 0., 4.); }
+  void test_omega_apply() { runTest(0., 0., 4., 5., true); }
+  void test_all() { runTest(-2., 2., 2.); }
+  void test_all_apply() { runTest(-2., 2., 2., 5., true); }
+  void test_all_large_error() { runTest(30., 28., -27., 35); }
+  void test_all_large_error2() { runTest(-27., 12., -32., 35); }
+
+  // error in goniometer is larger than max_angle
+  void test_failure() { runTest(-7., 8., -7., 5, false, true); }
 };

--- a/Framework/Crystal/test/FindGoniometerAnglesTest.h
+++ b/Framework/Crystal/test/FindGoniometerAnglesTest.h
@@ -1,0 +1,52 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidCrystal/FindGoniometerAngles.h"
+
+using Mantid::Crystal::FindGoniometerAngles;
+
+class FindGoniometerAnglesTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static FindGoniometerAnglesTest *createSuite() { return new FindGoniometerAnglesTest(); }
+  static void destroySuite(FindGoniometerAnglesTest *suite) { delete suite; }
+
+  void test_Init() {
+    FindGoniometerAngles alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
+
+  void test_exec() {
+    // Create test input if necessary
+    MatrixWorkspace_sptr
+        inputWS = //-- Fill in appropriate code. Consider using MantidFrameworkTestHelpers/WorkspaceCreationHelper.h --
+
+        FindGoniometerAngles alg;
+    // Don't put output in ADS by default
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
+    // be the type using in declareProperty for the "OutputWorkspace" type.
+    // We can't use auto as it's an implicit conversion.
+    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);
+    TS_FAIL("TODO: Check the results and remove this line");
+  }
+
+  void test_Something() { TS_FAIL("You forgot to write a test!"); }
+};

--- a/docs/source/algorithms/FindGoniometerAngles-v1.rst
+++ b/docs/source/algorithms/FindGoniometerAngles-v1.rst
@@ -1,0 +1,46 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+TODO: Enter a full rst-markup description of your algorithm here.
+
+
+Usage
+-----
+..  Try not to use files in your examples,
+    but if you cannot avoid it then the (small) files must be added to
+    autotestdata\UsageData and the following tag unindented
+    .. include:: ../usagedata-note.txt
+
+**Example - FindGoniometerAngles**
+
+.. testcode:: FindGoniometerAnglesExample
+
+   # Create a host workspace
+   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
+   or
+   ws = CreateSampleWorkspace()
+
+   wsOut = FindGoniometerAngles()
+
+   # Print the result
+   print "The output workspace has %%i spectra" %% wsOut.getNumberHistograms()
+
+Output:
+
+.. testoutput:: FindGoniometerAnglesExample
+
+  The output workspace has ?? spectra
+
+.. categories::
+
+.. sourcelink::
+

--- a/docs/source/algorithms/FindGoniometerAngles-v1.rst
+++ b/docs/source/algorithms/FindGoniometerAngles-v1.rst
@@ -10,7 +10,9 @@
 Description
 -----------
 
-TODO: Enter a full rst-markup description of your algorithm here.
+Do a brute force search for the goniometer rotation angles that maximize the number of peaks indexed by the UB on the peaks workspace.  The peaks must have peaks from only one run.  The search will start with the goniometer position set on the PeaksWoskpace and deviations from that goniometer up to MaxAngle will be tried, seaching for the gonomater angles that maximize the number of peaks indexed and minimize the total indexing error. This algorithm was ported from ISAW.
+
+The best goniometer angles found will be returned in terms of phi, chi, omega ("YZY") and if Apply is selected then the goniometer will be updated on the PeaksWorkspace and the Peaks.
 
 
 Usage
@@ -24,21 +26,35 @@ Usage
 
 .. testcode:: FindGoniometerAnglesExample
 
-   # Create a host workspace
-   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
-   or
-   ws = CreateSampleWorkspace()
+   # create a peaks workspace with particular lattice and goniometer
+   ws = LoadEmptyInstrument(InstrumentName="TOPAZ")
+   SetGoniometer(ws, Axis0="45,0,0,1,1")
+   SetUB(ws, a=5, b=5, c=5, alpha=90, beta=90, gamma=90)
+   peaks = PredictPeaks(ws)
+   num_peaks = peaks.getNumberPeaks()
 
-   wsOut = FindGoniometerAngles()
+   # create new peaks workspace with wrong goniometer
+   new_peaks = CreatePeaksWorkspace(ws, 0)
+   SetGoniometer(new_peaks, Axis0="42,0,0,1,1")
+   SetUB(new_peaks, a=5, b=5, c=5, alpha=90, beta=90, gamma=90)
 
-   # Print the result
-   print "The output workspace has %%i spectra" %% wsOut.getNumberHistograms()
+   # copy peak q_lab vectors, q_sample will be wrong since wrong goniometer
+   from mantid.kernel import SpecialCoordinateSystem
+   for i in range(num_peaks):
+       new_peaks.addPeak(peaks.getPeak(i).getQLabFrame(), SpecialCoordinateSystem.QLab)
+
+   results = IndexPeaks(new_peaks, 0.05)
+   print(f"Starting with {results.NumIndexed} out of {num_peaks} peaks indexed")
+   angles = FindGoniometerAngles(new_peaks, Apply=True)
+   results = IndexPeaks(new_peaks, 0.05)
+   print(f"Found Chi={angles.Chi:.2f} and there are now {results.NumIndexed} out of {num_peaks} peaks indexed")
 
 Output:
 
 .. testoutput:: FindGoniometerAnglesExample
 
-  The output workspace has ?? spectra
+  Starting with 0 out of 65 peaks indexed
+  Found Chi=44.99 and there are now 65 out of 65 peaks indexed
 
 .. categories::
 

--- a/docs/source/release/v6.10.0/Diffraction/Single_Crystal/New_features/37305.rst
+++ b/docs/source/release/v6.10.0/Diffraction/Single_Crystal/New_features/37305.rst
@@ -1,0 +1,1 @@
+- New algorithm :ref:`FindGoniometerAngles <algm-FindGoniometerAngles>` that does a brute force search for the goniometer rotation angles that maximize the number of peaks indexed by the UB.


### PR DESCRIPTION
### Description of work

This implements a brute force goniometer finder, ported from [ISAW](https://github.com/ornl-ndav/ISAW/blob/master/Operators/TOF_SCD/PeaksFileUtils.java#L1561).


#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [EWM4666](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=4666)
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
This case TOPAZ_42314 has the wrong goniometer stored so we use the UB from TOPAZ_42313 to find the correct one
```python
LoadEventNexus(Filename='/SNS/TOPAZ/IPTS-26952/nexus/TOPAZ_42313.nxs.h5',
               OutputWorkspace='TOPAZ_42313')
LoadEventNexus(Filename='/SNS/TOPAZ/IPTS-26952/nexus/TOPAZ_42314.nxs.h5',
               OutputWorkspace='TOPAZ_42314')
ConvertToMD(InputWorkspace='TOPAZ_42313',
            QDimensions='Q3D',
            dEAnalysisMode='Elastic',
            Q3DFrames='Q_sample',
            LorentzCorrection=True,
            OutputWorkspace='md_42313',
            MinValues='-10,-10,-10',
            MaxValues='10,10,10')
ConvertToMD(InputWorkspace='TOPAZ_42314',
            QDimensions='Q3D',
            dEAnalysisMode='Elastic',
            Q3DFrames='Q_sample',
            LorentzCorrection=True,
            OutputWorkspace='md_42314',
            MinValues='-10,-10,-10',
            MaxValues='10,10,10')
FindPeaksMD(InputWorkspace='md_42313',
            PeakDistanceThreshold=0.34,
            MaxPeaks=1000,
            DensityThresholdFactor=100,
            OutputWorkspace='peaks_42313')
FindPeaksMD(InputWorkspace='md_42314',
            PeakDistanceThreshold=0.34,
            MaxPeaks=1000,
            DensityThresholdFactor=100,
            OutputWorkspace='peaks_42314')
FindUBUsingFFT(PeaksWorkspace='peaks_42313', MinD=3, MaxD=20)
ShowPossibleCells(PeaksWorkspace='peaks_42313')
SelectCellWithForm(PeaksWorkspace='peaks_42313',
                   FormNumber=34,
                   Apply=True,
                   TransformationMatrix='-1,0,0,0,0,-1,0,-1,0')
CopySample(InputWorkspace='peaks_42313',
           OutputWorkspace='peaks_42314',
           CopyName=False,
           CopyMaterial=False,
           CopyEnvironment=False,
           CopyShape=False)

IndexPeaks(PeaksWorkspace='peaks_42313', Tolerance=0.05)
IndexPeaks(PeaksWorkspace='peaks_42314', Tolerance=0.05)
CloneWorkspace(InputWorkspace='peaks_42314',
               OutputWorkspace='peaks_42314_corr')

FindGoniometerAngles('peaks_42314_corr', Apply=True)
IndexPeaks(PeaksWorkspace='peaks_42314', Tolerance=0.05)
IndexPeaks(PeaksWorkspace='peaks_42314_corr', Tolerance=0.05)
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
