### PR TITLE
Move verify and clear method to tear down method in isis reflectometry unit tests

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MainWindowPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MainWindowPresenterTest.h
@@ -59,19 +59,21 @@ public:
     auto &config = Mantid::Kernel::ConfigService::Instance();
     config.setString("default.facility", backup_facility);
     config.setString("default.instrument", backup_instrument);
+    // Verifying and clearing of expectations happens when mock variables are destroyed.
+    // Some of our mocks are created as member variables and will exist until all tests have run, so we need to
+    // explicitly verify and clear them after each test.
+    verifyAndClear();
   }
 
   void testPresenterSubscribesToView() {
     EXPECT_CALL(m_view, subscribe(_)).Times(1);
     auto presenter = makePresenter();
-    verifyAndClear();
   }
 
   void testMainWindowPresenterSubscribesToOptionsPresenter() {
     auto optionsPresenter = makeOptionsPresenter();
     EXPECT_CALL(*m_optionsPresenter, subscribe(_)).Times(1);
     auto presenter = makePresenter(std::move(optionsPresenter));
-    verifyAndClear();
   }
 
   void testConstructorAddsBatchPresenterForAllBatchViews() {
@@ -81,7 +83,6 @@ public:
 
     auto presenter = makePresenter();
     TS_ASSERT_EQUALS(presenter.m_batchPresenters.size(), m_batchViews.size());
-    verifyAndClear();
   }
 
   void testBatchPresenterAddedWhenNewBatchRequested() {
@@ -93,7 +94,6 @@ public:
     expectBatchAdded(batchPresenter);
 
     presenter.notifyNewBatchRequested();
-    verifyAndClear();
   }
 
   void testBatchRemovedWhenCloseBatchRequested() {
@@ -103,7 +103,6 @@ public:
     expectBatchRemovedFromView(batchIndex);
     presenter.notifyCloseBatchRequested(batchIndex);
     assertFirstBatchWasRemovedFromModel(presenter);
-    verifyAndClear();
   }
 
   void testBatchNotRemovedIfRequestCloseFailed() {
@@ -113,7 +112,6 @@ public:
     expectBatchNotRemovedFromView(batchIndex);
     presenter.notifyCloseBatchRequested(batchIndex);
     assertBatchNotRemovedFromModel(presenter);
-    verifyAndClear();
   }
 
   void testBatchNotRemovedIfAutoreducing() {
@@ -123,7 +121,6 @@ public:
     expectBatchNotRemovedFromView(batchIndex);
     presenter.notifyCloseBatchRequested(batchIndex);
     assertBatchNotRemovedFromModel(presenter);
-    verifyAndClear();
   }
 
   void testBatchNotRemovedIfProcessing() {
@@ -133,7 +130,6 @@ public:
     expectBatchNotRemovedFromView(batchIndex);
     presenter.notifyCloseBatchRequested(batchIndex);
     assertBatchNotRemovedFromModel(presenter);
-    verifyAndClear();
   }
 
   void testWarningGivenIfRemoveBatchWhileAutoreducing() {
@@ -142,7 +138,6 @@ public:
     expectBatchIsAutoreducing(batchIndex);
     expectCannotCloseBatchWarning();
     presenter.notifyCloseBatchRequested(batchIndex);
-    verifyAndClear();
   }
 
   void testWarningGivenIfRemoveBatchWhileProcessing() {
@@ -151,7 +146,6 @@ public:
     expectBatchIsProcessing(batchIndex);
     expectCannotCloseBatchWarning();
     presenter.notifyCloseBatchRequested(batchIndex);
-    verifyAndClear();
   }
 
   void testWarningGivenIfRemoveUnsavedBatchOptionChecked() {
@@ -163,7 +157,6 @@ public:
     expectBatchUnsaved(batchIndex);
     expectAskDiscardChanges();
     presenter.notifyCloseBatchRequested(batchIndex);
-    verifyAndClear();
   }
 
   void testNoWarningGivenIfRemoveUnsavedBatchOptionUnchecked() {
@@ -174,7 +167,6 @@ public:
     expectBatchSaved(batchIndex);
     expectDoNotAskDiscardChanges();
     presenter.notifyCloseBatchRequested(batchIndex);
-    verifyAndClear();
   }
 
   void testNoWarningIfRemoveSavedBatchOptionChecked() {
@@ -185,7 +177,6 @@ public:
     expectBatchSaved(batchIndex);
     expectDoNotAskDiscardChanges();
     presenter.notifyCloseBatchRequested(batchIndex);
-    verifyAndClear();
   }
 
   void testNoWarningIfRemoveSavedBatchOptionUnchecked() {
@@ -196,7 +187,6 @@ public:
     expectBatchSaved(batchIndex);
     expectDoNotAskDiscardChanges();
     presenter.notifyCloseBatchRequested(batchIndex);
-    verifyAndClear();
   }
 
   void testReductionResumedNotifiesAllBatchPresenters() {
@@ -204,7 +194,6 @@ public:
     for (auto batchPresenter : m_batchPresenters)
       EXPECT_CALL(*batchPresenter, notifyAnyBatchReductionResumed());
     presenter.notifyAnyBatchReductionResumed();
-    verifyAndClear();
   }
 
   void testReductionPausedNotifiesAllBatchPresenters() {
@@ -212,14 +201,12 @@ public:
     for (auto batchPresenter : m_batchPresenters)
       EXPECT_CALL(*batchPresenter, notifyAnyBatchReductionPaused());
     presenter.notifyAnyBatchReductionPaused();
-    verifyAndClear();
   }
 
   void testShowOptionsOpensDialog() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_optionsPresenter, showView()).Times(AtLeast(1));
     presenter.notifyShowOptionsRequested();
