### PR TITLE
Report underlying processor arch on Arm Macs

### DIFF
--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1180,7 +1180,7 @@ std::string ConfigServiceImpl::getUsername() {
     if (!username.empty()) {
       return username;
     }
-  } catch (Poco::NotFoundException &e) {
+  } catch (const Poco::NotFoundException &e) {
     UNUSED_ARG(e); // let it drop on the floor
   }
 
@@ -1190,7 +1190,7 @@ std::string ConfigServiceImpl::getUsername() {
     if (!username.empty()) {
       return username;
     }
-  } catch (Poco::NotFoundException &e) {
+  } catch (const Poco::NotFoundException &e) {
     UNUSED_ARG(e); // let it drop on the floor
   }
 

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -65,6 +65,7 @@
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
+#include <sys/sysctl.h>
 #endif
 
 namespace Mantid {
@@ -1009,7 +1010,21 @@ std::string ConfigServiceImpl::getOSName() { return m_pSysConfig->getString("sys
  *
  *  @returns The  name of the computer
  */
-std::string ConfigServiceImpl::getOSArchitecture() { return m_pSysConfig->getString("system.osArchitecture"); }
+std::string ConfigServiceImpl::getOSArchitecture() {
+  auto osArch = m_pSysConfig->getString("system.osArchitecture");
+#ifdef __APPLE__
+  if (osArch == "x86_64") {
+    // This could be running under Rosetta on an Arm Mac
+    // https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment
+    int ret = 0;
+    size_t size = sizeof(ret);
+    if (sysctlbyname("sysctl.proc_translated", &ret, &size, nullptr, 0) != -1 && ret == 1) {
+      osArch = "arm64_(x86_64)";
+    }
+  }
+#endif
+  return osArch;
+}
 
 /** Gets the name of the operating system Architecture
  *

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -91,9 +91,7 @@ returnByReference:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ConfigSe
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ConfigService.h:197
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ThreadScheduler.h:174
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ThreadScheduler.h:278
-passedByValue:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/ConfigService.cpp:1904
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/ConfigService.cpp:1168
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/ConfigService.cpp:1178
+passedByValue:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/ConfigService.cpp:1919
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/TopicInfo.cpp:38
 returnStdMoveLocal:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp:408
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/PropertyManagerProperty.cpp:149


### PR DESCRIPTION
If someone with an Arm chip is running an x86_64 Mantid (currently the only type we make for MacOS), then it will run under the Rosetta translation layer. This means the OS architecture will be reported as x86_64. This bit of code is how Apple recommends to check if your code is running on Rosetta, which will then allow us to correctly determine how many Arm Mac users we have.

See [here](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment#Determine-Whether-Your-App-Is-Running-as-a-Translated-Binary) for the Apple docs. The example is in Objective-C but it's pretty similar in this case to C++.

Fixes #37592

### Description of work
If running on an Apple machine, and the OS architecture is given as `x86_64`, then check if the code is running on Rosetta. If it is then change the `osArch` entry in the usage report to `arm64_(x86_64)`. A native app will say the architecture is `arm64` so I think it would be useful to distinguish between the two cases later (when we have a native version).

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

We don't want to actually send any usage reports, so e.g. comment out line 332 of `UsageService.cpp`
```C++
status = helper.sendRequest(url, responseStream);
```
Turn on usage reporting, put a breakpoint somewhere where you can see which OS architecture is going to get put into the `osArch` field of the usage report, e.g. in `ConfigService.cpp::1013 getOSArchitecture`. If you have an Arm Mac running a native build, then you should get `arm64`. If you have an Arm Mac and are running under Rosetta (you'll need a package build for this) then the string should be `arm64_(x86_64)`. If you have an Intel Mac then it should be `x86_64`.

I think you can also check the OS string by running `SegFault` and checking the error report (usage reporting must be on still).

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


*This does not require release notes* because **this does not change any user-facing behaviour.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
