### PR TITLE
Fix crash on drag overplot using table workspace

### DIFF
--- a/docs/source/release/v6.10.0/Workbench/Bugfixes/37315.rst
+++ b/docs/source/release/v6.10.0/Workbench/Bugfixes/37315.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where dragging a table workspace onto a plot could cause a crash.

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -33,7 +33,7 @@ def _validate_workspaces(names: List[str]) -> List[bool]:
     ads = AnalysisDataServiceImpl.Instance()
     has_multiple_bins = []
     for name in names:
-        result = False
+        result = None
         ws = ads.retrieve(name)
         if isinstance(ws, WorkspaceGroup):
             result = all(_validate_workspaces(ws.getNames()))
@@ -47,7 +47,8 @@ def _validate_workspaces(names: List[str]) -> List[bool]:
                         result = True
                         break
 
-        has_multiple_bins.append(result)
+        if result is not None:
+            has_multiple_bins.append(result)
 
     return has_multiple_bins
 

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -41,7 +41,7 @@ def _validate_workspaces(names: List[str]) -> List[bool]:
             try:
                 result = ws.blocksize() > 1
             except RuntimeError:
-                # blocksize() implementation in Workspace2D and EventWorkspace can through an error if histograms are not equal
+                # blocksize() implementation in Workspace2D and EventWorkspace can throw an error if histograms are not equal
                 for i in ws.getNumberHistograms():
                     if ws.y(i).size() > 1:
                         result = True


### PR DESCRIPTION
### Description of work

Recently saw an error report leading back to the `ws.blocksize()` call in `_validate_workspaces()` whose job is to check all workspaces have more than one bin before overplotting. The user had dragged a table workspace onto the plot, which doesn't have a `blocksize()` funciton.

Instead of making this function more and more complicated as it considers every type of workspace, I've changed it so it will safely look at only matrix and group workspaces.

I am also aware of this issue with the function https://github.com/mantidproject/mantid/issues/37040 but this is being left as an induction issue for new starters.

*There is no associated issue.*

**Report to:** Stephen Cottrell


### To test:

- Tests from https://github.com/mantidproject/mantid/pull/36458
- Tests from https://github.com/mantidproject/mantid/pull/35932
- Create a table workspace with
```
tableWS = CreateEmptyTableWorkspace()
tableWS.addColumn("int", "spectrum", 1)
tableWS.addColumn("double", "dead-time", 2)

for i in range(10):
    tableWS.addRow([i, i*i])
```
- Load some other data and plot a spectrum
- Drag the table workspace onto the plot, should be rejected in the normal way without a crash.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
