### PR TITLE
35956 move verify and clear to tear down method in isis reflectometry unit tests

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchJobManagerProcessingTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchJobManagerProcessingTest.h
@@ -23,11 +23,17 @@ public:
   static BatchJobManagerProcessingTest *createSuite() { return new BatchJobManagerProcessingTest(); }
   static void destroySuite(BatchJobManagerProcessingTest *suite) { delete suite; }
 
+  void tearDown() override {
+    // Verifying and clearing of expectations happens when mock variables are destroyed.
+    // Some of our mocks are created as member variables and will exist until all tests have run, so we need to
+    // explicitly verify and clear them after each test.
+    verifyAndClear();
+  }
+
   void testInitialisedWithNonRunningState() {
     auto jobManager = makeJobManager();
     TS_ASSERT_EQUALS(jobManager.isProcessing(), false);
     TS_ASSERT_EQUALS(jobManager.isAutoreducing(), false);
-    verifyAndClear();
   }
 
   void testReductionResumed() {
@@ -39,14 +45,12 @@ public:
     TS_ASSERT_EQUALS(jobManager.m_reprocessFailed, hasSelection);
     TS_ASSERT_EQUALS(jobManager.m_processAll, !hasSelection);
     TS_ASSERT_EQUALS(jobManager.m_processPartial, hasSelection);
-    verifyAndClear();
   }
 
   void testReductionPaused() {
     auto jobManager = makeJobManager();
     jobManager.notifyReductionPaused();
     TS_ASSERT_EQUALS(jobManager.isProcessing(), false);
-    verifyAndClear();
   }
 
   void testAutoreductionResumed() {
@@ -57,21 +61,18 @@ public:
     TS_ASSERT_EQUALS(jobManager.m_reprocessFailed, true);
     TS_ASSERT_EQUALS(jobManager.m_processAll, true);
     TS_ASSERT_EQUALS(jobManager.m_processPartial, false);
-    verifyAndClear();
   }
 
   void testAutoreductionPaused() {
     auto jobManager = makeJobManager();
     jobManager.notifyAutoreductionPaused();
     TS_ASSERT_EQUALS(jobManager.isAutoreducing(), false);
-    verifyAndClear();
   }
 
   void testSetReprocessFailedItems() {
     auto jobManager = makeJobManager();
     jobManager.setReprocessFailedItems(true);
     TS_ASSERT_EQUALS(jobManager.m_reprocessFailed, true);
-    verifyAndClear();
   }
 
   void testReductionResumedWithNoSelection() {
@@ -82,7 +83,6 @@ public:
     TS_ASSERT_EQUALS(jobManager.m_reprocessFailed, false);
     TS_ASSERT_EQUALS(jobManager.m_processAll, true);
     TS_ASSERT_EQUALS(jobManager.m_processPartial, false);
-    verifyAndClear();
   }
 
   void testReductionResumedWithBothGroupsSelected() {
@@ -95,7 +95,6 @@ public:
     TS_ASSERT_EQUALS(jobManager.m_reprocessFailed, true);
     TS_ASSERT_EQUALS(jobManager.m_processAll, false);
     TS_ASSERT_EQUALS(jobManager.m_processPartial, false);
-    verifyAndClear();
   }
 
   void testReductionResumedWithBothGroupsSelectedAndEmptyGroupNotSelected() {
@@ -108,7 +107,6 @@ public:
     TS_ASSERT_EQUALS(jobManager.m_reprocessFailed, true);
     TS_ASSERT_EQUALS(jobManager.m_processAll, false);
     TS_ASSERT_EQUALS(jobManager.m_processPartial, false);
-    verifyAndClear();
   }
 
   void testReductionResumedWithGroupAndRowSelected() {
@@ -121,7 +119,6 @@ public:
     TS_ASSERT_EQUALS(jobManager.m_reprocessFailed, true);
     TS_ASSERT_EQUALS(jobManager.m_processAll, false);
     TS_ASSERT_EQUALS(jobManager.m_processPartial, false);
-    verifyAndClear();
   }
 
   void testReductionResumedWithGroupAndNonInvalidRowSelected() {
@@ -134,7 +131,6 @@ public:
     TS_ASSERT_EQUALS(jobManager.m_reprocessFailed, true);
     TS_ASSERT_EQUALS(jobManager.m_processAll, false);
     TS_ASSERT_EQUALS(jobManager.m_processPartial, false);
-    verifyAndClear();
   }
 
   void testReductionResumedWithAllRowsSelected() {
@@ -147,7 +143,6 @@ public:
     TS_ASSERT_EQUALS(jobManager.m_reprocessFailed, true);
     TS_ASSERT_EQUALS(jobManager.m_processAll, false);
     TS_ASSERT_EQUALS(jobManager.m_processPartial, false);
-    verifyAndClear();
   }
 
   void testReductionResumedWithAllNonInvalidRowsSelected() {
@@ -160,7 +155,6 @@ public:
     TS_ASSERT_EQUALS(jobManager.m_reprocessFailed, true);
     TS_ASSERT_EQUALS(jobManager.m_processAll, false);
     TS_ASSERT_EQUALS(jobManager.m_processPartial, false);
-    verifyAndClear();
   }
 
   void testReductionResumedWithSomeRowsSelected() {
@@ -173,7 +167,6 @@ public:
     TS_ASSERT_EQUALS(jobManager.m_reprocessFailed, true);
     TS_ASSERT_EQUALS(jobManager.m_processAll, false);
     TS_ASSERT_EQUALS(jobManager.m_processPartial, true);
-    verifyAndClear();
   }
 
   void testReductionResumedWithGroupAndSomeRowsSelected() {
@@ -186,7 +179,6 @@ public:
     TS_ASSERT_EQUALS(jobManager.m_reprocessFailed, true);
     TS_ASSERT_EQUALS(jobManager.m_processAll, false);
     TS_ASSERT_EQUALS(jobManager.m_processPartial, true);
-    verifyAndClear();
   }
 
   void testReductionResumedWithGroupAndChildRowSelected() {
@@ -199,7 +191,6 @@ public:
     TS_ASSERT_EQUALS(jobManager.m_reprocessFailed, true);
     TS_ASSERT_EQUALS(jobManager.m_processAll, false);
     TS_ASSERT_EQUALS(jobManager.m_processPartial, false);
-    verifyAndClear();
   }
 
   void testGetAlgorithmsWithMultipleMatchingRows() {
@@ -255,7 +246,6 @@ public:
     auto jobManager = makeJobManager();
     auto const algorithms = jobManager.getAlgorithms();
     TS_ASSERT_EQUALS(algorithms, std::deque<IConfiguredAlgorithm_sptr>());
-    verifyAndClear();
   }
 
   void testGetAlgorithmsWithMultiGroupModel() {
@@ -263,7 +253,6 @@ public:
     auto jobManager = makeJobManager();
     auto const algorithms = jobManager.getAlgorithms();
     TS_ASSERT_EQUALS(algorithms, std::deque<IConfiguredAlgorithm_sptr>());
-    verifyAndClear();
   }
 
   void testAlgorithmStarted() {
@@ -277,7 +266,6 @@ public:
     TS_ASSERT_EQUALS(row.reducedWorkspaceNames().iVsLambda(), "");
     TS_ASSERT_EQUALS(row.reducedWorkspaceNames().iVsQ(), "");
     TS_ASSERT_EQUALS(row.reducedWorkspaceNames().iVsQBinned(), "");
-    verifyAndClear();
   }
 
   void testAlgorithmComplete() {
@@ -291,7 +279,6 @@ public:
 
     jobManager.algorithmComplete(m_jobAlgorithm);
     TS_ASSERT_EQUALS(row.state(), State::ITEM_SUCCESS);
-    verifyAndClear();
   }
 
   void testAlgorithmError() {
@@ -307,7 +294,6 @@ public:
     TS_ASSERT_EQUALS(row.reducedWorkspaceNames().iVsLambda(), "");
     TS_ASSERT_EQUALS(row.reducedWorkspaceNames().iVsQ(), "");
     TS_ASSERT_EQUALS(row.reducedWorkspaceNames().iVsQBinned(), "");
-    verifyAndClear();
   }
 
   void testAlgorithmCompleteSetsParentsSingleRow() {
@@ -322,8 +308,6 @@ public:
 
     TS_ASSERT_EQUALS(row->state(), State::ITEM_SUCCESS);
     TS_ASSERT_EQUALS(group.state(), State::ITEM_CHILDREN_SUCCESS);
-
-    verifyAndClear();
   }
 
   void testAlgorithmCompleteSetsParentsMultipleRows() {
@@ -346,8 +330,6 @@ public:
     TS_ASSERT_EQUALS(row1->state(), State::ITEM_SUCCESS);
     TS_ASSERT_EQUALS(row2->state(), State::ITEM_SUCCESS);
     TS_ASSERT_EQUALS(group.state(), State::ITEM_CHILDREN_SUCCESS);
-
-    verifyAndClear();
   }
 
   void testAlgorithmErrorSetsParentIncomplete() {
@@ -370,7 +352,5 @@ public:
     TS_ASSERT_EQUALS(row1->state(), State::ITEM_ERROR);
     TS_ASSERT_EQUALS(row2->state(), State::ITEM_SUCCESS);
     TS_ASSERT_EQUALS(group.state(), State::ITEM_NOT_STARTED);
-
-    verifyAndClear();
   }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -55,11 +55,17 @@ public:
     Mantid::API::FrameworkManager::Instance();
   }
 
