### PR TITLE
Revert adding plugin dll directory to path

### DIFF
--- a/installers/conda/win/sitecustomize.py
+++ b/installers/conda/win/sitecustomize.py
@@ -9,17 +9,13 @@
 
 def _add_executable_path_to_path():
     """
-    Adds the sys.executable and plugin directory to the DLL load list of allowed directories
+    Adds the sys.executable directory to the DLL load list of allowed directories
     """
     import os
     import sys
 
-    executable_dir = os.path.dirname(sys.executable)
-    plugin_dir = os.path.join(executable_dir, os.pardir, "plugins", "qt5")
-
-    os.environ["PATH"] = f'{executable_dir};{plugin_dir};{os.environ["PATH"]}'
-    os.add_dll_directory(executable_dir)
-    os.add_dll_directory(plugin_dir)
+    os.environ["PATH"] = f'{os.path.dirname(sys.executable)};{os.environ["PATH"]}'
+    os.add_dll_directory(os.path.dirname(sys.executable))
 
 
 _add_executable_path_to_path()

--- a/qt/scientific_interfaces/Inelastic/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/CMakeLists.txt
@@ -35,7 +35,7 @@ mtd_add_qt_library(
             Qt5::Concurrent
             Qt5::Xml
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsPlotting MantidQtWidgetsMplCpp MantidQtIcons
-  INSTALL_DIR_BASE ${WORKBENCH_PLUGINS_DIR}
+  INSTALL_DIR ${WORKBENCH_LIB_DIR}
   OSX_INSTALL_RPATH @loader_path/../../MacOS @loader_path/../../Frameworks @loader_path/../../plugins/qt5
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../plugins/qt5/"
 )


### PR DESCRIPTION
### Description of work
Reverts the changes made in #36674 because the plugin dll directory only gets added to the path for the bundled package, and not for the conda package on Windows. Because the Indirect plugin dll depends on the Inelastic plugin dll, we therefore need to store the Inelastic plugin dll in the Library dll directory.

This is a temporary measure for this release. We want to extract the common functionality in both Inelastic and Indirect plugin libraries, and put this into a non-plugin library. We can then get the Inelastic and Indirect plugin libraries to depend on this new library, and the Inelastic plugin library can then be installed in the plugin directory as we were previously doing.

See the following issue to do this follow-up work: #37591 

Fixes #37587 

### To test:
When this job has finished
https://builds.mantidproject.org/job/build_packages_from_branch/821/
The Windows packages should be installable by
`mamba install -c mantid/label/indirect_dll_fix mantidworkbench`

On Windows:
1. Install `mantidworkbench` into a new Conda env, as above.
2. Check no DLL errors
3. Check Indirect and Inelastic interface categories exist
4. Install and open a bundled Mantid from the build packages from branch
5. Check no DLL errors
6. Check Indirect and Inelastic interface categories exist


*This does not require release notes* because **no user-facing changes**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
