### PR TITLE
Only Show Runs in the Data Cache When It is Available

### DIFF
--- a/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
+++ b/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
@@ -11,7 +11,9 @@
 //----------------------------------------------------------------------
 #include "MantidAPI/DllConfig.h"
 #include "MantidKernel/ConfigService.h"
+#include <json/value.h>
 #include <string>
+#include <utility>
 
 namespace Mantid {
 namespace API {
@@ -26,6 +28,7 @@ private:
   std::pair<Mantid::Kernel::InstrumentInfo, std::string> validateInstrumentAndNumber(const std::string &filename) const;
   std::string makeIndexFilePath(const std::string &instrumentName) const;
   std::pair<std::string, std::string> splitIntoInstrumentAndNumber(const std::string &filename) const;
+  [[nodiscard]] std::pair<std::string, Json::Value> openCacheJsonFile(std::string const &instrumentName) const;
   std::string m_dataCachePath;
 };
 } // namespace API

--- a/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
+++ b/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
@@ -23,7 +23,7 @@ public:
   ISISInstrumentDataCache(const std::string &path) : m_dataCachePath(path) {}
   std::string getFileParentDirectoryPath(const std::string &filename) const;
   bool isIndexFileAvailable(std::string const &instrument) const;
-  std::vector<std::string> getRunNumbersInCache(const std::string &instrument) const;
+  std::vector<std::string> getRunNumbersInCache(const Kernel::InstrumentInfo &instrument) const;
 
 private:
   std::pair<Mantid::Kernel::InstrumentInfo, std::string> validateInstrumentAndNumber(const std::string &filename) const;

--- a/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
+++ b/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
@@ -23,7 +23,7 @@ public:
   ISISInstrumentDataCache(const std::string &path) : m_dataCachePath(path) {}
   std::string getFileParentDirectoryPath(const std::string &filename) const;
   bool isIndexFileAvailable(std::string const &instrument) const;
-  std::vector<std::string> getRunNumbersInCache(const Kernel::InstrumentInfo &instrument) const;
+  std::vector<std::string> getRunNumbersInCache(std::string const &instrumentName) const;
 
 private:
   std::pair<Mantid::Kernel::InstrumentInfo, std::string> validateInstrumentAndNumber(const std::string &filename) const;

--- a/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
+++ b/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
@@ -23,8 +23,7 @@ public:
   ISISInstrumentDataCache(const std::string &path) : m_dataCachePath(path) {}
   std::string getFileParentDirectoryPath(const std::string &filename) const;
   bool isIndexFileAvailable(std::string const &instrument) const;
-  std::vector<std::string> getRunNumbersInCache(const std::string &instrument,
-                                                std::vector<std::string> runNumbers) const;
+  std::vector<std::string> getRunNumbersInCache(const std::string &instrument) const;
 
 private:
   std::pair<Mantid::Kernel::InstrumentInfo, std::string> validateInstrumentAndNumber(const std::string &filename) const;

--- a/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
+++ b/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
@@ -29,7 +29,9 @@ private:
   std::pair<Mantid::Kernel::InstrumentInfo, std::string> validateInstrumentAndNumber(const std::string &filename) const;
   std::string makeIndexFilePath(const std::string &instrumentName) const;
   std::pair<std::string, std::string> splitIntoInstrumentAndNumber(const std::string &filename) const;
-  [[nodiscard]] std::pair<std::string, Json::Value> openCacheJsonFile(std::string const &instrumentName) const;
+  [[nodiscard]] std::pair<std::string, Json::Value>
+  openCacheJsonFile(const Mantid::Kernel::InstrumentInfo &instrumentName) const;
+  [[nodiscard]] Mantid::Kernel::InstrumentInfo getInstrumentFromName(const std::string &instName) const;
   std::string m_dataCachePath;
 };
 } // namespace API

--- a/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
+++ b/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
@@ -11,6 +11,7 @@
 //----------------------------------------------------------------------
 #include "MantidAPI/DllConfig.h"
 #include "MantidKernel/ConfigService.h"
+#include <filesystem>
 #include <json/value.h>
 #include <string>
 #include <utility>
