### PR TITLE
Fix mapping Elwin bool properties

### DIFF
--- a/docs/source/release/v6.10.0/Inelastic/Bugfixes/37434.rst
+++ b/docs/source/release/v6.10.0/Inelastic/Bugfixes/37434.rst
@@ -1,0 +1,1 @@
+- Fix bug in the :ref:`Elwin Tab <elwin>` where the "Background Subtraction" and "Normalise to Lowest Temp" properties were ignored

--- a/qt/scientific_interfaces/Inelastic/Manipulation/ElwinPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Manipulation/ElwinPresenter.cpp
@@ -155,9 +155,9 @@ void ElwinPresenter::handleValueChanged(std::string const &propName, double valu
 }
 
 void ElwinPresenter::handleValueChanged(std::string const &propName, bool value) {
-  if (propName == "BackgroundSubtraction") {
+  if (propName == "Background Subtraction") {
     m_model->setBackgroundSubtraction(value);
-  } else if (propName == "Normalise") {
+  } else if (propName == "Normalise to Lowest Temp") {
     m_model->setNormalise(value);
   }
 }

--- a/qt/scientific_interfaces/Inelastic/test/Manipulation/ElwinPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Manipulation/ElwinPresenterTest.h
@@ -68,10 +68,10 @@ public:
   void test_handleValueChanged_sets_correct_bool_property() {
 
     EXPECT_CALL(*m_model, setNormalise(true)).Times((Exactly(1)));
-    m_presenter->handleValueChanged("Normalise", true);
+    m_presenter->handleValueChanged("Normalise to Lowest Temp", true);
 
     EXPECT_CALL(*m_model, setBackgroundSubtraction(true)).Times((Exactly(1)));
-    m_presenter->handleValueChanged("BackgroundSubtraction", true);
+    m_presenter->handleValueChanged("Background Subtraction", true);
   }
 
   void test_handleValueChanged_sets_correct_double_property() {


### PR DESCRIPTION
### Description of work

This was discovered by the basis instrument team while testing this next release but I believe it may have been broken for a while, still good to fix it for this release.

The bool values for "Background Subtraction" and "Nomalise to Lowest Temp" has no effect when set to True.

When you press Run and look at the log output for the `ElasticWindowMultiple` algorithm you should see `BackgroundRangeStart` and `BackgroundRangeEnd` be set when `Background Subtraction==True` and the `OutputELT` set to a output workspace name when `Nomalise to Lowest Temp==True` but that is not happening.

The issue is that the property names were not correctly mapped when handling a value change.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [5378: [Defect] Elwin for BASIS: Temperatures were not found in normalization](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/5378)


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Open the Elwin interface, Menu->Interfaces->Inelastic->Data Manipulation. Click the "Elwin" tab.

Load some data, can use `osi92762_graphite002_red.nxs` and `osi92763_graphite002_red.nxs` from the SystemTest data.

When you check `Background Subtraction` True and click Run you should see the `BackgroundRangeStart` and `BackgroundRangeEnd` be correctly passed to the `ElasticWindowMultiple` algorithm in the log.

When you check `Nomalise to Lowest Temp` True and click Run you should see the `OutputELT` property of `ElasticWindowMultiple` set to a workspace name ending in `_elt` in the log and a new output workspace created ending `_elt`.


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
