### PR TITLE
Move plotting in FitTab to plot presenter

### DIFF
--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -251,7 +251,7 @@ void ALFAnalysisView::replot() { m_plot->replot(); }
 void ALFAnalysisView::openExternalPlot(Mantid::API::MatrixWorkspace_sptr const &workspace,
                                        std::vector<int> const &workspaceIndices) const {
   // Externally plot the plotted workspace.
-  MantidQt::Widgets::MplCpp::plot({workspace}, boost::none, workspaceIndices);
+  MantidQt::Widgets::MplCpp::plot({workspace}, std::nullopt, workspaceIndices);
 }
 
 std::pair<double, double> ALFAnalysisView::getRange() const {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.cpp
@@ -47,7 +47,7 @@ void Plotter::reflectometryPlot(const std::vector<std::string> &workspaces) cons
     }
   }
 
-  plot(actualWorkspaces, boost::none, wksp_indices, boost::none, boost::none, ax_properties, window_title,
+  plot(actualWorkspaces, std::nullopt, wksp_indices, std::nullopt, std::nullopt, ax_properties, window_title,
        plotErrorBars, false);
 }
 

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.cpp
@@ -111,17 +111,10 @@ constructActions(std::optional<std::map<std::string, std::string>> const &availa
 namespace MantidQt::CustomInterfaces {
 
 OutputPlotOptionsModel::OutputPlotOptionsModel(
+    std::unique_ptr<IExternalPlotter> plotter,
     std::optional<std::map<std::string, std::string>> const &availableActions)
     : m_actions(constructActions(availableActions)), m_fixedIndices(false), m_workspaceIndices(std::nullopt),
-      m_workspaceName(std::nullopt), m_plotter(std::make_unique<ExternalPlotter>()) {}
-
-/// Used by the unit tests so that m_plotter can be mocked
-OutputPlotOptionsModel::OutputPlotOptionsModel(
-    ExternalPlotter *plotter, std::optional<std::map<std::string, std::string>> const &availableActions)
-    : m_actions(constructActions(availableActions)), m_fixedIndices(false), m_workspaceIndices(std::nullopt),
-      m_workspaceName(std::nullopt), m_plotter(plotter) {}
-
-OutputPlotOptionsModel::~OutputPlotOptionsModel() = default;
+      m_workspaceName(std::nullopt), m_plotter(std::move(plotter)) {}
 
 bool OutputPlotOptionsModel::setWorkspace(std::string const &workspaceName) {
   auto &ads = AnalysisDataService::Instance();

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.h
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsModel.h
@@ -18,42 +18,65 @@ using namespace MantidQt::Widgets::MplCpp;
 namespace MantidQt {
 namespace CustomInterfaces {
 
-class MANTIDQT_INELASTIC_DLL OutputPlotOptionsModel {
+class MANTIDQT_INELASTIC_DLL IOutputPlotOptionsModel {
 public:
-  OutputPlotOptionsModel(std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
-  /// Used by the unit tests so that m_plotter can be mocked
-  OutputPlotOptionsModel(ExternalPlotter *plotter,
+  virtual ~IOutputPlotOptionsModel() = default;
+
+  virtual bool setWorkspace(std::string const &workspaceName) = 0;
+  virtual void removeWorkspace() = 0;
+  virtual std::vector<std::string> getAllWorkspaceNames(std::vector<std::string> const &workspaceNames) const = 0;
+  virtual std::optional<std::string> workspace() const = 0;
+  virtual void setFixedIndices(std::string const &indices) = 0;
+  virtual bool indicesFixed() const = 0;
+  virtual void setUnit(std::string const &unit) = 0;
+  virtual std::optional<std::string> unit() = 0;
+  virtual std::string formatIndices(std::string const &indices) const = 0;
+  virtual bool validateIndices(std::string const &indices, MantidAxis const &axisType = MantidAxis::Spectrum) const = 0;
+  virtual bool setIndices(std::string const &indices) = 0;
+  virtual std::optional<std::string> indices() const = 0;
+  virtual void plotSpectra() = 0;
+  virtual void plotBins(std::string const &binIndices) = 0;
+  virtual void plotTiled() = 0;
+  virtual void plot3DSurface() = 0;
+  virtual void showSliceViewer() = 0;
+  virtual std::optional<std::string> singleDataPoint(MantidAxis const &axisType) const = 0;
+  virtual std::map<std::string, std::string> availableActions() const = 0;
+};
+
+class MANTIDQT_INELASTIC_DLL OutputPlotOptionsModel final : public IOutputPlotOptionsModel {
+public:
+  OutputPlotOptionsModel(std::unique_ptr<IExternalPlotter> plotter,
                          std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
-  virtual ~OutputPlotOptionsModel();
+  virtual ~OutputPlotOptionsModel() = default;
 
-  virtual bool setWorkspace(std::string const &workspaceName);
-  virtual void removeWorkspace();
+  bool setWorkspace(std::string const &workspaceName) override;
+  void removeWorkspace() override;
 
-  virtual std::vector<std::string> getAllWorkspaceNames(std::vector<std::string> const &workspaceNames) const;
+  std::vector<std::string> getAllWorkspaceNames(std::vector<std::string> const &workspaceNames) const override;
 
-  std::optional<std::string> workspace() const;
+  std::optional<std::string> workspace() const override;
 
-  virtual void setFixedIndices(std::string const &indices);
-  virtual bool indicesFixed() const;
+  void setFixedIndices(std::string const &indices) override;
+  bool indicesFixed() const override;
 
-  virtual void setUnit(std::string const &unit);
-  std::optional<std::string> unit();
+  void setUnit(std::string const &unit) override;
+  std::optional<std::string> unit() override;
 
-  virtual std::string formatIndices(std::string const &indices) const;
-  virtual bool validateIndices(std::string const &indices, MantidAxis const &axisType = MantidAxis::Spectrum) const;
-  virtual bool setIndices(std::string const &indices);
+  std::string formatIndices(std::string const &indices) const override;
+  bool validateIndices(std::string const &indices, MantidAxis const &axisType = MantidAxis::Spectrum) const override;
+  bool setIndices(std::string const &indices) override;
 
-  std::optional<std::string> indices() const;
+  std::optional<std::string> indices() const override;
 
-  virtual void plotSpectra();
-  virtual void plotBins(std::string const &binIndices);
-  virtual void plotTiled();
-  virtual void plot3DSurface();
-  virtual void showSliceViewer();
+  void plotSpectra() override;
+  void plotBins(std::string const &binIndices) override;
+  void plotTiled() override;
+  void plot3DSurface() override;
+  void showSliceViewer() override;
 
-  std::optional<std::string> singleDataPoint(MantidAxis const &axisType) const;
+  std::optional<std::string> singleDataPoint(MantidAxis const &axisType) const override;
 
-  std::map<std::string, std::string> availableActions() const;
+  std::map<std::string, std::string> availableActions() const override;
 
 private:
   bool validateSpectra(const Mantid::API::MatrixWorkspace_sptr &workspace, std::string const &spectra) const;
@@ -67,7 +90,7 @@ private:
   std::optional<std::string> m_workspaceIndices;
   std::optional<std::string> m_workspaceName;
   std::optional<std::string> m_unit;
-  std::unique_ptr<ExternalPlotter> m_plotter;
+  std::unique_ptr<IExternalPlotter> m_plotter;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.cpp
@@ -37,7 +37,8 @@ namespace MantidQt::CustomInterfaces {
 OutputPlotOptionsPresenter::OutputPlotOptionsPresenter(
     IOutputPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
     std::optional<std::map<std::string, std::string>> const &availableActions)
-    : m_view(view), m_model(std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>(), availableActions)) {
+    : m_view(view),
+      m_model(std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>(), availableActions)) {
   setupPresenter(plotType, fixedIndices);
 }
 

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.cpp
@@ -37,14 +37,15 @@ namespace MantidQt::CustomInterfaces {
 OutputPlotOptionsPresenter::OutputPlotOptionsPresenter(
     IOutputPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
     std::optional<std::map<std::string, std::string>> const &availableActions)
-    : m_view(view), m_model(std::make_unique<OutputPlotOptionsModel>(availableActions)) {
+    : m_view(view), m_model(std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>(), availableActions)) {
   setupPresenter(plotType, fixedIndices);
 }
 
 /// Used by the unit tests so that m_plotter can be mocked
-OutputPlotOptionsPresenter::OutputPlotOptionsPresenter(IOutputPlotOptionsView *view, OutputPlotOptionsModel *model,
+OutputPlotOptionsPresenter::OutputPlotOptionsPresenter(IOutputPlotOptionsView *view,
+                                                       std::unique_ptr<IOutputPlotOptionsModel> model,
                                                        PlotWidget const &plotType, std::string const &fixedIndices)
-    : m_view(view), m_model(model) {
+    : m_view(view), m_model(std::move(model)) {
   setupPresenter(plotType, fixedIndices);
 }
 

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.h
@@ -38,7 +38,7 @@ public:
                              std::string const &fixedIndices = "",
                              std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
   /// Used by the unit tests so that the view and model can be mocked
-  OutputPlotOptionsPresenter(IOutputPlotOptionsView *view, OutputPlotOptionsModel *model,
+  OutputPlotOptionsPresenter(IOutputPlotOptionsView *view, std::unique_ptr<IOutputPlotOptionsModel> model,
                              PlotWidget const &plotType = PlotWidget::Spectra, std::string const &fixedIndices = "");
   ~OutputPlotOptionsPresenter() = default;
 
@@ -73,7 +73,7 @@ private:
   bool validateWorkspaceSize(MantidAxis const &axisType);
 
   IOutputPlotOptionsView *m_view;
-  std::unique_ptr<OutputPlotOptionsModel> m_model;
+  std::unique_ptr<IOutputPlotOptionsModel> m_model;
   PlotWidget m_plotType;
 };
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsModel.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsModel.h
@@ -35,11 +35,8 @@ public:
   bool isResultGroupPlottable() const override;
   bool isPDFGroupPlottable() const override;
 
-  void clearSpectraToPlot() override;
-  std::vector<SpectrumToPlot> getSpectraToPlot() const override;
-
-  void plotResult(std::string const &plotType) override;
-  void plotPDF(std::string const &workspaceName, std::string const &plotType) override;
+  std::vector<SpectrumToPlot> plotResult(std::string const &plotType) const override;
+  std::vector<SpectrumToPlot> plotPDF(std::string const &workspaceName, std::string const &plotType) const override;
 
   void saveResult() const override;
 
@@ -52,15 +49,24 @@ public:
                         std::string const &outputName) override;
 
 private:
-  void plotResult(const Mantid::API::WorkspaceGroup_const_sptr &groupWorkspace, std::string const &plotType);
-  void plotAll(const Mantid::API::WorkspaceGroup_const_sptr &groupWorkspace);
-  void plotAll(const Mantid::API::MatrixWorkspace_const_sptr &workspace);
-  void plotAllSpectra(const Mantid::API::MatrixWorkspace_const_sptr &workspace);
-  void plotParameter(const Mantid::API::WorkspaceGroup_const_sptr &groupWorkspace, std::string const &parameter);
-  void plotParameter(const Mantid::API::MatrixWorkspace_const_sptr &workspace, std::string const &parameter);
-  void plotParameterSpectrum(const Mantid::API::MatrixWorkspace_const_sptr &workspace, std::string const &parameter);
+  void plotResult(std::vector<SpectrumToPlot> &spectraToPlot,
+                  const Mantid::API::WorkspaceGroup_const_sptr &groupWorkspace, std::string const &plotType) const;
+  void plotAll(std::vector<SpectrumToPlot> &spectraToPlot,
+               const Mantid::API::WorkspaceGroup_const_sptr &groupWorkspace) const;
+  void plotAll(std::vector<SpectrumToPlot> &spectraToPlot,
+               const Mantid::API::MatrixWorkspace_const_sptr &workspace) const;
+  void plotAllSpectra(std::vector<SpectrumToPlot> &spectraToPlot,
+                      const Mantid::API::MatrixWorkspace_const_sptr &workspace) const;
+  void plotParameter(std::vector<SpectrumToPlot> &spectraToPlot,
+                     const Mantid::API::WorkspaceGroup_const_sptr &groupWorkspace, std::string const &parameter) const;
+  void plotParameter(std::vector<SpectrumToPlot> &spectraToPlot,
+                     const Mantid::API::MatrixWorkspace_const_sptr &workspace, std::string const &parameter) const;
+  void plotParameterSpectrum(std::vector<SpectrumToPlot> &spectraToPlot,
+                             const Mantid::API::MatrixWorkspace_const_sptr &workspace,
+                             std::string const &parameter) const;
 
-  void plotPDF(const Mantid::API::MatrixWorkspace_const_sptr &workspace, std::string const &plotType);
+  void plotPDF(std::vector<SpectrumToPlot> &spectraToPlot, const Mantid::API::MatrixWorkspace_const_sptr &workspace,
+               std::string const &plotType) const;
 
   void replaceFitResult(const Mantid::API::MatrixWorkspace_sptr &inputWorkspace,
                         const Mantid::API::MatrixWorkspace_sptr &singleFitWorkspace, std::string const &outputName);
@@ -69,7 +75,6 @@ private:
 
   Mantid::API::WorkspaceGroup_sptr m_resultGroup;
   Mantid::API::WorkspaceGroup_sptr m_pdfGroup;
-  std::vector<SpectrumToPlot> m_spectraToPlot;
 };
 
 } // namespace Inelastic

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "FitOutputOptionsPresenter.h"
+#include "Common/SettingsHelper.h"
 #include "FitTab.h"
 
 #include <utility>
@@ -66,10 +67,13 @@ void FitOutputOptionsPresenter::handlePlotClicked() {
   setPlotting(true);
   try {
     plotResult(m_view->getSelectedGroupWorkspace());
-    m_tab->handlePlotSelectedSpectra();
+    for (auto const &spectrum : m_model->getSpectraToPlot())
+      m_plotter->plotSpectra(spectrum.first, std::to_string(spectrum.second), SettingsHelper::externalPlotErrorBars());
+    m_model->clearSpectraToPlot();
   } catch (std::runtime_error const &ex) {
     displayWarning(ex.what());
   }
+  setPlotting(false);
 }
 
 void FitOutputOptionsPresenter::plotResult(std::string const &selectedGroup) {
@@ -115,10 +119,6 @@ void FitOutputOptionsPresenter::setPlotEnabled(bool enable) {
 void FitOutputOptionsPresenter::setEditResultEnabled(bool enable) { m_view->setEditResultEnabled(enable); }
 
 void FitOutputOptionsPresenter::setSaveEnabled(bool enable) { m_view->setSaveEnabled(enable); }
-
-void FitOutputOptionsPresenter::clearSpectraToPlot() { m_model->clearSpectraToPlot(); }
-
-std::vector<SpectrumToPlot> FitOutputOptionsPresenter::getSpectraToPlot() const { return m_model->getSpectraToPlot(); }
 
 void FitOutputOptionsPresenter::setEditResultVisible(bool visible) { m_view->setEditResultVisible(visible); }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.cpp
@@ -5,8 +5,11 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "FitOutputOptionsPresenter.h"
+
 #include "Common/SettingsHelper.h"
 #include "FitTab.h"
+
+#include "MantidQtWidgets/Common/WorkspaceUtils.h"
 
 #include <utility>
 
@@ -39,8 +42,16 @@ void FitOutputOptionsPresenter::setResultWorkspace(WorkspaceGroup_sptr groupWork
   m_model->setResultWorkspace(std::move(groupWorkspace));
 }
 
-void FitOutputOptionsPresenter::setPDFWorkspace(WorkspaceGroup_sptr groupWorkspace) {
-  m_model->setPDFWorkspace(std::move(groupWorkspace));
+void FitOutputOptionsPresenter::setPDFWorkspace(std::string const &workspaceName, std::string const &minimizer) {
+  auto const enablePDFOptions = WorkspaceUtils::doesExistInADS(workspaceName) && minimizer == "FABADA";
+
+  if (enablePDFOptions) {
+    m_model->setPDFWorkspace(WorkspaceUtils::getADSWorkspace<WorkspaceGroup>(workspaceName));
+    setPlotWorkspaces();
+  } else {
+    m_model->removePDFWorkspace();
+  }
+  setMultiWorkspaceOptionsVisible(enablePDFOptions);
 }
 
 void FitOutputOptionsPresenter::setPlotWorkspaces() {
@@ -60,8 +71,6 @@ void FitOutputOptionsPresenter::setPlotTypes(std::string const &selectedGroup) {
     m_view->setPlotTypeIndex(0);
   }
 }
-
-void FitOutputOptionsPresenter::removePDFWorkspace() { m_model->removePDFWorkspace(); }
 
 void FitOutputOptionsPresenter::handlePlotClicked() {
   setPlotting(true);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.cpp
@@ -14,8 +14,9 @@ using namespace Mantid::API;
 namespace MantidQt::CustomInterfaces::Inelastic {
 
 FitOutputOptionsPresenter::FitOutputOptionsPresenter(IFitTab *tab, IFitOutputOptionsView *view,
-                                                     std::unique_ptr<IFitOutputOptionsModel> model)
-    : m_tab(tab), m_view(view), m_model(std::move(model)) {
+                                                     std::unique_ptr<IFitOutputOptionsModel> model,
+                                                     std::unique_ptr<Widgets::MplCpp::IExternalPlotter> plotter)
+    : m_tab(tab), m_view(view), m_model(std::move(model)), m_plotter(std::move(plotter)) {
   setMultiWorkspaceOptionsVisible(false);
   m_view->subscribePresenter(this);
 }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.cpp
@@ -38,8 +38,19 @@ void FitOutputOptionsPresenter::handleGroupWorkspaceChanged(std::string const &s
   m_view->setPlotEnabled(isSelectedGroupPlottable());
 }
 
-void FitOutputOptionsPresenter::setResultWorkspace(WorkspaceGroup_sptr groupWorkspace) {
-  m_model->setResultWorkspace(std::move(groupWorkspace));
+void FitOutputOptionsPresenter::enableOutputOptions(bool const enable, WorkspaceGroup_sptr resultWorkspace,
+                                                    std::string const &basename, std::string const &minimizer) {
+  if (enable) {
+    m_model->setResultWorkspace(resultWorkspace);
+    setPDFWorkspace(basename + "_PDFs", minimizer);
+    setPlotTypes("Result Group");
+  } else {
+    setMultiWorkspaceOptionsVisible(enable);
+  }
+
+  setPlotEnabled(enable);
+  m_view->setEditResultEnabled(enable);
+  m_view->setSaveEnabled(enable);
 }
 
 void FitOutputOptionsPresenter::setPDFWorkspace(std::string const &workspaceName, std::string const &minimizer) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.cpp
@@ -39,10 +39,13 @@ void FitOutputOptionsPresenter::handleGroupWorkspaceChanged(std::string const &s
 }
 
 void FitOutputOptionsPresenter::enableOutputOptions(bool const enable, WorkspaceGroup_sptr resultWorkspace,
-                                                    std::string const &basename, std::string const &minimizer) {
+                                                    std::optional<std::string> const &basename,
+                                                    std::string const &minimizer) {
   if (enable) {
     m_model->setResultWorkspace(resultWorkspace);
-    setPDFWorkspace(basename + "_PDFs", minimizer);
+    if (basename) {
+      setPDFWorkspace(*basename + "_PDFs", minimizer);
+    }
     setPlotTypes("Result Group");
   } else {
     setMultiWorkspaceOptionsVisible(enable);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
@@ -49,9 +49,6 @@ public:
   void setEditResultEnabled(bool enable);
   void setSaveEnabled(bool enable);
 
-  void clearSpectraToPlot();
-  std::vector<SpectrumToPlot> getSpectraToPlot() const;
-
   void setEditResultVisible(bool visible);
 
   void handleGroupWorkspaceChanged(std::string const &selectedGroup) override;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
@@ -30,7 +30,7 @@ public:
 
 class MANTIDQT_INELASTIC_DLL FitOutputOptionsPresenter final : public IFitOutputOptionsPresenter {
 public:
-  FitOutputOptionsPresenter(IFitTab *tab, IFitOutputOptionsView *view, std::unique_ptr<IFitOutputOptionsModel> model,
+  FitOutputOptionsPresenter(IFitOutputOptionsView *view, std::unique_ptr<IFitOutputOptionsModel> model,
                             std::unique_ptr<Widgets::MplCpp::IExternalPlotter> plotter);
 
   void setMultiWorkspaceOptionsVisible(bool visible);
@@ -58,7 +58,7 @@ public:
                                     std::string const &outputName) override;
 
 private:
-  void plotResult(std::string const &selectedGroup);
+  std::vector<SpectrumToPlot> getSpectraToPlot(std::string const &selectedGroup) const;
   void setSaving(bool saving);
 
   void setEditingResult(bool editing);
@@ -68,7 +68,6 @@ private:
 
   void displayWarning(std::string const &message);
 
-  IFitTab *m_tab;
   IFitOutputOptionsView *m_view;
   std::unique_ptr<IFitOutputOptionsModel> m_model;
   std::unique_ptr<Widgets::MplCpp::IExternalPlotter> m_plotter;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
@@ -33,18 +33,8 @@ public:
   FitOutputOptionsPresenter(IFitOutputOptionsView *view, std::unique_ptr<IFitOutputOptionsModel> model,
                             std::unique_ptr<Widgets::MplCpp::IExternalPlotter> plotter);
 
-  void setMultiWorkspaceOptionsVisible(bool visible);
-
-  void setResultWorkspace(Mantid::API ::WorkspaceGroup_sptr groupWorkspace);
-  void setPDFWorkspace(std::string const &workspaceName, std::string const &minimizer);
-  void setPlotTypes(std::string const &selectedGroup);
-
-  bool isSelectedGroupPlottable() const;
-
-  void setPlotting(bool plotting);
-  void setPlotEnabled(bool enable);
-  void setEditResultEnabled(bool enable);
-  void setSaveEnabled(bool enable);
+  void enableOutputOptions(bool const enable, Mantid::API::WorkspaceGroup_sptr resultWorkspace,
+                           std::string const &basename, std::string const &minimizer);
 
   void setEditResultVisible(bool visible);
 
@@ -55,7 +45,17 @@ public:
                                     std::string const &outputName) override;
 
 private:
+  bool isSelectedGroupPlottable() const;
+
+  void setMultiWorkspaceOptionsVisible(bool visible);
+  void setPDFWorkspace(std::string const &workspaceName, std::string const &minimizer);
   void setPlotWorkspaces();
+  void setPlotTypes(std::string const &selectedGroup);
+
+  void setPlotting(bool plotting);
+  void setPlotEnabled(bool enable);
+  void setEditResultEnabled(bool enable);
+  void setSaveEnabled(bool enable);
 
   std::vector<SpectrumToPlot> getSpectraToPlot(std::string const &selectedGroup) const;
   void setSaving(bool saving);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
@@ -36,11 +36,8 @@ public:
   void setMultiWorkspaceOptionsVisible(bool visible);
 
   void setResultWorkspace(Mantid::API ::WorkspaceGroup_sptr groupWorkspace);
-  void setPDFWorkspace(Mantid::API ::WorkspaceGroup_sptr groupWorkspace);
-  void setPlotWorkspaces();
+  void setPDFWorkspace(std::string const &workspaceName, std::string const &minimizer);
   void setPlotTypes(std::string const &selectedGroup);
-
-  void removePDFWorkspace();
 
   bool isSelectedGroupPlottable() const;
 
@@ -58,6 +55,8 @@ public:
                                     std::string const &outputName) override;
 
 private:
+  void setPlotWorkspaces();
+
   std::vector<SpectrumToPlot> getSpectraToPlot(std::string const &selectedGroup) const;
   void setSaving(bool saving);
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
@@ -44,16 +44,18 @@ public:
   void handleReplaceSingleFitResult(std::string const &inputName, std::string const &singleBinName,
                                     std::string const &outputName) override;
 
+  // Public for testing purposes
+  void setPlotting(bool plotting);
+  void setPlotWorkspaces();
+  void setPlotTypes(std::string const &selectedGroup);
+  void setPlotEnabled(bool enable);
+
 private:
   bool isSelectedGroupPlottable() const;
 
   void setMultiWorkspaceOptionsVisible(bool visible);
   void setPDFWorkspace(std::string const &workspaceName, std::string const &minimizer);
-  void setPlotWorkspaces();
-  void setPlotTypes(std::string const &selectedGroup);
 
-  void setPlotting(bool plotting);
-  void setPlotEnabled(bool enable);
   void setEditResultEnabled(bool enable);
   void setSaveEnabled(bool enable);
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
@@ -11,6 +11,7 @@
 
 #include "DllConfig.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidQtWidgets/Plotting/ExternalPlotter.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -29,7 +30,8 @@ public:
 
 class MANTIDQT_INELASTIC_DLL FitOutputOptionsPresenter final : public IFitOutputOptionsPresenter {
 public:
-  FitOutputOptionsPresenter(IFitTab *tab, IFitOutputOptionsView *view, std::unique_ptr<IFitOutputOptionsModel> model);
+  FitOutputOptionsPresenter(IFitTab *tab, IFitOutputOptionsView *view, std::unique_ptr<IFitOutputOptionsModel> model,
+                            std::unique_ptr<Widgets::MplCpp::IExternalPlotter> plotter);
 
   void setMultiWorkspaceOptionsVisible(bool visible);
 
@@ -72,6 +74,7 @@ private:
   IFitTab *m_tab;
   IFitOutputOptionsView *m_view;
   std::unique_ptr<IFitOutputOptionsModel> m_model;
+  std::unique_ptr<Widgets::MplCpp::IExternalPlotter> m_plotter;
 };
 
 } // namespace Inelastic

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsPresenter.h
@@ -34,7 +34,7 @@ public:
                             std::unique_ptr<Widgets::MplCpp::IExternalPlotter> plotter);
 
   void enableOutputOptions(bool const enable, Mantid::API::WorkspaceGroup_sptr resultWorkspace,
-                           std::string const &basename, std::string const &minimizer);
+                           std::optional<std::string> const &basename, std::string const &minimizer);
 
   void setEditResultVisible(bool visible);
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
@@ -139,7 +139,8 @@ void FitTab::enableFitButtons(bool enable) {
 void FitTab::enableOutputOptions(bool enable) {
   if (enable) {
     m_outOptionsPresenter->setResultWorkspace(m_fittingPresenter->getResultWorkspace());
-    setPDFWorkspace(m_fittingPresenter->getOutputBasename() + "_PDFs");
+    m_outOptionsPresenter->setPDFWorkspace(m_fittingPresenter->getOutputBasename() + "_PDFs",
+                                           m_fittingPresenter->minimizer());
     m_outOptionsPresenter->setPlotTypes("Result Group");
   } else
     m_outOptionsPresenter->setMultiWorkspaceOptionsVisible(enable);
@@ -147,23 +148,6 @@ void FitTab::enableOutputOptions(bool enable) {
   m_outOptionsPresenter->setPlotEnabled(enable && m_outOptionsPresenter->isSelectedGroupPlottable());
   m_outOptionsPresenter->setEditResultEnabled(enable);
   m_outOptionsPresenter->setSaveEnabled(enable);
-}
-
-/**
- * Sets the active PDF workspace within the output options if one exists for the
- * current run
- * @param workspaceName :: the name of the PDF workspace if it exists
- */
-void FitTab::setPDFWorkspace(std::string const &workspaceName) {
-  auto const fabMinimizer = m_fittingPresenter->minimizer() == "FABADA";
-  auto const enablePDFOptions = WorkspaceUtils::doesExistInADS(workspaceName) && fabMinimizer;
-
-  if (enablePDFOptions) {
-    m_outOptionsPresenter->setPDFWorkspace(WorkspaceUtils::getADSWorkspace<WorkspaceGroup>(workspaceName));
-    m_outOptionsPresenter->setPlotWorkspaces();
-  } else
-    m_outOptionsPresenter->removePDFWorkspace();
-  m_outOptionsPresenter->setMultiWorkspaceOptionsVisible(enablePDFOptions);
 }
 
 void FitTab::updateParameterEstimationData() {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
@@ -11,6 +11,7 @@
 
 #include "MantidAPI/MultiDomainFunction.h"
 #include "MantidQtWidgets/Common/WorkspaceUtils.h"
+#include "MantidQtWidgets/Plotting/ExternalPlotter.h"
 
 #include <QString>
 
@@ -34,8 +35,9 @@ void FitTab::setup() {
 
 void FitTab::setupOutputOptionsPresenter(bool const editResults) {
   auto model = std::make_unique<FitOutputOptionsModel>();
-  m_outOptionsPresenter =
-      std::make_unique<FitOutputOptionsPresenter>(this, m_uiForm->ovOutputOptionsView, std::move(model));
+  auto plotter = std::make_unique<Widgets::MplCpp::ExternalPlotter>();
+  m_outOptionsPresenter = std::make_unique<FitOutputOptionsPresenter>(this, m_uiForm->ovOutputOptionsView,
+                                                                      std::move(model), std::move(plotter));
   m_outOptionsPresenter->setEditResultVisible(editResults);
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "FitTab.h"
 #include "Common/InterfaceUtils.h"
-#include "Common/SettingsHelper.h"
 #include "FitPlotView.h"
 
 #include "MantidAPI/MultiDomainFunction.h"
@@ -88,18 +87,6 @@ void FitTab::handleEndXChanged(double endX) {
   updateParameterEstimationData();
   m_plotPresenter->updateGuess();
   m_dataPresenter->updateTableFromModel();
-}
-
-/**
- * Plots the spectra corresponding to the selected parameters
- */
-void FitTab::handlePlotSelectedSpectra() {
-  enableFitButtons(false);
-  for (auto const &spectrum : m_outOptionsPresenter->getSpectraToPlot())
-    m_plotter->plotSpectra(spectrum.first, std::to_string(spectrum.second), SettingsHelper::externalPlotErrorBars());
-  m_outOptionsPresenter->clearSpectraToPlot();
-  enableFitButtons(true);
-  m_outOptionsPresenter->setPlotting(false);
 }
 
 void FitTab::handleSingleFitClicked() {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
@@ -35,8 +35,8 @@ void FitTab::setup() {
 void FitTab::setupOutputOptionsPresenter(bool const editResults) {
   auto model = std::make_unique<FitOutputOptionsModel>();
   auto plotter = std::make_unique<Widgets::MplCpp::ExternalPlotter>();
-  m_outOptionsPresenter = std::make_unique<FitOutputOptionsPresenter>(this, m_uiForm->ovOutputOptionsView,
-                                                                      std::move(model), std::move(plotter));
+  m_outOptionsPresenter =
+      std::make_unique<FitOutputOptionsPresenter>(m_uiForm->ovOutputOptionsView, std::move(model), std::move(plotter));
   m_outOptionsPresenter->setEditResultVisible(editResults);
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
@@ -13,7 +13,6 @@
 #include "FitPlotPresenter.h"
 #include "FittingPresenter.h"
 #include "FunctionBrowser/TemplateSubType.h"
-#include "InelasticFitPropertyBrowser.h"
 #include "MantidQtWidgets/Common/AlgorithmRunner.h"
 #include "MantidQtWidgets/Common/QtJobRunner.h"
 #include "ui_FitTab.h"
@@ -114,11 +113,10 @@ private:
   bool validate() override;
   void run() override;
 
-  void enableFitButtons(bool enable);
-  void setModelFitFunction();
-
   void updateParameterEstimationData();
   void updateDataReferences();
+  void updateFitFunction();
+  void updateFitButtons(bool const enable);
   void updateOutputOptions(bool const enable);
 
   std::unique_ptr<Ui::FitTab> m_uiForm;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
@@ -116,7 +116,6 @@ private:
 
   void enableFitButtons(bool enable);
   void enableOutputOptions(bool enable);
-  void setPDFWorkspace(std::string const &workspaceName);
   void setModelFitFunction();
 
   void updateParameterEstimationData();

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
@@ -115,12 +115,11 @@ private:
   void run() override;
 
   void enableFitButtons(bool enable);
-  void enableOutputOptions(bool enable);
   void setModelFitFunction();
 
   void updateParameterEstimationData();
   void updateDataReferences();
-  void updateResultOptions();
+  void updateOutputOptions(bool const enable);
 
   std::unique_ptr<Ui::FitTab> m_uiForm;
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
@@ -44,9 +44,6 @@ public:
   virtual void handleFwhmChanged(double fwhm) = 0;
   virtual void handleBackgroundChanged(double background) = 0;
 
-  // Used by FitOutputOptionsPresenter
-  virtual void handlePlotSelectedSpectra() = 0;
-
   // Used by FittingPresenter
   virtual void handleFunctionChanged() = 0;
   virtual void handleFitComplete(bool const error) = 0;
@@ -108,8 +105,6 @@ public:
   void handlePlotSpectrumChanged() override;
   void handleFwhmChanged(double fwhm) override;
   void handleBackgroundChanged(double background) override;
-
-  void handlePlotSelectedSpectra() override;
 
   void handleFunctionChanged() override;
   void handleFitComplete(bool const error) override;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.cpp
@@ -371,14 +371,14 @@ std::string FittingModel::createOutputName(const std::string &fitMode, const std
 }
 
 std::optional<std::string> FittingModel::sequentialFitOutputName() const {
-  auto workspaceNames = m_fitDataModel->getWorkspaceNames();
+  auto const workspaceNames = m_fitDataModel->getWorkspaceNames();
   if (workspaceNames.empty())
     return std::nullopt;
   return createOutputName(SEQ_STRING, workspaceNames[0], m_fitDataModel->getSpectra(WorkspaceID{0}).getString());
 }
 
 std::optional<std::string> FittingModel::simultaneousFitOutputName() const {
-  auto workspaceNames = m_fitDataModel->getWorkspaceNames();
+  auto const workspaceNames = m_fitDataModel->getWorkspaceNames();
   if (workspaceNames.empty())
     return std::nullopt;
   return createOutputName(SIM_STRING, workspaceNames[0], m_fitDataModel->getSpectra(WorkspaceID{0}).getString());
@@ -558,10 +558,14 @@ IAlgorithm_sptr FittingModel::createSequentialFit(const IFunction_sptr function)
 }
 
 IAlgorithm_sptr FittingModel::createSequentialFit(const IFunction_sptr function, const std::string &input) const {
+  auto const outputName = sequentialFitOutputName();
+  if (!outputName) {
+    throw std::runtime_error("Data has not been loaded.");
+  }
   auto fitAlgorithm = sequentialFitAlgorithm();
   addFitProperties(*fitAlgorithm, function, getResultXAxisUnit());
   fitAlgorithm->setProperty("Input", input);
-  fitAlgorithm->setProperty("OutputWorkspace", *sequentialFitOutputName());
+  fitAlgorithm->setProperty("OutputWorkspace", *outputName);
   fitAlgorithm->setProperty("LogName", getResultLogName());
   std::stringstream startX;
   std::stringstream endX;
@@ -588,10 +592,14 @@ IAlgorithm_sptr FittingModel::createSequentialFit(const IFunction_sptr function,
 }
 
 IAlgorithm_sptr FittingModel::createSimultaneousFit(const MultiDomainFunction_sptr &function) const {
+  auto const outputName = simultaneousFitOutputName();
+  if (!outputName) {
+    throw std::runtime_error("Data has not been loaded.");
+  }
   auto fitAlgorithm = simultaneousFitAlgorithm();
   addFitProperties(*fitAlgorithm, function, getResultXAxisUnit());
   addInputDataToSimultaneousFit(fitAlgorithm, m_fitDataModel.get());
-  fitAlgorithm->setProperty("OutputWorkspace", *simultaneousFitOutputName());
+  fitAlgorithm->setProperty("OutputWorkspace", *outputName);
   return fitAlgorithm;
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.h
@@ -85,7 +85,7 @@ public:
   Mantid::API::IAlgorithm_sptr getFittingAlgorithm(FittingMode mode) const override;
   Mantid::API::IAlgorithm_sptr getSingleFittingAlgorithm() const override;
   Mantid::API::IFunction_sptr getSingleFunction(WorkspaceID workspaceID, WorkspaceIndex spectrum) const override;
-  std::string getOutputBasename() const override;
+  std::optional<std::string> getOutputBasename() const override;
 
   void cleanFailedRun(const Mantid::API::IAlgorithm_sptr &fittingAlgorithm) override;
   void removeFittingData() override;
@@ -118,8 +118,8 @@ private:
                                                    const std::string &input) const;
   virtual Mantid::API::IAlgorithm_sptr sequentialFitAlgorithm() const;
   virtual Mantid::API::IAlgorithm_sptr simultaneousFitAlgorithm() const;
-  virtual std::string sequentialFitOutputName() const;
-  virtual std::string simultaneousFitOutputName() const;
+  virtual std::optional<std::string> sequentialFitOutputName() const;
+  virtual std::optional<std::string> simultaneousFitOutputName() const;
   virtual std::string singleFitOutputName(std::string workspaceName, WorkspaceIndex spectrum) const;
   virtual std::unordered_map<std::string, ParameterValue> createDefaultParameters(WorkspaceID workspaceID) const;
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingPresenter.cpp
@@ -91,7 +91,7 @@ void FittingPresenter::notifyBatchComplete(MantidQt::API::IConfiguredAlgorithm_s
 
 Mantid::API::WorkspaceGroup_sptr FittingPresenter::getResultWorkspace() const { return m_model->getResultWorkspace(); }
 
-std::string FittingPresenter::getOutputBasename() const { return m_model->getOutputBasename(); }
+std::optional<std::string> FittingPresenter::getOutputBasename() const { return m_model->getOutputBasename(); }
 
 IFitDataModel *FittingPresenter::getFitDataModel() const { return m_model->getFitDataModel(); }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingPresenter.h
@@ -77,7 +77,7 @@ public:
   void notifyBatchComplete(MantidQt::API::IConfiguredAlgorithm_sptr &lastAlgorithm, bool error) override;
 
   Mantid::API::WorkspaceGroup_sptr getResultWorkspace() const;
-  std::string getOutputBasename() const;
+  std::optional<std::string> getOutputBasename() const;
 
   IFitDataModel *getFitDataModel() const;
   IFitPlotModel *getFitPlotModel() const;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/IFitOutputOptionsModel.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/IFitOutputOptionsModel.h
@@ -31,11 +31,8 @@ public:
   virtual bool isResultGroupPlottable() const = 0;
   virtual bool isPDFGroupPlottable() const = 0;
 
-  virtual void clearSpectraToPlot() = 0;
-  virtual std::vector<SpectrumToPlot> getSpectraToPlot() const = 0;
-
-  virtual void plotResult(std::string const &plotType) = 0;
-  virtual void plotPDF(std::string const &workspaceName, std::string const &plotType) = 0;
+  virtual std::vector<SpectrumToPlot> plotResult(std::string const &plotType) const = 0;
+  virtual std::vector<SpectrumToPlot> plotPDF(std::string const &workspaceName, std::string const &plotType) const = 0;
 
   virtual void saveResult() const = 0;
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/IFittingModel.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/IFittingModel.h
@@ -72,7 +72,7 @@ public:
   virtual Mantid::API::IAlgorithm_sptr getFittingAlgorithm(FittingMode mode) const = 0;
   virtual Mantid::API::IAlgorithm_sptr getSingleFittingAlgorithm() const = 0;
   virtual Mantid::API::IFunction_sptr getSingleFunction(WorkspaceID workspaceID, WorkspaceIndex spectrum) const = 0;
-  virtual std::string getOutputBasename() const = 0;
+  virtual std::optional<std::string> getOutputBasename() const = 0;
 
   virtual void cleanFailedRun(const Mantid::API::IAlgorithm_sptr &fittingAlgorithm) = 0;
   virtual void removeFittingData() = 0;

--- a/qt/scientific_interfaces/Inelastic/test/Common/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/Common/MockObjects.h
@@ -58,7 +58,7 @@ public:
   MOCK_METHOD1(displayWarning, void(QString const &message));
 };
 
-class MockOutputPlotOptionsModel : public OutputPlotOptionsModel {
+class MockOutputPlotOptionsModel : public IOutputPlotOptionsModel {
 public:
   virtual ~MockOutputPlotOptionsModel() = default;
 
@@ -66,19 +66,27 @@ public:
   MOCK_METHOD0(removeWorkspace, void());
 
   MOCK_CONST_METHOD1(getAllWorkspaceNames, std::vector<std::string>(std::vector<std::string> const &workspaceNames));
+  MOCK_CONST_METHOD0(workspace, std::optional<std::string>());
 
   MOCK_METHOD1(setFixedIndices, void(std::string const &indices));
   MOCK_CONST_METHOD0(indicesFixed, bool());
 
+  MOCK_METHOD1(setUnit, void(std::string const &unit));
+  MOCK_METHOD0(unit, std::optional<std::string>());
+
   MOCK_CONST_METHOD1(formatIndices, std::string(std::string const &indices));
   MOCK_CONST_METHOD2(validateIndices, bool(std::string const &indices, MantidAxis const &axisType));
   MOCK_METHOD1(setIndices, bool(std::string const &indices));
+  MOCK_CONST_METHOD0(indices, std::optional<std::string>());
 
   MOCK_METHOD0(plotSpectra, void());
   MOCK_METHOD1(plotBins, void(std::string const &binIndices));
   MOCK_METHOD0(showSliceViewer, void());
   MOCK_METHOD0(plotTiled, void());
   MOCK_METHOD0(plot3DSurface, void());
+
+  MOCK_CONST_METHOD1(singleDataPoint, std::optional<std::string>(MantidAxis const &axisType));
+  MOCK_CONST_METHOD0(availableActions, std::map<std::string, std::string>());
 };
 
 class MockSettingsView : public ISettingsView {

--- a/qt/scientific_interfaces/Inelastic/test/Common/OutputPlotOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Common/OutputPlotOptionsPresenterTest.h
@@ -50,9 +50,10 @@ public:
 
   void setUp() override {
     m_view = std::make_unique<NiceMock<MockOutputPlotOptionsView>>();
-    m_model = new NiceMock<MockOutputPlotOptionsModel>();
+    auto model = std::make_unique<NiceMock<MockOutputPlotOptionsModel>>();
+    m_model = model.get();
 
-    m_presenter = std::make_unique<OutputPlotOptionsPresenter>(m_view.get(), m_model);
+    m_presenter = std::make_unique<OutputPlotOptionsPresenter>(m_view.get(), std::move(model));
   }
 
   void tearDown() override {
@@ -76,14 +77,15 @@ public:
   void test_that_the_expected_setup_is_performed_when_instantiating_the_presenter() {
     tearDown();
     m_view = std::make_unique<NiceMock<MockOutputPlotOptionsView>>();
-    m_model = new NiceMock<MockOutputPlotOptionsModel>();
+    auto model = std::make_unique<NiceMock<MockOutputPlotOptionsModel>>();
+    m_model = model.get();
 
     EXPECT_CALL(*m_view, setIndicesRegex(_)).Times(1);
     EXPECT_CALL(*m_view, setPlotType(PlotWidget::Spectra, constructActions(boost::none))).Times(1);
     EXPECT_CALL(*m_view, setIndices(QString(""))).Times(1);
     EXPECT_CALL(*m_model, setFixedIndices("")).Times(1);
 
-    m_presenter = std::make_unique<OutputPlotOptionsPresenter>(m_view.get(), m_model);
+    m_presenter = std::make_unique<OutputPlotOptionsPresenter>(m_view.get(), std::move(model));
   }
 
   ///----------------------------------------------------------------------

--- a/qt/scientific_interfaces/Inelastic/test/Common/OutputPlotOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Common/OutputPlotOptionsPresenterTest.h
@@ -23,10 +23,10 @@ std::string const WORKSPACE_NAME = "WorkspaceName";
 std::string const WORKSPACE_INDICES = "0-2,4";
 
 std::map<std::string, std::string>
-constructActions(boost::optional<std::map<std::string, std::string>> const &availableActions) {
+constructActions(std::optional<std::map<std::string, std::string>> const &availableActions) {
   std::map<std::string, std::string> actions;
   if (availableActions)
-    actions = availableActions.get();
+    actions = *availableActions;
   if (actions.find("Plot Spectra") == actions.end())
     actions["Plot Spectra"] = "Plot Spectra";
   if (actions.find("Plot Bins") == actions.end())
@@ -80,8 +80,10 @@ public:
     auto model = std::make_unique<NiceMock<MockOutputPlotOptionsModel>>();
     m_model = model.get();
 
+    auto actions = constructActions(std::nullopt);
     EXPECT_CALL(*m_view, setIndicesRegex(_)).Times(1);
-    EXPECT_CALL(*m_view, setPlotType(PlotWidget::Spectra, constructActions(boost::none))).Times(1);
+    ON_CALL(*m_model, availableActions()).WillByDefault(Return(actions));
+    EXPECT_CALL(*m_view, setPlotType(PlotWidget::Spectra, actions)).Times(1);
     EXPECT_CALL(*m_view, setIndices(QString(""))).Times(1);
     EXPECT_CALL(*m_model, setFixedIndices("")).Times(1);
 
@@ -209,7 +211,9 @@ public:
   ///----------------------------------------------------------------------
 
   void test_setPlotType_sets_the_view() {
-    EXPECT_CALL(*m_view, setPlotType(PlotWidget::Spectra, constructActions(boost::none))).Times(1);
+    auto actions = constructActions(std::nullopt);
+    ON_CALL(*m_model, availableActions()).WillByDefault(Return(actions));
+    EXPECT_CALL(*m_view, setPlotType(PlotWidget::Spectra, actions)).Times(1);
     m_presenter->setPlotType(PlotWidget::Spectra);
   }
 

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitOutputOptionsModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitOutputOptionsModelTest.h
@@ -70,10 +70,9 @@ public:
     m_model.reset();
   }
 
-  void test_that_the_model_is_instantiated_without_stored_workspaces_or_spectraToPlot() {
+  void test_that_the_model_is_instantiated_without_stored_workspaces() {
     TS_ASSERT(!m_model->getResultWorkspace());
     TS_ASSERT(!m_model->getPDFWorkspace());
-    TS_ASSERT(m_model->getSpectraToPlot().empty());
   }
 
   void test_that_setResultWorkspace_will_set_the_stored_result_group() {
@@ -131,66 +130,51 @@ public:
     TS_ASSERT(!m_model->isPDFGroupPlottable());
   }
 
-  void test_that_clearSpectraToPlot_will_remove_the_stored_spectraToPlot() {
-    m_model->setResultWorkspace(m_groupWorkspace);
-    m_model->plotResult("Amplitude");
-    m_model->clearSpectraToPlot();
-
-    TS_ASSERT(m_model->getSpectraToPlot().empty());
-  }
-
-  void test_that_getSpectraToPlot_will_return_an_empty_vector_if_none_of_the_workspaces_are_plottable() {
+  void test_that_plotResult_will_return_an_empty_vector_if_none_of_the_workspaces_are_plottable() {
     auto const resultGroup =
         createGroupWorkspaceWithTextAxes(NUMBER_OF_WORKSPACES, getThreeAxisLabels(), NUMBER_OF_SPECTRA, 1);
 
     m_model->setResultWorkspace(resultGroup);
-    m_model->plotResult("Amplitude");
 
-    TS_ASSERT(m_model->getSpectraToPlot().empty());
+    TS_ASSERT(m_model->plotResult("Amplitude").empty());
   }
 
-  void test_that_getSpectraToPlot_will_return_an_empty_vector_if_the_parameter_passed_does_not_exist() {
+  void test_that_plotResult_will_return_an_empty_vector_if_the_parameter_passed_does_not_exist() {
     m_model->setResultWorkspace(m_groupWorkspace);
-    m_model->plotResult("Not a parameter");
-
-    TS_ASSERT(m_model->getSpectraToPlot().empty());
+    TS_ASSERT(m_model->plotResult("Not a parameter").empty());
   }
 
   void
   test_that_getSpectraToPlot_will_return_a_vector_with_the_correct_number_of_spectra_information_when_plotting_all() {
     m_model->setResultWorkspace(m_groupWorkspace);
-    m_model->plotResult("All");
 
     /// Here the size should be equal to numberOfWorkspaces * numberOfSpectra as
     /// it plots all the spectra in each of the workspaces
     auto const expectedSize = NUMBER_OF_WORKSPACES * toSizet(NUMBER_OF_SPECTRA);
-    TS_ASSERT_EQUALS(m_model->getSpectraToPlot().size(), expectedSize);
+    TS_ASSERT_EQUALS(m_model->plotResult("All").size(), expectedSize);
   }
 
   void
   test_that_getSpectraToPlot_will_return_a_vector_with_the_correct_number_of_spectra_information_when_plotting_a_parameter() {
     m_model->setResultWorkspace(m_groupWorkspace);
-    m_model->plotResult("Amplitude");
 
     /// Here the size should be equal to the numberOfWorkspaces as it will be
     /// plotting one spectra from each workspace
-    TS_ASSERT_EQUALS(m_model->getSpectraToPlot().size(), NUMBER_OF_WORKSPACES);
+    TS_ASSERT_EQUALS(m_model->plotResult("Amplitude").size(), NUMBER_OF_WORKSPACES);
   }
 
   void test_that_getSpectraToPlot_will_return_a_vector_containing_the_correct_spectra_indices_when_plotting_all() {
     m_model->setResultWorkspace(m_groupWorkspace);
-    m_model->plotResult("All");
 
-    TS_ASSERT_EQUALS(m_model->getSpectraToPlot(), getExpectedAllSpectra(NUMBER_OF_WORKSPACES, NUMBER_OF_SPECTRA));
+    TS_ASSERT_EQUALS(m_model->plotResult("All"), getExpectedAllSpectra(NUMBER_OF_WORKSPACES, NUMBER_OF_SPECTRA));
   }
 
   void
   test_that_getSpectraToPlot_will_return_a_vector_containing_the_correct_spectra_indices_when_plotting_a_parameter() {
     m_model->setResultWorkspace(m_groupWorkspace);
-    m_model->plotResult("HWHM");
 
     auto const parameterIndex(1); /// This parameter has a workspace index of 1
-    TS_ASSERT_EQUALS(m_model->getSpectraToPlot(), getExpectedParameterSpectra(NUMBER_OF_WORKSPACES, parameterIndex));
+    TS_ASSERT_EQUALS(m_model->plotResult("HWHM"), getExpectedParameterSpectra(NUMBER_OF_WORKSPACES, parameterIndex));
   }
 
   void test_that_plotResult_will_throw_when_there_is_no_result_workspace_set() {

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitOutputOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitOutputOptionsPresenterTest.h
@@ -17,6 +17,7 @@
 #include "QENSFitting/IFitOutputOptionsView.h"
 
 #include "MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h"
+#include "MantidQtWidgets/Plotting/MockExternalPlotter.h"
 
 using namespace Mantid::API;
 using namespace Mantid::IndirectFitDataCreationHelper;
@@ -40,8 +41,11 @@ public:
     m_view = std::make_unique<NiceMock<MockFitOutputOptionsView>>();
     auto model = std::make_unique<NiceMock<MockFitOutputOptionsModel>>();
     m_model = model.get();
+    auto plotter = std::make_unique<NiceMock<MockExternalPlotter>>();
+    m_plotter = plotter.get();
 
-    m_presenter = std::make_unique<FitOutputOptionsPresenter>(m_tab.get(), m_view.get(), std::move(model));
+    m_presenter =
+        std::make_unique<FitOutputOptionsPresenter>(m_tab.get(), m_view.get(), std::move(model), std::move(plotter));
   }
 
   void tearDown() override {
@@ -315,5 +319,6 @@ private:
   std::unique_ptr<NiceMock<MockFitTab>> m_tab;
   std::unique_ptr<NiceMock<MockFitOutputOptionsView>> m_view;
   NiceMock<MockFitOutputOptionsModel> *m_model;
+  NiceMock<MockExternalPlotter> *m_plotter;
   std::unique_ptr<FitOutputOptionsPresenter> m_presenter;
 };

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitOutputOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitOutputOptionsPresenterTest.h
@@ -37,15 +37,13 @@ public:
   static void destroySuite(FitOutputOptionsPresenterTest *suite) { delete suite; }
 
   void setUp() override {
-    m_tab = std::make_unique<NiceMock<MockFitTab>>();
     m_view = std::make_unique<NiceMock<MockFitOutputOptionsView>>();
     auto model = std::make_unique<NiceMock<MockFitOutputOptionsModel>>();
     m_model = model.get();
     auto plotter = std::make_unique<NiceMock<MockExternalPlotter>>();
     m_plotter = plotter.get();
 
-    m_presenter =
-        std::make_unique<FitOutputOptionsPresenter>(m_tab.get(), m_view.get(), std::move(model), std::move(plotter));
+    m_presenter = std::make_unique<FitOutputOptionsPresenter>(m_view.get(), std::move(model), std::move(plotter));
   }
 
   void tearDown() override {
@@ -64,15 +62,6 @@ public:
     TS_ASSERT(m_view);
     TS_ASSERT(m_model);
     TS_ASSERT(m_presenter);
-  }
-
-  void test_that_calling_a_presenter_method_will_invoke_the_relevant_model_and_view_methods() {
-    std::string const selectedGroup("Result Group");
-
-    EXPECT_CALL(*m_view, clearPlotTypes()).Times(1);
-    EXPECT_CALL(*m_model, getWorkspaceParameters(selectedGroup)).Times(1);
-
-    m_presenter->setPlotTypes(selectedGroup);
   }
 
   ///----------------------------------------------------------------------
@@ -135,15 +124,16 @@ public:
   void test_that_handlePlotClicked_will_invoke_plotResult_if_the_selected_group_is_the_result_group() {
     std::string const selectedGroup("Result Group");
     std::string const plotType("All");
+    std::string const workspaceName("Name");
+    std::size_t const workspaceIndex(2u);
+    std::vector<SpectrumToPlot> spectraToPlot;
+    spectraToPlot.emplace_back(std::make_pair(workspaceName, workspaceIndex));
 
     ON_CALL(*m_view, getSelectedGroupWorkspace()).WillByDefault(Return(selectedGroup));
     ON_CALL(*m_model, isResultGroupSelected(selectedGroup)).WillByDefault(Return(true));
     ON_CALL(*m_view, getSelectedPlotType()).WillByDefault(Return(plotType));
-
-    ExpectationSet getSelectedWorkspace =
-        EXPECT_CALL(*m_view, getSelectedGroupWorkspace()).Times(1).WillOnce(Return(selectedGroup));
-    getSelectedWorkspace += EXPECT_CALL(*m_model, isResultGroupSelected(selectedGroup)).Times(1);
-    EXPECT_CALL(*m_model, plotResult(plotType)).Times(1).After(getSelectedWorkspace);
+    ON_CALL(*m_model, plotResult(plotType)).WillByDefault(Return(spectraToPlot));
+    EXPECT_CALL(*m_plotter, plotSpectra(workspaceName, std::to_string(workspaceIndex), false)).Times(1);
 
     m_presenter->handlePlotClicked();
   }
@@ -151,15 +141,16 @@ public:
   void test_that_handlePlotClicked_will_invoke_plotPDF_if_the_selected_group_is_the_pdf_group() {
     std::string const selectedGroup("PDF Group");
     std::string const plotType("All");
+    std::string const workspaceName("Name");
+    std::size_t const workspaceIndex(2u);
+    std::vector<SpectrumToPlot> spectraToPlot;
+    spectraToPlot.emplace_back(std::make_pair(workspaceName, workspaceIndex));
 
     ON_CALL(*m_view, getSelectedGroupWorkspace()).WillByDefault(Return(selectedGroup));
     ON_CALL(*m_model, isResultGroupSelected(selectedGroup)).WillByDefault(Return(false));
     ON_CALL(*m_view, getSelectedPlotType()).WillByDefault(Return(plotType));
-
-    ExpectationSet getSelectedWorkspace =
-        EXPECT_CALL(*m_view, getSelectedGroupWorkspace()).Times(1).WillOnce(Return(selectedGroup));
-    getSelectedWorkspace += EXPECT_CALL(*m_model, isResultGroupSelected(selectedGroup)).Times(1);
-    EXPECT_CALL(*m_model, plotPDF("", plotType)).Times(1).After(getSelectedWorkspace);
+    ON_CALL(*m_model, plotPDF("", plotType)).WillByDefault(Return(spectraToPlot));
+    EXPECT_CALL(*m_plotter, plotSpectra(workspaceName, std::to_string(workspaceIndex), false)).Times(1);
 
     m_presenter->handlePlotClicked();
   }
@@ -185,24 +176,12 @@ public:
     m_presenter->handleSaveClicked();
   }
 
-  ///----------------------------------------------------------------------
-  /// Unit Tests that test the methods of the presenter
-  ///----------------------------------------------------------------------
-
   void test_that_setResultWorkspace_will_invoke_setResultWorkspace_in_the_model() {
     auto const groupWorkspace = createGroupWorkspaceWithTextAxes(2, getThreeParameters(), 3);
 
     EXPECT_CALL(*m_model, setResultWorkspace(groupWorkspace)).Times(1);
 
-    m_presenter->setResultWorkspace(groupWorkspace);
-  }
-
-  void test_that_setPDFWorkspace_will_invoke_setPDFWorkspace_in_the_model() {
-    auto const groupWorkspace = createGroupWorkspaceWithTextAxes(2, getThreeParameters(), 3);
-
-    EXPECT_CALL(*m_model, setPDFWorkspace(groupWorkspace)).Times(1);
-
-    m_presenter->setPDFWorkspace(groupWorkspace);
+    m_presenter->enableOutputOptions(true, groupWorkspace, "basename", "FABADA");
   }
 
   void
@@ -230,20 +209,6 @@ public:
     EXPECT_CALL(*m_view, setPlotTypeIndex(0)).Times(1).After(setAvailablePlotTypes);
 
     m_presenter->setPlotTypes(selectedGroup);
-  }
-
-  void test_that_removePDFWorkspace_will_invoke_removePDFWorkspace_in_the_model() {
-    EXPECT_CALL(*m_model, removePDFWorkspace()).Times(1);
-    m_presenter->removePDFWorkspace();
-  }
-
-  void test_that_isSelectedGroupPlottable_will_invoke_isSelectedGroupPlottable_in_the_model() {
-    std::string const selectedGroup("Result Group");
-    ON_CALL(*m_view, getSelectedGroupWorkspace()).WillByDefault(Return(selectedGroup));
-
-    EXPECT_CALL(*m_model, isSelectedGroupPlottable(selectedGroup)).Times(1);
-
-    m_presenter->isSelectedGroupPlottable();
   }
 
   void test_that_setPlotting_will_attempt_to_set_the_plot_button_text_and_disable_all_buttons_when_passed_true() {
@@ -290,33 +255,12 @@ public:
     m_presenter->setPlotEnabled(true);
   }
 
-  void test_that_setEditResultEnabled_will_invoke_setEditResultEnabled_in_the_view() {
-    EXPECT_CALL(*m_view, setEditResultEnabled(true)).Times(1);
-    m_presenter->setEditResultEnabled(true);
-  }
-
-  void test_that_setSaveEnabled_will_invoke_setSaveEnabled_in_the_view() {
-    EXPECT_CALL(*m_view, setSaveEnabled(true)).Times(1);
-    m_presenter->setSaveEnabled(true);
-  }
-
-  void test_that_clearSpectraToPlot_will_invoke_clearSpectraToPlot_in_the_model() {
-    EXPECT_CALL(*m_model, clearSpectraToPlot()).Times(1);
-    m_presenter->clearSpectraToPlot();
-  }
-
-  void test_that_getSpectraToPlot_will_invoke_getSpectraToPlot_in_the_model() {
-    EXPECT_CALL(*m_model, getSpectraToPlot()).Times(1);
-    m_presenter->getSpectraToPlot();
-  }
-
   void test_that_setEditResultVisible_will_invoke_setEditResultVisible_in_the_view() {
     EXPECT_CALL(*m_view, setEditResultVisible(true)).Times(1);
     m_presenter->setEditResultVisible(true);
   }
 
 private:
-  std::unique_ptr<NiceMock<MockFitTab>> m_tab;
   std::unique_ptr<NiceMock<MockFitOutputOptionsView>> m_view;
   NiceMock<MockFitOutputOptionsModel> *m_model;
   NiceMock<MockExternalPlotter> *m_plotter;

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -214,11 +214,9 @@ public:
   MOCK_CONST_METHOD0(isResultGroupPlottable, bool());
   MOCK_CONST_METHOD0(isPDFGroupPlottable, bool());
 
-  MOCK_METHOD0(clearSpectraToPlot, void());
-  MOCK_CONST_METHOD0(getSpectraToPlot, std::vector<SpectrumToPlot>());
-
-  MOCK_METHOD1(plotResult, void(std::string const &plotType));
-  MOCK_METHOD2(plotPDF, void(std::string const &workspaceName, std::string const &plotType));
+  MOCK_CONST_METHOD1(plotResult, std::vector<SpectrumToPlot>(std::string const &plotType));
+  MOCK_CONST_METHOD2(plotPDF,
+                     std::vector<SpectrumToPlot>(std::string const &workspaceName, std::string const &plotType));
 
   MOCK_CONST_METHOD0(saveResult, void());
 

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -268,7 +268,7 @@ public:
   MOCK_CONST_METHOD1(getFittingAlgorithm, Mantid::API::IAlgorithm_sptr(FittingMode mode));
   MOCK_CONST_METHOD0(getSingleFittingAlgorithm, Mantid::API::IAlgorithm_sptr());
   MOCK_CONST_METHOD2(getSingleFunction, Mantid::API::IFunction_sptr(WorkspaceID workspaceID, WorkspaceIndex spectrum));
-  MOCK_CONST_METHOD0(getOutputBasename, std::string());
+  MOCK_CONST_METHOD0(getOutputBasename, std::optional<std::string>());
 
   MOCK_METHOD1(cleanFailedRun, void(const Mantid::API::IAlgorithm_sptr &fittingAlgorithm));
   MOCK_METHOD0(removeFittingData, void());

--- a/qt/scientific_interfaces/Muon/ALCInterface.cpp
+++ b/qt/scientific_interfaces/Muon/ALCInterface.cpp
@@ -52,8 +52,8 @@ QHash<QString, QVariant> createLineKwargs() {
   return kwargs;
 }
 
-std::vector<boost::optional<QHash<QString, QVariant>>> createPointAndLineKwargs() {
-  std::vector<boost::optional<QHash<QString, QVariant>>> kwargs;
+std::vector<std::optional<QHash<QString, QVariant>>> createPointAndLineKwargs() {
+  std::vector<std::optional<QHash<QString, QVariant>>> kwargs;
   kwargs.emplace_back(createPointKwargs());
   kwargs.emplace_back(createLineKwargs());
   return kwargs;
@@ -328,7 +328,7 @@ void ALCInterface::externalPlotRequested() {
  */
 void ALCInterface::externallyPlotWorkspace(MatrixWorkspace_sptr &data, std::string const &workspaceName,
                                            std::string const &workspaceIndices, bool errorBars,
-                                           boost::optional<QHash<QString, QVariant>> const &kwargs) {
+                                           std::optional<QHash<QString, QVariant>> const &kwargs) {
   AnalysisDataService::Instance().addOrReplace(workspaceName, data);
   m_externalPlotter->plotSpectra(workspaceName, workspaceIndices, errorBars, kwargs);
 }
@@ -344,7 +344,7 @@ void ALCInterface::externallyPlotWorkspace(MatrixWorkspace_sptr &data, std::stri
 void ALCInterface::externallyPlotWorkspaces(MatrixWorkspace_sptr &data, std::vector<std::string> const &workspaceNames,
                                             std::vector<int> const &workspaceIndices,
                                             std::vector<bool> const &errorBars,
-                                            std::vector<boost::optional<QHash<QString, QVariant>>> const &kwargs) {
+                                            std::vector<std::optional<QHash<QString, QVariant>>> const &kwargs) {
   AnalysisDataService::Instance().addOrReplace(workspaceNames[0], data);
   m_externalPlotter->plotCorrespondingSpectra(workspaceNames, workspaceIndices, errorBars, kwargs);
 }

--- a/qt/scientific_interfaces/Muon/ALCInterface.h
+++ b/qt/scientific_interfaces/Muon/ALCInterface.h
@@ -62,10 +62,10 @@ private:
   void importPeakData(const std::string &workspaceName);
   void externallyPlotWorkspace(Mantid::API ::MatrixWorkspace_sptr &data, std::string const &workspaceName,
                                std::string const &workspaceIndices, bool errorBars,
-                               boost::optional<QHash<QString, QVariant>> const &kwargs);
+                               std::optional<QHash<QString, QVariant>> const &kwargs);
   void externallyPlotWorkspaces(Mantid::API::MatrixWorkspace_sptr &data, std::vector<std::string> const &workspaceNames,
                                 std::vector<int> const &workspaceIndices, std::vector<bool> const &errorBars,
-                                std::vector<boost::optional<QHash<QString, QVariant>>> const &spectraKwargs);
+                                std::vector<std::optional<QHash<QString, QVariant>>> const &spectraKwargs);
   void externalPlotDataLoading();
   void externalPlotBaselineModel();
   void externalPlotPeakFitting();

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Plot.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Plot.h
@@ -15,8 +15,8 @@
 #include <QString>
 #include <QStringList>
 #include <QVariant>
-#include <boost/none_t.hpp>
-#include <boost/optional.hpp>
+
+#include <optional>
 #include <vector>
 
 namespace MantidQt {
@@ -35,8 +35,8 @@ enum class MantidAxType : int { Bin = 0, Spectrum = 1 };
  * Makes a call to mantidqt.plotting.plot.
  *
  * Each of the inputs to this function are optional and thus can be replaced
- * with boost::none if no other item should be given. However it does require
- * that boost::none be given for all items that are not the defaulted bools, on
+ * with std::nullopt if no other item should be given. However it does require
+ * that std::nullopt be given for all items that are not the defaulted bools, on
  * every call.
  *
  * @param workspaces A vector of workspace names that are present in the ADS
@@ -68,50 +68,50 @@ enum class MantidAxType : int { Bin = 0, Spectrum = 1 };
  * function in Python
  */
 MANTID_MPLCPP_DLL Common::Python::Object plot(const std::vector<std::string> &workspaces,
-                                              boost::optional<std::vector<int>> spectrumNums,
-                                              boost::optional<std::vector<int>> wkspIndices,
-                                              boost::optional<Common::Python::Object> fig = boost::none,
-                                              boost::optional<QHash<QString, QVariant>> plotKwargs = boost::none,
-                                              boost::optional<QHash<QString, QVariant>> axProperties = boost::none,
-                                              boost::optional<std::string> windowTitle = boost::none,
+                                              std::optional<std::vector<int>> spectrumNums,
+                                              std::optional<std::vector<int>> wkspIndices,
+                                              std::optional<Common::Python::Object> fig = std::nullopt,
+                                              std::optional<QHash<QString, QVariant>> plotKwargs = std::nullopt,
+                                              std::optional<QHash<QString, QVariant>> axProperties = std::nullopt,
+                                              std::optional<std::string> windowTitle = std::nullopt,
                                               bool errors = false, bool overplot = false, bool tiled = false);
 
 /**
  * \overload plot(const std::vector<std::string> &workspaces,
-     boost::optional<std::vector<int>> spectrumNums,
-     boost::optional<std::vector<int>> wkspIndices,
-     boost::optional<Common::Python::Object> fig = boost::none,
-     boost::optional<QHash<QString, QVariant>> plotKwargs = boost::none,
-     boost::optional<QHash<QString, QVariant>> axProperties = boost::none,
-     boost::optional<std::string> windowTitle = boost::none,
+     std::optional<std::vector<int>> spectrumNums,
+     std::optional<std::vector<int>> wkspIndices,
+     std::optional<Common::Python::Object> fig = std::nullopt,
+     std::optional<QHash<QString, QVariant>> plotKwargs = std::nullopt,
+     std::optional<QHash<QString, QVariant>> axProperties = std::nullopt,
+     std::optional<std::string> windowTitle = std::nullopt,
      bool errors = false, bool overplot = false)
  */
 MANTID_MPLCPP_DLL Common::Python::Object plot(const QStringList &workspaces,
-                                              boost::optional<std::vector<int>> spectrumNums,
-                                              boost::optional<std::vector<int>> wkspIndices,
-                                              boost::optional<Common::Python::Object> fig = boost::none,
-                                              boost::optional<QHash<QString, QVariant>> plotKwargs = boost::none,
-                                              boost::optional<QHash<QString, QVariant>> axProperties = boost::none,
-                                              boost::optional<std::string> windowTitle = boost::none,
+                                              std::optional<std::vector<int>> spectrumNums,
+                                              std::optional<std::vector<int>> wkspIndices,
+                                              std::optional<Common::Python::Object> fig = std::nullopt,
+                                              std::optional<QHash<QString, QVariant>> plotKwargs = std::nullopt,
+                                              std::optional<QHash<QString, QVariant>> axProperties = std::nullopt,
+                                              std::optional<std::string> windowTitle = std::nullopt,
                                               bool errors = false, bool overplot = false, bool tiled = false);
 
 /**
  * \overload plot(const std::vector<MatrixWorkspace_sptr> &workspaces,
-     boost::optional<std::vector<int>> spectrumNums,
-     boost::optional<std::vector<int>> wkspIndices,
-     boost::optional<Common::Python::Object> fig = boost::none,
-     boost::optional<QHash<QString, QVariant>> plotKwargs = boost::none,
-     boost::optional<QHash<QString, QVariant>> axProperties = boost::none,
-     boost::optional<std::string> windowTitle = boost::none,
+     std::optional<std::vector<int>> spectrumNums,
+     std::optional<std::vector<int>> wkspIndices,
+     std::optional<Common::Python::Object> fig = std::nullopt,
+     std::optional<QHash<QString, QVariant>> plotKwargs = std::nullopt,
+     std::optional<QHash<QString, QVariant>> axProperties = std::nullopt,
+     std::optional<std::string> windowTitle = std::nullopt,
      bool errors = false, bool overplot = false)
  */
 MANTID_MPLCPP_DLL Common::Python::Object plot(const std::vector<Mantid::API::MatrixWorkspace_sptr> &workspaces,
-                                              boost::optional<std::vector<int>> spectrumNums,
-                                              boost::optional<std::vector<int>> wkspIndices,
-                                              boost::optional<Common::Python::Object> fig = boost::none,
-                                              boost::optional<QHash<QString, QVariant>> plotKwargs = boost::none,
-                                              boost::optional<QHash<QString, QVariant>> axProperties = boost::none,
-                                              boost::optional<std::string> windowTitle = boost::none,
+                                              std::optional<std::vector<int>> spectrumNums,
+                                              std::optional<std::vector<int>> wkspIndices,
+                                              std::optional<Common::Python::Object> fig = std::nullopt,
+                                              std::optional<QHash<QString, QVariant>> plotKwargs = std::nullopt,
+                                              std::optional<QHash<QString, QVariant>> axProperties = std::nullopt,
+                                              std::optional<std::string> windowTitle = std::nullopt,
                                               bool errors = false, bool overplot = false, bool tiled = false);
 /**
  * Makes a call to mantidqt.plotting.plotsubplots.
@@ -143,11 +143,11 @@ MANTID_MPLCPP_DLL Common::Python::Object plot(const std::vector<Mantid::API::Mat
  * function in Python
  */
 MANTID_MPLCPP_DLL Common::Python::Object
-plotsubplots(const QStringList &workspaces, boost::optional<std::vector<int>> spectrumNums,
-             boost::optional<std::vector<int>> wkspIndices, boost::optional<Common::Python::Object> fig = boost::none,
-             boost::optional<QHash<QString, QVariant>> plotKwargs = boost::none,
-             boost::optional<QHash<QString, QVariant>> axProperties = boost::none,
-             boost::optional<std::string> windowTitle = boost::none, bool errors = false);
+plotsubplots(const QStringList &workspaces, std::optional<std::vector<int>> spectrumNums,
+             std::optional<std::vector<int>> wkspIndices, std::optional<Common::Python::Object> fig = std::nullopt,
+             std::optional<QHash<QString, QVariant>> plotKwargs = std::nullopt,
+             std::optional<QHash<QString, QVariant>> axProperties = std::nullopt,
+             std::optional<std::string> windowTitle = std::nullopt, bool errors = false);
 
 /**
  * Makes a call to mantidqt.plotting.pcolormesh.
@@ -160,7 +160,7 @@ plotsubplots(const QStringList &workspaces, boost::optional<std::vector<int>> sp
  * function in Python
  */
 MANTID_MPLCPP_DLL Common::Python::Object pcolormesh(const QStringList &workspaces,
-                                                    boost::optional<Common::Python::Object> fig = boost::none);
+                                                    std::optional<Common::Python::Object> fig = std::nullopt);
 
 /**
  * Makes a call to mantidqt.plotting.plot_surface.
@@ -173,7 +173,7 @@ MANTID_MPLCPP_DLL Common::Python::Object pcolormesh(const QStringList &workspace
  * function in Python
  */
 MANTID_MPLCPP_DLL Common::Python::Object surface(const QStringList &workspaces,
-                                                 boost::optional<Common::Python::Object> fig = boost::none);
+                                                 std::optional<Common::Python::Object> fig = std::nullopt);
 
 /**
  * Externall call to slice viewer GUI

--- a/qt/widgets/mplcpp/src/Plot.cpp
+++ b/qt/widgets/mplcpp/src/Plot.cpp
@@ -71,46 +71,46 @@ Python::Object constructArgs(const QStringList &workspaces) {
 /**
  * Construct kwargs list for the plot function
  */
-Python::Object constructKwargs(boost::optional<std::vector<int>> spectrumNums,
-                               boost::optional<std::vector<int>> wkspIndices, boost::optional<Python::Object> fig,
-                               boost::optional<QHash<QString, QVariant>> plotKwargs,
-                               boost::optional<QHash<QString, QVariant>> axProperties,
-                               boost::optional<std::string> windowTitle, boost::optional<bool> errors,
-                               boost::optional<bool> overplot, boost::optional<bool> tiled) {
+Python::Object constructKwargs(std::optional<std::vector<int>> spectrumNums,
+                               std::optional<std::vector<int>> wkspIndices, std::optional<Python::Object> fig,
+                               std::optional<QHash<QString, QVariant>> plotKwargs,
+                               std::optional<QHash<QString, QVariant>> axProperties,
+                               std::optional<std::string> windowTitle, std::optional<bool> errors,
+                               std::optional<bool> overplot, std::optional<bool> tiled) {
   // Make sure to decide whether spectrum numbers or workspace indices
   Python::Dict kwargs;
 
   if (spectrumNums && !wkspIndices) {
-    kwargs["spectrum_nums"] = Converters::ToPyList<int>()(spectrumNums.get());
+    kwargs["spectrum_nums"] = Converters::ToPyList<int>()(*spectrumNums);
   } else if (wkspIndices && !spectrumNums) {
-    kwargs["wksp_indices"] = Converters::ToPyList<int>()(wkspIndices.get());
+    kwargs["wksp_indices"] = Converters::ToPyList<int>()(*wkspIndices);
   } else {
     throw std::invalid_argument("Passed spectrum numbers and workspace indices, please only pass one, "
-                                "with the other being boost::none.");
+                                "with the other being std::nullopt.");
   }
 
   if (errors)
-    kwargs["errors"] = errors.get();
+    kwargs["errors"] = *errors;
   if (overplot)
-    kwargs["overplot"] = overplot.get();
+    kwargs["overplot"] = *overplot;
   if (tiled)
-    kwargs["tiled"] = tiled.get();
+    kwargs["tiled"] = *tiled;
   if (fig)
-    kwargs["fig"] = fig.get();
+    kwargs["fig"] = *fig;
   if (plotKwargs)
-    kwargs["plot_kwargs"] = Python::qHashToDict(plotKwargs.get());
+    kwargs["plot_kwargs"] = Python::qHashToDict(*plotKwargs);
   if (axProperties)
-    kwargs["ax_properties"] = Python::qHashToDict(axProperties.get());
+    kwargs["ax_properties"] = Python::qHashToDict(*axProperties);
   if (windowTitle)
-    kwargs["window_title"] = windowTitle.get();
+    kwargs["window_title"] = *windowTitle;
 
   return std::move(kwargs);
 }
 
-Python::Object plot(const Python::Object &args, boost::optional<std::vector<int>> spectrumNums,
-                    boost::optional<std::vector<int>> wkspIndices, boost::optional<Python::Object> fig,
-                    boost::optional<QHash<QString, QVariant>> plotKwargs,
-                    boost::optional<QHash<QString, QVariant>> axProperties, boost::optional<std::string> windowTitle,
+Python::Object plot(const Python::Object &args, std::optional<std::vector<int>> spectrumNums,
+                    std::optional<std::vector<int>> wkspIndices, std::optional<Python::Object> fig,
+                    std::optional<QHash<QString, QVariant>> plotKwargs,
+                    std::optional<QHash<QString, QVariant>> axProperties, std::optional<std::string> windowTitle,
                     bool errors, bool overplot, bool tiled) {
   const auto kwargs =
       constructKwargs(std::move(spectrumNums), std::move(wkspIndices), std::move(fig), std::move(plotKwargs),
@@ -124,56 +124,56 @@ Python::Object plot(const Python::Object &args, boost::optional<std::vector<int>
 
 } // namespace
 
-Python::Object plot(const std::vector<std::string> &workspaces, boost::optional<std::vector<int>> spectrumNums,
-                    boost::optional<std::vector<int>> wkspIndices, boost::optional<Python::Object> fig,
-                    boost::optional<QHash<QString, QVariant>> plotKwargs,
-                    boost::optional<QHash<QString, QVariant>> axProperties, boost::optional<std::string> windowTitle,
+Python::Object plot(const std::vector<std::string> &workspaces, std::optional<std::vector<int>> spectrumNums,
+                    std::optional<std::vector<int>> wkspIndices, std::optional<Python::Object> fig,
+                    std::optional<QHash<QString, QVariant>> plotKwargs,
+                    std::optional<QHash<QString, QVariant>> axProperties, std::optional<std::string> windowTitle,
                     bool errors, bool overplot, bool tiled) {
   GlobalInterpreterLock lock;
   return plot(constructArgs(workspaces), std::move(spectrumNums), std::move(wkspIndices), std::move(fig),
               std::move(plotKwargs), std::move(axProperties), std::move(windowTitle), errors, overplot, tiled);
 }
 
-Python::Object plot(const QStringList &workspaces, boost::optional<std::vector<int>> spectrumNums,
-                    boost::optional<std::vector<int>> wkspIndices, boost::optional<Python::Object> fig,
-                    boost::optional<QHash<QString, QVariant>> plotKwargs,
-                    boost::optional<QHash<QString, QVariant>> axProperties, boost::optional<std::string> windowTitle,
+Python::Object plot(const QStringList &workspaces, std::optional<std::vector<int>> spectrumNums,
+                    std::optional<std::vector<int>> wkspIndices, std::optional<Python::Object> fig,
+                    std::optional<QHash<QString, QVariant>> plotKwargs,
+                    std::optional<QHash<QString, QVariant>> axProperties, std::optional<std::string> windowTitle,
                     bool errors, bool overplot, bool tiled) {
   GlobalInterpreterLock lock;
   return plot(constructArgs(workspaces), std::move(spectrumNums), std::move(wkspIndices), std::move(fig),
               std::move(plotKwargs), std::move(axProperties), std::move(windowTitle), errors, overplot, tiled);
 }
 
-Python::Object plot(const std::vector<MatrixWorkspace_sptr> &workspaces, boost::optional<std::vector<int>> spectrumNums,
-                    boost::optional<std::vector<int>> wkspIndices, boost::optional<Python::Object> fig,
-                    boost::optional<QHash<QString, QVariant>> plotKwargs,
-                    boost::optional<QHash<QString, QVariant>> axProperties, boost::optional<std::string> windowTitle,
+Python::Object plot(const std::vector<MatrixWorkspace_sptr> &workspaces, std::optional<std::vector<int>> spectrumNums,
+                    std::optional<std::vector<int>> wkspIndices, std::optional<Python::Object> fig,
+                    std::optional<QHash<QString, QVariant>> plotKwargs,
+                    std::optional<QHash<QString, QVariant>> axProperties, std::optional<std::string> windowTitle,
                     bool errors, bool overplot, bool tiled) {
   GlobalInterpreterLock lock;
   return plot(constructArgs(workspaces), std::move(spectrumNums), std::move(wkspIndices), std::move(fig),
               std::move(plotKwargs), std::move(axProperties), std::move(windowTitle), errors, overplot, tiled);
 }
 
-Python::Object pcolormesh(const QStringList &workspaces, boost::optional<Python::Object> fig) {
+Python::Object pcolormesh(const QStringList &workspaces, std::optional<Python::Object> fig) {
   GlobalInterpreterLock lock;
   try {
     const auto args = constructArgs(workspaces);
     Python::Dict kwargs;
     if (fig)
-      kwargs["fig"] = fig.get();
+      kwargs["fig"] = *fig;
     return functionsModule().attr("pcolormesh")(*args, **kwargs);
   } catch (Python::ErrorAlreadySet &) {
     throw PythonException();
   }
 }
 
-Python::Object surface(const QStringList &workspaces, boost::optional<Python::Object> fig) {
+Python::Object surface(const QStringList &workspaces, std::optional<Python::Object> fig) {
   GlobalInterpreterLock lock;
   try {
     const auto args = constructArgs(workspaces);
     Python::Dict kwargs;
     if (fig)
-      kwargs["fig"] = fig.get();
+      kwargs["fig"] = *fig;
     return functionsModule().attr("plot_surface")(*args, **kwargs);
   } catch (Python::ErrorAlreadySet &) {
     throw PythonException();

--- a/qt/widgets/mplcpp/test/PlotTest.h
+++ b/qt/widgets/mplcpp/test/PlotTest.h
@@ -14,6 +14,8 @@
 #include "MantidPythonInterface/core/ErrorHandling.h"
 #include "MantidQtWidgets/MplCpp/Plot.h"
 
+#include <optional>
+
 using namespace MantidQt::Widgets::Common;
 using namespace MantidQt::Widgets::MplCpp;
 using namespace Mantid::API;
@@ -29,19 +31,19 @@ public:
   void testPlottingWorksWithWorkspaceIndex() {
     const std::vector<std::string> workspaces = {m_testws_name};
     const std::vector<int> index = {1};
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, boost::none, index))
+    TS_ASSERT_THROWS_NOTHING(plot(workspaces, std::nullopt, index))
   }
 
   void testPlottingWorksQStrings() {
     const QStringList workspaces = {m_testws_name};
     const std::vector<int> index = {1};
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, boost::none, index))
+    TS_ASSERT_THROWS_NOTHING(plot(workspaces, std::nullopt, index))
   }
 
   void testPlottingWorksWithSpecNum() {
     const std::vector<std::string> workspaces = {m_testws_name};
     const std::vector<int> index = {1};
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, boost::none))
+    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, std::nullopt))
   }
 
   void testPlottingThrowsWithSpecNumAndWorkspaceIndex() {
@@ -55,7 +57,7 @@ public:
     const std::vector<int> index = {1};
     QHash<QString, QVariant> hash;
     hash.insert(QString("linewidth"), QVariant(10));
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, boost::none, boost::none, hash))
+    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, std::nullopt, std::nullopt, hash))
   }
 
   void testPlottingWorksWhenPlottingABin() {
@@ -64,7 +66,7 @@ public:
     QHash<QString, QVariant> hash;
     hash["axis"] = static_cast<int>(MantidAxType::Bin);
 
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, boost::none, boost::none, hash))
+    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, std::nullopt, std::nullopt, hash))
   }
 
   void testPlottingWithIncorrectPlotKwargsThrows() {
@@ -72,7 +74,7 @@ public:
     const std::vector<int> index = {1};
     QHash<QString, QVariant> hash;
     hash.insert(QString("asdasdasdasdasd"), QVariant(1));
-    TS_ASSERT_THROWS(plot(workspaces, index, boost::none, boost::none, hash), const PythonException &)
+    TS_ASSERT_THROWS(plot(workspaces, index, std::nullopt, std::nullopt, hash), const PythonException &)
   }
 
   void testPlottingWithAxProperties() {
@@ -80,7 +82,7 @@ public:
     const std::vector<int> index = {1};
     QHash<QString, QVariant> hash;
     hash.insert(QString("xscale"), QVariant("log"));
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, boost::none, boost::none, boost::none, hash))
+    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, std::nullopt, std::nullopt, std::nullopt, hash))
   }
 
   void testPlottingWithIncorrectAxPropertiesThrows() {
@@ -88,21 +90,22 @@ public:
     const std::vector<int> index = {1};
     QHash<QString, QVariant> hash;
     hash.insert(QString("asdasdasdasdasd"), QVariant(QString(1)));
-    TS_ASSERT_THROWS(plot(workspaces, index, boost::none, boost::none, boost::none, hash), const PythonException &)
+    TS_ASSERT_THROWS(plot(workspaces, index, std::nullopt, std::nullopt, std::nullopt, hash), const PythonException &)
   }
 
   void testPlottingWithWindowTitle() {
     const std::vector<std::string> workspaces = {m_testws_name};
     const std::vector<int> index = {1};
     const std::string window_title = "window_title";
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, boost::none, index, boost::none, boost::none, boost::none, window_title))
+    TS_ASSERT_THROWS_NOTHING(
+        plot(workspaces, std::nullopt, index, std::nullopt, std::nullopt, std::nullopt, window_title))
   }
 
   void testPlottingWithErrors() {
     const std::vector<std::string> workspaces = {m_testws_name};
     const std::vector<int> index = {1};
     TS_ASSERT_THROWS_NOTHING(
-        plot(workspaces, boost::none, index, boost::none, boost::none, boost::none, boost::none, true))
+        plot(workspaces, std::nullopt, index, std::nullopt, std::nullopt, std::nullopt, std::nullopt, true))
   }
 
   void testPlottingWithOverplotAndMultipleWorkspaces() {
@@ -111,7 +114,7 @@ public:
     const std::vector<std::string> workspaces = {m_testws_name, "ws1", "ws2"};
     const std::vector<int> index = {1, 1, 1};
     TS_ASSERT_THROWS_NOTHING(
-        plot(workspaces, boost::none, index, boost::none, boost::none, boost::none, boost::none, false, true))
+        plot(workspaces, std::nullopt, index, std::nullopt, std::nullopt, std::nullopt, std::nullopt, false, true))
   }
 
   void testPlottingWithoutOverplotButWithMultipleWorkspace() {
@@ -120,7 +123,7 @@ public:
     const std::vector<std::string> workspaces = {"ws", "ws1", "ws2"};
     const std::vector<int> index = {1, 1, 1};
     TS_ASSERT_THROWS_NOTHING(
-        plot(workspaces, boost::none, index, boost::none, boost::none, boost::none, boost::none, false, false))
+        plot(workspaces, std::nullopt, index, std::nullopt, std::nullopt, std::nullopt, std::nullopt, false, false))
   }
 
   void testPcolormesh() {
@@ -133,7 +136,8 @@ public:
     const std::vector<int> index = {1};
     const std::string window_title = "window_title";
 
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, boost::none, index, boost::none, boost::none, boost::none, window_title))
+    TS_ASSERT_THROWS_NOTHING(
+        plot(workspaces, std::nullopt, index, std::nullopt, std::nullopt, std::nullopt, window_title))
   }
 
   void testPlottingSubplotsWithErrorsWillNotThrow() {
@@ -141,7 +145,7 @@ public:
     const std::vector<int> index = {1};
 
     TS_ASSERT_THROWS_NOTHING(
-        plot(workspaces, boost::none, index, boost::none, boost::none, boost::none, boost::none, true))
+        plot(workspaces, std::nullopt, index, std::nullopt, std::nullopt, std::nullopt, std::nullopt, true))
   }
 
 private:

--- a/qt/widgets/plotting/CMakeLists.txt
+++ b/qt/widgets/plotting/CMakeLists.txt
@@ -25,6 +25,7 @@ set(MPL_INC_FILES
     inc/MantidQtWidgets/Plotting/ExternalPlotter.h
     inc/MantidQtWidgets/Plotting/AxisID.h
     inc/MantidQtWidgets/Plotting/PlotWidget/IPlotView.h
+    inc/MantidQtWidgets/Plotting/MockExternalPlotter.h
     inc/MantidQtWidgets/Plotting/PlotWidget/PlotModel.h
     inc/MantidQtWidgets/Plotting/PlotWidget/PlotPresenter.h
     inc/MantidQtWidgets/Plotting/PlotWidget/QtPlotView.h
@@ -38,7 +39,7 @@ mtd_add_qt_library(
   NOMOC ${MPL_INC_FILES}
   DEFS IN_MANTIDQT_PLOTTING
   INCLUDE_DIRS inc
-  LINK_LIBS ${CORE_MANTIDLIBS} Mantid::PythonInterfaceCore ${POCO_LIBRARIES}
+  LINK_LIBS ${CORE_MANTIDLIBS} Mantid::PythonInterfaceCore ${POCO_LIBRARIES} gmock
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsMplCpp
   INSTALL_DIR ${WORKBENCH_LIB_DIR}
   OSX_INSTALL_RPATH @loader_path/../MacOS @loader_path/../Frameworks

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ExternalPlotter.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ExternalPlotter.h
@@ -9,8 +9,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Plotting/DllOption.h"
 
-#include <boost/none_t.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <QHash>
 #include <QVariant>
@@ -27,20 +26,20 @@ public:
 
   virtual void plotSpectra(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars) = 0;
   virtual void plotSpectra(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars,
-                           boost::optional<QHash<QString, QVariant>> const &kwargs) = 0;
+                           std::optional<QHash<QString, QVariant>> const &kwargs) = 0;
   virtual void plotCorrespondingSpectra(std::vector<std::string> const &workspaceNames,
                                         std::vector<int> const &workspaceIndices,
                                         std::vector<bool> const &errorBars) = 0;
   virtual void plotCorrespondingSpectra(std::vector<std::string> const &workspaceNames,
                                         std::vector<int> const &workspaceIndices, std::vector<bool> const &errorBars,
-                                        std::vector<boost::optional<QHash<QString, QVariant>>> const &kwargs) = 0;
+                                        std::vector<std::optional<QHash<QString, QVariant>>> const &kwargs) = 0;
   virtual void plotBins(std::string const &workspaceName, std::string const &binIndices, bool errorBars) = 0;
   virtual void plotContour(std::string const &workspaceName) = 0;
   virtual void plotTiled(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars) = 0;
   virtual void plot3DSurface(std::string const &workspaceName) = 0;
   virtual void showSliceViewer(std::string const &workspaceName) = 0;
-  virtual bool validate(std::string const &workspaceName, boost::optional<std::string> const &workspaceIndices,
-                        boost::optional<MantidAxis> const &axisType) const = 0;
+  virtual bool validate(std::string const &workspaceName, std::optional<std::string> const &workspaceIndices,
+                        std::optional<MantidAxis> const &axisType) const = 0;
 };
 
 class EXPORT_OPT_MANTIDQT_PLOTTING ExternalPlotter final : public IExternalPlotter {
@@ -48,24 +47,24 @@ class EXPORT_OPT_MANTIDQT_PLOTTING ExternalPlotter final : public IExternalPlott
 public:
   void plotSpectra(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars) override;
   void plotSpectra(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars,
-                   boost::optional<QHash<QString, QVariant>> const &kwargs) override;
+                   std::optional<QHash<QString, QVariant>> const &kwargs) override;
   void plotCorrespondingSpectra(std::vector<std::string> const &workspaceNames,
                                 std::vector<int> const &workspaceIndices, std::vector<bool> const &errorBars) override;
   void plotCorrespondingSpectra(std::vector<std::string> const &workspaceNames,
                                 std::vector<int> const &workspaceIndices, std::vector<bool> const &errorBars,
-                                std::vector<boost::optional<QHash<QString, QVariant>>> const &kwargs) override;
+                                std::vector<std::optional<QHash<QString, QVariant>>> const &kwargs) override;
   void plotBins(std::string const &workspaceName, std::string const &binIndices, bool errorBars) override;
   void plotContour(std::string const &workspaceName) override;
   void plotTiled(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars) override;
   void plot3DSurface(std::string const &workspaceName) override;
   void showSliceViewer(std::string const &workspaceName) override;
-  bool validate(std::string const &workspaceName, boost::optional<std::string> const &workspaceIndices = boost::none,
-                boost::optional<MantidAxis> const &axisType = boost::none) const override;
+  bool validate(std::string const &workspaceName, std::optional<std::string> const &workspaceIndices = std::nullopt,
+                std::optional<MantidAxis> const &axisType = std::nullopt) const override;
 
 private:
   bool validate(const Mantid::API::MatrixWorkspace_const_sptr &workspace,
-                boost::optional<std::string> const &workspaceIndices = boost::none,
-                boost::optional<MantidAxis> const &axisType = boost::none) const;
+                std::optional<std::string> const &workspaceIndices = std::nullopt,
+                std::optional<MantidAxis> const &axisType = std::nullopt) const;
   bool validateSpectra(const Mantid::API::MatrixWorkspace_const_sptr &workspace,
                        std::string const &workspaceIndices) const;
   bool validateBins(const Mantid::API::MatrixWorkspace_const_sptr &workspace, std::string const &binIndices) const;

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ExternalPlotter.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ExternalPlotter.h
@@ -21,31 +21,46 @@ namespace MplCpp {
 
 enum MantidAxis { Spectrum, Bin, Both };
 
-/**
- @class ExternalPlotter
- ExternalPlotter is a class used for external plotting within Indirect
- */
-class EXPORT_OPT_MANTIDQT_PLOTTING ExternalPlotter {
-
+class EXPORT_OPT_MANTIDQT_PLOTTING IExternalPlotter {
 public:
-  ExternalPlotter();
-  virtual ~ExternalPlotter();
+  virtual ~IExternalPlotter() = default;
 
-  virtual void plotSpectra(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars);
+  virtual void plotSpectra(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars) = 0;
   virtual void plotSpectra(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars,
-                           boost::optional<QHash<QString, QVariant>> const &kwargs);
+                           boost::optional<QHash<QString, QVariant>> const &kwargs) = 0;
   virtual void plotCorrespondingSpectra(std::vector<std::string> const &workspaceNames,
-                                        std::vector<int> const &workspaceIndices, std::vector<bool> const &errorBars);
+                                        std::vector<int> const &workspaceIndices,
+                                        std::vector<bool> const &errorBars) = 0;
   virtual void plotCorrespondingSpectra(std::vector<std::string> const &workspaceNames,
                                         std::vector<int> const &workspaceIndices, std::vector<bool> const &errorBars,
-                                        std::vector<boost::optional<QHash<QString, QVariant>>> const &kwargs);
-  virtual void plotBins(std::string const &workspaceName, std::string const &binIndices, bool errorBars);
-  virtual void plotContour(std::string const &workspaceName);
-  virtual void plotTiled(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars);
-  virtual void plot3DSurface(std::string const &workspaceName);
-  virtual void showSliceViewer(std::string const &workspaceName);
+                                        std::vector<boost::optional<QHash<QString, QVariant>>> const &kwargs) = 0;
+  virtual void plotBins(std::string const &workspaceName, std::string const &binIndices, bool errorBars) = 0;
+  virtual void plotContour(std::string const &workspaceName) = 0;
+  virtual void plotTiled(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars) = 0;
+  virtual void plot3DSurface(std::string const &workspaceName) = 0;
+  virtual void showSliceViewer(std::string const &workspaceName) = 0;
+  virtual bool validate(std::string const &workspaceName, boost::optional<std::string> const &workspaceIndices,
+                        boost::optional<MantidAxis> const &axisType) const = 0;
+};
+
+class EXPORT_OPT_MANTIDQT_PLOTTING ExternalPlotter final : public IExternalPlotter {
+
+public:
+  void plotSpectra(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars) override;
+  void plotSpectra(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars,
+                   boost::optional<QHash<QString, QVariant>> const &kwargs) override;
+  void plotCorrespondingSpectra(std::vector<std::string> const &workspaceNames,
+                                std::vector<int> const &workspaceIndices, std::vector<bool> const &errorBars) override;
+  void plotCorrespondingSpectra(std::vector<std::string> const &workspaceNames,
+                                std::vector<int> const &workspaceIndices, std::vector<bool> const &errorBars,
+                                std::vector<boost::optional<QHash<QString, QVariant>>> const &kwargs) override;
+  void plotBins(std::string const &workspaceName, std::string const &binIndices, bool errorBars) override;
+  void plotContour(std::string const &workspaceName) override;
+  void plotTiled(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars) override;
+  void plot3DSurface(std::string const &workspaceName) override;
+  void showSliceViewer(std::string const &workspaceName) override;
   bool validate(std::string const &workspaceName, boost::optional<std::string> const &workspaceIndices = boost::none,
-                boost::optional<MantidAxis> const &axisType = boost::none) const;
+                boost::optional<MantidAxis> const &axisType = boost::none) const override;
 
 private:
   bool validate(const Mantid::API::MatrixWorkspace_const_sptr &workspace,

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/MockExternalPlotter.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/MockExternalPlotter.h
@@ -1,0 +1,46 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidQtWidgets/Plotting/ExternalPlotter.h"
+
+#include <string>
+
+using namespace MantidQt::Widgets::MplCpp;
+using namespace testing;
+
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
+
+class MockExternalPlotter : public IExternalPlotter {
+public:
+  virtual ~MockExternalPlotter() = default;
+
+  MOCK_METHOD3(plotSpectra,
+               void(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars));
+  MOCK_METHOD4(plotSpectra, void(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars,
+                                 boost::optional<QHash<QString, QVariant>> const &kwargs));
+  MOCK_METHOD3(plotCorrespondingSpectra,
+               void(std::vector<std::string> const &workspaceNames, std::vector<int> const &workspaceIndices,
+                    std::vector<bool> const &errorBars));
+  MOCK_METHOD4(plotCorrespondingSpectra,
+               void(std::vector<std::string> const &workspaceNames, std::vector<int> const &workspaceIndices,
+                    std::vector<bool> const &errorBars,
+                    std::vector<boost::optional<QHash<QString, QVariant>>> const &kwargs));
+  MOCK_METHOD3(plotBins, void(std::string const &workspaceName, std::string const &binIndices, bool errorBars));
+  MOCK_METHOD1(showSliceViewer, void(std::string const &workspaceName));
+  MOCK_METHOD1(plot3DSurface, void(std::string const &workspaceName));
+  MOCK_METHOD3(plotTiled, void(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars));
+  MOCK_METHOD1(plotContour, void(std::string const &workspaceName));
+  MOCK_CONST_METHOD3(validate,
+                     bool(std::string const &workspaceName, boost::optional<std::string> const &workspaceIndices,
+                          boost::optional<MantidAxis> const &axisType));
+};
+
+GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/MockExternalPlotter.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/MockExternalPlotter.h
@@ -11,6 +11,7 @@
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidQtWidgets/Plotting/ExternalPlotter.h"
 
+#include <optional>
 #include <string>
 
 using namespace MantidQt::Widgets::MplCpp;
@@ -25,22 +26,22 @@ public:
   MOCK_METHOD3(plotSpectra,
                void(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars));
   MOCK_METHOD4(plotSpectra, void(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars,
-                                 boost::optional<QHash<QString, QVariant>> const &kwargs));
+                                 std::optional<QHash<QString, QVariant>> const &kwargs));
   MOCK_METHOD3(plotCorrespondingSpectra,
                void(std::vector<std::string> const &workspaceNames, std::vector<int> const &workspaceIndices,
                     std::vector<bool> const &errorBars));
   MOCK_METHOD4(plotCorrespondingSpectra,
                void(std::vector<std::string> const &workspaceNames, std::vector<int> const &workspaceIndices,
                     std::vector<bool> const &errorBars,
-                    std::vector<boost::optional<QHash<QString, QVariant>>> const &kwargs));
+                    std::vector<std::optional<QHash<QString, QVariant>>> const &kwargs));
   MOCK_METHOD3(plotBins, void(std::string const &workspaceName, std::string const &binIndices, bool errorBars));
   MOCK_METHOD1(showSliceViewer, void(std::string const &workspaceName));
   MOCK_METHOD1(plot3DSurface, void(std::string const &workspaceName));
   MOCK_METHOD3(plotTiled, void(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars));
   MOCK_METHOD1(plotContour, void(std::string const &workspaceName));
   MOCK_CONST_METHOD3(validate,
-                     bool(std::string const &workspaceName, boost::optional<std::string> const &workspaceIndices,
-                          boost::optional<MantidAxis> const &axisType));
+                     bool(std::string const &workspaceName, std::optional<std::string> const &workspaceIndices,
+                          std::optional<MantidAxis> const &axisType));
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/widgets/plotting/src/ExternalPlotter.cpp
+++ b/qt/widgets/plotting/src/ExternalPlotter.cpp
@@ -81,23 +81,23 @@ template <typename T> std::vector<T> createIndicesVector(std::string const &indi
 using namespace Mantid::PythonInterface;
 using namespace MantidQt::Widgets::Common;
 
-boost::optional<Python::Object> workbenchPlot(QStringList const &workspaceNames, std::vector<int> const &indices,
-                                              bool errorBars, bool overplot = false,
-                                              boost::optional<QHash<QString, QVariant>> kwargs = boost::none,
-                                              boost::optional<Python::Object> figure = boost::none) {
+std::optional<Python::Object> workbenchPlot(QStringList const &workspaceNames, std::vector<int> const &indices,
+                                            bool errorBars, bool overplot = false,
+                                            std::optional<QHash<QString, QVariant>> kwargs = std::nullopt,
+                                            std::optional<Python::Object> figure = std::nullopt) {
   QHash<QString, QVariant> plotKwargs;
   if (kwargs)
-    plotKwargs = kwargs.get();
+    plotKwargs = *kwargs;
   if (errorBars)
     plotKwargs["capsize"] = ERROR_CAPSIZE;
 
   using MantidQt::Widgets::MplCpp::plot;
   try {
-    return plot(workspaceNames, boost::none, indices, std::move(figure), plotKwargs, boost::none, boost::none,
+    return plot(workspaceNames, std::nullopt, indices, std::move(figure), plotKwargs, std::nullopt, std::nullopt,
                 errorBars, overplot);
   } catch (PythonException const &ex) {
     g_log.error() << ex.what();
-    return boost::none;
+    return std::nullopt;
   }
 }
 
@@ -110,7 +110,7 @@ namespace MantidQt::Widgets::MplCpp {
  */
 void ExternalPlotter::plotSpectra(std::string const &workspaceName, std::string const &workspaceIndices,
                                   bool errorBars) {
-  return plotSpectra(workspaceName, workspaceIndices, errorBars, boost::none);
+  return plotSpectra(workspaceName, workspaceIndices, errorBars, std::nullopt);
 }
 
 /**
@@ -123,7 +123,7 @@ void ExternalPlotter::plotSpectra(std::string const &workspaceName, std::string 
  * @param kwargs The kwargs to be used when plotting the workspace
  */
 void ExternalPlotter::plotSpectra(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars,
-                                  boost::optional<QHash<QString, QVariant>> const &kwargs) {
+                                  std::optional<QHash<QString, QVariant>> const &kwargs) {
   if (validate(workspaceName, workspaceIndices, MantidAxis::Spectrum)) {
     workbenchPlot(QStringList(QString::fromStdString(workspaceName)), createIndicesVector<int>(workspaceIndices),
                   errorBars, false, kwargs);
@@ -138,7 +138,7 @@ void ExternalPlotter::plotCorrespondingSpectra(std::vector<std::string> const &w
                                                std::vector<bool> const &errorBars) {
   return plotCorrespondingSpectra(
       workspaceNames, workspaceIndices, errorBars,
-      std::vector<boost::optional<QHash<QString, QVariant>>>(workspaceNames.size(), boost::none));
+      std::vector<std::optional<QHash<QString, QVariant>>>(workspaceNames.size(), std::nullopt));
 }
 
 /**
@@ -153,7 +153,7 @@ void ExternalPlotter::plotCorrespondingSpectra(std::vector<std::string> const &w
 void ExternalPlotter::plotCorrespondingSpectra(std::vector<std::string> const &workspaceNames,
                                                std::vector<int> const &workspaceIndices,
                                                std::vector<bool> const &errorBars,
-                                               std::vector<boost::optional<QHash<QString, QVariant>>> const &kwargs) {
+                                               std::vector<std::optional<QHash<QString, QVariant>>> const &kwargs) {
   if (workspaceNames.empty() || workspaceIndices.empty() || errorBars.empty() || kwargs.empty())
     return;
   auto const numberOfPlots = workspaceNames.size();
@@ -165,7 +165,7 @@ void ExternalPlotter::plotCorrespondingSpectra(std::vector<std::string> const &w
   for (auto i = 1u; i < workspaceNames.size(); ++i) {
     if (figure)
       figure = workbenchPlot(QStringList(QString::fromStdString(workspaceNames[i])), {workspaceIndices[i]},
-                             errorBars[i], true, kwargs[i], figure.get());
+                             errorBars[i], true, kwargs[i], *figure);
   }
 }
 
@@ -230,8 +230,8 @@ void ExternalPlotter::plotTiled(std::string const &workspaceName, std::string co
     QHash<QString, QVariant> plotKwargs;
     if (errorBars)
       plotKwargs["capsize"] = ERROR_CAPSIZE;
-    plot(QStringList(QString::fromStdString(workspaceName)), boost::none, createIndicesVector<int>(workspaceIndices),
-         boost::none, plotKwargs, boost::none, "Tiled Plot: " + workspaceName, errorBars, false, true);
+    plot(QStringList(QString::fromStdString(workspaceName)), std::nullopt, createIndicesVector<int>(workspaceIndices),
+         std::nullopt, plotKwargs, std::nullopt, "Tiled Plot: " + workspaceName, errorBars, false, true);
   }
 }
 
@@ -245,8 +245,8 @@ void ExternalPlotter::plotTiled(std::string const &workspaceName, std::string co
  * @param axisType The axis to validate (i.e. Spectrum or Bin)
  * @return True if the data is valid
  */
-bool ExternalPlotter::validate(std::string const &workspaceName, boost::optional<std::string> const &workspaceIndices,
-                               boost::optional<MantidAxis> const &axisType) const {
+bool ExternalPlotter::validate(std::string const &workspaceName, std::optional<std::string> const &workspaceIndices,
+                               std::optional<MantidAxis> const &axisType) const {
   auto &ads = AnalysisDataService::Instance();
   if (ads.doesExist(workspaceName))
     if (auto const workspace = ads.retrieveWS<MatrixWorkspace>(workspaceName))
@@ -264,12 +264,12 @@ bool ExternalPlotter::validate(std::string const &workspaceName, boost::optional
  * @return True if the data is valid
  */
 bool ExternalPlotter::validate(const MatrixWorkspace_const_sptr &workspace,
-                               boost::optional<std::string> const &workspaceIndices,
-                               boost::optional<MantidAxis> const &axisType) const {
-  if (workspaceIndices && axisType && axisType.get() == MantidAxis::Spectrum)
-    return validateSpectra(workspace, workspaceIndices.get());
-  else if (workspaceIndices && axisType && axisType.get() == MantidAxis::Bin)
-    return validateBins(workspace, workspaceIndices.get());
+                               std::optional<std::string> const &workspaceIndices,
+                               std::optional<MantidAxis> const &axisType) const {
+  if (workspaceIndices && axisType && *axisType == MantidAxis::Spectrum)
+    return validateSpectra(workspace, *workspaceIndices);
+  else if (workspaceIndices && axisType && *axisType == MantidAxis::Bin)
+    return validateBins(workspace, *workspaceIndices);
   return true;
 }
 

--- a/qt/widgets/plotting/src/ExternalPlotter.cpp
+++ b/qt/widgets/plotting/src/ExternalPlotter.cpp
@@ -105,10 +105,6 @@ boost::optional<Python::Object> workbenchPlot(QStringList const &workspaceNames,
 
 namespace MantidQt::Widgets::MplCpp {
 
-ExternalPlotter::ExternalPlotter() = default;
-
-ExternalPlotter::~ExternalPlotter() = default;
-
 /**
  * Calls plotSpectra with no kwargs
  */

--- a/qt/widgets/plotting/src/PlotWidget/QtPlotView.cpp
+++ b/qt/widgets/plotting/src/PlotWidget/QtPlotView.cpp
@@ -45,8 +45,8 @@ void QtPlotView::setScaleLog(const AxisID axisID) {
 
 void QtPlotView::plot(const std::vector<Mantid::API::MatrixWorkspace_sptr> &workspaces,
                       const std::vector<int> &workspaceIndices, const bool plotErrorBars) {
-  Widgets::MplCpp::plot(workspaces, boost::none, workspaceIndices, m_canvas->gcf().pyobj(), boost::none,
-                        m_axisProperties, boost::none, plotErrorBars, false);
+  Widgets::MplCpp::plot(workspaces, std::nullopt, workspaceIndices, m_canvas->gcf().pyobj(), std::nullopt,
+                        m_axisProperties, std::nullopt, plotErrorBars, false);
 }
 
 void QtPlotView::createLayout() {


### PR DESCRIPTION
### Description of work
This PR finishes off the refactor of the FitTab by moving the remaining plotting code to the OutputOptionsPresenter. To do this I needed the presenter to hold a unique pointer to an `ExternalPlotter` object.

Fixes #36390

### To test:
1. Follow the instructions here
https://developer.mantidproject.org/Testing/Inelastic/QENSFittingTests.html

2. Attempt to use the plotting in the "Output options" after doing a run

*This does not require release notes* because **its an internal change**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
