### PR TITLE
Prevent crash when self-tie in Inelastic Fit Property Browser

### DIFF
--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -301,7 +301,7 @@ void IFunction::addTie(std::unique_ptr<ParameterTie> tie) {
       const auto oldExp = oldTieStr.substr(oldTieStr.find("=") + 1);
       *it = std::make_unique<ParameterTie>(this, parameterName(iPar), oldExp);
     } else {
-      removeTie(m_ties.size() - 1);
+      removeTie(iPar);
     }
     throw;
   }

--- a/docs/source/release/v6.10.0/Inelastic/Bugfixes/37360.rst
+++ b/docs/source/release/v6.10.0/Inelastic/Bugfixes/37360.rst
@@ -1,0 +1,1 @@
+- Fixed a bug crashing Mantid on the Fit Property Browser of :ref:`QENS Fitting <interface-inelastic-qens-fitting>` interface when trying to set a fit function with a parameter having a tie to itself.

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
@@ -211,6 +211,8 @@ MultiDomainFunction_sptr InelasticFitPropertyBrowser::getFitFunction() const {
     }
   } catch (const std::invalid_argument &) {
     return std::make_shared<MultiDomainFunction>();
+  } catch (const std::runtime_error &) {
+    return std::make_shared<MultiDomainFunction>();
   }
 }
 

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -423,7 +423,6 @@ void FunctionModel::setLocalParameterTie(std::string const &parameterName, int i
     } catch (const std::invalid_argument &e) {
       logError(e.what());
     } catch (const std::runtime_error &e) {
-      fun->removeTie(fun->parameterIndex(name));
       logError(e.what());
     }
   }

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -423,6 +423,7 @@ void FunctionModel::setLocalParameterTie(std::string const &parameterName, int i
     } catch (const std::invalid_argument &e) {
       logError(e.what());
     } catch (const std::runtime_error &e) {
+      fun->removeTie(fun->parameterIndex(name));
       logError(e.what());
     }
   }


### PR DESCRIPTION
### Description of work
This PR fixes a crash report ocurring when trying to set a tie of a parameter to itself. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
There are two changes in this PR: 
- There was an unhandled exception on the ``InelasticFitPropertyBrowser`` ocurring whenever the self-tie throws.
- Even if the tie is wrong, it seems the manager class does not properly remove the tie. I have remove it manually just after the crash occurs, but the reason why the tie is not being removed in `IFunction.cpp` may require more investigation.
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37360. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Follow instructions on #37360. Error message should be sent, but Mantid shouldn't crash. 
- When you try to add a tie again, the `EditParameterDialog` shouldn't remember the wrong tie. 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
