### PR TITLE
Optionally Output Fit Results in HeliumAnalyserEfficiency Algorithm

### DIFF
--- a/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
@@ -205,6 +205,13 @@ void HeliumAnalyserEfficiency::fitAnalyserEfficiency(const double mu, MatrixWork
   ITableWorkspace_sptr fitParameters = fit->getProperty("OutputParameters");
   MatrixWorkspace_sptr fitWorkspace = fit->getProperty("OutputWorkspace");
 
+  if (!getPropertyValue(PropertyNames::OUTPUT_FIT_PARAMS).empty()) {
+    setProperty(PropertyNames::OUTPUT_FIT_PARAMS, fitParameters);
+  }
+  if (!API::Algorithm::getPropertyValue(PropertyNames::OUTPUT_FIT_CURVES).empty()) {
+    setProperty(PropertyNames::OUTPUT_FIT_CURVES, fitWorkspace);
+  }
+
   pHe = fitParameters->getRef<double>("Value", 0);
   pHeError = fitParameters->getRef<double>("Error", 0);
   eCalc = MantidVec(wavelengthValues.size());

--- a/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
@@ -30,16 +30,16 @@ using namespace API;
 constexpr double HeliumAnalyserEfficiency::ABSORPTION_CROSS_SECTION_CONSTANT = 0.0733;
 
 namespace PropertyNames {
-static const std::string INPUT_WORKSPACE = "InputWorkspace";
-static const std::string OUTPUT_WORKSPACE = "OutputWorkspace";
-static const std::string SPIN_STATES = "SpinStates";
-static const std::string PD = "GasPressureTimesCellLength";
-static const std::string PD_ERROR = "GasPressureTimesCellLengthError";
-static const std::string START_LAMBDA = "StartLambda";
-static const std::string END_LAMBDA = "EndLambda";
-static const std::string IGNORE_FIT_QUALITY_ERROR = "IgnoreFitQualityError";
-static const std::string GROUP_INPUTS = "Inputs";
-static const std::string GROUP_FIT_OPTIONS = "Fit Options";
+auto constexpr INPUT_WORKSPACE{"InputWorkspace"};
+auto constexpr OUTPUT_WORKSPACE{"OutputWorkspace"};
+auto constexpr SPIN_STATES{"SpinStates"};
+auto constexpr PD{"GasPressureTimesCellLength"};
+auto constexpr PD_ERROR{"GasPressureTimesCellLengthError"};
+auto constexpr START_LAMBDA{"StartLambda"};
+auto constexpr END_LAMBDA{"EndLambda"};
+auto constexpr IGNORE_FIT_QUALITY_ERROR{"IgnoreFitQualityError"};
+auto constexpr GROUP_INPUTS{"Inputs"};
+auto constexpr GROUP_FIT_OPTIONS{"Fit Options"};
 } // namespace PropertyNames
 
 void HeliumAnalyserEfficiency::init() {

--- a/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
@@ -32,14 +32,18 @@ constexpr double HeliumAnalyserEfficiency::ABSORPTION_CROSS_SECTION_CONSTANT = 0
 namespace PropertyNames {
 auto constexpr INPUT_WORKSPACE{"InputWorkspace"};
 auto constexpr OUTPUT_WORKSPACE{"OutputWorkspace"};
+auto constexpr OUTPUT_FIT_CURVES{"OutputFitCurves"};
+auto constexpr OUTPUT_FIT_PARAMS{"OutputFitParameters"};
 auto constexpr SPIN_STATES{"SpinStates"};
 auto constexpr PD{"GasPressureTimesCellLength"};
 auto constexpr PD_ERROR{"GasPressureTimesCellLengthError"};
 auto constexpr START_LAMBDA{"StartLambda"};
 auto constexpr END_LAMBDA{"EndLambda"};
 auto constexpr IGNORE_FIT_QUALITY_ERROR{"IgnoreFitQualityError"};
+
 auto constexpr GROUP_INPUTS{"Inputs"};
 auto constexpr GROUP_FIT_OPTIONS{"Fit Options"};
+auto constexpr GROUP_OUTPUTS{"Outputs"};
 } // namespace PropertyNames
 
 void HeliumAnalyserEfficiency::init() {
@@ -50,8 +54,6 @@ void HeliumAnalyserEfficiency::init() {
   declareProperty(
       std::make_unique<WorkspaceProperty<>>(PropertyNames::INPUT_WORKSPACE, "", Direction::Input, validator),
       "Input group workspace to use for polarization calculation");
-  declareProperty(std::make_unique<WorkspaceProperty<>>(PropertyNames::OUTPUT_WORKSPACE, "", Direction::Output),
-                  "Helium analyzer efficiency as a function of wavelength");
 
   auto spinValidator = std::make_shared<SpinStateValidator>(std::unordered_set<int>{4});
   declareProperty(PropertyNames::SPIN_STATES, "11,10,01,00", spinValidator,
@@ -69,6 +71,16 @@ void HeliumAnalyserEfficiency::init() {
                   "Whether the algorithm should ignore a poor chi-squared (fit cost value) of greater than 1 and "
                   "therefore not throw an error",
                   Direction::Input);
+  declareProperty(std::make_unique<WorkspaceProperty<>>(PropertyNames::OUTPUT_WORKSPACE, "", Direction::Output),
+                  "Helium analyzer efficiency as a function of wavelength");
+  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(std::string(PropertyNames::OUTPUT_FIT_CURVES),
+                                                                       "", Kernel::Direction::Output,
+                                                                       PropertyMode::Optional),
+                  "The name of the matrix workspace containing the calculated fit curve.");
+  declareProperty(std::make_unique<WorkspaceProperty<ITableWorkspace>>(std::string(PropertyNames::OUTPUT_FIT_PARAMS),
+                                                                       "", Kernel::Direction::Output,
+                                                                       PropertyMode::Optional),
+                  "The name of the table workspace containing the fit parameter results.");
 
   setPropertyGroup(PropertyNames::SPIN_STATES, PropertyNames::GROUP_INPUTS);
   setPropertyGroup(PropertyNames::PD, PropertyNames::GROUP_INPUTS);
@@ -77,6 +89,10 @@ void HeliumAnalyserEfficiency::init() {
   setPropertyGroup(PropertyNames::START_LAMBDA, PropertyNames::GROUP_FIT_OPTIONS);
   setPropertyGroup(PropertyNames::END_LAMBDA, PropertyNames::GROUP_FIT_OPTIONS);
   setPropertyGroup(PropertyNames::IGNORE_FIT_QUALITY_ERROR, PropertyNames::GROUP_FIT_OPTIONS);
+
+  setPropertyGroup(PropertyNames::OUTPUT_WORKSPACE, PropertyNames::GROUP_OUTPUTS);
+  setPropertyGroup(PropertyNames::OUTPUT_FIT_CURVES, PropertyNames::GROUP_OUTPUTS);
+  setPropertyGroup(PropertyNames::OUTPUT_FIT_PARAMS, PropertyNames::GROUP_OUTPUTS);
 }
 
 /**

--- a/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
@@ -76,7 +76,8 @@ void HeliumAnalyserEfficiency::init() {
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(std::string(PropertyNames::OUTPUT_FIT_CURVES),
                                                                        "", Kernel::Direction::Output,
                                                                        PropertyMode::Optional),
-                  "The name of the matrix workspace containing the calculated fit curve.");
+                  "The name of the matrix workspace containing the calculated fit curve, the original data, and the "
+                  "difference between the two.");
   declareProperty(std::make_unique<WorkspaceProperty<ITableWorkspace>>(std::string(PropertyNames::OUTPUT_FIT_PARAMS),
                                                                        "", Kernel::Direction::Output,
                                                                        PropertyMode::Optional),

--- a/Framework/Algorithms/test/PolarizationCorrections/HeliumAnalyserEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/HeliumAnalyserEfficiencyTest.h
@@ -114,6 +114,25 @@ public:
     TS_ASSERT_EQUALS(originalXPoints.size(), xPoints.size());
   }
 
+  void testFitCurvesOutputWhenOptionalPropertySet() {
+    // GIVEN
+    MantidVec e;
+    const WorkspaceGroup_sptr &wsGrp = createExampleGroupWorkspace("wsGrp", e, "Wavelength");
+    auto alg = createHeliumAnalyserEfficiencyAlgorithm(wsGrp, "E");
+
+    // WHEN
+    alg->setPropertyValue("OutputFitCurves", "__unused_for_child");
+    alg->setChild(true);
+    alg->execute();
+
+    // THEN
+    TS_ASSERT(alg->isExecuted());
+    const MatrixWorkspace_sptr &outputWs = alg->getProperty("OutputWorkspace");
+    const MatrixWorkspace_sptr &fitWs = alg->getProperty("OutputFitCurves");
+    TS_ASSERT_EQUALS(outputWs->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(fitWs->getNumberHistograms(), 3);
+  }
+
 private:
   IAlgorithm_sptr createHeliumAnalyserEfficiencyAlgorithm(WorkspaceGroup_sptr inputWs,
                                                           const std::string &outputWsName) {

--- a/Framework/Algorithms/test/PolarizationCorrections/HeliumAnalyserEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/HeliumAnalyserEfficiencyTest.h
@@ -133,6 +133,26 @@ public:
     TS_ASSERT_EQUALS(fitWs->getNumberHistograms(), 3);
   }
 
+  void testParametersTableOutputWhenOptionalPropertySet() {
+    // GIVEN
+    MantidVec e;
+    const WorkspaceGroup_sptr &wsGrp = createExampleGroupWorkspace("wsGrp", e, "Wavelength");
+    auto alg = createHeliumAnalyserEfficiencyAlgorithm(wsGrp, "E");
+
+    // WHEN
+    alg->setPropertyValue("OutputFitParameters", "__unused_for_child");
+    alg->setChild(true);
+    alg->execute();
+
+    // THEN
+    TS_ASSERT(alg->isExecuted());
+    const MatrixWorkspace_sptr &outputWs = alg->getProperty("OutputWorkspace");
+    const ITableWorkspace_sptr &paramsWs = alg->getProperty("OutputFitParameters");
+    TS_ASSERT_EQUALS(outputWs->getNumberHistograms(), 1);
+    const std::vector<std::string> &expectedColumns = {"Name", "Value", "Error"};
+    TS_ASSERT_EQUALS(paramsWs->getColumnNames(), expectedColumns);
+  }
+
 private:
   IAlgorithm_sptr createHeliumAnalyserEfficiencyAlgorithm(WorkspaceGroup_sptr inputWs,
                                                           const std::string &outputWsName) {


### PR DESCRIPTION
### Description of work

#### Summary of work
Add a couple of additional properties to the algorithm that can output the results from the fitting algorithm that is run internally. 

Fixes #37447 

#### Further detail of work
Adds two new optional properties `OutputFitCurves` and `OutputFitParameters` that output the resulting fit workspace and the parameters table workspace respectively. One, either, or both can be given for flexibility. Also did some refactoring to simplify the algorithm. 

### To test:
1. Build the docs
2. Use the script from [the docs](https://docs.mantidproject.org/nightly/algorithms/HeliumAnalyserEfficiency-v1.html) to run the algorithm.
```python
wsPara = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=0.5*exp(-0.0733*12*x*(1-0.9))',XUnit='Wavelength', xMin='1',XMax='8', BinWidth='1')
wsPara1 = CloneWorkspace(wsPara)
wsAnti = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=0.5*exp(-0.0733*12*x*(1+0.9))',XUnit='Wavelength', xMin='1',XMax='8', BinWidth='1')
wsAnti1 = CloneWorkspace(wsAnti)

grp = GroupWorkspaces([wsPara,wsAnti,wsPara1,wsAnti1])
eff = HeliumAnalyserEfficiency(grp, SpinStates='11,01,00,10')

print('Efficiency at ' + str(mtd['eff'].dataX(0)[0]) + ' Å = ' + str(mtd['eff'].dataY(0)[0]))
print('Error in efficiency at ' + str(mtd['eff'].dataX(0)[0]) + ' Å = ' + str(mtd['eff'].dataE(0)[0]))
```
3. Check it runs as normal and produces an output workspace. 
4. Now run it with the new properties. 
```python
wsPara = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=0.5*exp(-0.0733*12*x*(1-0.9))',XUnit='Wavelength', xMin='1',XMax='8', BinWidth='1')
wsPara1 = CloneWorkspace(wsPara)
wsAnti = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=0.5*exp(-0.0733*12*x*(1+0.9))',XUnit='Wavelength', xMin='1',XMax='8', BinWidth='1')
wsAnti1 = CloneWorkspace(wsAnti)

grp = GroupWorkspaces([wsPara,wsAnti,wsPara1,wsAnti1])
eff = HeliumAnalyserEfficiency(grp, SpinStates='11,01,00,10', OutputFitParameters="fit_params", OutputFitCurves="curves")

print('Efficiency at ' + str(mtd['eff'].dataX(0)[0]) + ' Å = ' + str(mtd['eff'].dataY(0)[0]))
print('Error in efficiency at ' + str(mtd['eff'].dataX(0)[0]) + ' Å = ' + str(mtd['eff'].dataE(0)[0]))
```

*This does not require release notes* because **it changes functionality that was new to mantid 6.10.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
