### PR TITLE
Fix selection and remove crash on elwin tab of Data Manipulation Interface

### DIFF
--- a/docs/source/release/v6.10.0/Inelastic/Bugfixes/37321.rst
+++ b/docs/source/release/v6.10.0/Inelastic/Bugfixes/37321.rst
@@ -1,0 +1,2 @@
+- Fix a crash in the :ref:`Elwin Tab <elwin>` of the Data Manipulation Interface ocurring when all items of the table were selected with the keyboard and the clicked on `Remove Selected` button.
+- Add `Select All` push button on :ref:`Elwin Tab <elwin>` to select all rows when clicked.

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ElwinTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ElwinTab.ui
@@ -415,6 +415,13 @@
           </widget>
          </item>
          <item>
+          <widget class="QPushButton" name="pbSelAll">
+           <property name="text">
+            <string>Select All</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QPushButton" name="wkspRemove">
            <property name="text">
             <string>Remove Selected</string>

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ElwinView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ElwinView.cpp
@@ -104,6 +104,7 @@ void ElwinView::setup() {
 
   connect(m_uiForm.wkspAdd, SIGNAL(clicked()), this, SLOT(notifyAddWorkspaceDialog()));
   connect(m_uiForm.wkspRemove, SIGNAL(clicked()), this, SLOT(notifyRemoveDataClicked()));
+  connect(m_uiForm.pbSelAll, SIGNAL(clicked()), this, SLOT(notifySelectAllClicked()));
 
   connect(m_uiForm.cbPreviewFile, SIGNAL(currentIndexChanged(int)), this, SLOT(notifyPreviewIndexChanged(int)));
   connect(m_uiForm.spPlotSpectrum, SIGNAL(valueChanged(int)), this, SLOT(notifySelectedSpectrumChanged(int)));
@@ -140,6 +141,8 @@ void ElwinView::notifyPreviewIndexChanged(int index) { m_presenter->handlePrevie
 void ElwinView::notifyRowModeChanged() { m_presenter->handleRowModeChanged(); }
 
 void ElwinView::notifyRemoveDataClicked() { m_presenter->handleRemoveSelectedData(); }
+
+void ElwinView::notifySelectAllClicked() { selectAllRows(); }
 
 void ElwinView::notifyAddWorkspaceDialog() { showAddWorkspaceDialog(); }
 
@@ -185,6 +188,7 @@ void ElwinView::setHorizontalHeaders() {
   auto header = m_uiForm.tbElwinData->horizontalHeader();
   header->setSectionResizeMode(0, QHeaderView::Stretch);
   m_uiForm.tbElwinData->verticalHeader()->setVisible(false);
+  m_uiForm.tbElwinData->setSelectionBehavior(QAbstractItemView::SelectRows);
 }
 
 void ElwinView::clearDataTable() { m_uiForm.tbElwinData->setRowCount(0); }
@@ -206,7 +210,9 @@ void ElwinView::setCell(std::unique_ptr<QTableWidgetItem> cell, int row, int col
   m_uiForm.tbElwinData->setItem(static_cast<int>(row), column, cell.release());
 }
 
-QModelIndexList ElwinView::getSelectedData() { return m_uiForm.tbElwinData->selectionModel()->selectedIndexes(); }
+QModelIndexList ElwinView::getSelectedData() { return m_uiForm.tbElwinData->selectionModel()->selectedRows(); }
+
+void ElwinView::selectAllRows() { m_uiForm.tbElwinData->selectAll(); }
 
 void ElwinView::setDefaultSampleLog(const Mantid::API::MatrixWorkspace_const_sptr &ws) {
   auto inst = ws->getInstrument();

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ElwinView.h
@@ -51,6 +51,7 @@ public:
   void clearDataTable() override;
   void addTableEntry(int row, std::string const &name, std::string const &wsIndexes) override;
   QModelIndexList getSelectedData() override;
+  void selectAllRows() override;
 
   // boolean flags for LoadHistory/GroupInput Checkboxes
   bool isGroupInput() const override;
@@ -88,6 +89,7 @@ private slots:
   void notifyAddWorkspaceDialog();
   void notifyAddData(MantidWidgets::IAddWorkspaceDialog *dialog);
   void notifyRemoveDataClicked();
+  void notifySelectAllClicked();
 
 private:
   void setHorizontalHeaders();

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
@@ -53,6 +53,7 @@ public:
   virtual void addTableEntry(int row, std::string const &name, std::string const &wsIndexes) = 0;
 
   virtual QModelIndexList getSelectedData() = 0;
+  virtual void selectAllRows() = 0;
 
   // boolean flags for LoadHistory/GroupInput Checkboxes
   virtual bool isGroupInput() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IElwinView.h
@@ -29,6 +29,7 @@ class IElwinPresenter;
 class MANTIDQT_INELASTIC_DLL IElwinView {
 
 public:
+  virtual ~IElwinView() = default;
   virtual void subscribePresenter(IElwinPresenter *presenter) = 0;
   virtual void setup() = 0;
   virtual IOutputPlotOptionsView *getPlotOptions() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IIqtView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IIqtView.h
@@ -24,6 +24,7 @@ class IIqtPresenter;
 class MANTIDQT_INELASTIC_DLL IIqtView {
 
 public:
+  virtual ~IIqtView() = default;
   virtual void subscribePresenter(IIqtPresenter *presenter) = 0;
 
   virtual OutputPlotOptionsView *getPlotOptions() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/IMomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/IMomentsView.h
@@ -22,6 +22,7 @@ class IMomentsPresenter;
 class MANTIDQT_INELASTIC_DLL IMomentsView {
 
 public:
+  virtual ~IMomentsView() = default;
   virtual void subscribePresenter(IMomentsPresenter *presenter) = 0;
 
   virtual void setupProperties() = 0;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ISqwView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ISqwView.h
@@ -24,6 +24,7 @@ class ISqwPresenter;
 class MANTIDQT_INELASTIC_DLL ISqwView {
 
 public:
+  virtual ~ISqwView() = default;
   virtual void subscribePresenter(ISqwPresenter *presenter) = 0;
 
   virtual OutputPlotOptionsView *getPlotOptions() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ISymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ISymmetriseView.h
@@ -24,6 +24,7 @@ class ISymmetrisePresenter;
 class MANTIDQT_INELASTIC_DLL ISymmetriseView {
 
 public:
+  virtual ~ISymmetriseView() = default;
   virtual void subscribePresenter(ISymmetrisePresenter *presenter) = 0;
 
   virtual void setDefaults() = 0;

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -395,6 +395,7 @@ public:
   MOCK_METHOD3(addTableEntry, void(int row, std::string const &name, std::string const &wsIndexes));
 
   MOCK_METHOD0(getSelectedData, QModelIndexList());
+  MOCK_METHOD0(selectAllRows, void());
 
   MOCK_CONST_METHOD0(isGroupInput, bool());
   MOCK_CONST_METHOD0(isRowCollapsed, bool());


### PR DESCRIPTION
### Description of work
There was a crash on the elwin tab ocurring whenever all the workspace entries on the table were selected by clicking <ctrl+a> and then the `Remove Selected` button clicked. 
Additionally, a button to select all items on the table at once has been added. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
The crash was ocurring because the selection mode on the table was on a per-item base and not per-row, so whenever the selected indices were being passed to the presenter there were as twice more items than rows to remove (because table has two columns)
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37321. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Follow test instructions on #37321 . Mantid shouldn't crash. 
- Check that clicking on `Select All` button works correctly (and doesn't crash when removing the selection)
- 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

**Added release notes on 6.10 folder**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
