### PR TITLE
Add instructions for fixing a merge conflict between protected branches

### DIFF
--- a/dev-docs/source/Gatekeeping.rst
+++ b/dev-docs/source/Gatekeeping.rst
@@ -119,6 +119,62 @@ While not vital and often not something I'd ask for changes on, it is good to ke
 * Commits that nicely encapsulate increments of work - if developers are making multiple subsequent commits that should logically be part of a previous commit encourage use of ``amend`` and ``fixup``.
 * Using ``#re`` or ``#refs`` in the comment where appropriate (either title or body; we have a mix of styles but a developer should pick one and be consistent).
 
+.. _FixProtectedBranchMergeConflict:
+
+Fixing a merge conflict between ``main`` and a protected branch
+===============================================================
+
+There may occasionally be a merge conflict when the automated "Merge protected branches" workflow attempts to merge a protected branch into ``main``. The following instructions detail how to fix the conflict, using the ``release-next`` branch as an example:
+
+From a fork
+-----------
+
+Assuming your fork has the following remote setup
+
+    $ git remote -v
+    mantid  https://github.com/mantidproject/mantid.git (fetch)
+    mantid  https://github.com/mantidproject/mantid.git (push)
+    origin  https://github.com/<username>/mantid.git (fetch)
+    origin  https://github.com/<username>/mantid.git (push)
+
+
+then you can follow these instructions to fix the merge conflict:
+
+.. code-block:: bash
+
+    git fetch --all
+    git checkout release-next
+    git pull mantid release-next
+    git checkout main
+    git pull mantid main
+    git checkout -b 0-fix-conflicts
+    git merge release-next
+
+You should then fix the merge conflicts, git add and commit the changes. Then push the branch to the ``mantid`` remote repository and open a PR. The PR should be reviewed and then merged into ``main``.
+
+From a non-fork
+---------------
+
+Assuming you have the following remote setup
+
+    $ git remote -v
+    origin  https://github.com/mantidproject/mantid.git (fetch)
+    origin  https://github.com/mantidproject/mantid.git (push)
+
+
+then you can follow these instructions to fix the merge conflict:
+
+.. code-block:: bash
+
+    git fetch --all
+    git checkout release-next
+    git pull origin release-next
+    git checkout main
+    git pull origin main
+    git checkout -b 0-fix-conflicts
+    git merge release-next
+
+You should then fix the merge conflicts, git add and commit the changes. Then push the branch to the ``origin`` remote repository and open a PR. The PR should be reviewed and then merged into ``main``.
 
 Specific quirks of Mantid
 =========================

--- a/dev-docs/source/Gatekeeping.rst
+++ b/dev-docs/source/Gatekeeping.rst
@@ -131,6 +131,8 @@ From a fork
 
 Assuming your fork has the following remote setup
 
+.. code-block:: bash
+
     $ git remote -v
     mantid  https://github.com/mantidproject/mantid.git (fetch)
     mantid  https://github.com/mantidproject/mantid.git (push)
@@ -156,6 +158,8 @@ From a non-fork
 ---------------
 
 Assuming you have the following remote setup
+
+.. code-block:: bash
 
     $ git remote -v
     origin  https://github.com/mantidproject/mantid.git (fetch)

--- a/dev-docs/source/GitWorkflow.rst
+++ b/dev-docs/source/GitWorkflow.rst
@@ -207,3 +207,8 @@ To fix this situation we use the ``rebase`` command, providing the
 
     git fetch
     git rebase --onto origin/release-next $(git merge-base origin/main origin/topic) topic
+
+Fixing a merge conflict between protected branches
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A Gatekeeper should follow :ref:`these instructions <FixProtectedBranchMergeConflict>` if there is a merge conflict between two protected branches e.g. ``main`` and ``release-next``.


### PR DESCRIPTION
### Description of work
This PR adds instructions for gatekeepers when fixing a merge conflict between protected branches (e.g. between `main` and `release-next`. The key is to make sure a PR is created to resolve the conflict, rather than pushing straight to `main`.

### To test:
A gatekeeper should review this.

Read the instructions and build the dev docs. Will these instructions work in all cases? Was there a reason to push directly to main previously?

If fixing a conflict via a branch is a good idea, is it better to use `git rebase` rather than `git merge`? Or is `git merge` preferred in this instance?

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