-    verifyAndClear();
   }
 
   void testShowSlitCalculatorSetsInstrument() {
@@ -227,14 +214,12 @@ public:
     auto const instrument = setupInstrument(presenter, "TEST_INSTRUMENT");
     expectSlitCalculatorInstrumentUpdated(instrument);
     presenter.notifyShowSlitCalculatorRequested();
-    verifyAndClear();
   }
 
   void testShowSlitCalculatorOpensDialog() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_slitCalculator, show()).Times(1);
     presenter.notifyShowSlitCalculatorRequested();
-    verifyAndClear();
   }
 
   void testAutoreductionResumedNotifiesAllBatchPresenters() {
@@ -242,7 +227,6 @@ public:
     for (auto batchPresenter : m_batchPresenters)
       EXPECT_CALL(*batchPresenter, notifyAnyBatchAutoreductionResumed());
     presenter.notifyAnyBatchAutoreductionResumed();
-    verifyAndClear();
   }
 
   void testAutoreductionPausedNotifiesAllBatchPresenters() {
@@ -250,7 +234,6 @@ public:
     for (auto batchPresenter : m_batchPresenters)
       EXPECT_CALL(*batchPresenter, notifyAnyBatchAutoreductionPaused());
     presenter.notifyAnyBatchAutoreductionPaused();
-    verifyAndClear();
   }
 
   void testAnyBatchIsProcessing() {
@@ -259,7 +242,6 @@ public:
     expectBatchIsProcessing(1);
     auto isProcessing = presenter.isAnyBatchProcessing();
     TS_ASSERT_EQUALS(isProcessing, true);
-    verifyAndClear();
   }
 
   void testNoBatchesAreProcessing() {
@@ -268,7 +250,6 @@ public:
     expectBatchIsNotProcessing(1);
     auto isProcessing = presenter.isAnyBatchProcessing();
     TS_ASSERT_EQUALS(isProcessing, false);
-    verifyAndClear();
   }
 
   void testAnyBatchIsAutoreducing() {
@@ -277,7 +258,6 @@ public:
     expectBatchIsAutoreducing(1);
     auto isAutoreducing = presenter.isAnyBatchAutoreducing();
     TS_ASSERT_EQUALS(isAutoreducing, true);
-    verifyAndClear();
   }
 
   void testNoBatchesAreAutoreducing() {
@@ -286,7 +266,6 @@ public:
     expectBatchIsNotAutoreducing(1);
     auto isAutoreducing = presenter.isAnyBatchAutoreducing();
     TS_ASSERT_EQUALS(isAutoreducing, false);
-    verifyAndClear();
   }
 
   void testChangeInstrumentRequestedUpdatesInstrumentInModel() {
@@ -294,7 +273,6 @@ public:
     auto const instrument = std::string("POLREF");
     presenter.notifyChangeInstrumentRequested(instrument);
     TS_ASSERT_EQUALS(presenter.instrumentName(), instrument);
-    verifyAndClear();
   }
 
   void testChangeInstrumentRequestedUpdatesInstrumentInChildPresenters() {
@@ -304,7 +282,6 @@ public:
     EXPECT_CALL(*m_batchPresenters[0], notifyInstrumentChanged(instrument)).Times(1);
     EXPECT_CALL(*m_batchPresenters[1], notifyInstrumentChanged(instrument)).Times(1);
     presenter.notifyChangeInstrumentRequested(instrument);
-    verifyAndClear();
   }
 
   void testChangeInstrumentRequestedDoesNotUpdateInstrumentIfNotChanged() {
@@ -313,7 +290,6 @@ public:
     EXPECT_CALL(*m_batchPresenters[0], notifyInstrumentChanged(instrument)).Times(0);
     EXPECT_CALL(*m_batchPresenters[1], notifyInstrumentChanged(instrument)).Times(0);
     presenter.notifyChangeInstrumentRequested(instrument);
-    verifyAndClear();
   }
 
   void testChangeInstrumentUpdatesInstrumentInSlitCalculator() {
@@ -322,7 +298,6 @@ public:
     auto const instrument = std::string("POLREF");
     expectSlitCalculatorInstrumentUpdated(instrument);
     presenter.notifyChangeInstrumentRequested(instrument);
-    verifyAndClear();
   }
 
   void testChangeInstrumentDoesNotUpdateInstrumentInSlitCalculatorIfNotChanged() {
@@ -330,7 +305,6 @@ public:
     auto const instrument = setupInstrument(presenter, "POLREF");
     expectSlitCalculatorInstrumentNotUpdated();
     presenter.notifyChangeInstrumentRequested(instrument);
-    verifyAndClear();
   }
 
   void testUpdateInstrumentDoesNotUpdateInstrumentInSlitCalculator() {
@@ -338,7 +312,6 @@ public:
     auto const instrument = setupInstrument(presenter, "POLREF");
     expectSlitCalculatorInstrumentNotUpdated();
     presenter.notifyUpdateInstrumentRequested();
-    verifyAndClear();
   }
 
   void testUpdateInstrumentDoesNotUpdateInstrumentInChildPresenters() {
@@ -347,7 +320,6 @@ public:
     EXPECT_CALL(*m_batchPresenters[0], notifyInstrumentChanged(instrument)).Times(0);
     EXPECT_CALL(*m_batchPresenters[1], notifyInstrumentChanged(instrument)).Times(0);
     presenter.notifyUpdateInstrumentRequested();
-    verifyAndClear();
   }
 
   void testUpdateInstrumentDoesNotChangeInstrumentName() {
@@ -355,13 +327,11 @@ public:
     auto const instrument = setupInstrument(presenter, "POLREF");
     presenter.notifyUpdateInstrumentRequested();
     TS_ASSERT_EQUALS(presenter.instrumentName(), instrument);
-    verifyAndClear();
   }
 
   void testUpdateInstrumentThrowsIfInstrumentNotSet() {
     auto presenter = makePresenter();
     TS_ASSERT_THROWS_ANYTHING(presenter.notifyUpdateInstrumentRequested());
-    verifyAndClear();
   }
 
   void testUpdateInstrumentSetsFacilityInConfig() {
@@ -371,7 +341,6 @@ public:
     config.setString("default.facility", "OLD_FACILITY");
     presenter.notifyUpdateInstrumentRequested();
     TS_ASSERT_EQUALS(config.getString("default.facility"), "ISIS");
-    verifyAndClear();
   }
 
   void testUpdateInstrumentSetsInstrumentInConfig() {
@@ -381,7 +350,6 @@ public:
     config.setString("default.instrument", "OLD_INSTRUMENT");
     presenter.notifyUpdateInstrumentRequested();
     TS_ASSERT_EQUALS(config.getString("default.instrument"), instrument);
-    verifyAndClear();
   }
 
   void testCloseEventChecksIfPrevented() {
@@ -392,7 +360,6 @@ public:
     EXPECT_CALL(*m_batchPresenters[1], isAutoreducing).Times(1);
     EXPECT_CALL(m_view, acceptCloseEvent).Times(1);
     presenter.notifyCloseEvent();
-    verifyAndClear();
   }
 
   void testCloseEventIgnoredIfAutoreducing() {
@@ -400,7 +367,6 @@ public:
     expectBatchIsAutoreducing(0);
     EXPECT_CALL(m_view, ignoreCloseEvent).Times(1);
     presenter.notifyCloseEvent();
-    verifyAndClear();
   }
 
   void testCloseEventIgnoredIfProcessing() {
@@ -408,7 +374,6 @@ public:
     expectBatchIsProcessing(0);
     EXPECT_CALL(m_view, ignoreCloseEvent).Times(1);
     presenter.notifyCloseEvent();
-    verifyAndClear();
   }
 
   void testCloseEventAcceptedIfNotWorking() {
@@ -417,7 +382,6 @@ public:
     expectBatchIsNotProcessing(0);
     EXPECT_CALL(m_view, acceptCloseEvent).Times(1);
     presenter.notifyCloseEvent();
-    verifyAndClear();
   }
 
   void testSaveBatch() {
@@ -425,7 +389,6 @@ public:
     auto const batchIndex = 1;
     expectBatchIsSavedToFile(batchIndex);
     presenter.notifySaveBatchRequested(batchIndex);
-    verifyAndClear();
   }
 
   void testSaveBatchToInvalidPath() {
@@ -433,7 +396,6 @@ public:
     auto const batchIndex = 1;
     expectBatchIsNotSavedToInvalidFile(batchIndex);
     presenter.notifySaveBatchRequested(batchIndex);
-    verifyAndClear();
   }
 
   void testSaveBatchHandlesFailedSave() {
@@ -441,7 +403,6 @@ public:
     auto const batchIndex = 1;
     expectBatchIsNotSavedWhenSaveFails(batchIndex);
     presenter.notifySaveBatchRequested(batchIndex);
-    verifyAndClear();
   }
 
   void testLoadBatch() {
@@ -449,7 +410,6 @@ public:
     auto const batchIndex = 1;
     expectBatchIsLoadedFromFile(batchIndex);
     presenter.notifyLoadBatchRequested(batchIndex);
-    verifyAndClear();
   }
 
   void testWarningGivenIfLoadBatchOverUnsavedBatch() {
@@ -459,7 +419,6 @@ public:
     expectBatchUnsaved(batchIndex);
     expectAskDiscardChanges();
     presenter.notifyLoadBatchRequested(batchIndex);
-    verifyAndClear();
   }
 
   void testNoWarningGivenIfLoadBatchOverSavedBatch() {
@@ -468,7 +427,6 @@ public:
     expectBatchSaved(batchIndex);
     expectDoNotAskDiscardChanges();
     presenter.notifyLoadBatchRequested(batchIndex);
-    verifyAndClear();
   }
 
   void testLoadBatchDiscardChanges() {
@@ -483,7 +441,6 @@ public:
     EXPECT_CALL(m_fileHandler, loadJSONFromFile(filename)).Times(1).WillOnce(Return(map));
     EXPECT_CALL(*m_decoder, decodeBatch(&m_view, batchIndex, map)).Times(1);
     presenter.notifyLoadBatchRequested(batchIndex);
-    verifyAndClear();
   }
 
   void testWarningGivenCloseGUIWithUnsavedChanges() {
@@ -493,7 +450,6 @@ public:
     expectBatchUnsaved(batchIndex);
     expectAskDiscardChanges();
     presenter.isCloseEventPrevented();
-    verifyAndClear();
   }
 
   void testBatchPresentersNotifySetRoundPrecisionOnOptionsChanged() {
@@ -505,7 +461,6 @@ public:
       EXPECT_CALL(*batchPresenter, notifySetRoundPrecision(prec));
     }
     presenter.notifyOptionsChanged();
