### PR TITLE
Only run doctests on Linux in the nightly pipeline

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -484,7 +484,12 @@ def build_and_test(platform) {
     bat "\"${WIN_BASH}\" -ex -c \"${buildscript_path}\
       ${workspace_unix_style}/${CHECKOUT_DIR} ${cmake_preset} ${common_args}\""
   } else {
-    sh "${buildscript_path} ${WORKSPACE}/${CHECKOUT_DIR} ${cmake_preset} ${common_args} --enable-doctests"
+    // Only run doctests on Linux
+    doctests = ""
+    if(platform.startsWith('linux')) {
+      doctests = "--enable-doctests"
+    }
+    sh "${buildscript_path} ${WORKSPACE}/${CHECKOUT_DIR} ${cmake_preset} ${common_args} ${doctests}"
   }
 }
 


### PR DESCRIPTION
[this](https://github.com/mantidproject/mantid/pull/37431) was supposed to go into `release-next` so I'm just doing that here.