### PR TITLE
Enable Slice Viewer and 3D Plottings options from Elwin tab

### DIFF
--- a/docs/source/release/v6.11.0/Inelastic/New_features/37092.rst
+++ b/docs/source/release/v6.11.0/Inelastic/New_features/37092.rst
@@ -1,0 +1,1 @@
+- It is possible to access the Slice Viewer or 3D Plot from the OutputPlot widget of the in :ref:`Elwin Tab <elwin>` of  :ref:`Data Processor Interface <interface-inelastic-data-processor>` for output workspaces containing more than 1 histogram.

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.cpp
@@ -46,7 +46,7 @@ ElwinPresenter::ElwinPresenter(QWidget *parent, IElwinView *view, std::unique_pt
       m_selectedSpectrum(0) {
   m_view->subscribePresenter(this);
   setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::Spectra));
+      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraSliceSurface));
 }
 
 ElwinPresenter::ElwinPresenter(QWidget *parent, IElwinView *view, std::unique_ptr<IElwinModel> model,
@@ -55,7 +55,7 @@ ElwinPresenter::ElwinPresenter(QWidget *parent, IElwinView *view, std::unique_pt
       m_selectedSpectrum(0) {
   m_view->subscribePresenter(this);
   setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::Spectra));
+      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraSliceSurface));
 }
 
 ElwinPresenter::~ElwinPresenter() {}


### PR DESCRIPTION
### Description of work
This PR enables the option to access the Slice Viewer or plot in 3D from the output plot widget of the Elwin tab. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37092 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Go to Elwin tab. 
- Add the Workspace named `irs26176_graphite002_red.nxs` from the dialog. 
- Click Run. 
- On the output plot widget, you can `Plot Spectra`, but if you try to select `Open Slice Viewer` or `Plot 3D`, a warning message
  appears, informing that is it not possible with 1 histogram workspace. 
- Remove the workspace from the elwin tab. 
- Add all the workspaces  from the sample data at:  #37092
- Click Run
- On the output plot widget, you can `Plot Spectra`, or use the `Slice Viewer` or `Plot 3D`
*Added release note*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
