### PR TITLE
Remove reference to deprecated numpy.distutils

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
@@ -693,7 +693,7 @@ def is_sequence(seq):
 def calc_hessian(func, x0, step_size, *args):
     nparam = len(x0)
     if not is_sequence(step_size):
-        step_size = nparam * [epsilon]
+        step_size = nparam * [step_size]
     hessian = np.zeros((nparam, nparam))
     jac = approx_fprime(x0, func, step_size, *args)
     for iparam in range(nparam):

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
@@ -30,7 +30,7 @@ from mantid.kernel import (
 )
 from mantid.fitfunctions import FunctionWrapper
 import numpy as np
-from numpy.distutils.misc_util import is_sequence
+from collections.abc import Sequence
 from scipy.optimize import approx_fprime, minimize
 from scipy.ndimage import binary_dilation
 from IntegratePeaksSkew import InstrumentArrayConverter, get_fwhm_from_back_to_back_params
@@ -680,6 +680,14 @@ def calc_sigma_from_hessian(result, profile_func, x, y, weights, cost_func, nfix
     hess = calc_hessian(calc_cost_func, result.x, step_size, profile_func, x, y, weights, cost_func)
     cov = np.linalg.inv(hess) * 2.0 * result.fun / (len(y) - (len(result.x) - nfixed))
     return np.sqrt(cov[0, 0])  # first parameter is intenisity for BackToBackExponential (only func supported)
+
+
+def is_sequence(seq):
+    # Strings are sequences so check for those separately
+    if isinstance(seq, str):
+        return False
+    # NumPy array is not a Sequence
+    return isinstance(seq, np.ndarray) or isinstance(seq, Sequence)
 
 
 def calc_hessian(func, x0, step_size, *args):

--- a/docs/source/release/v6.11.0/Framework/Algorithms/Bugfixes/37421.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/Bugfixes/37421.rst
@@ -1,0 +1,1 @@
+- Remove reference to `numpy.distutils` in `IntegratePeaks1DProfile`, since as of NumPy 1.23.0 it is deprecated.


### PR DESCRIPTION
As of NumPy 1.23.0, `numpy.distutils` is deprecated. It was used here to check if an argument is a sequence, so I just implemented an equivalent method and deleted the `numpy.distutils` import.

See [here](https://github.com/numpy/numpy/blob/v1.26.0/numpy/distutils/misc_util.py#L497-L504) for what NumPy was doing.

Fixes #37421 

### To test:

Tests should pass, `IntegratePeaks1DProfile` should still work.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
