### PR TITLE
Increase autoprocessing timeout in ISIS Reflectometry GUI

### DIFF
--- a/docs/source/release/v6.10.0/Reflectometry/New_features/37435.rst
+++ b/docs/source/release/v6.10.0/Reflectometry/New_features/37435.rst
@@ -1,0 +1,1 @@
+- Increased the time between polling for new runs when using the Autoprocessing feature in the :ref:`ISIS Reflectometry GUI<interface-isis-refl>` from 15 seconds to 30 seconds.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogRunNotifier.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogRunNotifier.h
@@ -20,7 +20,7 @@ poll for new runs.
 */
 class MANTIDQT_ISISREFLECTOMETRY_DLL CatalogRunNotifier : public IRunNotifier, public RunsViewTimerSubscriber {
 public:
-  static auto constexpr POLLING_INTERVAL_MILLISECONDS = 15000;
+  static auto constexpr POLLING_INTERVAL_MILLISECONDS = 30000;
 
   explicit CatalogRunNotifier(IRunsView *view);
   ~CatalogRunNotifier() override = default;


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
As described on the linked issue, we're increasing the interval between polling for new runs when autoprocessing in the ISIS Reflectometry GUI to try and provide a short-term improvement for timing issues we're experiencing with file availability on IDAaaS. A longer term fix is in progress, but is aimed at 6.11.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37435 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

It's difficult to test this with live data from an instrument as part of a quick PR test (although I have tested this locally), but the following will confirm that the functionality is still working:

1) Open the ISIS Reflectometry GUI.
1) On the Runs tab, enter investigation ID `1120015` and cycle `11_3`.
1) Click the `Autoprocess` button. This should retrieve all available runs and display them in the search bar. Then it should automatically transfer them to the main table on the right hand side and start reducing them. You do not need to wait to ensure they all complete, just wait for a few and then click `Pause` to stop the Autoprocessing (this can take some time to stop).

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
