### PR TITLE
Fix OpenGL segmentation fault on Linux

### DIFF
--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -134,6 +134,12 @@ MantidOptions.InvisibleWorkspaces=0
 # Change to Off to disable OpenGL and use normal windows graphics.
 MantidOptions.InstrumentView.UseOpenGL = On
 
+# This will reduce the size of the OpenGL display lists used when drawing the
+# Instrument View. By doing this we reduce the chance that we will hit
+# a memory allocation bug in the Mesa graphics library that has been
+# fixed in version 24.1
+MantidOptions.InstrumentView.MesaBugWorkaround = Off
+
 # Controls the default normalization mode for graph plotting
 # Allowed values are:
 #   On: Normalize to the bin width for 1d and 2d plots

--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -137,7 +137,8 @@ MantidOptions.InstrumentView.UseOpenGL = On
 # This will reduce the size of the OpenGL display lists used when drawing the
 # Instrument View. By doing this we reduce the chance that we will hit
 # a memory allocation bug in the Mesa graphics library that has been
-# fixed in version 24.1
+# fixed in version 24.1. This is only relevant if you are using both Linux and
+# a broken version of Mesa.
 MantidOptions.InstrumentView.MesaBugWorkaround = Off
 
 # Controls the default normalization mode for graph plotting

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1362,7 +1362,7 @@ constParameterPointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowse
 constParameterPointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp:5116
 unusedStructMember:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp:1628
 internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/MultiplyMD.cpp:0
-unknownMacro:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h:256
+unknownMacro:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h:257
 unknownMacro:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/MiniPlotMpl.h:46
 constVariablePointer:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/WorkspaceSelector.cpp:174
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h:300

