### PR TITLE
Fix bug in plotting Qspace integration in BaseSX class

### DIFF
--- a/scripts/Diffraction/single_crystal/CMakeLists.txt
+++ b/scripts/Diffraction/single_crystal/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Tests for common single crystal reduction
 
-set(TEST_PY_FILES test/test_base_sx.py)
-set(TEST_PY_FILES test/test_sxd.py)
+set(TEST_PY_FILES test/test_base_sx.py test/test_sxd.py)
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -673,7 +673,7 @@ class BaseSX(ABC):
                         # plot slice
                         im = ax.imshow(ws_cut.getSignalArray().sum(axis=iax)[:, ::-1].T)  # reshape to match sliceviewer
                         im.set_extent([-1, 1, -1, 1])  # so that ellipsoid is a circle
-                        if log_norm:
+                        if log_norm and not np.allclose(im.get_array(), 0):
                             im.set_norm(LogNorm())
                         # plot peak position
                         ax.plot(0, 0, "xr")
@@ -776,7 +776,7 @@ class BaseSX(ABC):
         """
         shape_info = json_loads(peak_shape.toJSON())
         if peak_shape.shapeName().lower() == "spherical":
-            BaseSX.convert_spherical_representation_to_ellipsoid(shape_info)
+            BaseSX._convert_spherical_representation_to_ellipsoid(shape_info)
         # get radii
         radii = np.array([shape_info[f"radius{iax}"] for iax in range(ndims)])
         bg_inner_radii = np.array([shape_info[f"background_inner_radius{iax}"] for iax in range(ndims)])

--- a/scripts/Diffraction/single_crystal/test/test_base_sx.py
+++ b/scripts/Diffraction/single_crystal/test/test_base_sx.py
@@ -18,6 +18,7 @@ from mantid.dataobjects import Workspace2D
 from Diffraction.single_crystal.base_sx import BaseSX
 import tempfile
 import shutil
+from os import path
 
 base_sx_path = "Diffraction.single_crystal.base_sx"
 
@@ -172,7 +173,7 @@ class BaseSXTest(unittest.TestCase):
         # generate fake data at (0,1,0)
         FakeMDEventData(ws, EllipsoidParams="1e+03,0,1,0,1,0,0,0,1,0,0,0,1,0.01,0.04,0.02,1", RandomSeed="3873875")
         # create peak at (0,1,0) and integrate
-        peaks = self._make_peaks_HKL(hs=[0], ks=[1], ls=[0], wsname="peaks_md")
+        peaks = self._make_peaks_HKL(hs=[1], ks=[1, 6], ls=[1], wsname="peaks_md")
         peaks_int = IntegratePeaksMD(
             InputWorkspace=ws,
             PeakRadius=0.6,

--- a/scripts/Diffraction/single_crystal/test/test_base_sx.py
+++ b/scripts/Diffraction/single_crystal/test/test_base_sx.py
@@ -26,7 +26,7 @@ base_sx_path = "Diffraction.single_crystal.base_sx"
 class BaseSXTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.ws = LoadEmptyInstrument(InstrumentName="SXD", OutputWorkspace="empty")
+        cls.ws = LoadEmptyInstrument(Filename="SXD_Definition.xml", OutputWorkspace="empty")
         axis = cls.ws.getAxis(0)
         axis.setUnit("TOF")
         cls._test_dir = tempfile.mkdtemp()
@@ -135,7 +135,7 @@ class BaseSXTest(unittest.TestCase):
         peaks = self._make_peaks_HKL(hs=[1], wsname="peaks7")
         ispec = self.ws.getIndicesFromDetectorIDs(peaks.column("DetID"))[0]
 
-        self.assertAlmostEqual(0.003802, BaseSX.get_radius(peaks.getPeak(0), self.ws, ispec, scale=1), delta=1e-6)
+        self.assertAlmostEqual(0.01020, BaseSX.get_radius(peaks.getPeak(0), self.ws, ispec, scale=1), delta=1e-4)
 
     @patch(base_sx_path + ".mantid.IntegratePeaksMD")
     def test_integrate_peaks_md(self, mock_integrate):


### PR DESCRIPTION
Fix bug in plotting Qspace integration in BaseSX class when no signal (i.e. data all 0s)
Updated a test to stop regression and noticed that original test was failing on main locally - I think there was a typo in CmakeLists that meant unit tests for BaseSX weren't running - hopefully this fixes it!

Fixes #37506

**Report to:** Nick Funnell

### To test:
(1) Run this without error
```
from mantid.simpleapi import *
from Diffraction.single_crystal.base_sx import BaseSX

# create  peeak table
ws = LoadEmptyInstrument(Filename="SXD_Definition.xml", OutputWorkspace="empty")
axis = ws.getAxis(0)
axis.setUnit("TOF")
peaks = CreatePeaksWorkspace(InstrumentWOrkspace=ws, NumberOfPeaks=0)
AddPeak(PeaksWorkspace=peaks, RunWorkspace=ws, TOF=1000, DetectorID=35004)

# make empty MD workspace
md = CreateMDWorkspace(Dimensions=3, Extents=[0,1,0,1,0,1], Names="Qx,Qy,Qz", 
                       Frames='QLab,QLab,QLab',Units='Ang^-1,Ang^-1,Ang^-1')
# integrate
peaks_int = IntegratePeaksMD(InputWorkspace=md, PeakRadius=0.1, BackgroundInnerRadius=0.12, 
                            BackgroundOuterRadius=0.13, PeaksWorkspace=peaks)
# plot
BaseSX.plot_integrated_peaks_MD(md, peaks_int, r"\\olympic\Babylon5\Public\RWaite\test_plot_MD.pdf", nbins_max=21, extent=1.5, log_norm=True)
```


*This does not require release notes* because **was added this release**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
