### PR TITLE
Fix bug where all workspaces are excluded in the Elwin interface when "Restrict allowed input files by name" is deselected

### DIFF
--- a/qt/scientific_interfaces/Inelastic/Common/InterfaceUtils.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/InterfaceUtils.cpp
@@ -102,7 +102,7 @@ QStringList getFBSuffixes(std::string const &interfaceName, std::string const &f
 
 QStringList getWSSuffixes(std::string const &interfaceName, std::string const &fileType) {
   if (!restrictInputDataByName()) {
-    return QStringList{""};
+    return QStringList{};
   }
   return toQStringList(getInterfaceProperty(interfaceName, "WORKSPACE-SUFFIXES", fileType), ",");
 }

--- a/qt/scientific_interfaces/Inelastic/test/Common/InterfaceUtilsTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Common/InterfaceUtilsTest.h
@@ -33,7 +33,7 @@ public:
     InterfaceUtils::restrictInputDataByName = mockRestrictInputDataByName;
 
     // There are many similar functions in the interface, this test will try only one pair of such functions
-    TS_ASSERT_EQUALS(getResolutionWSSuffixes("Iqt"), QStringList({""}));
+    TS_ASSERT_EQUALS(getResolutionWSSuffixes("Iqt"), QStringList());
     TS_ASSERT_EQUALS(getResolutionFBSuffixes("Iqt"), QStringList({".nxs"}));
   }
 


### PR DESCRIPTION
This bug was introduced by #37193 during this release.

This was discovered during testing for the new release from the BASIS instrument team.

Menu->Interfaces->Inelastic->Data Manipulation. Click the "Elwin" tab. 

From the cog icon in the dialog, if you deselect "Restrict allowed input files by name" then no workspaces appear in the "Add Workspaces" dialog.

![2024-05-29-143425_596x377_scrot](https://github.com/mantidproject/mantid/assets/5595210/b2414c02-a4c5-4ac6-a0e7-1b02ca892bee)


![2024-05-29-143346_462x489_scrot](https://github.com/mantidproject/mantid/assets/5595210/f9560930-c514-4e4a-9c9b-98a95b2a4771)


``QStringList{""}`` is actually creating a list with 1 item that is an empty string instead of creating an empty list. This causes the check ``WorkspaceMultiSelector::hasValidSuffix`` to always return false.

### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [5377: [Defect] Elwin file loading function not working properly in mantidworkbench nightly](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/5377)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Menu->Interfaces->Inelastic->Data Manipulation. Click the "Elwin" tab. 

Click "Add Workspaces" After valid workspaces are loaded and the "Restrict allowed input files by name"  is unchecked, you should be able to see workspaces.


![2024-05-29-141757_462x489_scrot](https://github.com/mantidproject/mantid/assets/5595210/db35b3ee-c20b-4beb-aa46-6a90bbde4836)

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


*This does not require release notes* because it was only introduced during this release.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
