### PR TITLE
Use RunWidget in Data Processor interface

### DIFF
--- a/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
@@ -50,7 +50,7 @@ void DiffractionReduction::initLayout() {
   m_uiForm.setupUi(this);
   m_uiForm.pbSettings->setIcon(Settings::icon());
 
-  m_runPresenter = std::make_unique<RunPresenter>(this, new RunView(m_uiForm.runWidget));
+  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
   m_plotOptionsPresenter =
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraUnit, "0");
 

--- a/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.ui
+++ b/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>551</width>
-    <height>623</height>
+    <width>547</width>
+    <height>614</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,8 +40,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>547</width>
-         <height>571</height>
+         <width>543</width>
+         <height>570</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout">
@@ -423,7 +423,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QWidget" name="runWidget" native="true"/>
+         <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
         </item>
         <item>
          <widget class="QGroupBox" name="gbOutput">
@@ -601,6 +601,12 @@
    <class>MantidQt::API::FileFinderWidget</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/qt/scientific_interfaces/Indirect/Simulation/DensityOfStates.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/DensityOfStates.cpp
@@ -26,7 +26,7 @@ enum class DensityOfStates::InputFormat : int { Unsupported = 0, Phonon, Castep,
 
 DensityOfStates::DensityOfStates(QWidget *parent) : SimulationTab(parent) {
   m_uiForm.setupUi(parent);
-  m_runPresenter = std::make_unique<RunPresenter>(this, new RunView(m_uiForm.runWidget));
+  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::Spectra));
 

--- a/qt/scientific_interfaces/Indirect/Simulation/DensityOfStates.ui
+++ b/qt/scientific_interfaces/Indirect/Simulation/DensityOfStates.ui
@@ -57,8 +57,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>500</width>
-        <height>381</height>
+        <width>480</width>
+        <height>364</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -515,7 +515,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="runWidget" native="true"/>
+    <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
@@ -577,6 +577,12 @@
    <class>MantidQt::API::FileFinderWidget</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/qt/scientific_interfaces/Indirect/Simulation/MolDyn.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/MolDyn.cpp
@@ -19,7 +19,7 @@ using namespace Mantid::API;
 namespace MantidQt::CustomInterfaces {
 MolDyn::MolDyn(QWidget *parent) : SimulationTab(parent), m_runPresenter() {
   m_uiForm.setupUi(parent);
-  m_runPresenter = std::make_unique<RunPresenter>(this, new RunView(m_uiForm.runWidget));
+  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface, "0"));
 

--- a/qt/scientific_interfaces/Indirect/Simulation/MolDyn.ui
+++ b/qt/scientific_interfaces/Indirect/Simulation/MolDyn.ui
@@ -270,7 +270,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="QWidget" name="runWidget" native="true"/>
+    <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
@@ -323,11 +323,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
-  </customwidget>
-  <customwidget>
    <class>MantidQt::CustomInterfaces::OutputPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>Common/OutputPlotOptionsView.h</header>
@@ -338,6 +333,17 @@
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/qt/scientific_interfaces/Indirect/Simulation/Sassena.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/Sassena.cpp
@@ -15,7 +15,7 @@
 namespace MantidQt::CustomInterfaces {
 Sassena::Sassena(QWidget *parent) : SimulationTab(parent) {
   m_uiForm.setupUi(parent);
-  m_runPresenter = std::make_unique<RunPresenter>(this, new RunView(m_uiForm.runWidget));
+  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::Spectra));
 

--- a/qt/scientific_interfaces/Indirect/Simulation/Sassena.ui
+++ b/qt/scientific_interfaces/Indirect/Simulation/Sassena.ui
@@ -114,7 +114,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="QWidget" name="runWidget" native="true"/>
+    <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
@@ -176,6 +176,12 @@
    <class>MantidQt::API::FileFinderWidget</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
