### PR TITLE
Add option to correct for attenuation post integration in ISIS single-crystal reduction classes

### DIFF
--- a/Testing/SystemTests/tests/framework/SXDAnalysis.py
+++ b/Testing/SystemTests/tests/framework/SXDAnalysis.py
@@ -92,7 +92,7 @@ class SXDProcessSampleData(systemtesting.MantidSystemTest):
         ADS.clear()
 
     def runTest(self):
-        sxd = SXD(vanadium_runno=23769, empty_runno=23768)
+        sxd = SXD(vanadium_runno=23769, empty_runno=23768, scale_integrated=False)
         sxd.van_ws = LoadNexus(Filename="SXD23779_processed_vanadium.nxs", OutputWorkspace="SXD23779_vanadium")
         sxd.set_sample(
             Geometry={"Shape": "CSG", "Value": sxd.sphere_shape},

--- a/docs/source/release/v6.11.0/Diffraction/Single_Crystal/New_features/37575.rst
+++ b/docs/source/release/v6.11.0/Diffraction/Single_Crystal/New_features/37575.rst
@@ -1,0 +1,1 @@
+- Add method `calc_absorption_weighted_path_lengths` to ISIS single-crystal reduction classes that calculate tbar for each peak (saved in a column of the table) and optionally apply an attenuation correction to the integrated intensity of each peak. By default the correction will be applied if class has property scale_integrated = True)

--- a/docs/source/techniques/ISIS_SingleCrystalDiffraction_Workflow.rst
+++ b/docs/source/techniques/ISIS_SingleCrystalDiffraction_Workflow.rst
@@ -173,6 +173,7 @@ The reduction proceeds as follows:
     for run in runs:
         skew_args = {**skew_args, 'OutputFile': path.join(save_dir, f"{run}_{peak_type.value}_int.pdf")}
         sxd.integrate_data(integration_type, peak_type, run=run, **skew_args)
+        sxd.calc_absorption_weighted_path_lengths(peak_type, integration_type, run=run, ApplyCorrection=True)
         sxd.save_peak_table(run, peak_type, integration_type, save_dir, save_format='SHELX')
 
     # save combined table

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -268,6 +268,16 @@ class BaseSX(ABC):
 
     @default_apply_to_all_runs
     def calc_absorption_weighted_path_lengths(self, peak_type, int_type=None, run=None, **kwargs):
+        """
+        Method to calculate tbar for each peak (saved in a column of the table) and optionally apply an attenuation
+        correction to the integrated intensity of each peak. By default the correction will be applied if
+        self.scale_integrated = True - which is the case for SXD but not WISH, but can be overridden by supplying
+        keyword ApplyCorrection.
+        :param peak_type: PEAK_TYPE Enum to identify peak table to use
+        :param int_type: INTEGRATION_TYPE Enum to identify peak table to use
+        :param run: run number to identify peak table to use (if not supplied default will be to apply to all runs)
+        :param kwargs: keyword arguments passed to AddAbsorptionWeightedPathLengths algorithm
+        """
         default_kwargs = {"ApplyCorrection": self.scale_integrated, "EventsPerPoint": 1500, "MaxScatterPtAttempts": 7500}
         kwargs = {**default_kwargs, **kwargs}
         ws = self.get_ws(run)

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -36,7 +36,7 @@ class INTEGRATION_TYPE(Enum):
 
 
 class BaseSX(ABC):
-    def __init__(self, vanadium_runno: str, file_ext: str = ".raw", scale_integrated: bool = False):
+    def __init__(self, vanadium_runno: Optional[str] = None, file_ext: str = ".raw", scale_integrated: bool = False):
         self.runs = dict()
         self.van_runno = vanadium_runno
         self.van_ws = None

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -36,7 +36,7 @@ class INTEGRATION_TYPE(Enum):
 
 
 class BaseSX(ABC):
-    def __init__(self, vanadium_runno: str, file_ext: str):
+    def __init__(self, vanadium_runno: str, file_ext: str = ".raw", scale_integrated: bool = False):
         self.runs = dict()
         self.van_runno = vanadium_runno
         self.van_ws = None
@@ -44,6 +44,7 @@ class BaseSX(ABC):
         self.sample_dict = None
         self.n_mcevents = 1200
         self.file_ext = file_ext  # file extension
