### PR TITLE
Add filter bad pulses functionality to LoadEventNexus

### DIFF
--- a/Framework/API/inc/MantidAPI/Run.h
+++ b/Framework/API/inc/MantidAPI/Run.h
@@ -65,6 +65,9 @@ public:
   /// Integrate the proton charge over the whole run time - default log
   /// proton_charge
   void integrateProtonCharge(const std::string &logname = "proton_charge") const;
+  /// determine the range of bad pulses to filter
+  std::tuple<double, double, double> getBadPulseRange(const std::string &logname = "proton_charge",
+                                                      const double &cutoff = 95.) const;
 
   /// update property "duration" with the duration of the Run's TimeROI attribute
   void setDuration();

--- a/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
@@ -54,8 +54,10 @@ public:
    * This will return an empty vector if all pulse indices are between the start and stop.
    */
   std::vector<size_t> getPulseIndices(const Mantid::Types::Core::DateAndTime &start,
-                                      const Mantid::Types::Core::DateAndTime &stop,
-                                      const bool include_last_pulse = true) const;
+                                      const Mantid::Types::Core::DateAndTime &stop) const;
+
+  // convert a list of time intervals to pulse indices
+  std::vector<size_t> getPulseIndices(const std::vector<Mantid::Kernel::TimeInterval> &splitters) const;
 
   /// Equals
   bool equals(size_t otherNumPulse, const std::string &otherStartTime);

--- a/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/BankPulseTimes.h
@@ -54,7 +54,8 @@ public:
    * This will return an empty vector if all pulse indices are between the start and stop.
    */
   std::vector<size_t> getPulseIndices(const Mantid::Types::Core::DateAndTime &start,
-                                      const Mantid::Types::Core::DateAndTime &stop) const;
+                                      const Mantid::Types::Core::DateAndTime &stop,
+                                      const bool include_last_pulse = true) const;
 
   /// Equals
   bool equals(size_t otherNumPulse, const std::string &otherStartTime);

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -162,6 +162,9 @@ public:
   /// if wall-clock filtering was requested
   bool m_is_time_filtered{false};
 
+  bool filter_bad_pulses{false};
+  std::shared_ptr<Mantid::Kernel::TimeROI> bad_pulses_timeroi;
+
   /// Mutex protecting tof limits
   std::mutex m_tofMutex;
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -200,6 +200,8 @@ private:
   /// Execution code
   void execLoader() override;
 
+  std::map<std::string, std::string> validateInputs() override;
+
   LoadEventNexus::LoaderType defineLoaderType(const bool haveWeights, const bool oldNeXusFileNames,
                                               const std::string &classType) const;
 

