### PR TITLE
Fix LoadEventNexus when using compression with weighted events and period data

### DIFF
--- a/Framework/DataHandling/src/DefaultEventLoader.cpp
+++ b/Framework/DataHandling/src/DefaultEventLoader.cpp
@@ -62,7 +62,9 @@ DefaultEventLoader::DefaultEventLoader(LoadEventNexus *alg, EventWorkspaceCollec
     if (alg->compressEvents && alg->compressTolerance != 0) {
       // Convert to weighted events
       for (size_t i = 0; i < m_ws.getNumberHistograms(); i++) {
-        m_ws.getSpectrum(i).switchTo(API::WEIGHTED_NOTIME);
+        for (size_t period = 0; period < m_ws.nPeriods(); ++period) {
+          m_ws.getSpectrum(i, period).switchTo(API::WEIGHTED_NOTIME);
+        }
       }
       makeMapToEventLists(weightedNoTimeEventVectors);
     } else {
@@ -71,7 +73,9 @@ DefaultEventLoader::DefaultEventLoader(LoadEventNexus *alg, EventWorkspaceCollec
   } else {
     // Convert to weighted events
     for (size_t i = 0; i < m_ws.getNumberHistograms(); i++) {
-      m_ws.getSpectrum(i).switchTo(API::WEIGHTED);
+      for (size_t period = 0; period < m_ws.nPeriods(); ++period) {
+        m_ws.getSpectrum(i, period).switchTo(API::WEIGHTED);
+      }
     }
     makeMapToEventLists(weightedEventVectors);
   }

--- a/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
+++ b/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
@@ -336,7 +336,7 @@ void LoadBankFromDiskTask::run() {
     file.openGroup(entry_name, entry_type);
 
     const bool needPulseInfo = (!m_loader.alg->compressEvents) || m_loader.alg->compressTolerance == 0 ||
-                               m_loader.m_ws.nPeriods() > 1 || m_loader.alg->m_is_time_filtered;
+                               m_loader.m_ws.nPeriods() > 1 || m_loader.alg->m_is_time_filtered || m_have_weight;
 
     // Load the event_index field.
     if (needPulseInfo)
@@ -346,10 +346,10 @@ void LoadBankFromDiskTask::run() {
 
     if (!m_loadError) {
       // Load and validate the pulse times
-      if (m_loader.alg->compressEvents && m_loader.alg->compressTolerance != 0)
-        thisBankPulseTimes = nullptr;
-      else
+      if (needPulseInfo)
         this->loadPulseTimes(file);
+      else
+        thisBankPulseTimes = nullptr;
       // The event_index should be the same length as the pulse times from DAS
       // logs.
       if (event_index && event_index->size() != thisBankPulseTimes->numberOfPulses())

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -830,7 +830,7 @@ const std::vector<WeightedEvent> &EventList::getWeightedEvents() const {
  * */
 std::vector<WeightedEventNoTime> &EventList::getWeightedEventsNoTime() {
   if (eventType != WEIGHTED_NOTIME)
-    throw std::runtime_error("EventList::getWeightedEvents() called for an "
+    throw std::runtime_error("EventList::getWeightedEventsNoTime() called for an "
                              "EventList not of type WeightedEventNoTime. Use "
                              "getEvents() or getWeightedEvents().");
   return this->weightedEventsNoTime;


### PR DESCRIPTION
### Description of work

Discovered 2 more bugs in `LoadEventNexus` when using `CompressTolerance` similar to #37443

It is due to changes from https://github.com/mantidproject/mantid/pull/37141 which was only added in the 6.10 release.

First it segfaults when using weighted events

```python
ws = LoadEventNexus(Filename="ARCS_sim_event.nxs", CompressTolerance=0.01)
```

Second it fails when using period data

```python
ws = LoadEventNexus(Filename="LARMOR00003368.nxs", CompressTolerance=0.01)
```

fails with
```
RuntimeError: EventList::getWeightedEvents() called for an EventList not of type WeightedEventNoTime. Use getEvents() or getWeightedEvents().
```


#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes *There is no associated issue.*


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Check that the above no longer fail

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


*This does not require release notes* because this bug was only introduced during this release.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
