### PR TITLE
Fix Muon error when switching to TF Asymmetry fitting

### DIFF
--- a/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/37392.rst
+++ b/docs/source/release/v6.10.0/Muon/Muon_Analysis/Bugfixes/37392.rst
@@ -1,0 +1,1 @@
+- Fixed a bug when switching between "Normal" fitting and "TF Asymmetry" fitting modes.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid import AlgorithmManager, logger
-from mantid.api import IFunction, MultiDomainFunction
+from mantid.api import CompositeFunction, IFunction, MultiDomainFunction
 from mantid.simpleapi import CopyLogs, ConvertFitFunctionForMuonTFAsymmetry
 
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.workspace_naming import (
@@ -302,10 +302,11 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
 
     def _get_normal_fit_function_from(self, tf_asymmetry_function: IFunction) -> IFunction:
         """Returns the ordinary fit function embedded within the TF Asymmetry fit function."""
-        if tf_asymmetry_function is not None:
-            return tf_asymmetry_function.getFunction(0).getFunction(1).getFunction(1)
-        else:
-            return tf_asymmetry_function
+        if isinstance(tf_asymmetry_function, CompositeFunction):
+            domain_function = tf_asymmetry_function.getFunction(0)
+            if isinstance(domain_function, CompositeFunction) and isinstance(domain_function.getFunction(1), CompositeFunction):
+                return domain_function.getFunction(1).getFunction(1)
+        return None
 
     def _update_tf_asymmetry_parameter_value(self, dataset_index: int, full_parameter: str, value: float) -> None:
         """Updates a parameters value within the current TF Asymmetry single function or simultaneous function."""

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
@@ -698,6 +698,24 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         filtered_functions_fwd = self.model.get_all_fit_functions_for("fwd")
         self.assertEqual(str(filtered_functions_fwd[0]), str(self.tf_simultaneous_fit_function))
 
+    def test_get_normal_fit_function_from_does_not_error_if_the_function_has_an_unexpected_structure(self):
+        function_string = (
+            "composite=MultiDomainFunction,NumDeriv=true;(composite=CompositeFunction,NumDeriv=false,"
+            "$domains=i;(composite=ProductFunction,NumDeriv=false;name=FlatBackground,A0=0.859525;"
+            "(name=FlatBackground,A0=1,ties=(A0=1);name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0));"
+            "name=ExpDecayMuon,A=0,Lambda=-2.19698,ties=(A=0,Lambda=-2.19698));(composite=CompositeFunction,"
+            "NumDeriv=false,$domains=i;(composite=ProductFunction,NumDeriv=false;name=FlatBackground,"
+            "A0=1.22426;(name=FlatBackground,A0=1,ties=(A0=1);name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0));"
+            "name=ExpDecayMuon,A=0,Lambda=-2.19698,ties=(A=0,Lambda=-2.19698))"
+        )
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fitting_mode = True
+        self.model.tf_asymmetry_mode = True
+
+        func = FunctionFactory.createInitialized(function_string)
+
+        self.assertEqual(None, self.model._get_normal_fit_function_from(func))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of work
This PR fixes a bug on the Muon Analysis interface when switching between normal fitting mode and TF Asymmetry fitting. The solution was to check if the tf asymmetry fit function can be parsed before attempting to get individual functions from its structure.

Fixes #37392

### To test:
1. Open Muon Analysis interface
2. Select `MUSR` instrument
3. Load 62260
4. Go to Fitting tab
5. Right click and add function `GausOsc` in the function browser
6. Tick `Simultaneous fit over`
7. Change fitting mode from "Normal" to "TF Asymmetry"
8. There should be no error!

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
