### PR TITLE
Fix key shortcuts for quickly switching plot axis

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/Bugfixes/37438.rst
+++ b/docs/source/release/v6.11.0/Workbench/Bugfixes/37438.rst
@@ -1,1 +1,1 @@
-- Fixed key shortcuts `k` and `l` in mantid plot for quickly switching between `linear` and `log` axis.
+- Fixed key shortcuts `k` and `l` in mantid plot for quickly switching between `linear` and `log` scales.

--- a/docs/source/release/v6.11.0/Workbench/Bugfixes/37438.rst
+++ b/docs/source/release/v6.11.0/Workbench/Bugfixes/37438.rst
@@ -1,0 +1,1 @@
+- Fixed key shortcuts `k` and `l` in mantid plot for quickly switching between `linear` and `log` axis.

--- a/docs/source/tutorials/mantid_basic_course/loading_and_displaying_data/06_formatting_plots.rst
+++ b/docs/source/tutorials/mantid_basic_course/loading_and_displaying_data/06_formatting_plots.rst
@@ -100,6 +100,43 @@ File > Settings
 |
 |
 
+Useful Key Shortcuts
+====================
+
+Mantid plots support multiple key shortcuts by default.
+Please note especially the shortcuts `k` and `l`, which are useful for quickly switching between linear and log axes scales.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Action
+     - Key shortcuts
+   * - Toggle fullscreen
+     - f, ctrl+f
+   * - Reset to homme
+     - h, r
+   * - Go back to previous view
+     - c, backspace
+   * - Go forward to next view
+     - v
+   * - Pan
+     - p
+   * - Zoom
+     - o
+   * - Save
+     - s
+   * - Quit figure
+     - q, ctrl+w, cmd+w
+   * - Toggle major grids
+     - g
+   * - Toggle minor grids
+     - G
+   * - Switch x scale between log/linear
+     - k
+   * - Switch y scale between log/linear
+     - l
+
+
 **Other Plotting Documentation**
 
 * :ref:`02_scripting_plots`

--- a/qt/applications/workbench/workbench/plotting/config.py
+++ b/qt/applications/workbench/workbench/plotting/config.py
@@ -39,6 +39,10 @@ def initialize_matplotlib():
     mpl.rcParams["figure.dpi"] = QApplication.instance().desktop().physicalDpiX()
     # Hide warning made by matplotlib before checking our backend.
     warnings.filterwarnings("ignore", message="Starting a Matplotlib GUI outside of the main thread will likely fail.")
+    # Disabling default key shortcuts for toggling axes scale
+    mpl.rcParams["keymap.xscale"].remove("k")
+    mpl.rcParams["keymap.xscale"].remove("L")
+    mpl.rcParams["keymap.yscale"].remove("l")
 
 
 def init_mpl_gcf():

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -150,7 +150,7 @@ class FigureInteraction(object):
     def on_key_press(self, event):
 
         ax = event.inaxes
-        if ax is None or isinstance(ax, Axes3D) or len(ax.images) == 0 and len(ax.lines) == 0:
+        if ax is None or isinstance(ax, Axes3D) or len(ax.get_images()) == 0 and len(ax.get_lines()) == 0:
             return
 
         if event.key == "k":

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -57,8 +57,6 @@ AXES_SCALE_MENU_OPTS = OrderedDict(
         ("Log x/Lin y", ("log", "linear")),
     ]
 )
-# Options to quickly switch axes scales with key shortcuts
-AXES_SCALE_DEFAULT_SWITCH = ["linear", "log"]
 COLORBAR_SCALE_MENU_OPTS = OrderedDict([("Linear", Normalize), ("Log", LogNorm)])
 
 
@@ -148,7 +146,6 @@ class FigureInteraction(object):
         event.canvas.draw()
 
     def on_key_press(self, event):
-
         ax = event.inaxes
         if ax is None or isinstance(ax, Axes3D) or len(ax.get_images()) == 0 and len(ax.get_lines()) == 0:
             return
@@ -164,10 +161,9 @@ class FigureInteraction(object):
             self._quick_change_axes((ax.get_xscale(), next_yscale), ax)
 
     def _get_next_axis_scale(self, current_scale):
-        available_scales = AXES_SCALE_DEFAULT_SWITCH
-        scale_index = available_scales.index(current_scale) if current_scale in available_scales else 0
-        next_scale = available_scales[(scale_index + 1) % len(available_scales)]
-        return next_scale
+        if current_scale == "linear":
+            return "log"
+        return "linear"
 
     def on_mouse_button_press(self, event):
         """Respond to a MouseEvent where a button was pressed"""

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -87,6 +87,7 @@ class FigureInteractionTest(unittest.TestCase):
             call("resize_event", interactor.mpl_redraw_annotations),
             call("figure_leave_event", interactor.on_leave),
             call("scroll_event", interactor.on_scroll),
