### PR TITLE
Add log compression option to AlignAndFocusPowder

### DIFF
--- a/Framework/WorkflowAlgorithms/test/AlignAndFocusPowderTest.h
+++ b/Framework/WorkflowAlgorithms/test/AlignAndFocusPowderTest.h
@@ -93,6 +93,8 @@ public:
     AnalysisDataService::Instance().remove(m_inputWS);
 
     // Test the output
+    auto eventWS = std::dynamic_pointer_cast<EventWorkspace>(m_outWS);
+    TS_ASSERT_EQUALS(eventWS->getNumberEvents(), 870622);
     // [99] 1920.2339999999983, 41
     TS_ASSERT_DELTA(m_outWS->x(0)[99], 1920.23400, 0.0001);
     TS_ASSERT_EQUALS(m_outWS->y(0)[99], 41.);
@@ -418,6 +420,38 @@ public:
     TS_ASSERT_EQUALS(m_outWS->y(0)[599], 277.);
     TS_ASSERT_DELTA(m_outWS->x(0)[899], 15013.033999999987, 0.0001);
     TS_ASSERT_EQUALS(m_outWS->y(0)[899], 673.);
+    AnalysisDataService::Instance().remove(m_outputWS);
+  }
+
+  void testEventWksp_preserveEvents_logCompressTolerance() {
+    // Setup the event workspace
+    setUp_EventWorkspace("EventWksp_preserveEvents_logCompressTolerance");
+
+    // Set the inputs for doTestEventWksp
+    m_preserveEvents = true;
+    m_useGroupAll = false;
+    m_useResamplex = true;
+    m_compressTolerance = "-1e-5";
+
+    // Run the main test function
+    doTestEventWksp();
+
+    // Reset inputs to default values
+    m_compressTolerance = "0";
+
+    // Test the input
+    docheckEventInputWksp();
+    AnalysisDataService::Instance().remove(m_inputWS);
+
+    // Test the output: expected result shall be same as testEventWksp_preserveEvents but have fewer events
+    auto eventWS = std::dynamic_pointer_cast<EventWorkspace>(m_outWS);
+    TS_ASSERT_EQUALS(eventWS->getNumberEvents(), 451436);
+    // [99] 1920.2339999999983, 41
+    TS_ASSERT_DELTA(m_outWS->x(0)[99], 1920.23400, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[99], 41.);
+    // [899] 673.0, 15013.033999999987
+    TS_ASSERT_DELTA(m_outWS->x(0)[899], 15013.03400, 0.0001);
+    TS_ASSERT_EQUALS(m_outWS->y(0)[899], 673.0);
     AnalysisDataService::Instance().remove(m_outputWS);
   }
 

--- a/docs/source/release/v6.11.0/Diffraction/Powder/New_features/37352.rst
+++ b/docs/source/release/v6.11.0/Diffraction/Powder/New_features/37352.rst
@@ -1,0 +1,1 @@
+- Added option to :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>` to support logarithmic compression


### PR DESCRIPTION
### Description of work

Modify the CompressTolerance parameter and add a parameter CompressBinningMode to allow for logorithmic compression that is now available in CompressEvents. The logic of AlignAndFocusPowder::shouldCompressUnfocused() method should be updated as well since the predicted number of logorithmic compressed events is different than linear compression.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [5163: Modify AlignAndFocusPowder to take advantage of new capability in CompressEvents](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/5163)
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Taken from the unit test, you play with the difference between linear and log binning.

```python
ws = CreateSampleWorkspace("Event", "Powder Diffraction", XMin=300, XMax=16666, BinWidth=1.0, NumBanks=1, BankPixelWidth=12, NumEvents=10000)
RotateInstrumentComponent(ws, ComponentName="bank1", Y=1, Angle=90.)
MoveInstrumentComponent(ws, ComponentName="bank1", X=5, Y=-.1, Z=.1, RelativePosition=False)

out  = AlignAndFocusPowder(ws, Dspacing=False, PreserveEvents=True, CompressTolerance=-1e-5, ResampleX=1000)
out2 = AlignAndFocusPowder(ws, Dspacing=False, PreserveEvents=True, CompressTolerance=1e-5, ResampleX=1000)

```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
