### PR TITLE
Only Change PxD when Fitting Polarised SANS Analyser Transmission (`release-next` Special Edition)

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/DepolarizedAnalyserTransmission.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/DepolarizedAnalyserTransmission.h
@@ -41,9 +41,5 @@ private:
 
   /// Fit using UserFunction1D to find the pxd and transmission values.
   void calcWavelengthDependentTransmission(API::MatrixWorkspace_sptr const &inputWs, std::string const &outputWsName);
-
-  /// Calculate and output the non-normalised covariance matrix for the fit.
-  void calcNonNormCovarianceMatrix(API::ITableWorkspace_sptr const &normCovMatrix,
-                                   API::ITableWorkspace_sptr const &paramsWs);
 };
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/PolarizationCorrections/DepolarizedAnalyserTransmission.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/DepolarizedAnalyserTransmission.cpp
@@ -14,29 +14,29 @@
 namespace {
 /// Property Names
 namespace PropNames {
-std::string_view constexpr DEP_WORKSPACE{"DepolarizedWorkspace"};
-std::string_view constexpr MT_WORKSPACE{"EmptyCellWorkspace"};
-std::string_view constexpr DEPOL_OPACITY_START{"PxDStartingValue"};
-std::string_view constexpr START_X = "StartX";
-std::string_view constexpr END_X = "EndX";
-std::string_view constexpr IGNORE_FIT_QUALITY{"IgnoreFitQualityError"};
-std::string_view constexpr OUTPUT_WORKSPACE{"OutputWorkspace"};
-std::string_view constexpr OUTPUT_FIT{"OutputFitCurves"};
-std::string_view constexpr GROUP_INPUT{"Input Workspaces"};
-std::string_view constexpr GROUP_OUTPUT{"Output Workspaces"};
-std::string_view constexpr GROUP_FIT{"Fit Starting Values"};
+auto constexpr DEP_WORKSPACE{"DepolarizedWorkspace"};
+auto constexpr MT_WORKSPACE{"EmptyCellWorkspace"};
+auto constexpr DEPOL_OPACITY_START{"PxDStartingValue"};
+auto constexpr START_X = "StartX";
+auto constexpr END_X = "EndX";
+auto constexpr IGNORE_FIT_QUALITY{"IgnoreFitQualityError"};
+auto constexpr OUTPUT_WORKSPACE{"OutputWorkspace"};
+auto constexpr OUTPUT_FIT{"OutputFitCurves"};
+auto constexpr GROUP_INPUT{"Input Workspaces"};
+auto constexpr GROUP_OUTPUT{"Output Workspaces"};
+auto constexpr GROUP_FIT{"Fit Starting Values"};
 } // namespace PropNames
 
 /// Initial fitting function values.
 namespace FitValues {
 using namespace Mantid::API;
 
-double constexpr LAMBDA_CONVERSION_FACTOR = -0.0733;
-double constexpr DEPOL_OPACITY_START = 12.6;
-std::string_view constexpr DEPOL_OPACITY_NAME = "pxd";
-double constexpr START_X_START = 1.75;
-double constexpr END_X_START = 14;
-std::string_view constexpr FIT_SUCCESS{"success"};
+auto constexpr LAMBDA_CONVERSION_FACTOR = -0.0733;
+auto constexpr DEPOL_OPACITY_START = 12.6;
+auto constexpr DEPOL_OPACITY_NAME{"pxd"};
+auto constexpr START_X_START = 1.75;
+auto constexpr END_X_START = 14.0;
+auto constexpr FIT_SUCCESS{"success"};
 
 std::shared_ptr<IFunction> createFunction(std::string const &depolOpacStart) {
   std::ostringstream funcSS;
@@ -75,82 +75,81 @@ void DepolarizedAnalyserTransmission::init() {
   wsValidator->add<WorkspaceUnitValidator>("Wavelength");
   wsValidator->add<HistogramValidator>();
   declareProperty(
-      std::make_unique<WorkspaceProperty<MatrixWorkspace>>(std::string(PropNames::DEP_WORKSPACE), "",
-                                                           Kernel::Direction::Input, wsValidator),
+      std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropNames::DEP_WORKSPACE, "", Kernel::Direction::Input,
+                                                           wsValidator),
       "The fully depolarized helium cell workspace. Should contain a single spectra. Units must be in wavelength.");
-  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(std::string(PropNames::MT_WORKSPACE), "",
+  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(PropNames::MT_WORKSPACE, "",
                                                                        Kernel::Direction::Input, wsValidator),
                   "The empty cell workspace. Must contain a single spectra. Units must be in wavelength");
-  declareProperty(std::string(PropNames::DEPOL_OPACITY_START), FitValues::DEPOL_OPACITY_START,
+  declareProperty(PropNames::DEPOL_OPACITY_START, FitValues::DEPOL_OPACITY_START,
                   "Starting value for the depolarized cell transmission fit property " +
                       std::string(FitValues::DEPOL_OPACITY_NAME) + ".");
-  declareProperty(std::string(PropNames::START_X), FitValues::START_X_START, "StartX value for the fit.");
-  declareProperty(std::string(PropNames::END_X), FitValues::END_X_START, "EndX value for the fit.");
-  declareProperty(std::string(PropNames::IGNORE_FIT_QUALITY), false,
+  declareProperty(PropNames::START_X, FitValues::START_X_START, "StartX value for the fit.");
+  declareProperty(PropNames::END_X, FitValues::END_X_START, "EndX value for the fit.");
+  declareProperty(PropNames::IGNORE_FIT_QUALITY, false,
                   "Whether the algorithm should ignore a poor chi-squared (fit cost value) of greater than 1 and "
                   "therefore not throw an error.");
-  declareProperty(std::make_unique<WorkspaceProperty<ITableWorkspace>>(std::string(PropNames::OUTPUT_WORKSPACE), "",
-                                                                       Kernel::Direction::Output),
-                  "The name of the table workspace containing the fit parameter results.");
+  declareProperty(
+      std::make_unique<WorkspaceProperty<ITableWorkspace>>(PropNames::OUTPUT_WORKSPACE, "", Kernel::Direction::Output),
+      "The name of the table workspace containing the fit parameter results.");
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
-                      std::string(PropNames::OUTPUT_FIT), "", Kernel::Direction::Output, PropertyMode::Optional),
+                      PropNames::OUTPUT_FIT, "", Kernel::Direction::Output, PropertyMode::Optional),
                   "The name of the workspace containing the calculated fit curve.");
 
-  auto const &inputGroup = std::string(PropNames::GROUP_INPUT);
-  setPropertyGroup(std::string(PropNames::DEP_WORKSPACE), inputGroup);
-  setPropertyGroup(std::string(PropNames::MT_WORKSPACE), inputGroup);
-  auto const &fitGroup = std::string(PropNames::GROUP_FIT);
-  setPropertyGroup(std::string(PropNames::DEPOL_OPACITY_START), fitGroup);
-  auto const &outputGroup = std::string(PropNames::GROUP_OUTPUT);
-  setPropertyGroup(std::string(PropNames::OUTPUT_WORKSPACE), outputGroup);
-  setPropertyGroup(std::string(PropNames::OUTPUT_FIT), outputGroup);
+  auto const &inputGroup = PropNames::GROUP_INPUT;
+  setPropertyGroup(PropNames::DEP_WORKSPACE, inputGroup);
+  setPropertyGroup(PropNames::MT_WORKSPACE, inputGroup);
+  auto const &fitGroup = PropNames::GROUP_FIT;
+  setPropertyGroup(PropNames::DEPOL_OPACITY_START, fitGroup);
+  auto const &outputGroup = PropNames::GROUP_OUTPUT;
+  setPropertyGroup(PropNames::OUTPUT_WORKSPACE, outputGroup);
+  setPropertyGroup(PropNames::OUTPUT_FIT, outputGroup);
 }
 
 std::map<std::string, std::string> DepolarizedAnalyserTransmission::validateInputs() {
   std::map<std::string, std::string> result;
-  MatrixWorkspace_sptr const &depWs = getProperty(std::string(PropNames::DEP_WORKSPACE));
+  MatrixWorkspace_sptr const &depWs = getProperty(PropNames::DEP_WORKSPACE);
   if (depWs == nullptr) {
-    result[std::string(PropNames::DEP_WORKSPACE)] =
-        std::string(PropNames::DEP_WORKSPACE) + " must be a MatrixWorkspace.";
+    result[PropNames::DEP_WORKSPACE] = std::string(PropNames::DEP_WORKSPACE) + " must be a MatrixWorkspace.";
     return result;
   }
-  validateWorkspace(depWs, std::string(PropNames::DEP_WORKSPACE), result);
+  validateWorkspace(depWs, PropNames::DEP_WORKSPACE, result);
 
-  MatrixWorkspace_sptr const &mtWs = getProperty(std::string(PropNames::MT_WORKSPACE));
+  MatrixWorkspace_sptr const &mtWs = getProperty(PropNames::MT_WORKSPACE);
   if (mtWs == nullptr) {
-    result[std::string(PropNames::MT_WORKSPACE)] = std::string(PropNames::MT_WORKSPACE) + " must be a MatrixWorkspace.";
+    result[PropNames::MT_WORKSPACE] = std::string(PropNames::MT_WORKSPACE) + " must be a MatrixWorkspace.";
     return result;
   }
-  validateWorkspace(mtWs, std::string(PropNames::MT_WORKSPACE), result);
+  validateWorkspace(mtWs, PropNames::MT_WORKSPACE, result);
 
   if (!WorkspaceHelpers::matchingBins(*depWs, *mtWs, true)) {
-    result[std::string(PropNames::DEP_WORKSPACE)] = "The bins in the " + std::string(PropNames::DEP_WORKSPACE) +
-                                                    " and " + std::string(PropNames::MT_WORKSPACE) + " do not match.";
+    result[PropNames::DEP_WORKSPACE] = "The bins in the " + std::string(PropNames::DEP_WORKSPACE) + " and " +
+                                       PropNames::MT_WORKSPACE + " do not match.";
   }
   return result;
 }
 
 void DepolarizedAnalyserTransmission::exec() {
   auto const &dividedWs = calcDepolarizedProportion();
-  calcWavelengthDependentTransmission(dividedWs, getPropertyValue(std::string(PropNames::OUTPUT_WORKSPACE)));
+  calcWavelengthDependentTransmission(dividedWs, getPropertyValue(PropNames::OUTPUT_WORKSPACE));
 }
 
 MatrixWorkspace_sptr DepolarizedAnalyserTransmission::calcDepolarizedProportion() {
-  MatrixWorkspace_sptr const &depWs = getProperty(std::string(PropNames::DEP_WORKSPACE));
-  MatrixWorkspace_sptr const &mtWs = getProperty(std::string(PropNames::MT_WORKSPACE));
+  MatrixWorkspace_sptr const &depWs = getProperty(PropNames::DEP_WORKSPACE);
+  MatrixWorkspace_sptr const &mtWs = getProperty(PropNames::MT_WORKSPACE);
   auto divideAlg = createChildAlgorithm("Divide");
   divideAlg->setProperty("LHSWorkspace", depWs);
   divideAlg->setProperty("RHSWorkspace", mtWs);
   divideAlg->execute();
-  return divideAlg->getProperty(std::string(PropNames::OUTPUT_WORKSPACE));
+  return divideAlg->getProperty(PropNames::OUTPUT_WORKSPACE);
 }
 
 void DepolarizedAnalyserTransmission::calcWavelengthDependentTransmission(MatrixWorkspace_sptr const &inputWs,
                                                                           std::string const &outputWsName) {
-  auto func = FitValues::createFunction(getPropertyValue(std::string(PropNames::DEPOL_OPACITY_START)));
+  auto func = FitValues::createFunction(getPropertyValue(PropNames::DEPOL_OPACITY_START));
   auto fitAlg = createChildAlgorithm("Fit");
-  double const &startX = getProperty(std::string(PropNames::START_X));
-  double const &endX = getProperty(std::string(PropNames::END_X));
+  double const &startX = getProperty(PropNames::START_X);
+  double const &endX = getProperty(PropNames::END_X);
   fitAlg->setProperty("Function", func);
   fitAlg->setProperty("InputWorkspace", inputWs);
   fitAlg->setProperty("IgnoreInvalidData", true);
@@ -165,7 +164,7 @@ void DepolarizedAnalyserTransmission::calcWavelengthDependentTransmission(Matrix
     throw std::runtime_error(errMsg);
   }
   double const &fitQuality = fitAlg->getProperty("OutputChi2overDoF");
-  bool const &qualityOverride = getProperty(std::string(PropNames::IGNORE_FIT_QUALITY));
+  bool const &qualityOverride = getProperty(PropNames::IGNORE_FIT_QUALITY);
   if (fitQuality == 0 || (fitQuality > 1 && !qualityOverride)) {
     throw std::runtime_error("Failed to fit to transmission workspace, " + inputWs->getName() +
                              ": Fit quality (chi-squared) is too poor (" + std::to_string(fitQuality) +
@@ -173,11 +172,11 @@ void DepolarizedAnalyserTransmission::calcWavelengthDependentTransmission(Matrix
                              "fitting values were provided.");
   }
   ITableWorkspace_sptr const &paramWs = fitAlg->getProperty("OutputParameters");
-  setProperty(std::string(PropNames::OUTPUT_WORKSPACE), paramWs);
+  setProperty(PropNames::OUTPUT_WORKSPACE, paramWs);
 
-  if (!getPropertyValue(std::string(PropNames::OUTPUT_FIT)).empty()) {
+  if (!getPropertyValue(PropNames::OUTPUT_FIT).empty()) {
     MatrixWorkspace_sptr const &fitWs = fitAlg->getProperty("OutputWorkspace");
-    setProperty(std::string(PropNames::OUTPUT_FIT), fitWs);
+    setProperty(PropNames::OUTPUT_FIT, fitWs);
   }
 }
 

--- a/Framework/Algorithms/test/PolarizationCorrections/DepolarizedAnalyserTransmissionTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/DepolarizedAnalyserTransmissionTest.h
@@ -16,13 +16,9 @@ constexpr double T_E_VALUE = 82593.9;
 constexpr double PXD_VALUE = 14.9860;
 constexpr double T_E_ERROR = 26088049.0;
 constexpr double PXD_ERROR = 467.994241;
-constexpr double T_E_COV = 680586304785150.26;
-constexpr double PXD_COV = 219018.61;
-constexpr double OFF_DIAG_COV = 11828693410.21;
 constexpr double COST_FUNC_MAX = 5e-15;
 
 constexpr double FIT_DELTA = 1e-6;
-constexpr double COV_DELTA = 1e-10;
 } // namespace
 
 using Mantid::Algorithms::CreateSampleWorkspace;
@@ -74,25 +70,6 @@ public:
     MatrixWorkspace_sptr const &fitWs = alg->getProperty("OutputFitCurves");
     validateOutputParameters(outputWs);
     TS_ASSERT_EQUALS(fitWs->getNumberHistograms(), 3);
-  }
-
-  void test_covariance_matrix_is_output_when_optional_prop_set() {
-    // GIVEN
-    MatrixWorkspace_sptr const &mtWs = createTestingWorkspace("__mt", "1.465e-07*exp(0.0733*4.76*x)");
-    auto const &depWs = createTestingWorkspace("__dep", "0.0121*exp(-0.0733*10.226*x)");
-    auto alg = createAlgorithm(mtWs, depWs);
-    alg->setPropertyValue("OutputCovarianceMatrix", "__unused_for_child");
-    alg->execute();
-
-    // THEN
-    TS_ASSERT(alg->isExecuted());
-    ITableWorkspace_sptr const &outputWs = alg->getProperty("OutputWorkspace");
-    ITableWorkspace_sptr const &covWs = alg->getProperty("OutputCovarianceMatrix");
-    validateOutputParameters(outputWs);
-    TS_ASSERT_DELTA(covWs->getColumn("T_E")->toDouble(0), T_E_COV, T_E_COV * COV_DELTA);
-    TS_ASSERT_DELTA(covWs->getColumn("T_E")->toDouble(1), OFF_DIAG_COV, OFF_DIAG_COV * COV_DELTA);
-    TS_ASSERT_DELTA(covWs->getColumn("pxd")->toDouble(0), OFF_DIAG_COV, OFF_DIAG_COV * COV_DELTA);
-    TS_ASSERT_DELTA(covWs->getColumn("pxd")->toDouble(1), PXD_COV, PXD_COV * COV_DELTA);
   }
 
   void test_different_start_end_x() {

--- a/docs/source/algorithms/DepolarizedAnalyserTransmission-v1.rst
+++ b/docs/source/algorithms/DepolarizedAnalyserTransmission-v1.rst
@@ -9,20 +9,32 @@
 Description
 -----------
 
-Takes a pair of normalised, single-spectra workspaces representing a depolarized helium cell and the empty cell. It will
-then determine the empty cell transmission value, ``T_E``, and the cell path length multiplied by the gas pressure
-``pxd`` by using an exponential fit. The parameters table is then output for use in later calculations. Optionally, the
-calculated fit curve and a non-normalised version of the covariance matrix can also be output to check the quality of
-the fit. See :ref:`algm-Fit` for more details.
+Takes a pair of monitor-normalised, single-spectra workspaces representing a depolarized helium cell and the empty cell to
+calculate the transmission of the depolarized cell.
 
-A polarised He\ :sub:`3`\  cell decays over time. At the end of its life, it will be fully depolarized and a run is
-created to find the depolarized transmission rate through the helium. This allows for more effective efficiency
+.. math::
+
+    T(\lambda) = T_E(\lambda) * exp(-\mu) = T_E(\lambda) * exp(-0.0733 * p * d * \lambda)
+
+
+We first normalise the depolarised workspace :math:`T(\lambda)` by the empty cell workspace :math:`T_E(\lambda)`,
+accounting for the neutrons lost to the glass cell and only considering the helium inside:
+
+.. math::
+
+    \frac{T(\lambda)}{T_E(\lambda)} = exp(-\mu) = exp(-0.0733 * p * d * \lambda)
+
+
+We can then determine the cell path length multiplied by the gas pressure :math:`p * d` by using an exponential fit to
+the curve of :math:`exp(-0.0733 * p * d * \lambda)`. The parameters table is then output, allowing for :math:`p * d`
+(``PxD``) to be used in further corrections. Optionally, the calculated fit curves can also be output. See
+:ref:`algm-Fit` for more details.
+
+A polarised He\ :sub:`3`\  cell decays over time. At the end of its life, the cell is be actively depolarized and a run
+is created to find the depolarized transmission rate through the helium. This allows for more effective efficiency
 corrections.
 
-When depolarized, :math:`P_{He} = 0`, therefore the transmission can be determined using
-:math:`T(\lambda) = T_E(\lambda) * exp(-\mu) = T_E(\lambda) * exp(-0.0733 * p * d * \lambda)`. We can then use this
-equation, after normalising the ``DepolarizedWorkspace`` by the ``EmptyCellWorkspace``, to perform a fit to determine
-our :math:`T_E` (``T_E``) and :math:`p * d` (``pxd``) values.
+When depolarized, :math:`P_{He} = 0`, allowing the transmission to be be determined using the above equations.
 
 
 Usage

--- a/docs/source/algorithms/DepolarizedAnalyserTransmission-v1.rst
+++ b/docs/source/algorithms/DepolarizedAnalyserTransmission-v1.rst
@@ -45,13 +45,12 @@ Usage
 .. testcode:: ExDepolTransmissionCalc
 
    # Create example workspaces.
-   CreateSampleWorkspace(OutputWorkspace='mt', Function='User Defined', UserDefinedFunction='name=UserFunction, Formula=1.465e-07*exp(0.0733*4.76*x)', XUnit='wavelength', NumMonitors=1, NumBanks=0, BankPixelWidth=1, XMin=3.5, XMax=16.5, BinWidth=0.1)
-   CreateSampleWorkspace(OutputWorkspace='dep', Function='User Defined', UserDefinedFunction='name=UserFunction, Formula=0.0121*exp(-0.0733*10.226*x)', XUnit='wavelength', NumMonitors=1, NumBanks=0, BankPixelWidth=1, XMin=3.5, XMax=16.5, BinWidth=0.1)
+   CreateSampleWorkspace(OutputWorkspace='mt', Function='User Defined', UserDefinedFunction='name=LinearBackground, A0=-0.112, A1=-0.004397', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=3.5, XMax=16.5, BinWidth=0.1)
+   CreateSampleWorkspace(OutputWorkspace='dep', Function='User Defined', UserDefinedFunction='name=ExpDecay, Height=0.1239, Lifetime=1.338', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=3.5, XMax=16.5, BinWidth=0.1)
 
    output = DepolarizedAnalyserTransmission("dep", "mt")
 
    print("PXD Value = " + str(output.column("Value")[0]) + ".")
-   print("T_E Value = " + str(output.column("Value")[1]) + ".")
 
 Output:
 
@@ -60,7 +59,6 @@ Output:
    :options: +ELLIPSIS +NORMALIZE_WHITESPACE
 
    PXD Value = ...
-   T_E Value = ...
 
 
 References

--- a/docs/source/algorithms/DepolarizedAnalyserTransmission-v1.rst
+++ b/docs/source/algorithms/DepolarizedAnalyserTransmission-v1.rst
@@ -10,7 +10,7 @@ Description
 -----------
 
 Takes a pair of monitor-normalised, single-spectra workspaces representing a depolarized helium cell and the empty cell to
-calculate the transmission of the depolarized cell.
+calculate the transmission of the depolarized cell, as described by Wildes [#WILDES]_ and by Krycka et al. [#KRYCKA]_.
 
 .. math::
 
@@ -61,6 +61,16 @@ Output:
 
    PXD Value = ...
    T_E Value = ...
+
+
+References
+----------
+
+.. [#WILDES] A. R. Wildes, *Neutron News*, **17** 17 (2006)
+             `doi: 10.1080/10448630600668738 <https://doi.org/10.1080/10448630600668738>`_
+.. [#KRYCKA] K. Krycka et al., *J. Appl. Crystallogr.*, **45** (2012)
+             `doi: 10.1107/S0021889812003445 <https://doi.org/10.1107/S0021889812003445>`_
+
 
 .. categories::
 


### PR DESCRIPTION
Clone of #37481 for the `release-next` branch. 

### Description of work


#### Summary of work
Adjust the algorithm (after discussions with the scientists) to only fit the PxD parameter (explanations for why we're doing this can be found in the documentation and the issue description).


Fixes #37445 
Refs #37459

#### Further detail of work
- Removed the T_E calculation from the fitting formula.
- Removed the covariance matrix calculation now that we only have one fitting parameter. 
- Adjusted the tests to fit the new calculation. 
- Some refactoring to improve readability. 

Note: this PR does not cover the changes to the error calculation for this algorithm. That will come later. 

### To test:
1. Run the following script:
```python
CreateSampleWorkspace(OutputWorkspace='mt', Function='User Defined', UserDefinedFunction='name=LinearBackground, A0=-0.112, A1=-0.004397', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=3.5, XMax=16.5, BinWidth=0.1)
CreateSampleWorkspace(OutputWorkspace='dep', Function='User Defined', UserDefinedFunction='name=ExpDecay, Height=0.1239, Lifetime=1.338', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=3.5, XMax=16.5, BinWidth=0.1)

output = DepolarizedAnalyserTransmission("dep", "mt", OutputFitCurves='out_fit')
```
2. Check the outputted curves and parameter look sensible (is it a good fit?)
3. Run the algorithm from the Algorithm window and check the validation is working
4. Build the docs and check they are formatted correctly. 


*This does not require release notes* because **this functionality is new to this release.**


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
