### PR TITLE
Pin jemalloc to v5.2.0 for install package

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -24,6 +24,10 @@ boost:
 hdf5: # this is to move to libcurl>=8.4
   - '>1.14.0,<1.15'
 
+# this must match the version in the developer dependencies
+jemalloc:
+  - 5.2.0
+
 # We follow conda-forge and build with the lowest supported version of numpy for forward compatibility.
 numpy:
   - 1.24.*

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - {{ compiler("cxx") }}
     - llvm-openmp                            # [osx]
     - libgomp                                # [linux]
-    - ninja                                  # [unix]
+    - ninja                                  # [osx or linux]
     - cmake
     - git
     - python {{ python }}                    # [build_platform != target_platform]
@@ -38,7 +38,7 @@ requirements:
     - gsl {{ gsl }}
     - h5py
     - hdf5 {{ hdf5 }}
-    - jemalloc  {{ jemalloc }} # [unix]
+    - jemalloc  {{ jemalloc }} # [osx or linux]
     - jsoncpp
     - libopenblas {{ libopenblas }}  # [osx or linux]
     - librdkafka {{ librdkafka }}
@@ -59,7 +59,7 @@ requirements:
     - {{ pin_compatible("gsl", max_pin="x.x") }}
     - h5py
     - {{ pin_compatible("hdf5", max_pin="x.x") }}
-    - jemalloc  {{ jemalloc }} # [unix]
+    - jemalloc  {{ jemalloc }} # [os or linux]
     - lib3mf  # [win]
     - nexus
     - {{ pin_compatible("numpy", upper_bound="1.27") }}

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -59,7 +59,7 @@ requirements:
     - {{ pin_compatible("gsl", max_pin="x.x") }}
     - h5py
     - {{ pin_compatible("hdf5", max_pin="x.x") }}
-    - jemalloc  {{ jemalloc }} # [os or linux]
+    - jemalloc  {{ jemalloc }} # [osx or linux]
     - lib3mf  # [win]
     - nexus
     - {{ pin_compatible("numpy", upper_bound="1.27") }}

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - gsl {{ gsl }}
     - h5py
     - hdf5 {{ hdf5 }}
-    - jemalloc  # [unix]
+    - jemalloc  {{ jemalloc }} # [unix]
     - jsoncpp
     - libopenblas {{ libopenblas }}  # [osx or linux]
     - librdkafka {{ librdkafka }}
@@ -59,6 +59,7 @@ requirements:
     - {{ pin_compatible("gsl", max_pin="x.x") }}
     - h5py
     - {{ pin_compatible("hdf5", max_pin="x.x") }}
+    - jemalloc  {{ jemalloc }} # [unix]
     - lib3mf  # [win]
     - nexus
     - {{ pin_compatible("numpy", upper_bound="1.27") }}
@@ -74,6 +75,11 @@ requirements:
     - joblib
     - orsopy {{ orsopy }}
     - quasielasticbayes
+
+test:
+  imports:
+    - mantid
+    - mantid.kernel
 
 about:
   home: https://github.com/mantidproject/mantid

--- a/conda/recipes/mantiddocs/meta.yaml
+++ b/conda/recipes/mantiddocs/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler("cxx") }}
-    - ninja  # [unix]
+    - ninja  # [osx or linux]
     - cmake
     - git
     - python {{ python }}                    # [build_platform != target_platform]

--- a/conda/recipes/mantidqt/meta.yaml
+++ b/conda/recipes/mantidqt/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - {{ compiler("cxx") }}
     - llvm-openmp  # [osx]
     - libgomp  # [linux]
-    - ninja  # [unix]
+    - ninja  # [osx or linux]
     - cmake
     - git
     - python {{ python }}                    # [build_platform != target_platform]

--- a/conda/recipes/mantidqt/meta.yaml
+++ b/conda/recipes/mantidqt/meta.yaml
@@ -37,7 +37,6 @@ requirements:
 
   host:
     - eigen
-    - jemalloc  # [unix]
     - libopenblas {{ libopenblas }}  # [osx or linux]
     - mantid {{ version }}
     - python {{ python }}

--- a/conda/recipes/mantidworkbench/meta.yaml
+++ b/conda/recipes/mantidworkbench/meta.yaml
@@ -18,7 +18,7 @@ build:
 requirements:
   build:
     - {{ compiler("cxx") }}
-    - ninja  # [unix]
+    - ninja  # [osx or linux]
     - cmake
     - git
     - python {{ python }}                    # [build_platform != target_platform]

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -14,12 +14,11 @@ dependencies:
   - gsl=2.7 # Keep gsl a specific version to reduce changes in our fitting
   - h5py
   - hdf5>1.14.0,<1.15 # gets libcurl>=8.4
