### PR TITLE
Use int instead of long in Inelastic Corrections tab properties

### DIFF
--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
@@ -175,19 +175,19 @@ void AbsorptionCorrections::run() {
   // General details
   monteCarloAbsCor->setProperty("BeamHeight", m_uiForm.spBeamHeight->value());
   monteCarloAbsCor->setProperty("BeamWidth", m_uiForm.spBeamWidth->value());
-  long const events = static_cast<long>(m_uiForm.spNumberEvents->value());
+  auto const events = m_uiForm.spNumberEvents->value();
   monteCarloAbsCor->setProperty("EventsPerPoint", events);
   auto const interpolation = m_uiForm.cbInterpolation->currentText().toStdString();
   monteCarloAbsCor->setProperty("Interpolation", interpolation);
-  long const maxAttempts = static_cast<long>(m_uiForm.spMaxScatterPtAttempts->value());
+  auto const maxAttempts = m_uiForm.spMaxScatterPtAttempts->value();
   monteCarloAbsCor->setProperty("MaxScatterPtAttempts", maxAttempts);
 
   bool const isSparseInstrument = m_uiForm.cbSparseInstrument->isChecked();
   if (isSparseInstrument) {
     monteCarloAbsCor->setProperty("SparseInstrument", isSparseInstrument);
-    long const numberOfDetectorRows = static_cast<long>(m_uiForm.spNumberDetectorRows->value());
+    auto const numberOfDetectorRows = m_uiForm.spNumberDetectorRows->value();
     monteCarloAbsCor->setProperty("NumberOfDetectorRows", numberOfDetectorRows);
-    long const numberOfDetectorColumns = static_cast<long>(m_uiForm.spNumberDetectorColumns->value());
+    auto const numberOfDetectorColumns = m_uiForm.spNumberDetectorColumns->value();
     monteCarloAbsCor->setProperty("NumberOfDetectorColumns", numberOfDetectorColumns);
   }
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
@@ -118,7 +118,7 @@ void CalculatePaalmanPings::run() {
   const auto efixed = m_uiForm.doubleEfixed->value();
   absCorAlgo->setProperty("EFixed", efixed);
 
-  const long int numwave = m_uiForm.spNwave->value();
+  const auto numwave = m_uiForm.spNwave->value();
   absCorAlgo->setProperty("NumberWavelengths", numwave);
 
   const bool inter = m_uiForm.cbInterpolate->isChecked();


### PR DESCRIPTION
### Description of work
This PR fixes a crash on the Calculate Paalman Pings and Calculate Monte Carlo Absorption tabs of the Inelastic Corrections interface. It was caused by changes in the following PR https://github.com/mantidproject/mantid/pull/37196

I am adding manual testing instructions in a separate PR so that similar problems will be discovered earlier on in the release cycle next time.https://github.com/mantidproject/mantid/issues/37541

### To test:

**Calculate Paalman Pings:**
Sample: [irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2460924/irs26176_graphite002_red.zip)
Sample Thickness: `0.1cm`
Chemical Formula: `H2-O`
Click Run, there should be no crash and a workspace ending in _Corrections should be produced

**Calculate Monte Carlo Absorption:**
Sample: `26176` (on the system)
Shape: `FlatPlate`
Sample Height & width: `1.0`
Sample and Container Thickness: `0.1`
Sample mass density: `1`
Sample Formula: `H2-O`
Container mass density: `6`
Container Formula: `V`
Click Run, there should be no crash and a workspace ending in _Corrections should be produced

*This does not require release notes* because **it is a regression**


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
