### PR TITLE
Add error calculation to FlipperEfficiency algorithm

### DIFF
--- a/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/FlipperEfficiencyTest.h
@@ -136,11 +136,16 @@ public:
     auto const &group = createTestingWorkspace("testWs");
     auto alg = initialize_alg(group);
     alg->execute();
+
     MatrixWorkspace_sptr const outWs = alg->getProperty("OutputWorkspace");
     TS_ASSERT_EQUALS(outWs->getNumberHistograms(),
                      std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(group->getItem(0))->getNumberHistograms())
-    for (const double &eff : outWs->dataY(0)) {
-      TS_ASSERT_EQUALS(1.0, eff)
+    auto const &outY = outWs->dataY(0);
+    auto const &outE = outWs->dataE(0);
+    auto const numBins = outY.size();
+    for (size_t i = 0; i < numBins; ++i) {
+      TS_ASSERT_EQUALS(1.0, outY[i])
+      TS_ASSERT_DELTA(0.4216370213557839, outE[i], 1e-8);
     }
   }
 
@@ -148,11 +153,16 @@ public:
     auto const &group = createTestingWorkspace("testWs", 0.9);
     auto alg = initialize_alg(group);
     alg->execute();
+
     MatrixWorkspace_sptr const outWs = alg->getProperty("OutputWorkspace");
     TS_ASSERT_EQUALS(outWs->getNumberHistograms(),
                      std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(group->getItem(0))->getNumberHistograms())
-    for (const double &eff : outWs->dataY(0)) {
-      TS_ASSERT_DELTA(0.9710144925, eff, 1e-8);
+    auto const &outY = outWs->dataY(0);
+    auto const &outE = outWs->dataE(0);
+    auto const numBins = outY.size();
+    for (size_t i = 0; i < numBins; ++i) {
+      TS_ASSERT_DELTA(0.9710144925, outY[i], 1e-8);
+      TS_ASSERT_DELTA(0.42616729754693666, outE[i], 1e-8);
     }
   }
 

--- a/docs/source/algorithms/FlipperEfficiency-v1.rst
+++ b/docs/source/algorithms/FlipperEfficiency-v1.rst
@@ -27,6 +27,29 @@ the flipper directly using:
 
    \epsilon_{F} = \frac{T_{11}T_{00} - T_{10}T_{01}}{(T_{11} + T_{10})(T_{00} - T_{01})}
 
+The errors are calculated as follows:
+
+.. math::
+
+   \sigma_{\epsilon_{F}} = \sqrt{| \frac{\delta \epsilon_{F}}{\delta T_{11}}|^2 * \sigma^2_{T_{11}} + | \frac{\delta \epsilon_{F}}{\delta T_{00}}|^2 * \sigma^2_{T_{00}} + | \frac{\delta \epsilon_{F}}{\delta T_{10}}|^2 * \sigma^2_{T_{10}} + | \frac{\delta \epsilon_{F}}{\delta T_{01}}|^2 * \sigma^2_{T_{01}}}
+
+Where:
+
+.. math::
+
+   \frac{\delta \epsilon_{F}}{\delta T_{11}} = \frac{T_{10} * (T_{00} + T_{01})}{(T_{11} + T_{10})^2 * (T_{00} - T_{01})}
+
+.. math::
+
+   \frac{\delta \epsilon_{F}}{\delta T_{00}} = \frac{T_{01} * (T_{10} - T_{11})}{(T_{11} + T_{10}) * (T_{00} - T_{01})^2}
+
+.. math::
+
+   \frac{\delta \epsilon_{F}}{\delta T_{10}} = \frac{-T_{11} * (T_{00} + T_{01})}{(T_{11} + T_{10})^2 * (T_{00} - T_{01})}
+
+.. math::
+
+   \frac{\delta \epsilon_{F}}{\delta T_{01}} = \frac{T_{00} * (T_{11} - T_{10})}{(T_{11} + T_{10}) * (T_{00} - T_{01})^2}
 
 Outputs
 =======


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Calculates the errors using the equation given on the linked issue. This is required because default Mantid error calculation is not sufficiently accurate when applying polarisation corrections.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37458 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
This change should be a direct implementation of the equation on the linked issue. The only exception is that the equation shown includes the modulus symbol around the square of the partial derivatives, which I haven't included in the implementation. My understanding is that because the values are being squared it won't make a difference here, but please let me know if this is not correct.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Can be tested with the following script:

```
CreateSampleWorkspace(OutputWorkspace='out_00', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=48000, PeakCentre=2.65, FWHM=1.2', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
CreateSampleWorkspace(OutputWorkspace='out_11', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=47000, PeakCentre=2.65, FWHM=1.2', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
CreateSampleWorkspace(OutputWorkspace='out_10', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=22685, PeakCentre=2.55, FWHM=0.6', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)
CreateSampleWorkspace(OutputWorkspace='out_01', Function='User Defined', UserDefinedFunction='name=Lorentzian, Amplitude=22685, PeakCentre=2.55, FWHM=0.6', XUnit='wavelength', NumBanks=1, BankPixelWidth=1, XMin=0, XMax=16.5, BinWidth=0.1)

group = GroupWorkspaces(['out_00','out_11','out_10','out_01'])

group = ConvertUnits(group, "Wavelength")

out = FlipperEfficiency(group, SpinStates="00, 11, 10, 01")

# Should give result approximately equal to 0.024600439254069618
print(out.readE(0)[0])
```

To check the documentation changes, build the `docs-html` target.

*This does not require release notes* because **it is a change to an algorithm that is new in version 6.10**.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
