### PR TITLE
Don't run doc tests if only dev docs have changed

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -117,10 +117,15 @@ create_and_activate_mantid_developer_env
 
 # Check whether this is an incremental build that only changes rst files
 if [ -d $BUILD_DIR ]; then
-    if ${SCRIPT_DIR}/../check_for_changes dev-docs-only || ${SCRIPT_DIR}/../check_for_changes user-docs-only; then
+    if ${SCRIPT_DIR}/../check_for_changes user-docs-only; then
       ENABLE_BUILD_CODE=false
       ENABLE_UNIT_TESTS=false
       ENABLE_SYSTEM_TESTS=false
+    elif ${SCRIPT_DIR}/../check_for_changes dev-docs-only; then
+      ENABLE_BUILD_CODE=false
+      ENABLE_UNIT_TESTS=false
+      ENABLE_SYSTEM_TESTS=false
+      ENABLE_DOC_TESTS=false
     fi
     rm -rf ${BUILD_DIR}/bin ${BUILD_DIR}/ExternalData ${BUILD_DIR}/Testing
     find $WORKSPACE \( -iname 'TEST-*.xml' -o -name 'Test.xml' \) -delete


### PR DESCRIPTION
### Description of work

Fixes #37147

### To test:

- Made this pr from a branch based on this one. If you look at the output of the docs job you can see it hasn't run the doc tests: https://github.com/mantidproject/mantid/pull/37361
- This pr (also branching from and back into this branch) has a change to the user docs, so should run the doc tests as normal https://github.com/mantidproject/mantid/pull/37362


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