@@ -27,10 +28,10 @@ public:
 
 private:
   std::pair<Mantid::Kernel::InstrumentInfo, std::string> validateInstrumentAndNumber(const std::string &filename) const;
-  std::string makeIndexFilePath(const std::string &instrumentName) const;
+  std::filesystem::path makeIndexFilePath(const std::string &instrumentName) const;
   std::pair<std::string, std::string> splitIntoInstrumentAndNumber(const std::string &filename) const;
   [[nodiscard]] std::pair<std::string, Json::Value>
-  openCacheJsonFile(const Mantid::Kernel::InstrumentInfo &instrumentName) const;
+  openCacheJsonFile(const Mantid::Kernel::InstrumentInfo &instrument) const;
   [[nodiscard]] Mantid::Kernel::InstrumentInfo getInstrumentFromName(const std::string &instName) const;
   std::string m_dataCachePath;
 };

--- a/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
+++ b/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
@@ -23,6 +23,8 @@ public:
   ISISInstrumentDataCache(const std::string &path) : m_dataCachePath(path) {}
   std::string getFileParentDirectoryPath(const std::string &filename) const;
   bool isIndexFileAvailable(std::string const &instrument) const;
+  std::vector<std::string> getRunNumbersInCache(const std::string &instrument,
+                                                std::vector<std::string> runNumbers) const;
 
 private:
   std::pair<Mantid::Kernel::InstrumentInfo, std::string> validateInstrumentAndNumber(const std::string &filename) const;