+        self.scale_integrated = scale_integrated
 
     # --- decorator to apply to all runs is run=None ---
     def default_apply_to_all_runs(func):
@@ -267,12 +268,12 @@ class BaseSX(ABC):
 
     @default_apply_to_all_runs
     def correct_integrated_peaks_for_attenuation(self, peak_type, run=None, **kwargs):
-        default_kwargs = {"EventsPerPoint": 1500, "MaxScatterPtAttempts": 6000}
+        default_kwargs = {"ApplyCorrection": self.scale_integrated, "EventsPerPoint": 1500, "MaxScatterPtAttempts": 7500}
         kwargs = {**default_kwargs, **kwargs}
         ws = self.get_ws(run)
         peaks = self.get_peaks(run, peak_type)
         mantid.CopySample(InputWorkspace=ws, OutputWorkspace=peaks, CopyEnvironment=False)
-        mantid.AddAbsorptionWeightedPathLengths(InputWorkspace=peaks, ApplyCorrection=True, **kwargs)
+        mantid.AddAbsorptionWeightedPathLengths(InputWorkspace=peaks, **kwargs)
 
     @staticmethod
     def get_back_to_back_exponential_func(pk, ws, ispec):

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -267,7 +267,7 @@ class BaseSX(ABC):
             self.set_peaks(run, out_peaks_name, peak_type)
 
     @default_apply_to_all_runs
-    def correct_integrated_peaks_for_attenuation(self, peak_type, int_type=None, run=None, **kwargs):
+    def calc_absorption_weighted_path_lengths(self, peak_type, int_type=None, run=None, **kwargs):
         default_kwargs = {"ApplyCorrection": self.scale_integrated, "EventsPerPoint": 1500, "MaxScatterPtAttempts": 7500}
         kwargs = {**default_kwargs, **kwargs}
         ws = self.get_ws(run)

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -267,11 +267,11 @@ class BaseSX(ABC):
             self.set_peaks(run, out_peaks_name, peak_type)
 
     @default_apply_to_all_runs
-    def correct_integrated_peaks_for_attenuation(self, peak_type, run=None, **kwargs):
+    def correct_integrated_peaks_for_attenuation(self, peak_type, int_type=None, run=None, **kwargs):
         default_kwargs = {"ApplyCorrection": self.scale_integrated, "EventsPerPoint": 1500, "MaxScatterPtAttempts": 7500}
         kwargs = {**default_kwargs, **kwargs}
         ws = self.get_ws(run)
-        peaks = self.get_peaks(run, peak_type)
+        peaks = self.get_peaks(run, peak_type, int_type)
         mantid.CopySample(InputWorkspace=ws, OutputWorkspace=peaks, CopyEnvironment=False)
         mantid.AddAbsorptionWeightedPathLengths(InputWorkspace=peaks, **kwargs)
 

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -265,6 +265,15 @@ class BaseSX(ABC):
                     mantid.PredictFractionalPeaks(Peaks=pred_peaks, FracPeaks=out_peaks_name, EnableLogging=False, **kwargs)
             self.set_peaks(run, out_peaks_name, peak_type)
 
+    @default_apply_to_all_runs
+    def correct_integrated_peaks_for_attenuation(self, peak_type, run=None, **kwargs):
+        default_kwargs = {"EventsPerPoint": 1500, "MaxScatterPtAttempts": 6000}
+        kwargs = {**default_kwargs, **kwargs}
+        ws = self.get_ws(run)
+        peaks = self.get_peaks(run, peak_type)
+        mantid.CopySample(InputWorkspace=ws, OutputWorkspace=peaks, CopyEnvironment=False)
+        mantid.AddAbsorptionWeightedPathLengths(InputWorkspace=peaks, ApplyCorrection=True, **kwargs)
+
     @staticmethod
     def get_back_to_back_exponential_func(pk, ws, ispec):
         tof = pk.getTOF()

--- a/scripts/Diffraction/single_crystal/test/test_sxd.py
+++ b/scripts/Diffraction/single_crystal/test/test_sxd.py
@@ -222,7 +222,7 @@ class SXDTest(unittest.TestCase):
 
         self.assertFalse("Material" in self.sxd.sample_dict)
 
