### PR TITLE
Consolidate code in AlignAndFocusPowder for selecting whether to CompressEvents

### DIFF
--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -698,11 +698,7 @@ void AlignAndFocusPowder::exec() {
   } else if (DIFCref > 0.) {
     m_outputW = convertUnits(m_outputW, "TOF");
     // this correction has some assumptions on the events being compressed
-    if (auto outputEW = std::dynamic_pointer_cast<EventWorkspace>(m_outputW)) {
-      if (compressEventsTolerance > 0.) {
-        compressEventsOutputWS(compressEventsTolerance, wallClockTolerance);
-      }
-    }
+    compressEventsOutputWS(compressEventsTolerance, wallClockTolerance);
 
     // this is a legacy way for describing the minimum wavelength to remove from the data
     // it is uncommon that it is used
@@ -817,9 +813,7 @@ void AlignAndFocusPowder::exec() {
   m_progress->report();
 
   // compress again if appropriate
-  if (compressEventsTolerance > 0.) {
-    compressEventsOutputWS(compressEventsTolerance, wallClockTolerance);
-  }
+  compressEventsOutputWS(compressEventsTolerance, wallClockTolerance);
   m_progress->report();
 
   if (!binInDspace && !m_delta_ragged.empty()) {
@@ -1207,6 +1201,9 @@ void AlignAndFocusPowder::loadCalFile(const std::string &calFilename, const std:
 
 void AlignAndFocusPowder::compressEventsOutputWS(const double compressEventsTolerance,
                                                  const double wallClockTolerance) {
+  if (compressEventsTolerance == 0.)
+    return; // no compression is required
+
   if (auto outputEW = std::dynamic_pointer_cast<EventWorkspace>(m_outputW)) {
     g_log.information() << "running CompressEvents(Tolerance=" << compressEventsTolerance;
     if (!isEmpty(wallClockTolerance))
@@ -1237,7 +1234,7 @@ bool AlignAndFocusPowder::shouldCompressUnfocused(const double compressTolerance
   if (hasWallClockTolerance)
     return false;
   // compressing isn't an option
-  if (compressTolerance == 0)
+  if (compressTolerance == 0.)
     return false;
 
   if (const auto eventWS = std::dynamic_pointer_cast<const EventWorkspace>(m_outputW)) {

--- a/docs/source/release/v6.11.0/Diffraction/Powder/Bugfixes/37629.rst
+++ b/docs/source/release/v6.11.0/Diffraction/Powder/Bugfixes/37629.rst
@@ -1,0 +1,1 @@
+- Fix bug where compression isn't run when logarithmic is selected in :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder-v1>`


### PR DESCRIPTION
While doing some benchmarking it was discovered that two spots were missed while doing #37352. This fixes that (somewhat minor) issue of not compressing the `EventWorkspace` when log tolerance is selected.

*There is no associated issue.*

### To test:

The best test is to use log-tolerance for compression and see that it is run (via logs) near the end of the workflow.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
