### PR TITLE
Re-enabled PythonChannelTest

### DIFF
--- a/Testing/SystemTests/tests/framework/PythonChannels.py
+++ b/Testing/SystemTests/tests/framework/PythonChannels.py
@@ -48,7 +48,6 @@ ConfigService["CheckMantidVersion.OnStartup"] = "{CheckMantidVersion}"
 ConfigService["UpdateInstrumentDefinitions.OnStartup"] = "{UpdateInstrumentDefinitions}"
 
 import mantid.simpleapi
-time.sleep(10)
 """
 
 TEST_SCRIPT_NAME = "pythonloggingtestscript.py"
@@ -95,7 +94,7 @@ class PythonLoggingTests(unittest.TestCase):
                 )
             )
 
-        result = subprocess.run([sys.executable, TEST_SCRIPT_NAME], timeout=60)  # This will raise subprocess.TimeoutExpired if deadlocke
+        result = subprocess.run([sys.executable, TEST_SCRIPT_NAME], timeout=600)  # This will raise subprocess.TimeoutExpired if deadlocke
         result.check_returncode()
 
 
@@ -105,8 +104,8 @@ class PythonChannelTest(systemtesting.MantidSystemTest):
         os.remove(TEST_SCRIPT_NAME)
 
     def skipTests(self):
-        # temporarily skip this test for all platforms
-        return True
+        # skip if OSX because multiprocessing uses `spawn` instead of `fork` which causes this test to fail
+        return platform.system() == "Darwin"
 
     def runTest(self):
         self._server = Process(target=run_server)

--- a/Testing/SystemTests/tests/framework/PythonChannels.py
+++ b/Testing/SystemTests/tests/framework/PythonChannels.py
@@ -26,6 +26,7 @@ import time
 import unittest
 import subprocess
 import systemtesting
+import platform
 from multiprocessing import Process
 from http.server import HTTPServer, BaseHTTPRequestHandler
 


### PR DESCRIPTION
### Description of work

#### Summary of work
This PR re-enables a system test that had been disabled after frequent, but random, failures.

In addition, I followed the advice from a comment on the original issue and did the following changes:

1. A 10 second sleep was removed as it had only been added as a temporary bug fix for a bug now permanently fixed.
2. The timeout for the sub-process was increased from 60 to 600 seconds. This should hopefully at least reduce the frequency of failures. In case it does not, it will give us new insights on why this test fails.

Fixes #[37366](https://github.com/mantidproject/mantid/issues/37366)

### To test:

Testing this PR will be difficult as the failures of this test were random. Realistically we can keep monitoring the behaviour of the test after merging and decide in a few weeks whether it should be removed altogether.

*This does not require release notes* because **it re-enabled an unreliable test not visible to our users.**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
