### PR TITLE
Fix link to Data Processor Interface in release note index for v6.10

### DIFF
--- a/docs/source/release/v6.10.0/index.rst
+++ b/docs/source/release/v6.10.0/index.rst
@@ -43,7 +43,7 @@ Other important highlights include:
 - New detector grouping options on the :ref:`interface-indirect-diffraction` interface
   (including ``All``, ``Groups``, ``Custom`` and ``File`` options).
 - New way to easily load multiple files into :ref:`Elwin Tab <elwin>` of
-  :ref:`Data Manipulation Interface <interface-inelastic-data-manipulation>`.
+  :ref:`Data Processor Interface <interface-inelastic-data-manipulation>`.
 
 These are just some of the many improvements in this release, so please take a
 look at the release notes, which are filled with details of the


### PR DESCRIPTION
### Description of work
A change to the index of the v6.10 release notes to deal with 
#### Summary of work
Change to link to Data Manipulation Processor page from index of v6.10 release notes.


#### Purpose of work
Doc Test failures on several PRs indicated that there is a problem with line 45 of the index page of the v6.10 release notes. 

```
/jenkins_workdir/workspace/pull_requests-doc-tests/docs/source/release/v6.10.0/index.rst:45: WARNING: undefined label: 'interface-inelastic-data-manipulation'
```

Recent changes to naming of the interface undertaken in #37467 may have been the cause.

*There is no associated issue.*


### To test:

- Doc tests should pass




---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