+  void tearDown() override {
+    // Verifying and clearing of expectations happens when mock variables are destroyed.
+    // Some of our mocks are created as member variables and will exist until all tests have run, so we need to
+    // explicitly verify and clear them after each test.
+    verifyAndClear();
+  }
+
   void testInitInstrumentListUpdatesRunsPresenter() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, initInstrumentList(_)).Times(1);
     presenter->initInstrumentList();
-    verifyAndClear();
   }
 
   void testMainPresenterUpdatedWhenChangeInstrumentRequested() {
@@ -67,7 +73,6 @@ public:
     auto const instrument = std::string("POLREF");
     EXPECT_CALL(m_mainPresenter, notifyChangeInstrumentRequested(instrument)).Times(1);
     presenter->notifyChangeInstrumentRequested(instrument);
-    verifyAndClear();
   }
 
   void testChildPresentersAreUpdatedWhenInstrumentChanged() {
@@ -77,7 +82,6 @@ public:
     EXPECT_CALL(*m_experimentPresenter, notifyInstrumentChanged(instrument)).Times(1);
     EXPECT_CALL(*m_instrumentPresenter, notifyInstrumentChanged(instrument)).Times(1);
     presenter->notifyInstrumentChanged(instrument);
-    verifyAndClear();
   }
 
   void testMainPresenterUpdatedWhenUpdateInstrumentRequested() {
@@ -85,35 +89,30 @@ public:
     auto const instrument = std::string("POLREF");
     EXPECT_CALL(m_mainPresenter, notifyUpdateInstrumentRequested()).Times(1);
     presenter->notifyUpdateInstrumentRequested();
-    verifyAndClear();
   }
 
   void testChildPresentersUpdatedWhenSettingsChanged() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, settingsChanged()).Times(1);
     presenter->notifySettingsChanged();
