### PR TITLE
Use previous index as lower bound for finding pulse in PulseIndexer

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/PulseIndexer.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/PulseIndexer.h
@@ -101,7 +101,7 @@ private:
   size_t determineFirstPulseIndex() const;
   size_t determineLastPulseIndex() const;
   /// returns true when the roi says the pulse should be used
-  bool includedPulse(const size_t pulseIndex) const;
+  bool includedPulse(const size_t pulseIndex, const size_t prevPulseIndex = 0) const;
 
   /// vector of indices (length of # of pulses) into the event arrays
   const std::shared_ptr<std::vector<uint64_t>> m_event_index;

--- a/docs/source/release/v6.11.0/Framework/37630.rst
+++ b/docs/source/release/v6.11.0/Framework/37630.rst
@@ -1,0 +1,1 @@
+- Improve performance of the ``PulseIndexer`` class for having many regions of interest. This will have an effect when using the ``FilterBadPulsesLowerCutoff`` of :ref:`LoadEventNexus <algm-LoadEventNexus>`.


### PR DESCRIPTION
Since the current pulse index is known, use it to reduce the indices searched in lower_bound.

### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
