### PR TITLE
Add new disableReplaceWSButton Property flag. Disable button creation on the WANDPowderReduction algorithm.

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/Property.h
+++ b/Framework/Kernel/inc/MantidKernel/Property.h
@@ -196,6 +196,9 @@ public:
   bool autoTrim() const;
   void setAutoTrim(const bool &setting);
 
+  bool disableReplaceWSButton() const;
+  void setDisableReplaceWSButton(const bool &disable);
+
 protected:
   /// Constructor
   Property(std::string name, const std::type_info &type, const unsigned int &direction = Direction::Input);
@@ -232,6 +235,9 @@ private:
   /// Flag to determine if string inputs to the property should be automatically
   /// trimmed of whitespace
   bool m_autotrim;
+
+  /// Flag to disable the generation of the "Replace Workspace" button on the OutputWorkspace property
+  bool m_disableReplaceWSButton;
 };
 
 /// Compares this to another property for equality

--- a/Framework/Kernel/src/Property.cpp
+++ b/Framework/Kernel/src/Property.cpp
@@ -28,7 +28,7 @@ namespace Kernel {
  */
 Property::Property(std::string name, const std::type_info &type, const unsigned int &direction)
     : m_name(std::move(name)), m_documentation(""), m_typeinfo(&type), m_direction(direction), m_units(""), m_group(""),
-      m_remember(true), m_autotrim(true) {
+      m_remember(true), m_autotrim(true), m_disableReplaceWSButton(false) {
   if (m_name.empty()) {
     throw std::invalid_argument("An empty property name is not permitted");
   }
@@ -43,7 +43,7 @@ Property::Property(std::string name, const std::type_info &type, const unsigned 
 Property::Property(const Property &right)
     : m_name(right.m_name), m_documentation(right.m_documentation), m_typeinfo(right.m_typeinfo),
       m_direction(right.m_direction), m_units(right.m_units), m_group(right.m_group), m_remember(right.m_remember),
-      m_autotrim(right.m_autotrim) {
+      m_autotrim(right.m_autotrim), m_disableReplaceWSButton(right.m_disableReplaceWSButton) {
   if (m_name.empty()) {
     throw std::invalid_argument("An empty property name is not permitted");
   }
@@ -342,6 +342,18 @@ bool Property::autoTrim() const { return m_autotrim; }
  * @param setting The new setting value
  */
 void Property::setAutoTrim(const bool &setting) { m_autotrim = setting; }
+
+/**
+ * Returns if the property is set to disable the creation of the "Replace Workspace" button
+ * @returns True/False
+ */
+bool Property::disableReplaceWSButton() const { return m_disableReplaceWSButton; }
+
+/**
+ * Sets the property to disable the creation of the "Replace Workspace" button
+ * @param disable The option to disable or not
+ */
+void Property::setDisableReplaceWSButton(const bool &disable) { m_disableReplaceWSButton = disable; }
 } // namespace Kernel
 
 } // namespace Mantid

--- a/Framework/Kernel/test/PropertyTest.h
+++ b/Framework/Kernel/test/PropertyTest.h
@@ -99,6 +99,15 @@ public:
     TS_ASSERT(p3->remember());
   }
 
+  void testDisableReplaceWSButton() {
+    auto p = std::make_unique<PropertyHelper>();
+    TS_ASSERT(!p->disableReplaceWSButton());
+    p->setDisableReplaceWSButton(true);
+    TS_ASSERT(p->disableReplaceWSButton());
+    p->setDisableReplaceWSButton(false);
+    TS_ASSERT(!p->disableReplaceWSButton());
+  }
+
 private:
   std::unique_ptr<Property> p;
 };

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
@@ -175,5 +175,7 @@ void export_Property() {
       .add_static_property("EMPTY_LONG", emptyLong)
 
       .def("setAutoTrim", &Property::setAutoTrim, (arg("setting")), "Setting automatic trimming of whitespaces.")
-      .def("getAutoTrim", &Property::autoTrim, "Gets the setting of automatic trimming of whitespaces.");
+      .def("getAutoTrim", &Property::autoTrim, "Gets the setting of automatic trimming of whitespaces.")
+      .def("setDisableReplaceWSButton", &Property::setDisableReplaceWSButton, (arg("disable")),
+           "Disable the creation of the Replace Workspace button.");
 }

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
@@ -169,6 +169,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
             WorkspaceProperty("OutputWorkspace", "", direction=Direction.Output),
             doc="Output Workspace",
         )
+        self.getProperty("OutputWorkspace").setDisableReplaceWSButton(True)
 
         self.declareProperty(
             "Sum",

--- a/docs/source/release/v6.10.0/Diffraction/Powder/Bugfixes/37314.rst
+++ b/docs/source/release/v6.10.0/Diffraction/Powder/Bugfixes/37314.rst
@@ -1,0 +1,1 @@
+- Remove the confusing "Replace input workspace" button in the :ref:`WANDPowderReduction <algm-WANDPowderReduction>` algorithm

--- a/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
@@ -255,7 +255,7 @@ void AlgorithmPropertiesWidget::initLayout() {
 
       // Only show the "Replace Workspace" button if the algorithm has an input
       // workspace.
-      if (hasInputWS)
+      if (hasInputWS && !prop->disableReplaceWSButton())
         widget->addReplaceWSButton();
 
       ++row;


### PR DESCRIPTION
### Description of work

This button was confusing users with its behavior not what was expected, particularly when the input was a group workspace. So this disables it for the WANDPowderReduction algorithm. Other algorithms can make use of the same option.

Before:
![2024-05-10-131840_494x584_scrot](https://github.com/mantidproject/mantid/assets/5595210/733d1bd7-2f5a-4be4-a653-ac2d507db66a)
Now:
![2024-05-10-131800_460x583_scrot](https://github.com/mantidproject/mantid/assets/5595210/60fdbd4b-fe93-4497-8c7a-695890dafe50)


#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [EWM855](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/855)
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Open the WANDPowderReduction algorithm dialog and check that button is gone.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
