### PR TITLE
clarify report usage data checkbox

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/New_features/33275.rst
+++ b/docs/source/release/v6.11.0/Workbench/New_features/33275.rst
@@ -1,0 +1,1 @@
+- Clarified ``Report Usage Data`` checkbox on the Workbench About page to explain that usage reporting is required to use the Error Reporter.

--- a/qt/applications/workbench/workbench/widgets/about/usage_verification_view.py
+++ b/qt/applications/workbench/workbench/widgets/about/usage_verification_view.py
@@ -48,7 +48,8 @@ class UsageReportingVerificationView(QDialog):
             "All usage data is anonymous and untraceable.\n"
             "We use the usage data to inform the future development of Mantid.\n\n"
             "Disabling usage reporting means features you need risk being deprecated in\n"
-            "future versions if we think they are not used."
+            "future versions if we think they are not used.\n\n"
+            "Error reporting will also be disabled."
         )
         textLayout.addWidget(labelInformation)
 

--- a/qt/applications/workbench/workbench/widgets/about/view.py
+++ b/qt/applications/workbench/workbench/widgets/about/view.py
@@ -275,7 +275,6 @@ font: {self.rescale_w(12)}px;
         personal_setup_form_layout.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
         personal_setup_form_layout.setHorizontalSpacing(self.rescale_w(5))
         personal_setup_form_layout.setVerticalSpacing(self.rescale_h(5))
-        personal_setup_form_layout.setLabelAlignment(Qt.AlignRight)
         # default Facility
         lbl_default_facilty = QLabel()
         lbl_default_facilty.setText("Default Facility")
@@ -291,7 +290,10 @@ font: {self.rescale_w(12)}px;
         personal_setup_form_layout.addRow(lbl_mud, self.pb_manage_user_directories)
         # Usage data
         lbl_allow_usage_data = QLabel()
-        lbl_allow_usage_data.setText("Report Usage Data")
+        lbl_allow_usage_data.setText(
+            f"<span style='text-align: right; font-size:{self.rescale_h(12)}px;'>Report Usage Data</span><br/>"
+            f"<span style='text-align: right; font-size:{self.rescale_h(8)}px;'>Required to use the Error Reporter</span>"
+        )
         usagelayout = QHBoxLayout()
         usagelayout.setContentsMargins(0, 0, 0, 0)
         self.chk_allow_usage_data.setChecked(True)


### PR DESCRIPTION
### Description of work

The 'Report Usage Data' option on the about widget is required for the Error Reporter to launch. I have been confused by this in the past.

Added a note below the label to mention this and a line in the warning that appears when you uncheck the box

Fixes #33275

### To test:

Launch workbench and check things are formatting correctly, and the warnings make sense.


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
