### PR TITLE
Add option to ignore masked pixels in integration algorithms and improve skew background determination

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
@@ -188,14 +188,14 @@ class IntegratePeaks1DProfile(DataProcessorAlgorithm):
             name="NRowsEdge",
             defaultValue=1,
             direction=Direction.Input,
-            validator=IntBoundedValidator(lower=1),
+            validator=IntBoundedValidator(lower=0),
             doc="Shoeboxes containing detectors NRowsEdge from the detector edge are defined as on the edge.",
         )
         self.declareProperty(
             name="NColsEdge",
             defaultValue=1,
             direction=Direction.Input,
-            validator=IntBoundedValidator(lower=1),
+            validator=IntBoundedValidator(lower=0),
             doc="Shoeboxes containing detectors NColsEdge from the detector edge are defined as on the edge.",
         )
         edge_check_enabled = EnabledWhenProperty("IntegrateIfOnEdge", PropertyCriterion.IsDefault)

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
@@ -250,14 +250,14 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
             name="NRowsEdge",
             defaultValue=1,
             direction=Direction.Input,
-            validator=IntBoundedValidator(lower=1),
+            validator=IntBoundedValidator(lower=0),
             doc="Shoeboxes containing detectors NRowsEdge from the detector edge are defined as on the edge.",
         )
         self.declareProperty(
             name="NColsEdge",
             defaultValue=1,
             direction=Direction.Input,
-            validator=IntBoundedValidator(lower=1),
+            validator=IntBoundedValidator(lower=0),
             doc="Shoeboxes containing detectors NColsEdge from the detector edge are defined as on the edge.",
         )
         edge_check_enabled = EnabledWhenProperty("IntegrateIfOnEdge", PropertyCriterion.IsDefault)

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
@@ -222,7 +222,7 @@ class InstrumentArrayConverter:
         for irow in range(det_edges.shape[0]):
             for icol in range(det_edges.shape[1]):
                 if det_info.isMasked(det_info.indexOf(int(detids[irow, icol]))):
-                    det_edges = True
+                    det_edges[irow, icol] = True
         peak_data = PeakData(irow_peak, icol_peak, det_edges, detids, peak, self.ws)
         return peak_data
 
@@ -830,15 +830,15 @@ class IntegratePeaksSkew(DataProcessorAlgorithm):
             name="NRowsEdge",
             defaultValue=1,
             direction=Direction.Input,
