### PR TITLE
Fix output workspace overwriting in ISIS SANS GUI

### DIFF
--- a/docs/source/release/v6.10.0/SANS/Bugfixes/37356.rst
+++ b/docs/source/release/v6.10.0/SANS/Bugfixes/37356.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where rows in the table on the :ref:`ISIS_SANS_Runs_Tab-ref` would sometimes pick up an output name from a different row and then overwrite the data in that output workspace.

--- a/scripts/SANS/sans/gui_logic/presenter/gui_state_director.py
+++ b/scripts/SANS/sans/gui_logic/presenter/gui_state_director.py
@@ -59,9 +59,7 @@ class GuiStateDirector(object):
             gui_state.all_states.save = copy.deepcopy(self._state_gui_model.all_states.save)
             gui_state.reduction_dimensionality = self._state_gui_model.reduction_dimensionality
 
-        output_name = row_entry.output_name
-        if output_name:
-            gui_state.output_name = output_name
+        gui_state.output_name = row_entry.output_name if row_entry.output_name else None
 
         if row_entry.sample_thickness:
             gui_state.sample_thickness = float(row_entry.sample_thickness)

--- a/scripts/SANS/sans/gui_logic/presenter/gui_state_director.py
+++ b/scripts/SANS/sans/gui_logic/presenter/gui_state_director.py
@@ -54,12 +54,14 @@ class GuiStateDirector(object):
         self._apply_column_options_to_state(row_entry, gui_state)
 
         # 3. Add other columns
-        gui_state.all_states.save = self._state_gui_model.all_states.save
+        if row_user_file:
+            # We need to copy these particular settings from the GUI when custom user file settings are being applied
+            gui_state.all_states.save = copy.deepcopy(self._state_gui_model.all_states.save)
+            gui_state.reduction_dimensionality = self._state_gui_model.reduction_dimensionality
 
         output_name = row_entry.output_name
         if output_name:
             gui_state.output_name = output_name
-        gui_state.reduction_dimensionality = self._state_gui_model.reduction_dimensionality
 
         if row_entry.sample_thickness:
             gui_state.sample_thickness = float(row_entry.sample_thickness)

--- a/scripts/test/SANS/gui_logic/gui_state_director_test.py
+++ b/scripts/test/SANS/gui_logic/gui_state_director_test.py
@@ -19,12 +19,13 @@ from sans.user_file.txt_parsers.UserFileReaderAdapter import UserFileReaderAdapt
 
 class GuiStateDirectorTest(unittest.TestCase):
     @staticmethod
-    def _get_row_entry(option_string="", sample_thickness=8.0, background_workspace="test", scale_factor=1.1):
+    def _get_row_entry(option_string="", sample_thickness=8.0, background_workspace="test", scale_factor=1.1, output_name=None):
         row_entry = RowEntries(
             sample_scatter="SANS2D00022024",
             sample_thickness=sample_thickness,
             background_ws=background_workspace,
             scale_factor=scale_factor,
+            output_name=output_name,
         )
         row_entry.options.set_user_options(option_string)
         return row_entry
@@ -106,6 +107,21 @@ class GuiStateDirectorTest(unittest.TestCase):
         new_state = director.create_state(self._get_row_entry(), row_user_file="NotThere.txt")
 
         self.assertEqual(expected_output_name, new_state.all_states.save.user_specified_output_name)
+
+    def test_output_name_set_correctly_on_row_state(self):
+        test_cases = [(None, None), (None, "row_output_name"), ("state_output_name", None), ("state_output_name", "row_output_name")]
+
+        for state_model_output_name, row_output_name in test_cases:
+            with self.subTest(state_model_output_name=state_model_output_name, row_output_name=row_output_name):
+                state_model = self._get_state_gui_model()
+                state_save = StateSave()
+                state_save.user_specified_output_name = state_model_output_name
+                state_model.all_states.save = state_save
+
+                director = GuiStateDirector(state_model, SANSFacility.ISIS)
+                new_state = director.create_state(self._get_row_entry(output_name=row_output_name))
+
+                self.assertEqual(row_output_name, new_state.all_states.save.user_specified_output_name)
 
 
 if __name__ == "__main__":

--- a/scripts/test/SANS/gui_logic/gui_state_director_test.py
+++ b/scripts/test/SANS/gui_logic/gui_state_director_test.py
@@ -11,6 +11,7 @@ from unittest import mock
 from sans.common.enums import SANSFacility
 from sans.gui_logic.models.RowEntries import RowEntries
 from sans.gui_logic.models.state_gui_model import StateGuiModel
+from sans.state.StateObjects.StateSave import StateSave
 from sans.gui_logic.presenter.gui_state_director import GuiStateDirector
 from sans.test_helper.user_file_test_helper import create_user_file, sample_user_file
 from sans.user_file.txt_parsers.UserFileReaderAdapter import UserFileReaderAdapter
@@ -91,7 +92,10 @@ class GuiStateDirectorTest(unittest.TestCase):
 
     def test_save_settings_copied_from_gui(self):
         state_model = mock.Mock(spec=self._get_state_gui_model())
-        state_model.all_states.save = mock.NonCallableMock()
+        expected_output_name = "user_specified_name"
+        state_save = StateSave()
+        state_save.user_specified_output_name = expected_output_name
+        state_model.all_states.save = state_save
 
         # Copy the top level model and reset save rather than load a file
         copied_state = copy.deepcopy(state_model)
@@ -101,7 +105,7 @@ class GuiStateDirectorTest(unittest.TestCase):
         director._load_current_state = mock.Mock(return_value=copied_state)
         new_state = director.create_state(self._get_row_entry(), row_user_file="NotThere.txt")
 
-        self.assertEqual(state_model.all_states.save, new_state.all_states.save)
+        self.assertEqual(expected_output_name, new_state.all_states.save.user_specified_output_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
This PR fixes the linked issue to ensure that if output names are set for some but not all rows in the ISIS SANS GUI then re-processing a row won't cause the wrong output workspace to be updated.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37356. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

**Report to:** Steve and Dirk in the ISIS SANS Group

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
There were a couple of issues found when investigating that are described on this comment: https://github.com/mantidproject/mantid/issues/37356#issuecomment-2110174302.

The first bullet point (the fact that changing the output name on row state objects caused the main state object to be updated) is addressed in this PR by copying the save settings rather than assigning the save settings object reference to the row state. I've also changed the code so that we only do this if a custom user file has been passed in, as otherwise we are already taking a deep copy of the main state object and so will get all of the GUI settings anyway.

The second issue is addressed by making sure that we are updating the output name on the row state even when that row doesn't have anything set. This will ensure that we clear any value that may have been copied across from the main state.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
See instructions on linked issue and check that we now get the expected behaviour.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
