### PR TITLE
Fix deadlock that is maybe causing test to occasionally fail in PythonChannelTest

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -10,6 +10,7 @@
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/core/Converters/PySequenceToVector.h"
 #include "MantidPythonInterface/core/GetPointer.h"
+#include "MantidPythonInterface/core/ReleaseGlobalInterpreterLock.h"
 #include "MantidPythonInterface/core/StlExportDefinitions.h"
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>
@@ -21,6 +22,7 @@ using Mantid::Kernel::ConfigService;
 using Mantid::Kernel::ConfigServiceImpl;
 using Mantid::Kernel::FacilityInfo;
 using Mantid::Kernel::InstrumentInfo;
+using Mantid::PythonInterface::ReleaseGlobalInterpreterLock;
 using Mantid::PythonInterface::Converters::PySequenceToVector;
 
 using namespace boost::python;
@@ -42,6 +44,7 @@ void setDataSearchDirs(ConfigServiceImpl &self, const object &paths) {
 
 /// Forward call from __getitem__ to getString with use_cache_true
 std::string getStringUsingCache(ConfigServiceImpl const *const self, const std::string &key) {
+  ReleaseGlobalInterpreterLock releaseGIL;
   return self->getString(key, true);
 }
 
@@ -55,6 +58,7 @@ const InstrumentInfo &getInstrument(ConfigServiceImpl const *const self, const o
 /// duck typing emulating dict.get method
 std::string getStringUsingCacheElseDefault(ConfigServiceImpl const *const self, const std::string &key,
                                            const std::string &defaultValue) {
+  ReleaseGlobalInterpreterLock releaseGIL;
   if (self->hasProperty(key))
     return self->getString(key, true);
   else

--- a/Testing/SystemTests/tests/framework/PythonChannels.py
+++ b/Testing/SystemTests/tests/framework/PythonChannels.py
@@ -95,7 +95,7 @@ class PythonLoggingTests(unittest.TestCase):
                 )
             )
 
-        result = subprocess.run([sys.executable, TEST_SCRIPT_NAME], timeout=600)  # This will raise subprocess.TimeoutExpired if deadlocke
+        result = subprocess.run([sys.executable, TEST_SCRIPT_NAME], timeout=60)  # This will raise subprocess.TimeoutExpired if deadlocke
         result.check_returncode()
 
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -911,7 +911,7 @@ cstyleCast:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/Converters/PyO
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/Converters/PyObjectToMatrix.cpp:72
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/Converters/WrapWithNDArray.cpp:82
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/Converters/WrapWithNDArray.cpp:87
-unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp:69
+unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp:73
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/MuonNexusReader.cpp:248
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp:102
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/kernel/src/Exports/Quat.cpp:55


### PR DESCRIPTION
### Description of work

Following on from #36326 I found another place that a deadlock can occur that is most probably the reason for the test failures as related to #37366. The changes in #37427 didn't fully address the issue.

We need to release GIL before doing `ConfigService::getString` as it will [log to debug](https://github.com/mantidproject/mantid/blob/main/Framework/Kernel/src/ConfigService.cpp#L775) if the key doesn't exist and this is called in `simpleapi.py`. You may need to read the description from #36326 to fully understand the issue. 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

It is hard to reproduce the failing test, I ran the following for over an hour for it to happen. This will continuously run the command until it fails.

```shell
while ./systemtest -R PythonChannel --quiet --output-on-failure ; do :; done
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


*This does not require release notes* because this issue hasn't been observed by users and is only to stabilize a test

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
