### PR TITLE
Ensure Fit Single Spectrum calls correct validate method

### DIFF
--- a/qt/scientific_interfaces/Inelastic/Common/RunWidget/RunPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Common/RunWidget/RunPresenter.h
@@ -24,7 +24,8 @@ public:
 
   virtual void setRunEnabled(bool const enable) = 0;
 
-  virtual bool validate(std::unique_ptr<IUserInputValidator> validator) const = 0;
+  virtual bool
+  validate(std::unique_ptr<IUserInputValidator> validator = std::make_unique<UserInputValidator>()) const = 0;
 };
 
 class MANTIDQT_INELASTIC_DLL RunPresenter final : public IRunPresenter {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
@@ -81,7 +81,7 @@ void FitTab::handleEndXChanged(double endX) {
 }
 
 void FitTab::handleSingleFitClicked() {
-  if (validate()) {
+  if (m_runPresenter->validate()) {
     m_plotPresenter->setFitSingleSpectrumIsFitting(true);
     updateFitButtons(false);
     updateOutputOptions(false);


### PR DESCRIPTION
### Description of work
This PR fixes an issue where the legacy `validate()` method was being called in the QENS Fitting interface when clicking `Fit Single Spectrum`. The solution was to call the `validate()` method in the new RunPresenter.

*There is no associated issue.*

### To test:
1. Open Inelastic QENS Fitting
2. Click `Fit Single Spectrum` below the plots. A validation message should appear about missing data and fit function
3. Load some data
4. Click `Fit Single Spectrum` below the plots. A validation message should appear about missing fit function
5. Select a Fit function
6. Click `Fit Single Spectrum` below the plots.  It should run successfully

*This does not require release notes* because **it is a regression**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
