### PR TITLE
Package .json files as part of Mantid package so `peak_data.json` is found

### DIFF
--- a/Framework/PythonInterface/setup.py
+++ b/Framework/PythonInterface/setup.py
@@ -15,5 +15,5 @@ setup(
     name="mantid",
     version=os.environ["MANTID_VERSION_STR"],
     packages=find_packages(exclude=["*.test", "plugins*"]),
-    package_data={"": ["*.ui"]},
+    package_data={"": ["*.json", "*.ui"]},
 )


### PR DESCRIPTION
### Description of work
Package .json files as part of Mantid package

### Why?
The peak_data.json file was [moved](https://github.com/mantidproject/mantid/pull/37154) into the framework to avoid the framework depending on a file within mantidqt. However, the file was not being packaged any more, and is erquired by the elemental analysis interface.

### To test:
Use the package generated by the job below
Open the Elemental Analysis interface (muon category)

No release notes required because it's a regression.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