-    verifyAndClear();
   }
 
   void testModelUpdatedWhenReductionResumed() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, notifyReductionResumed()).Times(1);
     presenter->notifyResumeReductionRequested();
-    verifyAndClear();
   }
 
   void testBatchIsExecutedWhenReductionResumed() {
     auto presenter = makePresenter(makeModel());
     expectBatchIsExecuted();
     presenter->notifyResumeReductionRequested();
-    verifyAndClear();
   }
 
   void testOtherPresentersUpdatedWhenReductionResumed() {
     auto presenter = makePresenter(makeModel());
     expectReductionResumed();
     presenter->notifyResumeReductionRequested();
-    verifyAndClear();
   }
 
   void testJobManagerGetProcessAll() {
@@ -121,7 +120,6 @@ public:
     TS_ASSERT_EQUALS(m_jobManager->getProcessAll(), false);
     expectReductionResumed();
     presenter->notifyResumeReductionRequested();
-    verifyAndClear();
   }
 
   void testJobManagerGetProcessPartial() {
@@ -129,7 +127,6 @@ public:
     TS_ASSERT_EQUALS(m_jobManager->getProcessPartial(), false);
     expectReductionResumed();
     presenter->notifyResumeReductionRequested();
-    verifyAndClear();
   }
 
   void testWarnProcessAllWhenReductionResumedOptionChecked() {
@@ -138,7 +135,6 @@ public:
     EXPECT_CALL(*m_jobManager, notifyReductionResumed()).Times(1);
     EXPECT_CALL(m_mainPresenter, isProcessAllPrevented()).Times(1).WillOnce(Return(true));
     presenter->notifyResumeReductionRequested();
-    verifyAndClear();
   }
 
   void testNoWarnProcessAllWhenReductionResumedOptionUnchecked() {
@@ -147,7 +143,6 @@ public:
     EXPECT_CALL(*m_jobManager, notifyReductionResumed()).Times(1);
     EXPECT_CALL(m_mainPresenter, isProcessAllPrevented()).Times(1).WillOnce(Return(false));
     presenter->notifyResumeReductionRequested();
-    verifyAndClear();
   }
 
   void testWarnProcessPartialGroupWhenReductionResumedOptionChecked() {
@@ -156,7 +151,6 @@ public:
     EXPECT_CALL(*m_jobManager, notifyReductionResumed()).Times(1);
     EXPECT_CALL(m_mainPresenter, isProcessPartialGroupPrevented()).Times(1).WillOnce(Return(true));
     presenter->notifyResumeReductionRequested();
-    verifyAndClear();
   }
 
   void testNoWarnProcessPartialGroupWhenReductionResumedOptionUnchecked() {
@@ -165,14 +159,12 @@ public:
     EXPECT_CALL(*m_jobManager, notifyReductionResumed()).Times(1);
     EXPECT_CALL(m_mainPresenter, isProcessPartialGroupPrevented()).Times(1).WillOnce(Return(false));
     presenter->notifyResumeReductionRequested();
-    verifyAndClear();
   }
 
   void testChildPresentersUpdatedWhenAnyBatchReductionResumed() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyAnyBatchReductionResumed()).Times(1);
     presenter->notifyAnyBatchReductionResumed();
-    verifyAndClear();
   }
 
   void testChildPresentersUpdatedWhenAnyBatchReductionPaused() {
@@ -186,14 +178,12 @@ public:
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyAnyBatchAutoreductionResumed()).Times(1);
     presenter->notifyAnyBatchAutoreductionResumed();
-    verifyAndClear();
   }
 
   void testChildPresentersUpdatedWhenAnyBatchAutoreductionPaused() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyAnyBatchAutoreductionPaused()).Times(1);
     presenter->notifyAnyBatchAutoreductionPaused();
-    verifyAndClear();
   }
 
   void testMainPresenterQueriedWhenCheckingAnyBatchProcessing() {
@@ -201,7 +191,6 @@ public:
     EXPECT_CALL(m_mainPresenter, isAnyBatchProcessing()).Times(1).WillOnce(Return(true));
     auto result = presenter->isAnyBatchProcessing();
     TS_ASSERT_EQUALS(result, true);
-    verifyAndClear();
   }
 
   void testMainPresenterQueriedWhenCheckingAnyBatchAutoreducing() {
@@ -209,7 +198,6 @@ public:
     EXPECT_CALL(m_mainPresenter, isAnyBatchAutoreducing()).Times(1).WillOnce(Return(true));
     auto result = presenter->isAnyBatchAutoreducing();
     TS_ASSERT_EQUALS(result, true);
-    verifyAndClear();
   }
 
   void testAutoreductionCompletedWhenReductionResumedWithNoRemainingJobs() {
@@ -218,28 +206,24 @@ public:
     EXPECT_CALL(*m_jobManager, isAutoreducing()).Times(AtLeast(1)).WillRepeatedly(Return(true));
     EXPECT_CALL(*m_runsPresenter, autoreductionCompleted()).Times(1);
     presenter->notifyResumeReductionRequested();
-    verifyAndClear();
   }
 
   void testAutoreductionNotCompletedWhenReductionResumedWithRemainingJobs() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, autoreductionCompleted()).Times(0);
     presenter->notifyResumeReductionRequested();
