### PR TITLE
Fix coverity scan warnings in Indirect/Inelastic

### DIFF
--- a/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
@@ -37,7 +37,8 @@ using MantidQt::API::BatchAlgorithmRunner;
 
 DiffractionReduction::DiffractionReduction(QWidget *parent)
     : InelasticInterface(parent), m_valDbl(nullptr), m_settingsGroup("CustomInterfaces/DEMON"),
-      m_batchAlgoRunner(new BatchAlgorithmRunner(parent)) {}
+      m_batchAlgoRunner(new BatchAlgorithmRunner(parent)), m_plotWorkspaces(), m_plotOptionsPresenter(),
+      m_groupingWidget() {}
 
 DiffractionReduction::~DiffractionReduction() { saveSettings(); }
 

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReduction.cpp
@@ -89,7 +89,7 @@ void DataReduction::initLayout() {
           SIGNAL(instrumentConfigurationUpdated(const QString &, const QString &, const QString &)), this,
           SLOT(instrumentSetupChanged(const QString &, const QString &, const QString &)));
 
-  auto const facility = Mantid::Kernel::ConfigService::Instance().getFacility();
+  auto const &facility = Mantid::Kernel::ConfigService::Instance().getFacility();
   filterUiForFacility(QString::fromStdString(facility.name()));
 
   // Update the instrument configuration across the UI
@@ -181,7 +181,7 @@ void DataReduction::loadInstrumentIfNotExist(const std::string &instrumentName, 
     loadAlg->setProperty("OutputWorkspace", "__IDR_Inst");
     loadAlg->execute();
     MatrixWorkspace_sptr instWorkspace = loadAlg->getProperty("OutputWorkspace");
-    m_instWorkspace = instWorkspace;
+    m_instWorkspace = std::move(instWorkspace);
 
     // Load the IPF if given an analyser and reflection
     if (!analyser.empty() && !reflection.empty()) {
@@ -272,7 +272,7 @@ void DataReduction::loadInstrumentDetails() {
       if (value.isEmpty() && component != nullptr)
         value = getInstrumentParameterFrom(component, key);
 
-      m_instDetails[QString::fromStdString(key)] = value;
+      m_instDetails[QString::fromStdString(key)] = std::move(value);
     }
     // In the case that the parameter does not exist
     catch (Mantid::Kernel::Exception::NotFoundError &nfe) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingPresenter.cpp
@@ -112,7 +112,7 @@ void FittingPresenter::executeFit(Mantid::API::IAlgorithm_sptr fitAlgorithm) {
   auto properties = m_fitPropertyBrowser->fitProperties(m_model->getFittingMode());
   MantidQt::API::IConfiguredAlgorithm_sptr confAlg =
       std::make_shared<MantidQt::API::ConfiguredAlgorithm>(fitAlgorithm, std::move(properties));
-  m_algorithmRunner->execute(confAlg);
+  m_algorithmRunner->execute(std::move(confAlg));
 }
 
 void FittingPresenter::updateFitBrowserParameterValues(const std::unordered_map<std::string, ParameterValue> &params) {


### PR DESCRIPTION
### Description of work
This PR fixes a few coverity scan warnings which have recently been flagged since changes were made in these files.

### To test:
Follow testing instructions here
https://developer.mantidproject.org/Testing/Indirect/DataReductionTests.html
and here
https://developer.mantidproject.org/Testing/Inelastic/QENSFittingTests.html


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