-    def test_correct_integrated_peaks_for_attenuation(self):
+    def test_calc_absorption_weighted_path_lengths(self):
         # make workspace with sample
         ws_with_sample = CloneWorkspace(self.ws)
         SetSample(
@@ -238,7 +238,7 @@ class SXDTest(unittest.TestCase):
         self.sxd.set_ws(runno, ws_with_sample)
         self.sxd.set_peaks(runno, peaks_to_correct, PEAK_TYPE.FOUND)
 
-        self.sxd.correct_integrated_peaks_for_attenuation(PEAK_TYPE.FOUND)
+        self.sxd.calc_absorption_weighted_path_lengths(PEAK_TYPE.FOUND)
 
         self.assertAlmostEqual(peaks_to_correct.getPeak(0).getIntensity(), 8.7690, delta=1e-4)
 

--- a/scripts/Diffraction/single_crystal/test/test_sxd.py
+++ b/scripts/Diffraction/single_crystal/test/test_sxd.py
@@ -15,6 +15,7 @@ from mantid.simpleapi import (
     ClearUB,
     HasUB,
     ClearCache,
+    SetSample,
 )
 from Diffraction.single_crystal.sxd import SXD
 from Diffraction.single_crystal.base_sx import PEAK_TYPE, INTEGRATION_TYPE
@@ -220,6 +221,26 @@ class SXDTest(unittest.TestCase):
         self.sxd.set_sample(Geometry={"Shape": "CSG", "Value": self.sxd.sphere_shape})
 
         self.assertFalse("Material" in self.sxd.sample_dict)
+
+    def test_correct_integrated_peaks_for_attenuation(self):
+        # make workspace with sample
+        ws_with_sample = CloneWorkspace(self.ws)
+        SetSample(
+            ws_with_sample,
+            Geometry={"Shape": "CSG", "Value": self.sxd.sphere_shape},
+            Material={"ChemicalFormula": "C2 H4", "SampleNumberDensity": 0.02, "NumberDensityUnit": "Formula Units"},
+        )
+        # make peaks workspace and set intensity to 1
+        peaks_to_correct = CloneWorkspace(self.peaks)
+        peaks_to_correct.getPeak(0).setIntensity(1.0)
+        # store in class
+        runno = 1234
+        self.sxd.set_ws(runno, ws_with_sample)
+        self.sxd.set_peaks(runno, peaks_to_correct, PEAK_TYPE.FOUND)
+
+        self.sxd.correct_integrated_peaks_for_attenuation(PEAK_TYPE.FOUND)
+
+        self.assertAlmostEqual(peaks_to_correct.getPeak(0).getIntensity(), 8.7690, delta=1e-4)
 
     #  --- methods specific to SXD class ---
 

--- a/scripts/Diffraction/wish/wishSX.py
+++ b/scripts/Diffraction/wish/wishSX.py
@@ -17,8 +17,8 @@ lambda_min = 0.8
 
 
 class WishSX(BaseSX):
-    def __init__(self, vanadium_runno=None, file_ext=".raw"):
-        super().__init__(vanadium_runno, file_ext)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.sphere_shape = """<sphere id="sphere">
                                <centre x="0.0"  y="0.0" z="0.0" />
                                <radius val="0.0025"/>
@@ -62,16 +62,19 @@ class WishSX(BaseSX):
             # set sample (must be done after gonio to rotate shape) and correct for attenuation
             if self.sample_dict is not None:
                 mantid.SetSample(wsname, EnableLogging=False, **self.sample_dict)
-                mantid.ConvertUnits(InputWorkspace=wsname, OutputWorkspace=wsname, Target="Wavelength", EnableLogging=False)
-                if "<sphere" in ADS.retrieve(wsname).sample().getShape().getShapeXML():
-                    transmission = mantid.SphericalAbsorption(InputWorkspace=wsname, OutputWorkspace="transmission", EnableLogging=False)
-                else:
-                    transmission = mantid.MonteCarloAbsorption(
-                        InputWorkspace=wsname, OutputWorkspace="transmission", EventsPerPoint=self.n_mcevents, EnableLogging=False
-                    )
-                self._divide_workspaces(wsname, transmission)
-                mantid.DeleteWorkspace(transmission)
-                mantid.ConvertUnits(InputWorkspace=wsname, OutputWorkspace=wsname, Target="TOF", EnableLogging=False)
+                if not self.scale_integrated:
+                    mantid.ConvertUnits(InputWorkspace=wsname, OutputWorkspace=wsname, Target="Wavelength", EnableLogging=False)
+                    if "<sphere" in ADS.retrieve(wsname).sample().getShape().getShapeXML():
+                        transmission = mantid.SphericalAbsorption(
+                            InputWorkspace=wsname, OutputWorkspace="transmission", EnableLogging=False
+                        )
+                    else:
+                        transmission = mantid.MonteCarloAbsorption(
+                            InputWorkspace=wsname, OutputWorkspace="transmission", EventsPerPoint=self.n_mcevents, EnableLogging=False
+                        )
+                    self._divide_workspaces(wsname, transmission)
+                    mantid.DeleteWorkspace(transmission)
+                    mantid.ConvertUnits(InputWorkspace=wsname, OutputWorkspace=wsname, Target="TOF", EnableLogging=False)
             # save results in dictionary
             self.set_ws(run, wsname)
         return wsname


### PR DESCRIPTION
### Description of work
Adds a method to apply attenuation correction post-integration - this is how SXD like to apply the correction, in addition it is quicker than applying the correction to every bin in the raw workspace.

Fixes #37235

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

(1) Run through script in docs

```
from mantid.simpleapi import *
from os import path
from Diffraction.single_crystal.base_sx import PEAK_TYPE, INTEGRATION_TYPE
from Diffraction.single_crystal.sxd import SXD

# Setup SXD
###########

sxd = SXD(vanadium_runno=32857, empty_runno=32856, detcal_path=detcal_path)
sxd.set_sample(Geometry={'Shape': 'CSG', 'Value': sxd.sphere_shape},
               Material={'ChemicalFormula': 'Na Cl', 'SampleNumberDensity': 0.0223})
sxd.set_goniometer_axes([0,1,0,1])  # ccw rotation around vertical

# load and normalise data
#########################

runs = range(32863,32865)
sxd.process_vanadium()
sxd.process_data(runs, "wccr") # wccr is the goniometer motor log name - one arg for each axis added
# if there was no log value then the angles have to be set with a sequence e.g.
# sxd.process_data(runs, [0,45])

# Find peaks and optimise UBs
##############################

for run in runs:
    ws = sxd.get_ws(run)
    peaks = sxd.find_sx_peaks(ws, nstd=8)
    sxd.remove_peaks_on_detector_edge(peaks, 2)
    sxd.set_peaks(run, peaks)
# find UB with consistent indexing across runs
sxd.find_ub_using_lattice_params(global_B=True, tol=0.15,
                                 a=5.6402, b=5.6402, c=5.6402,
                                 alpha=90, beta=90, gamma=90)
sxd.calibrate_sample_pos(tol=0.15)  # calibrates each run independently

# Integrate and save
####################

# input arguments for skew integration
save_dir = "/babylon/Public/UserName"
skew_args= {'UseNearestPeak': True, 'IntegrateIfOnEdge': False,
            'LorentzCorrection': True,
            'NVacanciesMax': 2, 'NPixPerVacancyMin': 2, 'NTOFBinsMin': 2,
            'UpdatePeakPosition': True, 'OptimiseMask': True,
            'GetTOFWindowFromBackToBackParams': False,
            'BackScatteringTOFResolution': 0.06, 'ThetaWidth': 1.5,
            'ScaleThetaWidthByWavelength': True,
            'OptimiseXWindowSize': True, 'ThresholdIoverSigma': 15}

# integrate and save each run
peak_type = PEAK_TYPE.FOUND
integration_type = INTEGRATION_TYPE.SKEW
for run in runs:
    skew_args = {**skew_args, 'OutputFile': path.join(save_dir, f"{run}_{peak_type.value}_int.pdf")}
    sxd.integrate_data(integration_type, peak_type, run=run, **skew_args)
    sxd.calc_absorption_weighted_path_lengths(peak_type, integration_type, run=run, ApplyCorrection=True)
    sxd.save_peak_table(run, peak_type, integration_type, save_dir, save_format='SHELX')

# save combined table
sxd.save_all_peaks(peak_type, integration_type, save_dir=save_dir, save_format=fmt)
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