-    verifyAndClear();
   }
 
   void testBatchIsCancelledWhenReductionPaused() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobRunner, cancelAlgorithmQueue()).Times(1);
     presenter->notifyPauseReductionRequested();
-    verifyAndClear();
   }
 
   void testModelUpdatedWhenBatchCancelled() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, notifyReductionPaused()).Times(1);
     presenter->notifyBatchCancelled();
-    verifyAndClear();
   }
 
   void testChildPresentersUpdatedWhenBatchCancelled() {
@@ -247,7 +231,6 @@ public:
     expectReductionPaused();
     expectAutoreductionPaused();
     presenter->notifyBatchCancelled();
-    verifyAndClear();
   }
 
   void testModelUpdatedWhenAutoreductionResumed() {
@@ -255,14 +238,12 @@ public:
     EXPECT_CALL(*m_jobManager, notifyAutoreductionResumed()).Times(1);
     EXPECT_CALL(*m_jobManager, notifyAutoreductionPaused()).Times(0);
     presenter->notifyResumeAutoreductionRequested();
-    verifyAndClear();
   }
 
   void testRunsPresenterCalledWhenAutoreductionResumed() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, resumeAutoreduction()).Times(1);
     presenter->notifyResumeAutoreductionRequested();
-    verifyAndClear();
   }
 
   void testModelResetWhenAutoreductionCancelled() {
@@ -270,14 +251,12 @@ public:
     EXPECT_CALL(*m_runsPresenter, resumeAutoreduction()).Times(1).WillOnce(Return(false));
     EXPECT_CALL(*m_jobManager, notifyAutoreductionPaused()).Times(1);
     presenter->notifyResumeAutoreductionRequested();
-    verifyAndClear();
   }
 
   void testOtherPresentersUpdatedWhenAutoreductionResumed() {
     auto presenter = makePresenter(makeModel());
     expectAutoreductionResumed();
     presenter->notifyResumeAutoreductionRequested();
-    verifyAndClear();
   }
 
   void testChildPresentersNotUpdatedWhenAutoreductionCanelled() {
@@ -289,28 +268,24 @@ public:
     EXPECT_CALL(*m_instrumentPresenter, notifyAutoreductionResumed()).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyAutoreductionResumed()).Times(0);
     presenter->notifyResumeAutoreductionRequested();
-    verifyAndClear();
   }
 
   void testModelUpdatedWhenAutoreductionPaused() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, notifyAutoreductionPaused()).Times(1);
     presenter->notifyPauseAutoreductionRequested();
-    verifyAndClear();
   }
 
   void testBatchIsCancelledWhenAutoreductionPaused() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobRunner, cancelAlgorithmQueue()).Times(1);
     presenter->notifyPauseAutoreductionRequested();
-    verifyAndClear();
   }
 
   void testOtherPresentersUpdatedWhenAutoreductionPaused() {
     auto presenter = makePresenter(makeModel());
     expectAutoreductionPaused();
     presenter->notifyPauseAutoreductionRequested();
-    verifyAndClear();
   }
 
   void testAutoreductionComplete() {
@@ -318,14 +293,12 @@ public:
     EXPECT_CALL(*m_runsPresenter, autoreductionCompleted()).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged()).Times(1);
     presenter->notifyAutoreductionCompleted();
