### PR TITLE
Fix Plot Preview in Quasi Bayes interface

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi2.py
@@ -71,7 +71,7 @@ class BayesQuasi2(QuickBayesTemplate):
             axis_names.append(f"fit {j+1}")
             axis_names.append(f"diff {j+1}")
         ws = self.create_ws(
-            OutputWorkspace=f"{name}_workspace",
+            OutputWorkspace=name,
             DataX=np.array(x),
             DataY=np.array(y),
             NSpec=len(axis_names),
@@ -198,7 +198,7 @@ class BayesQuasi2(QuickBayesTemplate):
             engine = workflow.fit_engine
 
             ws_list = self.make_fit_ws(
-                engine=engine, max_features=max_num_peaks, ws_list=ws_list, x_unit="DeltaE", name=f"{name}_{prog}_{spec}_"
+                engine=engine, max_features=max_num_peaks, ws_list=ws_list, x_unit="DeltaE", name=f"{name}_{prog}_Workspace_{spec}"
             )
 
         sample_logs = [("background", BG_str), ("elastic_peak", elastic), ("energy_min", start_x), ("energy_max", end_x)]

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
@@ -358,14 +358,14 @@ void Quasi::plotCurrentPreview() {
   if (m_uiForm.ppPlot->hasCurve("fit 1")) {
     QString program = m_uiForm.cbProgram->currentText();
     auto fitName = m_QuasiAlg->getPropertyValue("OutputWorkspaceFit");
-    checkADSForPlotSaveWorkspace(fitName, false);
-    fitName.pop_back();
-    auto fitWS = fitName + "_";
-    fitWS += std::to_string(m_previewSpec);
-    if (program == "Lorentzians")
-      m_plotter->plotSpectra(fitWS, "0-4", errorBars);
-    else
-      m_plotter->plotSpectra(fitWS, "0-2", errorBars);
+    if (checkADSForPlotSaveWorkspace(fitName, false)) {
+      auto wsFit = Mantid::API::AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(fitName);
+      std::vector<std::string> names = (wsFit)->getNames();
+      if (program == "Lorentzians")
+        m_plotter->plotSpectra(names.at(m_previewSpec), "0-4", errorBars);
+      else
+        m_plotter->plotSpectra(names.at(m_previewSpec), "0-2", errorBars);
+    }
   } else if (m_uiForm.ppPlot->hasCurve("Sample")) {
     m_plotter->plotSpectra(m_uiForm.dsSample->getCurrentDataName().toStdString(), std::to_string(m_previewSpec),
                            errorBars);


### PR DESCRIPTION
### Description of work
This PR fixes a regression in the latest release candidate for Mantid 6.10. 
When a fit is made in the `Quasi` tab of the bayes fitting interface. the `Plot Preview` spectrum button stops working. This is caused because the output name of the workspaces to plot have changed recently to have the suffix `_Fit`. 
![image](https://github.com/mantidproject/mantid/assets/146007827/0615b042-1c5a-4393-a068-87f281ad1b81)

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->


#### Purpose of work
Fix a regression.

*There is no associated issue.*


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
I have additionally swapped the output string for the workspace name in `QuasiBayes2` to homogenize it with `QuasiBayes`, the format in the former is `{specNo}_Workspace_` and in the latter `Workspace_{specNo}`. I have tried to put both in the same format. 
### To test:
1. Go to Interfaces->Inelastic->Bayes Fitting
2. Go to Quasi tab. 
3. Open `irs26176_graphite002_red.nxs` as sample and `irs26173_graphite002_res.nxs` as resolution. 
4. Click Run
5. When you click `Plot Current Preview` button, a new plot window should  appear with the correct plot (the same as in the embedded plot). 
6. Repeat 3-5 but untick `Sequential Fit` option.
7. Open `Settings` (cog icon) and on `Developer featur flags` type :"quickbayes"
8. Repeat steps 3-6

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
