### PR TITLE
37041 scrolling on plot when cursor is above legend will grab the legend

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/Bugfixes/37473.rst
+++ b/docs/source/release/v6.11.0/Workbench/Bugfixes/37473.rst
@@ -1,0 +1,1 @@
+- Legend in plots is no longer accidentally picked up by a mouse scroll

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -137,6 +137,9 @@ class FigureInteraction(object):
             and len(event.inaxes.lines) == 0
         ):
             return
+
+        self._correct_for_scroll_event_on_legend(event)
+
         zoom_factor = 1.05 + abs(event.step) / 6
         if event.button == "up":  # zoom in
             zoom(event.inaxes, event.xdata, event.ydata, factor=zoom_factor)
@@ -164,6 +167,13 @@ class FigureInteraction(object):
         if current_scale == "linear":
             return "log"
         return "linear"
+
+    def _correct_for_scroll_event_on_legend(self, event):
+        # Corrects default behaviour in Matplotlib where legend is picked up by scroll event
+        legend = event.inaxes.axes.get_legend()
+        if legend.get_draggable() and legend.contains(event):
+            legend_set_draggable(legend, False)
+            legend_set_draggable(legend, True)
 
     def on_mouse_button_press(self, event):
         """Respond to a MouseEvent where a button was pressed"""

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -756,6 +756,17 @@ class FigureInteractionTest(unittest.TestCase):
         key_press_event.inaxes.set_xlim.assert_called_once_with((0, 100))
         key_press_event.inaxes.set_ylim.assert_called_once_with((5, 10))
 
+    def test_legend_not_picked_up_from_scroll_event(self):
+        event = self._create_mock_scroll_event(button="up")
+        type(event.inaxes).lines = PropertyMock(return_value=["fake_line"])
+        legend = MagicMock()
+        legend.get_draggable.return_value = True
+        legend.contains.return_value = True
+        event.inaxes.axes.get_legend.return_value = legend
+        self.interactor.on_scroll(event)
+        calls = [call(False, False, "loc"), call(True, False, "loc")]
+        legend.set_draggable.assert_has_calls(calls)
+
     # Private methods
     def _create_mock_fig_manager_to_accept_right_click(self):
         fig_manager = MagicMock()
@@ -764,7 +775,7 @@ class FigureInteractionTest(unittest.TestCase):
         fig_manager.canvas = canvas
         return fig_manager
 
-    def _create_mock_fig_manager_to_accept_middle_click(self):
+    def _create_mock_fig_manager_to_accept_middle_click(self) -> object:
         fig_manager = MagicMock()
         canvas = MagicMock()
         type(canvas).buttond = PropertyMock(return_value={Qt.MiddleButton: 4})
@@ -788,7 +799,7 @@ class FigureInteractionTest(unittest.TestCase):
         type(mouse_event).button = PropertyMock(return_value=4)
         return mouse_event
 
-    def _create_mock_double_left_click(self):
+    def _create_mock_double_left_click(self) -> object:
         mouse_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections=[], creation_args=[{}]))
         type(mouse_event).button = PropertyMock(return_value=1)
         type(mouse_event).dblclick = PropertyMock(return_value=True)
@@ -798,6 +809,11 @@ class FigureInteractionTest(unittest.TestCase):
         key_press_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections=[], creation_args=[{}]))
         type(key_press_event).key = PropertyMock(return_value=key)
         return key_press_event
+
+    def _create_mock_scroll_event(self, button):
+        event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections=[], creation_args=[{}]))
+        type(event).button = MagicMock(return_value=button)
+        return event
 
     def _create_axes_for_axes_editor_test(self, mouse_over: str):
         ax = MagicMock()

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -775,7 +775,7 @@ class FigureInteractionTest(unittest.TestCase):
         fig_manager.canvas = canvas
         return fig_manager
 
-    def _create_mock_fig_manager_to_accept_middle_click(self) -> object:
+    def _create_mock_fig_manager_to_accept_middle_click(self):
         fig_manager = MagicMock()
         canvas = MagicMock()
         type(canvas).buttond = PropertyMock(return_value={Qt.MiddleButton: 4})


### PR DESCRIPTION
### Description of work
The default behaviour in Matplotlib is that the legend gets grabbed 
when the cursor is over it during a plot scroll event.
To fix this issue, I set the legend's draggability to false during scrolling 
and re-enable it once the scrolling ends.

Fixes: #37041 

### To test:

### To test:
1. Create a plot
2. scroll the plot to zoom in/out, 
3. scroll when the cursor is above the legend
4. the cursor doesn't grab the legend

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
