### PR TITLE
Update Muon testing instructions

### DIFF
--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon Analysis Unscripted Testing Guide.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon Analysis Unscripted Testing Guide.rst
@@ -39,9 +39,9 @@ Group 2: PSI data
 
 This group tests bin data from the PSI facility and introduces background corrections.
 Test instructions can be found at :ref:`Muon_Analysis_PSI-ref`.
-You will need the following run:
+You will need the following file from the unit test data:
 
-- dolly 1529
+- deltat_tdc_dolly_1529.bin
 
 Group 3: HIFI data
 ^^^^^^^^^^^^^^^^^^

--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_Analysis_PSI.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_Analysis_PSI.rst
@@ -23,7 +23,7 @@ Loading Data Test
 - Open Muon Analysis
 - On the **Home** tab set the instrument to **PSI**
 - The load current run button should be greyed out
-- Load **dolly 1529** using the **Browse** button
+- Load **deltat_tdc_dolly_1529.bin** from the unit test data using the **Browse** button
 - Set `Rebin` to `Fixed` and enter a value of `5`
 - You will get 4 lines that all curve upwards
 - If you tick the `Plot raw` option the data will change

--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_FDA.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_FDA.rst
@@ -23,7 +23,7 @@ FFT Test
 - Change *Instrument* to **MUSR**, found in the *Home* tab
 - In the loading bar enter ``62260``
 - Go to the **Transform** tab
-    - Set the workspace to "MUSR00062260; Group; bkwd; Asym; FD"
+    - Set the workspace to "MUSR00062260; Group; bkwd; Asymmetry; FD"
     - Click the calculate FFT button and a plot will appear
     - The plot window will show a broad peak
 - In the **Fitting** tab it will contain 3 workspace ending in `Re_unit_MHz` (real), `Im_unit_MHz` (imaginary) and `mod_unit_MHz` (modulus)
@@ -36,7 +36,7 @@ FFT Test
     - The "padding" adds zeros to the end of the time domain data set, to improve the sampling of the FFT
     - Set the xrange for the plot to be from ``0`` to ``2`` by changing the x min and x max values below the plot
     - Set the "padding" to zero and press calculate
-    - The plots should be a nice peak, but it will have lots of straight lines
+    - The plot should still have a peak, but it will be less smooth
     - Set the "padding" to ``50`` and press calculate
     - The plot will now be nice and smooth
 - At the top of the plotting window change the unit from "Frequency" to "Field", the data will have different x axis

--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_HIFI.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_HIFI.rst
@@ -54,8 +54,8 @@ HIFI Transverse Field Simultaneous Fitting
 	- Click **Undo Fits**
 	- Click the value for the **Frequency** parameter; A ``...`` should appear
 	  next to it, click it. A new window should appear
-	- Enter values for each run in the table as from ``0.0`` to ``1.1`` in
-	  steps of ``0.1``
+	- Enter a value of ``0.01`` for the first run in the table
+	- For each of the other runs in the table, enter values from ``0.1`` to ``1.1`` in steps of ``0.1``
 	- Click **Ok**
 	- Click **Fit**
 	- This time the fit should work with a significantly lower value for **Chi-squared** (``<10``)
@@ -83,6 +83,7 @@ HIFI MultiPeriod Data
 - Go to the **Sequential Fitting** tab
 	- Press ``Sequentially fit all``
 	- When its complete the table should update
+	- It is ok if some of the rows say "Failed". This happens because these rows need more iterations to converge. However, if you go to the Fitting tab and cycle through the datasets, you can see that the fits are still reasonably good.
 	- Selecting rows will show you the data and fit for those rows
 - Go to the **Grouping** tab
 	- The ``Period`` column in the group table will show a series of numbers (1, 2, 3 or 4)


### PR DESCRIPTION
### Description of work
This PR updates some of the Muon testing instructions to make it clearer what is expected when testing, and where to find a dataset for PSI testing.

Fixes #37393

Fixes #37394

### To test:
Build the dev docs and make sure the Muon testing instructions are formatted as expected

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