+            call("key_press_event", interactor.on_key_press),
         ]
         fig_manager.canvas.mpl_connect.assert_has_calls(expected_call)
         self.assertEqual(len(expected_call), fig_manager.canvas.mpl_connect.call_count)
@@ -723,6 +724,22 @@ class FigureInteractionTest(unittest.TestCase):
 
         mock_y_editor.assert_called_once()
 
+    def test_keyboard_shortcuts_switch_axes_scale(self):
+        key_press_event = self._create_mock_key_press_event("k")
+        key_press_event.inaxes.get_xscale.return_value = "linear"
+        key_press_event.inaxes.get_yscale.return_value = "log"
+        key_press_event.inaxes.get_xlim.return_value = (0, 100)
+        key_press_event.inaxes.get_ylim.return_value = (5, 10)
+        key_press_event.inaxes.get_lines.return_value = ["fake_line"]
+        fig_manager = MagicMock()
+        fig_manager.canvas = MagicMock()
+        interactor = FigureInteraction(fig_manager)
+        interactor.on_key_press(key_press_event)
+        key_press_event.inaxes.set_xscale.assert_called_once_with("log")
+        key_press_event.inaxes.set_yscale.assert_called_once_with("log")
+        key_press_event.inaxes.set_xlim.assert_called_once_with((0, 100))
+        key_press_event.inaxes.set_ylim.assert_called_once_with((5, 10))
+
     # Private methods
     def _create_mock_fig_manager_to_accept_right_click(self):
         fig_manager = MagicMock()
@@ -760,6 +777,11 @@ class FigureInteractionTest(unittest.TestCase):
         type(mouse_event).button = PropertyMock(return_value=1)
         type(mouse_event).dblclick = PropertyMock(return_value=True)
         return mouse_event
+
+    def _create_mock_key_press_event(self, key):
+        key_press_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections=[], creation_args=[{}]))
+        type(key_press_event).key = PropertyMock(return_value=key)
+        return key_press_event
 
     def _create_axes_for_axes_editor_test(self, mouse_over: str):
         ax = MagicMock()

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -724,7 +724,7 @@ class FigureInteractionTest(unittest.TestCase):
 
         mock_y_editor.assert_called_once()
 
-    def test_keyboard_shortcuts_switch_axes_scale(self):
+    def test_keyboard_shortcut_switch_x_scale(self):
         key_press_event = self._create_mock_key_press_event("k")
         key_press_event.inaxes.get_xscale.return_value = "linear"
         key_press_event.inaxes.get_yscale.return_value = "log"
@@ -737,6 +737,22 @@ class FigureInteractionTest(unittest.TestCase):
         interactor.on_key_press(key_press_event)
         key_press_event.inaxes.set_xscale.assert_called_once_with("log")
         key_press_event.inaxes.set_yscale.assert_called_once_with("log")
+        key_press_event.inaxes.set_xlim.assert_called_once_with((0, 100))
+        key_press_event.inaxes.set_ylim.assert_called_once_with((5, 10))
+
+    def test_keyboard_shortcut_switch_y_scale(self):
+        key_press_event = self._create_mock_key_press_event("l")
+        key_press_event.inaxes.get_xscale.return_value = "linear"
+        key_press_event.inaxes.get_yscale.return_value = "log"
+        key_press_event.inaxes.get_xlim.return_value = (0, 100)
+        key_press_event.inaxes.get_ylim.return_value = (5, 10)
+        key_press_event.inaxes.get_lines.return_value = ["fake_line"]
+        fig_manager = MagicMock()
+        fig_manager.canvas = MagicMock()
+        interactor = FigureInteraction(fig_manager)
+        interactor.on_key_press(key_press_event)
+        key_press_event.inaxes.set_xscale.assert_called_once_with("linear")
+        key_press_event.inaxes.set_yscale.assert_called_once_with("linear")
         key_press_event.inaxes.set_xlim.assert_called_once_with((0, 100))
         key_press_event.inaxes.set_ylim.assert_called_once_with((5, 10))
 


### PR DESCRIPTION
Reported by Maximilian Skoda, ISIS

### Description of work
Previous key shortcut behaviour was the default matplotlib shortcuts, which were flakey in a lot of plots.
Fixes #37402 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
I disabled the default keymaps and implemented our own event for key presses.

#### Purpose of work
Correct scaling of axis for MantidAxes and non-MantidAxes plots by using the keys `k` and `l`.


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
Run the script in #37402 and check that issue is fixed when switching axes by pressing `k` and `l`.
(For the shortcuts to work, your cursor needs to be on top of the plot)

- Check that shortcuts do nothing for 3D plots
- Open Colorfill and check that if the cursor is on top of the colorbar, nothing happens when you press the shortcuts
- Open a plot with tiled subplots and check that shortcuts work.
- Build documentation and check that table of shortcuts looks okay

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