-    verifyAndClear();
   }
 
   void testBatchPresentersNotifyResetRoundPrecisionOnOptionsChanged() {
@@ -515,7 +470,6 @@ public:
       EXPECT_CALL(*batchPresenter, notifyResetRoundPrecision());
     }
     presenter.notifyOptionsChanged();
-    verifyAndClear();
   }
 
 private:

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/CatalogRunNotifierTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/CatalogRunNotifierTest.h
@@ -25,24 +25,28 @@ public:
   static CatalogRunNotifierTest *createSuite() { return new CatalogRunNotifierTest(); }
   static void destroySuite(CatalogRunNotifierTest *suite) { delete suite; }
 
+  void tearDown() override {
+    // Verifying and clearing of expectations happens when mock variables are destroyed.
+    // Some of our mocks are created as member variables and will exist until all tests have run, so we need to
+    // explicitly verify and clear them after each test.
+    verifyAndClear();
+  }
+
   void testConstructorSubscribesToView() {
     EXPECT_CALL(m_view, subscribeTimer(_)).Times(1);
     auto runNotifier = makeRunNotifier();
-    verifyAndClear();
   }
 
   void testStartPollingStartsTimer() {
     auto runNotifier = makeRunNotifier();
     EXPECT_CALL(m_view, startTimer(_)).Times(1);
     runNotifier.startPolling();
-    verifyAndClear();
   }
 
   void testStopPollingStopsTimer() {
     auto runNotifier = makeRunNotifier();
     EXPECT_CALL(m_view, stopTimer()).Times(1);
     runNotifier.stopPolling();
-    verifyAndClear();
   }
 
   void testTimerEventNotifiesPresenter() {
@@ -50,7 +54,6 @@ public:
     EXPECT_CALL(m_notifyee, notifyCheckForNewRuns()).Times(1);
     runNotifier.subscribe(&m_notifyee);
     runNotifier.notifyTimerEvent();
-    verifyAndClear();
   }
 
 private:

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtCatalogSearcherTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtCatalogSearcherTest.h
@@ -146,11 +146,17 @@ public:
 
   QtCatalogSearcherTest() : m_view(), m_notifyee(), m_searchAlg(std::make_shared<MockSearchAlgorithm>()) {}
 
