### PR TITLE
Fix unresponsive plot sliders on Moments tab

### DIFF
--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37428.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37428.rst
@@ -1,1 +1,1 @@
-- Fix a bug in which sliders didn't respond to changes in `Emin` and `EMax` proeprty when changed from the property browser in the :ref:`Moments<inelastic-moments>` tab of the :ref:`Data Processor <interface-inelastic-data-processor>` interface.
+- Fix a bug in which sliders didn't respond to changes in `Emin` and `EMax` properties when changed from the property browser in the :ref:`Moments<inelastic-moments>` tab of the :ref:`Data Processor <interface-inelastic-data-processor>` interface.

--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37428.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37428.rst
@@ -1,0 +1,1 @@
+- Fix a bug in which sliders didn't respond to changes in `Emin` and `EMax` proeprty when changed from the property browser in the :ref:`Moments<inelastic_moments>` tab of the :ref:`Data Processor <interface-inelastic-data-processor>` interface.

--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37428.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37428.rst
@@ -1,1 +1,1 @@
-- Fix a bug in which sliders didn't respond to changes in `Emin` and `EMax` proeprty when changed from the property browser in the :ref:`Moments<inelastic_moments>` tab of the :ref:`Data Processor <interface-inelastic-data-processor>` interface.
+- Fix a bug in which sliders didn't respond to changes in `Emin` and `EMax` proeprty when changed from the property browser in the :ref:`Moments<inelastic-moments>` tab of the :ref:`Data Processor <interface-inelastic-data-processor>` interface.

