### PR TITLE
Fix instrument data cache for ENGINX

### DIFF
--- a/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
+++ b/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
@@ -10,6 +10,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/DllConfig.h"
+#include "MantidKernel/ConfigService.h"
 #include <string>
 
 namespace Mantid {
@@ -21,7 +22,8 @@ public:
   std::string getFileParentDirectoryPath(const std::string &filename) const;
 
 private:
-  std::pair<std::string, std::string> validateInstrumentAndNumber(const std::string &filename) const;
+  std::pair<Mantid::Kernel::InstrumentInfo, std::string> validateInstrumentAndNumber(const std::string &filename) const;
+  std::string makeIndexFilePath(const std::string &instrumentName) const;
   std::pair<std::string, std::string> splitIntoInstrumentAndNumber(const std::string &filename) const;
   std::string m_dataCachePath;
 };


### PR DESCRIPTION
### Description of work
Fix to account for "ENGINX" (shortname) being used in the data cache instead of "ENGIN-X" (name)

#### Summary of work
Files were not being loaded from the data cache for the ENGIN-X instrument because the name is spelled in its shortname version "ENGINX" instead of the name version "ENGIN-X", with an hyphen.
I included a second try to look for the shortname if the default name fails.

Fixes [37398](https://github.com/mantidproject/mantid/issues/37398)

### Note
This commit can be reverted in the future if IDAaaS changes the name of the instrument to "ENGIN-X".

### To test:
1. Install the package through conda on IDAaaS
`mamba install -c thomashampson/label/enginx_data_cache mantidworkbench`
2. Use the Load algorithm and try to load an ENGINX file
3. Should get a permissions denied error, rather than an index file not found error


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

