### PR TITLE
Temporarily disable PythonChannel test

### DIFF
--- a/Testing/SystemTests/tests/framework/PythonChannels.py
+++ b/Testing/SystemTests/tests/framework/PythonChannels.py
@@ -24,7 +24,6 @@ import os
 import sys
 import time
 import unittest
-import platform
 import subprocess
 import systemtesting
 from multiprocessing import Process
@@ -106,8 +105,8 @@ class PythonChannelTest(systemtesting.MantidSystemTest):
         os.remove(TEST_SCRIPT_NAME)
 
     def skipTests(self):
-        # skip if OSX because multiprocessing uses `spawn` instead of `fork` which causes this test to fail
-        return platform.system() == "Darwin"
+        # temporarily skip this test for all platforms
+        return True
 
     def runTest(self):
         self._server = Process(target=run_server)


### PR DESCRIPTION
### Description of work

#### Summary of work
This PR disables `PythonChannels.PythonChannelTest` to avoid random system test failures. I will raise an issue for a permanent solution for the upcoming 6.10 release.

*There is no associated issue.*


### To test:

Code review only.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
