### PR TITLE
Fix recent coverity scan warnings

### DIFF
--- a/Framework/Kernel/src/IPropertyManager.cpp
+++ b/Framework/Kernel/src/IPropertyManager.cpp
@@ -53,7 +53,7 @@ IPropertyManager *IPropertyManager::setProperty<std::string>(const std::string &
  * @return True if the property is managed by this.
  */
 bool IPropertyManager::existsProperty(const std::string &name) const {
-  auto props = this->getProperties();
+  auto const &props = this->getProperties();
   return std::any_of(props.cbegin(), props.cend(), [&name](const auto prop) { return name == prop->name(); });
 }
 

--- a/qt/scientific_interfaces/Inelastic/Common/DataModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/DataModel.cpp
@@ -177,7 +177,7 @@ std::vector<std::string> DataModel::getWorkspaceNames() const {
   std::vector<std::string> names;
   names.reserve(m_fittingData->size());
   std::transform(m_fittingData->cbegin(), m_fittingData->cend(), std::back_inserter(names),
-                 [](const auto &fittingData) { return fittingData.workspace()->getName(); });
+                 [](const auto &fittingData) -> const std::string & { return fittingData.workspace()->getName(); });
   return names;
 }
 
@@ -188,7 +188,7 @@ void DataModel::addWorkspace(const std::string &workspaceName, const FunctionMod
     throw std::runtime_error("Fitting Data must consist of one or more spectra.");
 
   auto ws = m_adsInstance.retrieveWS<Mantid::API::MatrixWorkspace>(workspaceName);
-  addWorkspace(ws, spectra);
+  addWorkspace(std::move(ws), spectra);
 }
 
 void DataModel::addWorkspace(Mantid::API::MatrixWorkspace_sptr workspace, const FunctionModelSpectra &spectra) {

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
@@ -345,7 +345,7 @@ void ApplyAbsorptionCorrections::handleRun() {
   if (m_uiForm.ckUseCan->isChecked()) {
     auto const canName = m_uiForm.dsContainer->getCurrentDataName().toStdString();
     auto const containerWs = getADSWorkspace(canName);
-    auto logs = containerWs->run();
+    auto const &logs = containerWs->run();
     if (logs.hasProperty("run_number")) {
       outputWsName += "_" + QString::fromStdString(logs.getProperty("run_number")->value());
     } else {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataView.cpp
@@ -50,7 +50,7 @@ void ConvolutionDataView::showAddWorkspaceDialog() {
   dialog->show();
 }
 
-void ConvolutionDataView::addTableEntry(size_t row, FitDataRow newRow) {
+void ConvolutionDataView::addTableEntry(size_t row, FitDataRow const &newRow) {
   FitDataView::addTableEntry(row, newRow);
 
   auto cell = std::make_unique<QTableWidgetItem>(QString::fromStdString(newRow.resolution));

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataView.h
@@ -23,7 +23,7 @@ class MANTIDQT_INELASTIC_DLL ConvolutionDataView : public FitDataView {
   Q_OBJECT
 public:
   ConvolutionDataView(QWidget *parent);
-  void addTableEntry(size_t row, FitDataRow newRow) override;
+  void addTableEntry(size_t row, FitDataRow const &newRow) override;
 
 protected:
   ConvolutionDataView(const QStringList &headers, QWidget *parent);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionModel.cpp
@@ -281,7 +281,7 @@ void ConvolutionModel::addSampleLogs() {
 }
 
 void ConvolutionModel::addOutput(Mantid::API::IAlgorithm_sptr fitAlgorithm) {
-  FittingModel::addOutput(fitAlgorithm);
+  FittingModel::addOutput(std::move(fitAlgorithm));
   addSampleLogs();
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
@@ -77,7 +77,7 @@ void FitDataView::displayWarning(const std::string &warning) {
   QMessageBox::warning(parentWidget(), "MantidPlot - Warning", QString::fromStdString(warning));
 }
 
-void FitDataView::addTableEntry(size_t row, FitDataRow newRow) {
+void FitDataView::addTableEntry(size_t row, FitDataRow const &newRow) {
   m_uiForm->tbFitData->insertRow(static_cast<int>(row));
 
   auto cell = std::make_unique<QTableWidgetItem>(QString::fromStdString(newRow.name));

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.h
@@ -37,7 +37,7 @@ public:
   bool isTableEmpty() const override;
 
   void validate(IUserInputValidator *validator) override;
-  virtual void addTableEntry(size_t row, FitDataRow newRow) override;
+  virtual void addTableEntry(size_t row, FitDataRow const &newRow) override;
   virtual void updateNumCellEntry(double numEntry, size_t row, size_t column) override;
   int getColumnIndexFromName(std::string const &ColName) override;
   void clearTable() override;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.cpp
@@ -321,13 +321,14 @@ void FunctionQDataPresenter::setActiveWorkspaceIDToCurrentWorkspace(MantidWidget
   //  update active data index with correct index based on the workspace name
   //  and the vector in m_fitDataModel which is in the base class
   //  FittingModel get table workspace index
-  const auto wsName = dialog->workspaceName().append("_HWHM");
+  auto const &wsName = dialog->workspaceName();
+  auto const hwhmWsName = wsName + "_HWHM";
   // This a vector of workspace names currently loaded
-  auto wsVector = m_model->getWorkspaceNames();
+  auto const wsVector = m_model->getWorkspaceNames();
   // this is an iterator pointing to the current wsName in wsVector
-  auto wsIt = std::find(wsVector.begin(), wsVector.end(), wsName);
+  auto const wsIt = std::find(wsVector.cbegin(), wsVector.cend(), hwhmWsName);
   // this is the index of the workspace.
-  const auto index = WorkspaceID(std::distance(wsVector.begin(), wsIt));
+  auto const index = WorkspaceID(std::distance(wsVector.cbegin(), wsIt));
   updateActiveWorkspaceID(index);
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataView.cpp
@@ -73,7 +73,7 @@ void FunctionQDataView::notifyParameterTypeChanged(FunctionQAddWorkspaceDialog *
   }
 }
 
-void FunctionQDataView::addTableEntry(size_t row, FitDataRow newRow) {
+void FunctionQDataView::addTableEntry(size_t row, FitDataRow const &newRow) {
   FitDataView::addTableEntry(row, newRow);
 
   auto cell = std::make_unique<QTableWidgetItem>(QString::fromStdString(newRow.parameter));

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataView.h
@@ -24,7 +24,7 @@ class MANTIDQT_INELASTIC_DLL FunctionQDataView : public FitDataView {
   Q_OBJECT
 public:
   FunctionQDataView(QWidget *parent);
-  void addTableEntry(size_t row, FitDataRow newRow) override;
+  void addTableEntry(size_t row, FitDataRow const &newRow) override;
 
 protected:
   FunctionQDataView(const QStringList &headers, QWidget *parent);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/IFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/IFitDataView.h
@@ -37,7 +37,7 @@ public:
   virtual bool isTableEmpty() const = 0;
 
   virtual void validate(IUserInputValidator *validator) = 0;
-  virtual void addTableEntry(size_t row, FitDataRow newRow) = 0;
+  virtual void addTableEntry(size_t row, FitDataRow const &newRow) = 0;
   virtual void updateNumCellEntry(double numEntry, size_t row, size_t column) = 0;
   virtual int getColumnIndexFromName(std::string const &ColName) = 0;
   virtual void clearTable() = 0;

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -287,7 +287,7 @@ public:
   MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
   MOCK_CONST_METHOD0(isTableEmpty, bool());
   MOCK_METHOD1(validate, void(MantidQt::CustomInterfaces::IUserInputValidator *validator));
-  MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow newRow));
+  MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow const &newRow));
   MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
   MOCK_METHOD1(getColumnIndexFromName, int(std::string const &ColName));
   MOCK_METHOD0(clearTable, void());


### PR DESCRIPTION
### Description of work
This PR fixes several coverity scan defects that have been logged since the renaming of some of the Indirect/Inelastic files. These defects have been around for a long time and have only been logged now because of the change to the name of these files triggering a coverity scan on these files.

### To test:
Follow the testing instructions here
https://developer.mantidproject.org/Testing/Inelastic/QENSFittingTests.html

*This does not require release notes* because **this is not a user-facing change**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
