### PR TITLE
Pin occt to novtk build variant

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -41,6 +41,10 @@ libcxx:
 matplotlib:
   - 3.7.*
 
+# Use novtk version, otherwise a lot of extra packages are installed, including qt6-main, which can cause issues when launching on Windows
+occt:
+  - '=*=novtk*'
+
 # Fix the version to avoid updates being pulled in automatically, which might change the Reflectometry ORSO file content or layout and cause tests to fail.
 orsopy:
   - 1.2.0

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - muparser
     - nexus
     - numpy {{ numpy }}
-    - occt
+    - occt {{ occt }}
     - python {{ python }}
     - poco {{ poco }}
     - setuptools
@@ -63,7 +63,7 @@ requirements:
     - lib3mf  # [win]
     - nexus
     - {{ pin_compatible("numpy", upper_bound="1.27") }}
-    - {{ pin_compatible("occt", max_pin="x.x.x") }}
+    - occt {{ occt }}
     - pycifrw {{ pycifrw }}
     - python
     - python-dateutil

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -24,7 +24,7 @@ dependencies:
   - nexus=4.4.*
   - ninja>=1.10.2
   - numpy>=1.24,<1.27
-  - occt
+  - occt=*=novtk* # Use novtk version, otherwise a lot of extra packages are installed, including qt6-main, which can cause issues when launching on Windows
   - pip>=21.0.1
   - poco=1.12.1|>=1.12.6 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch but not yet included in a release, as of 1.12.5.
   - psutil>=5.8.0

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -22,7 +22,7 @@ dependencies:
   - nexus=4.4.*
   - ninja>=1.10.2
   - numpy>=1.24,<1.27
-  - occt
+  - occt=*=novtk* # Use novtk version, otherwise a lot of extra packages are installed, including qt6-main, which can cause issues when launching on Windows
   - pip>=21.0.1
   - poco=1.12.1|>=1.12.6 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch but not yet included in a release, as of 1.12.5.
   - psutil>=5.8.0

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -23,7 +23,7 @@ dependencies:
   - nexus=4.4.*
   - ninja>=1.10.2
   - numpy>=1.24,<1.27
-  - occt
+  - occt=*=novtk* # Use novtk version, otherwise a lot of extra packages are installed, including qt6-main, which can cause issues when launching on Windows
   - pip>=21.0.1
   - poco=1.12.1|>=1.12.6 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch but not yet included in a release, as of 1.12.5.
   - psutil>=5.8.0


### PR DESCRIPTION
### Description of work
Specify the `novtk` build of `occt`. Otherwise `vtk` is installed as an `occt` dependency. This then brings in a lot of other dependencies and adds a lot of unnecessary bloat. One of the packages that is installed is `qt6-main`, which has caused problems on some Windows machines when attempting to launch `workbench` from a Conda install (see attached issue). Removing the `vtk` dependency should resolve that issue.

Fixes #37581. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->



### To test:
Once this build
https://builds.mantidproject.org/job/build_packages_from_branch/823
has finished, the conda packages should be available on our conda channel. Create a new env and install with
```
mamba create -n novtk_test
mamba activate novtk_test
mamba install -c mantid/label/occt_novtk_test mantidworkbench
```
1. Verify that the `novtk` version of `occt` is installed in the conda environment (use the `conda list` to display all installed packages)
2. Also check that `vtk` and `qt6-main` are **not** in the environment.

*This does not require release notes* because **it's a packaging change that won't directly affect users**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