@@ -26,7 +26,7 @@ namespace MantidQt::CustomInterfaces {
 Quasi::Quasi(QWidget *parent) : BayesFittingTab(parent), m_previewSpec(0) {
   m_uiForm.setupUi(parent);
 
-  m_runPresenter = std::make_unique<RunPresenter>(this, new RunView(m_uiForm.runWidget));
+  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
 
   // Create range selector
   auto eRangeSelector = m_uiForm.ppPlot->addRangeSelector("QuasiERange");

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.ui
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.ui
@@ -24,8 +24,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>876</width>
-        <height>576</height>
+        <width>880</width>
+        <height>580</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -401,7 +401,7 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="QWidget" name="runWidget" native="true"/>
+           <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
           </item>
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_44">
@@ -500,6 +500,18 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>MantidQt::API::FileFinderWidget</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>MantidQt::MantidWidgets::DataSelector</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/DataSelector.h</header>
@@ -509,11 +521,6 @@
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Plotting/PreviewPlot.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>MantidQt::API::FileFinderWidget</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
@@ -27,7 +27,7 @@ namespace MantidQt::CustomInterfaces {
 ResNorm::ResNorm(QWidget *parent) : BayesFittingTab(parent), m_previewSpec(0) {
   m_uiForm.setupUi(parent);
 
-  m_runPresenter = std::make_unique<RunPresenter>(this, new RunView(m_uiForm.runWidget));
+  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
 
   // Create range selector
   auto eRangeSelector = m_uiForm.ppPlot->addRangeSelector("ResNormERange");

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.ui
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.ui
@@ -24,8 +24,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>876</width>
-        <height>576</height>
+        <width>880</width>
+        <height>580</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -189,7 +189,7 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="QWidget" name="runWidget" native="true"/>
+           <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
           </item>
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_44">
@@ -282,6 +282,12 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>MantidQt::MantidWidgets::DataSelector</class>
    <extends>QWidget</extends>

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
@@ -25,7 +25,7 @@ namespace MantidQt::CustomInterfaces {
 Stretch::Stretch(QWidget *parent) : BayesFittingTab(parent), m_previewSpec(0), m_save(false) {
   m_uiForm.setupUi(parent);
 
-  m_runPresenter = std::make_unique<RunPresenter>(this, new RunView(m_uiForm.runWidget));
+  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
 
   // Create range selector
   auto eRangeSelector = m_uiForm.ppPlot->addRangeSelector("StretchERange");

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.ui
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.ui
@@ -24,8 +24,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>876</width>
-        <height>576</height>
+        <width>880</width>
+        <height>580</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -256,7 +256,7 @@
            <number>0</number>
           </property>
           <item>
-           <widget class="QWidget" name="runWidget" native="true"/>
+           <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
           </item>
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_44">
@@ -382,6 +382,12 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>MantidQt::MantidWidgets::DataSelector</class>
    <extends>QWidget</extends>

--- a/qt/scientific_interfaces/Inelastic/Common/RunWidget/RunPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/RunWidget/RunPresenter.cpp
@@ -21,7 +21,12 @@ RunPresenter::RunPresenter(IRunSubscriber *subscriber, IRunView *view) : m_subsc
 void RunPresenter::handleRunClicked() {
   if (validate()) {
     setRunEnabled(false);
-    m_subscriber->handleRun();
+    try {
+      m_subscriber->handleRun();
+    } catch (std::exception const &ex) {
+      m_view->displayWarning(ex.what());
+      setRunEnabled(true);
+    }
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/Common/RunWidget/RunView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/RunWidget/RunView.cpp
@@ -20,7 +20,7 @@ namespace MantidQt {
 namespace CustomInterfaces {
 
 RunView::RunView(QWidget *parent) : QWidget(parent), m_presenter() {
-  m_uiForm.setupUi(parent);
+  m_uiForm.setupUi(this);
 
   connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(notifyRunClicked()));
 }

--- a/qt/scientific_interfaces/Inelastic/Common/RunWidget/RunView.h
+++ b/qt/scientific_interfaces/Inelastic/Common/RunWidget/RunView.h
@@ -35,7 +35,8 @@ class MANTIDQT_INELASTIC_DLL RunView final : public QWidget, public IRunView {
   Q_OBJECT
 
 public:
-  RunView(QWidget *parent);
+  RunView(QWidget *parent = nullptr);
+  ~RunView() = default;
 
   void subscribePresenter(IRunPresenter *presenter) override;
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
@@ -111,7 +111,7 @@ AbsorptionCorrections::AbsorptionCorrections(QWidget *parent)
   std::map<std::string, std::string> actions;
   actions["Plot Spectra"] = "Plot Wavelength";
   actions["Plot Bins"] = "Plot Angle";
-  m_runPresenter = std::make_unique<RunPresenter>(this, new RunView(m_uiForm.runWidget));
+  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraBin, "", actions));
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
@@ -144,10 +144,6 @@ AbsorptionCorrections::AbsorptionCorrections(QWidget *parent)
   connect(m_uiForm.spSampleDensity, SIGNAL(valueChanged(double)), this, SLOT(setSampleDensity(double)));
   connect(m_uiForm.spCanDensity, SIGNAL(valueChanged(double)), this, SLOT(setCanDensity(double)));
 
-  connect(m_uiForm.leSampleChemicalFormula, SIGNAL(editingFinished()), this, SLOT(doValidation()));
-  connect(m_uiForm.leCanChemicalFormula, SIGNAL(editingFinished()), this, SLOT(doValidation()));
-  connect(m_uiForm.cbUseCan, SIGNAL(stateChanged(int)), this, SLOT(doValidation()));
-
   // Allows empty workspace selector when initially selected
   m_uiForm.dsSampleInput->isOptional(true);
 }
@@ -605,11 +601,6 @@ void AbsorptionCorrections::saveClicked() {
   addSaveWorkspace(m_pythonExportWsName);
   addSaveWorkspace(factorsWs);
   m_batchAlgoRunner->executeBatchAsync();
-}
-
-void AbsorptionCorrections::runClicked() {
-  clearOutputPlotOptionsWorkspaces();
-  runTab();
 }
 
 void AbsorptionCorrections::setSampleDensityOptions(QString const &method) {

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.h
@@ -35,7 +35,6 @@ public:
 private slots:
   virtual void algorithmComplete(bool error);
   void saveClicked();
-  void runClicked();
   void getParameterDefaults(QString const &dataName);
   void setSampleDensityOptions(QString const &method);
   void setCanDensityOptions(QString const &method);
@@ -72,8 +71,6 @@ private:
                          std::string const &beamWidthParamName) const;
   void setBeamHeightValue(const Mantid::Geometry::Instrument_const_sptr &instrument,
                           std::string const &beamHeightParamName) const;
-  void setWavelengthsValue(const Mantid::Geometry::Instrument_const_sptr &instrument,
-                           std::string const &wavelengthsParamName) const;
   void setEventsValue(const Mantid::Geometry::Instrument_const_sptr &instrument,
                       std::string const &eventsParamName) const;
   void setInterpolationValue(const Mantid::Geometry::Instrument_const_sptr &instrument,

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.ui
@@ -26,9 +26,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-54</y>
-        <width>929</width>
-        <height>821</height>
+        <y>0</y>
+        <width>954</width>
+        <height>771</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -1251,7 +1251,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="runWidget" native="true"/>
+        <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
        </item>
        <item>
         <widget class="QGroupBox" name="gbOutput">
@@ -1308,15 +1308,21 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
-  </customwidget>
-  <customwidget>
    <class>MantidQt::CustomInterfaces::OutputPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>Common/OutputPlotOptionsView.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
@@ -36,7 +36,7 @@ namespace MantidQt::CustomInterfaces {
 ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent)
     : CorrectionsTab(parent), m_spectra(0u), m_runPresenter() {
   m_uiForm.setupUi(parent);
-  m_runPresenter = std::make_unique<RunPresenter>(this, new RunView(m_uiForm.runWidget));
+  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface));
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.ui
@@ -23,9 +23,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-126</y>
-        <width>706</width>
-        <height>846</height>
+        <y>0</y>
+        <width>714</width>
+        <height>798</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -315,7 +315,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="runWidget" native="true"/>
+        <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
        </item>
        <item>
         <widget class="QGroupBox" name="gbOutput">
@@ -366,15 +366,21 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
-  </customwidget>
-  <customwidget>
    <class>MantidQt::CustomInterfaces::OutputPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>Common/OutputPlotOptionsView.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
   <customwidget>
    <class>MantidQt::MantidWidgets::PreviewPlot</class>

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
@@ -28,7 +28,7 @@ Mantid::Kernel::Logger g_log("ContainerSubtraction");
 namespace MantidQt::CustomInterfaces {
 ContainerSubtraction::ContainerSubtraction(QWidget *parent) : CorrectionsTab(parent), m_spectra(0), m_runPresenter() {
   m_uiForm.setupUi(parent);
-  m_runPresenter = std::make_unique<RunPresenter>(this, new RunView(m_uiForm.runWidget));
+  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface));
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.ui
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.ui
@@ -23,9 +23,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-78</y>
-        <width>962</width>
-        <height>784</height>
+        <y>0</y>
+        <width>970</width>
+        <height>745</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -275,7 +275,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="runWidget" native="true"/>
+        <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
        </item>
        <item>
         <widget class="QGroupBox" name="gbOutput">
@@ -326,15 +326,21 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
-  </customwidget>
-  <customwidget>
    <class>MantidQt::CustomInterfaces::OutputPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>Common/OutputPlotOptionsView.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
   <customwidget>
    <class>MantidQt::MantidWidgets::PreviewPlot</class>

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
@@ -76,7 +76,6 @@ void DataProcessor::tabExecutionComplete(bool error) {
     m_tabRunning = false;
     m_runPresenter->setRunEnabled(true);
     runComplete(error);
-    auto const enableOutputButtons = error == false ? "enable" : "disable";
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
@@ -43,25 +43,6 @@ void DataProcessor::setOutputPlotOptionsWorkspaces(std::vector<std::string> cons
   m_plotOptionsPresenter->setWorkspaces(outputWorkspaces);
 }
 
-void DataProcessor::runTab() {
-  if (m_runPresenter->validate()) {
-    m_tabStartTime = DateAndTime::getCurrentTime();
-    m_tabRunning = true;
-    try {
-      if (m_plotOptionsPresenter) {
-        m_plotOptionsPresenter->clearWorkspaces();
-      }
-      run();
-    } catch (std::exception const &ex) {
-      m_tabRunning = false;
-      emit showMessageBox(ex.what());
-    }
-  } else {
-    g_log.warning("Failed to validate input!");
-    m_runPresenter->setRunEnabled(true);
-  }
-}
-
 /**
  * Slot used to update the run button when an algorithm that was strted by the
  * Run button complete.

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
@@ -43,6 +43,8 @@ void DataProcessor::setOutputPlotOptionsWorkspaces(std::vector<std::string> cons
   m_plotOptionsPresenter->setWorkspaces(outputWorkspaces);
 }
 
+bool DataProcessor::validate() { return m_runPresenter->validate(); }
+
 void DataProcessor::runTab() {
   if (m_runPresenter->validate()) {
     m_tabStartTime = DateAndTime::getCurrentTime();

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
@@ -43,8 +43,6 @@ void DataProcessor::setOutputPlotOptionsWorkspaces(std::vector<std::string> cons
   m_plotOptionsPresenter->setWorkspaces(outputWorkspaces);
 }
 
-bool DataProcessor::validate() { return m_runPresenter->validate(); }
-
 void DataProcessor::runTab() {
   if (m_runPresenter->validate()) {
     m_tabStartTime = DateAndTime::getCurrentTime();

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
@@ -33,6 +33,10 @@ void DataProcessor::setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOpti
   m_plotOptionsPresenter = std::move(presenter);
 }
 
+void DataProcessor::setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter) {
+  m_runPresenter = std::move(presenter);
+}
+
 void DataProcessor::clearOutputPlotOptionsWorkspaces() { m_plotOptionsPresenter->clearWorkspaces(); }
 
 void DataProcessor::setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces) {
@@ -40,10 +44,9 @@ void DataProcessor::setOutputPlotOptionsWorkspaces(std::vector<std::string> cons
 }
 
 void DataProcessor::runTab() {
-  if (validate()) {
+  if (m_runPresenter->validate()) {
     m_tabStartTime = DateAndTime::getCurrentTime();
     m_tabRunning = true;
-    emit updateRunButton(false, "disable", "Running...", "Running data reduction...");
     try {
       if (m_plotOptionsPresenter) {
         m_plotOptionsPresenter->clearWorkspaces();
@@ -51,11 +54,11 @@ void DataProcessor::runTab() {
       run();
     } catch (std::exception const &ex) {
       m_tabRunning = false;
-      emit updateRunButton(true, "enable");
       emit showMessageBox(ex.what());
     }
   } else {
     g_log.warning("Failed to validate input!");
+    m_runPresenter->setRunEnabled(true);
   }
 }
 
@@ -69,9 +72,9 @@ void DataProcessor::tabExecutionComplete(bool error) {
   UNUSED_ARG(error);
   if (m_tabRunning) {
     m_tabRunning = false;
+    m_runPresenter->setRunEnabled(true);
     runComplete(error);
     auto const enableOutputButtons = error == false ? "enable" : "disable";
-    emit updateRunButton(true, enableOutputButtons);
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
@@ -72,11 +72,8 @@ void DataProcessor::runTab() {
  */
 void DataProcessor::tabExecutionComplete(bool error) {
   UNUSED_ARG(error);
-  if (m_tabRunning) {
-    m_tabRunning = false;
-    m_runPresenter->setRunEnabled(true);
-    runComplete(error);
-  }
+  m_runPresenter->setRunEnabled(true);
+  runComplete(error);
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
@@ -8,6 +8,7 @@
 
 #include "Common/InelasticTab.h"
 #include "Common/OutputPlotOptionsPresenter.h"
+#include "Common/RunWidget/RunPresenter.h"
 #include "DllConfig.h"
 
 // Suppress a warning coming out of code that isn't ours
@@ -46,9 +47,12 @@ public:
 
   /// Set the presenter for the output plotting options
   void setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter);
-  /// Set the active workspaces used in the plotting options
+  /// Set the presenter for the run widget
+  void setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter);
+
   /// Clear the workspaces held by the output plotting options
   void clearOutputPlotOptionsWorkspaces();
+  /// Set the active workspaces used in the plotting options
   void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces);
 
   /// Prevent loading of data with incorrect naming
@@ -56,11 +60,6 @@ public:
 
 public slots:
   void runTab();
-
-signals:
-  /// Update the Run button on the IDR main window
-  void updateRunButton(bool enabled = true, std::string const &enableOutputButtons = "unchanged",
-                       QString message = "Run", QString tooltip = "");
 
 private slots:
   void tabExecutionComplete(bool error);
@@ -72,6 +71,7 @@ private:
   virtual void setFileExtensionsByName(bool filter) { (void)filter; };
 
   std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
+  std::unique_ptr<RunPresenter> m_runPresenter;
   bool m_tabRunning;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
@@ -55,7 +55,6 @@ public:
   /// Set the active workspaces used in the plotting options
   void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces);
 
-  bool validate() override;
   /// Prevent loading of data with incorrect naming
   void filterInputData(bool filter);
 
@@ -67,12 +66,12 @@ private slots:
 
 protected:
   virtual void runComplete(bool error) { (void)error; };
+  std::unique_ptr<RunPresenter> m_runPresenter;
 
 private:
   virtual void setFileExtensionsByName(bool filter) { (void)filter; };
 
   std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
-  std::unique_ptr<RunPresenter> m_runPresenter;
   bool m_tabRunning;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
@@ -55,6 +55,7 @@ public:
   /// Set the active workspaces used in the plotting options
   void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces);
 
+  bool validate() override;
   /// Prevent loading of data with incorrect naming
   void filterInputData(bool filter);
 

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
@@ -58,9 +58,6 @@ public:
   /// Prevent loading of data with incorrect naming
   void filterInputData(bool filter);
 
-public slots:
-  void runTab();
-
 private slots:
   void tabExecutionComplete(bool error);
 

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.cpp
@@ -319,12 +319,12 @@ void ElwinPresenter::updateAvailableSpectra() {
   m_view->setAvailableSpectra(spectra.begin(), spectra.end());
 }
 
-size_t ElwinPresenter::findWorkspaceID() {
+WorkspaceID ElwinPresenter::findWorkspaceID() {
   auto currentWorkspace = m_view->getCurrentPreview();
   auto allWorkspaces = m_dataModel->getWorkspaceNames();
   auto findWorkspace = find(allWorkspaces.begin(), allWorkspaces.end(), currentWorkspace);
   size_t workspaceID = findWorkspace - allWorkspaces.begin();
-  return workspaceID;
+  return WorkspaceID{workspaceID};
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
@@ -87,7 +87,7 @@ private:
   bool checkForELTWorkspace();
   void newPreviewFileSelected(const std::string &workspaceName, const std::string &filename);
   void newPreviewWorkspaceSelected(const std::string &workspaceName);
-  size_t findWorkspaceID();
+  WorkspaceID findWorkspaceID();
 
   IElwinView *m_view;
   std::unique_ptr<IElwinModel> m_model;

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
@@ -50,9 +50,6 @@ public:
                  std::unique_ptr<IDataModel> dataModel);
   ~ElwinPresenter();
 
-  void run() override;
-  void setup() override;
-
   // runWidget
   void handleRun() override;
   void handleValidation(IUserInputValidator *validator) const override;

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
@@ -9,7 +9,6 @@
 #include "Common/DataModel.h"
 #include "Common/IDataModel.h"
 #include "Common/RunWidget/IRunSubscriber.h"
-#include "Common/Runwidget/RunPresenter.h"
 #include "DataProcessor.h"
 #include "DataProcessorInterface.h"
 

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
@@ -8,6 +8,8 @@
 
 #include "Common/DataModel.h"
 #include "Common/IDataModel.h"
+#include "Common/RunWidget/IRunSubscriber.h"
+#include "Common/Runwidget/RunPresenter.h"
 #include "DataProcessor.h"
 #include "DataProcessorInterface.h"
 
@@ -18,6 +20,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/Common/FunctionModelSpectra.h"
 #include "MantidQtWidgets/Common/IAddWorkspaceDialog.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
 #include "ui_ElwinTab.h"
 
 namespace MantidQt {
@@ -31,7 +34,6 @@ class IElwinPresenter {
 public:
   virtual void handleValueChanged(std::string const &propName, double value) = 0;
   virtual void handleValueChanged(std::string const &propName, bool value) = 0;
-  virtual void handleRunClicked() = 0;
   virtual void handleSaveClicked() = 0;
   virtual void handlePlotPreviewClicked() = 0;
   virtual void handlePreviewSpectrumChanged(int spectrum) = 0;
@@ -42,7 +44,7 @@ public:
   virtual void updateAvailableSpectra() = 0;
 };
 
-class MANTIDQT_INELASTIC_DLL ElwinPresenter : public DataProcessor, public IElwinPresenter {
+class MANTIDQT_INELASTIC_DLL ElwinPresenter : public DataProcessor, public IElwinPresenter, public IRunSubscriber {
 public:
   ElwinPresenter(QWidget *parent, IElwinView *view, std::unique_ptr<IElwinModel> model);
   ElwinPresenter(QWidget *parent, IElwinView *view, std::unique_ptr<IElwinModel> model,
@@ -51,12 +53,14 @@ public:
 
   void run() override;
   void setup() override;
-  bool validate() override;
+
+  // runWidget
+  void handleRun() override;
+  void handleValidation(IUserInputValidator *validator) const override;
 
   // Elwin interface methods
   void handleValueChanged(std::string const &propName, double) override;
   void handleValueChanged(std::string const &propName, bool) override;
-  void handleRunClicked() override;
   void handleSaveClicked() override;
   void handlePlotPreviewClicked() override;
   void handlePreviewSpectrumChanged(int spectrum) override;

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinTab.ui
@@ -25,8 +25,98 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QFrame" name="inputChoice">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="toolTip">
+      <string>For every workspace added, it checks whether to show every spectra of the each workspace as individual rows, or collapse all spectra into one row per workspace</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0">
+      <item row="0" column="1" alignment="Qt::AlignTop">
+       <widget class="QFrame" name="frame_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QPushButton" name="wkspAdd">
+           <property name="text">
+            <string>Add Workspaces</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pbSelAll">
+           <property name="text">
+            <string>Select All</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="wkspRemove">
+           <property name="text">
+            <string>Remove Selected</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="ckCollapse">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="text">
+            <string>Collapse rows</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="ckGroupOutput">
+           <property name="text">
+            <string>Group Output</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QTableWidget" name="tbElwinData">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>400</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QSplitter" name="splitterPlot">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -120,7 +210,7 @@
             <number>-1</number>
            </property>
            <property name="currentIndex">
-            <number>1</number>
+            <number>0</number>
            </property>
            <widget class="QWidget" name="pgPlotSpinBox">
             <widget class="QSpinBox" name="spPlotSpectrum">
@@ -277,69 +367,10 @@
      </widget>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="gbRun">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Run</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_3">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QCheckBox" name="ckGroupOutput">
-          <property name="text">
-           <string>Group Output</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Expanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>125</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>244</width>
-          <height>17</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
+   <item>
+    <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
    </item>
-   <item row="3" column="0">
+   <item>
     <widget class="QGroupBox" name="gbOutput">
      <property name="minimumSize">
       <size>
@@ -380,92 +411,15 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QFrame" name="inputChoice">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>For every workspace added, it checks whether to show every spectra of the each workspace as individual rows, or collapse all spectra into one row per workspace</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0">
-      <item row="0" column="1" alignment="Qt::AlignTop">
-       <widget class="QFrame" name="frame_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
-         <item>
-          <widget class="QPushButton" name="wkspAdd">
-           <property name="text">
-            <string>Add Workspaces</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pbSelAll">
-           <property name="text">
-            <string>Select All</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="wkspRemove">
-           <property name="text">
-            <string>Remove Selected</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="ckCollapse">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="text">
-            <string>Collapse rows</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QTableWidget" name="tbElwinData">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>400</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>MantidQt::CustomInterfaces::OutputPlotOptionsView</class>
    <extends>QWidget</extends>

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
@@ -112,7 +112,6 @@ void ElwinView::setup() {
   connect(m_uiForm.ckCollapse, SIGNAL(stateChanged(int)), this, SLOT(notifyRowModeChanged()));
 
   // Handle plot and save
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(notifyRunClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
   connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this, SLOT(notifyPlotPreviewClicked()));
 
@@ -127,8 +126,6 @@ void ElwinView::setup() {
 }
 
 void ElwinView::subscribePresenter(IElwinPresenter *presenter) { m_presenter = presenter; }
-
-void ElwinView::notifyRunClicked() { m_presenter->handleRunClicked(); }
 
 void ElwinView::notifySaveClicked() { m_presenter->handleSaveClicked(); }
 
@@ -176,6 +173,8 @@ void ElwinView::addData(MantidWidgets::IAddWorkspaceDialog const *dialog) {
     QMessageBox::warning(this->parentWidget(), "Warning! ", ex.what());
   }
 }
+
+IRunView *ElwinView::getRunView() const { return m_uiForm.runWidget; }
 
 IOutputPlotOptionsView *ElwinView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
 
@@ -430,17 +429,9 @@ void ElwinView::setRangeSelectorMax(QtProperty *minProperty, QtProperty *maxProp
 }
 
 void ElwinView::setRunIsRunning(const bool running) {
-  m_uiForm.pbRun->setText(running ? "Running..." : "Run");
-  setButtonsEnabled(!running);
+  setSaveResultEnabled(!running);
   m_uiForm.ppPlot->watchADS(!running);
 }
-
-void ElwinView::setButtonsEnabled(const bool enabled) {
-  setRunEnabled(enabled);
-  setSaveResultEnabled(enabled);
-}
-
-void ElwinView::setRunEnabled(const bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
 
 void ElwinView::setSaveResultEnabled(const bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }
 

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinView.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "Common/RunWidget/RunView.h"
 #include "DataProcessor.h"
 #include "ElwinPresenter.h"
 #include "IElwinView.h"
@@ -30,6 +31,7 @@ public:
   void subscribePresenter(IElwinPresenter *presenter) override;
   void setup() override;
 
+  IRunView *getRunView() const override;
   IOutputPlotOptionsView *getPlotOptions() const override;
 
   void setAvailableSpectra(WorkspaceIndex minimum, WorkspaceIndex maximum) override;
@@ -80,7 +82,6 @@ private slots:
   void notifyDoubleValueChanged(QtProperty *, double);
   void notifyCheckboxValueChanged(QtProperty *, bool);
   void notifyPlotPreviewClicked();
-  void notifyRunClicked();
   void notifySaveClicked();
   void notifySelectedSpectrumChanged(int);
   void notifyPreviewIndexChanged(int);
@@ -109,8 +110,6 @@ private:
                            MantidWidgets::RangeSelector *rangeSelector, double newValue);
   void showAddWorkspaceDialog();
   void setPreviewToDefault();
-  void setButtonsEnabled(const bool enabled);
-  void setRunEnabled(const bool enabled);
   void setCell(std::unique_ptr<QTableWidgetItem> cell, int row, int column);
   void addData(MantidWidgets::IAddWorkspaceDialog const *dialog);
 

--- a/qt/scientific_interfaces/Inelastic/Processor/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IElwinView.h
@@ -33,6 +33,7 @@ public:
   virtual ~IElwinView() = default;
   virtual void subscribePresenter(IElwinPresenter *presenter) = 0;
   virtual void setup() = 0;
+
   virtual IRunView *getRunView() const = 0;
   virtual IOutputPlotOptionsView *getPlotOptions() const = 0;
 

--- a/qt/scientific_interfaces/Inelastic/Processor/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IElwinView.h
@@ -23,6 +23,7 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
+class IRunView;
 class IOutputPlotOptionsView;
 class IElwinPresenter;
 
@@ -32,6 +33,7 @@ public:
   virtual ~IElwinView() = default;
   virtual void subscribePresenter(IElwinPresenter *presenter) = 0;
   virtual void setup() = 0;
+  virtual IRunView *getRunView() const = 0;
   virtual IOutputPlotOptionsView *getPlotOptions() const = 0;
 
   virtual void setAvailableSpectra(MantidWidgets::WorkspaceIndex minimum, MantidWidgets::WorkspaceIndex maximum) = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/IIqtView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IIqtView.h
@@ -16,9 +16,13 @@
 #include <tuple>
 
 namespace MantidQt {
+namespace MantidWidgets {
+class DataSelector;
+}
 namespace CustomInterfaces {
 
-class OutputPlotOptionsView;
+class IRunView;
+class IOutputPlotOptionsView;
 class IIqtPresenter;
 
 class MANTIDQT_INELASTIC_DLL IIqtView {
@@ -27,20 +31,20 @@ public:
   virtual ~IIqtView() = default;
   virtual void subscribePresenter(IIqtPresenter *presenter) = 0;
 
-  virtual OutputPlotOptionsView *getPlotOptions() const = 0;
+  virtual IRunView *getRunView() const = 0;
+  virtual IOutputPlotOptionsView *getPlotOptions() const = 0;
+  virtual MantidWidgets::DataSelector *getDataSelector(const std::string &selectorName) const = 0;
+
   virtual void plotInput(Mantid::API::MatrixWorkspace_sptr inputWS, int spectrum) = 0;
   virtual void setPreviewSpectrumMaximum(int value) = 0;
   virtual void updateDisplayedBinParameters() = 0;
   virtual void setRangeSelectorDefault(const Mantid::API::MatrixWorkspace_sptr inputWorkspace,
                                        const QPair<double, double> &range) = 0;
-  virtual bool validate() = 0;
   virtual void setSampleFBSuffixes(const QStringList &suffix) = 0;
   virtual void setSampleWSSuffixes(const QStringList &suffix) = 0;
   virtual void setResolutionFBSuffixes(const QStringList &suffix) = 0;
   virtual void setResolutionWSSuffixes(const QStringList &suffix) = 0;
-  virtual void setRunEnabled(bool enabled) = 0;
   virtual void setSaveResultEnabled(bool enabled) = 0;
-  virtual void setRunText(bool running) = 0;
   virtual void setWatchADS(bool watch) = 0;
   virtual void setup() = 0;
   virtual void showMessageBox(const std::string &message) const = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/IMomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IMomentsView.h
@@ -19,6 +19,7 @@ class DataSelector;
 }
 namespace CustomInterfaces {
 
+class IRunView;
 class IOutputPlotOptionsView;
 class IMomentsPresenter;
 
@@ -27,10 +28,12 @@ class MANTIDQT_INELASTIC_DLL IMomentsView {
 public:
   virtual ~IMomentsView() = default;
   virtual void subscribePresenter(IMomentsPresenter *presenter) = 0;
-
   virtual void setupProperties() = 0;
+
+  virtual IRunView *getRunView() const = 0;
   virtual IOutputPlotOptionsView *getPlotOptions() const = 0;
   virtual MantidWidgets::DataSelector *getDataSelector() const = 0;
+
   virtual std::string getDataName() const = 0;
   virtual void showMessageBox(std::string const &message) const = 0;
 
@@ -45,6 +48,7 @@ public:
   virtual void setRangeSelectorMin(double newValue) = 0;
   /// Sets the max of the range selector if it is more than the min
   virtual void setRangeSelectorMax(double newValue) = 0;
+  virtual void setSaveResultEnabled(bool enable) = 0;
 
   virtual void plotNewData(std::string const &filename) = 0;
   virtual void replot() = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/ISqwView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ISqwView.h
@@ -30,6 +30,7 @@ public:
 
   virtual IRunView *getRunView() const = 0;
   virtual IOutputPlotOptionsView *getPlotOptions() const = 0;
+
   virtual void setFBSuffixes(QStringList const &suffix) = 0;
   virtual void setWSSuffixes(QStringList const &suffix) = 0;
   virtual std::tuple<double, double> getQRangeFromPlot() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/ISqwView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ISqwView.h
@@ -18,7 +18,8 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-class OutputPlotOptionsView;
+class IRunView;
+class IOutputPlotOptionsView;
 class ISqwPresenter;
 
 class MANTIDQT_INELASTIC_DLL ISqwView {
@@ -27,7 +28,8 @@ public:
   virtual ~ISqwView() = default;
   virtual void subscribePresenter(ISqwPresenter *presenter) = 0;
 
-  virtual OutputPlotOptionsView *getPlotOptions() const = 0;
+  virtual IRunView *getRunView() const = 0;
+  virtual IOutputPlotOptionsView *getPlotOptions() const = 0;
   virtual void setFBSuffixes(QStringList const &suffix) = 0;
   virtual void setWSSuffixes(QStringList const &suffix) = 0;
   virtual std::tuple<double, double> getQRangeFromPlot() const = 0;
@@ -37,7 +39,6 @@ public:
   virtual void setDefaultQAndEnergy() = 0;
   virtual bool validate() = 0;
   virtual void showMessageBox(std::string const &message) const = 0;
-  virtual void setRunButtonText(std::string const &runText) = 0;
   virtual void setEnableOutputOptions(bool const enable) = 0;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Processor/ISymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ISymmetriseView.h
@@ -17,7 +17,7 @@
 #include <tuple>
 
 namespace MantidQt {
-namespace MantidWidget {
+namespace MantidWidgets {
 class DataSelector;
 }
 namespace CustomInterfaces {

--- a/qt/scientific_interfaces/Inelastic/Processor/ISymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ISymmetriseView.h
@@ -9,6 +9,7 @@
 #include "DllConfig.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 
+#include <QPair>
 #include <QStringList>
 
 #include <memory>
@@ -16,9 +17,13 @@
 #include <tuple>
 
 namespace MantidQt {
+namespace MantidWidget {
+class DataSelector;
+}
 namespace CustomInterfaces {
 
-class OutputPlotOptionsView;
+class IRunView;
+class IOutputPlotOptionsView;
 class ISymmetrisePresenter;
 
 class MANTIDQT_INELASTIC_DLL ISymmetriseView {
@@ -26,9 +31,12 @@ class MANTIDQT_INELASTIC_DLL ISymmetriseView {
 public:
   virtual ~ISymmetriseView() = default;
   virtual void subscribePresenter(ISymmetrisePresenter *presenter) = 0;
-
   virtual void setDefaults() = 0;
-  virtual OutputPlotOptionsView *getPlotOptions() const = 0;
+
+  virtual IRunView *getRunView() const = 0;
+  virtual IOutputPlotOptionsView *getPlotOptions() const = 0;
+  virtual MantidWidgets::DataSelector *getDataSelector() const = 0;
+
   virtual void setFBSuffixes(QStringList const &suffix) = 0;
   virtual void setWSSuffixes(QStringList const &suffix) = 0;
 
@@ -44,10 +52,11 @@ public:
   virtual bool verifyERange(std::string const &workspaceName) = 0;
   virtual void setRawPlotWatchADS(bool watchADS) = 0;
 
+  virtual void resetEDefaults(bool isPositive) = 0;
+  virtual void resetEDefaults(bool isPositive, QPair<double, double> range) = 0;
+
   virtual void previewAlgDone() = 0;
   virtual void enableSave(bool save) = 0;
-  virtual void enableRun(bool run) = 0;
-  virtual bool validate() = 0;
   virtual void showMessageBox(std::string const &message) const = 0;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtModel.cpp
@@ -58,4 +58,8 @@ void IqtModel::setCalculateErrors(bool calculateErrors) { m_calculateErrors = ca
 
 void IqtModel::setEnforceNormalization(bool enforceNormalization) { m_enforceNormalization = enforceNormalization; }
 
+double IqtModel::EMin() { return m_energyMin; }
+
+double IqtModel::EMax() { return m_energyMax; }
+
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtModel.cpp
@@ -58,8 +58,8 @@ void IqtModel::setCalculateErrors(bool calculateErrors) { m_calculateErrors = ca
 
 void IqtModel::setEnforceNormalization(bool enforceNormalization) { m_enforceNormalization = enforceNormalization; }
 
-double IqtModel::EMin() { return m_energyMin; }
+double IqtModel::EMin() const { return m_energyMin; }
 
-double IqtModel::EMax() { return m_energyMax; }
+double IqtModel::EMax() const { return m_energyMax; }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtModel.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtModel.h
@@ -31,8 +31,8 @@ public:
   virtual void setNumBins(double numBins) = 0;
   virtual void setCalculateErrors(bool calculateErrors) = 0;
   virtual void setEnforceNormalization(bool enforceNormalization) = 0;
-  virtual double EMin() = 0;
-  virtual double EMax() = 0;
+  virtual double EMin() const = 0;
+  virtual double EMax() const = 0;
 };
 
 class MANTIDQT_INELASTIC_DLL IqtModel : public IIqtModel {
@@ -50,8 +50,8 @@ public:
   void setNumBins(double numBins) override;
   void setCalculateErrors(bool calculateErrors) override;
   void setEnforceNormalization(bool enforceNormalization) override;
-  double EMin() override;
-  double EMax() override;
+  double EMin() const override;
+  double EMax() const override;
 
 private:
   std::string m_sampleWorkspace;

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtModel.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtModel.h
@@ -31,6 +31,8 @@ public:
   virtual void setNumBins(double numBins) = 0;
   virtual void setCalculateErrors(bool calculateErrors) = 0;
   virtual void setEnforceNormalization(bool enforceNormalization) = 0;
+  virtual double EMin() = 0;
+  virtual double EMax() = 0;
 };
 
 class MANTIDQT_INELASTIC_DLL IqtModel : public IIqtModel {
@@ -48,6 +50,8 @@ public:
   void setNumBins(double numBins) override;
   void setCalculateErrors(bool calculateErrors) override;
   void setEnforceNormalization(bool enforceNormalization) override;
+  double EMin() override;
+  double EMax() override;
 
 private:
   std::string m_sampleWorkspace;

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.h
@@ -36,9 +36,6 @@ public:
   IqtPresenter(QWidget *parent, IIqtView *view, std::unique_ptr<IIqtModel> model);
   ~IqtPresenter() = default;
 
-  void setup() override;
-  void run() override;
-
   // runWidget
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "Common/RunWidget/IRunSubscriber.h"
 #include "DataProcessor.h"
 #include "IIqtView.h"
 #include "IqtModel.h"
@@ -20,7 +21,6 @@ public:
   virtual void handleSampDataReady(const std::string &wsname) = 0;
   virtual void handleResDataReady(const std::string &resWorkspace) = 0;
   virtual void handleIterationsChanged(int iterations) = 0;
-  virtual void handleRunClicked() = 0;
   virtual void handleSaveClicked() = 0;
   virtual void handlePlotCurrentPreview() = 0;
   virtual void handleErrorsClicked(int state) = 0;
@@ -30,7 +30,7 @@ public:
 };
 
 using namespace Mantid::API;
-class MANTIDQT_INELASTIC_DLL IqtPresenter : public DataProcessor, public IIqtPresenter {
+class MANTIDQT_INELASTIC_DLL IqtPresenter : public DataProcessor, public IIqtPresenter, public IRunSubscriber {
 
 public:
   IqtPresenter(QWidget *parent, IIqtView *view, std::unique_ptr<IIqtModel> model);
@@ -38,12 +38,14 @@ public:
 
   void setup() override;
   void run() override;
-  bool validate() override;
+
+  // runWidget
+  void handleValidation(IUserInputValidator *validator) const override;
+  void handleRun() override;
 
   void handleSampDataReady(const std::string &wsname) override;
   void handleResDataReady(const std::string &resWorkspace) override;
   void handleIterationsChanged(int iterations) override;
-  void handleRunClicked() override;
   void handleSaveClicked() override;
   void handlePlotCurrentPreview() override;
   void handleErrorsClicked(int state) override;
@@ -63,8 +65,6 @@ private:
   void setPreviewPlotWorkspace(const MatrixWorkspace_sptr &previewPlotWorkspace);
   /// Set input workspace
   void setInputWorkspace(Mantid::API::MatrixWorkspace_sptr inputWorkspace);
-  void setButtonsEnabled(bool enabled);
-  void setRunIsRunning(bool running);
 
   IIqtView *m_view;
   std::unique_ptr<IIqtModel> m_model;

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtTab.ui
@@ -341,52 +341,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gbRun">
-     <property name="title">
-      <string>Run</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_3">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>7</number>
-      </property>
-      <item>
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
+    <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
@@ -433,9 +388,10 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <class>MantidQt::CustomInterfaces::RunView</class>
    <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>MantidQt::CustomInterfaces::OutputPlotOptionsView</class>
@@ -448,6 +404,11 @@
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Plotting/PreviewPlot.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtView.h
@@ -33,19 +33,18 @@ public:
 
   void subscribePresenter(IIqtPresenter *presenter) override;
 
-  OutputPlotOptionsView *getPlotOptions() const override;
+  IRunView *getRunView() const override;
+  IOutputPlotOptionsView *getPlotOptions() const override;
+  MantidWidgets::DataSelector *getDataSelector(const std::string &selectorName) const override;
   void plotInput(MatrixWorkspace_sptr inputWS, int spectrum) override;
   void setPreviewSpectrumMaximum(int value) override;
   void updateDisplayedBinParameters() override;
   void setRangeSelectorDefault(const MatrixWorkspace_sptr inputWorkspace, const QPair<double, double> &range) override;
-  bool validate() override;
   void setSampleFBSuffixes(const QStringList &suffix) override;
   void setSampleWSSuffixes(const QStringList &suffix) override;
   void setResolutionFBSuffixes(const QStringList &suffix) override;
   void setResolutionWSSuffixes(const QStringList &suffix) override;
-  void setRunEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
-  void setRunText(bool running) override;
   void setWatchADS(bool watch) override;
   void setup() override;
   void showMessageBox(const std::string &message) const override;
@@ -57,7 +56,6 @@ private slots:
   void notifySampDataReady(const QString &filename);
   void notifyResDataReady(const QString &resFilename);
   void notifyIterationsChanged(int iterations);
-  void notifyRunClicked();
   void notifySaveClicked();
   void notifyPlotCurrentPreview();
   void notifyErrorsClicked(int state);

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
@@ -39,7 +39,7 @@ MomentsPresenter::MomentsPresenter(QWidget *parent, IMomentsView *view, std::uni
  *
  */
 void MomentsPresenter::handleDataReady(std::string const &dataName) {
-  if (validate()) {
+  if (m_runPresenter->validate()) {
     m_model->setInputWorkspace(m_view->getDataName());
     plotNewData(dataName);
   }

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
@@ -29,6 +29,7 @@ namespace MantidQt::CustomInterfaces {
 MomentsPresenter::MomentsPresenter(QWidget *parent, IMomentsView *view, std::unique_ptr<IMomentsModel> model)
     : DataProcessor(parent), m_view(view), m_model(std::move(model)) {
   m_view->subscribePresenter(this);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_view->getRunView()));
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::Spectra, "0,2,4"));
 }
@@ -58,14 +59,8 @@ void MomentsPresenter::handleScaleValueChanged(double value) { m_model->setScale
 
 void MomentsPresenter::run() { runAlgorithm(m_model->setupAlgorithm()); }
 
-bool MomentsPresenter::validate() {
-  auto uiv = std::make_unique<UserInputValidator>();
-  validateDataIsOfType(uiv.get(), m_view->getDataSelector(), "Sample", DataType::Sqw);
-
-  auto const errorMessage = uiv->generateErrorMessage();
-  if (!errorMessage.empty())
-    m_view->showMessageBox(errorMessage);
-  return errorMessage.empty();
+void MomentsPresenter::handleValidation(IUserInputValidator *validator) const {
+  validateDataIsOfType(validator, m_view->getDataSelector(), "Sample", DataType::Sqw);
 }
 
 /**
@@ -129,7 +124,7 @@ void MomentsPresenter::setFileExtensionsByName(bool filter) {
 /**
  * Handle when Run is clicked
  */
-void MomentsPresenter::handleRunClicked() { runTab(); }
+void MomentsPresenter::handleRun() { runTab(); }
 
 /**
  * Handles saving of workspaces

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
@@ -34,8 +34,6 @@ MomentsPresenter::MomentsPresenter(QWidget *parent, IMomentsView *view, std::uni
       std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::Spectra, "0,2,4"));
 }
 
-void MomentsPresenter::setup() {}
-
 /**
  * Handles the event of data being loaded. Validates the loaded data.
  *
@@ -56,8 +54,6 @@ void MomentsPresenter::handleScaleChanged(bool state) { m_model->setScale(state)
  * Handles the scale value being changed.
  */
 void MomentsPresenter::handleScaleValueChanged(double value) { m_model->setScaleValue(value); }
-
-void MomentsPresenter::run() { runAlgorithm(m_model->setupAlgorithm()); }
 
 void MomentsPresenter::handleValidation(IUserInputValidator *validator) const {
   validateDataIsOfType(validator, m_view->getDataSelector(), "Sample", DataType::Sqw);
@@ -124,7 +120,10 @@ void MomentsPresenter::setFileExtensionsByName(bool filter) {
 /**
  * Handle when Run is clicked
  */
-void MomentsPresenter::handleRun() { runTab(); }
+void MomentsPresenter::handleRun() {
+  clearOutputPlotOptionsWorkspaces();
+  runAlgorithm(m_model->setupAlgorithm());
+}
 
 /**
  * Handles saving of workspaces

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "Common/RunWidget/IRunSubscriber.h"
 #include "DataProcessor.h"
 #include "IMomentsView.h"
 #include "MomentsModel.h"
@@ -26,8 +27,6 @@ public:
   virtual void handleScaleChanged(bool state) = 0;
   virtual void handleScaleValueChanged(double const value) = 0;
   virtual void handleValueChanged(std::string const &propName, double value) = 0;
-
-  virtual void handleRunClicked() = 0;
   virtual void handleSaveClicked() = 0;
 };
 /** MomentsPresenter : Calculates the S(Q,w) Moments of the provided data with
@@ -37,7 +36,7 @@ public:
   @author Samuel Jackson
   @date 13/08/2013
 */
-class MANTIDQT_INELASTIC_DLL MomentsPresenter : public DataProcessor, public IMomentsPresenter {
+class MANTIDQT_INELASTIC_DLL MomentsPresenter : public DataProcessor, public IMomentsPresenter, public IRunSubscriber {
 
 public:
   MomentsPresenter(QWidget *parent, IMomentsView *view, std::unique_ptr<IMomentsModel> model);
@@ -45,7 +44,10 @@ public:
 
   void setup() override;
   void run() override;
-  bool validate() override;
+
+  // runWidget
+  void handleRun() override;
+  void handleValidation(IUserInputValidator *validator) const override;
 
   void handleDataReady(std::string const &dataName) override;
 
@@ -53,7 +55,6 @@ public:
   void handleScaleValueChanged(double const value) override;
   void handleValueChanged(std::string const &propName, double value) override;
 
-  void handleRunClicked() override;
   void handleSaveClicked() override;
 
 protected:

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.h
@@ -42,9 +42,6 @@ public:
   MomentsPresenter(QWidget *parent, IMomentsView *view, std::unique_ptr<IMomentsModel> model);
   ~MomentsPresenter() = default;
 
-  void setup() override;
-  void run() override;
-
   // runWidget
   void handleRun() override;
   void handleValidation(IUserInputValidator *validator) const override;

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsTab.ui
@@ -209,64 +209,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gbRun">
-     <property name="title">
-      <string>Run</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>7</number>
-      </property>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>185</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>180</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>184</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
+    <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
@@ -313,9 +256,10 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <class>MantidQt::CustomInterfaces::RunView</class>
    <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>MantidQt::CustomInterfaces::OutputPlotOptionsView</class>
@@ -328,6 +272,11 @@
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Plotting/PreviewPlot.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
@@ -38,7 +38,6 @@ MomentsView::MomentsView(QWidget *parent) : QWidget(parent), m_presenter() {
   connect(m_uiForm.ckScale, SIGNAL(stateChanged(int)), this, SLOT(notifyScaleChanged(int)));
   connect(m_uiForm.spScale, SIGNAL(valueChanged(double)), this, SLOT(notifyScaleValueChanged(double)));
 
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(notifyRunClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
 
   connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyRangeChanged(double, double)));
@@ -87,8 +86,6 @@ void MomentsView::notifyValueChanged(QtProperty *prop, double value) {
   prop->propertyName() == "EMin" ? setRangeSelectorMin(value) : setRangeSelectorMax(value);
 }
 
-void MomentsView::notifyRunClicked() { m_presenter->handleRunClicked(); }
-
 void MomentsView::notifySaveClicked() { m_presenter->handleSaveClicked(); }
 
 void MomentsView::setupProperties() {
@@ -114,6 +111,8 @@ void MomentsView::setWSSuffixes(QStringList const &suffix) { m_uiForm.dsInput->s
 IOutputPlotOptionsView *MomentsView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
 
 MantidWidgets::DataSelector *MomentsView::getDataSelector() const { return m_uiForm.dsInput; }
+
+IRunView *MomentsView::getRunView() const { return m_uiForm.runWidget; }
 
 std::string MomentsView::getDataName() const { return m_uiForm.dsInput->getCurrentDataName().toStdString(); }
 
@@ -215,8 +214,10 @@ void MomentsView::plotOutput(std::string const &outputWorkspace) {
   m_uiForm.ppMomentsPreview->resizeX();
 
   // Enable plot and save buttons
-  m_uiForm.pbSave->setEnabled(true);
+  setSaveResultEnabled(true);
 }
+
+void MomentsView::setSaveResultEnabled(bool enable) { m_uiForm.pbSave->setEnabled(enable); }
 
 void MomentsView::showMessageBox(std::string const &message) const {
   QMessageBox::information(parentWidget(), this->windowTitle(), QString::fromStdString(message));

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.h
@@ -27,11 +27,13 @@ public:
   ~MomentsView();
 
   void subscribePresenter(IMomentsPresenter *presenter) override;
-
   void setupProperties() override;
+
+  IRunView *getRunView() const override;
   IOutputPlotOptionsView *getPlotOptions() const override;
-  std::string getDataName() const override;
   MantidWidgets::DataSelector *getDataSelector() const override;
+
+  std::string getDataName() const override;
   void setFBSuffixes(QStringList const &suffix) override;
   void setWSSuffixes(QStringList const &suffix) override;
 
@@ -43,10 +45,10 @@ public:
   void setRangeSelectorMin(double newValue) override;
   /// Sets the max of the range selector if it is more than the min
   void setRangeSelectorMax(double newValue) override;
+  void setSaveResultEnabled(bool enable) override;
   void plotNewData(std::string const &filename) override;
   void replot() override;
   void plotOutput(std::string const &outputWorkspace) override;
-
   void showMessageBox(const std::string &message) const override;
 
 private slots:
@@ -56,8 +58,6 @@ private slots:
   void notifyScaleChanged(int);
   void notifyScaleValueChanged(double);
   void notifyRangeChanged(double, double);
-
-  void notifyRunClicked();
   void notifySaveClicked();
 
 private:

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwModel.cpp
@@ -122,26 +122,23 @@ MatrixWorkspace_sptr SqwModel::getRqwWorkspace() const {
   return getADSWorkspace(outputName);
 }
 
-UserInputValidator SqwModel::validate(std::tuple<double, double> const qRange,
-                                      std::tuple<double, double> const eRange) const {
+void SqwModel::validate(IUserInputValidator *validator, std::tuple<double, double> const qRange,
+                        std::tuple<double, double> const eRange) const {
 
   double const tolerance = 1e-10;
 
-  UserInputValidator uiv;
-
   // Validate Q binning
-  uiv.checkBins(m_qLow, m_qWidth, m_qHigh, tolerance);
-  uiv.checkRangeIsEnclosed("The contour plots Q axis", convertTupleToPair(qRange), "the Q range provided",
-                           std::make_pair(m_qLow, m_qHigh));
+  validator->checkBins(m_qLow, m_qWidth, m_qHigh, tolerance);
+  validator->checkRangeIsEnclosed("The contour plots Q axis", convertTupleToPair(qRange), "the Q range provided",
+                                  std::make_pair(m_qLow, m_qHigh));
 
   // If selected, validate energy binning
   if (m_rebinInEnergy) {
 
-    uiv.checkBins(m_eLow, m_eWidth, m_eHigh, tolerance);
-    uiv.checkRangeIsEnclosed("The contour plots Energy axis", convertTupleToPair(eRange), "the E range provided",
-                             std::make_pair(m_eLow, m_eHigh));
+    validator->checkBins(m_eLow, m_eWidth, m_eHigh, tolerance);
+    validator->checkRangeIsEnclosed("The contour plots Energy axis", convertTupleToPair(eRange), "the E range provided",
+                                    std::make_pair(m_eLow, m_eHigh));
   }
-  return uiv;
 }
 
 std::string SqwModel::getEFixedFromInstrument(std::string const &instrumentName, std::string analyser,

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwModel.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwModel.h
@@ -38,8 +38,8 @@ public:
                                               std::string const &reflection) const = 0;
   virtual std::string getOutputWorkspace() const = 0;
   virtual MatrixWorkspace_sptr getRqwWorkspace() const = 0;
-  virtual UserInputValidator validate(std::tuple<double, double> const qRange,
-                                      std::tuple<double, double> const eRange) const = 0;
+  virtual void validate(IUserInputValidator *validator, std::tuple<double, double> const qRange,
+                        std::tuple<double, double> const eRange) const = 0;
   virtual MatrixWorkspace_sptr loadInstrumentWorkspace(const std::string &instrumentName, const std::string &analyser,
                                                        const std::string &reflection) const = 0;
 };
@@ -65,8 +65,8 @@ public:
                                       std::string const &reflection) const override;
   std::string getOutputWorkspace() const override;
   MatrixWorkspace_sptr getRqwWorkspace() const override;
-  UserInputValidator validate(std::tuple<double, double> const qRange,
-                              std::tuple<double, double> const eRange) const override;
+  void validate(IUserInputValidator *validator, std::tuple<double, double> const qRange,
+                std::tuple<double, double> const eRange) const override;
   MatrixWorkspace_sptr loadInstrumentWorkspace(const std::string &instrumentName, const std::string &analyser,
                                                const std::string &reflection) const override;
 

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.cpp
@@ -42,8 +42,6 @@ SqwPresenter::SqwPresenter(QWidget *parent, ISqwView *view, std::unique_ptr<ISqw
       std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraSliceSurface));
 }
 
-void SqwPresenter::setup() {}
-
 /**
  * Handles the event of data being loaded. Validates the loaded data.
  *
@@ -66,15 +64,6 @@ void SqwPresenter::handleDataReady(std::string const &dataName) {
 
 void SqwPresenter::handleValidation(IUserInputValidator *validator) const {
   m_model->validate(validator, m_view->getQRangeFromPlot(), m_view->getERangeFromPlot());
-}
-
-void SqwPresenter::run() {
-  m_model->setupRebinAlgorithm(m_batchAlgoRunner);
-  m_model->setupSofQWAlgorithm(m_batchAlgoRunner);
-  m_model->setupAddSampleLogAlgorithm(m_batchAlgoRunner);
-  m_view->setEnableOutputOptions(false);
-
-  m_batchAlgoRunner->executeBatch();
 }
 
 /**
@@ -112,7 +101,15 @@ void SqwPresenter::setFileExtensionsByName(bool filter) {
   m_view->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
 }
 
-void SqwPresenter::handleRun() { runTab(); }
+void SqwPresenter::handleRun() {
+  clearOutputPlotOptionsWorkspaces();
+  m_model->setupRebinAlgorithm(m_batchAlgoRunner);
+  m_model->setupSofQWAlgorithm(m_batchAlgoRunner);
+  m_model->setupAddSampleLogAlgorithm(m_batchAlgoRunner);
+  m_view->setEnableOutputOptions(false);
+
+  m_batchAlgoRunner->executeBatch();
+}
 
 void SqwPresenter::handleSaveClicked() {
   if (checkADSForPlotSaveWorkspace(m_model->getOutputWorkspace(), false))

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.h
@@ -5,7 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
-
+#include "Common/RunWidget/IRunSubscriber.h"
 #include "DataProcessor.h"
 #include "ISqwView.h"
 #include "SqwModel.h"
@@ -30,7 +30,6 @@ public:
   virtual void handleEHighChanged(double const value) = 0;
   virtual void handleRebinEChanged(int const value) = 0;
 
-  virtual void handleRunClicked() = 0;
   virtual void handleSaveClicked() = 0;
 };
 
@@ -39,7 +38,7 @@ public:
   @author Dan Nixon
   @date 23/07/2014
 */
-class MANTIDQT_INELASTIC_DLL SqwPresenter : public DataProcessor, public ISqwPresenter {
+class MANTIDQT_INELASTIC_DLL SqwPresenter : public DataProcessor, public ISqwPresenter, public IRunSubscriber {
 
 public:
   SqwPresenter(QWidget *parent, ISqwView *view, std::unique_ptr<ISqwModel> model);
@@ -47,7 +46,10 @@ public:
 
   void setup() override;
   void run() override;
-  bool validate() override;
+
+  // runSubscriber
+  void handleRun() override;
+  void handleValidation(IUserInputValidator *validator) const override;
 
   void handleDataReady(std::string const &dataName) override;
 
@@ -60,7 +62,6 @@ public:
   void handleEHighChanged(double const value) override;
   void handleRebinEChanged(int const value) override;
 
-  void handleRunClicked() override;
   void handleSaveClicked() override;
 
 protected:

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.h
@@ -44,9 +44,6 @@ public:
   SqwPresenter(QWidget *parent, ISqwView *view, std::unique_ptr<ISqwModel> model);
   ~SqwPresenter() = default;
 
-  void setup() override;
-  void run() override;
-
   // runSubscriber
   void handleRun() override;
   void handleValidation(IUserInputValidator *validator) const override;

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwTab.ui
@@ -20,47 +20,6 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="gbInput">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>150</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Input</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_12">
-      <item>
-       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsInput" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="autoLoad" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="workspaceSuffixes" stdset="0">
-         <stringlist>
-          <string>_red</string>
-         </stringlist>
-        </property>
-        <property name="fileBrowserSuffixes" stdset="0">
-         <stringlist>
-          <string>_red.nxs</string>
-         </stringlist>
-        </property>
-        <property name="showLoad" stdset="0">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="1" column="0">
     <widget class="QGroupBox" name="gbOptions">
      <property name="title">
@@ -405,50 +364,43 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Run</string>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="gbInput">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>150</height>
+      </size>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>7</number>
-      </property>
+     <property name="title">
+      <string>Input</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_12">
       <item>
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsInput" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>198</width>
-          <height>20</height>
-         </size>
+        <property name="autoLoad" stdset="0">
+         <bool>true</bool>
         </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="text">
-         <string>Run</string>
+        <property name="workspaceSuffixes" stdset="0">
+         <stringlist>
+          <string>_red</string>
+         </stringlist>
+        </property>
+        <property name="fileBrowserSuffixes" stdset="0">
+         <stringlist>
+          <string>_red.nxs</string>
+         </stringlist>
+        </property>
+        <property name="showLoad" stdset="0">
+         <bool>false</bool>
         </property>
        </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>197</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
       </item>
      </layout>
     </widget>
@@ -500,19 +452,28 @@
      </layout>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
+   </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <class>MantidQt::CustomInterfaces::RunView</class>
    <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>MantidQt::CustomInterfaces::OutputPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>Common/OutputPlotOptionsView.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
   <customwidget>
    <class>MantidQt::MantidWidgets::ContourPreviewPlot</class>

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
@@ -46,8 +46,6 @@ SqwView::SqwView(QWidget *parent) : QWidget(parent), m_presenter() {
   connect(m_uiForm.spEWidth, SIGNAL(valueChanged(double)), this, SLOT(notifyEWidthChanged(double)));
   connect(m_uiForm.spEHigh, SIGNAL(valueChanged(double)), this, SLOT(notifyEHighChanged(double)));
   connect(m_uiForm.ckRebinInEnergy, SIGNAL(stateChanged(int)), this, SLOT(notifyRebinEChanged(int)));
-
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(notifyRunClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
   // Allows empty workspace selector when initially selected
   m_uiForm.dsInput->isOptional(true);
@@ -63,7 +61,9 @@ SqwView::~SqwView() {}
 
 void SqwView::subscribePresenter(ISqwPresenter *presenter) { m_presenter = presenter; }
 
-OutputPlotOptionsView *SqwView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
+IRunView *SqwView::getRunView() const { return m_uiForm.runWidget; }
+
+IOutputPlotOptionsView *SqwView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
 
 std::string SqwView::getDataName() const { return m_uiForm.dsInput->getCurrentDataName().toStdString(); }
 
@@ -97,14 +97,7 @@ void SqwView::notifyEHighChanged(double value) { m_presenter->handleEHighChanged
 
 void SqwView::notifyRebinEChanged(int value) { m_presenter->handleRebinEChanged(value); }
 
-void SqwView::notifyRunClicked() { m_presenter->handleRunClicked(); }
-
 void SqwView::notifySaveClicked() { m_presenter->handleSaveClicked(); }
-
-void SqwView::setRunButtonText(std::string const &runText) {
-  m_uiForm.pbRun->setText(QString::fromStdString(runText));
-  m_uiForm.pbRun->setEnabled(runText == "Run");
-}
 
 void SqwView::setEnableOutputOptions(bool const enable) {
   m_uiForm.ipoPlotOptions->setEnabled(enable);

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwView.h
@@ -32,6 +32,7 @@ public:
 
   IRunView *getRunView() const override;
   IOutputPlotOptionsView *getPlotOptions() const override;
+
   void setFBSuffixes(QStringList const &suffix) override;
   void setWSSuffixes(QStringList const &suffix) override;
   std::tuple<double, double> getQRangeFromPlot() const override;

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwView.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "Common/RunWidget/RunView.h"
 #include "DllConfig.h"
 #include "ISqwView.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -29,7 +30,8 @@ public:
 
   void subscribePresenter(ISqwPresenter *presenter) override;
 
-  OutputPlotOptionsView *getPlotOptions() const override;
+  IRunView *getRunView() const override;
+  IOutputPlotOptionsView *getPlotOptions() const override;
   void setFBSuffixes(QStringList const &suffix) override;
   void setWSSuffixes(QStringList const &suffix) override;
   std::tuple<double, double> getQRangeFromPlot() const override;
@@ -39,7 +41,6 @@ public:
   void setDefaultQAndEnergy() override;
   bool validate() override;
   void showMessageBox(std::string const &message) const override;
-  void setRunButtonText(std::string const &runText) override;
   void setEnableOutputOptions(bool const enable) override;
 
 private slots:
@@ -51,7 +52,6 @@ private slots:
   void notifyEWidthChanged(double value);
   void notifyEHighChanged(double value);
   void notifyRebinEChanged(int value);
-  void notifyRunClicked();
   void notifySaveClicked();
 
 private:

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
@@ -117,7 +117,7 @@ void SymmetrisePresenter::setFileExtensionsByName(bool filter) {
 }
 
 void SymmetrisePresenter::handleReflectTypeChanged(int value) {
-  if (validate()) {
+  if (m_runPresenter->validate()) {
     m_model->setIsPositiveReflect(value == 0);
     m_view->resetEDefaults(value == 0);
   }

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
@@ -141,7 +141,7 @@ void SymmetrisePresenter::handlePreviewClicked() {
   handleRun();
 }
 void SymmetrisePresenter::handleDataReady(std::string const &dataName) {
-  if (validate()) {
+  if (m_runPresenter->validate()) {
     m_view->plotNewData(dataName);
   }
   m_model->setWorkspaceName(dataName);

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.h
@@ -6,8 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "Common/RunWidget/IRunSubscriber.h"
 #include "DataProcessor.h"
-
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidKernel/System.h"
 #include "SymmetriseModel.h"
@@ -40,8 +40,9 @@ public:
   virtual void handleReflectTypeChanged(int value) = 0;
   virtual void handleDoubleValueChanged(std::string const &propname, double value) = 0;
   virtual void handleDataReady(std::string const &dataName) = 0;
-  virtual void handleRunOrPreviewClicked(bool isPreview) = 0;
+  virtual void handlePreviewClicked() = 0;
   virtual void handleSaveClicked() = 0;
+  virtual void setIsPreview(bool preview) = 0;
 };
 
 /** SymmetrisePresenter
@@ -49,22 +50,27 @@ public:
   @author Dan Nixon
   @date 23/07/2014
 */
-class MANTIDQT_INELASTIC_DLL SymmetrisePresenter : public DataProcessor, public ISymmetrisePresenter {
+class MANTIDQT_INELASTIC_DLL SymmetrisePresenter : public DataProcessor,
+                                                   public ISymmetrisePresenter,
+                                                   public IRunSubscriber {
 public:
   SymmetrisePresenter(QWidget *parent, ISymmetriseView *view, std::unique_ptr<ISymmetriseModel> model);
   ~SymmetrisePresenter() override;
 
   void setup() override;
   void run() override;
-  bool validate() override;
+
+  // run widget
+  void handleRun() override;
+  void handleValidation(IUserInputValidator *validator) const override;
 
   void handleReflectTypeChanged(int value) override;
   void handleDoubleValueChanged(std::string const &propname, double value) override;
   void handleDataReady(std::string const &dataName) override;
-  void handleRunOrPreviewClicked(bool isPreview) override;
+  void handlePreviewClicked() override;
   void handleSaveClicked() override;
 
-  void setIsPreview(bool preview);
+  void setIsPreview(bool preview) override;
 
 protected:
   void runComplete(bool error) override;

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.h
@@ -57,9 +57,6 @@ public:
   SymmetrisePresenter(QWidget *parent, ISymmetriseView *view, std::unique_ptr<ISymmetriseModel> model);
   ~SymmetrisePresenter() override;
 
-  void setup() override;
-  void run() override;
-
   // run widget
   void handleRun() override;
   void handleValidation(IUserInputValidator *validator) const override;

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseTab.ui
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseTab.ui
@@ -189,64 +189,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gbRun">
-     <property name="title">
-      <string>Run</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>7</number>
-      </property>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>185</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>180</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>184</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
+    <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
@@ -299,9 +242,10 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <class>MantidQt::CustomInterfaces::RunView</class>
    <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>MantidQt::CustomInterfaces::OutputPlotOptionsView</class>
@@ -314,6 +258,11 @@
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Plotting/PreviewPlot.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
@@ -131,7 +131,6 @@ SymmetriseView::SymmetriseView(QWidget *parent) : QWidget(parent), m_presenter()
   connect(rangeESelector, SIGNAL(minValueChanged(double)), this, SLOT(notifyXrangeLowChanged(double)));
   connect(rangeESelector, SIGNAL(maxValueChanged(double)), this, SLOT(notifyXrangeHighChanged(double)));
   // Handle running, plotting and saving
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(notifyRunClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
 }
 
@@ -158,7 +157,6 @@ void SymmetriseView::setDefaults() {
   m_uiForm.ppPreviewPlot->setAxisRange(defaultRange, AxisID::XBottom);
 
   // Disable run until preview is clicked
-  m_uiForm.pbRun->setEnabled(false);
   m_uiForm.pbPreview->setEnabled(false);
 
   // Allows empty workspace selector when initially selected
@@ -168,7 +166,11 @@ void SymmetriseView::setDefaults() {
   m_uiForm.dsInput->isForRunFiles(false);
 }
 
-OutputPlotOptionsView *SymmetriseView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
+MantidWidgets::DataSelector *SymmetriseView::getDataSelector() const { return m_uiForm.dsInput; }
+
+IRunView *SymmetriseView::getRunView() const { return m_uiForm.runWidget; }
+
+IOutputPlotOptionsView *SymmetriseView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
 
 void SymmetriseView::notifyDoubleValueChanged(QtProperty *prop, double value) {
   m_presenter->handleDoubleValueChanged(prop->propertyName().toStdString(), value);
@@ -176,9 +178,7 @@ void SymmetriseView::notifyDoubleValueChanged(QtProperty *prop, double value) {
 
 void SymmetriseView::notifyDataReady(QString const &dataName) { m_presenter->handleDataReady(dataName.toStdString()); }
 
-void SymmetriseView::notifyRunClicked() { m_presenter->handleRunOrPreviewClicked(false); }
-
-void SymmetriseView::notifyPreviewClicked() { m_presenter->handleRunOrPreviewClicked(true); }
+void SymmetriseView::notifyPreviewClicked() { m_presenter->handlePreviewClicked(); }
 
 void SymmetriseView::notifySaveClicked() { m_presenter->handleSaveClicked(); }
 /**
@@ -202,20 +202,16 @@ void SymmetriseView::notifyXrangeHighChanged(double value) {
 }
 
 void SymmetriseView::notifyReflectTypeChanged(QtProperty *prop, int value) {
-  if (prop->propertyName() == "ReflectType") {
-    QString workspaceName = m_uiForm.dsInput->getCurrentDataName();
-
-    if (validate()) {
-      m_presenter->handleReflectTypeChanged(value);
-
-      MatrixWorkspace_sptr sampleWS =
-          AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName.toStdString());
-      auto const axisRange = getXRangeFromWorkspace(sampleWS);
-
-      resetEDefaults(value == 0, axisRange);
-    }
-  }
+  if (prop->propertyName() == "ReflectType")
+    m_presenter->handleReflectTypeChanged(value);
 }
+
+void SymmetriseView::resetEDefaults(bool isPositive) {
+  MatrixWorkspace_sptr sampleWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(getDataName());
+  auto const axisRange = getXRangeFromWorkspace(sampleWS);
+  resetEDefaults(isPositive, axisRange);
+}
+
 /**
  * Updates boundaries and initial values for Selector and Data properties when changing between negative/positive side
  * of spectrum.
@@ -385,15 +381,6 @@ void SymmetriseView::replotNewSpectrum(double value) {
   updateMiniPlots();
 }
 
-bool SymmetriseView::validate() {
-  auto uiv = std::make_unique<UserInputValidator>();
-  validateDataIsOfType(uiv.get(), m_uiForm.dsInput, "Sample", DataType::Red);
-  auto const errorMessage = uiv->generateErrorMessage();
-  if (!errorMessage.empty())
-    showMessageBox(errorMessage);
-  return errorMessage.empty();
-}
-
 void SymmetriseView::setRawPlotWatchADS(bool watchADS) { m_uiForm.ppRawPlot->watchADS(watchADS); }
 
 double SymmetriseView::getElow() const { return m_dblManager->value(m_properties["Elow"]); }
@@ -437,8 +424,6 @@ void SymmetriseView::previewAlgDone() {
 }
 
 void SymmetriseView::enableSave(bool save) { m_uiForm.pbSave->setEnabled(save); }
-
-void SymmetriseView::enableRun(bool run) { m_uiForm.pbRun->setEnabled(run); }
 
 void SymmetriseView::showMessageBox(std::string const &message) const {
   QMessageBox::information(parentWidget(), this->windowTitle(), QString::fromStdString(message));

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.h
@@ -51,8 +51,8 @@ public:
   void previewAlgDone() override;
   void enableSave(bool save) override;
   void showMessageBox(std::string const &message) const override;
-  void resetEDefaults(bool isPositive);
-  void resetEDefaults(bool isPositive, QPair<double, double> range);
+  void resetEDefaults(bool isPositive) override;
+  void resetEDefaults(bool isPositive, QPair<double, double> range) override;
 
 private slots:
   void notifyDoubleValueChanged(QtProperty *, double);

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.h
@@ -29,7 +29,10 @@ public:
   void subscribePresenter(ISymmetrisePresenter *presenter) override;
 
   void setDefaults() override;
-  OutputPlotOptionsView *getPlotOptions() const override;
+  IRunView *getRunView() const override;
+  IOutputPlotOptionsView *getPlotOptions() const override;
+  MantidWidgets::DataSelector *getDataSelector() const override;
+
   void setFBSuffixes(QStringList const &suffix) override;
   void setWSSuffixes(QStringList const &suffix) override;
 
@@ -47,22 +50,20 @@ public:
 
   void previewAlgDone() override;
   void enableSave(bool save) override;
-  void enableRun(bool run) override;
-  bool validate() override;
   void showMessageBox(std::string const &message) const override;
+  void resetEDefaults(bool isPositive);
+  void resetEDefaults(bool isPositive, QPair<double, double> range);
 
 private slots:
   void notifyDoubleValueChanged(QtProperty *, double);
   void notifyReflectTypeChanged(QtProperty *, int value);
   void notifyDataReady(QString const &);
   void notifyPreviewClicked();
-  void notifyRunClicked();
   void notifySaveClicked();
   void notifyXrangeLowChanged(double value);
   void notifyXrangeHighChanged(double value);
 
 private:
-  void resetEDefaults(bool isPositive, QPair<double, double> range);
   void updateHorizontalMarkers(QPair<double, double> yrange);
 
   Ui::SymmetriseTab m_uiForm;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
@@ -22,7 +22,7 @@ FitTab::FitTab(QWidget *parent, std::string const &tabName)
       m_runPresenter(), m_outOptionsPresenter() {
   m_uiForm->setupUi(parent);
   parent->setWindowTitle(QString::fromStdString(tabName));
-  m_runPresenter = std::make_unique<RunPresenter>(this, new RunView(m_uiForm->runWidget));
+  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm->runWidget);
 }
 
 void FitTab::setup() { updateOutputOptions(false); }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.ui
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.ui
@@ -43,7 +43,7 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QWidget" name="runWidget" native="true"/>
+       <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
       </item>
       <item>
        <widget class="MantidQt::CustomInterfaces::Inelastic::FitOutputOptionsView" name="ovOutputOptionsView" native="true"/>
@@ -54,6 +54,12 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>MantidQt::CustomInterfaces::Inelastic::FitOutputOptionsView</class>
    <extends>QWidget</extends>

--- a/qt/scientific_interfaces/Inelastic/test/Processor/ElwinPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Processor/ElwinPresenterTest.h
@@ -35,6 +35,7 @@ public:
   void setUp() override {
     m_view = std::make_unique<NiceMock<MockElwinView>>();
     m_outputPlotView = std::make_unique<NiceMock<MockOutputPlotOptionsView>>();
+    m_runView = std::make_unique<NiceMock<MockRunView>>();
 
     auto model = std::make_unique<NiceMock<MockElwinModel>>();
     auto dataModel = std::make_unique<NiceMock<MockDataModel>>();
@@ -42,6 +43,7 @@ public:
     m_dataModel = dataModel.get();
 
     ON_CALL(*m_view, getPlotOptions()).WillByDefault(Return((m_outputPlotView.get())));
+    ON_CALL(*m_view, getRunView()).WillByDefault(Return((m_runView.get())));
     m_presenter = std::make_unique<ElwinPresenter>(nullptr, m_view.get(), std::move(model), std::move(dataModel));
 
     m_workspace = createWorkspace(5);
@@ -55,10 +57,12 @@ public:
     TS_ASSERT(Mock::VerifyAndClearExpectations(&m_model));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&m_dataModel));
     TS_ASSERT(Mock::VerifyAndClearExpectations(m_outputPlotView.get()));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_runView.get()));
 
     m_presenter.reset();
     m_view.reset();
     m_outputPlotView.reset();
+    m_runView.reset();
   }
 
   ///----------------------------------------------------------------------
@@ -89,8 +93,7 @@ public:
 
   void test_handleRunClicked_doesnt_run_with_invalid_ranges() {
     EXPECT_CALL(*m_outputPlotView, clearWorkspaces()).Times(1);
-    EXPECT_CALL(*m_view, isTableEmpty()).Times(1);
-    m_presenter->handleRunClicked();
+    m_presenter->handleRun();
   }
 
   void test_handlePlotPreviewClicked_calls_warning_when_no_workspace() {
@@ -133,6 +136,7 @@ private:
   NiceMock<MockDataModel> *m_dataModel;
   NiceMock<MockElwinModel> *m_model;
   std::unique_ptr<NiceMock<MockOutputPlotOptionsView>> m_outputPlotView;
+  std::unique_ptr<NiceMock<MockRunView>> m_runView;
   std::unique_ptr<NiceMock<MockElwinView>> m_view;
   std::unique_ptr<ElwinPresenter> m_presenter;
 

--- a/qt/scientific_interfaces/Inelastic/test/Processor/ElwinPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Processor/ElwinPresenterTest.h
@@ -44,6 +44,8 @@ public:
 
     ON_CALL(*m_view, getPlotOptions()).WillByDefault(Return((m_outputPlotView.get())));
     ON_CALL(*m_view, getRunView()).WillByDefault(Return((m_runView.get())));
+    ON_CALL(*m_dataModel, getSpectra(WorkspaceID{0})).WillByDefault(Return(FunctionModelSpectra("0-1")));
+
     m_presenter = std::make_unique<ElwinPresenter>(nullptr, m_view.get(), std::move(model), std::move(dataModel));
 
     m_workspace = createWorkspace(5);

--- a/qt/scientific_interfaces/Inelastic/test/Processor/MomentsPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Processor/MomentsPresenterTest.h
@@ -85,13 +85,6 @@ public:
     m_presenter->handleValueChanged("EMax", value);
   }
 
-  void test_handleDataReady_does_not_work_with_invalid_data() {
-    auto dataSelector = std::make_unique<DataSelector>();
-    ON_CALL(*m_view, getDataSelector()).WillByDefault(Return(dataSelector.get()));
-    TS_ASSERT(!m_presenter->validate());
-    dataSelector.reset();
-  }
-
 private:
   NiceMock<MockMomentsModel> *m_model;
   std::unique_ptr<NiceMock<MockOutputPlotOptionsView>> m_outputPlotView;

--- a/qt/scientific_interfaces/Inelastic/test/Processor/MomentsPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Processor/MomentsPresenterTest.h
@@ -36,11 +36,13 @@ public:
   void setUp() override {
     m_view = std::make_unique<NiceMock<MockMomentsView>>();
     m_outputPlotView = std::make_unique<NiceMock<MockOutputPlotOptionsView>>();
+    m_runView = std::make_unique<NiceMock<MockRunView>>();
 
     auto model = std::make_unique<NiceMock<MockMomentsModel>>();
     m_model = model.get();
 
     ON_CALL(*m_view, getPlotOptions()).WillByDefault(Return((m_outputPlotView.get())));
+    ON_CALL(*m_view, getRunView()).WillByDefault(Return((m_runView.get())));
     m_presenter = std::make_unique<MomentsPresenter>(nullptr, m_view.get(), std::move(model));
 
     m_workspace = createWorkspace(5);
@@ -53,10 +55,12 @@ public:
     TS_ASSERT(Mock::VerifyAndClearExpectations(m_view.get()));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&m_model));
     TS_ASSERT(Mock::VerifyAndClearExpectations(m_outputPlotView.get()));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_runView.get()));
 
     m_presenter.reset();
     m_view.reset();
     m_outputPlotView.reset();
+    m_runView.reset();
   }
 
   ///----------------------------------------------------------------------
@@ -91,6 +95,7 @@ public:
 private:
   NiceMock<MockMomentsModel> *m_model;
   std::unique_ptr<NiceMock<MockOutputPlotOptionsView>> m_outputPlotView;
+  std::unique_ptr<NiceMock<MockRunView>> m_runView;
   std::unique_ptr<NiceMock<MockMomentsView>> m_view;
   std::unique_ptr<MomentsPresenter> m_presenter;
 

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -431,6 +431,7 @@ public:
 
   MOCK_METHOD1(subscribePresenter, void(IElwinPresenter *presenter));
   MOCK_METHOD0(setup, void());
+  MOCK_CONST_METHOD0(getRunView, IRunView *());
   MOCK_CONST_METHOD0(getPlotOptions, IOutputPlotOptionsView *());
 
   MOCK_METHOD2(setAvailableSpectra,
@@ -511,6 +512,7 @@ public:
 
   MOCK_METHOD1(subscribePresenter, void(IMomentsPresenter *presenter));
   MOCK_METHOD0(setupProperties, void());
+  MOCK_CONST_METHOD0(getRunView, IRunView *());
   MOCK_CONST_METHOD0(getPlotOptions, IOutputPlotOptionsView *());
   MOCK_CONST_METHOD0(getDataSelector, DataSelector *());
   MOCK_CONST_METHOD0(getDataName, std::string());
@@ -523,6 +525,7 @@ public:
   MOCK_METHOD1(setRangeSelector, void(const QPair<double, double> &bounds));
   MOCK_METHOD1(setRangeSelectorMin, void(double newValue));
   MOCK_METHOD1(setRangeSelectorMax, void(double newValue));
+  MOCK_METHOD1(setSaveResultEnabled, void(bool enable));
 
   MOCK_METHOD1(plotNewData, void(std::string const &filename));
   MOCK_METHOD0(replot, void());

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MockUserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MockUserInputValidator.h
@@ -26,6 +26,11 @@ public:
   MOCK_METHOD3(checkDataSelectorIsValid, bool(const QString &name, DataSelector *widget, bool silent));
   MOCK_METHOD3(checkWorkspaceGroupIsValid, bool(QString const &groupName, QString const &inputType, bool silent));
   MOCK_METHOD2(checkWorkspaceExists, bool(QString const &workspaceName, bool silent));
+  MOCK_METHOD2(checkValidRange, bool(QString const &name, std::pair<double, double> range));
+  MOCK_METHOD2(checkRangesDontOverlap, bool(std::pair<double, double> rangeA, std::pair<double, double> rangeB));
+  MOCK_METHOD4(checkRangeIsEnclosed, bool(const QString &outerName, std::pair<double, double> outer,
+                                          const QString &innerName, std::pair<double, double> inner));
+  MOCK_METHOD4(checkBins, bool(double lower, double binWidth, double upper, double tolerance));
 
   MOCK_METHOD2(setErrorLabel, void(QLabel *errorLabel, bool valid));
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -35,6 +35,11 @@ public:
   virtual bool checkDataSelectorIsValid(const QString &name, DataSelector *widget, bool silent = false) = 0;
   virtual bool checkWorkspaceGroupIsValid(QString const &groupName, QString const &inputType, bool silent = false) = 0;
   virtual bool checkWorkspaceExists(QString const &workspaceName, bool silent = false) = 0;
+  virtual bool checkValidRange(const QString &name, std::pair<double, double> range) = 0;
+  virtual bool checkRangesDontOverlap(std::pair<double, double> rangeA, std::pair<double, double> rangeB) = 0;
+  virtual bool checkRangeIsEnclosed(const QString &outerName, std::pair<double, double> outer, const QString &innerName,
+                                    std::pair<double, double> inner) = 0;
+  virtual bool checkBins(double lower, double binWidth, double upper, double tolerance = 0.00000001) = 0;
   template <typename T = Mantid::API::MatrixWorkspace>
   bool checkWorkspaceType(QString const &workspaceName, QString const &inputType, QString const &validType,
                           bool silent = false);
@@ -73,14 +78,14 @@ public:
   /// Check that the given DataSelector widget has valid input.
   bool checkDataSelectorIsValid(const QString &name, DataSelector *widget, bool silent = false) override;
   /// Check that the given start and end range is valid.
-  bool checkValidRange(const QString &name, std::pair<double, double> range);
+  bool checkValidRange(const QString &name, std::pair<double, double> range) override;
   /// Check that the given ranges dont overlap.
-  bool checkRangesDontOverlap(std::pair<double, double> rangeA, std::pair<double, double> rangeB);
+  bool checkRangesDontOverlap(std::pair<double, double> rangeA, std::pair<double, double> rangeB) override;
   /// Check that the given "outer" range completely encloses the given "inner" range.
   bool checkRangeIsEnclosed(const QString &outerName, std::pair<double, double> outer, const QString &innerName,
-                            std::pair<double, double> inner);
+                            std::pair<double, double> inner) override;
   /// Check that the given range can be split evenly into bins of the given width.
-  bool checkBins(double lower, double binWidth, double upper, double tolerance = 0.00000001);
+  bool checkBins(double lower, double binWidth, double upper, double tolerance = 0.00000001) override;
   /// Checks two values are not equal
   bool checkNotEqual(const QString &name, double x, double y = 0.0, double tolerance = 0.00000001);
 

--- a/qt/widgets/common/src/WorkspaceUtils.cpp
+++ b/qt/widgets/common/src/WorkspaceUtils.cpp
@@ -234,6 +234,9 @@ std::string parseRunNumbers(std::vector<std::string> const &workspaceNames) {
   std::smatch match;
   std::vector<int> runNumbers;
   std::string prefix;
+  if (workspaceNames.empty()) {
+    return std::string("");
+  }
   std::string suffix = workspaceNames[0].substr(workspaceNames[0].find_first_of('_'));
   for (auto const &name : names)
     if (std::regex_search(name, match, regDigits)) {

--- a/qt/widgets/common/test/WorkspaceUtilsTest.h
+++ b/qt/widgets/common/test/WorkspaceUtilsTest.h
@@ -120,6 +120,11 @@ public:
     TS_ASSERT_EQUALS(parseRunNumbers(individual_workspace), "irs123_test");
   }
 
+  void test_parseRunNumber_call_with_empty_array_returns_empty_string() {
+    std::vector<std::string> empty_workspace{};
+    TS_ASSERT_EQUALS(parseRunNumbers(empty_workspace), "");
+  }
+
   void test_MaximumIndex_returns_properIndex() {
     auto const testWorkspace = createWorkspace(3);
 


### PR DESCRIPTION
### Description of work
This PR adds the runwidget as a substitute for the run button on the tabs of the Data Processor interface. The presenter of the runwidget is held by the parent data processor class. The view of the run button is created on the automatic ui file created by qt. 
Additionally, there's a refactor of the 


<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Part of #37381. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Open Data Processor interface. 
- Click on every `Run` button of every tab withouth adding any data to the bats. Every click should produce a floating
  warning message telling you why you can't run the algorithm.
- Follow `DataProcessor` manual test: https://developer.mantidproject.org/Testing/Inelastic/DataProcessorTests.html

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