-            validator=IntBoundedValidator(lower=1),
-            doc="Masks including pixels on rows NRowsEdge from the detector edge are " "defined as on the edge.",
+            validator=IntBoundedValidator(lower=0),
+            doc="Masks including pixels on rows NRowsEdge from the detector edge are defined as on the edge.",
         )
         self.declareProperty(
             name="NColsEdge",
             defaultValue=1,
             direction=Direction.Input,
-            validator=IntBoundedValidator(lower=1),
-            doc="Masks including pixels on cols NColsEdge from the detector edge are " "defined as on the edge.",
+            validator=IntBoundedValidator(lower=0),
+            doc="Masks including pixels on cols NColsEdge from the detector edge are defined as on the edge.",
         )
         self.declareProperty(
             name="NPixMin",

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
@@ -429,7 +429,7 @@ class PeakData:
         prev_skew = moment(signal[ibg_seed[isort[istart:iend]]], 3)
         for istart in range(1, iend):
             this_skew = moment(signal[ibg_seed[isort[istart:iend]]], 3)
-            if this_skew >= prev_skew:
+            if this_skew >= prev_skew or this_skew < 0:
                 istart -= 1
                 break
             else:

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
@@ -217,6 +217,12 @@ class InstrumentArrayConverter:
         row, col = peak.getRow(), peak.getCol()
         drows, dcols = int(nrows) // 2, int(ncols) // 2
         detids, det_edges, irow_peak, icol_peak = self.get_detid_array(bank, detid, row, col, drows, dcols, nrows_edge, ncols_edge)
+        # add masked pixels to edges (sometimes used to denote edges or broken components)
+        det_info = self.ws.detectorInfo()
+        for irow in range(det_edges.shape[0]):
+            for icol in range(det_edges.shape[1]):
+                if det_info.isMasked(det_info.indexOf(int(detids[irow, icol]))):
+                    det_edges = True
         peak_data = PeakData(irow_peak, icol_peak, det_edges, detids, peak, self.ws)
         return peak_data
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaks1DProfileTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaks1DProfileTest.py
@@ -86,6 +86,21 @@ class IntegratePeaks1DProfileTest(unittest.TestCase):
         self.assertAlmostEqual(out.column("Intens/SigInt")[0], 19.59, delta=1e-1)
         self.assertAlmostEqual(out.column("Intens/SigInt")[1], 0.0, delta=1e-2)
 
+    def test_exec_IntegrateIfOnEdge_False_respects_detector_masking(self):
+        kwargs = self.profile_kwargs.copy()
+        kwargs["IntegrateIfOnEdge"] = False
+        kwargs["NRowsEdge"] = 0
+        kwargs["NColsEdge"] = 0
+        ws_masked = CloneWorkspace(InputWorkspace=self.ws)
+        det_info = ws_masked.detectorInfo()
+        det_info.setMasked(det_info.indexOf(self.peaks_edge.getPeak(1).getDetectorID()), True)
+
+        out = IntegratePeaks1DProfile(
+            InputWorkspace=ws_masked, PeaksWorkspace=self.peaks_edge, OutputWorkspace="peaks_int_2_masked", **kwargs
+        )
+        self.assertAlmostEqual(out.column("Intens/SigInt")[0], 19.59, delta=1e-1)
+        self.assertAlmostEqual(out.column("Intens/SigInt")[1], 0.0, delta=1e-2)
+
     def test_exec_poisson_cost_func(self):
         kwargs = self.profile_kwargs.copy()
         kwargs["CostFunction"] = "Poisson"

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksShoeboxTOFTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksShoeboxTOFTest.py
@@ -13,6 +13,7 @@ from mantid.simpleapi import (
     LoadParameterFile,
     AnalysisDataService,
     SortPeaksWorkspace,
+    CloneWorkspace,
 )
 from testhelpers import WorkspaceCreationHelper
 from numpy import array, sqrt
@@ -98,6 +99,28 @@ class FindSXPeaksConvolveTest(unittest.TestCase):
             NRows=3,
             NCols=3,
             NBins=3,
+            WeakPeakThreshold=0.0,
+            OptimiseShoebox=False,
+            IntegrateIfOnEdge=False,
+        )
+        # check edge peak integrated but lower I/sigma as shell would overlap edge
+        self._assert_found_correct_peaks(out, 2 * [0.0])
+
+    def test_exec_IntegrateIfOnEdge_False_respects_detector_masking(self):
+        ws_masked = CloneWorkspace(InputWorkspace=self.ws)
+        det_info = ws_masked.detectorInfo()
+        [det_info.setMasked(det_info.indexOf(pk.getDetectorID()), True) for pk in self.peaks]
+
+        out = IntegratePeaksShoeboxTOF(
+            InputWorkspace=ws_masked,
+            PeaksWorkspace=self.peaks,
+            OutputWorkspace="peaks1_masked",
+            GetNBinsFromBackToBackParams=False,
+            NRows=3,
+            NCols=3,
+            NBins=3,
+            NRowsEdge=0,
+            NColsEdge=0,
             WeakPeakThreshold=0.0,
             OptimiseShoebox=False,
             IntegrateIfOnEdge=False,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
@@ -74,9 +74,26 @@ class IntegratePeaksSkewTest(unittest.TestCase):
             IntegrateIfOnEdge=False,
             OutputWorkspace="out0",
         )
-        # check peaks in bank 1 were not integrated (mask touches edge)
+        # check peaks in bank 1 were not integrated (mask touches masked pixel)
         for ipk, pk in enumerate(out):
             self.assertEqual(pk.getIntensity(), 0)
+
+    def test_integrate_on_edge_option_respects_detector_masking(self):
+        ws_masked = CloneWorkspace(InputWorkspace=self.ws)
+        det_info = ws_masked.detectorInfo()
+        det_info.setMasked(det_info.indexOf(self.peaks.getPeak(0).getDetectorID()), True)
+        out = IntegratePeaksSkew(
+            InputWorkspace=ws_masked,
+            PeaksWorkspace=self.peaks,
+            ThetaWidth=0,
+            BackscatteringTOFResolution=0.3,
+            IntegrateIfOnEdge=False,
+            NRowsEdge=0,
+            NColsEdge=0,
+            OutputWorkspace="out0",
+        )
+        # check peaks in bank 1 were not integrated (mask touches edge)
+        self.assertEqual(out.getPeak(0).getIntensity(), 0)
 
     def test_integrate_use_nearest_peak_false_update_peak_position_false(self):
         out = IntegratePeaksSkew(

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
@@ -90,7 +90,7 @@ class IntegratePeaksSkewTest(unittest.TestCase):
             IntegrateIfOnEdge=False,
             NRowsEdge=0,
             NColsEdge=0,
-            OutputWorkspace="out0",
+            OutputWorkspace="out0_masked",
         )
         # check peaks in bank 1 were not integrated (mask touches edge)
         self.assertEqual(out.getPeak(0).getIntensity(), 0)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
@@ -367,7 +367,7 @@ class IntegratePeaksSkewTest(unittest.TestCase):
             OutputWorkspace="out8",
         )
         self.assertGreater(out.getPeak(0).getIntensityOverSigma(), 0)
