### PR TITLE
Run open interface system tests with both window behaviours

### DIFF
--- a/Testing/SystemTests/tests/qt/CppInterfacesStartupTest.py
+++ b/Testing/SystemTests/tests/qt/CppInterfacesStartupTest.py
@@ -9,6 +9,7 @@ from itertools import chain
 
 from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.utils.qt.testing import get_application
+from workbench.config import CONF
 from workbench.utils.gather_interfaces import gather_cpp_interface_names
 
 from qtpy.QtCore import Qt
@@ -35,6 +36,11 @@ class CppInterfacesStartupTest(systemtesting.MantidSystemTest):
         if len(self._cpp_interface_names) == 0:
             self.fail("Failed to find the names of the c++ interfaces.")
 
+        self._open_interfaces("On Top")
+        self._open_interfaces("Floating")
+
+    def _open_interfaces(self, window_behaviour):
+        CONF.set("AdditionalWindows/behaviour", window_behaviour)
         for interface_name in self._cpp_interface_names:
             self._attempt_to_open_cpp_interface(interface_name)
 

--- a/Testing/SystemTests/tests/qt/CppInterfacesStartupTest.py
+++ b/Testing/SystemTests/tests/qt/CppInterfacesStartupTest.py
@@ -9,7 +9,7 @@ from itertools import chain
 
 from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.utils.qt.testing import get_application
-from workbench.config import CONF
+from workbench.config import CONF, WINDOW_ONTOP_FLAGS, WINDOW_STANDARD_FLAGS
 from workbench.utils.gather_interfaces import gather_cpp_interface_names
 
 from qtpy.QtCore import Qt
@@ -42,13 +42,23 @@ class CppInterfacesStartupTest(systemtesting.MantidSystemTest):
     def _open_interfaces(self, window_behaviour):
         CONF.set("AdditionalWindows/behaviour", window_behaviour)
         for interface_name in self._cpp_interface_names:
-            self._attempt_to_open_cpp_interface(interface_name)
+            self._attempt_to_open_cpp_interface(interface_name, window_behaviour)
 
-    def _attempt_to_open_cpp_interface(self, interface_name):
+    def _attempt_to_open_cpp_interface(self, interface_name, window_behaviour):
         try:
             interface = self._interface_manager.createSubWindow(interface_name)
             interface.setAttribute(Qt.WA_DeleteOnClose, True)
             interface.show()
+            if window_behaviour == "On Top":
+                self.assertTrue(
+                    interface.windowFlags() & WINDOW_ONTOP_FLAGS,
+                    f"{interface_name} is not using correct window flags for 'On Top' behaviour",
+                )
+            else:
+                self.assertTrue(
+                    interface.windowFlags() & WINDOW_STANDARD_FLAGS,
+                    f"{interface_name} is not using correct window flags for 'Floating' behaviour",
+                )
             interface.close()
 
             # Delete the interface manually because the destructor is not being called as expected on close (even with

--- a/Testing/SystemTests/tests/qt/PythonInterfacesStartupTest.py
+++ b/Testing/SystemTests/tests/qt/PythonInterfacesStartupTest.py
@@ -10,6 +10,7 @@ import systemtesting
 
 from mantidqt.utils.qt.testing import get_application
 from workbench.utils.gather_interfaces import gather_python_interface_names
+from workbench.config import CONF
 
 from qtpy.QtCore import QCoreApplication, QSettings
 
@@ -52,10 +53,15 @@ class PythonInterfacesStartupTest(systemtesting.MantidSystemTest):
 
         self._qapp = get_application()  # keep QApp reference alive
         try:
-            for interface_script in self._interface_scripts:
-                self._attempt_to_open_and_close_python_interface(interface_script)
+            self._open_interfaces("On Top")
+            self._open_interfaces("Floating")
         finally:
             self._qapp = None
+
+    def _open_interfaces(self, window_behaviour):
+        CONF.set("AdditionalWindows/behaviour", window_behaviour)
+        for interface_script in self._interface_scripts:
+            self._attempt_to_open_and_close_python_interface(interface_script)
 
     def _attempt_to_open_and_close_python_interface(self, interface_script):
         # Ensures the interfaces close after their script has been executed


### PR DESCRIPTION
### Description of work

Test interface opening with both kinds of additional window behaviour.

Fixes #31303

### To test:

- Code review
- Tests should pass

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
