### PR TITLE
Fix Issue 37040: Dragging text onto plot not handled well

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/Bugfixes/37040.rst
+++ b/docs/source/release/v6.11.0/Workbench/Bugfixes/37040.rst
@@ -1,0 +1,1 @@
+- Fixed issue with dragging text onto the plot: Previously, dragging invalid text onto the plot resulted in unexpected behavior Now, when invalid text is dragged onto the plot, a warning is displayed to the user indicating that the workspace is invalid.

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -30,10 +30,10 @@ def _validate_workspaces(names: List[str]) -> List[bool]:
     :param names: A list of workspace names
     :return: List of bools, True if all workspaces have multiple bins
     """
-    ws = None
     ads = AnalysisDataServiceImpl.Instance()
     has_multiple_bins = []
     for name in names:
+        ws = None
         result = None
 
         try:

--- a/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
@@ -48,7 +48,7 @@ class Test(unittest.TestCase):
         self.assertEqual(2, len(ax.lines))
 
     def test_drag_and_drop_wont_plot_a_single_binned_workspace(self):
-        ax = self._drop_workspace("single_bin_wsff")
+        ax = self._drop_workspace("single_bin_ws")
         self.assertEqual(1, len(ax.lines))
 
     def test_validate_workspaces_does_not_raise_keyerror_for_non_existent_workspace(self):

--- a/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
@@ -13,7 +13,7 @@ from mantid import plots  # noqa: F401  # need mantid projection
 from unittest.mock import Mock, patch
 from mantid.simpleapi import CreateWorkspace
 from mantidqt.utils.qt.testing import start_qapplication
-from workbench.plotting.figurewindow import FigureWindow
+from workbench.plotting.figurewindow import FigureWindow, _validate_workspaces
 
 matplotlib.use("Qt5Agg")
 import matplotlib.pyplot as plt
@@ -48,8 +48,14 @@ class Test(unittest.TestCase):
         self.assertEqual(2, len(ax.lines))
 
     def test_drag_and_drop_wont_plot_a_single_binned_workspace(self):
-        ax = self._drop_workspace("single_bin_ws")
+        ax = self._drop_workspace("single_bin_wsff")
         self.assertEqual(1, len(ax.lines))
+
+    def test_validate_workspaces_does_not_raise_keyerror_for_non_existent_workspace(self):
+        try:
+            _validate_workspaces(["non_existent_workspace", "second_non_existent_workspace"])
+        except KeyError:
+            self.fail("KeyError was raised for non-existent workspaces.")
 
     def _drop_workspace(self, ws_name: str):
         ax = self.fig.get_axes()[1]

--- a/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
@@ -53,7 +53,8 @@ class Test(unittest.TestCase):
 
     def test_validate_workspaces_does_not_raise_keyerror_for_non_existent_workspace(self):
         try:
-            _validate_workspaces(["non_existent_workspace", "second_non_existent_workspace"])
+            result = _validate_workspaces(["non_existent_workspace", "second_non_existent_workspace"])
+            self.assertEqual(result, [False, False])
         except KeyError:
             self.fail("KeyError was raised for non-existent workspaces.")
 


### PR DESCRIPTION


### Description of work
Dragging text onto the plot throws a KeyError.

#### Summary of work
Introduced error handling to gracefully handle the KeyError when dragging text onto the plot. Displays a warning to the user for invalid workspaces.

Fixes: https://github.com/mantidproject/mantid/issues/37040

### To test:
1. Create a plot
2. Drag some text onto the plot
3. A warning is displayed to the user in the message box

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