-    verifyAndClear();
   }
 
   void testNextBatchIsStartedWhenBatchFinished() {
     auto presenter = makePresenter(makeModel());
     expectBatchIsExecuted();
     presenter->notifyBatchComplete(false);
-    verifyAndClear();
   }
 
   void testChildPresentersUpdatedWhenBatchFinishedAndNothingLeftToProcess() {
@@ -333,7 +306,6 @@ public:
     EXPECT_CALL(*m_jobManager, getAlgorithms()).Times(1).WillOnce(Return(std::deque<IConfiguredAlgorithm_sptr>()));
     expectReductionPaused();
     presenter->notifyBatchComplete(false);
-    verifyAndClear();
   }
 
   void testNotifyAlgorithmStarted() {
@@ -344,7 +316,6 @@ public:
     EXPECT_CALL(*m_jobManager, algorithmStarted(algorithm)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
     presenter->notifyAlgorithmStarted(algorithm);
-    verifyAndClear();
   }
 
   void testNotifyAlgorithmComplete() {
@@ -355,7 +326,6 @@ public:
     EXPECT_CALL(*m_jobManager, algorithmComplete(algorithm)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
     presenter->notifyAlgorithmComplete(algorithm);
-    verifyAndClear();
   }
 
   void testNotifyAlgorithmStartedSkipsNonItems() {
@@ -365,7 +335,6 @@ public:
     EXPECT_CALL(*m_jobManager, algorithmStarted(_)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(0);
     presenter->notifyAlgorithmStarted(algorithm);
-    verifyAndClear();
   }
 
   void testNotifyAlgorithmCompleteSkipsNonItems() {
@@ -375,7 +344,6 @@ public:
     EXPECT_CALL(*m_jobManager, algorithmComplete(_)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(0);
     presenter->notifyAlgorithmComplete(algorithm);
-    verifyAndClear();
   }
 
   void testNotifyAlgorithmErrorSkipsNonItems() {
@@ -385,7 +353,6 @@ public:
     EXPECT_CALL(*m_jobManager, algorithmError(_, _)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(0);
     presenter->notifyAlgorithmError(algorithm, "");
-    verifyAndClear();
   }
 
   void testOutputWorkspacesSavedOnAlgorithmComplete() {
@@ -400,7 +367,6 @@ public:
     EXPECT_CALL(*m_jobManager, algorithmOutputWorkspacesToSave(algorithm, false)).Times(1).WillOnce(Return(workspaces));
     EXPECT_CALL(*m_savePresenter, saveWorkspaces(workspaces, true)).Times(1);
     presenter->notifyAlgorithmComplete(algorithm);
-    verifyAndClear();
   }
 
   void testOutputWorkspacesSavedOnAlgorithmCompleteWithAutosaveGroupRows() {
@@ -415,7 +381,6 @@ public:
     EXPECT_CALL(*m_jobManager, algorithmOutputWorkspacesToSave(algorithm, true)).Times(1).WillOnce(Return(workspaces));
     EXPECT_CALL(*m_savePresenter, saveWorkspaces(workspaces, true)).Times(1);
     presenter->notifyAlgorithmComplete(algorithm);
-    verifyAndClear();
   }
 
   void testOutputWorkspacesNotSavedIfAutosaveDisabled() {
@@ -428,7 +393,6 @@ public:
     EXPECT_CALL(*m_jobManager, algorithmOutputWorkspacesToSave(_, _)).Times(0);
     EXPECT_CALL(*m_savePresenter, saveWorkspaces(_, true)).Times(0);
     presenter->notifyAlgorithmComplete(algorithm);
-    verifyAndClear();
   }
 
   void testOutputWorkspacesNotSavedWithAutosaveIfNoWorkspacesToSave() {
@@ -443,7 +407,6 @@ public:
     EXPECT_CALL(*m_jobManager, algorithmOutputWorkspacesToSave(algorithm, true)).Times(1).WillOnce(Return(workspaces));
     EXPECT_CALL(*m_savePresenter, saveWorkspaces(workspaces, true)).Times(0);
     presenter->notifyAlgorithmComplete(algorithm);
-    verifyAndClear();
   }
 
   void testNotifyAlgorithmError() {
@@ -455,7 +418,6 @@ public:
     EXPECT_CALL(*m_jobManager, algorithmError(algorithm, errorMessage)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
     presenter->notifyAlgorithmError(algorithm, errorMessage);
-    verifyAndClear();
   }
 
   void testModelUpdatedWhenWorkspaceDeleted() {
@@ -463,14 +425,12 @@ public:
     auto name = std::string("test_workspace");
     EXPECT_CALL(*m_jobManager, notifyWorkspaceDeleted(name)).Times(1);
     presenter->postDeleteHandle(name);
-    verifyAndClear();
   }
 
   void testRowStateUpdatedWhenWorkspaceDeleted() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
     presenter->postDeleteHandle("");
-    verifyAndClear();
   }
 
   void testModelUpdatedWhenWorkspaceRenamed() {
@@ -479,28 +439,24 @@ public:
     auto newName = std::string("test_workspace2");
     EXPECT_CALL(*m_jobManager, notifyWorkspaceRenamed(oldName, newName)).Times(1);
     presenter->renameHandle(oldName, newName);
-    verifyAndClear();
   }
 
   void testRowStateUpdatedWhenWorkspaceRenamed() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
     presenter->renameHandle("", "");
-    verifyAndClear();
   }
 
   void testModelUpdatedWhenWorkspacesCleared() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, notifyAllWorkspacesDeleted()).Times(1);
     presenter->clearADSHandle();
-    verifyAndClear();
   }
 
   void testRowStateUpdatedWhenWorkspacesCleared() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged()).Times(1);
     presenter->clearADSHandle();
-    verifyAndClear();
   }
 
   void testPercentCompleteIsRequestedFromJobManager() {
@@ -508,7 +464,6 @@ public:
     auto progress = 33;
     EXPECT_CALL(*m_jobManager, percentComplete()).Times(1).WillOnce(Return(progress));
     TS_ASSERT_EQUALS(presenter->percentComplete(), progress);
-    verifyAndClear();
   }
 
   void testRunsPresenterNotifiesSetRoundPrecision() {
@@ -516,21 +471,18 @@ public:
     auto prec = 2;
     EXPECT_CALL(*m_runsPresenter, setRoundPrecision(prec));
     presenter->notifySetRoundPrecision(prec);
-    verifyAndClear();
   }
 
   void testRunsPresenterNotifiesResetRoundPrecision() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, resetRoundPrecision());
     presenter->notifyResetRoundPrecision();