--- a/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
+++ b/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
@@ -20,6 +20,7 @@ class MANTID_API_DLL ISISInstrumentDataCache {
 public:
   ISISInstrumentDataCache(const std::string &path) : m_dataCachePath(path) {}
   std::string getFileParentDirectoryPath(const std::string &filename) const;
+  bool isIndexFileAvailable(std::string const &instrument) const;
 
 private:
   std::pair<Mantid::Kernel::InstrumentInfo, std::string> validateInstrumentAndNumber(const std::string &filename) const;

--- a/Framework/API/src/ISISInstrumentDataCache.cpp
+++ b/Framework/API/src/ISISInstrumentDataCache.cpp
@@ -1,11 +1,13 @@
 #include "MantidAPI/ISISInstrumentDataCache.h"
 #include "MantidAPI/FileFinder.h"
-#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/InstrumentInfo.h"
 #include "MantidKernel/Logger.h"
+#include <filesystem>
 #include <fstream>
 #include <json/reader.h>
+
+using Mantid::API::ISISInstrumentDataCache;
 
 namespace {
 Mantid::Kernel::Logger g_log("ISISInstrumentDataCache");
@@ -90,4 +92,10 @@ Mantid::API::ISISInstrumentDataCache::splitIntoInstrumentAndNumber(const std::st
   std::string instrName = fileNameUpperCase.substr(0, nChars);
 
   return std::pair(instrName, runNumber);
+}
+
+bool ISISInstrumentDataCache::isIndexFileAvailable(std::string const &instrument) const {
+  std::filesystem::path const indexPath =
+      std::filesystem::path(m_dataCachePath) / instrument / (instrument + "_index.json");
+  return std::filesystem::exists(indexPath);
 }

--- a/Framework/API/src/ISISInstrumentDataCache.cpp
+++ b/Framework/API/src/ISISInstrumentDataCache.cpp
@@ -41,13 +41,14 @@ std::string ISISInstrumentDataCache::getFileParentDirectoryPath(const std::strin
   return dirPath;
 }
 
-std::vector<std::string> ISISInstrumentDataCache::getRunNumbersInCache(const std::string &instrument,
-                                                                       std::vector<std::string> runNumbers) const {
+/**
+ * Get a vector of the run numbers' files present in the given instrument's data cache.
+ * @param instrumentName The instrument to get run numbers for.
+ * @return A vector containing the run numbers that can be accessed from the data cache.
+ */
+std::vector<std::string> ISISInstrumentDataCache::getRunNumbersInCache(const std::string &instrument) const {
   const auto &json = openCacheJsonFile(instrument).second;
-  runNumbers.erase(std::remove_if(runNumbers.begin(), runNumbers.end(),
-                                  [&](const std::string &runNumber) { return json[runNumber].asString().empty(); }),
-                   runNumbers.end());
-  return runNumbers;
+  return json.getMemberNames();
 }
 
 /**

--- a/Framework/API/src/ISISInstrumentDataCache.cpp
+++ b/Framework/API/src/ISISInstrumentDataCache.cpp
@@ -70,7 +70,7 @@ ISISInstrumentDataCache::openCacheJsonFile(std::string const &instrumentName) co
   // Read directory path from json file
   Json::Value json;
   ifstrm >> json;
-  return std::pair(jsonPath, json);
+  return {jsonPath.string(), json};
 }
 
 std::pair<Mantid::Kernel::InstrumentInfo, std::string>

--- a/Framework/API/src/ISISInstrumentDataCache.cpp
+++ b/Framework/API/src/ISISInstrumentDataCache.cpp
@@ -1,3 +1,9 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAPI/ISISInstrumentDataCache.h"
 #include "MantidAPI/FileFinder.h"
 #include "MantidKernel/Exception.h"
@@ -13,7 +19,7 @@ namespace {
 Mantid::Kernel::Logger g_log("ISISInstrumentDataCache");
 } // namespace
 
-std::string Mantid::API::ISISInstrumentDataCache::getFileParentDirectoryPath(const std::string &fileName) const {
+std::string ISISInstrumentDataCache::getFileParentDirectoryPath(const std::string &fileName) const {
   g_log.debug() << "ISISInstrumentDataCache::getFileParentDirectoryPath(" << fileName << ")" << std::endl;
 
   auto [instrumentInfo, runNumber] = validateInstrumentAndNumber(fileName);
@@ -48,7 +54,7 @@ std::string Mantid::API::ISISInstrumentDataCache::getFileParentDirectoryPath(con
 }
 
 std::pair<Mantid::Kernel::InstrumentInfo, std::string>
-Mantid::API::ISISInstrumentDataCache::validateInstrumentAndNumber(const std::string &fileName) const {
+ISISInstrumentDataCache::validateInstrumentAndNumber(const std::string &fileName) const {
 
   // Check if suffix eg. -add is present in filename
   std::string fileNameCopy = fileName;
@@ -80,7 +86,7 @@ std::string Mantid::API::ISISInstrumentDataCache::makeIndexFilePath(const std::s
 }
 
 std::pair<std::string, std::string>
-Mantid::API::ISISInstrumentDataCache::splitIntoInstrumentAndNumber(const std::string &fileName) const {
+ISISInstrumentDataCache::splitIntoInstrumentAndNumber(const std::string &fileName) const {
 
   // Find the last non-digit as the instrument name can contain numbers
   const auto itRev = std::find_if(fileName.rbegin(), fileName.rend(), std::not_fn(isdigit));

--- a/Framework/API/src/ISISInstrumentDataCache.cpp
+++ b/Framework/API/src/ISISInstrumentDataCache.cpp
@@ -46,9 +46,8 @@ std::string ISISInstrumentDataCache::getFileParentDirectoryPath(const std::strin
  * @param instrumentName The instrument to get run numbers for.
  * @return A vector containing the run numbers that can be accessed from the data cache.
  */
-std::vector<std::string>
-ISISInstrumentDataCache::getRunNumbersInCache(const Mantid::Kernel::InstrumentInfo &instrument) const {
-  const auto &json = openCacheJsonFile(instrument.name()).second;
+std::vector<std::string> ISISInstrumentDataCache::getRunNumbersInCache(const std::string &instrumentName) const {
+  const auto &json = openCacheJsonFile(instrumentName).second;
   return json.getMemberNames();
 }
 

--- a/Framework/API/src/ISISInstrumentDataCache.cpp
+++ b/Framework/API/src/ISISInstrumentDataCache.cpp
@@ -10,7 +10,6 @@
 #include "MantidKernel/InstrumentInfo.h"
 #include "MantidKernel/Logger.h"
 #include <algorithm>
-#include <filesystem>
 #include <fstream>
 #include <json/reader.h>
 
@@ -54,7 +53,7 @@ std::vector<std::string> ISISInstrumentDataCache::getRunNumbersInCache(const std
 
 /**
  * Open the Json file and return the path and the opened file object.
- * @param instrumentName The name of the instrument to open the index file for.
+ * @param instrument The instrument to open the index file for.
  * @return A pair containing the path and the contents of the json file.
  * @throws std::invalid_argument if the file could not be found.
  */
@@ -104,7 +103,7 @@ InstrumentInfo ISISInstrumentDataCache::getInstrumentFromName(const std::string 
   }
 }
 
-std::string ISISInstrumentDataCache::makeIndexFilePath(const std::string &instrumentName) const {
+std::filesystem::path ISISInstrumentDataCache::makeIndexFilePath(const std::string &instrumentName) const {
   g_log.debug() << "ISISInstrumentDataCache::makeIndexFilePath(" << instrumentName << ")" << std::endl;
   auto const &indexFilePath =
       std::filesystem::path(m_dataCachePath) / instrumentName / (instrumentName + "_index.json");
@@ -128,7 +127,7 @@ ISISInstrumentDataCache::splitIntoInstrumentAndNumber(const std::string &fileNam
 
 /**
  * Check if the data cache index file is available on the current system for a given instrument.
- * @param instrument The instrument to find the index file for.
+ * @param instrumentName The instrument to find the index file for.
  * @return if there is an index file (and therefore instrument data cache) on the system.
  */
 bool ISISInstrumentDataCache::isIndexFileAvailable(std::string const &instrumentName) const {

--- a/Framework/API/src/ISISInstrumentDataCache.cpp
+++ b/Framework/API/src/ISISInstrumentDataCache.cpp
@@ -59,10 +59,11 @@ std::vector<std::string> ISISInstrumentDataCache::getRunNumbersInCache(const std
 std::pair<std::string, Json::Value>
 ISISInstrumentDataCache::openCacheJsonFile(std::string const &instrumentName) const {
   // Open index json file
-  std::string const &jsonPath = m_dataCachePath + "/" + instrumentName + "/" + instrumentName + "_index.json";
+  std::filesystem::path const &jsonPath =
+      std::filesystem::path(m_dataCachePath) / instrumentName / (instrumentName + "_index.json");
   std::ifstream ifstrm{jsonPath};
   if (!ifstrm) {
-    throw std::invalid_argument("Could not open index file: " + jsonPath);
+    throw std::invalid_argument("Could not open index file: " + jsonPath.string());
   }
 
   // Read directory path from json file

--- a/Framework/API/src/ISISInstrumentDataCache.cpp
+++ b/Framework/API/src/ISISInstrumentDataCache.cpp
@@ -46,8 +46,9 @@ std::string ISISInstrumentDataCache::getFileParentDirectoryPath(const std::strin
  * @param instrumentName The instrument to get run numbers for.
  * @return A vector containing the run numbers that can be accessed from the data cache.
  */
-std::vector<std::string> ISISInstrumentDataCache::getRunNumbersInCache(const std::string &instrument) const {
-  const auto &json = openCacheJsonFile(instrument).second;
+std::vector<std::string>
+ISISInstrumentDataCache::getRunNumbersInCache(const Mantid::Kernel::InstrumentInfo &instrument) const {
+  const auto &json = openCacheJsonFile(instrument.name()).second;
   return json.getMemberNames();
 }
 

--- a/Framework/API/test/ISISInstrumentDataCacheTest.h
+++ b/Framework/API/test/ISISInstrumentDataCacheTest.h
@@ -1,3 +1,10 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
 #pragma once
 
 #include <cxxtest/TestSuite.h>

--- a/Framework/API/test/ISISInstrumentDataCacheTest.h
+++ b/Framework/API/test/ISISInstrumentDataCacheTest.h
@@ -98,9 +98,9 @@ public:
 
   void testMissingIndexFile() {
     ISISInstrumentDataCache dc(m_dataCacheDir);
-    TS_ASSERT_THROWS_EQUALS(dc.getFileParentDirectoryPath("WISH12345"), const std::invalid_argument &e,
-                            std::string(e.what()),
-                            "Could not open index file: " + m_dataCacheDir + "/WISH/WISH_index.json");
+    TS_ASSERT_THROWS_EQUALS(
+        dc.getFileParentDirectoryPath("WISH12345"), const std::invalid_argument &e, std::string(e.what()),
+        "Could not open index file: " + (std::filesystem::path(m_dataCacheDir) / "WISH" / "WISH_index.json").string());
   }
 
   void testRunNumberNotFound() {

--- a/Framework/API/test/ISISInstrumentDataCacheTest.h
+++ b/Framework/API/test/ISISInstrumentDataCacheTest.h
@@ -100,6 +100,16 @@ public:
                             std::string(e.what()), "Run number 1234 not found for instrument SANS2D.");
   }
 
+  void testIndexFileExistsWhenExists() {
+    ISISInstrumentDataCache dc(m_dataCacheDir);
+    TS_ASSERT(dc.isIndexFileAvailable("MARI"));
+  }
+
+  void testIndexFileExistsWhenDoesNotExist() {
+    ISISInstrumentDataCache dc(m_dataCacheDir);
+    TS_ASSERT(!dc.isIndexFileAvailable("MARO"));
+  }
+
 private:
   std::string m_dataCacheDir;
 };

--- a/Framework/API/test/ISISInstrumentDataCacheTest.h
+++ b/Framework/API/test/ISISInstrumentDataCacheTest.h
@@ -117,6 +117,14 @@ public:
     TS_ASSERT(!dc.isIndexFileAvailable("MARO"));
   }
 
+  void testRunNumberInCacheTrimming() {
+    ISISInstrumentDataCache dc(m_dataCacheDir);
+    std::vector<std::string> runNumbers{"25054", "25055"};
+    std::vector<std::string> expectedResult{"25054"};
+    auto const &result = dc.getRunNumbersInCache("MARI", runNumbers);
+    TS_ASSERT_EQUALS(result, expectedResult);
+  }
+
 private:
   std::string m_dataCacheDir;
 };

--- a/Framework/API/test/ISISInstrumentDataCacheTest.h
+++ b/Framework/API/test/ISISInstrumentDataCacheTest.h
@@ -121,9 +121,8 @@ public:
 
   void testRunNumberInCacheTrimming() {
     ISISInstrumentDataCache dc(m_dataCacheDir);
-    auto const &instrumentInfo = FileFinder::Instance().getInstrument("MARI", false);
     std::vector<std::string> expectedResult{"25054"};
-    auto const &result = dc.getRunNumbersInCache(instrumentInfo);
+    auto const &result = dc.getRunNumbersInCache("MARI");
     TS_ASSERT_EQUALS(result, expectedResult);
   }
 

--- a/Framework/API/test/ISISInstrumentDataCacheTest.h
+++ b/Framework/API/test/ISISInstrumentDataCacheTest.h
@@ -13,7 +13,9 @@
 #include <iostream>
 #include <unordered_map>
 
+#include "MantidAPI/FileFinder.h"
 #include "MantidAPI/ISISInstrumentDataCache.h"
+#include "MantidKernel/InstrumentInfo.h"
 #include "MantidKernel/Strings.h"
 #include <boost/algorithm/string.hpp>
 
@@ -119,9 +121,9 @@ public:
 
   void testRunNumberInCacheTrimming() {
     ISISInstrumentDataCache dc(m_dataCacheDir);
-    std::vector<std::string> runNumbers{"25054", "25055"};
+    auto const &instrumentInfo = FileFinder::Instance().getInstrument("MARI", false);
     std::vector<std::string> expectedResult{"25054"};
-    auto const &result = dc.getRunNumbersInCache("MARI", runNumbers);
+    auto const &result = dc.getRunNumbersInCache(instrumentInfo);
     TS_ASSERT_EQUALS(result, expectedResult);
   }
 

--- a/docs/source/interfaces/reflectometry/ISIS Reflectometry.rst
+++ b/docs/source/interfaces/reflectometry/ISIS Reflectometry.rst
@@ -507,10 +507,11 @@ search or if there are no runs in the experiment yet, the table will remain
 empty. If an experiment is currently running, you can re-run the search to
 check for new runs and they will be added to the results table.
 
-If the Search Data Archive setting is set to "Off", only runs that are available
-in the ISIS Data Cache will appear in the search results. This ensures that users
-without archive access do not add runs, when transferring or auto-processing, that
-will not be found by Mantid.
+When working on IDAaaS with the "Search Data Archive" setting set to "Off", only
+runs that are available in the ISIS Instrument Data Cache will appear in the
+search results. This does not take user permissions into account. The user must
+still have access to these files in order to process them, otherwise a "File Not
+Found" error will occur when the reduction is run.
 
 Note that some runs will be highlighted in blue. This indicates that they are
 not valid for reduction, e.g. transmission runs, or runs without a valid

--- a/docs/source/interfaces/reflectometry/ISIS Reflectometry.rst
+++ b/docs/source/interfaces/reflectometry/ISIS Reflectometry.rst
@@ -507,6 +507,11 @@ search or if there are no runs in the experiment yet, the table will remain
 empty. If an experiment is currently running, you can re-run the search to
 check for new runs and they will be added to the results table.
 
+If the Search Data Archive setting is set to "Off", only runs that are available
+in the ISIS Data Cache will appear in the search results. This ensures that users
+without archive access do not add runs, when transferring or auto-processing, that
+will not be found by Mantid.
+
 Note that some runs will be highlighted in blue. This indicates that they are
 not valid for reduction, e.g. transmission runs, or runs without a valid
 angle. Hover over the row to see a tooltip with the reason the run is invalid.

--- a/docs/source/release/v6.11.0/Reflectometry/Bugfixes/36860.rst
+++ b/docs/source/release/v6.11.0/Reflectometry/Bugfixes/36860.rst
@@ -1,0 +1,2 @@
+- When on IDAaaS, only runs that are available in the ISIS Instrument Data Cache will appear in the ``Search Runs``
+  section of the :ref:`Runs tab <refl_runs>`.

--- a/docs/source/release/v6.11.0/Reflectometry/Bugfixes/36860.rst
+++ b/docs/source/release/v6.11.0/Reflectometry/Bugfixes/36860.rst
@@ -1,2 +1,2 @@
 - When on IDAaaS, only runs that are available in the ISIS Instrument Data Cache will appear in the ``Search Runs``
-  section of the :ref:`Runs tab <refl_runs>`.
+  section of the :ref:`Runs tab <refl_runs>` when the ``Search Data Archive`` setting is set to ``Off``.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
@@ -82,24 +82,24 @@ ITableWorkspace_sptr QtCatalogSearcher::getSearchAlgorithmResultsTable(IAlgorith
 }
 
 SearchResults QtCatalogSearcher::convertResultsTableToSearchResults(const ITableWorkspace_sptr &resultsTable) {
-  auto results = requiresICat() ? convertICatResultsTableToSearchResults(resultsTable)
-                                : convertJournalResultsTableToSearchResults(resultsTable);
+  auto searchResults = requiresICat() ? convertICatResultsTableToSearchResults(resultsTable)
+                                      : convertJournalResultsTableToSearchResults(resultsTable);
 
-  // Simply put, check if we're on IDAaaS.
+  // Check if we're on IDAaaS with the Data Cache available.
   auto const &dataCache = Mantid::API::ISISInstrumentDataCache(
       Mantid::Kernel::ConfigService::Instance().getString("datacachesearch.directory"));
   if (!dataCache.isIndexFileAvailable(searchCriteria().instrument)) {
-    return results;
+    return searchResults;
   }
   // If so, only show the runs available in the instrument data cache.
   std::vector<std::string> runNumbers = dataCache.getRunNumbersInCache(searchCriteria().instrument);
-  results.erase(std::remove_if(results.begin(), results.end(),
-                               [&](auto &result) {
-                                 return std::find(runNumbers.cbegin(), runNumbers.cend(), result.runNumber()) ==
-                                        std::end(runNumbers);
-                               }),
-                results.end());
-  return results;
+  searchResults.erase(std::remove_if(searchResults.begin(), searchResults.end(),
+                                     [&](auto &result) {
+                                       return std::find(runNumbers.cbegin(), runNumbers.cend(), result.runNumber()) ==
+                                              std::end(runNumbers);
+                                     }),
+                      searchResults.end());
+  return searchResults;
 }
 
 SearchResults QtCatalogSearcher::convertICatResultsTableToSearchResults(const ITableWorkspace_sptr &tableWorkspace) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
@@ -85,7 +85,11 @@ ITableWorkspace_sptr QtCatalogSearcher::getSearchAlgorithmResultsTable(IAlgorith
 SearchResults QtCatalogSearcher::convertResultsTableToSearchResults(const ITableWorkspace_sptr &resultsTable) {
   auto searchResults = requiresICat() ? convertICatResultsTableToSearchResults(resultsTable)
                                       : convertJournalResultsTableToSearchResults(resultsTable);
-
+  // If the archive is switched on, just return the whole set of results.
+  auto const &archiveSetting = ConfigService::Instance().getString("datasearch.searcharchive");
+  if (archiveSetting != "off") {
+    return searchResults;
+  }
   // Check if we're on IDAaaS with the Data Cache available.
   auto const &dataCache = ISISInstrumentDataCache(ConfigService::Instance().getString("datacachesearch.directory"));
   if (!dataCache.isIndexFileAvailable(searchCriteria().instrument)) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
@@ -92,9 +92,9 @@ SearchResults QtCatalogSearcher::convertResultsTableToSearchResults(const ITable
     return searchResults;
   }
   // If so, only show the runs available in the instrument data cache.
-  std::vector<std::string> runNumbers = dataCache.getRunNumbersInCache(searchCriteria().instrument);
+  auto const &runNumbers = dataCache.getRunNumbersInCache(searchCriteria().instrument);
   searchResults.erase(std::remove_if(searchResults.begin(), searchResults.end(),
-                                     [&](auto &result) {
+                                     [&](auto const &result) {
                                        return std::find(runNumbers.cbegin(), runNumbers.cend(), result.runNumber()) ==
                                               std::end(runNumbers);
                                      }),

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
@@ -16,7 +16,9 @@
 #include "MantidQtWidgets/Common/InterfaceManager.h"
 #include "MantidQtWidgets/Common/QtAlgorithmRunner.h"
 
+#include <algorithm>
 #include <boost/regex.hpp>
+#include <vector>
 
 using namespace Mantid::API;
 
@@ -82,22 +84,21 @@ ITableWorkspace_sptr QtCatalogSearcher::getSearchAlgorithmResultsTable(IAlgorith
 SearchResults QtCatalogSearcher::convertResultsTableToSearchResults(const ITableWorkspace_sptr &resultsTable) {
   auto results = requiresICat() ? convertICatResultsTableToSearchResults(resultsTable)
                                 : convertJournalResultsTableToSearchResults(resultsTable);
+
+  // Simply put, check if we're on IDAaaS.
   auto const &dataCache = Mantid::API::ISISInstrumentDataCache(
       Mantid::Kernel::ConfigService::Instance().getString("datacachesearch.directory"));
   if (!dataCache.isIndexFileAvailable(searchCriteria().instrument)) {
     return results;
   }
-  for (auto result = results.begin(); result != results.end(); ++result) {
-    try {
-      dataCache.getFileParentDirectoryPath(result->runNumber());
-    } catch (...) {
-      g_log.information() << "Did not find run number " << result->runNumber()
-                          << " in the Instrument Data Cache. Skipping...\n";
-      results.erase(result);
-      --result;
-      continue;
-    }
-  }
+  // If so, only show the runs available in the instrument data cache.
+  std::vector<std::string> runNumbers = dataCache.getRunNumbersInCache(searchCriteria().instrument);
+  results.erase(std::remove_if(results.begin(), results.end(),
+                               [&](auto &result) {
+                                 return std::find(runNumbers.cbegin(), runNumbers.cend(), result.runNumber()) ==
+                                        std::end(runNumbers);
+                               }),
+                results.end());
   return results;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 using namespace Mantid::API;
+using namespace Mantid::Kernel;
 
 namespace {
 Mantid::Kernel::Logger g_log("Reflectometry Catalog Searcher");
@@ -86,8 +87,7 @@ SearchResults QtCatalogSearcher::convertResultsTableToSearchResults(const ITable
                                       : convertJournalResultsTableToSearchResults(resultsTable);
 
   // Check if we're on IDAaaS with the Data Cache available.
-  auto const &dataCache = Mantid::API::ISISInstrumentDataCache(
-      Mantid::Kernel::ConfigService::Instance().getString("datacachesearch.directory"));
+  auto const &dataCache = ISISInstrumentDataCache(ConfigService::Instance().getString("datacachesearch.directory"));
   if (!dataCache.isIndexFileAvailable(searchCriteria().instrument)) {
     return searchResults;
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtCatalogSearcherTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtCatalogSearcherTest.h
@@ -315,14 +315,17 @@ public:
   }
 
   void test_search_results_in_data_cache() {
+    auto const &defaultArchiveSetting = ConfigService::Instance().getString("datasearch.searcharchive");
     auto const &defaultSaveDirectory = ConfigService::Instance().getString("datacachesearch.directory");
     setupFakeDataCache();
+    ConfigService::Instance().setString("datasearch.searcharchive", "off");
 
     auto searcher = makeCatalogSearcher();
     searcher.subscribe(&m_notifyee);
     auto results = doJournalSearch(searcher);
     checkFilteredSearchResults(results);
     ConfigService::Instance().setString("datacachesearch.directory", defaultSaveDirectory);
+    ConfigService::Instance().setString("datasearch.searcharchive", defaultArchiveSetting);
     verifyAndClear();
   }
 


### PR DESCRIPTION
### Description of work

#### Summary of work
When the Data Cache is available (such as on IDAaaS), only the runs that are available in it will be shown in the investigation menu, and therefore be available for transfer and auto-processing. 

This is to account for two problems:
1. Not all of the files in the archive are available in the data cache (yet).
2. Items are added to the archive (which is what we query with the invesigation ID to get the runs list) _before_ the runs are available in the data cache. 

Making sure only the items in the data cache before showing them to auto-processing ensures that we don't just instantly fail by not finding the file. 

Fixes #36860 

#### Further detail of work

- Adds some functionality to the ISISInstrumentDataCache class to check if the cache is available and to get the list of runs available within it. 
- Makes a change to the conversion to the search results generator, so that it filters out any of the runs that aren't present in the data cache. 

### To test:
The easiest way to do this is probably to just make a package build to use on IDAaaS, but if you want to test it locally, here you go (you'll need access to the archive or at least a decent number of INTER files with the same investigation ID):

1. Boot workbench and open the ISIS Reflectometry Interface
2. Enter 1120015 and 11_3
3. Use Ctrl+Shift to select a bunch of files and transfer them to the runs table
4. Process the files and save out the workspaces from the TOF group.
5. In your file browser rename the files to INTER000[11991].nxs (replacing the run number with the correct one)
6. Pick a location on your machine for your fake data cache. 
7. Have the files in a directory named after the instrument. `INTER` in this case. 
8. In the `INTER` directory, create an `INTER_index.json` file containing the following (making the run numbers match, obviously): 
```json
{
   "11990": "11_3",
    "11991": "11_3",
    "11992": "11_3",
    "11993": "11_3",
    "11994": "11_3",
    "HIDE_11995": "11_3",
    "11996": "11_3",
    "11997": "11_3",
    "11998": "11_3",
    "HIDE_11999": "11_3",
    "12000": "11_3",
    "12001": "11_3",
    "12002": "11_3",
    "12003": "11_3",
    "12004": "11_3"
}
```
10. in the end, your structure should look like this:
<img width="681" alt="image" src="https://github.com/mantidproject/mantid/assets/47181718/c0dd7e05-7ab8-4efd-8c42-713041ab06c3">

11. Final bit of setup, set the datacache location in your `mantid.user.properties` file: `datacachesearch.directory=/path/to/FakeCache`
12. Then restart mantid to pick up the change to the properties
13. Open the Refl interface
14. Enter your run number and cycle from before
15. Click autoprocess
16. Only the files present in the index file should be moved over to the runs table
17. Edit the index file to remove the `HIDE` parts.
18. The autoprocessing should pick up the newly added runs and process them automatically. 


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