--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -184,21 +184,26 @@ More details on logging can be found in the :ref:`developer docs <mantid-dev:Log
 Mantid Graphical User Interface Properties
 ******************************************
 
-+--------------------------------------------+---------------------------------------------------+-----------------+
-|Property                                    |Description                                        |Example value    |
-+============================================+===================================================+=================+
-| ``Notifications.Enabled``                  |Should Mantid use System Notifications for         | ``On``, ``Off`` |
-|                                            |important messages?                                |                 |
-+--------------------------------------------+---------------------------------------------------+-----------------+
-| ``cluster.submission``                     |Enable cluster submission elements in GUIs         | ``On``, ``Off`` |
-+--------------------------------------------+---------------------------------------------------+-----------------+
-| ``MantidOptions.InstrumentView.UseOpenGL`` |Controls the use of OpenGL in rendering the        | ``On``, ``Off`` |
-|                                            |"unwrapped" (flat) instrument views.               |                 |
-+--------------------------------------------+---------------------------------------------------+-----------------+
-| ``MantidOptions.InvisibleWorkspaces``      |Do not show 'invisible' workspaces                 | ``0``, ``1``    |
-+--------------------------------------------+---------------------------------------------------+-----------------+
-| ``PeakColumn.hklPrec``                     |Precision of hkl values shown in tables            | ``2``           |
-+--------------------------------------------+---------------------------------------------------+-----------------+
++----------------------------------------------------+----------------------------------------------------+-----------------+
+|Property                                            |Description                                         |Example value    |
++====================================================+====================================================+=================+
+| ``Notifications.Enabled``                          |Should Mantid use System Notifications for          | ``On``, ``Off`` |
+|                                                    |important messages?                                 |                 |
++----------------------------------------------------+----------------------------------------------------+-----------------+
+| ``cluster.submission``                             |Enable cluster submission elements in GUIs          | ``On``, ``Off`` |
++----------------------------------------------------+----------------------------------------------------+-----------------+
+| ``MantidOptions.InstrumentView.UseOpenGL``         |Controls the use of OpenGL in rendering the         | ``On``, ``Off`` |
+|                                                    |"unwrapped" (flat) instrument views.                |                 |
++----------------------------------------------------+----------------------------------------------------+-----------------+
+| ``MantidOptions.InstrumentView.MesaBugWorkaround`` |Will reduce the size of the OpenGL display lists    | ``On``, ``Off`` |
+|                                                    |used when drawing the Instrument View. By doing     |                 |
+|                                                    |this we reduce the chance that we will hit a memory |                 |
+|                                                    |allocation bug in the Mesa graphics library.        |                 |
++----------------------------------------------------+----------------------------------------------------+-----------------+
+| ``MantidOptions.InvisibleWorkspaces``              |Do not show 'invisible' workspaces                  | ``0``, ``1``    |
++----------------------------------------------------+----------------------------------------------------+-----------------+
+| ``PeakColumn.hklPrec``                             |Precision of hkl values shown in tables             | ``2``           |
++----------------------------------------------------+----------------------------------------------------+-----------------+
 
 
 Network Properties

--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -198,7 +198,9 @@ Mantid Graphical User Interface Properties
 | ``MantidOptions.InstrumentView.MesaBugWorkaround`` |Will reduce the size of the OpenGL display lists    | ``On``, ``Off`` |
 |                                                    |used when drawing the Instrument View. By doing     |                 |
 |                                                    |this we reduce the chance that we will hit a memory |                 |
-|                                                    |allocation bug in the Mesa graphics library.        |                 |
+|                                                    |allocation bug in the Mesa graphics library. This   |                 |
+|                                                    |is only relevant if you using both Linux and a      |                 |
+|                                                    |broken version of Mesa.                             |                 |
 +----------------------------------------------------+----------------------------------------------------+-----------------+
 | ``MantidOptions.InvisibleWorkspaces``              |Do not show 'invisible' workspaces                  | ``0``, ``1``    |
 +----------------------------------------------------+----------------------------------------------------+-----------------+

--- a/docs/source/release/v6.10.0/Workbench/Bugfixes/36220.rst
+++ b/docs/source/release/v6.10.0/Workbench/Bugfixes/36220.rst
@@ -1,0 +1,1 @@
+- Fix crash when using the full 3D view with certain instruments on some versions of Linux.

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -22,6 +22,8 @@ set(SRC_FILES
     src/InstrumentWidgetMaskTab.cpp
     src/InstrumentWidgetPickTab.cpp
     src/InstrumentWidgetRenderTab.cpp
+    src/InstrumentRendererClassic.cpp
+    src/InstrumentRendererMultiList.cpp
     src/InstrumentRenderer.cpp
     src/InstrumentWidgetTab.cpp
     src/InstrumentWidgetTreeTab.cpp
@@ -94,6 +96,8 @@ set(INC_FILES
     inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
     inc/MantidQtWidgets/InstrumentView/InstrumentWidgetEncoder.h
     inc/MantidQtWidgets/InstrumentView/InstrumentWidgetDecoder.h
+    inc/MantidQtWidgets/InstrumentView/InstrumentRendererClassic.h
+    inc/MantidQtWidgets/InstrumentView/InstrumentRendererMultiList.h
     inc/MantidQtWidgets/InstrumentView/InstrumentRenderer.h
     inc/MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h
     inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
@@ -10,6 +10,7 @@
 #include "MantidQtWidgets/InstrumentView/ColorMap.h"
 #include "MantidQtWidgets/InstrumentView/DllOption.h"
 #include "MantidQtWidgets/InstrumentView/GLColor.h"
+#include "MantidQtWidgets/InstrumentView/InstrumentRenderer.h"
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -274,6 +275,7 @@ private:
   /// Sum the counts in detectors if the workspace is ragged
   void sumDetectorsRagged(const std::vector<size_t> &dets, std::vector<double> &x, std::vector<double> &y,
                           size_t size) const;
+  void resetInstrumentRenderer();
 
   /// The workspace whose data are shown
   std::shared_ptr<Mantid::API::MatrixWorkspace> m_workspace;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRenderer.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRenderer.h
@@ -75,6 +75,7 @@ private:
   void drawStructuredBank(size_t bankIndex, bool picking);
   void drawTube(size_t bankIndex, bool picking);
   void drawSingleDetector(size_t detIndex, bool picking);
+  void invalidateAndDeleteDisplayList(std::vector<GLuint> &displayList, bool &useList);
 };
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRenderer.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRenderer.h
@@ -10,6 +10,7 @@
 #include "DllOption.h"
 #include "GLColor.h"
 
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Rendering/OpenGL_Headers.h"
 #include "MantidQtWidgets/InstrumentView/BankTextureBuilder.h"
 #include "MantidQtWidgets/InstrumentView/ColorMap.h"
@@ -26,10 +27,6 @@ private:
   const InstrumentActor &m_actor;
   std::vector<GLColor> m_colors;
   std::vector<GLColor> m_pickColors;
-  std::vector<GLuint> m_nonPickingDisplayListId;
-  std::vector<GLuint> m_pickingDisplayListId;
-  bool m_usePickingDisplayList;
-  bool m_useNonPickingDisplayList;
   std::vector<detail::BankTextureBuilder> m_textures;
   std::map<size_t, size_t> m_reverseTextureIndexMap;
   ColorMap m_colorMap;
@@ -40,9 +37,9 @@ private:
 public:
   InstrumentRenderer(const InstrumentActor &actor);
 
-  ~InstrumentRenderer();
+  virtual ~InstrumentRenderer() = default;
 
-  void renderInstrument(const std::vector<bool> &visibleComps, bool showGuides, bool picking = false);
+  virtual void renderInstrument(const std::vector<bool> &visibleComps, bool showGuides, bool picking = false) = 0;
 
   void reset();
 
@@ -66,16 +63,24 @@ public:
 
   size_t selectedLayer() const { return m_layer; }
 
-private:
-  void resetColors();
-  void resetPickColors();
-  void draw(const std::vector<bool> &visibleComps, bool showGuides, bool picking);
+protected:
+  virtual void draw(const std::vector<bool> &visibleComps, bool showGuides, bool picking) = 0;
   void drawGridBank(size_t bankIndex, bool picking);
   void drawRectangularBank(size_t bankIndex, bool picking);
   void drawStructuredBank(size_t bankIndex, bool picking);
   void drawTube(size_t bankIndex, bool picking);
   void drawSingleDetector(size_t detIndex, bool picking);
   void invalidateAndDeleteDisplayList(std::vector<GLuint> &displayList, bool &useList);
+  void updateVisited(const Mantid::Geometry::ComponentInfo &compInfo, const size_t bankIndex,
+                     std::vector<bool> &visited);
+  virtual void resetDisplayLists() = 0;
+  const InstrumentActor &instrActor() const { return m_actor; };
+  void drawComponent(const size_t index, const std::vector<bool> &visibleComps, bool showGuides, bool picking,
+                     const Mantid::Geometry::ComponentInfo &compInfo, std::vector<bool> &visited);
+
+private:
+  void resetColors();
+  void resetPickColors();
 };
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRenderer.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRenderer.h
@@ -26,10 +26,12 @@ private:
   const InstrumentActor &m_actor;
   std::vector<GLColor> m_colors;
   std::vector<GLColor> m_pickColors;
-  mutable GLuint m_displayListId[2];
-  mutable bool m_useDisplayList[2];
-  mutable std::vector<detail::BankTextureBuilder> m_textures;
-  mutable std::map<size_t, size_t> m_reverseTextureIndexMap;
+  std::vector<GLuint> m_nonPickingDisplayListId;
+  std::vector<GLuint> m_pickingDisplayListId;
+  bool m_usePickingDisplayList;
+  bool m_useNonPickingDisplayList;
+  std::vector<detail::BankTextureBuilder> m_textures;
+  std::map<size_t, size_t> m_reverseTextureIndexMap;
   ColorMap m_colorMap;
   bool m_isUsingLayers;
   size_t m_layer;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRendererClassic.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRendererClassic.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidQtWidgets/InstrumentView/InstrumentRenderer.h"
+#include <array>
 
 namespace MantidQt::MantidWidgets {
 class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW InstrumentRendererClassic : public InstrumentRenderer {
@@ -20,7 +21,7 @@ protected:
   void resetDisplayLists() override;
 
 private:
-  GLuint m_displayListId[2];
-  bool m_useDisplayList[2];
+  std::array<GLuint, 2> m_displayListId;
+  std::array<bool, 2> m_useDisplayList;
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRendererClassic.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRendererClassic.h
@@ -1,0 +1,26 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidQtWidgets/InstrumentView/InstrumentRenderer.h"
+
+namespace MantidQt::MantidWidgets {
+class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW InstrumentRendererClassic : public InstrumentRenderer {
+public:
+  InstrumentRendererClassic(const InstrumentActor &actor);
+  ~InstrumentRendererClassic() override;
+  void renderInstrument(const std::vector<bool> &visibleComps, bool showGuides, bool picking = false) override;
+
+protected:
+  void draw(const std::vector<bool> &visibleComps, bool showGuides, bool picking) override;
+  void resetDisplayLists() override;
+
+private:
+  GLuint m_displayListId[2];
+  bool m_useDisplayList[2];
+};
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRendererMultiList.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRendererMultiList.h
@@ -9,6 +9,12 @@
 #include "MantidQtWidgets/InstrumentView/InstrumentRenderer.h"
 
 namespace MantidQt::MantidWidgets {
+/*
+This class will use a separate OpenGL display list for drawing each instrument component. By doing
+this we reduce the chance that we run into a specific memory allocation bug in the Mesa
+graphics library on Linux, which was fixed in Mesa version 24.1. The original method was to put
+all the OpenGL commands in one big display list.
+*/
 class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW InstrumentRendererMultiList : public InstrumentRenderer {
 public:
   InstrumentRendererMultiList(const InstrumentActor &actor);

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRendererMultiList.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentRendererMultiList.h
@@ -1,0 +1,28 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidQtWidgets/InstrumentView/InstrumentRenderer.h"
+
+namespace MantidQt::MantidWidgets {
+class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW InstrumentRendererMultiList : public InstrumentRenderer {
+public:
+  InstrumentRendererMultiList(const InstrumentActor &actor);
+  ~InstrumentRendererMultiList() override;
+  void renderInstrument(const std::vector<bool> &visibleComps, bool showGuides, bool picking = false) override;
+
+protected:
+  void draw(const std::vector<bool> &visibleComps, bool showGuides, bool picking) override;
+  void resetDisplayLists() override;
+
+private:
+  std::vector<GLuint> m_nonPickingDisplayListId;
+  std::vector<GLuint> m_pickingDisplayListId;
+  bool m_usePickingDisplayList;
+  bool m_useNonPickingDisplayList;
+};
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/OpenGLError.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/OpenGLError.h
@@ -23,6 +23,7 @@ public:
   static bool hasError(const std::string &funName) { return check(funName); }
   static std::ostream &log();
   static std::ostream &logDebug();
+  static std::string openGlVersion();
 
 private:
   std::string m_msg;

--- a/qt/widgets/instrumentview/src/InstrumentRenderer.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentRenderer.cpp
@@ -319,16 +319,16 @@ void InstrumentRenderer::reset() {
 
   /// Invalidate the OpenGL display lists to force full re-drawing of the
   /// instrument and creation of new lists.
-  m_usePickingDisplayList = false;
-  m_useNonPickingDisplayList = false;
+  invalidateAndDeleteDisplayList(m_pickingDisplayListId, m_usePickingDisplayList);
+  invalidateAndDeleteDisplayList(m_nonPickingDisplayListId, m_useNonPickingDisplayList);
+}
+
+void InstrumentRenderer::invalidateAndDeleteDisplayList(std::vector<GLuint> &displayList, bool &useList) {
+  useList = false;
   for (size_t i = 0; i < m_actor.componentInfo().size(); ++i) {
-    if (m_nonPickingDisplayListId[i] != 0) {
-      glDeleteLists(m_nonPickingDisplayListId[i], 1);
-      m_nonPickingDisplayListId[i] = 0;
-    }
-    if (m_pickingDisplayListId[i] != 0) {
-      glDeleteLists(m_pickingDisplayListId[i], 1);
-      m_pickingDisplayListId[i] = 0;
+    if (displayList[i] != 0) {
+      glDeleteLists(displayList[i], 1);
+      displayList[i] = 0;
     }
   }
 }

--- a/qt/widgets/instrumentview/src/InstrumentRendererClassic.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentRendererClassic.cpp
@@ -1,0 +1,74 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidQtWidgets/InstrumentView/InstrumentRendererClassic.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidQtWidgets/InstrumentView/InstrumentActor.h"
+#include "MantidQtWidgets/InstrumentView/OpenGLError.h"
+
+using Mantid::Beamline::ComponentType;
+
+namespace MantidQt::MantidWidgets {
+InstrumentRendererClassic::InstrumentRendererClassic(const InstrumentActor &actor) : InstrumentRenderer(actor) {
+  m_displayListId[0] = 0;
+  m_displayListId[1] = 0;
+  m_useDisplayList[0] = false;
+  m_useDisplayList[1] = false;
+}
+
+InstrumentRendererClassic::~InstrumentRendererClassic() {
+  for (unsigned int i : m_displayListId) {
+    if (i != 0) {
+      glDeleteLists(i, 1);
+    }
+  }
+}
+
+void InstrumentRendererClassic::renderInstrument(const std::vector<bool> &visibleComps, bool showGuides, bool picking) {
+  if (std::none_of(visibleComps.cbegin(), visibleComps.cend(), [](bool visible) { return visible; }))
+    return;
+  if (!instrActor().isInitialized()) {
+    return;
+  }
+
+  OpenGLError::check("InstrumentActor::draw()");
+  size_t i = picking ? 1 : 0;
+  if (m_useDisplayList[i]) {
+    glCallList(m_displayListId[i]);
+  } else {
+    m_displayListId[i] = glGenLists(1);
+    m_useDisplayList[i] = true;
+    glNewList(m_displayListId[i],
+              GL_COMPILE); // Construct display list for object representation
+    draw(visibleComps, showGuides, picking);
+    glEndList();
+    if (glGetError() == GL_OUT_OF_MEMORY) // Throw an exception
+      throw Mantid::Kernel::Exception::OpenGLError("OpenGL: Out of video memory");
+    glCallList(m_displayListId[i]);
+  }
+  OpenGLError::check("InstrumentActor::draw()");
+}
+
+void InstrumentRendererClassic::draw(const std::vector<bool> &visibleComps, bool showGuides, bool picking) {
+  const auto &compInfo = instrActor().componentInfo();
+  std::vector<bool> visited(compInfo.size(), false);
+
+  for (size_t i = compInfo.root(); i != std::numeric_limits<size_t>::max(); --i) {
+    drawComponent(i, visibleComps, showGuides, picking, compInfo, visited);
+  }
+}
+
+void InstrumentRendererClassic::resetDisplayLists() {
+  for (size_t i = 0; i < 2; ++i) {
+    if (m_displayListId[i] != 0) {
+      glDeleteLists(m_displayListId[i], 1);
+      m_displayListId[i] = 0;
+      m_useDisplayList[i] = false;
+    }
+  }
+}
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/InstrumentRendererClassic.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentRendererClassic.cpp
@@ -10,14 +10,14 @@
 #include "MantidQtWidgets/InstrumentView/InstrumentActor.h"
 #include "MantidQtWidgets/InstrumentView/OpenGLError.h"
 
+#include <algorithm>
+
 using Mantid::Beamline::ComponentType;
 
 namespace MantidQt::MantidWidgets {
 InstrumentRendererClassic::InstrumentRendererClassic(const InstrumentActor &actor) : InstrumentRenderer(actor) {
-  m_displayListId[0] = 0;
-  m_displayListId[1] = 0;
-  m_useDisplayList[0] = false;
-  m_useDisplayList[1] = false;
+  m_displayListId = {0, 0};
+  m_useDisplayList = {false, false};
 }
 
 InstrumentRendererClassic::~InstrumentRendererClassic() {

--- a/qt/widgets/instrumentview/src/InstrumentRendererMultiList.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentRendererMultiList.cpp
@@ -10,6 +10,8 @@
 #include "MantidQtWidgets/InstrumentView/InstrumentActor.h"
 #include "MantidQtWidgets/InstrumentView/OpenGLError.h"
 
+#include <algorithm>
+
 using Mantid::Beamline::ComponentType;
 
 namespace MantidQt::MantidWidgets {
@@ -21,10 +23,8 @@ InstrumentRendererMultiList::InstrumentRendererMultiList(const InstrumentActor &
 
   m_pickingDisplayListId.resize(componentInfo.size());
   m_nonPickingDisplayListId.resize(componentInfo.size());
-  for (size_t i = 0; i < componentInfo.size(); ++i) {
-    m_nonPickingDisplayListId[i] = 0;
-    m_pickingDisplayListId[i] = 0;
-  }
+  std::fill(m_nonPickingDisplayListId.begin(), m_nonPickingDisplayListId.end(), 0);
+  std::fill(m_pickingDisplayListId.begin(), m_pickingDisplayListId.end(), 0);
 }
 
 InstrumentRendererMultiList::~InstrumentRendererMultiList() {

--- a/qt/widgets/instrumentview/src/InstrumentRendererMultiList.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentRendererMultiList.cpp
@@ -1,0 +1,89 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidQtWidgets/InstrumentView/InstrumentRendererMultiList.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidQtWidgets/InstrumentView/InstrumentActor.h"
+#include "MantidQtWidgets/InstrumentView/OpenGLError.h"
+
+using Mantid::Beamline::ComponentType;
+
+namespace MantidQt::MantidWidgets {
+InstrumentRendererMultiList::InstrumentRendererMultiList(const InstrumentActor &actor) : InstrumentRenderer(actor) {
+  const auto &componentInfo = actor.componentInfo();
+
+  m_useNonPickingDisplayList = false;
+  m_usePickingDisplayList = false;
+
+  m_pickingDisplayListId.resize(componentInfo.size());
+  m_nonPickingDisplayListId.resize(componentInfo.size());
+  for (size_t i = 0; i < componentInfo.size(); ++i) {
+    m_nonPickingDisplayListId[i] = 0;
+    m_pickingDisplayListId[i] = 0;
+  }
+}
+
+InstrumentRendererMultiList::~InstrumentRendererMultiList() {
+  for (unsigned int i : m_nonPickingDisplayListId) {
+    if (i != 0) {
+      glDeleteLists(i, 1);
+    }
+  }
+  for (unsigned int i : m_pickingDisplayListId) {
+    if (i != 0) {
+      glDeleteLists(i, 1);
+    }
+  }
+}
+
+void InstrumentRendererMultiList::renderInstrument(const std::vector<bool> &visibleComps, bool showGuides,
+                                                   bool picking) {
+  if (std::none_of(visibleComps.cbegin(), visibleComps.cend(), [](bool visible) { return visible; }))
+    return;
+
+  if (!instrActor().isInitialized()) {
+    return;
+  }
+
+  OpenGLError::check("InstrumentActor::draw()");
+  const auto &displayListIds = picking ? m_pickingDisplayListId : m_nonPickingDisplayListId;
+  auto &useDisplayList = picking ? m_usePickingDisplayList : m_useNonPickingDisplayList;
+  if (useDisplayList) {
+    for (size_t componentIndex = 0; componentIndex < instrActor().componentInfo().size(); ++componentIndex) {
+      glCallList(displayListIds[componentIndex]);
+    }
+  } else {
+    useDisplayList = true;
+    draw(visibleComps, showGuides, picking);
+  }
+  OpenGLError::check("InstrumentActor::draw()");
+}
+
+void InstrumentRendererMultiList::draw(const std::vector<bool> &visibleComps, bool showGuides, bool picking) {
+  const auto &compInfo = instrActor().componentInfo();
+  std::vector<bool> visited(compInfo.size(), false);
+
+  auto &displayListIds = picking ? m_pickingDisplayListId : m_nonPickingDisplayListId;
+  for (size_t componentIndex = compInfo.root(); componentIndex != std::numeric_limits<size_t>::max();
+       --componentIndex) {
+    displayListIds[componentIndex] = glGenLists(1);
+    glNewList(displayListIds[componentIndex],
+              GL_COMPILE); // Construct display list for object representation
+    drawComponent(componentIndex, visibleComps, showGuides, picking, compInfo, visited);
+    glEndList();
+    if (glGetError() == GL_OUT_OF_MEMORY)
+      throw Mantid::Kernel::Exception::OpenGLError("OpenGL: Out of video memory");
+    glCallList(displayListIds[componentIndex]);
+  }
+}
+
+void InstrumentRendererMultiList::resetDisplayLists() {
+  invalidateAndDeleteDisplayList(m_pickingDisplayListId, m_usePickingDisplayList);
+  invalidateAndDeleteDisplayList(m_nonPickingDisplayListId, m_useNonPickingDisplayList);
+}
+
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/OpenGLError.cpp
+++ b/qt/widgets/instrumentview/src/OpenGLError.cpp
@@ -33,6 +33,11 @@ bool OpenGLError::check(const std::string &funName) {
   return false;
 }
 
+std::string OpenGLError::openGlVersion() {
+  const unsigned char *verString = glGetString(GL_VERSION);
+  return std::string(reinterpret_cast<const char *>(verString));
+}
+
 std::ostream &OpenGLError::log() { return g_log.error(); }
 
 std::ostream &OpenGLError::logDebug() { return g_log.debug(); }


### PR DESCRIPTION
When drawing some instruments in full 3d (with OpenGL), putting all the draw commands for the instrument in one big list seems to cause a segmentation fault on certain versions of Linux, including the version used on IDAaaS. This changes `InstrumentRenderer` to draw each component of the instrument using a separate list, when the `MantidOptions.InstrumentView.MesaBugWorkaround` option in the user properties file is set to `On`.

The original bug in Mesa was fixed [here](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/27556), but that version has not made it onto IDAaaS yet.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
- Draw each instrument component in a separate display list when the new option is enabled.
- If option is disabled then behaviour should be the same.
- Add a method that will give you the OpenGL version string (someone will thank me in the future).
- Split the picking and non-picking display lists into named member variables instead of using two indices.

Fixes #36220 

### To test:
See #36220, or what caused the original segmentation fault for me was to view full 3D for MAR11001 (on Rocky 8 IDAaaS and Ubuntu). Other instruments and files will need checking as well.

Updated conda packages have bee uploaded to thomashampson/label/mesa_workaround:
`mamba install -c thomashampson/label/opengl_segfault_fix mantidworkbench`
Install this on IDAaaS and check that it doesn't crash.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
