### PR TITLE
Fix PulseIndexer when everything is filtered

### DIFF
--- a/Framework/DataHandling/src/PulseIndexer.cpp
+++ b/Framework/DataHandling/src/PulseIndexer.cpp
@@ -32,7 +32,14 @@ PulseIndexer::PulseIndexer(std::shared_ptr<std::vector<uint64_t>> event_index, c
     // new roi is the intersection of these two
     auto roi_combined = Mantid::Kernel::ROI::calculate_intersection(m_roi, pulse_roi);
     m_roi.clear();
-    m_roi.assign(roi_combined.cbegin(), roi_combined.cend());
+    if (roi_combined.empty()) {
+      // if roi_combined is empty then no pulses should be included, just set range to 0
+      m_roi.push_back(0);
+      m_roi.push_back(0);
+      m_roi_complex = false;
+      return;
+    } else
+      m_roi.assign(roi_combined.cbegin(), roi_combined.cend());
     m_roi_complex = bool(m_roi.size() > 2);
   }
 
@@ -56,7 +63,12 @@ PulseIndexer::PulseIndexer(std::shared_ptr<std::vector<uint64_t>> event_index, c
   if ((firstPulseIndex != m_roi.front()) || (lastPulseIndex != m_roi.back())) {
     auto roi_combined = Mantid::Kernel::ROI::calculate_intersection(m_roi, {firstPulseIndex, lastPulseIndex});
     m_roi.clear();
-    m_roi.assign(roi_combined.cbegin(), roi_combined.cend());
+    if (roi_combined.empty()) {
+      // if roi_combined is empty then no pulses should be included, just set range to 0
+      m_roi.push_back(0);
+      m_roi.push_back(0);
+    } else
+      m_roi.assign(roi_combined.cbegin(), roi_combined.cend());
   }
 
   // after the updates, recalculate if the roi is more than a single region

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -915,6 +915,27 @@ public:
     TS_ASSERT_EQUALS(WS, ads.retrieveWS<MatrixWorkspace>("cncs_compressed")->monitorWorkspace());
   }
 
+  void test_Load_And_Filter_Everything() {
+    // This test set the FilterByTimeStart value so that everything should be filtered
+    // So we should end up with 0 events
+    const std::string filename{"ARCS_sim_event.nxs"};
+    std::string ws_name = "arcs_filtered0";
+    LoadEventNexus ld;
+    ld.initialize();
+    ld.setPropertyValue("Filename", filename);
+    ld.setPropertyValue("OutputWorkspace", ws_name);
+    ld.setPropertyValue("FilterByTimeStart", "1000");
+    ld.setProperty("NumberOfBins", 1);
+    ld.execute();
+    TS_ASSERT(ld.isExecuted());
+
+    EventWorkspace_sptr ws;
+    TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(ws_name));
+    TS_ASSERT(ws); // it is an EventWorkspace
+
+    TS_ASSERT_EQUALS(ws->getNumberEvents(), 0);
+  }
+
   void test_Load_And_CompressEvents_weighted() {
     constexpr std::size_t NUM_HIST{117760};
     const std::string filename{"ARCS_sim_event.nxs"};


### PR DESCRIPTION
### Description of work

Discovered while working on #37470

It is due to changes from https://github.com/mantidproject/mantid/pull/37141 which was only added in the 6.10 release.

When all events should be filtered, then PulseIndexer should return nothing. But the real bahaviour is chaotic and OS dependent. Also different if using jemalloc or not.

It can fail by either getting stuck in an infinite loop, segmentation fault or just giving the wrong answer.

On linux from the command line, not workbench, you get

```python
ws = LoadEventNexus("ARCS_sim_event.nxs")
print(ws.getNumberEvents())
```

gives `128`

But

```python
ws = LoadEventNexus("ARCS_sim_event.nxs", FilterByTimeStart=1000)
print(ws.getNumberEvents())
```

gives `2689` when it should be `0`. You end up with more events if you filter :laughing:  (mantid 6.9 gives `0`)

I pushed the failing test first so you can see how it fails on different OS's on the build servers.

Linux failed by ([link](https://builds.mantidproject.org/job/pull_requests-conda-linux/7580/))
```
/jenkins_workdir/workspace/pull_requests-conda-linux/Framework/DataHandling/test/LoadEventNexusTest.h:936: Error: Expected (ws->getNumberEvents() == 0), found (2241 != 0)
```

Windows failed by ([link](https://builds.mantidproject.org/job/pull_requests-conda-windows/6282/))

```
Access violation
```

OSX failed by ([link](https://builds.mantidproject.org/job/pull_requests-conda-osx/6128/))

```
Segmentation fault
```

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes *There is no associated issue.*


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

```python
ws = LoadEventNexus("ARCS_sim_event.nxs", FilterByTimeStart=1000)
print(ws.getNumberEvents())
```

should give `0`.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


*This does not require release notes* because this bug was only introduced during this release.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
