### PR TITLE
Create interface class for UserInputValidator

### DIFF
--- a/qt/scientific_interfaces/Indirect/Reduction/DataReduction.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReduction.h
@@ -138,7 +138,8 @@ private:
     tabIDRContent->setupTab();
     tabContent->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-    connect(tabIDRContent, SIGNAL(showMessageBox(const QString &)), this, SLOT(showMessageBox(const QString &)));
+    connect(tabIDRContent, SIGNAL(showMessageBox(const std::string &)), this,
+            SLOT(showMessageBox(const std::string &)));
 
     // Add to the cache
     m_tabs[name] = qMakePair(tabWidget, tabIDRContent);
@@ -178,7 +179,8 @@ private:
     presenter->setupTab();
     tabContent->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-    connect(presenter.get(), SIGNAL(showMessageBox(const QString &)), this, SLOT(showMessageBox(const QString &)));
+    connect(presenter.get(), SIGNAL(showMessageBox(const std::string &)), this,
+            SLOT(showMessageBox(const std::string &)));
 
     // Add to the cache
     m_tabs[name] = qMakePair(tabWidget, presenter.get());

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
@@ -359,10 +359,10 @@ bool ISISCalibration::validate() {
     uiv.checkBins(eLow, eWidth, eHigh);
   }
 
-  QString error = uiv.generateErrorMessage();
+  auto const error = uiv.generateErrorMessage();
 
   if (error != "")
-    g_log.warning(error.toStdString());
+    g_log.warning(error);
 
   return (error == "");
 }

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
@@ -203,11 +203,11 @@ bool ISISDiagnostics::validate() {
       std::make_pair(m_dblManager->value(m_properties["SpecMin"]), m_dblManager->value(m_properties["SpecMax"]) + 1);
   uiv.checkValidRange("Spectra Range", specRange);
 
-  QString error = uiv.generateErrorMessage();
+  auto const error = uiv.generateErrorMessage();
   bool isError = error != "";
 
   if (isError)
-    g_log.warning(error.toStdString());
+    g_log.warning(error);
 
   return !isError;
 }

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
@@ -180,9 +180,9 @@ bool IETPresenter::validate() {
       uiv.addErrorMessage(QString::fromStdString(error));
   }
 