-        self.assertAlmostEqual(out.getPeak(0).getIntensityOverSigma(), 10.84209, delta=1e-4)
+        self.assertAlmostEqual(out.getPeak(0).getIntensityOverSigma(), 8.8002, delta=1e-4)
         out = IntegratePeaksSkew(
             InputWorkspace=self.ws,
             PeaksWorkspace=self.peaks,

--- a/docs/source/release/v6.11.0/Diffraction/Single_Crystal/New_features/37596.rst
+++ b/docs/source/release/v6.11.0/Diffraction/Single_Crystal/New_features/37596.rst
@@ -1,4 +1,4 @@
-- Improve determination of background bins by minimsing third-moment (skew) in :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>` by forcing skew > 0 (minimum skew would expect in background)
+- Improve determination of background bins by minimising third-moment (skew) in :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>` by forcing skew > 0 (minimum skew would expect in background)
 - Add cabability to not integrate peaks which include a masked detector in the following algorithms
 
   - :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`

--- a/docs/source/release/v6.11.0/Diffraction/Single_Crystal/New_features/37596.rst
+++ b/docs/source/release/v6.11.0/Diffraction/Single_Crystal/New_features/37596.rst
@@ -1,0 +1,6 @@
+- Improve determination of background bins by minimsing third-moment (skew) in :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>` by forcing skew > 0 (minimum skew would expect in background)
+- Add cabability to not integrate peaks which include a masked detector in the following algorithms
+
+  - :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`
+  - :ref:`IntegratePeaksShoeboxTOF <algm-IntegratePeaksShoeboxTOF>`
+  - :ref:`IntegratePeaks1DProfile <algm-IntegratePeaks1DProfile>`


### PR DESCRIPTION
### Description of work

This work comprises 2 improvements to single-crystal integration methods:
1. When determining background bins by minimising third moment (skew) in `IntegratePeaksSkew` - ensure loop terminates if skew < 0 (we expect minimum skew of background to be 0 - for low counts it should in fact be positive) 
2. Add option to ignore peaks for which mask (or shoebox etc.) includes a masked detector - this affects
    - `IntegratePeaksSkew`
    - `IntegratePeaksShoeboxTOF`
    - `IntegratePeaks1DProfile`

#### Purpose of work

Change (1) stops peak mask of `IntegratePEaksSkew` including too many pixels due to small diffuse scattering  - see issue #37105

![image](https://github.com/mantidproject/mantid/assets/55979119/9e55bae0-106d-468b-9042-74e3123ea43d)

Change (2) allows the user to make a custom mask for edges (or dodgy tube etc.) - whereas `NcolsEdge` and `NRowsEdge` are assumed to be the same for all banks. To support this functionality the minimum value for `NrowsEdge` and `NColsEdge` has been decreased to 0  - i.e. it is now possible to only define edges using masked detectors on the workspace.  Note this is how detector edges are denoted in other integration algorithms such as` IntegratePeaksMD`.

Fixes #37105

### To test:
(1) Run this script
```
ws = Load(Filename=r'C:\mantid-conda\mantid\build\ExternalData\Testing\Data\DocTest\SXD23767.raw', OutputWorkspace='SXD23767')
# peaks = FindSXPeaksConvolve(InputWorkspace='SXD23767', PeaksWorkspace='peaks_out', ThresholdIoverSigma=4, GetNBinsFromBackToBackParams=True, NFWHM=6, PeakFindingStrategy='VarianceOverMean', ThresholdVarianceOverMean=1.25)

peaks = CreatePeaksWorkspace(InstrumentWorkspace=ws, NumberOfPeaks=0, OutputWorkspace="peaks_out")
pk_pos = [(3169, 1851.59), (752, 2292.94), (1971, 3169.28), (3633, 4623.41), (6469, 1531.5)]
for detid, tof in pk_pos:
    AddPeak(PeaksWorkspace=peaks, RunWorkspace=ws, TOF=tof, DetectorID=detid, EnableLogging=False)
                    
skew_params = {'UseNearestPeak': True, 'IntegrateIfOnEdge': False,
             'NRowsEdge': 1, 'NColsEdge': 1, 
             'LorentzCorrection': True,
             'NVacanciesMax': 2, 'NPixPerVacancyMin': 2, 'NTOFBinsMin': 2,
             'UpdatePeakPosition': False, 'OptimiseMask': True,
             'GetTOFWindowFromBackToBackParams': False, 
              'ScaleThetaWidthByWavelength': True,
             'BackScatteringTOFResolution': 0.035, 'ThetaWidth': 1.5,
             'OptimiseXWindowSize':True, 'ThresholdIoverSigma': 20}
skew_params['OutputFile'] = rf"C:\Users\xhg73778\Desktop\{ws.name()}_peaks_skew_zero_skew.pdf"
peaks_int = IntegratePeaksSkew(InputWorkspace=ws, PeaksWorkspace=peaks, **skew_params)
```
(2) Open the pdf output and check the mask still covers the peaks (should look like the left hand column in the screenshots above)

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
