### PR TITLE
Don't merge. Test pr for conda build script change

### DIFF
--- a/dev-docs/source/AlgorithmProfiler.rst
+++ b/dev-docs/source/AlgorithmProfiler.rst
@@ -15,6 +15,8 @@ Due to the need of investigation of algorithms performance issues, the proper me
 It consists two to parts: special mantid build and analytical tool.
 Available for Linux only.
 
+this is a fake change to test the conda build script!!!!
+
 Mantid build
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
This branch was made off of `37147_no_doc_tests_for_dev_docs` which has a change so that the doc tests aren't run for a pr only making changes to the dev docs. See pr https://github.com/mantidproject/mantid/pull/37349 . Can't test that change on the main pr since it makes changes to the build script.

This pr should not run the doc tests for this to be a successful test