-    verifyAndClear();
   }
 
   void testNotifyBatchLoaded() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyBatchLoaded());
     presenter->notifyBatchLoaded();
-    verifyAndClear();
   }
 
   void testWarningShownOnResumeWhenExperimentSettingsInvalid() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Event/EventPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Event/EventPresenterTest.h
@@ -27,16 +27,21 @@ public:
 
   EventPresenterTest() : m_view() {}
 
+  void tearDown() override {
+    // Verifying and clearing of expectations happens when mock variables are destroyed.
+    // Some of our mocks are created as member variables and will exist until all tests have run, so we need to
+    // explicitly verify and clear them after each test.
+    verifyAndClear();
+  }
+
   void testPresenterSubscribesToView() {
     EXPECT_CALL(m_view, subscribe(_)).Times(1);
     auto presenter = makePresenter();
-    verifyAndClear();
   }
 
   void testNoEventSlicingByDefault() {
     auto presenter = makePresenter();
     TS_ASSERT(isNoSlicing(presenter.slicing()));
-    verifyAndClear();
   }
 
   void testInitializesWithStateFromViewWhenChangingToUniformSlicingByTime() {
@@ -51,7 +56,6 @@ public:
     TS_ASSERT_EQUALS(presenter.slicing().which(), 2);
     auto const &uniformSlicingByTime = boost::get<UniformSlicingByTime>(presenter.slicing());
     TS_ASSERT(uniformSlicingByTime == UniformSlicingByTime(secondsPerSlice));
-    verifyAndClear();
   }
 
   void testInitializesWithStateFromViewWhenChangingToUniformSlicingByNumberOfSlices() {
@@ -66,7 +70,6 @@ public:
     TS_ASSERT_EQUALS(presenter.slicing().which(), 3);
     auto const &uniformSlicingByNumberOfSlices = boost::get<UniformSlicingByNumberOfSlices>(presenter.slicing());
     TS_ASSERT(uniformSlicingByNumberOfSlices == UniformSlicingByNumberOfSlices(numberOfSlices));
-    verifyAndClear();
   }
 
   void testInitializesWithStateFromViewWhenChangingToCustomSlicing() {
@@ -83,7 +86,6 @@ public:
     TS_ASSERT_EQUALS(presenter.slicing().which(), 4);
     auto const &sliceTimes = boost::get<CustomSlicingByList>(presenter.slicing());
     TS_ASSERT(sliceTimes == CustomSlicingByList(expectedSliceTimes));
-    verifyAndClear();
   }
 
   void testInitializedWithStateFromViewWhenChangingToSlicingByEventLog() {
@@ -102,7 +104,6 @@ public:
     TS_ASSERT_EQUALS(presenter.slicing().which(), 5);
     auto const &sliceValues = boost::get<SlicingByEventLog>(presenter.slicing());
     TS_ASSERT(sliceValues == SlicingByEventLog(expectedSliceValues, logBlockName));
-    verifyAndClear();
   }
 
   void testChangingSliceCountUpdatesModel() {
@@ -117,7 +118,6 @@ public:
     presenter.notifyUniformSliceCountChanged(expectedSliceCount);
     auto const &sliceValues = boost::get<UniformSlicingByNumberOfSlices>(presenter.slicing());
     TS_ASSERT(sliceValues == UniformSlicingByNumberOfSlices(expectedSliceCount));
-    verifyAndClear();
   }
 
   void testViewUpdatedWhenInvalidSliceValuesEntered() {
@@ -131,7 +131,6 @@ public:
 
     EXPECT_CALL(m_view, showCustomBreakpointsInvalid()).Times(1);
     presenter.notifyCustomSliceValuesChanged(invalidCustomBreakpoints);
-    verifyAndClear();
   }
 
   void testModelUpdatedWhenInvalidSliceValuesEntered() {
@@ -146,7 +145,6 @@ public:
     presenter.notifyCustomSliceValuesChanged(invalidCustomBreakpoints);
     auto const &slicing = boost::get<InvalidSlicing>(presenter.slicing());
     TS_ASSERT(slicing == InvalidSlicing());
-    verifyAndClear();
   }
 
   void testModelUpdatedWhenInvalidSliceValuesCorrected() {
@@ -160,7 +158,6 @@ public:
 
     presenter.notifyCustomSliceValuesChanged(validCustomBreakpoints);
     TS_ASSERT(!isInvalid(presenter.slicing()));
-    verifyAndClear();
   }
 
   void testViewUpdatedWhenInvalidSliceValuesCorrected() {
@@ -174,14 +171,12 @@ public:
 
     EXPECT_CALL(m_view, showCustomBreakpointsValid());
     presenter.notifyCustomSliceValuesChanged(validCustomBreakpoints);
-    verifyAndClear();
   }
 
   void testChangingSliceTypeNotifiesMainPresenter() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(AtLeast(1));
     presenter.notifySliceTypeChanged(SliceType::None);
-    verifyAndClear();
   }
 
   void testChangingSliceCountNotifiesMainPresenter() {
@@ -189,14 +184,12 @@ public:
     presenter.notifySliceTypeChanged(SliceType::UniformEven);
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(AtLeast(1));
     presenter.notifyUniformSliceCountChanged(1);
-    verifyAndClear();
   }
 
   void testChangingCustomSliceValuesNotifiesMainPresenter() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(AtLeast(1));
     presenter.notifyCustomSliceValuesChanged("");
