### PR TITLE
Use ADSObserver in ContourPreviewPlot widget

### DIFF
--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ContourPreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/ContourPreviewPlot.h
@@ -7,11 +7,10 @@
 #pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/AnalysisDataServiceObserver.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidQtWidgets/Plotting/AxisID.h"
 #include "MantidQtWidgets/Plotting/DllOption.h"
-
-#include <Poco/NObserver.h>
 
 #include <QColor>
 #include <QWidget>
@@ -28,12 +27,11 @@ class FigureCanvasQt;
 
 namespace MantidWidgets {
 
-class EXPORT_OPT_MANTIDQT_PLOTTING ContourPreviewPlot : public QWidget {
+class EXPORT_OPT_MANTIDQT_PLOTTING ContourPreviewPlot : public QWidget, public AnalysisDataServiceObserver {
   Q_OBJECT
 
 public:
   ContourPreviewPlot(QWidget *parent = nullptr, bool observeADS = true);
-  ~ContourPreviewPlot() override;
 
   void watchADS(bool on);
 
@@ -47,15 +45,11 @@ public:
 private:
   void createLayout();
 
-  void onWorkspaceRemoved(Mantid::API::WorkspacePreDeleteNotification_ptr nf);
-  void onWorkspaceReplaced(Mantid::API::WorkspaceBeforeReplaceNotification_ptr nf);
+  void replaceHandle(const std::string &wsName, const Workspace_sptr &workspace) override;
+  void deleteHandle(const std::string &wsName, const Workspace_sptr &workspace) override;
 
   /// Canvas objects
   Widgets::MplCpp::FigureCanvasQt *m_canvas;
-
-  /// Observers for ADS Notifications
-  Poco::NObserver<ContourPreviewPlot, Mantid::API::WorkspacePreDeleteNotification> m_wsRemovedObserver;
-  Poco::NObserver<ContourPreviewPlot, Mantid::API::WorkspaceBeforeReplaceNotification> m_wsReplacedObserver;
 };
 
 } // namespace MantidWidgets


### PR DESCRIPTION
### Description of work
This PR ensures the ContourPreviewPlot widget uses the ADSObserver class to observe changes in the ADS. This makes the code simpler in the ContourPreviewPlot, and also helps avoid a bug as the ADSObserver class will make sure the previewplot is not subscribed to ADS notifications more than once. This has caused a crash in the past for other similar widgets: https://github.com/mantidproject/mantid/pull/37074

### To test:
I have not found a crash for this widget. I think because the `watchADS` function is not called on the ContourPreviewPlot from outside the widget. Just do a simple test to make sure Inelastic S(Q,w) is still working:

1. Open Inelastic Data Manipulations
2. Go to S(Q,w) tab
3. Load `irs26176_graphite002_red` file from sample data
4. Click `Run`. It should run without a crash or an error

*This does not require release notes* because **there is no user-facing change**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
