### PR TITLE
Fix segfault in LoadEventNexus when CompressTolerance=0

### DIFF
--- a/Framework/DataHandling/src/DefaultEventLoader.cpp
+++ b/Framework/DataHandling/src/DefaultEventLoader.cpp
@@ -59,7 +59,7 @@ DefaultEventLoader::DefaultEventLoader(LoadEventNexus *alg, EventWorkspaceCollec
 
   // Cache a map for speed.
   if (!haveWeights) {
-    if (alg->compressEvents) {
+    if (alg->compressEvents && alg->compressTolerance != 0) {
       // Convert to weighted events
       for (size_t i = 0; i < m_ws.getNumberHistograms(); i++) {
         m_ws.getSpectrum(i).switchTo(API::WEIGHTED_NOTIME);

--- a/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
+++ b/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
@@ -335,8 +335,8 @@ void LoadBankFromDiskTask::run() {
     // Open the bankN_event group
     file.openGroup(entry_name, entry_type);
 
-    const bool needPulseInfo =
-        (!m_loader.alg->compressEvents) || m_loader.m_ws.nPeriods() > 1 || m_loader.alg->m_is_time_filtered;
+    const bool needPulseInfo = (!m_loader.alg->compressEvents) || m_loader.alg->compressTolerance == 0 ||
+                               m_loader.m_ws.nPeriods() > 1 || m_loader.alg->m_is_time_filtered;
 
     // Load the event_index field.
     if (needPulseInfo)
@@ -346,7 +346,7 @@ void LoadBankFromDiskTask::run() {
 
     if (!m_loadError) {
       // Load and validate the pulse times
-      if (m_loader.alg->compressEvents)
+      if (m_loader.alg->compressEvents && m_loader.alg->compressTolerance != 0)
         thisBankPulseTimes = nullptr;
       else
         this->loadPulseTimes(file);

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -915,6 +915,38 @@ public:
     TS_ASSERT_EQUALS(WS, ads.retrieveWS<MatrixWorkspace>("cncs_compressed")->monitorWorkspace());
   }
 
+  void test_Load_And_CompressEvents_tolerance_0() {
+    // the is to verify that the compresssion works when the CompressTolerance=0
+    const std::string filename{"CNCS_7860_event.nxs"};
+
+    Mantid::API::FrameworkManager::Instance();
+
+    // create compressed
+    std::string compressed_name = "cncs_compressed0";
+    {
+      LoadEventNexus ld;
+      ld.initialize();
+      ld.setPropertyValue("Filename", filename);
+      ld.setPropertyValue("OutputWorkspace", compressed_name);
+      ld.setProperty<bool>("Precount", false);
+      ld.setProperty<bool>("LoadLogs", false); // Time-saver
+      ld.setPropertyValue("CompressTolerance", "0");
+      ld.setProperty("NumberOfBins", 1);
+      ld.execute();
+      TS_ASSERT(ld.isExecuted());
+    }
+    // get a reference to the compressed workspace
+    EventWorkspace_sptr ws_compressed;
+    TS_ASSERT_THROWS_NOTHING(ws_compressed =
+                                 AnalysisDataService::Instance().retrieveWS<EventWorkspace>(compressed_name));
+    TS_ASSERT(ws_compressed); // it is an EventWorkspace
+
+    /// CNCS_7860_event.nxs has 112266 so we expect slightly fewer events when compressed
+    TS_ASSERT_EQUALS(ws_compressed->getNumberEvents(), 111274)
+    // cleanup
+    AnalysisDataService::Instance().remove(compressed_name);
+  }
+
   void doTestSingleBank(bool SingleBankPixelsOnly, bool Precount, const std::string &BankName = "bank36",
                         bool willFail = false) {
     Mantid::API::FrameworkManager::Instance();


### PR DESCRIPTION
### Description of work

Just discovered this bug while working on other things.

This will cause a Segmentation fault
```python
ws = LoadEventNexus('CNCS_7860_event.nxs', CompressTolerance=0)
```
It is due to changes from #37141 which was only added in the 6.10 release.

The issue it that the new [ProcessBankCompressed](https://github.com/mantidproject/mantid/blob/ba112cdacd8472baa873b8a5a6f6c307fd417906/Framework/DataHandling/src/ProcessBankCompressed.cpp) only runs when `m_loader.alg->compressEvents && (m_loader.alg->compressTolerance != 0))` ([this line](https://github.com/mantidproject/mantid/blob/ba112cdacd8472baa873b8a5a6f6c307fd417906/Framework/DataHandling/src/LoadBankFromDiskTask.cpp#L472)) otherwise it will use `ProcessBankData`. But the checks for loading required data only checked `alg->compressEvents` and not `alg->compressTolerance != 0`. So when `CompressTolerance=0` it will try to use `ProcessBankData` but fail because not all the require data has been loaded.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes *There is no associated issue.*


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

The following should no longer segfault

```python
ws = LoadEventNexus('CNCS_7860_event.nxs', CompressTolerance=0)
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


*This does not require release notes* because this bug was only added in this release.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