+  void tearDown() override {
+    // Verifying and clearing of expectations happens when mock variables are destroyed.
+    // Some of our mocks are created as member variables and will exist until all tests have run, so we need to
+    // explicitly verify and clear them after each test.
+    verifyAndClear();
+  }
+
   void test_constructor_subscribes_to_view() {
     EXPECT_CALL(m_view, subscribeSearch(_)).Times(1);
     auto searcher = makeCatalogSearcher();
     searcher.subscribe(&m_notifyee);
-    verifyAndClear();
   }
 
   void test_journal_search() {
@@ -180,7 +186,6 @@ public:
     expectGetAlgorithmRunner();
     auto success = startAsyncJournalSearch(searcher);
     TS_ASSERT_EQUALS(success, true);
-    verifyAndClear();
   }
 
   void test_async_catalog_search_returns_success_if_has_active_session() {
@@ -189,7 +194,6 @@ public:
     expectGetAlgorithmRunner();
     auto success = startAsyncCatalogSearch(searcher);
     TS_ASSERT_EQUALS(success, true);
-    verifyAndClear();
   }
 
   void test_async_journal_search_sets_in_progress_flag() {
@@ -198,7 +202,6 @@ public:
     expectGetAlgorithmRunner();
     startAsyncJournalSearch(searcher);
     TS_ASSERT_EQUALS(searcher.searchInProgress(), true);
-    verifyAndClear();
   }
 
   void test_async_catalog_search_sets_in_progress_flag() {
@@ -207,7 +210,6 @@ public:
     expectGetAlgorithmRunner();
     startAsyncCatalogSearch(searcher);
     TS_ASSERT_EQUALS(searcher.searchInProgress(), true);
-    verifyAndClear();
   }
 
   void test_async_journal_search_starts_algorithm_runner() {
@@ -216,7 +218,6 @@ public:
     auto algRunner = expectGetAlgorithmRunner();
     expectAlgorithmStarted(m_searchAlg, algRunner);
     startAsyncJournalSearch(searcher);
-    verifyAndClear();
   }
 
   void test_async_catalog_search_starts_algorithm_runner() {
@@ -225,7 +226,6 @@ public:
     auto algRunner = expectGetAlgorithmRunner();
     expectAlgorithmStarted(m_searchAlg, algRunner);
     startAsyncCatalogSearch(searcher);
-    verifyAndClear();
   }
 
   void test_async_catalog_search_returns_success_when_not_logged_in() {
@@ -248,7 +248,6 @@ public:
     EXPECT_CALL(m_view, getAlgorithmRunner()).Times(0);
     auto success = startAsyncCatalogSearch(searcher);
     TS_ASSERT_EQUALS(success, true);
-    verifyAndClear();
   }
 
   void test_finish_handle_starts_async_search_if_active_session() {
@@ -257,7 +256,6 @@ public:
     auto algRunner = expectGetAlgorithmRunner();
     expectAlgorithmStarted(m_searchAlg, algRunner);
     searcher.finishHandle(m_searchAlg.get());
-    verifyAndClear();
   }
 
   void test_finish_does_not_notify_failure_if_active_session() {
@@ -266,7 +264,6 @@ public:
     expectGetAlgorithmRunner();
     expectNotNotifiedSearchFailed();
     searcher.finishHandle(m_searchAlg.get());
-    verifyAndClear();
   }
 
   void test_finish_handle_notifies_failure_if_no_active_session() {
@@ -274,7 +271,6 @@ public:
     searcher.subscribe(&m_notifyee);
     expectNotifySearchFailed();
     searcher.finishHandle(m_searchAlg.get());
-    verifyAndClear();
   }
 
   void test_error_handle_notifies_failure_if_no_active_session() {
@@ -282,7 +278,6 @@ public:
     searcher.subscribe(&m_notifyee);
     expectNotifySearchFailed();
     searcher.errorHandle(m_searchAlg.get(), "test error message");
-    verifyAndClear();
   }
 
   void test_error_handle_does_not_notify_failure_if_active_session() {
@@ -290,28 +285,24 @@ public:
     searcher.subscribe(&m_notifyee);
     expectNotNotifiedSearchFailed();
     searcher.errorHandle(m_searchAlg.get(), "test error message");
-    verifyAndClear();
   }
 
   void test_set_saved_flag() {
     auto searcher = makeCatalogSearcher(true);
     EXPECT_CALL(m_searchResults, setSaved()).Times(1);
     searcher.setSaved();
-    verifyAndClear();
   }
 
   void test_notify_search_results_changed_sets_unsaved_flag() {
     auto searcher = makeCatalogSearcher(true);
     EXPECT_CALL(m_searchResults, setUnsaved()).Times(1);
     searcher.notifySearchResultsChanged();
-    verifyAndClear();
   }
 
   void test_search_results_collection_passed_to_results() {
     auto searcher = makeCatalogSearcher(true);
     EXPECT_CALL(m_searchResults, getSearchResultsCSV()).Times(1);
     searcher.getSearchResultsCSV();
-    verifyAndClear();
   }
 
   void test_search_results_in_data_cache() {
@@ -326,7 +317,6 @@ public:
     checkFilteredSearchResults(results);
     ConfigService::Instance().setString("datacachesearch.directory", defaultSaveDirectory);
     ConfigService::Instance().setString("datasearch.searcharchive", defaultArchiveSetting);
-    verifyAndClear();
   }
 
   void test_search_with_archive_on_and_cache_set() {
@@ -341,7 +331,6 @@ public:
     checkSearchResults(results);
     ConfigService::Instance().setString("datacachesearch.directory", defaultSaveDirectory);
     ConfigService::Instance().setString("datasearch.searcharchive", defaultArchiveSetting);
-    verifyAndClear();
   }
 
 private:


### PR DESCRIPTION
### Description of work
Move verify and clear to tear down method in isis reflectometry unit tests 
#### Summary of work
- moved verify and clear to tear down method in the following files:
- MainWindowPresenterTest.h
- CatalogRunNotifierTest.h
- QtCatalogSearcherTest.h

Refs: https://github.com/mantidproject/mantid/issues/35956

#### To test:

Tests should pass.

*This does not require release notes* because **it is a unit test refactor.**