### PR TITLE
Clarify file numbers produced in ISIS SANS Manual Tests

### DIFF
--- a/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
+++ b/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
@@ -124,7 +124,7 @@ Processing
 #. In the workspaces list, there should be a series of new workspaces; four
    group workspaces and four 1D workspaces.
 #. Check your default save directory. For each reduction two banks (HAB/main) should
-   be saved. In total there should be 20 workspaces saved. For each row, file type, and bank there should be a
+   be saved. In total, there should be 20 workspaces saved. For each row, file type, and bank, there should be a
    reduced file (with no suffix) and a ``sample`` file. The ``first_time`` line should also produce a ``can`` workspace
    for each file type and bank. This is because both workspaces have the same ``can`` input run numbers and so the
    reduction only calculates it once.

--- a/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
+++ b/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
@@ -124,9 +124,10 @@ Processing
 #. In the workspaces list, there should be a series of new workspaces; four
    group workspaces and four 1D workspaces.
 #. Check your default save directory. For each reduction two banks (HAB/main) should
-   be saved. In total there should be 11 workspaces saved. For each row and file type there should be a reduced file
-   (with no suffix) and a ``sample`` file. The ``first_time`` line should also produce a ``can`` workspace. This is
-   because both workspaces have the same ``can`` output and so the reduction only produces it once.
+   be saved. In total there should be 20 workspaces saved. For each row, file type, and bank there should be a
+   reduced file (with no suffix) and a ``sample`` file. The ``first_time`` line should also produce a ``can`` workspace
+   for each file type and bank. This is because both workspaces have the same ``can`` input run numbers and so the
+   reduction only calculates it once.
 #. Double-click the 1D workspaces and you should get a single line plot.
 #. Clear the newly created files and workspaces to make the next test easier
 #. Change the contents of the first cell in the first row to ``74045`` and click

--- a/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
+++ b/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
@@ -124,8 +124,9 @@ Processing
 #. In the workspaces list, there should be a series of new workspaces; four
    group workspaces and four 1D workspaces.
 #. Check your default save directory. For each reduction two banks (HAB/main) should
-   be saved. In total there should be 12 workspaces (6 CanSAS ``.xml`` and 6 NXcanSAS ``.h5``) saved. For each row and
-   file type there should be a reduced file (with no suffix), a sample, and a can workspace.
+   be saved. In total there should be 11 workspaces saved. For each row and file type there should be a reduced file
+   (with no suffix) and a ``sample`` file. The ``first_time`` line should also produce a ``can`` workspace. This is
+   because both workspaces have the same ``can`` output and so the reduction only produces it once.
 #. Double-click the 1D workspaces and you should get a single line plot.
 #. Clear the newly created files and workspaces to make the next test easier
 #. Change the contents of the first cell in the first row to ``74045`` and click


### PR DESCRIPTION
RE #37373

### Description of work
Amend the manual tests for SANS to point out that the `can` file only gets produced once during the reduction. This is due to the can calculation being the same for both rows of the table. 

Fixes #37373 

### To test:
1. Build the dev-docs-html target
2. Check grammar & formatting. 
1. Follow the new instructions in the changed Processing -> 1D reduction section. 
2. Check the number of produced files is correct. 


*This does not require release notes* because **it only affects dev docs.**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