-  QString error = uiv.generateErrorMessage();
-  if (!error.isEmpty())
-    m_view->showMessageBox(error.toStdString());
+  auto const error = uiv.generateErrorMessage();
+  if (!error.empty())
+    m_view->showMessageBox(error);
 
   return validateInstrumentDetails() && uiv.isAllInputValid();
 }

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
@@ -177,7 +177,7 @@ bool IETPresenter::validate() {
 
   for (auto const &error : errors) {
     if (!error.empty())
-      uiv.addErrorMessage(QString::fromStdString(error));
+      uiv.addErrorMessage(error);
   }
 
   auto const error = uiv.generateErrorMessage();

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
@@ -305,8 +305,8 @@ void IETView::handleDataReady() {
   validateDataIsOfType(uiv, m_uiForm.dsCalibrationFile, "Calibration", DataType::Calib);
 
   auto const errorMessage = uiv.generateErrorMessage();
-  if (!errorMessage.isEmpty())
-    showMessageBox(errorMessage.toStdString());
+  if (!errorMessage.empty())
+    showMessageBox(errorMessage);
 }
 
 void IETView::pbRunEditing() { setRunButtonText("Editing..."); }

--- a/qt/scientific_interfaces/Indirect/Simulation/Simulation.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/Simulation.cpp
@@ -37,7 +37,7 @@ void Simulation::initLayout() {
   // Connect each tab to the actions available in this GUI
   std::map<unsigned int, SimulationTab *>::iterator iter;
   for (iter = m_simulationTabs.begin(); iter != m_simulationTabs.end(); ++iter) {
-    connect(iter->second, SIGNAL(showMessageBox(const QString &)), this, SLOT(showMessageBox(const QString &)));
+    connect(iter->second, SIGNAL(showMessageBox(const std::string &)), this, SLOT(showMessageBox(const std::string &)));
   }
 
   loadSettings();

--- a/qt/scientific_interfaces/Indirect/Tools/Tools.cpp
+++ b/qt/scientific_interfaces/Indirect/Tools/Tools.cpp
@@ -31,7 +31,7 @@ void Tools::initLayout() {
   // Connect each tab to the actions available in this GUI
   std::map<unsigned int, ToolsTab *>::iterator iter;
   for (iter = m_tabs.begin(); iter != m_tabs.end(); ++iter) {
-    connect(iter->second, SIGNAL(showMessageBox(const QString &)), this, SLOT(showMessageBox(const QString &)));
+    connect(iter->second, SIGNAL(showMessageBox(const std::string &)), this, SLOT(showMessageBox(const std::string &)));
     iter->second->setupTab();
   }
 

--- a/qt/scientific_interfaces/Indirect/Tools/TransmissionCalc.cpp
+++ b/qt/scientific_interfaces/Indirect/Tools/TransmissionCalc.cpp
@@ -63,7 +63,7 @@ bool TransmissionCalc::validate() {
   auto const error = uiv.generateErrorMessage();
   showMessageBox(error);
 
-  return error.isEmpty();
+  return error.empty();
 }
 
 /**
@@ -80,7 +80,7 @@ void TransmissionCalc::run() {
   try {
     transAlg->setProperty("Instrument", instrumentName);
   } catch (std::exception &) {
-    emit showMessageBox("Instrument " + QString::fromStdString(instrumentName) + " is not supported.");
+    emit showMessageBox("Instrument " + instrumentName + " is not supported.");
     setRunIsRunning(false);
     return;
   }

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
@@ -33,7 +33,7 @@ void BayesFitting::initLayout() {
   // Connect each tab to the actions available in this GUI
   std::map<unsigned int, BayesFittingTab *>::iterator iter;
   for (iter = m_bayesTabs.begin(); iter != m_bayesTabs.end(); ++iter) {
-    connect(iter->second, SIGNAL(showMessageBox(const QString &)), this, SLOT(showMessageBox(const QString &)));
+    connect(iter->second, SIGNAL(showMessageBox(const std::string &)), this, SLOT(showMessageBox(const std::string &)));
   }
 
   loadSettings();

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
@@ -115,7 +115,7 @@ void Quasi::setup() {}
  */
 bool Quasi::validate() {
   UserInputValidator uiv;
-  QString errors("");
+  std::string errors("");
   uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
   uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
 
@@ -137,7 +137,7 @@ bool Quasi::validate() {
 
   // Create and show error messages
   errors.append(uiv.generateErrorMessage());
-  if (!errors.isEmpty()) {
+  if (!errors.empty()) {
     emit showMessageBox(errors);
     return false;
   }

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
@@ -85,7 +85,7 @@ void ResNorm::setup() {}
  */
 bool ResNorm::validate() {
   UserInputValidator uiv;
-  QString errors("");
+  std::string errors("");
 
   bool const vanValid = uiv.checkDataSelectorIsValid("Vanadium", m_uiForm.dsVanadium);
   bool const resValid = uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
@@ -121,7 +121,7 @@ bool ResNorm::validate() {
 
   // Create and show error messages
   errors.append(uiv.generateErrorMessage());
-  if (!errors.isEmpty()) {
+  if (!errors.empty()) {
     emit showMessageBox(errors);
     return false;
   }

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
@@ -102,8 +102,8 @@ bool Stretch::validate() {
   uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
   uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
 
-  QString errors = uiv.generateErrorMessage();
-  if (!errors.isEmpty()) {
+  auto const errors = uiv.generateErrorMessage();
+  if (!errors.empty()) {
     emit showMessageBox(errors);
     return false;
   }

--- a/qt/scientific_interfaces/Inelastic/Common/InelasticInterface.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/InelasticInterface.cpp
@@ -46,6 +46,8 @@ void InelasticInterface::applySettings(std::map<std::string, QVariant> const &se
 
 void InelasticInterface::manageUserDirectories() { ManageUserDirectories::openManageUserDirectories(); }
 
-void InelasticInterface::showMessageBox(QString const &message) { showInformationBox(message); }
+void InelasticInterface::showMessageBox(std::string const &message) {
+  showInformationBox(QString::fromStdString(message));
+}
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Common/InelasticInterface.h
+++ b/qt/scientific_interfaces/Inelastic/Common/InelasticInterface.h
@@ -27,7 +27,7 @@ protected slots:
   void help();
   void settings();
   void manageUserDirectories();
-  void showMessageBox(QString const &message);
+  void showMessageBox(std::string const &message);
 
 protected:
   virtual void initLayout() override;

--- a/qt/scientific_interfaces/Inelastic/Common/InelasticTab.h
+++ b/qt/scientific_interfaces/Inelastic/Common/InelasticTab.h
@@ -160,7 +160,7 @@ private slots:
 
 signals:
   /// Send signal to parent window to show a message box to user
-  void showMessageBox(const QString &message);
+  void showMessageBox(const std::string &message);
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Corrections/Corrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/Corrections.cpp
@@ -58,7 +58,7 @@ void Corrections::initLayout() {
   // Set up all tabs
   for (auto &tab : m_tabs) {
     tab.second->setupTab();
-    connect(tab.second, SIGNAL(showMessageBox(const QString &)), this, SLOT(showMessageBox(const QString &)));
+    connect(tab.second, SIGNAL(showMessageBox(const std::string &)), this, SLOT(showMessageBox(const std::string &)));
   }
 
   m_uiForm.pbSettings->setIcon(Settings::icon());

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
@@ -137,8 +137,8 @@ boost::optional<std::string> CorrectionsTab::addConvertUnitsStep(const MatrixWor
  * @param log           The logger for sending log messages.
  */
 void CorrectionsTab::displayInvalidWorkspaceTypeError(const std::string &workspaceName, Mantid::Kernel::Logger &log) {
-  QString errorMessage = "Invalid workspace loaded, ensure a MatrixWorkspace is "
-                         "entered into the field.\n";
+  std::string errorMessage = "Invalid workspace loaded, ensure a MatrixWorkspace is "
+                             "entered into the field.\n";
 
   if (AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(workspaceName)) {
     errorMessage += "Consider loading the WorkspaceGroup first into mantid, "

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessorInterface.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessorInterface.h
@@ -95,7 +95,8 @@ private:
     presenter->setupTab();
     tabContent->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-    connect(presenter.get(), SIGNAL(showMessageBox(const QString &)), this, SLOT(showMessageBox(const QString &)));
+    connect(presenter.get(), SIGNAL(showMessageBox(const std::string &)), this,
+            SLOT(showMessageBox(const std::string &)));
 
     m_presenters[name] = std::move(presenter);
 

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.cpp
@@ -137,9 +137,9 @@ bool ElwinPresenter::validate() {
   }
 
   auto const errorMessage = uiv.generateErrorMessage();
-  if (!errorMessage.isEmpty())
-    m_view->showMessageBox(errorMessage.toStdString());
-  return errorMessage.isEmpty();
+  if (!errorMessage.empty())
+    m_view->showMessageBox(errorMessage);
+  return errorMessage.empty();
 }
 
 void ElwinPresenter::handleValueChanged(std::string const &propName, double value) {

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
@@ -296,10 +296,10 @@ bool IqtView::validate() {
     uiv.addErrorMessage("ELow must be less than EHigh.\n");
 
   auto const message = uiv.generateErrorMessage();
-  if (!message.isEmpty())
-    showMessageBox(message.toStdString());
+  if (!message.empty())
+    showMessageBox(message);
 
-  return message.isEmpty();
+  return message.empty();
 }
 
 void IqtView::setSampleFBSuffixes(const QStringList &suffix) { m_uiForm.dsInput->setFBSuffixes(suffix); }

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
@@ -119,9 +119,9 @@ bool MomentsView::validate() {
   validateDataIsOfType(uiv, m_uiForm.dsInput, "Sample", DataType::Sqw);
 
   auto const errorMessage = uiv.generateErrorMessage();
-  if (!errorMessage.isEmpty())
-    showMessageBox(errorMessage.toStdString());
-  return errorMessage.isEmpty();
+  if (!errorMessage.empty())
+    showMessageBox(errorMessage);
+  return errorMessage.empty();
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.cpp
@@ -67,9 +67,9 @@ bool SqwPresenter::validate() {
   UserInputValidator uiv = m_model->validate(m_view->getQRangeFromPlot(), m_view->getERangeFromPlot());
   auto const errorMessage = uiv.generateErrorMessage();
   // Show an error message if needed
-  if (!errorMessage.isEmpty())
-    m_view->showMessageBox(errorMessage.toStdString());
-  return errorMessage.isEmpty();
+  if (!errorMessage.empty())
+    m_view->showMessageBox(errorMessage);
+  return errorMessage.empty();
 }
 
 void SqwPresenter::run() {

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
@@ -76,9 +76,9 @@ bool SqwView::validate() {
   validateDataIsOfType(uiv, m_uiForm.dsInput, "Sample", DataType::Red);
 
   auto const errorMessage = uiv.generateErrorMessage();
-  if (!errorMessage.isEmpty())
-    showMessageBox(errorMessage.toStdString());
-  return errorMessage.isEmpty();
+  if (!errorMessage.empty())
+    showMessageBox(errorMessage);
+  return errorMessage.empty();
 }
 
 void SqwView::notifyDataReady(QString const &dataName) { m_presenter->handleDataReady(dataName.toStdString()); }

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
@@ -389,9 +389,9 @@ bool SymmetriseView::validate() {
   UserInputValidator uiv;
   validateDataIsOfType(uiv, m_uiForm.dsInput, "Sample", DataType::Red);
   auto const errorMessage = uiv.generateErrorMessage();
-  if (!errorMessage.isEmpty())
-    showMessageBox(errorMessage.toStdString());
-  return errorMessage.isEmpty();
+  if (!errorMessage.empty())
+    showMessageBox(errorMessage);
+  return errorMessage.empty();
 }
 
 void SymmetriseView::setRawPlotWatchADS(bool watchADS) { m_uiForm.ppRawPlot->watchADS(watchADS); }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
@@ -73,7 +73,7 @@ std::vector<std::pair<std::string, size_t>> FitDataPresenter::getResolutionsForF
   return m_model->getResolutionsForFit();
 }
 
-void FitDataPresenter::validate(UserInputValidator &validator) { m_view->validate(validator); }
+void FitDataPresenter::validate(IUserInputValidator *validator) { m_view->validate(validator); }
 
 void FitDataPresenter::handleAddData(MantidWidgets::IAddWorkspaceDialog const *dialog) {
   try {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
@@ -53,7 +53,7 @@ public:
   DataForParameterEstimationCollection getDataForParameterEstimation(const EstimationDataSelector &selector) const;
   std::vector<double> getQValuesForData() const;
   std::vector<std::string> createDisplayNames() const;
-  void validate(UserInputValidator &validator);
+  void validate(IUserInputValidator *validator);
 
   virtual void addWorkspace(const std::string &workspaceName, const std::string &paramType, const int &spectrum_index) {
     UNUSED_ARG(workspaceName);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
@@ -68,9 +68,9 @@ void FitDataView::setHorizontalHeaders(const QStringList &headers) {
   m_uiForm->tbFitData->verticalHeader()->setVisible(false);
 }
 
-void FitDataView::validate(UserInputValidator &validator) {
+void FitDataView::validate(IUserInputValidator *validator) {
   if (m_uiForm->tbFitData->rowCount() == 0)
-    validator.addErrorMessage("No input data has been provided.");
+    validator->addErrorMessage("No input data has been provided.");
 }
 
 void FitDataView::displayWarning(const std::string &warning) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.h
@@ -36,7 +36,7 @@ public:
   QTableWidget *getDataTable() const override;
   bool isTableEmpty() const override;
 
-  void validate(UserInputValidator &validator) override;
+  void validate(IUserInputValidator *validator) override;
   virtual void addTableEntry(size_t row, FitDataRow newRow) override;
   virtual void updateNumCellEntry(double numEntry, size_t row, size_t column) override;
   int getColumnIndexFromName(std::string const &ColName) override;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
@@ -47,11 +47,11 @@ void FitTab::setupPlotView(std::optional<std::pair<double, double>> const &xPlot
 std::string FitTab::tabName() const { return m_parentWidget->windowTitle().toStdString(); }
 
 bool FitTab::validate() {
-  UserInputValidator validator;
-  m_dataPresenter->validate(validator);
-  m_fittingPresenter->validate(validator);
+  auto validator = std::make_unique<UserInputValidator>();
+  m_dataPresenter->validate(validator.get());
+  m_fittingPresenter->validate(validator.get());
 
-  const auto error = validator.generateErrorMessage().toStdString();
+  const auto error = validator->generateErrorMessage();
   if (!error.empty()) {
     displayWarning(error);
   }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.cpp
@@ -314,9 +314,9 @@ FittingModel::FittingModel()
   m_fitPlotModel = std::make_unique<FitPlotModel>(m_fitDataModel->getFittingData(), m_fitOutput.get());
 }
 
-void FittingModel::validate(UserInputValidator &validator) const {
+void FittingModel::validate(IUserInputValidator *validator) const {
   if (auto const invalidFunction = isInvalidFunction())
-    validator.addErrorMessage(QString::fromStdString(*invalidFunction));
+    validator->addErrorMessage(*invalidFunction);
 }
 
 // Functions that interact with FitDataModel

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.h
@@ -46,7 +46,7 @@ public:
   FittingModel();
   virtual ~FittingModel() = default;
 
-  void validate(UserInputValidator &validator) const override;
+  void validate(IUserInputValidator *validator) const override;
 
   // Functions that interact with FitDataModel
   void clearWorkspaces() override;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingPresenter.cpp
@@ -23,7 +23,7 @@ FittingPresenter::FittingPresenter(IFitTab *tab, IInelasticFitPropertyBrowser *b
 
 void FittingPresenter::notifyFunctionChanged() { m_tab->handleFunctionChanged(); }
 
-void FittingPresenter::validate(UserInputValidator &validator) { m_model->validate(validator); }
+void FittingPresenter::validate(IUserInputValidator *validator) { m_model->validate(validator); }
 
 void FittingPresenter::setFitFunction(Mantid::API::MultiDomainFunction_sptr function) {
   m_model->setFitFunction(std::move(function));

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingPresenter.h
@@ -50,7 +50,7 @@ public:
 
   void notifyFunctionChanged() override;
 
-  void validate(UserInputValidator &validator);
+  void validate(IUserInputValidator *validator);
 
   void setFitFunction(Mantid::API::MultiDomainFunction_sptr function);
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/IFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/IFitDataView.h
@@ -36,7 +36,7 @@ public:
   virtual QTableWidget *getDataTable() const = 0;
   virtual bool isTableEmpty() const = 0;
 
-  virtual void validate(UserInputValidator &validator) = 0;
+  virtual void validate(IUserInputValidator *validator) = 0;
   virtual void addTableEntry(size_t row, FitDataRow newRow) = 0;
   virtual void updateNumCellEntry(double numEntry, size_t row, size_t column) = 0;
   virtual int getColumnIndexFromName(std::string const &ColName) = 0;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/IFittingModel.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/IFittingModel.h
@@ -48,7 +48,7 @@ public:
                                                                            WorkspaceIndex spectrum) const = 0;
   virtual std::unordered_map<std::string, ParameterValue> getDefaultParameters(WorkspaceID workspaceID) const = 0;
 
-  virtual void validate(MantidQt::CustomInterfaces::UserInputValidator &validator) const = 0;
+  virtual void validate(MantidQt::CustomInterfaces::IUserInputValidator *validator) const = 0;
 
   // Functions that interact with FitDataModel
   virtual void clearWorkspaces() = 0;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/QENSFitting.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/QENSFitting.cpp
@@ -32,7 +32,7 @@ void QENSFitting::initLayout() {
   // Set up all tabs
   for (auto &tab : m_tabs) {
     tab.second->setupTab();
-    connect(tab.second, SIGNAL(showMessageBox(const QString &)), this, SLOT(showMessageBox(const QString &)));
+    connect(tab.second, SIGNAL(showMessageBox(const std::string &)), this, SLOT(showMessageBox(const std::string &)));
   }
 
   connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this, SLOT(exportTabPython()));

--- a/qt/scientific_interfaces/Inelastic/test/Common/DataValidationHelperTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Common/DataValidationHelperTest.h
@@ -221,7 +221,7 @@ private:
     ON_CALL(*m_dataSelector, isValid()).WillByDefault(Return(true));
 
     TS_ASSERT(functor(*m_uiv, m_dataSelector.get(), errorLabel, false));
-    TS_ASSERT(m_uiv->generateErrorMessage().isEmpty());
+    TS_ASSERT(m_uiv->generateErrorMessage().empty());
   }
 
   template <typename Functor>
@@ -231,7 +231,7 @@ private:
     ON_CALL(*m_dataSelector, isValid()).WillByDefault(Return(true));
 
     TS_ASSERT(!functor(*m_uiv, m_dataSelector.get(), errorLabel, false));
-    TS_ASSERT(!m_uiv->generateErrorMessage().isEmpty());
+    TS_ASSERT(!m_uiv->generateErrorMessage().empty());
   }
 
   template <typename Functor>
@@ -242,7 +242,7 @@ private:
 
     (void)functor(*m_uiv, m_dataSelector.get(), errorLabel, false);
 
-    TS_ASSERT_EQUALS(m_uiv->generateErrorMessage().toStdString(), errorMessage);
+    TS_ASSERT_EQUALS(m_uiv->generateErrorMessage(), errorMessage);
   }
 
   AnalysisDataServiceImpl &m_ads;

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/FittingPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/FittingPresenterTest.h
@@ -10,6 +10,7 @@
 #include <gmock/gmock.h>
 
 #include "MantidQtWidgets/Common/MockAlgorithmRunner.h"
+#include "MantidQtWidgets/Common/MockUserInputValidator.h"
 #include "MockObjects.h"
 #include "QENSFitting/FittingPresenter.h"
 
@@ -52,10 +53,10 @@ public:
   }
 
   void test_validate_calls_the_model_validate() {
-    UserInputValidator validator;
+    auto validator = std::make_unique<NiceMock<MockUserInputValidator>>();
     EXPECT_CALL(*m_model, validate(_)).Times(1);
 
-    m_presenter->validate(validator);
+    m_presenter->validate(validator.get());
   }
 
   void test_setFitFunction_calls_the_model() {

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -247,7 +247,7 @@ public:
                      std::unordered_map<std::string, ParameterValue>(WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_CONST_METHOD1(getDefaultParameters, std::unordered_map<std::string, ParameterValue>(WorkspaceID workspaceID));
 
-  MOCK_CONST_METHOD1(validate, void(MantidQt::CustomInterfaces::UserInputValidator &validator));
+  MOCK_CONST_METHOD1(validate, void(MantidQt::CustomInterfaces::IUserInputValidator *validator));
 
   MOCK_METHOD0(clearWorkspaces, void());
   MOCK_CONST_METHOD1(getWorkspace, Mantid::API::MatrixWorkspace_sptr(WorkspaceID workspaceID));
@@ -339,7 +339,7 @@ public:
 
   MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
   MOCK_CONST_METHOD0(isTableEmpty, bool());
-  MOCK_METHOD1(validate, void(MantidQt::CustomInterfaces::UserInputValidator &validator));
+  MOCK_METHOD1(validate, void(MantidQt::CustomInterfaces::IUserInputValidator *validator));
   MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
   MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
   MOCK_METHOD1(getColumnIndexFromName, int(std::string const &ColName));

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -304,6 +304,7 @@ set(QT5_INC_FILES
     inc/MantidQtWidgets/Common/MantidDesktopServices.h
     inc/MantidQtWidgets/Common/MantidTreeWidgetItem.h
     inc/MantidQtWidgets/Common/MockJobRunner.h
+    inc/MantidQtWidgets/Common/MockUserInputValidator.h
     inc/MantidQtWidgets/Common/MultifitSetupDialog.h
     inc/MantidQtWidgets/Common/MuonPeriodInfo.h
     inc/MantidQtWidgets/Common/ParseKeyValueString.h

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MockUserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MockUserInputValidator.h
@@ -19,6 +19,8 @@ class MockUserInputValidator : public MantidQt::CustomInterfaces::IUserInputVali
 public:
   virtual ~MockUserInputValidator() = default;
 
+  MOCK_METHOD2(addErrorMessage, void(const std::string &message, bool const silent));
+
   MOCK_CONST_METHOD0(generateErrorMessage, std::string());
 };
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MockUserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MockUserInputValidator.h
@@ -1,0 +1,25 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
+
+#include <string>
+
+#include <gmock/gmock.h>
+
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
+
+class MockUserInputValidator : public MantidQt::CustomInterfaces::IUserInputValidator {
+public:
+  virtual ~MockUserInputValidator() = default;
+
+  MOCK_CONST_METHOD0(generateErrorMessage, std::string());
+};
+
+GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -22,6 +22,12 @@ class QStringList;
 
 namespace MantidQt {
 namespace CustomInterfaces {
+
+class DLLExport IUserInputValidator {
+public:
+  virtual std::string generateErrorMessage() const = 0;
+};
+
 /**
  * A class to try and get rid of some of the boiler-plate code surrounding input
  * validation, and hopefully as a result make it more readable.
@@ -31,7 +37,7 @@ namespace CustomInterfaces {
  *
  *
  */
-class DLLExport UserInputValidator {
+class DLLExport UserInputValidator : public IUserInputValidator {
 public:
   /// Default Constructor.
   UserInputValidator();
@@ -84,7 +90,7 @@ public:
 
   /// Returns an error message which contains all the error messages raised by
   /// the check functions.
-  std::string generateErrorMessage();
+  std::string generateErrorMessage() const override;
   /// Checks to see if all input is valid
   bool isAllInputValid();
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -25,6 +25,8 @@ namespace CustomInterfaces {
 
 class DLLExport IUserInputValidator {
 public:
+  virtual void addErrorMessage(const std::string &message, bool const silent = false) = 0;
+
   virtual std::string generateErrorMessage() const = 0;
 };
 
@@ -83,7 +85,7 @@ public:
   bool checkWorkspaceGroupIsValid(QString const &groupName, QString const &inputType, bool silent = false);
 
   /// Add a custom error message to the list.
-  void addErrorMessage(const QString &message, bool silent = false);
+  void addErrorMessage(const std::string &message, bool const silent = false) override;
 
   /// Sets a validation label
   void setErrorLabel(QLabel *errorLabel, bool valid);
@@ -119,7 +121,8 @@ bool UserInputValidator::checkWorkspaceType(QString const &workspaceName, QStrin
                                             QString const &validType, bool silent) {
   if (checkWorkspaceExists(workspaceName, silent)) {
     if (!getADSWorkspace<T>(workspaceName.toStdString())) {
-      addErrorMessage("The " + inputType + " workspace is not a " + validType + ".", silent);
+      addErrorMessage("The " + inputType.toStdString() + " workspace is not a " + validType.toStdString() + ".",
+                      silent);
       return false;
     } else
       return true;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -25,6 +25,8 @@ namespace CustomInterfaces {
 
 class DLLExport IUserInputValidator {
 public:
+  virtual ~IUserInputValidator() = default;
+
   virtual void addErrorMessage(const std::string &message, bool const silent = false) = 0;
 
   virtual std::string generateErrorMessage() const = 0;
@@ -39,7 +41,7 @@ public:
  *
  *
  */
-class DLLExport UserInputValidator : public IUserInputValidator {
+class DLLExport UserInputValidator final : public IUserInputValidator {
 public:
   /// Default Constructor.
   UserInputValidator();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -84,7 +84,7 @@ public:
 
   /// Returns an error message which contains all the error messages raised by
   /// the check functions.
-  QString generateErrorMessage();
+  std::string generateErrorMessage();
   /// Checks to see if all input is valid
   bool isAllInputValid();
 

--- a/qt/widgets/common/src/UserInputValidator.cpp
+++ b/qt/widgets/common/src/UserInputValidator.cpp
@@ -398,11 +398,11 @@ void UserInputValidator::addErrorMessage(const QString &message, bool silent) {
  * raised by
  * the check functions.
  */
-QString UserInputValidator::generateErrorMessage() {
+std::string UserInputValidator::generateErrorMessage() {
   if (m_errorMessages.isEmpty())
     return "";
 
-  return "Please correct the following:\n" + m_errorMessages.join("\n");
+  return "Please correct the following:\n" + m_errorMessages.join("\n").toStdString();
 }
 
 /**

--- a/qt/widgets/common/src/UserInputValidator.cpp
+++ b/qt/widgets/common/src/UserInputValidator.cpp
@@ -398,7 +398,7 @@ void UserInputValidator::addErrorMessage(const QString &message, bool silent) {
  * raised by
  * the check functions.
  */
-std::string UserInputValidator::generateErrorMessage() {
+std::string UserInputValidator::generateErrorMessage() const {
   if (m_errorMessages.isEmpty())
     return "";
 

--- a/qt/widgets/common/src/UserInputValidator.cpp
+++ b/qt/widgets/common/src/UserInputValidator.cpp
@@ -64,7 +64,7 @@ UserInputValidator::UserInputValidator() : m_errorMessages(), m_error(false) {}
 bool UserInputValidator::checkFieldIsNotEmpty(const QString &name, QLineEdit *field, QLabel *errorLabel) {
   if (field->text().trimmed().isEmpty()) {
     setErrorLabel(errorLabel, false);
-    addErrorMessage(name + " has been left blank.");
+    addErrorMessage(name.toStdString() + " has been left blank.");
     return false;
   } else {
     setErrorLabel(errorLabel, true);
@@ -91,7 +91,7 @@ bool UserInputValidator::checkFieldIsValid(const QString &errorMessage, QLineEdi
     return true;
   } else {
     setErrorLabel(errorLabel, false);
-    addErrorMessage(errorMessage);
+    addErrorMessage(errorMessage.toStdString());
     return false;
   }
 }
@@ -107,7 +107,7 @@ bool UserInputValidator::checkFieldIsValid(const QString &errorMessage, QLineEdi
  */
 bool UserInputValidator::checkWorkspaceSelectorIsNotEmpty(const QString &name, WorkspaceSelector *workspaceSelector) {
   if (workspaceSelector->currentText() == "") {
-    addErrorMessage("No " + name + " workspace has been selected.");
+    addErrorMessage("No " + name.toStdString() + " workspace has been selected.");
     return false;
   }
 
@@ -123,7 +123,7 @@ bool UserInputValidator::checkWorkspaceSelectorIsNotEmpty(const QString &name, W
  */
 bool UserInputValidator::checkFileFinderWidgetIsValid(const QString &name, const FileFinderWidget *widget) {
   if (!widget->isValid()) {
-    addErrorMessage(name + " file error: " + widget->getFileProblem());
+    addErrorMessage(name.toStdString() + " file error: " + widget->getFileProblem().toStdString());
     return false;
   }
 
@@ -140,7 +140,7 @@ bool UserInputValidator::checkFileFinderWidgetIsValid(const QString &name, const
  */
 bool UserInputValidator::checkDataSelectorIsValid(const QString &name, DataSelector *widget, bool silent) {
   if (!widget->isValid()) {
-    addErrorMessage(name + " error: " + widget->getProblem(), silent);
+    addErrorMessage(name.toStdString() + " error: " + widget->getProblem().toStdString(), silent);
     return false;
   }
 
@@ -156,12 +156,12 @@ bool UserInputValidator::checkDataSelectorIsValid(const QString &name, DataSelec
  */
 bool UserInputValidator::checkValidRange(const QString &name, std::pair<double, double> range) {
   if (range.second == range.first) {
-    addErrorMessage(name + " must have a non-zero width.");
+    addErrorMessage(name.toStdString() + " must have a non-zero width.");
     return false;
   }
 
   if (range.second < range.first) {
-    addErrorMessage("The start of " + name + " must be less than the end.");
+    addErrorMessage("The start of " + name.toStdString() + " must be less than the end.");
     return false;
   }
 
@@ -185,7 +185,7 @@ bool UserInputValidator::checkRangesDontOverlap(std::pair<double, double> rangeA
                           .arg(rangeA.second)
                           .arg(rangeB.first)
                           .arg(rangeB.second);
-    addErrorMessage(message);
+    addErrorMessage(message.toStdString());
     return false;
   }
 
@@ -208,7 +208,7 @@ bool UserInputValidator::checkRangeIsEnclosed(const QString &outerName, std::pai
   sortPair(outer);
 
   if (inner.first < outer.first || inner.second > outer.second) {
-    addErrorMessage(outerName + " must completely enclose " + innerName + ".");
+    addErrorMessage(outerName.toStdString() + " must completely enclose " + innerName.toStdString() + ".");
     return false;
   }
 
@@ -273,8 +273,7 @@ bool UserInputValidator::checkNotEqual(const QString &name, double x, double y, 
     std::stringstream msg;
     msg << name.toStdString() << " (" << x << ")"
         << " should not be equal to " << y << ".";
-    QString msgStr = QString::fromStdString(msg.str());
-    addErrorMessage(msgStr);
+    addErrorMessage(msg.str());
     return false;
   }
 
@@ -293,7 +292,7 @@ bool UserInputValidator::checkWorkspaceExists(QString const &workspaceName, bool
     return false;
 
   if (!doesExistInADS(workspaceName.toStdString())) {
-    addErrorMessage(workspaceName + " could not be found.", silent);
+    addErrorMessage(workspaceName.toStdString() + " could not be found.", silent);
     return false;
   }
   return true;
@@ -322,8 +321,7 @@ bool UserInputValidator::checkWorkspaceNumberOfHistograms(QString const &workspa
 bool UserInputValidator::checkWorkspaceNumberOfHistograms(const MatrixWorkspace_sptr &workspace,
                                                           std::size_t const &validSize) {
   if (workspace->getNumberHistograms() != validSize) {
-    addErrorMessage(QString::fromStdString(workspace->getName()) + " should contain " +
-                    QString::fromStdString(std::to_string(validSize)) + " spectra.");
+    addErrorMessage(workspace->getName() + " should contain " + std::to_string(validSize) + " spectra.");
     return false;
   }
   return true;
@@ -352,8 +350,7 @@ bool UserInputValidator::checkWorkspaceNumberOfBins(QString const &workspaceName
 bool UserInputValidator::checkWorkspaceNumberOfBins(const MatrixWorkspace_sptr &workspace,
                                                     std::size_t const &validSize) {
   if (workspace->x(0).size() != validSize) {
-    addErrorMessage(QString::fromStdString(workspace->getName()) + " should contain " +
-                    QString::fromStdString(std::to_string(validSize)) + " bins.");
+    addErrorMessage(workspace->getName() + " should contain " + std::to_string(validSize) + " bins.");
     return false;
   }
   return true;
@@ -372,7 +369,7 @@ bool UserInputValidator::checkWorkspaceGroupIsValid(QString const &groupName, QS
   if (checkWorkspaceType<WorkspaceGroup>(groupName, inputType, "WorkspaceGroup", silent)) {
     if (auto const group = getADSWorkspace<WorkspaceGroup>(groupName.toStdString())) {
       if (auto const error = containsInvalidWorkspace(group)) {
-        addErrorMessage(QString::fromStdString(error.get()), silent);
+        addErrorMessage(error.get(), silent);
         return false;
       }
       return true;
@@ -387,9 +384,9 @@ bool UserInputValidator::checkWorkspaceGroupIsValid(QString const &groupName, QS
  * @param message :: the message to add to the list
  * @param silent True if an error should not be added to the validator.
  */
-void UserInputValidator::addErrorMessage(const QString &message, bool silent) {
-  if (!silent && !m_errorMessages.contains(message))
-    m_errorMessages.append(message);
+void UserInputValidator::addErrorMessage(const std::string &message, bool const silent) {
+  if (!silent && !m_errorMessages.contains(QString::fromStdString(message)))
+    m_errorMessages.append(QString::fromStdString(message));
   m_error = true;
 }
 


### PR DESCRIPTION
### Description of work
This PR adds an interface class for the `UserInputValidator`. This allows us to create a `MockUserInputValidator` which can be used for testing in a future PR to mock out the UserInputValidator. This PR also changes `generateErrorMessage` to return a std::string instead of a QString.

*There is no associated issue.*

### To test:
1. Open Inelastic QENS Fitting.

2. Try Run the tabs without loading data, and then without adding a fit function. A message box should appear when clicking run.

3. Open Indirect Data Reduction

4. Try run the tabs without loading data. A message box should appear.

5. Do a similar test for the other Inelastic interfaces

*This does not require release notes* because **it is an internal change**


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
