### PR TITLE
Amendments to FlipperEfficiency algorithm

### DIFF
--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -105,8 +105,8 @@ MatrixWorkspace_sptr FlipperEfficiency::calculateEfficiency(WorkspaceGroup_sptr 
   auto const &t01Ws = workspaceForSpinState(groupWs, spinConfig, SpinStateValidator::ZERO_ONE);
   auto const &t00Ws = workspaceForSpinState(groupWs, spinConfig, SpinStateValidator::ZERO_ZERO);
 
-  auto const &numerator = t00Ws - t01Ws + t11Ws - t10Ws;
-  auto const &denominator = 2 * (t00Ws - t01Ws);
+  auto const &numerator = (t11Ws * t00Ws) - (t10Ws * t01Ws);
+  auto const &denominator = (t11Ws + t10Ws) * (t00Ws - t01Ws);
   auto const &efficiency = numerator / denominator;
   return efficiency;
 }

--- a/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/FlipperEfficiency.cpp
@@ -52,6 +52,22 @@ void FlipperEfficiency::init() {
                   "File name or path for the output to be saved to.");
 }
 
+namespace {
+void validateInputWorkspace(Mantid::API::MatrixWorkspace_sptr const &workspace,
+                            std::map<std::string, std::string> &problems) {
+  Kernel::Unit_const_sptr unit = workspace->getAxis(0)->unit();
+  if (unit->unitID() != "Wavelength") {
+    problems[PropNames::INPUT_WS] = "All input workspaces must be in units of Wavelength.";
+    return;
+  }
+
+  if (workspace->getNumberHistograms() != 1) {
+    problems[PropNames::INPUT_WS] = "All input workspaces must contain only a single spectrum.";
+    return;
+  }
+}
+} // namespace
+
 std::map<std::string, std::string> FlipperEfficiency::validateInputs() {
   std::map<std::string, std::string> problems;
   // Check input.
@@ -66,10 +82,7 @@ std::map<std::string, std::string> FlipperEfficiency::validateInputs() {
   } else {
     for (size_t i = 0; i < groupWs->size(); ++i) {
       MatrixWorkspace_sptr const stateWs = std::dynamic_pointer_cast<MatrixWorkspace>(groupWs->getItem(i));
-      Unit_const_sptr unit = stateWs->getAxis(0)->unit();
-      if (unit->unitID() != "Wavelength") {
-        problems[PropNames::INPUT_WS] = "All input workspaces must be in units of Wavelength.";
-      }
+      validateInputWorkspace(stateWs, problems);
     }
   }
 

--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -122,6 +122,14 @@ public:
                             std::string(e.what()), "Enter a name for the Input/InOut workspace")
   }
 
+  void test_invalid_workspace_length_is_captured() {
+    auto const &group = createTestingWorkspace("testWs", 1.0, false, 2);
+    auto alg = initialize_alg(group);
+    TS_ASSERT_THROWS_EQUALS(
+        alg->execute(), std::runtime_error const &e, std::string(e.what()),
+        "Some invalid Properties found: \n InputWorkspace: All input workspaces must contain only a single spectrum.")
+  }
+
   /// Calculation Tests
 
   void test_normal_perfect_calculation_occurs() {
@@ -153,7 +161,7 @@ private:
 
   Mantid::API::WorkspaceGroup_sptr createTestingWorkspace(std::string const &outName,
                                                           double const flipAmplitudeMultiplier = 1.0,
-                                                          bool const TOFWs = false) {
+                                                          bool const TOFWs = false, int const numBanks = 1) {
 
     CreateSampleWorkspace makeWsAlg;
     makeWsAlg.initialize();
@@ -163,7 +171,7 @@ private:
     } else {
       makeWsAlg.setPropertyValue("XUnit", "wavelength");
     }
-    makeWsAlg.setProperty("NumBanks", 1);
+    makeWsAlg.setProperty("NumBanks", numBanks);
     makeWsAlg.setProperty("BankPixelWidth", 1);
     makeWsAlg.setProperty("XMin", 1.45);
     makeWsAlg.setProperty("XMax", 9.50);

--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -144,7 +144,7 @@ public:
     TS_ASSERT_EQUALS(outWs->getNumberHistograms(),
                      std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(group->getItem(0))->getNumberHistograms())
     for (const double &eff : outWs->dataY(0)) {
-      TS_ASSERT_DELTA(0.9333333333, eff, 1e-8);
+      TS_ASSERT_DELTA(0.9710144925, eff, 1e-8);
     }
   }
 

--- a/docs/source/algorithms/FlipperEfficiency-v1.rst
+++ b/docs/source/algorithms/FlipperEfficiency-v1.rst
@@ -9,22 +9,23 @@
 Description
 -----------
 
