### PR TITLE
Fix bug with log CompressEvents when using WallClockTolerance

### DIFF
--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1612,8 +1612,9 @@ inline void EventList::compressFatEventsHelper(const std::vector<T> &events, std
     if (tof_min < 0)
       throw std::runtime_error("compressEvents with log binning doesn't work with negative TOF");
 
+    // can't start at 0 as this will create an infinite loop
     if (tof_min == 0)
-      bin_end = fabs(tolerance);
+      bin_end = tof_min = fabs(tolerance);
 
   } else { // linear
     // for linear we do "less than or equals" because that is how it was originally implemented

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -2384,6 +2384,7 @@ public:
     el += TofEvent(0.5, 1);
     el += TofEvent(1, 2);
     el += TofEvent(0, 3);
+    el += TofEvent(1, 15000000000); // 15 seconds, one event in second wall clock bin
 
     // Do compress events with log binning
     // Since there is a tof==0 then the first bin_end should be 1
@@ -2391,15 +2392,22 @@ public:
     TS_ASSERT_THROWS_NOTHING(el.compressFatEvents(-1, DateAndTime{0}, 10, &el_output))
 
     // now check individual events
-    TS_ASSERT_EQUALS(el_output.getNumberEvents(), 2)
+    TS_ASSERT_EQUALS(el_output.getNumberEvents(), 3)
 
     TS_ASSERT_EQUALS(el_output.getEvent(0).weight(), 2)
     TS_ASSERT_EQUALS(el_output.getEvent(0).errorSquared(), 2)
     TS_ASSERT_DELTA(el_output.getEvent(0).tof(), 0.25, 1e-5)
+    TS_ASSERT_DELTA(el_output.getEvent(0).pulseTime().totalNanoseconds(), 2, 1e-5)
 
     TS_ASSERT_EQUALS(el_output.getEvent(1).weight(), 1)
     TS_ASSERT_EQUALS(el_output.getEvent(1).errorSquared(), 1)
     TS_ASSERT_DELTA(el_output.getEvent(1).tof(), 1, 1e-5)
+    TS_ASSERT_DELTA(el_output.getEvent(1).pulseTime().totalNanoseconds(), 2, 1e-5)
+
+    TS_ASSERT_EQUALS(el_output.getEvent(2).weight(), 1)
+    TS_ASSERT_EQUALS(el_output.getEvent(2).errorSquared(), 1)
+    TS_ASSERT_DELTA(el_output.getEvent(2).tof(), 1, 1e-5)
+    TS_ASSERT_DELTA(el_output.getEvent(2).pulseTime().totalNanoseconds(), 15000000000, 1e-5)
 
     // now add a negative TOF and it should throw
     el += TofEvent(-1, 0);

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -762,10 +762,10 @@ virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDat
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:999
 identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1095
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h:199
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:3962
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4109
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4236
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:3963
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4110
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4237
+constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4238
 derefInvalidIterator:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1590
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TableWorkspace.cpp:253
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TableWorkspace.cpp:318


### PR DESCRIPTION
### Description of work

When `compressFatEventsHelper` moved past the first `eventPulseBin` then the `bin_end` was being reset to 0 ([here](https://github.com/mantidproject/mantid/blob/be7c13bff531a56a54c99f0cac5de1d578efc860/Framework/DataObjects/src/EventList.cpp#L1656)) if `tof_min==0`.

Log binning with compress events was added by #37203

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [5347: [DEFECT] CompressEvents enters infinite loop when using a finite wall clock tolerance](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/5347)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

The following should no longer enter an infinite loop

Same as unit test

```python
from mantid.simpleapi import *
from mantid.kernel import DateAndTime

ws = CreateSampleWorkspace(WorkspaceType='Event', NumEvents=0, NumBanks=1, BankPixelWidth=1)
ws.getSpectrum(0).addEventQuickly(0.5, DateAndTime(1))
ws.getSpectrum(0).addEventQuickly(1, DateAndTime(2))
ws.getSpectrum(0).addEventQuickly(0, DateAndTime(3))
ws.getSpectrum(0).addEventQuickly(1, DateAndTime(15000000000))
out = CompressEvents(ws, Tolerance=-0.1, WallClockTolerance=10., StartTime=DateAndTime(0).toISO8601String())
```
Real data test

```python
LoadEventNexus(Filename='/SNS/SNAP/IPTS-28913/nexus/SNAP_57474.nxs.h5', outputworkspace='ws')
CompressEvents(InputWorkspace='ws',OutputWorkspace='ws_c',Tolerance = -0.0008, WallClockTolerance=60,BinningMode='Logarithmic')
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


*This does not require release notes* as it was only added during this release, see #37203
<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
