### PR TITLE
Improve shoebox position determination in `IntegratePeaksShoeboxTOF`

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
@@ -440,7 +440,9 @@ class PeakFitter:
 
     def update_initial_peak_position(self, ws, peaks, ipk):
         itof = np.argmin(abs(self.tofs - self.pk.getTOF()))
-        peak_pos = find_nearest_peak_in_data_window(self.y, self.ispecs, self.tofs, ws, peaks, ipk, *self.peak_pos, itof, threshold=0.0)
+        peak_pos = find_nearest_peak_in_data_window(
+            self.y, self.ispecs, self.tofs, ws, peaks, ipk, (*self.peak_pos, itof), min_threshold=0.0
+        )
         self.peak_pos = (peak_pos[0], peak_pos[1]) if peak_pos is not None else None  # omit tof index
 
     def get_composite_function_with_initial_params(self, ws, peak_func_name, bg_func):

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
@@ -190,9 +190,9 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
         )
         self.declareProperty(
             name="NFWHM",
-            defaultValue=4,
+            defaultValue=4.0,
             direction=Direction.Input,
-            validator=IntBoundedValidator(lower=1),
+            validator=FloatBoundedValidator(lower=1.0),
             doc="If GetNBinsFromBackToBackParams=True then the number of TOF bins will be NFWHM x FWHM of the "
             "BackToBackExponential at the peak detector and TOF.",
         )

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
@@ -24,7 +24,6 @@ from mantid.kernel import (
 )
 from dataclasses import dataclass
 import numpy as np
-from scipy.ndimage import uniform_filter
 from scipy.signal import convolve
 from IntegratePeaksSkew import InstrumentArrayConverter, get_fwhm_from_back_to_back_params
 from FindSXPeaksConvolve import make_kernel, get_kernel_shape
@@ -575,7 +574,6 @@ def convolve_shoebox(y, esq, kernel, mode="same"):
         econv = np.sqrt(convolve(esq, kernel**2, mode=mode))
         intens_over_sig = yconv / econv
     intens_over_sig[~np.isfinite(intens_over_sig)] = 0
-    intens_over_sig = uniform_filter(intens_over_sig, size=len(y.shape))
     # zero edges where convolution is invalid
     if mode == "same":
         edge_mask = np.ones(intens_over_sig.shape, dtype=bool)

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
@@ -24,6 +24,7 @@ from mantid.kernel import (
 )
 from dataclasses import dataclass
 import numpy as np
+from scipy.ndimage import distance_transform_edt, maximum_position, label
 from scipy.signal import convolve
 from IntegratePeaksSkew import InstrumentArrayConverter, get_fwhm_from_back_to_back_params
 from FindSXPeaksConvolve import make_kernel, get_kernel_shape