-Calculates the efficiency of a single flipper  with regards to wavelength. The input workspace must be a group workspace
-containing four known spin states, which can be given by the ``SpinStates`` parameter. It then uses these four spin
-states to calculate the proportion of neutrons lost to the flipper with regards to wavelength.
+Calculates the efficiency of a single flipper as a function of wavelength, as described by Wildes [#WILDES]_ and by Krycka et al. [#KRYCKA]_.
+The input workspace must be a group of four single spectrum workspaces,
+each representing the transmission of a known spin state as specified by the ``SpinStates`` parameter. These four spin
+state transmissions are used to calculate the proportion of neutrons lost to the flipper as a function of wavelength.
 
 The polarization of the flipper :math:`P_{F}` is given by:
 
 .. math::
 
-   P_F = \frac{T_{11} - T_{10}}{T_{00} - T_{01}}
+   P_F = \frac{(\frac{T_{11} - T_{10}}{T_{11} + T_{10}})}{(\frac{T_{00} - T_{01}}{T_{00} + T_{01}})}
 
 Since the efficiency :math:`\epsilon_{F}` is equal to :math:`\frac{1 + P_{F}}{2}`, we can calculate the efficiency of
 the flipper directly using:
 
 .. math::
 
-   \epsilon_{F} = \frac{T_{00} - T_{01} + T_{11} - T_{10}}{2(T_{00} - T_{01})}
+   \epsilon_{F} = \frac{T_{11}T_{00} - T_{10}T_{01}}{(T_{11} + T_{10})(T_{00} - T_{01})}
 
 
 Outputs
@@ -65,6 +66,14 @@ Output:
     :options: +ELLIPSIS +NORMALIZE_WHITESPACE
 
     Flipper efficiency at a wavelength of 0.3 Å is ...
+
+References
+----------
+
+.. [#WILDES] A. R. Wildes, *Neutron News*, **17** 17 (2006)
+             `doi: 10.1080/10448630600668738 <https://doi.org/10.1080/10448630600668738>`_
+.. [#KRYCKA] K. Krycka et al., *J. Appl. Crystallogr.*, **45** (2012)
+             `doi: 10.1107/S0021889812003445 <https://doi.org/10.1107/S0021889812003445>`_
 
 .. categories::
 


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
This PR makes a couple of amendments to the `FlipperEfficiency` algorithm following feedback from our scientists. It also adds appropriate references to the algorithm documentation.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37448
Refs #37459 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
- Amends the efficiency calculation so that it includes the required normalisation to account for transmission measurements taken on a monitor.
- Adds validation to enforce that input workspaces should all contain a single spectrum.
- Updates the algorithm documentation, including adding appropriate references.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

1) Run the following script:

```
CreateSampleWorkspace(OutputWorkspace='out_00', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=48000, PeakCentre=2.65, FWHM=1.2', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
CreateSampleWorkspace(OutputWorkspace='out_11', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=47000, PeakCentre=2.65, FWHM=1.2', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
CreateSampleWorkspace(OutputWorkspace='out_10', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=22685, PeakCentre=2.55, FWHM=0.6', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
CreateSampleWorkspace(OutputWorkspace='out_01', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=22685, PeakCentre=2.55, FWHM=0.6', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)

group = GroupWorkspaces(['out_00','out_11','out_10','out_01'])

group = ConvertUnits(group, "Wavelength")

out = FlipperEfficiency(group, SpinStates="00, 11, 10, 01")

print("Flipper efficiency at a wavelength of " + str(mtd['out'].dataX(0)[3]) + " Å is " + str(mtd['out'].dataY(0)[3]))
```

The print statement should give:

> Flipper efficiency at a wavelength of 0.30000000000000004 Å is 0.9938100675522241

2) Now run this script, which creates input workspaces with more than one spectrum:

```
CreateSampleWorkspace(OutputWorkspace='out_00', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=48000, PeakCentre=2.65, FWHM=1.2', XUnit='wavelength', NumBanks=2, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
CreateSampleWorkspace(OutputWorkspace='out_11', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=47000, PeakCentre=2.65, FWHM=1.2', XUnit='wavelength', NumBanks=2, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
CreateSampleWorkspace(OutputWorkspace='out_10', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=22685, PeakCentre=2.55, FWHM=0.6', XUnit='wavelength', NumBanks=2, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
CreateSampleWorkspace(OutputWorkspace='out_01', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=22685, PeakCentre=2.55, FWHM=0.6', XUnit='wavelength', NumBanks=2, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)

group = GroupWorkspaces(['out_00','out_11','out_10','out_01'])

group = ConvertUnits(group, "Wavelength")

out = FlipperEfficiency(group, SpinStates="00, 11, 10, 01")
```
This should give the following error:

> All input workspaces must contain only a single spectrum.

*This does not require release notes* because **it is an amendment to an algorithm that will be new in version 6.10**.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
