### PR TITLE
Bug preventing Mantid from processing  algorithms from some indirect/inelastic interfaces

### DIFF
--- a/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
@@ -327,8 +327,8 @@ void DiffractionReduction::runGenericReduction(const QString &instName, const QS
 
   // Get detector range
   std::vector<int> detRange;
-  detRange.emplace_back(static_cast<int>(m_uiForm.spSpecMin->value()));
-  detRange.emplace_back(static_cast<int>(m_uiForm.spSpecMax->value()));
+  detRange.emplace_back(m_uiForm.spSpecMin->value());
+  detRange.emplace_back(m_uiForm.spSpecMax->value());
 
   // Get generic reduction algorithm instance
   IAlgorithm_sptr msgDiffReduction = AlgorithmManager::Instance().create("ISISDiffractionReduction");

--- a/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
@@ -326,9 +326,9 @@ void DiffractionReduction::runGenericReduction(const QString &instName, const QS
     rebin = rebinStart + "," + rebinWidth + "," + rebinEnd;
 
   // Get detector range
-  std::vector<long> detRange;
-  detRange.emplace_back(static_cast<long>(m_uiForm.spSpecMin->value()));
-  detRange.emplace_back(static_cast<long>(m_uiForm.spSpecMax->value()));
+  std::vector<int> detRange;
+  detRange.emplace_back(static_cast<int>(m_uiForm.spSpecMin->value()));
+  detRange.emplace_back(static_cast<int>(m_uiForm.spSpecMax->value()));
 
   // Get generic reduction algorithm instance
   IAlgorithm_sptr msgDiffReduction = AlgorithmManager::Instance().create("ISISDiffractionReduction");

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
@@ -145,9 +145,9 @@ void ISISDiagnostics::run() {
   QString suffix = "_" + getAnalyserName() + getReflectionName() + "_slice";
   QString filenames = m_uiForm.dsInputFiles->getFilenames().join(",");
 
-  std::vector<long> spectraRange;
-  spectraRange.emplace_back(static_cast<long>(m_dblManager->value(m_properties["SpecMin"])));
-  spectraRange.emplace_back(static_cast<long>(m_dblManager->value(m_properties["SpecMax"])));
+  std::vector<int> spectraRange;
+  spectraRange.emplace_back(static_cast<int>(m_dblManager->value(m_properties["SpecMin"])));
+  spectraRange.emplace_back(static_cast<int>(m_dblManager->value(m_properties["SpecMax"])));
 
   std::vector<double> peakRange;
   peakRange.emplace_back(m_dblManager->value(m_properties["PeakStart"]));

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModel.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModel.cpp
@@ -63,7 +63,7 @@ void IETModel::setInputProperties(IAlgorithmRuntimeProps &properties, IETInputDa
 
 void IETModel::setConversionProperties(IAlgorithmRuntimeProps &properties, IETConversionData const &conversionData,
                                        std::string const &instrument) {
-  std::vector<long> detectorRange;
+  std::vector<int> detectorRange;
 
   if (instrument == "IRIS" || instrument == "OSIRIS") {
     Mantid::API::AlgorithmProperties::update("Efixed", conversionData.getEfixed(), properties);

--- a/qt/scientific_interfaces/Indirect/test/Reduction/ISISEnergyTransferModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/Reduction/ISISEnergyTransferModelTest.h
@@ -54,7 +54,7 @@ private:
     declareProperty("CalibrationWorkspace", "");
 
     declareProperty("Efixed", 0.0);
-    declareProperty("SpectraRange", std::vector<long>{0, 2});
+    declareProperty("SpectraRange", std::vector<int>{0, 2});
     declareProperty("BackgroundRange", std::vector<double>{0.0, 0.0});
     declareProperty("RebinString", "");
 

--- a/qt/scientific_interfaces/Inelastic/Manipulation/SymmetriseModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/SymmetriseModel.cpp
@@ -25,7 +25,7 @@ SymmetriseModel::SymmetriseModel()
       m_eMin(), m_eMax(), m_isPositiveReflect(), m_spectraRange() {}
 
 void SymmetriseModel::setupPreviewAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
-                                            std::vector<long> const &spectraRange) {
+                                            std::vector<int> const &spectraRange) {
 
   if (!m_isPositiveReflect) {
     reflectNegativeToPositive();

--- a/qt/scientific_interfaces/Inelastic/Manipulation/SymmetriseModel.h
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/SymmetriseModel.h
@@ -23,7 +23,7 @@ public:
   SymmetriseModel();
   ~SymmetriseModel() = default;
   void setupPreviewAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
-                             std::vector<long> const &spectraRange);
+                             std::vector<int> const &spectraRange);
   std::string setupSymmetriseAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner);
   void reflectNegativeToPositive();
   void setWorkspaceName(std::string const &workspaceName);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/SymmetrisePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/SymmetrisePresenter.cpp
@@ -78,7 +78,7 @@ void SymmetrisePresenter::run() {
     return;
 
   if (m_isPreview) {
-    long spectrumNumber = static_cast<int>(m_view->getPreviewSpec());
+    int spectrumNumber = static_cast<int>(m_view->getPreviewSpec());
     std::vector<int> spectraRange(2, spectrumNumber);
 
     m_model->setupPreviewAlgorithm(m_batchAlgoRunner, spectraRange);

--- a/qt/scientific_interfaces/Inelastic/Manipulation/SymmetrisePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/SymmetrisePresenter.cpp
@@ -78,8 +78,8 @@ void SymmetrisePresenter::run() {
     return;
 
   if (m_isPreview) {
-    long spectrumNumber = static_cast<long>(m_view->getPreviewSpec());
-    std::vector<long> spectraRange(2, spectrumNumber);
+    long spectrumNumber = static_cast<int>(m_view->getPreviewSpec());
+    std::vector<int> spectraRange(2, spectrumNumber);
 
     m_model->setupPreviewAlgorithm(m_batchAlgoRunner, spectraRange);
   } else {

--- a/qt/scientific_interfaces/Inelastic/test/Manipulation/SymmetriseModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Manipulation/SymmetriseModelTest.h
@@ -29,7 +29,7 @@ private:
     declareProperty("OutputWorkspace", "OutputWorkspace");
     declareProperty("OutputPropertiesTable", "OutputPropertiesTable");
 
-    declareProperty("SpectraRange", std::vector<long>{0, 2});
+    declareProperty("SpectraRange", std::vector<int>{0, 2});
     declareProperty("XMin", 0.05);
     declareProperty("XMax", 0.6);
   };
@@ -80,7 +80,7 @@ public:
     m_model->setWorkspaceName(inputWS);
     m_model->setIsPositiveReflect(true);
 
-    std::vector<long> spectraRange(2, 4);
+    std::vector<int> spectraRange(2, 4);
     m_model->setupPreviewAlgorithm(&batch, spectraRange);
     batch.executeBatch();
 
@@ -107,7 +107,7 @@ public:
     m_model->setWorkspaceName(inputWS);
     m_model->setIsPositiveReflect(false);
 
-    std::vector<long> spectraRange(2, 4);
+    std::vector<int> spectraRange(2, 4);
     m_model->setupPreviewAlgorithm(&batch, spectraRange);
     batch.executeBatch();
 


### PR DESCRIPTION
### Description of work
Recently algortihms validators stopped checking against `long` type, #37196 
Some classes that use properties of type `IntArrayProperty` but were declared as `std::vector<long>` from cpp were not able to run the algorithms, we have detected that it affected: 
- Symmetrise interface
- ISIS Diagnostic
- Isis Diffraction Reduction
- Isis Energy Transfer   
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->


*There is no associated issue.*


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Check that the affected interfaces can execute the algorithm without an error message raising. 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