--- a/qt/scientific_interfaces/Inelastic/Processor/IMomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IMomentsView.h
@@ -14,6 +14,9 @@
 #include <tuple>
 
 namespace MantidQt {
+namespace MantidWidgets {
+class DataSelector;
+}
 namespace CustomInterfaces {
 
 class IOutputPlotOptionsView;
@@ -27,7 +30,7 @@ public:
 
   virtual void setupProperties() = 0;
   virtual IOutputPlotOptionsView *getPlotOptions() const = 0;
-  virtual DataSelector *getDataSelector() const = 0;
+  virtual MantidWidgets::DataSelector *getDataSelector() const = 0;
   virtual std::string getDataName() const = 0;
   virtual void showMessageBox(std::string const &message) const = 0;
 

--- a/qt/scientific_interfaces/Inelastic/Processor/IMomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IMomentsView.h
@@ -16,7 +16,7 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-class OutputPlotOptionsView;
+class IOutputPlotOptionsView;
 class IMomentsPresenter;
 
 class MANTIDQT_INELASTIC_DLL IMomentsView {
@@ -26,10 +26,9 @@ public:
   virtual void subscribePresenter(IMomentsPresenter *presenter) = 0;
 
   virtual void setupProperties() = 0;
-  virtual OutputPlotOptionsView *getPlotOptions() const = 0;
+  virtual IOutputPlotOptionsView *getPlotOptions() const = 0;
+  virtual DataSelector *getDataSelector() const = 0;
   virtual std::string getDataName() const = 0;
-
-  virtual bool validate() = 0;
   virtual void showMessageBox(std::string const &message) const = 0;
 
   virtual void setFBSuffixes(QStringList const &suffix) = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
@@ -40,7 +40,7 @@ void MomentsPresenter::setup() {}
  *
  */
 void MomentsPresenter::handleDataReady(std::string const &dataName) {
-  if (m_view->validate()) {
+  if (validate()) {
     m_model->setInputWorkspace(m_view->getDataName());
     plotNewData(dataName);
   }
@@ -58,7 +58,16 @@ void MomentsPresenter::handleScaleValueChanged(double value) { m_model->setScale
 
 void MomentsPresenter::run() { runAlgorithm(m_model->setupAlgorithm()); }
 
-bool MomentsPresenter::validate() { return true; }
+bool MomentsPresenter::validate() {
+  UserInputValidator uiv;
+  validateDataIsOfType(uiv, m_view->getDataSelector(), "Sample", DataType::Sqw);
+
+  auto const errorMessage = uiv.generateErrorMessage();
+  if (!errorMessage.empty())
+    m_view->showMessageBox(errorMessage);
+  return errorMessage.empty();
+}
+
 /**
  * Clears previous plot data (in both preview and raw plot) and sets the new
  * range bars

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
@@ -59,10 +59,10 @@ void MomentsPresenter::handleScaleValueChanged(double value) { m_model->setScale
 void MomentsPresenter::run() { runAlgorithm(m_model->setupAlgorithm()); }
 
 bool MomentsPresenter::validate() {
-  UserInputValidator uiv;
-  validateDataIsOfType(uiv, m_view->getDataSelector(), "Sample", DataType::Sqw);
+  auto uiv = std::make_unique<UserInputValidator>();
+  validateDataIsOfType(uiv.get(), m_view->getDataSelector(), "Sample", DataType::Sqw);
 
-  auto const errorMessage = uiv.generateErrorMessage();
+  auto const errorMessage = uiv->generateErrorMessage();
   if (!errorMessage.empty())
     m_view->showMessageBox(errorMessage);
   return errorMessage.empty();

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
@@ -113,7 +113,7 @@ void MomentsView::setWSSuffixes(QStringList const &suffix) { m_uiForm.dsInput->s
 
 IOutputPlotOptionsView *MomentsView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
 
-DataSelector *MomentsView::getDataSelector() const { return m_uiForm.dsInput; }
+MantidWidgets::DataSelector *MomentsView::getDataSelector() const { return m_uiForm.dsInput; }
 
 std::string MomentsView::getDataName() const { return m_uiForm.dsInput->getCurrentDataName().toStdString(); }
 

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
@@ -84,6 +84,7 @@ void MomentsView::notifyScaleValueChanged(double const value) { m_presenter->han
 
 void MomentsView::notifyValueChanged(QtProperty *prop, double value) {
   m_presenter->handleValueChanged(prop->propertyName().toStdString(), value);
+  prop->propertyName() == "EMin" ? setRangeSelectorMin(value) : setRangeSelectorMax(value);
 }
 
 void MomentsView::notifyRunClicked() { m_presenter->handleRunClicked(); }
@@ -110,19 +111,11 @@ void MomentsView::setFBSuffixes(QStringList const &suffix) { m_uiForm.dsInput->s
 
 void MomentsView::setWSSuffixes(QStringList const &suffix) { m_uiForm.dsInput->setWSSuffixes(suffix); }
 
-OutputPlotOptionsView *MomentsView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
+IOutputPlotOptionsView *MomentsView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
+
+DataSelector *MomentsView::getDataSelector() const { return m_uiForm.dsInput; }
 
 std::string MomentsView::getDataName() const { return m_uiForm.dsInput->getCurrentDataName().toStdString(); }
-
-bool MomentsView::validate() {
-  auto uiv = std::make_unique<UserInputValidator>();
-  validateDataIsOfType(uiv.get(), m_uiForm.dsInput, "Sample", DataType::Sqw);
-
-  auto const errorMessage = uiv->generateErrorMessage();
-  if (!errorMessage.empty())
-    showMessageBox(errorMessage);
-  return errorMessage.empty();
-}
 
 /**
  * Clears previous plot data (in both preview and raw plot) and sets the new

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.h
@@ -29,11 +29,9 @@ public:
   void subscribePresenter(IMomentsPresenter *presenter) override;
 
   void setupProperties() override;
-  OutputPlotOptionsView *getPlotOptions() const override;
+  IOutputPlotOptionsView *getPlotOptions() const override;
   std::string getDataName() const override;
-
-  bool validate() override;
-
+  DataSelector *getDataSelector() const override;
   void setFBSuffixes(QStringList const &suffix) override;
   void setWSSuffixes(QStringList const &suffix) override;
 

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.h
@@ -31,7 +31,7 @@ public:
   void setupProperties() override;
   IOutputPlotOptionsView *getPlotOptions() const override;
   std::string getDataName() const override;
-  DataSelector *getDataSelector() const override;
+  MantidWidgets::DataSelector *getDataSelector() const override;
   void setFBSuffixes(QStringList const &suffix) override;
   void setWSSuffixes(QStringList const &suffix) override;
 

--- a/qt/scientific_interfaces/Inelastic/test/Processor/CMakeLists.txt
+++ b/qt/scientific_interfaces/Inelastic/test/Processor/CMakeLists.txt
@@ -1,7 +1,13 @@
 get_filename_component(SUB_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}" NAME)
 
-set(TEST_FILES ElwinModelTest.h ElwinPresenterTest.h IqtModelTest.h MomentsModelTest.h SqwModelTest.h
-               SymmetriseModelTest.h
+set(TEST_FILES
+    ElwinModelTest.h
+    ElwinPresenterTest.h
+    IqtModelTest.h
+    MomentsModelTest.h
+    MomentsPresenterTest.h
+    SqwModelTest.h
+    SymmetriseModelTest.h
 )
 
 list(TRANSFORM TEST_FILES PREPEND ${SUB_DIRECTORY}/)

--- a/qt/scientific_interfaces/Inelastic/test/Processor/MomentsModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Processor/MomentsModelTest.h
@@ -22,7 +22,7 @@ public:
 
   void setUp() override { m_model = std::make_unique<MomentsModel>(); }
 
-  void test_algorrithm_set_up() {
+  void test_algorithm_set_up() {
     // The Moments algorithm is a python algorithm and so can not be called in c++ tests
     m_workspace = WorkspaceCreationHelper::create2DWorkspace(5, 4);
     Mantid::API::AnalysisDataService::Instance().addOrReplace("Workspace_name_sqw", m_workspace);

--- a/qt/scientific_interfaces/Inelastic/test/Processor/MomentsPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Processor/MomentsPresenterTest.h
@@ -1,0 +1,99 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+#include "Common/DataValidationHelper.h"
+#include "MantidQtWidgets/Common/AddWorkspaceDialog.h"
+#include "Processor/MomentsModel.h"
+#include "Processor/MomentsPresenter.h"
+#include "Processor/MomentsView.h"
+
+#include "../Common/MockObjects.h"
+#include "../QENSFitting/MockObjects.h"
+
+#include "MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h"
+#include "MantidKernel/WarningSuppressions.h"
+
+using namespace Mantid::API;
+using namespace Mantid::IndirectFitDataCreationHelper;
+using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::Inelastic;
+using namespace testing;
+
+class MomentsPresenterTest : public CxxTest::TestSuite {
+public:
+  static MomentsPresenterTest *createSuite() { return new MomentsPresenterTest(); }
+
+  static void destroySuite(MomentsPresenterTest *suite) { delete suite; }
+
+  void setUp() override {
+    m_view = std::make_unique<NiceMock<MockMomentsView>>();
+    m_outputPlotView = std::make_unique<NiceMock<MockOutputPlotOptionsView>>();
+
+    auto model = std::make_unique<NiceMock<MockMomentsModel>>();
+    m_model = model.get();
+
+    ON_CALL(*m_view, getPlotOptions()).WillByDefault(Return((m_outputPlotView.get())));
+    m_presenter = std::make_unique<MomentsPresenter>(nullptr, m_view.get(), std::move(model));
+
+    m_workspace = createWorkspace(5);
+    m_ads = std::make_unique<SetUpADSWithWorkspace>("workspace_test", m_workspace);
+  }
+
+  void tearDown() override {
+    AnalysisDataService::Instance().clear();
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_view.get()));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&m_model));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_outputPlotView.get()));
+
+    m_presenter.reset();
+    m_view.reset();
+    m_outputPlotView.reset();
+  }
+
+  ///----------------------------------------------------------------------
+  /// Unit Tests that test the signals, methods and slots of the presenter
+  ///----------------------------------------------------------------------
+
+  void test_handleScaleChanged_sets_correct_bool_property() {
+
+    EXPECT_CALL(*m_model, setScale(true)).Times((Exactly(1)));
+    m_presenter->handleScaleChanged(true);
+
+    EXPECT_CALL(*m_model, setScaleValue(true)).Times((Exactly(1)));
+    m_presenter->handleScaleValueChanged(true);
+  }
+
+  void test_handleValueChanged_sets_correct_double_property() {
+    double value = 0.1;
+
+    EXPECT_CALL(*m_model, setEMin(value)).Times((Exactly(1)));
+    m_presenter->handleValueChanged("EMin", value);
+    EXPECT_CALL(*m_model, setEMax(value)).Times((Exactly(1)));
+    m_presenter->handleValueChanged("EMax", value);
+  }
+
+  void test_handleDataReady_does_not_work_with_invalid_data() {
+    auto dataSelector = std::make_unique<DataSelector>();
+    ON_CALL(*m_view, getDataSelector()).WillByDefault(Return(dataSelector.get()));
+    TS_ASSERT(!m_presenter->validate());
+    dataSelector.reset();
+  }
+
+private:
+  NiceMock<MockMomentsModel> *m_model;
+  std::unique_ptr<NiceMock<MockOutputPlotOptionsView>> m_outputPlotView;
+  std::unique_ptr<NiceMock<MockMomentsView>> m_view;
+  std::unique_ptr<MomentsPresenter> m_presenter;
+
+  MatrixWorkspace_sptr m_workspace;
+  std::unique_ptr<SetUpADSWithWorkspace> m_ads;
+};

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -14,6 +14,9 @@
 #include "Processor/ElwinPresenter.h"
 #include "Processor/ElwinView.h"
 #include "Processor/IElwinView.h"
+#include "Processor/IMomentsView.h"
+#include "Processor/MomentsModel.h"
+#include "Processor/MomentsPresenter.h"
 #include "QENSFitting/FitOutput.h"
 #include "QENSFitting/FitPlotModel.h"
 #include "QENSFitting/FitTab.h"
@@ -500,6 +503,43 @@ public:
   MOCK_METHOD1(setNormalise, void(bool normalise));
   MOCK_METHOD1(setOutputWorkspaceNames, void(std::string const &workspaceBaseName));
   MOCK_CONST_METHOD0(getOutputWorkspaceNames, std::string());
+};
+
+class MockMomentsView : public IMomentsView {
+public:
+  virtual ~MockMomentsView() = default;
+
+  MOCK_METHOD1(subscribePresenter, void(IMomentsPresenter *presenter));
+  MOCK_METHOD0(setupProperties, void());
+  MOCK_CONST_METHOD0(getPlotOptions, IOutputPlotOptionsView *());
+  MOCK_CONST_METHOD0(getDataSelector, DataSelector *());
+  MOCK_CONST_METHOD0(getDataName, std::string());
+  MOCK_CONST_METHOD1(showMessageBox, void(std::string const &message));
+
+  MOCK_METHOD1(setFBSuffixes, void(QStringList const &suffix));
+  MOCK_METHOD1(setWSSuffixes, void(QStringList const &suffix));
+
+  MOCK_METHOD1(setPlotPropertyRange, void(const QPair<double, double> &bounds));
+  MOCK_METHOD1(setRangeSelector, void(const QPair<double, double> &bounds));
+  MOCK_METHOD1(setRangeSelectorMin, void(double newValue));
+  MOCK_METHOD1(setRangeSelectorMax, void(double newValue));
+
+  MOCK_METHOD1(plotNewData, void(std::string const &filename));
+  MOCK_METHOD0(replot, void());
+  MOCK_METHOD1(plotOutput, void(std::string const &outputWorkspace));
+};
+
+class MockMomentsModel : public IMomentsModel {
+public:
+  virtual ~MockMomentsModel() = default;
+
+  MOCK_METHOD0(setupAlgorithm, IAlgorithm_sptr());
+  MOCK_METHOD1(setInputWorkspace, void(const std::string &workspace));
+  MOCK_METHOD1(setEMin, void(double eMin));
+  MOCK_METHOD1(setEMax, void(double eMax));
+  MOCK_METHOD1(setScale, void(bool scale));
+  MOCK_METHOD1(setScaleValue, void(double scaleValue));
+  MOCK_CONST_METHOD0(getOutputWorkspace, std::string());
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE


### PR DESCRIPTION
### Description of work
This PR fixes a bug where the sliders of the Moments tab in the Data Processor interface were not responding to changes in the property browser. 
Additionally, I have done a small bit of refactoring of the Moments Presenter class and move the validator to the presenter instead of the view, as well as adding some unit tests for the presenter. 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37428. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Reproduce testing instructions in #37428 and see that the sliders respond to changes in the property browser. 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*Added release notes*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