-  - jemalloc>=5.2.1
   - jsoncpp>=1.9.4,<2
   - libopenblas!=0.3.23,!=0.3.24,!=0.3.25 # v0.3.23 causes a hang for the system tests on OSX, v0.3.24 causing unit test failure - investigation needed, v0.3.25 causing a system test failure.
   - librdkafka>=1.6.0
-  - muparser>=2.3.2
   - matplotlib=3.7.*
+  - muparser>=2.3.2
   - nexus=4.4.*
   - ninja>=1.10.2
   - numpy>=1.24,<1.27
@@ -42,18 +41,19 @@ dependencies:
   - scipy>=1.10.0
   - setuptools
   - sphinx>=4.5.*
-  - sphinx_bootstrap_theme=>0.8.1
+  - sphinx_bootstrap_theme>=0.8.1
   - tbb-devel=2021.*
   - texlive-core>=20180414
   - toml>=0.10.2
   - versioningit>=2.1
+  - joblib
+  - orsopy==1.2.0 # Fix the version to avoid updates being pulled in automatically, which might change the Reflectometry ORSO file content or layout and cause tests to fail.
+
   # Needed only for development
   - black  # may be out of sync with pre-commit
   - cppcheck==2.13.1
   - pre-commit>=2.12.0
   - libcxx<17
-  - joblib
-  - orsopy==1.2.0 # Fix the version to avoid updates being pulled in automatically, which might change the Reflectometry ORSO file content or layout and cause tests to fail.
 
   # Use conda version of clang to get matching CXXFLAGS.
   # Pinned to same version as conda forge: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -18,13 +18,12 @@ dependencies:
   - jsoncpp>=1.9.4,<2
   - librdkafka>=1.6.0
   - lib3mf # windows only
-  - muparser>=2.3.2
   - matplotlib=3.7.*
+  - muparser>=2.3.2
   - nexus=4.4.*
   - ninja>=1.10.2
   - numpy>=1.24,<1.27
   - occt
-  - conda-wrappers
   - pip>=21.0.1
   - poco=1.12.1|>=1.12.6 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch but not yet included in a release, as of 1.12.5.
   - psutil>=5.8.0
@@ -42,13 +41,13 @@ dependencies:
   - scipy>=1.10.0
   - setuptools
   - sphinx>=4.5.*
-  - sphinx_bootstrap_theme=>0.8.1
+  - sphinx_bootstrap_theme>=0.8.1
   - tbb-devel=2021.*
   - toml>=0.10.2
   - versioningit>=2.1
+  - joblib
+  - orsopy==1.2.0 # Fix the version to avoid updates being pulled in automatically, which might change the Reflectometry ORSO file content or layout and cause tests to fail.
   # Needed only for development
   - black  # may be out of sync with pre-commit
   - cppcheck==2.13.1
   - pre-commit>=2.12.0
-  - joblib
-  - orsopy==1.2.0 # Fix the version to avoid updates being pulled in automatically, which might change the Reflectometry ORSO file content or layout and cause tests to fail.


### PR DESCRIPTION
This makes the `mantid` package installer match the version of jemalloc that the developers are using.

Refs #36220 .

#### Further detail of work

The main change is to pin the version of jemalloc for the package to v5.2.0. It is unclear what is wrong with the newer versions, but comparing the [recipe from v5.2.0](https://github.com/conda-forge/jemalloc-feedstock/blob/54b2b91d8c5ac4df203d8c6d9f9e322f6aa9bb82/recipe/meta.yaml) and [recipe from v5.3.0](https://github.com/conda-forge/jemalloc-feedstock/blob/5e0cb55e668089c6ce730e449536585dd98752b8/recipe/meta.yaml) one will immediately discover that v5.3.0 reworked the packages so there is now a `jemalloc` package `libjemalloc` package where v5.2.0 only has `jemalloc` package. More investigation will need to be done to figure out how to move forward from v5.2.0.

The oddity is that both v5.2.0 and v5.3.0 work on rhel7, but only v5.2.0 works on rocky8 and rhel9.

There is some extra cleanup of the developer dependencies so they can more easily be compared using `diff` (sorting), removing duplicate dependencies (`conda-wrappers` twice in windows), removing unused osx dependency (`jemalloc` is not runtime for mac).

Bonus information: The [abi compatibility chart for jemalloc](https://abi-laboratory.pro/index.php?view=timeline&l=jemalloc) doesn't go all the way to v5.3.0.

### To test:

Install the built linux package on newer rhel and see that it can start and show the instrument view with opengl.

*This does not require release notes* because it is fixing a bug within the release cycle discovered when moving from rhel7.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
