### PR TITLE
Stitch1DMany Algorithm cant be run from the GUI

### DIFF
--- a/Framework/Algorithms/src/Stitch1DMany.cpp
+++ b/Framework/Algorithms/src/Stitch1DMany.cpp
@@ -295,7 +295,7 @@ void Stitch1DMany::exec() {
 void Stitch1DMany::doStitch1D(std::vector<MatrixWorkspace_sptr> &toStitch,
                               const std::vector<double> &manualScaleFactors, Workspace_sptr &outWS) {
 
-  auto lhsWS = toStitch.front();
+  auto &lhsWS = toStitch.front();
   // Support Python list syntax for selecting the last element in the list
   auto indexOfReference = m_indexOfReference == -1 ? toStitch.size() - 1 : m_indexOfReference;
 

--- a/Framework/Algorithms/src/Stitch1DMany.cpp
+++ b/Framework/Algorithms/src/Stitch1DMany.cpp
@@ -104,6 +104,10 @@ std::map<std::string, std::string> Stitch1DMany::validateInputs() {
        * Row:       each period only for groups
        */
       m_inputWSMatrix.reserve(inputWorkspacesStr.size());
+      /// When the StitchIDMany algorithm is called from the GUI, the validateInputs method is called twice.
+      /// This causes an unintended side effect on the m_inputWSMatrix variable.
+      /// To fix this, the clear method is called on m_inputWSMatrix to ensure it is always empty at this point.
+      m_inputWSMatrix.clear();
       std::vector<MatrixWorkspace_sptr> column;
       for (const auto &ws : inputWorkspacesStr) {
         auto groupWS = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(ws);

--- a/docs/source/release/v6.11.0/Reflectometry/Bugfixes/37619.rst
+++ b/docs/source/release/v6.11.0/Reflectometry/Bugfixes/37619.rst
@@ -1,0 +1,1 @@
+- Fix an issue that prevented the StitchIDMany algorithm from running successfully via the GUI.


### PR DESCRIPTION
### Description of work
Stitch1DMany cannot be run from the algorithm Execute dialog in the Workbench GUI because the validation (i.e. the validateInputs method) seems to run twice when called this way. The variable m_inputWSMatrix that holds the workspaces to be stitched is therefore populated twice as part of the validation, which means that on the second run it fails when we check that the number of workspaces matches the length of the input string.
#### Summary of work
The clear method is called on m_inputWSMatrix to ensure it is empty before it is used in the validateInputs method.


Fixes #35700 

### To test:
1. Load a couple of runs to stitch into the ADS
2. Run Stitch1DMany algorithm from the GUI dialog.
3. The algorithm runs successfully
