### PR TITLE
Fix for line order chagning when editing plot settings

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/Bugfixes/37465.rst
+++ b/docs/source/release/v6.11.0/Workbench/Bugfixes/37465.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where editing plot settings could reorder the line order.

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -8,7 +8,6 @@
 
 
 from matplotlib.lines import Line2D
-from matplotlib.container import ErrorbarContainer
 
 from mantid.plots.legend import LegendProperties
 from mantid.plots import datafunctions, MantidAxes
@@ -125,7 +124,7 @@ class CurvesTabWidgetPresenter:
             curve_index = ax.get_lines().index(curve)
             errorbar = False
         else:
-            curve_index = [artist for artist in ax.containers if isinstance(artist, ErrorbarContainer)].index(curve)
+            curve_index = ax.get_lines().index(curve[0])
             errorbar = True
 
         # When you remove the curve on a waterfall plot, the remaining curves are repositioned so that they are
@@ -149,11 +148,12 @@ class CurvesTabWidgetPresenter:
         # also just makes sense for the curve order to remain unchanged.
         # Since mpl 3.7 made ax.lines immutable, we have to do this workaround.
         lines_to_remove = ax.get_lines()[curve_index:]
-        for line in lines_to_remove:
-            line.remove()
-        ax.add_line(lines_to_remove.pop())
-        for line in lines_to_remove:
-            ax.add_line(line)
+        if lines_to_remove:
+            for line in lines_to_remove:
+                line.remove()
+            ax.add_line(lines_to_remove.pop())
+            for line in lines_to_remove:
+                ax.add_line(line)
 
         if waterfall:
             # Set the waterfall offsets to what they were previously.

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -8,6 +8,7 @@
 
 
 from matplotlib.lines import Line2D
+from matplotlib.container import ErrorbarContainer
 
 from mantid.plots.legend import LegendProperties
 from mantid.plots import datafunctions, MantidAxes
@@ -123,9 +124,11 @@ class CurvesTabWidgetPresenter:
         if isinstance(curve, Line2D):
             curve_index = ax.get_lines().index(curve)
             errorbar = False
-        else:
+        elif isinstance(curve, ErrorbarContainer):
             curve_index = ax.get_lines().index(curve[0])
             errorbar = True
+        else:
+            return
 
         # When you remove the curve on a waterfall plot, the remaining curves are repositioned so that they are
         # equally spaced apart. However since the curve is being replotted we don't want that to happen, so here

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
@@ -49,9 +49,9 @@ class CurvesTabWidgetPresenterTest(unittest.TestCase):
             if line.get_label() == "noerrors":
                 return line
 
-    def _generate_presenter(self, mock_view=None, fig=None):
+    def _generate_presenter(self, mock_view=None, fig=None, current_curve_name="Workspace"):
         if not mock_view:
-            mock_view = Mock(get_selected_ax_name=lambda: "Axes 0: (0, 0)", get_current_curve_name=lambda: "Workspace")
+            mock_view = Mock(get_selected_ax_name=lambda: "Axes 0: (0, 0)", get_current_curve_name=lambda: current_curve_name)
         if not fig:
             fig = self.fig
         mock_view.select_curve_list = Mock(selectedItems=lambda: [])
@@ -224,6 +224,20 @@ class CurvesTabWidgetPresenterTest(unittest.TestCase):
         self.assertEqual(new_err_container[0].get_marker(), "v")
         # Test only one errorbar is plotted
         self.assertEqual(1, len(new_err_container[2][0].get_segments()))
+
+    def test_replot_second_curve_twice_does_not_alter_line_order(self):
+        fig = self.make_figure_with_multiple_curves()
+        ax = fig.get_axes()[0]
+        presenter = self._generate_presenter(fig=fig, current_curve_name="Workspace 2")
+        presenter.view.select_curve_list.currentIndex.return_value = 1
+        new_plot_kwargs = {"errorevery": 2, "linestyle": "-.", "color": "r", "marker": "v"}
+        presenter._replot_current_curve(new_plot_kwargs)
+        second_curve = presenter.get_current_curve()[0]
+        self.assertEqual(ax.get_lines().index(second_curve), 1)
+        new_plot_kwargs = {"errorevery": 2, "linestyle": "-.", "color": "b", "marker": "v"}
+        presenter._replot_current_curve(new_plot_kwargs)
+        second_curve = presenter.get_current_curve()[0]
+        self.assertEqual(ax.get_lines().index(second_curve), 1)
 
     def test_curve_errorbars_are_hidden_on_apply_properties_when_hide_curve_is_ticked(self):
         fig = figure()


### PR DESCRIPTION
### Description of work

When the properties of a curve are changed using the plot settings, it is redrawn. The puts the new curve to the back of the line order. We want to maintain the line order for the legend etc. so we suffle it back into the right place. The problem is, when a curve gets redrawn, if it is from a workspace which has error data it gets redrawn as an ErrorBarContainer object. In this case, when calculating the index of the curve in the line order, the replotting function was using `ax.containers` (which holds the error bar containers). The order of `ax.containers` is not being maintained like we do the line order so this was leading to some strange results.
I've fixed the problem by getting the curve index as normal from the lines list by using the line stored within the error bar container.

Fixes #37465

**Report to:** Sanghamitra


### To test:

 - Follow instructions from the issue
 - Do other tests, changing different properties of the lines, making sure the order stays the same.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
