### PR TITLE
Use int for algorithm property when calling python algorithm from c++

### DIFF
--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
@@ -212,8 +212,8 @@ void Quasi::run() {
   double const eMin = m_properties["EMin"]->valueText().toDouble();
   double const eMax = m_properties["EMax"]->valueText().toDouble();
 
-  long const sampleBins = m_properties["SampleBinning"]->valueText().toLong();
-  long const resBins = m_properties["ResBinning"]->valueText().toLong();
+  auto const sampleBins = m_properties["SampleBinning"]->valueText().toInt();
+  auto const resBins = m_properties["ResBinning"]->valueText().toInt();
 
   // Construct an output base name for the output workspaces
   auto const resType = resName.substr(resName.length() - 3);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
@@ -134,9 +134,9 @@ void Stretch::run() {
   // Collect input from the properties browser
   auto const eMin = m_properties["EMin"]->valueText().toDouble();
   auto const eMax = m_properties["EMax"]->valueText().toDouble();
-  auto const beta = m_properties["Beta"]->valueText().toLong();
-  auto const sigma = m_properties["Sigma"]->valueText().toLong();
-  auto const nBins = m_properties["SampleBinning"]->valueText().toLong();
+  auto const beta = m_properties["Beta"]->valueText().toInt();
+  auto const sigma = m_properties["Sigma"]->valueText().toInt();
+  auto const nBins = m_properties["SampleBinning"]->valueText().toInt();
 
   // Bool options
   auto const elasticPeak = m_uiForm.chkElasticPeak->isChecked();


### PR DESCRIPTION
### Description of work
This PR fixes an error when attempting to use a `long` instead of an `int` for a property of a python algorithm. when calling the python algorithm from C++. 

```
Attempt to assign to property (SampleBins) of incorrect type
```
There was a recent change in behaviour for the `PropertyWithValue` class introduced in https://github.com/mantidproject/mantid/pull/37196 which caused this problem.

*There is no associated issue.*

### To test:
1. Go to Inelastic Bayes Fitting interface
2. Go to Quasi tab
3. Load the 26176 red from the sample data sets for sample
3. Load the 26173 res from the sample data sets for resolution
4. Click Run. It should run successfully

*This does not require release notes* because **it is a regression since the last release**


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
