### PR TITLE
Change (debug build) optimisation option for gcc on linux

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,7 +31,7 @@
       "description": "Inherited by all Unix-like presets for debugging. Overrides Conda CXX flags for debugging",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS_DEBUG": "-g -O0",
+        "CMAKE_CXX_FLAGS_DEBUG": "-g -Og",
         "CMAKE_BUILD_TYPE": "Debug"
       }
     },


### PR DESCRIPTION
The `-Og` optimisation option is recommended for 'the standard edit-compile-debug cycle'. Using this instead of `-O0` also stops the `-FORTIFY_SOURCE` warning from spamming the terminal on Linux. This warning occurred because we have `FORTIFY_SOURCE=2` in our config but all compiler optimisations were off. The `-Og` option switches on optimisations that do not interfere with debugging. This will also hopefully make debug Mantid slightly faster as a happy side effect.

For more information on the `gcc` optimisation options see [here](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-Og)

For more information on `FORTIFY_SOURCE` see [here](https://www.gnu.org/software/libc/manual/html_node/Source-Fortification.html)

### To test:

You should be able to compile on Linux without receiving the following warning:

```
warning: #warning _FORTIFY_SOURCE requires compiling with opimization (-O) [-Wcpp]
```

Make sure to explicitly run `cmake --preset=linux` before compiling so the changes are picked up.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **it only affects developers.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