@@ -497,7 +498,7 @@ def integrate_peak(
     intens_over_sig = convolve_shoebox(y, esq, kernel)  # array of I/sigma same size as data
 
     # identify best shoebox position near peak
-    ipos = find_nearest_peak_in_data_window(intens_over_sig, ispecs, x, ws, peaks, ipk, *ipos_predicted)
+    ipos = find_nearest_peak_in_data_window(intens_over_sig, ispecs, x, ws, peaks, ipk, tuple(ipos_predicted))
 
     # perform final integration if required
     intens, sigma, i_over_sig = 0.0, 0.0, 0.0
@@ -583,38 +584,30 @@ def convolve_shoebox(y, esq, kernel, mode="same"):
     return intens_over_sig
 
 
-def find_nearest_peak_in_data_window(data, ispecs, x, ws, peaks, ipk, irow, icol, ix, threshold=2):
-    ipks_near, ispecs_peaks = find_ipks_in_window(ws, peaks, ispecs, ipk, tof_min=x.min(), tof_max=x.max())
-    if len(ipks_near) > 0:
+def find_nearest_peak_in_data_window(data, ispecs, x, ws, peaks, ipk, ipos, min_threshold=2):
+    # find threshold
+    threshold = max(0.5 * (data[ipos] + min_threshold), min_threshold)
+    labels, nlabels = label(data > threshold)
+    if nlabels < 1:
+        return None  # no peak found
+    peak_label = labels[ipos]
+    if peak_label == 0:
+        dists, inearest = distance_transform_edt(labels == 0, return_distances=True, return_indices=True)
+        nearest_label = labels[tuple(inearest)]
+        # mask out labels closest to other peaks
+        ipks_near, ispecs_peaks = find_ipks_in_window(ws, peaks, ispecs, ipk, tof_min=x.min(), tof_max=x.max())
         tofs = peaks.column("TOF")
-        # get position of nearby peaks in data array in fractional coords
-        shape = np.array(data.shape)
-        pos_near = [
-            np.r_[np.argwhere(ispecs == ispecs_peaks[ii])[0], np.argmin(abs(x - tofs[ipk_near]))] / shape
-            for ii, ipk_near in enumerate(ipks_near)
-        ]
-        # sort data in descending order and select strongest data point nearest to pk (in fractional coordinates)
-        isort = list(zip(*np.unravel_index(np.argsort(-data, axis=None), data.shape)))
-        pk_pos = np.array([irow, icol, ix]) / np.array(data.shape)
-        imax_nearest = None
-        for ibin in isort:
-            if data[ibin] > threshold:
-                # calc distance to predicted peak position
-                bin_pos = np.array(ibin) / shape
-                pk_dist_sq = np.sum((pk_pos - bin_pos) ** 2)
-                for pos in pos_near:
-                    if np.sum((pos - bin_pos) ** 2) > pk_dist_sq:
-                        imax_nearest = ibin
-                        break
-                else:
-                    continue  # executed if inner loop did not break (i.e. pixel closer to nearby peak than this peak)
-                break  # execute if inner loop did break and else branch ignored (i.e. found bin closest to this peak)
-            else:
-                break
-        return imax_nearest  # could be None if no peak found
-    else:
-        # no nearby peaks - return position of maximum in data
-        return np.unravel_index(np.argmax(data), data.shape)
+        for ii, ipk_near in enumerate(ipks_near):
+            ipos_near = tuple([*np.argwhere(ispecs == ispecs_peaks[ii])[0], np.argmin(abs(x - tofs[ipk_near]))])
+            ilabel_near = nearest_label[ipos_near]
+            if ilabel_near != nearest_label[ipos] or dists[ipos] > dists[ipos_near]:
+                labels[labels == nearest_label[ipos_near]] = 0  # remove the label
+        if not labels.any():
+            # no more peak regions left
+            return None
+        inearest = distance_transform_edt(labels == 0, return_distances=False, return_indices=True)
+        peak_label = labels[tuple(inearest)][ipos]
+    return maximum_position(data, labels, peak_label)
 
 
 def find_ipks_in_window(ws, peaks, ispecs, ipk, tof_min=None, tof_max=None):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksShoeboxTOFTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksShoeboxTOFTest.py
@@ -75,7 +75,7 @@ class FindSXPeaksConvolveTest(unittest.TestCase):
         AnalysisDataService.clear()
         shutil.rmtree(cls._test_dir)
 
-    def _assert_found_correct_peaks(self, peak_ws, i_over_sigs=[6.4407, 2.4503]):
+    def _assert_found_correct_peaks(self, peak_ws, i_over_sigs=[6.4407, 4.0207]):
         self.assertEqual(peak_ws.getNumberPeaks(), 2)
         peak_ws = SortPeaksWorkspace(
             InputWorkspace=peak_ws, OutputWorkspace=peak_ws.name(), ColumnNameToSortBy="DetID", SortAscending=False
@@ -168,7 +168,7 @@ class FindSXPeaksConvolveTest(unittest.TestCase):
             IntegrateIfOnEdge=True,
         )
         # check I/sigmas much worse if not optimised
-        self._assert_found_correct_peaks(out, i_over_sigs=[2.7001, 1.1531])
+        self._assert_found_correct_peaks(out, i_over_sigs=[4.4631, 2.3966])
 
     def test_exec_OutputFile(self):
         out_file = path.join(self._test_dir, "out.pdf")

--- a/Testing/SystemTests/tests/framework/SXDAnalysis.py
+++ b/Testing/SystemTests/tests/framework/SXDAnalysis.py
@@ -156,7 +156,7 @@ class SXDIntegrateDataShoebox(systemtesting.MantidSystemTest):
         self.integrated_peaks = sxd.get_peaks(runno, PEAK_TYPE.FOUND, INTEGRATION_TYPE.SHOEBOX)
 
     def validate(self):
-        intens_over_sigma = [0.0, 10.50, 9.56, 135.83, 0.0]
+        intens_over_sigma = [0.0, 9.638, 10.265, 136.535, 0.0]
         self.assertTrue(np.allclose(self.integrated_peaks.column("Intens/SigInt"), intens_over_sigma, atol=1e-2))
 
 

--- a/docs/source/algorithms/IntegratePeaksShoeboxTOF-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksShoeboxTOF-v1.rst
@@ -97,7 +97,7 @@ Usage
 
 .. testoutput:: exampleIntegratePeaksShoeboxTOF
 
-    I/sigma = 100.49
+    I/sigma = 100.80
 
 References
 ----------

--- a/docs/source/release/v6.11.0/Diffraction/Single_Crystal/New_features/37621.rst
+++ b/docs/source/release/v6.11.0/Diffraction/Single_Crystal/New_features/37621.rst
@@ -1,0 +1,1 @@
+- Improve shoebox position optimisation in :ref:`IntegratePeaks1DProfile <algm-IntegratePeaks1DProfile>` - would previously be centred on nearby stronger peaks if present.


### PR DESCRIPTION
### Description of work
Improve shoebox position determination in `IntegratePeaksShoeboxTOF` by doing the following:

1. Stop smoothing the I/sigma from the shoebox convolution - this was over smoothing as the shoebox is effectively also doing some smoothing.
2. Use `label` to find contiguous regions of statistically significant I/sigma and find regions closer to predicted peak position than any other position 
3. Get a better initial shoebox dimensions by allowing float NFHWM

![image](https://github.com/mantidproject/mantid/assets/55979119/ceab27be-9329-4cc9-b63b-142dd845405b)


#### Purpose of work
In reducing SXD data for Nick Funnell it was found that the shoebox  would often find a region of I/sigma far away from weak peak positions - this was because it previously centred the shoebox on the maximum I/sigma, but if there was a nearby peak which wasn't in the peak table the shoebox could go to the wrong peak position. This should be fixed by (2)

*There is no associated issue.*

### To test:

(1) Run this script change `OuptutFile`
```
ws = Load(Filename=r'SXD23767.raw', OutputWorkspace='SXD23767')
peaks = FindSXPeaksConvolve(InputWorkspace=ws, PeakFindingStrategy="IOverSigma", NCols=7, NRows=7, NFWHM=6, ThresholdIoverSigma=5)
                         
kwargs = {"InputWorkspace": ws, "PeaksWorkspace": peaks, "OutputWorkspace": 'peaks_int', 
          "NRows": 7, "NCols": 7, "GetNBinsFromBackToBackParams": True, "NFWHM": 3, "NShoeboxInWindow": 3,
          "WeakPeakThreshold": 0, "IntegrateIfOnEdge": True, "LorentzCorrection": False,
          "OutputFile": '//olympic/Babylon5/Public/RWaite/test_shoebox.pdf'}
IntegratePeaksShoeboxTOF(**kwargs)

```
(2) Check the pdf - the box should be centered on the peak in the data nearest the red `x`

*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
