### PR TITLE
Pin libcxx in Conda recipes

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -28,6 +28,9 @@ hdf5: # this is to move to libcurl>=8.4
 numpy:
   - 1.24.*
 
+libcxx:
+  - '<17'
+
 matplotlib:
   - 3.7.*
 

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - {{ cdt('libxxf86vm') }}                # [linux]
     - {{ cdt('libx11-devel') }}              # [linux]
     - {{ cdt('xorg-x11-proto-devel') }}      # [linux]
-    - libcxx                                 # [osx]
+    - libcxx  {{ libcxx }}                   # [osx]
 
   host:
     - boost {{ boost }}

--- a/conda/recipes/mantidqt/meta.yaml
+++ b/conda/recipes/mantidqt/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - {{ cdt('libxxf86vm') }}  # [linux]
     - {{ cdt('libx11-devel') }}  # [linux]
     - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
-    - libcxx  # [osx]
+    - libcxx  {{ libcxx }}                   # [osx]
 
   host:
     - eigen


### PR DESCRIPTION
### Description of work

#### Summary of work
Package building for OSX started failing after recent upgrades to `libcxx`. That is why the version of `libcxx` is pinned to `<17` in the Conda recipes.

#### Purpose of work
This pin should allow us to build the nightly packages again. However, it is not meant to be a permanent fix.

An issue has been raised to unpin this [#37308](https://github.com/mantidproject/mantid/issues/37308)

*There is no associated issue.*


### To test:

Check that the OSX package is build successfully: https://builds.mantidproject.org/job/build_packages_from_branch/791


*This does not require release notes* because **it is not user facing.**


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