-    verifyAndClear();
   }
 
   void testNoSlicingOccursWhenSliceTypeIsNone() {
@@ -209,8 +202,6 @@ public:
     presenter.notifyCustomSliceValuesChanged("string");
     presenter.notifyLogSliceBreakpointsChanged("");
     presenter.notifyLogBlockNameChanged("");
-
-    verifyAndClear();
   }
 
 private:

--- a/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
@@ -36,10 +36,16 @@ public:
 
   InstrumentPresenterTest() : m_view() { Mantid::API::FrameworkManager::Instance(); }
 
+  void tearDown() override {
+    // Verifying and clearing of expectations happens when mock variables are destroyed.
+    // Some of our mocks are created as member variables and will exist until all tests have run, so we need to
+    // explicitly verify and clear them after each test.
+    verifyAndClear();
+  }
+
   void testPresenterSubscribesToView() {
     EXPECT_CALL(m_view, subscribe(_)).Times(1);
     auto presenter = makePresenter();
-    verifyAndClear();
   }
 
   void testSetValidWavelengthRange() {
@@ -80,7 +86,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.instrument().integratedMonitors(), integrate);
-    verifyAndClear();
   }
 
   void testSetMonitorIndex() {
@@ -91,7 +96,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.instrument().monitorIndex(), monitorIndex);
-    verifyAndClear();
   }
 
   void testSetValidMonitorIntegralRange() {
@@ -162,7 +166,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.instrument().correctDetectors(), correctDetectors);
-    verifyAndClear();
   }
 
   void testEnablingCorrectDetectorsEnablesCorrectionType() {
@@ -171,8 +174,6 @@ public:
     EXPECT_CALL(m_view, getCorrectDetectors()).WillOnce(Return(true));
     EXPECT_CALL(m_view, enableDetectorCorrectionType()).Times(1);
     presenter.notifySettingsChanged();
-
-    verifyAndClear();
   }
 
   void testDiablingCorrectDetectorsDisablesCorrectionType() {
@@ -181,8 +182,6 @@ public:
     EXPECT_CALL(m_view, getCorrectDetectors()).WillOnce(Return(false));
     EXPECT_CALL(m_view, disableDetectorCorrectionType()).Times(1);
     presenter.notifySettingsChanged();
-
-    verifyAndClear();
   }
 
   void testSetDetectorCorrectionTypeUpdatesModel() {
@@ -192,7 +191,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.instrument().detectorCorrectionType(), DetectorCorrectionType::RotateAroundSample);
-    verifyAndClear();
   }
 
   void testSetCalibrationFileUpdatesModel() {
@@ -203,7 +201,6 @@ public:
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.instrument().calibrationFilePath(), calibrationFilePath);
-    verifyAndClear();
   }
 
   void testAllWidgetsAreEnabledWhenReductionPaused() {
@@ -212,8 +209,6 @@ public:
     EXPECT_CALL(m_view, enableAll()).Times(1);
     expectNotProcessingOrAutoreducing();
     presenter.notifyReductionPaused();
-
-    verifyAndClear();
   }
 
   void testAllWidgetsAreDisabledWhenReductionResumed() {
@@ -222,8 +217,6 @@ public:
     EXPECT_CALL(m_view, disableAll()).Times(1);
     expectProcessing();
     presenter.notifyReductionResumed();
-
-    verifyAndClear();
   }
 
   void testAllWidgetsAreEnabledWhenAutoreductionPaused() {
@@ -232,8 +225,6 @@ public:
     EXPECT_CALL(m_view, enableAll()).Times(1);
     expectNotProcessingOrAutoreducing();
     presenter.notifyAutoreductionPaused();
-
-    verifyAndClear();
   }
 
   void testAllWidgetsAreDisabledWhenAutoreductionResumed() {
@@ -242,8 +233,6 @@ public:
     EXPECT_CALL(m_view, disableAll()).Times(1);
     expectAutoreducing();
     presenter.notifyAutoreductionResumed();
-
-    verifyAndClear();
   }
 
   void testSettingsChangedNotifiesMainPresenter() {
@@ -251,15 +240,12 @@ public:
 
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(AtLeast(1));
     presenter.notifySettingsChanged();
-
-    verifyAndClear();
   }
 
   void testRestoreDefaultsUpdatesInstrument() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifyUpdateInstrumentRequested()).Times(1);
     presenter.notifyRestoreDefaultsRequested();
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesMonitorOptionsInView() {
@@ -274,7 +260,6 @@ public:
     EXPECT_CALL(m_view, setMonitorIntegralMin(4.0)).Times(1);
     EXPECT_CALL(m_view, setMonitorIntegralMax(10.0)).Times(1);
     presenter.notifyInstrumentChanged("POLREF");
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesMonitorOptionsInModel() {
@@ -287,7 +272,6 @@ public:
     TS_ASSERT_EQUALS(presenter.instrument().integratedMonitors(), true);
     TS_ASSERT_EQUALS(presenter.instrument().monitorBackgroundRange(), RangeInLambda(17.0, 18.0));
     TS_ASSERT_EQUALS(presenter.instrument().monitorIntegralRange(), RangeInLambda(4.0, 10.0));
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesWavelengthRangeInView() {
@@ -297,7 +281,6 @@ public:
     EXPECT_CALL(m_view, setLambdaMin(1.5)).Times(1);
     EXPECT_CALL(m_view, setLambdaMax(17.0)).Times(1);
     presenter.notifyInstrumentChanged("POLREF");
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesWavelengthRangeInModel() {
@@ -306,7 +289,6 @@ public:
     auto presenter = makePresenter(std::move(defaultOptions));
     presenter.notifyInstrumentChanged("POLREF");
     TS_ASSERT_EQUALS(presenter.instrument().wavelengthRange(), RangeInLambda(1.5, 17.0));
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesUpdatesDetectorOptionsInView() {
@@ -317,7 +299,6 @@ public:
     EXPECT_CALL(m_view, setCorrectDetectors(true)).Times(1);
     EXPECT_CALL(m_view, setDetectorCorrectionType("RotateAroundSample")).Times(1);
     presenter.notifyInstrumentChanged("POLREF");
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesUpdatesDetectorOptionsInModel() {
@@ -328,7 +309,6 @@ public:
     presenter.notifyInstrumentChanged("POLREF");
     auto const expected = DetectorCorrections(true, DetectorCorrectionType::RotateAroundSample);
     TS_ASSERT_EQUALS(presenter.instrument().detectorCorrections(), expected);
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesCalibrationFilePathInView() {
@@ -338,7 +318,6 @@ public:
     auto presenter = makePresenter(std::move(defaultOptions));
     EXPECT_CALL(m_view, setCalibrationFilePath(defaultFilepath)).Times(1);
     presenter.notifyInstrumentChanged("POLREF");
-    verifyAndClear();
   }
 
   void testEnteringInvalidCalibrationFilePathTriggersError() {
@@ -347,7 +326,6 @@ public:
     EXPECT_CALL(m_fileHandler, fileExists("test")).WillOnce(Return(false));
     EXPECT_CALL(m_view, showCalibrationFilePathInvalid()).Times(1);
     presenter.notifySettingsChanged();
-    verifyAndClear();
   }
 
   void testEnteringEmptyCalibrationFilePathDoesNotTriggerError() {
@@ -356,7 +334,6 @@ public:
     EXPECT_CALL(m_fileHandler, fileExists("")).Times(0);
     EXPECT_CALL(m_view, showCalibrationFilePathValid()).Times(1);
     presenter.notifySettingsChanged();
-    verifyAndClear();
   }
 
 private:
@@ -428,7 +405,6 @@ private:
     EXPECT_CALL(m_view, showLambdaRangeValid()).Times(1);
     presenter.notifySettingsChanged();
     TS_ASSERT_EQUALS(presenter.instrument().wavelengthRange(), result);
-    verifyAndClear();
   }
 
   void runTestForInvalidWavelengthRange(RangeInLambda const &range) {
@@ -438,7 +414,6 @@ private:
     EXPECT_CALL(m_view, showLambdaRangeInvalid()).Times(1);
     presenter.notifySettingsChanged();
     TS_ASSERT_EQUALS(presenter.instrument().wavelengthRange(), boost::none);
-    verifyAndClear();
   }
 
   void runTestForValidMonitorIntegralRange(RangeInLambda const &range, boost::optional<RangeInLambda> const &result) {
@@ -448,7 +423,6 @@ private:
     EXPECT_CALL(m_view, showMonitorIntegralRangeValid()).Times(1);
     presenter.notifySettingsChanged();
     TS_ASSERT_EQUALS(presenter.instrument().monitorIntegralRange(), result);
-    verifyAndClear();
   }
 
   void runTestForInvalidMonitorIntegralRange(RangeInLambda const &range) {
@@ -458,7 +432,6 @@ private:
     EXPECT_CALL(m_view, showMonitorIntegralRangeInvalid()).Times(1);
     presenter.notifySettingsChanged();
     TS_ASSERT_EQUALS(presenter.instrument().monitorIntegralRange(), boost::none);
-    verifyAndClear();
   }
 
   void runTestForValidMonitorBackgroundRange(RangeInLambda const &range, boost::optional<RangeInLambda> const &result) {
@@ -468,7 +441,6 @@ private:
     EXPECT_CALL(m_view, showMonitorBackgroundRangeValid()).Times(1);
     presenter.notifySettingsChanged();
     TS_ASSERT_EQUALS(presenter.instrument().monitorBackgroundRange(), result);
-    verifyAndClear();
   }
 
   void runTestForInvalidMonitorBackgroundRange(RangeInLambda const &range) {
@@ -478,6 +450,5 @@ private:
     EXPECT_CALL(m_view, showMonitorBackgroundRangeInvalid()).Times(1);
     presenter.notifySettingsChanged();
     TS_ASSERT_EQUALS(presenter.instrument().monitorBackgroundRange(), boost::none);
-    verifyAndClear();
   }
 };


### PR DESCRIPTION
### Description of work
Move verify and clear to tear down method in isis reflectometry unit tests 
#### Summary of work
- moved verify and clear to tear down method in the following files:
- ExperimentPresenterTest
- BatchJobManagerProcessingTest
- BatchJobManagerWorkspacesTest
- BatchPresenterTest
- EventPresenterTest
- ExperimentPresenterTest
- InstrumentPresenterTest

Refs: https://github.com/mantidproject/mantid/issues/35956

#### To test:

Tests should pass.

*This does not require release notes* because **it is a unit test refactor.**