--- a/Framework/DataHandling/src/BankPulseTimes.cpp
+++ b/Framework/DataHandling/src/BankPulseTimes.cpp
@@ -192,7 +192,8 @@ std::size_t getFirstExcludedIndex(const std::vector<Mantid::Types::Core::DateAnd
 } // namespace
 
 std::vector<size_t> BankPulseTimes::getPulseIndices(const Mantid::Types::Core::DateAndTime &start,
-                                                    const Mantid::Types::Core::DateAndTime &stop) const {
+                                                    const Mantid::Types::Core::DateAndTime &stop,
+                                                    const bool include_last_pulse) const {
   std::vector<size_t> roi;
   if (this->arePulseTimesIncreasing()) {
     // sorted pulse times don't have to go through the whole vector, just look at the ends
@@ -214,7 +215,10 @@ std::vector<size_t> BankPulseTimes::getPulseIndices(const Mantid::Types::Core::D
         // do a linear search with the assumption that the index will be near the beginning
         for (size_t index = this->pulseTimes.size() - 1; index > start_index; --index) {
           if (this->pulseTime(index) <= stop) {
-            roi.push_back(index + 1); // include this pulse
+            if (include_last_pulse)
+              roi.push_back(index + 1); // include this pulse
+            else
+              roi.push_back(index); // don't include this pulse
             break;
           }
         }
@@ -232,6 +236,8 @@ std::vector<size_t> BankPulseTimes::getPulseIndices(const Mantid::Types::Core::D
       std::size_t firstInclude = getFirstIncludedIndex(this->pulseTimes, 0, start, stop);
       while (firstInclude < NUM_PULSES) {
         auto firstExclude = getFirstExcludedIndex(this->pulseTimes, firstInclude + 1, start, stop);
+        if (!include_last_pulse)
+          firstExclude--;
         if (firstInclude != firstExclude) {
           roi.push_back(firstInclude);
           roi.push_back(firstExclude);

--- a/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
+++ b/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
@@ -335,8 +335,8 @@ void LoadBankFromDiskTask::run() {
     // Open the bankN_event group
     file.openGroup(entry_name, entry_type);
 
-    const bool needPulseInfo =
-        (!m_loader.alg->compressEvents) || m_loader.m_ws.nPeriods() > 1 || m_loader.alg->m_is_time_filtered;
+    const bool needPulseInfo = (!m_loader.alg->compressEvents) || m_loader.m_ws.nPeriods() > 1 ||
+                               m_loader.alg->m_is_time_filtered || m_loader.alg->filter_bad_pulses;
 
     // Load the event_index field.
     if (needPulseInfo)
@@ -346,7 +346,7 @@ void LoadBankFromDiskTask::run() {
 
     if (!m_loadError) {
       // Load and validate the pulse times
-      if (m_loader.alg->compressEvents)
+      if (m_loader.alg->compressEvents && !m_loader.alg->filter_bad_pulses)
         thisBankPulseTimes = nullptr;
       else
         this->loadPulseTimes(file);
@@ -356,7 +356,6 @@ void LoadBankFromDiskTask::run() {
         m_loader.alg->getLogger().warning() << "Bank " << entry_name
                                             << " has a mismatch between the number of event_index entries "
                                                "and the number of pulse times in event_time_zero.\n";
-
       // Open and validate event_id field.
       int64_t start_event = 0;
       int64_t stop_event = 0;

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -316,6 +316,18 @@ void LoadEventNexus::init() {
                   "separated by a space).");
 }
 
+std::map<std::string, std::string> LoadEventNexus::validateInputs() {
+  std::map<std::string, std::string> result;
+
+  if (!isDefault(PropertyNames::BAD_PULSES_CUTOFF)) {
+    const double cutoff = getProperty(PropertyNames::BAD_PULSES_CUTOFF);
+    if (cutoff < 0 || cutoff > 100)
+      result[PropertyNames::BAD_PULSES_CUTOFF] = "Must be empty or between 0 and 100";
+  }
+
+  return result;
+}
+
 //----------------------------------------------------------------------------------------------
 /** set the name of the top level NXentry m_top_entry_name
  */

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -620,7 +620,7 @@ LoadEventNexus::runLoadNexusLogs(const std::string &nexusfilename, T localWorksp
     // If successful, we can try to load the pulse times
     std::vector<Types::Core::DateAndTime> temp;
     if (localWorkspace->run().hasProperty("proton_charge")) {
-      auto *log =
+      const auto *log =
           dynamic_cast<Kernel::TimeSeriesProperty<double> *>(localWorkspace->mutableRun().getProperty("proton_charge"));
       if (log)
         temp = log->timesAsVector();
@@ -1107,7 +1107,8 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
     if (!m_ws->run().hasProperty(LOG_CHARGE_NAME)) {
       throw std::runtime_error("Failed to find \"" + LOG_CHARGE_NAME + "\" in sample logs");
     }
-    auto *pcharge_log = dynamic_cast<Kernel::TimeSeriesProperty<double> *>(m_ws->run().getLogData(LOG_CHARGE_NAME));
+    const auto *pcharge_log =
+        dynamic_cast<Kernel::TimeSeriesProperty<double> *>(m_ws->run().getLogData(LOG_CHARGE_NAME));
     if (!pcharge_log) {
       throw std::logic_error("Failed to find \"" + LOG_CHARGE_NAME + "\" in sample logs");
     }

--- a/Framework/DataHandling/src/ProcessBankCompressed.cpp
+++ b/Framework/DataHandling/src/ProcessBankCompressed.cpp
@@ -115,15 +115,8 @@ void ProcessBankCompressed::collectEvents() {
     }
 
     if (alg->filter_bad_pulses) {
-      // TODO this is very slow, fix it
-
-      std::vector<size_t> tempBad;
-      for (const auto &splitter : alg->bad_pulses_timeroi->toTimeIntervals()) {
-        const auto tmp = m_bankPulseTimes->getPulseIndices(splitter.start(), splitter.stop(), false);
-        std::move(tmp.begin(), tmp.end(), std::back_inserter(tempBad));
-      }
-
-      pulseROI = Mantid::Kernel::ROI::calculate_intersection(pulseROI, tempBad);
+      pulseROI = Mantid::Kernel::ROI::calculate_intersection(
+          pulseROI, m_bankPulseTimes->getPulseIndices(alg->bad_pulses_timeroi->toTimeIntervals()));
     }
 
     const PulseIndexer pulseIndexer(m_event_index, m_firstEventIndex, NUM_EVENTS, m_entry_name, pulseROI);

--- a/Framework/DataHandling/src/ProcessBankCompressed.cpp
+++ b/Framework/DataHandling/src/ProcessBankCompressed.cpp
@@ -107,11 +107,23 @@ void ProcessBankCompressed::collectEvents() {
   const auto *alg = m_loader.alg;
 
   // iterate through all events in a single pulse
-  if (m_event_index || m_loader.m_ws.nPeriods() > 1 || alg->m_is_time_filtered) {
+  if (m_event_index || m_loader.m_ws.nPeriods() > 1 || alg->m_is_time_filtered || alg->filter_bad_pulses) {
     // set up wall-clock filtering if it was requested
     std::vector<size_t> pulseROI;
     if (alg->m_is_time_filtered) {
       pulseROI = m_bankPulseTimes->getPulseIndices(alg->filter_time_start, alg->filter_time_stop);
+    }
+
+    if (alg->filter_bad_pulses) {
+      // TODO this is very slow, fix it
+
+      std::vector<size_t> tempBad;
+      for (const auto &splitter : alg->bad_pulses_timeroi->toTimeIntervals()) {
+        const auto tmp = m_bankPulseTimes->getPulseIndices(splitter.start(), splitter.stop(), false);
+        std::move(tmp.begin(), tmp.end(), std::back_inserter(tempBad));
+      }
+
+      pulseROI = Mantid::Kernel::ROI::calculate_intersection(pulseROI, tempBad);
     }
 
     const PulseIndexer pulseIndexer(m_event_index, m_firstEventIndex, NUM_EVENTS, m_entry_name, pulseROI);

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -201,6 +201,9 @@ void ProcessBankData::run() {
         auto &el = outputWS.getSpectrum(wi);
         // set the sort order based on what is known
         el.setSortOrder(pulseSortingType);
+        // filter bad pulses if requested
+        if (alg->filter_bad_pulses)
+          el.filterInPlace(alg->bad_pulses_timeroi.get());
         // compress events if requested
         if (compress)
           el.compressEvents(alg->compressTolerance, &el);

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -119,14 +119,8 @@ void ProcessBankData::run() {
   }
 
   if (alg->filter_bad_pulses) {
-    // TODO this is very slow, fix it
-    std::vector<size_t> tempBad;
-    for (const auto &splitter : alg->bad_pulses_timeroi->toTimeIntervals()) {
-      const auto tmp = thisBankPulseTimes->getPulseIndices(splitter.start(), splitter.stop(), false);
-      std::move(tmp.begin(), tmp.end(), std::back_inserter(tempBad));
-    }
-
-    pulseROI = Mantid::Kernel::ROI::calculate_intersection(pulseROI, tempBad);
+    pulseROI = Mantid::Kernel::ROI::calculate_intersection(
+        pulseROI, thisBankPulseTimes->getPulseIndices(alg->bad_pulses_timeroi->toTimeIntervals()));
   }
 
   const PulseIndexer pulseIndexer(event_index, startAt, numEvents, entry_name, pulseROI);

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -916,6 +916,7 @@ public:
   }
 
   void test_Load_And_FilterBadPulses() {
+    // This will use ProcessBankData
     const std::string filename{"CNCS_7860_event.nxs"};
 
     Mantid::API::FrameworkManager::Instance();
@@ -965,6 +966,7 @@ public:
   }
 
   void test_Load_And_FilterBadPulses_with_start_time_filter() {
+    // This will use ProcessBankData
     // make sure the combination of bad pulse filter and start time filter work together
     const std::string filename{"CNCS_7860_event.nxs"};
 
@@ -1006,6 +1008,135 @@ public:
     }
 
     // validate the resulting workspace is the same for post filtered and filtering during loading
+    auto checkAlg = AlgorithmManager::Instance().create("CompareWorkspaces");
+    checkAlg->setProperty("Workspace1", filtered_name);
+    checkAlg->setProperty("Workspace2", post_filtered_name);
+    checkAlg->setProperty("CheckSample", true); // this will check that the logs get filtered correctly
+    checkAlg->execute();
+    TS_ASSERT(checkAlg->getProperty("Result"));
+
+    // cleanup
+    AnalysisDataService::Instance().remove(post_filtered_name);
+    AnalysisDataService::Instance().remove(filtered_name);
+  }
+
+  void test_Load_And_FilterBadPulses_and_compress() {
+    // This will use ProcessBankCompressed
+    const std::string filename{"CNCS_7860_event.nxs"};
+
+    Mantid::API::FrameworkManager::Instance();
+
+    // create expected output workspace by doing FilterBadPulses and CompressEvents after loading
+    std::string post_filtered_name = "cncs_post_filtered_compressed";
+    {
+      LoadEventNexus ld;
+      ld.initialize();
+      ld.setPropertyValue("Filename", filename);
+      ld.setPropertyValue("OutputWorkspace", post_filtered_name);
+      ld.setProperty("NumberOfBins", 1);
+      ld.execute();
+      TS_ASSERT(ld.isExecuted());
+
+      auto filter_bad = AlgorithmManager::Instance().create("FilterBadPulses", 1);
+      filter_bad->setPropertyValue("InputWorkspace", post_filtered_name);
+      filter_bad->setPropertyValue("OutputWorkspace", post_filtered_name);
+      filter_bad->execute();
+      TS_ASSERT(filter_bad->isExecuted());
+
+      auto compress = AlgorithmManager::Instance().create("CompressEvents", 1);
+      compress->setPropertyValue("InputWorkspace", post_filtered_name);
+      compress->setPropertyValue("OutputWorkspace", post_filtered_name);
+      compress->setProperty("Tolerance", 0.05);
+      compress->execute();
+      TS_ASSERT(compress->isExecuted());
+    }
+
+    // create filtered and compressed during load
+    std::string filtered_name = "cncs_filtered_compressed";
+    {
+      LoadEventNexus ld;
+      ld.initialize();
+      ld.setPropertyValue("Filename", filename);
+      ld.setPropertyValue("OutputWorkspace", filtered_name);
+      ld.setProperty("NumberOfBins", 1);
+      ld.setProperty("FilterBadPulsesLowerCutoff", 95.);
+      ld.setProperty("CompressTolerance", 0.05);
+      ld.execute();
+      TS_ASSERT(ld.isExecuted());
+
+      // need to sort events so we can directly compare to expected with CompareWorkspaces
+      auto sort = AlgorithmManager::Instance().create("SortEvents", 1);
+      sort->setPropertyValue("InputWorkspace", filtered_name);
+      sort->execute();
+      TS_ASSERT(sort->isExecuted());
+    }
+
+    // validate the resulting workspace is the same for post filtered/compressed and filtering/compressed during loading
+    auto checkAlg = AlgorithmManager::Instance().create("CompareWorkspaces");
+    checkAlg->setProperty("Workspace1", filtered_name);
+    checkAlg->setProperty("Workspace2", post_filtered_name);
+    checkAlg->setProperty("CheckSample", true); // this will check that the logs get filtered correctly
+    checkAlg->execute();
+    TS_ASSERT(checkAlg->getProperty("Result"));
+
+    // cleanup
+    AnalysisDataService::Instance().remove(post_filtered_name);
+    AnalysisDataService::Instance().remove(filtered_name);
+  }
+
+  void test_Load_And_FilterBadPulses_and_compress_and_start_time_filter() {
+    // This will use ProcessBankCompressed
+    const std::string filename{"CNCS_7860_event.nxs"};
+
+    Mantid::API::FrameworkManager::Instance();
+
+    // create expected output workspace by doing FilterBadPulses and CompressEvents after loading
+    std::string post_filtered_name = "cncs_post_filtered_compressed";
+    {
+      LoadEventNexus ld;
+      ld.initialize();
+      ld.setPropertyValue("Filename", filename);
+      ld.setPropertyValue("OutputWorkspace", post_filtered_name);
+      ld.setProperty("NumberOfBins", 1);
+      ld.setProperty("FilterByTimeStart", 10.);
+      ld.execute();
+      TS_ASSERT(ld.isExecuted());
+
+      auto filter_bad = AlgorithmManager::Instance().create("FilterBadPulses", 1);
+      filter_bad->setPropertyValue("InputWorkspace", post_filtered_name);
+      filter_bad->setPropertyValue("OutputWorkspace", post_filtered_name);
+      filter_bad->execute();
+      TS_ASSERT(filter_bad->isExecuted());
+      auto compress = AlgorithmManager::Instance().create("CompressEvents", 1);
+      compress->setPropertyValue("InputWorkspace", post_filtered_name);
+      compress->setPropertyValue("OutputWorkspace", post_filtered_name);
+      compress->setProperty("Tolerance", 0.05);
+      compress->execute();
+      TS_ASSERT(compress->isExecuted());
+    }
+
+    // create filtered during load
+    std::string filtered_name = "cncs_filtered_compressed";
+    {
+      LoadEventNexus ld;
+      ld.initialize();
+      ld.setPropertyValue("Filename", filename);
+      ld.setPropertyValue("OutputWorkspace", filtered_name);
+      ld.setProperty("NumberOfBins", 1);
+      ld.setProperty("FilterBadPulsesLowerCutoff", 95.);
+      ld.setProperty("CompressTolerance", 0.05);
+      ld.setProperty("FilterByTimeStart", 10.);
+      ld.execute();
+      TS_ASSERT(ld.isExecuted());
+
+      // need to sort events so we can directly compare to expected with CompareWorkspaces
+      auto sort = AlgorithmManager::Instance().create("SortEvents", 1);
+      sort->setPropertyValue("InputWorkspace", filtered_name);
+      sort->execute();
+      TS_ASSERT(sort->isExecuted());
+    }
+
+    // validate the resulting workspace is the same for post filtered/compressed and filtering/compressed during loading
     auto checkAlg = AlgorithmManager::Instance().create("CompareWorkspaces");
     checkAlg->setProperty("Workspace1", filtered_name);
     checkAlg->setProperty("Workspace2", post_filtered_name);

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -915,6 +915,109 @@ public:
     TS_ASSERT_EQUALS(WS, ads.retrieveWS<MatrixWorkspace>("cncs_compressed")->monitorWorkspace());
   }
 
+  void test_Load_And_FilterBadPulses() {
+    const std::string filename{"CNCS_7860_event.nxs"};
+
+    Mantid::API::FrameworkManager::Instance();
+
+    // create expected output workspace by doing FilterBadPulses after loading
+    std::string post_filtered_name = "cncs_post_filtered";
+    {
+      LoadEventNexus ld;
+      ld.initialize();
+      ld.setPropertyValue("Filename", filename);
+      ld.setPropertyValue("OutputWorkspace", post_filtered_name);
+      ld.setProperty("NumberOfBins", 1);
+      ld.execute();
+      TS_ASSERT(ld.isExecuted());
+
+      auto filter_bad = AlgorithmManager::Instance().create("FilterBadPulses", 1);
+      filter_bad->setPropertyValue("InputWorkspace", post_filtered_name);
+      filter_bad->setPropertyValue("OutputWorkspace", post_filtered_name);
+      filter_bad->execute();
+      TS_ASSERT(filter_bad->isExecuted());
+    }
+
+    // create filtered during load
+    std::string filtered_name = "cncs_filtered";
+    {
+      LoadEventNexus ld;
+      ld.initialize();
+      ld.setPropertyValue("Filename", filename);
+      ld.setPropertyValue("OutputWorkspace", filtered_name);
+      ld.setProperty("NumberOfBins", 1);
+      ld.setProperty("FilterBadPulsesLowerCutoff", 95.);
+      ld.execute();
+      TS_ASSERT(ld.isExecuted());
+    }
+
+    // validate the resulting workspace is the same for post filtered and filtering during loading
+    auto checkAlg = AlgorithmManager::Instance().create("CompareWorkspaces");
+    checkAlg->setProperty("Workspace1", filtered_name);
+    checkAlg->setProperty("Workspace2", post_filtered_name);
+    checkAlg->setProperty("CheckSample", true); // this will check that the logs get filtered correctly
+    checkAlg->execute();
+    TS_ASSERT(checkAlg->getProperty("Result"));
+
+    // cleanup
+    AnalysisDataService::Instance().remove(post_filtered_name);
+    AnalysisDataService::Instance().remove(filtered_name);
+  }
+
+  void test_Load_And_FilterBadPulses_with_start_time_filter() {
+    // make sure the combination of bad pulse filter and start time filter work together
+    const std::string filename{"CNCS_7860_event.nxs"};
+
+    Mantid::API::FrameworkManager::Instance();
+
+    // create expected output workspace by doing FilterBadPulses after loading
+    std::string post_filtered_name = "cncs_post_filtered";
+    {
+      LoadEventNexus ld;
+      ld.initialize();
+      ld.setPropertyValue("Filename", filename);
+      ld.setPropertyValue("OutputWorkspace", post_filtered_name);
+      ld.setProperty("NumberOfBins", 1);
+      ld.setProperty("FilterByTimeStart", 20.);
+      ld.setProperty("FilterByTimeStop", 50.);
+      ld.execute();
+      TS_ASSERT(ld.isExecuted());
+
+      auto filter_bad = AlgorithmManager::Instance().create("FilterBadPulses", 1);
+      filter_bad->setPropertyValue("InputWorkspace", post_filtered_name);
+      filter_bad->setPropertyValue("OutputWorkspace", post_filtered_name);
+      filter_bad->execute();
+      TS_ASSERT(filter_bad->isExecuted());
+    }
+
+    // create filtered during load
+    std::string filtered_name = "cncs_filtered";
+    {
+      LoadEventNexus ld;
+      ld.initialize();
+      ld.setPropertyValue("Filename", filename);
+      ld.setPropertyValue("OutputWorkspace", filtered_name);
+      ld.setProperty("NumberOfBins", 1);
+      ld.setProperty("FilterByTimeStart", 20.);
+      ld.setProperty("FilterByTimeStop", 50.);
+      ld.setProperty("FilterBadPulsesLowerCutoff", 95.);
+      ld.execute();
+      TS_ASSERT(ld.isExecuted());
+    }
+
+    // validate the resulting workspace is the same for post filtered and filtering during loading
+    auto checkAlg = AlgorithmManager::Instance().create("CompareWorkspaces");
+    checkAlg->setProperty("Workspace1", filtered_name);
+    checkAlg->setProperty("Workspace2", post_filtered_name);
+    checkAlg->setProperty("CheckSample", true); // this will check that the logs get filtered correctly
+    checkAlg->execute();
+    TS_ASSERT(checkAlg->getProperty("Result"));
+
+    // cleanup
+    AnalysisDataService::Instance().remove(post_filtered_name);
+    AnalysisDataService::Instance().remove(filtered_name);
+  }
+
   void doTestSingleBank(bool SingleBankPixelsOnly, bool Precount, const std::string &BankName = "bank36",
                         bool willFail = false) {
     Mantid::API::FrameworkManager::Instance();

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -362,8 +362,8 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/ScriptBuilder.cpp:2
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:200
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:283
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:302
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:668
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:701
+constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:699
+constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/Run.cpp:732
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Beamline/src/ComponentInfo.cpp:455
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Beamline/src/ComponentInfo.cpp:457
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Beamline/src/ComponentInfo.cpp:474

--- a/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37406.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37406.rst
@@ -1,0 +1,1 @@
+- Implemented the :ref:`FilterBadPulses <algm-FilterBadPulses>` functionality in :ref:`LoadEventNexus <algm-LoadEventNexus>`, adding the new ``FilterBadPulsesLowerCutoff`` parameter.


### PR DESCRIPTION
### Description of work

A new parameter `FilterBadPulsesLowerCutoff` is added to `LoadEventNexus` which is equivalent to running `FilterBadPulses` after loading.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [EWM3749](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=3749)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

##### compare bad pulse filtering during and after loading

```python
ws = LoadEventNexus(Filename="CNCS_7860_event.nxs")
filtered = FilterBadPulses(ws)
filtered_on_load = LoadEventNexus(Filename="CNCS_7860_event.nxs", FilterBadPulsesLowerCutoff=95)
CompareWorkspaces(filtered, filtered_on_load, CheckSample=True)
```

##### bad pulse filter combined with start time filter

```python
ws = LoadEventNexus(Filename="CNCS_7860_event.nxs", FilterByTimeStart=20, FilterByTimeStop=50)
filtered = FilterBadPulses(ws)
filtered_on_load = LoadEventNexus(Filename="CNCS_7860_event.nxs", FilterByTimeStart=20, FilterByTimeStop=50, FilterBadPulsesLowerCutoff=95)
CompareWorkspaces(filtered, filtered_on_load, CheckSample=True)
```

##### using compress events and bad pulse filter together, comparing during load and after loading

```python
ws = LoadEventNexus(Filename="CNCS_7860_event.nxs", NumberOfBins=1)
filtered = FilterBadPulses(ws)
filtered_compressed = CompressEvents(filtered, 0.05)
filtered_compressed_on_load = LoadEventNexus(Filename="CNCS_7860_event.nxs", FilterBadPulsesLowerCutoff=95, CompressTolerance=0.05, NumberOfBins=1)
SortEvents(filtered_compressed_on_load) # need to sort events so we can compare with CompareWorkspaces
CompareWorkspaces(filtered_compressed, filtered_compressed_on_load, CheckSample=True)
```

##### larger test file

```python
ws = LoadEventNexus(Filename="PG3_4866_event.nxs", NumberOfBins=1)
filtered = FilterBadPulses(ws)
filtered_on_load = LoadEventNexus(Filename="PG3_4866_event.nxs", FilterBadPulsesLowerCutoff=95, NumberOfBins=1)
CompareWorkspaces(filtered, filtered_on_load, CheckSample=True)
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
