### PR TITLE
Use RunWidget in Inelastic Data Reduction

### DIFF
--- a/qt/scientific_interfaces/Indirect/Reduction/DataReduction.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReduction.h
@@ -135,7 +135,6 @@ private:
     tabScrollArea->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     DataReductionTab *tabIDRContent = new T(this, tabContent);
-    tabIDRContent->setupTab();
     tabContent->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     connect(tabIDRContent, SIGNAL(showMessageBox(const std::string &)), this,
@@ -176,7 +175,6 @@ private:
     auto presenter = std::make_unique<TabPresenter>(this, new TabView(tabContent), std::make_unique<TabModel>(),
                                                     std::move(algorithmRunner));
 
-    presenter->setupTab();
     tabContent->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     connect(presenter.get(), SIGNAL(showMessageBox(const std::string &)), this,

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
@@ -25,14 +25,13 @@ Mantid::Kernel::Logger g_log("DataReductionTab");
 
 namespace MantidQt::CustomInterfaces {
 
-DataReductionTab::DataReductionTab(IDataReduction *idrUI, QObject *parent)
-    : InelasticTab(parent), m_idrUI(idrUI), m_tabRunning(false) {
+DataReductionTab::DataReductionTab(IDataReduction *idrUI, QObject *parent) : InelasticTab(parent), m_idrUI(idrUI) {
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(tabExecutionComplete(bool)));
   connect(this, SIGNAL(newInstrumentConfiguration()), this, SLOT(handleNewInstrumentConfiguration()));
 }
 
 DataReductionTab::DataReductionTab(IDataReduction *idrUI, std::unique_ptr<API::IAlgorithmRunner> algorithmRunner)
-    : InelasticTab(), m_idrUI(idrUI), m_algorithmRunner(std::move(algorithmRunner)), m_tabRunning(false) {
+    : InelasticTab(), m_idrUI(idrUI), m_algorithmRunner(std::move(algorithmRunner)) {
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(tabExecutionComplete(bool)));
   connect(this, SIGNAL(newInstrumentConfiguration()), this, SLOT(handleNewInstrumentConfiguration()));
 }
@@ -49,41 +48,6 @@ void DataReductionTab::setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotO
 
 void DataReductionTab::setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces) {
   m_plotOptionsPresenter->setWorkspaces(outputWorkspaces);
-}
-
-void DataReductionTab::runTab() {
-  if (validate()) {
-    m_tabStartTime = DateAndTime::getCurrentTime();
-    m_tabRunning = true;
-    emit updateRunButton(false, "disable", "Running...", "Running data reduction...");
-    try {
-      if (m_plotOptionsPresenter) {
-        m_plotOptionsPresenter->clearWorkspaces();
-      }
-      run();
-    } catch (std::exception const &ex) {
-      m_tabRunning = false;
-      emit updateRunButton(true, "enable");
-      emit showMessageBox(ex.what());
-    }
-  } else {
-    g_log.warning("Failed to validate indirect tab input!");
-  }
-}
-
-/**
- * Slot used to update the run button when an algorithm that was strted by the
- * Run button complete.
- *
- * @param error Unused
- */
-void DataReductionTab::tabExecutionComplete(bool error) {
-  UNUSED_ARG(error);
-  if (m_tabRunning) {
-    m_tabRunning = false;
-    auto const enableOutputButtons = error == false ? "enable" : "disable";
-    emit updateRunButton(true, enableOutputButtons);
-  }
 }
 
 void DataReductionTab::handleNewInstrumentConfiguration() { updateInstrumentConfiguration(); }

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
@@ -26,13 +26,11 @@ Mantid::Kernel::Logger g_log("DataReductionTab");
 namespace MantidQt::CustomInterfaces {
 
 DataReductionTab::DataReductionTab(IDataReduction *idrUI, QObject *parent) : InelasticTab(parent), m_idrUI(idrUI) {
-  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(tabExecutionComplete(bool)));
   connect(this, SIGNAL(newInstrumentConfiguration()), this, SLOT(handleNewInstrumentConfiguration()));
 }
 
 DataReductionTab::DataReductionTab(IDataReduction *idrUI, std::unique_ptr<API::IAlgorithmRunner> algorithmRunner)
     : InelasticTab(), m_idrUI(idrUI), m_algorithmRunner(std::move(algorithmRunner)) {
-  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(tabExecutionComplete(bool)));
   connect(this, SIGNAL(newInstrumentConfiguration()), this, SLOT(handleNewInstrumentConfiguration()));
 }
 

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
@@ -39,6 +39,10 @@ DataReductionTab::DataReductionTab(IDataReduction *idrUI, std::unique_ptr<API::I
 
 DataReductionTab::~DataReductionTab() = default;
 
+void DataReductionTab::setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter) {
+  m_runPresenter = std::move(presenter);
+}
+
 void DataReductionTab::setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter) {
   m_plotOptionsPresenter = std::move(presenter);
 }

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
@@ -38,10 +38,6 @@ DataReductionTab::DataReductionTab(IDataReduction *idrUI, std::unique_ptr<API::I
 
 DataReductionTab::~DataReductionTab() = default;
 
-void DataReductionTab::setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter) {
-  m_runPresenter = std::move(presenter);
-}
-
 void DataReductionTab::setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter) {
   m_plotOptionsPresenter = std::move(presenter);
 }

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
@@ -10,6 +10,7 @@
 #include "Common/InelasticTab.h"
 #include "Common/InstrumentConfig.h"
 #include "Common/OutputPlotOptionsPresenter.h"
+#include "Common/RunWidget/RunPresenter.h"
 
 #include "MantidQtWidgets/Common/AlgorithmRunner.h"
 
@@ -51,6 +52,8 @@ public:
   DataReductionTab(IDataReduction *idrUI, std::unique_ptr<API::IAlgorithmRunner> algorithmRunner);
   ~DataReductionTab() override;
 
+  /// Set the presenter for the run widget
+  void setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter);
   /// Set the presenter for the output plotting options
   void setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter);
   /// Set the active workspaces used in the plotting options
@@ -89,6 +92,7 @@ protected:
 protected:
   IDataReduction *m_idrUI;
   std::unique_ptr<API::IAlgorithmRunner> m_algorithmRunner;
+  std::unique_ptr<RunPresenter> m_runPresenter;
 
 private slots:
   void tabExecutionComplete(bool error);

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
@@ -10,7 +10,6 @@
 #include "Common/InelasticTab.h"
 #include "Common/InstrumentConfig.h"
 #include "Common/OutputPlotOptionsPresenter.h"
-#include "Common/RunWidget/RunPresenter.h"
 
 #include "MantidQtWidgets/Common/AlgorithmRunner.h"
 
@@ -52,8 +51,6 @@ public:
   DataReductionTab(IDataReduction *idrUI, std::unique_ptr<API::IAlgorithmRunner> algorithmRunner);
   ~DataReductionTab() override;
 
-  /// Set the presenter for the run widget
-  void setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter);
   /// Set the presenter for the output plotting options
   void setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter);
   /// Set the active workspaces used in the plotting options
@@ -88,7 +85,6 @@ protected:
 protected:
   IDataReduction *m_idrUI;
   std::unique_ptr<API::IAlgorithmRunner> m_algorithmRunner;
-  std::unique_ptr<RunPresenter> m_runPresenter;
 
 private slots:
   void handleNewInstrumentConfiguration();

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
@@ -63,12 +63,8 @@ public:
   void filterInputData(bool filter);
 
 public slots:
-  void runTab();
 
 signals:
-  /// Update the Run button on the IDR main window
-  void updateRunButton(bool enabled = true, std::string const &enableOutputButtons = "unchanged",
-                       QString message = "Run", QString tooltip = "");
   /// Emitted when the instrument setup is changed
   void newInstrumentConfiguration();
 
@@ -95,7 +91,6 @@ protected:
   std::unique_ptr<RunPresenter> m_runPresenter;
 
 private slots:
-  void tabExecutionComplete(bool error);
   void handleNewInstrumentConfiguration();
 
 private:
@@ -103,7 +98,6 @@ private:
   virtual void updateInstrumentConfiguration() = 0;
 
   std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
-  bool m_tabRunning;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.cpp
@@ -27,116 +27,96 @@ void saveNexusProcessed(std::string const &workspaceName, std::string const &fil
 } // namespace
 
 namespace MantidQt::CustomInterfaces {
-//----------------------------------------------------------------------------------------------
-/** Constructor
- */
+
 ILLEnergyTransfer::ILLEnergyTransfer(IDataReduction *idrUI, QWidget *parent) : DataReductionTab(idrUI, parent) {
   m_uiForm.setupUi(parent);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
 
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
-
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
-
-  connect(this, SIGNAL(updateRunButton(bool, std::string const &, QString const &, QString const &)), this,
-          SLOT(updateRunButton(bool, std::string const &, QString const &, QString const &)));
-
-  // Validate to remove invalid markers
-  validateTab();
 }
 
-//----------------------------------------------------------------------------------------------
-/** Destructor
- */
 ILLEnergyTransfer::~ILLEnergyTransfer() = default;
 
-bool ILLEnergyTransfer::validate() {
-  UserInputValidator uiv;
-
+void ILLEnergyTransfer::handleValidation(IUserInputValidator *validator) const {
   // Validate run file
   if (!m_uiForm.rfInput->isValid())
-    uiv.addErrorMessage("Run File is invalid.");
+    validator->addErrorMessage("Run File is invalid.");
 
   // Validate map file if it is being used
   bool useMapFile = m_uiForm.rdGroupChoose->isChecked();
   if (useMapFile && !m_uiForm.rfMapFile->isValid())
-    uiv.addErrorMessage("Grouping file is invalid.");
+    validator->addErrorMessage("Grouping file is invalid.");
 
   // Validate background file
   if (!m_uiForm.rfBackgroundRun->isValid()) {
-    uiv.addErrorMessage("Background Run File is invalid.");
+    validator->addErrorMessage("Background Run File is invalid.");
   } else {
     bool isDouble = true;
-    m_backScaling = m_uiForm.leBackgroundFactor->text().toDouble(&isDouble);
-    if ((!isDouble || m_backScaling <= 0) && !m_uiForm.rfBackgroundRun->getUserInput().toString().isEmpty()) {
-      uiv.addErrorMessage("BackgroundScaleFactor is invalid. "
-                          "It has to be a positive number.");
+    auto const backScaling = m_uiForm.leBackgroundFactor->text().toDouble(&isDouble);
+    if ((!isDouble || backScaling <= 0) && !m_uiForm.rfBackgroundRun->getUserInput().toString().isEmpty()) {
+      validator->addErrorMessage("BackgroundScaleFactor is invalid. "
+                                 "It has to be a positive number.");
     }
   }
 
   // Validate calibration file
   if (!m_uiForm.rfCalibrationRun->isValid()) {
-    uiv.addErrorMessage("Calibration Run File is invalid.");
+    validator->addErrorMessage("Calibration Run File is invalid.");
   } else if (!m_uiForm.rfCalibrationRun->getUserInput().toString().isEmpty()) {
     auto range = m_uiForm.lePeakRange->text().split(',');
     if (range.size() != 2) {
-      uiv.addErrorMessage("Calibration Peak Range is invalid. \n"
-                          "Provide comma separated two energy values in meV.");
+      validator->addErrorMessage("Calibration Peak Range is invalid. \n"
+                                 "Provide comma separated two energy values in meV.");
     } else {
       bool isDouble1 = true;
-      m_peakRange[0] = range[0].toDouble(&isDouble1);
+      auto const peakRangeMin = range[0].toDouble(&isDouble1);
       bool isDouble2 = true;
-      m_peakRange[1] = range[1].toDouble(&isDouble2);
-
-      if (!isDouble1 || !isDouble2) {
-        uiv.addErrorMessage("Calibration Peak Range is invalid. \n"
-                            "Provide comma separated two energy values in meV.");
-      } else {
-        if (m_peakRange[0] >= m_peakRange[1]) {
-          uiv.addErrorMessage("Calibration Peak Range is invalid. \n"
-                              "Start energy is >= than the end energy.");
-        }
+      auto const peakRangeMax = range[1].toDouble(&isDouble2);
+      if (peakRangeMin >= peakRangeMax) {
+        validator->addErrorMessage("Calibration Peak Range is invalid. \n"
+                                   "Start energy is >= than the end energy.");
       }
     }
   }
 
   // Validate the calibration background file
   if (!m_uiForm.rfBackCalibrationRun->isValid()) {
-    uiv.addErrorMessage("Background run for calibration is invalid.");
+    validator->addErrorMessage("Background run for calibration is invalid.");
   } else {
     bool isDouble = true;
-    m_backCalibScaling = m_uiForm.leBackCalibScale->text().toDouble(&isDouble);
-    if ((!isDouble || m_backCalibScaling <= 0) && !m_uiForm.rfBackCalibrationRun->getUserInput().toString().isEmpty()) {
-      uiv.addErrorMessage("Scale factor for calibration background is invalid. "
-                          "It has to be a positive number.");
+    auto const backCalibScaling = m_uiForm.leBackCalibScale->text().toDouble(&isDouble);
+    if ((!isDouble || backCalibScaling <= 0) && !m_uiForm.rfBackCalibrationRun->getUserInput().toString().isEmpty()) {
+      validator->addErrorMessage("Scale factor for calibration background is invalid. "
+                                 "It has to be a positive number.");
     }
   }
 
   // Calibration file required if calibration background is given
   if (!m_uiForm.rfBackCalibrationRun->getUserInput().toString().isEmpty() &&
       m_uiForm.rfCalibrationRun->getUserInput().toString().isEmpty()) {
-    uiv.addErrorMessage("Calibration file is required if calibration background is given");
+    validator->addErrorMessage("Calibration file is required if calibration background is given");
   }
 
   // Validate the manual PSD integration range
   if (m_uiForm.rdGroupRange->isChecked()) {
     auto range = m_uiForm.lePixelRange->text().split(',');
     if (range.size() != 2) {
-      uiv.addErrorMessage("PSD Integration Range is invalid. \n"
-                          "Provide comma separated two pixel numbers, e.g. 1,128");
+      validator->addErrorMessage("PSD Integration Range is invalid. \n"
+                                 "Provide comma separated two pixel numbers, e.g. 1,128");
     } else {
       bool isDouble1 = true;
-      m_pixelRange[0] = range[0].toInt(&isDouble1);
+      auto pixelRangeMin = range[0].toInt(&isDouble1);
       bool isDouble2 = true;
-      m_pixelRange[1] = range[1].toInt(&isDouble2);
+      auto pixelRangeMax = range[1].toInt(&isDouble2);
 
       if (!isDouble1 || !isDouble2) {
-        uiv.addErrorMessage("PSD Integration Range is invalid. \n"
-                            "Provide comma separated two pixel numbers, e.g. 1,128");
+        validator->addErrorMessage("PSD Integration Range is invalid. \n"
+                                   "Provide comma separated two pixel numbers, e.g. 1,128");
       } else {
-        if (m_pixelRange[0] >= m_pixelRange[1] || m_pixelRange[0] < 1 || m_pixelRange[1] > 128) {
-          uiv.addErrorMessage("PSD Integration Range is invalid. \n"
-                              "Start or end pixel number is outside range [1-128], "
-                              "or start pixel number is >= than the end pixel number.");
+        if (pixelRangeMin >= pixelRangeMax || pixelRangeMin < 1 || pixelRangeMax > 128) {
+          validator->addErrorMessage("PSD Integration Range is invalid. \n"
+                                     "Start or end pixel number is outside range [1-128], "
+                                     "or start pixel number is >= than the end pixel number.");
         }
       }
     }
@@ -144,7 +124,7 @@ bool ILLEnergyTransfer::validate() {
 
   // Validate if the output workspace name is not empty
   if (m_uiForm.leOutWS->text().isEmpty())
-    uiv.addErrorMessage("OutputWorkspace name is invalid.");
+    validator->addErrorMessage("OutputWorkspace name is invalid.");
 
   // Validate QENS specific
 
@@ -153,26 +133,20 @@ bool ILLEnergyTransfer::validate() {
     int useVanadiumRun = m_uiForm.sbUnmirrorOption->value();
     if ((useVanadiumRun == 5 || useVanadiumRun == 7) &&
         (!m_uiForm.rfAlignmentRun->isValid() || m_uiForm.rfAlignmentRun->getUserInput().toString().isEmpty()))
-      uiv.addErrorMessage("Alignment run is invalid.");
+      validator->addErrorMessage("Alignment run is invalid.");
   }
 
   // Validate FWS specific
 
   if (m_uiForm.rdFWS->isChecked()) {
     if (m_uiForm.cbObservable->currentText().isEmpty()) {
-      uiv.addErrorMessage("Observable is invalid, check the sample logs "
-                          "for available options");
+      validator->addErrorMessage("Observable is invalid, check the sample logs "
+                                 "for available options");
     }
   }
-
-  // Show error message for errors
-  if (!uiv.isAllInputValid())
-    showMessageBox(uiv.generateErrorMessage());
-
-  return uiv.isAllInputValid();
 }
 
-void ILLEnergyTransfer::run() {
+void ILLEnergyTransfer::handleRun() {
   QString runFilename = m_uiForm.rfInput->getUserInput().toString();
   QString backgroundFilename = m_uiForm.rfBackgroundRun->getUserInput().toString();
   QString calibrationFilename = m_uiForm.rfCalibrationRun->getUserInput().toString();
@@ -193,6 +167,9 @@ void ILLEnergyTransfer::run() {
 
     // Calibraiton peak range
     if (!calibrationFilename.toStdString().empty()) {
+      auto range = m_uiForm.lePeakRange->text().split(',');
+      m_peakRange[0] = range[0].toDouble();
+      m_peakRange[1] = range[1].toDouble();
       auto peakRange =
           boost::lexical_cast<std::string>(m_peakRange[0]) + "," + boost::lexical_cast<std::string>(m_peakRange[1]);
       reductionAlg->setProperty("CalibrationPeakRange", peakRange);
@@ -228,6 +205,7 @@ void ILLEnergyTransfer::run() {
   // Handle background file
   if (!backgroundFilename.toStdString().empty()) {
     reductionAlg->setProperty("BackgroundRun", backgroundFilename.toStdString());
+    m_backScaling = m_uiForm.leBackgroundFactor->text().toDouble();
     reductionAlg->setProperty("BackgroundScalingFactor", m_backScaling);
   }
 
@@ -239,6 +217,7 @@ void ILLEnergyTransfer::run() {
   // Handle calibration background file
   if (!calibrationBackgroundFilename.toStdString().empty()) {
     reductionAlg->setProperty("CalibrationBackgroundRun", calibrationBackgroundFilename.toStdString());
+    m_backCalibScaling = m_uiForm.leBackCalibScale->text().toDouble();
     reductionAlg->setProperty("CalibrationBackgroundScalingFactor", m_backCalibScaling);
   }
 
@@ -268,6 +247,9 @@ void ILLEnergyTransfer::run() {
 
   // Handle manual PSD integration range
   if (m_uiForm.rdGroupRange->isChecked()) {
+    auto range = m_uiForm.lePixelRange->text().split(',');
+    m_pixelRange[0] = range[0].toInt();
+    m_pixelRange[1] = range[1].toInt();
     auto pixelRange =
         boost::lexical_cast<std::string>(m_pixelRange[0]) + "," + boost::lexical_cast<std::string>(m_pixelRange[1]);
     reductionAlg->setProperty("ManualPSDIntegrationRange", pixelRange);
@@ -287,6 +269,7 @@ void ILLEnergyTransfer::run() {
  * @param error True if the algorithm was stopped due to error, false otherwise
  */
 void ILLEnergyTransfer::algorithmComplete(bool error) {
+  m_runPresenter->setRunEnabled(true);
   if (error)
     return;
   else {
@@ -296,15 +279,6 @@ void ILLEnergyTransfer::algorithmComplete(bool error) {
     if (m_uiForm.ckPlot->isChecked()) {
       plot();
     }
-  }
-}
-
-/**
- * Handle when Run is clicked
- */
-void ILLEnergyTransfer::runClicked() {
-  if (validate()) {
-    run();
   }
 }
 
@@ -341,16 +315,6 @@ void ILLEnergyTransfer::updateInstrumentConfiguration() {
   // Set instrument in run file widgets
   m_uiForm.rfInput->setInstrumentOverride(instrument);
   m_uiForm.rfMapFile->setInstrumentOverride(instrument);
-}
-
-void ILLEnergyTransfer::setRunEnabled(bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
-
-void ILLEnergyTransfer::updateRunButton(bool enabled, std::string const &enableOutputButtons, QString const &message,
-                                        QString const &tooltip) {
-  UNUSED_ARG(enableOutputButtons);
-  setRunEnabled(enabled);
-  m_uiForm.pbRun->setText(message);
-  m_uiForm.pbRun->setToolTip(tooltip);
 }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.cpp
@@ -304,7 +304,11 @@ void ILLEnergyTransfer::algorithmComplete(bool error) {
 /**
  * Handle when Run is clicked
  */
-void ILLEnergyTransfer::runClicked() { runTab(); }
+void ILLEnergyTransfer::runClicked() {
+  if (validate()) {
+    run();
+  }
+}
 
 /**
  * Handles plotting of the reduced ws.

--- a/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.cpp
@@ -49,8 +49,6 @@ ILLEnergyTransfer::ILLEnergyTransfer(IDataReduction *idrUI, QWidget *parent) : D
  */
 ILLEnergyTransfer::~ILLEnergyTransfer() = default;
 
-void ILLEnergyTransfer::setup() {}
-
 bool ILLEnergyTransfer::validate() {
   UserInputValidator uiv;
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.h
@@ -22,7 +22,6 @@ public:
   ILLEnergyTransfer(IDataReduction *idrUI, QWidget *parent = nullptr);
   ~ILLEnergyTransfer() override;
 
-  void setup() override;
   void run() override;
 
 public slots:

--- a/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "Common/RunWidget/IRunSubscriber.h"
 #include "DataReductionTab.h"
 
 #include "MantidKernel/System.h"
@@ -15,25 +16,18 @@ namespace MantidQt {
 namespace CustomInterfaces {
 class IDataReduction;
 
-class MANTIDQT_INDIRECT_DLL ILLEnergyTransfer : public DataReductionTab {
+class MANTIDQT_INDIRECT_DLL ILLEnergyTransfer : public DataReductionTab, public IRunSubscriber {
   Q_OBJECT
 
 public:
   ILLEnergyTransfer(IDataReduction *idrUI, QWidget *parent = nullptr);
   ~ILLEnergyTransfer() override;
 
-  void run() override;
-
-public slots:
-  bool validate() override;
+  void handleValidation(IUserInputValidator *validator) const override;
+  void handleRun() override;
 
 private slots:
   void algorithmComplete(bool error);
-
-  void runClicked();
-  void setRunEnabled(bool enabled);
-  void updateRunButton(bool enabled = true, std::string const &enableOutputButtons = "unchanged",
-                       QString const &message = "Run", QString const &tooltip = "");
 
 private:
   void updateInstrumentConfiguration() override;

--- a/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>672</width>
-    <height>663</height>
+    <height>690</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -977,64 +977,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gbRun">
-     <property name="title">
-      <string>Run</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_5">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>7</number>
-      </property>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>233</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>180</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>233</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
+    <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
    </item>
    <item>
     <spacer name="verticalSpacer">
@@ -1056,6 +999,12 @@
    <class>MantidQt::API::FileFinderWidget</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -1607,7 +1556,7 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="buttonGroup_2"/>
   <buttongroup name="buttonGroup"/>
+  <buttongroup name="buttonGroup_2"/>
  </buttongroups>
 </ui>

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
@@ -152,9 +152,6 @@ ISISCalibration::ISISCalibration(IDataReduction *idrUI, QWidget *parent)
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
   // Handle running, plotting and saving
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
-
-  connect(this, SIGNAL(updateRunButton(bool, std::string const &, QString const &, QString const &)), this,
-          SLOT(updateRunButton(bool, std::string const &, QString const &, QString const &)));
 }
 
 ISISCalibration::~ISISCalibration() {

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
@@ -44,6 +44,7 @@ namespace MantidQt::CustomInterfaces {
 ISISCalibration::ISISCalibration(IDataReduction *idrUI, QWidget *parent)
     : DataReductionTab(idrUI, parent), m_lastCalPlotFilename("") {
   m_uiForm.setupUi(parent);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraBin));
 
@@ -138,8 +139,6 @@ ISISCalibration::ISISCalibration(IDataReduction *idrUI, QWidget *parent)
   // Toggle RES file options when user toggles Create RES File checkbox
   connect(m_uiForm.ckCreateResolution, SIGNAL(toggled(bool)), this, SLOT(resCheck(bool)));
 
-  // Shows message on run button when user is inputting a run number
-  connect(m_uiForm.leRunNo, SIGNAL(fileTextChanged(const QString &)), this, SLOT(pbRunEditing()));
   // Shows message on run button when Mantid is finding the file for a given run
   // number
   connect(m_uiForm.leRunNo, SIGNAL(findingFiles()), this, SLOT(pbRunFinding()));
@@ -152,7 +151,6 @@ ISISCalibration::ISISCalibration(IDataReduction *idrUI, QWidget *parent)
 
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
   // Handle running, plotting and saving
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
 
   connect(this, SIGNAL(updateRunButton(bool, std::string const &, QString const &, QString const &)), this,
@@ -286,10 +284,27 @@ void ISISCalibration::setResolutionSpectraRange(const double &minimum, const dou
   m_dblManager->setValue(m_properties["ResSpecMax"], maximum);
 }
 
-void ISISCalibration::setup() {}
+/*
+ * Handle completion of the calibration and resolution algorithms.
+ *
+ * @param error If the algorithms failed.
+ */
+void ISISCalibration::algorithmComplete(bool error) {
+  m_runPresenter->setRunEnabled(true);
+  if (!error) {
+    std::vector<std::string> outputWorkspaces{m_outputCalibrationName.toStdString()};
+    if (m_uiForm.ckCreateResolution->isChecked() && !m_outputResolutionName.isEmpty()) {
+      outputWorkspaces.emplace_back(m_outputResolutionName.toStdString());
+      if (m_uiForm.ckSmoothResolution->isChecked())
+        outputWorkspaces.emplace_back(m_outputResolutionName.toStdString() + "_pre_smooth");
+    }
+    setOutputPlotOptionsWorkspaces(outputWorkspaces);
 
-void ISISCalibration::run() {
-  // Get properties
+    m_uiForm.pbSave->setEnabled(true);
+  }
+}
+
+void ISISCalibration::handleRun() {
   const auto filenames = m_uiForm.leRunNo->getFilenames().join(",");
   const auto outputWorkspaceNameStem = outputWorkspaceName().toLower();
 
@@ -319,52 +334,24 @@ void ISISCalibration::run() {
   m_batchAlgoRunner->executeBatchAsync();
 }
 
-/*
- * Handle completion of the calibration and resolution algorithms.
- *
- * @param error If the algorithms failed.
- */
-void ISISCalibration::algorithmComplete(bool error) {
-  if (!error) {
-    std::vector<std::string> outputWorkspaces{m_outputCalibrationName.toStdString()};
-    if (m_uiForm.ckCreateResolution->isChecked() && !m_outputResolutionName.isEmpty()) {
-      outputWorkspaces.emplace_back(m_outputResolutionName.toStdString());
-      if (m_uiForm.ckSmoothResolution->isChecked())
-        outputWorkspaces.emplace_back(m_outputResolutionName.toStdString() + "_pre_smooth");
-    }
-    setOutputPlotOptionsWorkspaces(outputWorkspaces);
-
-    m_uiForm.pbSave->setEnabled(true);
-  }
-}
-
-bool ISISCalibration::validate() {
-  MantidQt::CustomInterfaces::UserInputValidator uiv;
-
-  uiv.checkFileFinderWidgetIsValid("Run", m_uiForm.leRunNo);
+void ISISCalibration::handleValidation(IUserInputValidator *validator) const {
+  validator->checkFileFinderWidgetIsValid("Run", m_uiForm.leRunNo);
 
   auto rangeOfPeak = peakRange();
   auto rangeOfBackground = backgroundRange();
-  uiv.checkValidRange("Peak Range", rangeOfPeak);
-  uiv.checkValidRange("Back Range", rangeOfBackground);
-  uiv.checkRangesDontOverlap(rangeOfPeak, rangeOfBackground);
+  validator->checkValidRange("Peak Range", rangeOfPeak);
+  validator->checkValidRange("Back Range", rangeOfBackground);
+  validator->checkRangesDontOverlap(rangeOfPeak, rangeOfBackground);
 
   if (m_uiForm.ckCreateResolution->isChecked()) {
-    uiv.checkValidRange("Background", resolutionRange());
+    validator->checkValidRange("Background", resolutionRange());
 
     double eLow = m_dblManager->value(m_properties["ResELow"]);
     double eHigh = m_dblManager->value(m_properties["ResEHigh"]);
     double eWidth = m_dblManager->value(m_properties["ResEWidth"]);
 
-    uiv.checkBins(eLow, eWidth, eHigh);
+    validator->checkBins(eLow, eWidth, eHigh);
   }
-
-  auto const error = uiv.generateErrorMessage();
-
-  if (error != "")
-    g_log.warning(error);
-
-  return (error == "");
 }
 
 /**
@@ -669,17 +656,10 @@ void ISISCalibration::resCheck(bool state) {
 }
 
 /**
- * Called when a user starts to type / edit the runs to load.
- */
-void ISISCalibration::pbRunEditing() {
-  updateRunButton(false, "unchanged", "Editing...", "Run numbers are currently being edited.");
-}
-
-/**
  * Called when the FileFinder starts finding the files.
  */
 void ISISCalibration::pbRunFinding() {
-  updateRunButton(false, "unchanged", "Finding files...", "Searching for data files for the run numbers entered...");
+  m_runPresenter->setRunText("Finding files...");
   m_uiForm.leRunNo->setEnabled(false);
 }
 
@@ -688,11 +668,9 @@ void ISISCalibration::pbRunFinding() {
  */
 void ISISCalibration::pbRunFinished() {
   if (!m_uiForm.leRunNo->isValid())
-    updateRunButton(false, "unchanged", "Invalid Run(s)",
-                    "Cannot find data files for some of the run numbers entered.");
+    m_runPresenter->setRunText("Invalid Run(s)");
   else
-    updateRunButton();
-
+    m_runPresenter->setRunEnabled(true);
   m_uiForm.leRunNo->setEnabled(true);
 }
 /**
@@ -708,11 +686,6 @@ void ISISCalibration::saveClicked() {
   }
   m_batchAlgoRunner->executeBatchAsync();
 }
-
-/**
- * Handle when Run is clicked
- */
-void ISISCalibration::runClicked() { runTab(); }
 
 void ISISCalibration::addRuntimeSmoothing(const QString &workspaceName) {
   auto smoothAlg = AlgorithmManager::Instance().create("WienerSmooth");
@@ -775,17 +748,6 @@ IAlgorithm_sptr ISISCalibration::energyTransferReductionAlgorithm(const QString 
   return reductionAlg;
 }
 
-void ISISCalibration::setRunEnabled(bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
-
 void ISISCalibration::setSaveEnabled(bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }
-
-void ISISCalibration::updateRunButton(bool enabled, std::string const &enableOutputButtons, QString const &message,
-                                      QString const &tooltip) {
-  setRunEnabled(enabled);
-  m_uiForm.pbRun->setText(message);
-  m_uiForm.pbRun->setToolTip(tooltip);
-  if (enableOutputButtons != "unchanged")
-    setSaveEnabled(enableOutputButtons == "enable");
-}
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.h
@@ -47,8 +47,8 @@ public:
   void setBackgroundRangeLimits(const double &backgroundMin, const double &backgroundMax);
   void setResolutionSpectraRange(const double &minimum, const double &maximum);
 
-  void handleRun();
-  void handleValidation(IUserInputValidator *validator) const;
+  void handleRun() override;
+  void handleValidation(IUserInputValidator *validator) const override;
 
 private slots:
   void algorithmComplete(bool error);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "Common/RunWidget/IRunSubscriber.h"
 #include "DataReductionTab.h"
 #include "MantidKernel/System.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
@@ -21,16 +22,12 @@ class IDataReduction;
   @author Dan Nixon
   @date 23/07/2014
 */
-class MANTIDQT_INDIRECT_DLL ISISCalibration : public DataReductionTab {
+class MANTIDQT_INDIRECT_DLL ISISCalibration : public DataReductionTab, public IRunSubscriber {
   Q_OBJECT
 
 public:
   ISISCalibration(IDataReduction *idrUI, QWidget *parent = nullptr);
   ~ISISCalibration() override;
-
-  void setup() override;
-  void run() override;
-  bool validate() override;
 
   std::pair<double, double> peakRange() const;
   std::pair<double, double> backgroundRange() const;
@@ -50,6 +47,9 @@ public:
   void setBackgroundRangeLimits(const double &backgroundMin, const double &backgroundMax);
   void setResolutionSpectraRange(const double &minimum, const double &maximum);
 
+  void handleRun();
+  void handleValidation(IUserInputValidator *validator) const;
+
 private slots:
   void algorithmComplete(bool error);
   void calPlotRaw();
@@ -60,18 +60,13 @@ private slots:
   void calSetDefaultResolution(const Mantid::API::MatrixWorkspace_const_sptr &ws);
   void resCheck(bool state); ///< handles checking/unchecking of "Create RES
   /// File" checkbox
-  void pbRunEditing();  //< Called when a user starts to type / edit the runs to load.
   void pbRunFinding();  //< Called when the FileFinder starts finding the files.
   void pbRunFinished(); //< Called when the FileFinder has finished finding the
   // files.
   /// Handles running, saving and plotting
-  void runClicked();
   void saveClicked();
 
-  void setRunEnabled(bool enabled);
   void setSaveEnabled(bool enabled);
-  void updateRunButton(bool enabled = true, std::string const &enableOutputButtons = "unchanged",
-                       QString const &message = "Run", QString const &tooltip = "");
 
 private:
   void updateInstrumentConfiguration() override;
@@ -79,7 +74,6 @@ private:
   void setDefaultInstDetails(QMap<QString, QString> const &instrumentDetails);
   void connectRangeSelectors();
   void disconnectRangeSelectors();
-  void createRESfile(const QString &file);
   void addRuntimeSmoothing(const QString &workspaceName);
   void setRangeLimits(MantidWidgets::RangeSelector *rangeSelector, const double &minimum, const double &maximum,
                       const QString &minPropertyName, const QString &maxPropertyName);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.ui
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.ui
@@ -285,64 +285,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gbRun">
-     <property name="title">
-      <string>Run</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>7</number>
-      </property>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>185</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>180</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>184</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
+    <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
@@ -404,6 +347,12 @@
    <class>MantidQt::API::FileFinderWidget</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.h
@@ -48,8 +48,8 @@ public:
   ISISDiagnostics(IDataReduction *idrUI, QWidget *parent = nullptr);
   ~ISISDiagnostics() override;
 
-  void handleRun();
-  void handleValidation(IUserInputValidator *validator) const;
+  void handleRun() override;
+  void handleValidation(IUserInputValidator *validator) const override;
 
 private slots:
   void algorithmComplete(bool error);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "../DllConfig.h"
+#include "Common/RunWidget/IRunSubscriber.h"
 #include "DataReductionTab.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidKernel/System.h"
@@ -40,16 +41,15 @@ class IDataReduction;
   @author Dan Nixon
   @date 23/07/2014
 */
-class MANTIDQT_INDIRECT_DLL ISISDiagnostics : public DataReductionTab {
+class MANTIDQT_INDIRECT_DLL ISISDiagnostics : public DataReductionTab, public IRunSubscriber {
   Q_OBJECT
 
 public:
   ISISDiagnostics(IDataReduction *idrUI, QWidget *parent = nullptr);
   ~ISISDiagnostics() override;
 
-  void setup() override;
-  void run() override;
-  bool validate() override;
+  void handleRun();
+  void handleValidation(IUserInputValidator *validator) const;
 
 private slots:
   void algorithmComplete(bool error);
@@ -59,17 +59,12 @@ private slots:
   void rangeSelectorDropped(double /*min*/, double /*max*/);
   void doublePropertyChanged(QtProperty * /*prop*/, double /*val*/);
   void sliceAlgDone(bool error);
-  void pbRunEditing();  //< Called when a user starts to type / edit the runs to load.
   void pbRunFinding();  //< Called when the FileFinder starts finding the files.
   void pbRunFinished(); //< Called when the FileFinder has finished finding the
   // files.
-  void runClicked();
   void saveClicked();
 
-  void setRunEnabled(bool enabled);
   void setSaveEnabled(bool enabled);
-  void updateRunButton(bool enabled = true, std::string const &enableOutputButtons = "unchanged",
-                       QString const &message = "Run", QString const &tooltip = "");
 
 private:
   void updateInstrumentConfiguration() override;

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.ui
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>524</width>
-    <height>634</height>
+    <height>663</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -202,69 +202,13 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gbRun">
+    <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="title">
-      <string>Run</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>7</number>
-      </property>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>197</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>180</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>196</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
     </widget>
    </item>
    <item>
@@ -332,6 +276,12 @@
    <class>MantidQt::API::FileFinderWidget</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransfer.ui
@@ -712,64 +712,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gbRun">
-     <property name="title">
-      <string>Run</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_7">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>7</number>
-      </property>
-      <item>
-       <spacer name="horizontalSpacer_4">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>180</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_10">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
+    <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
@@ -1040,6 +983,12 @@
    <class>MantidQt::MantidWidgets::DataSelector</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/DataSelector.h</header>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
@@ -54,18 +54,15 @@ IETPresenter::IETPresenter(IDataReduction *idrUI, IIETView *view, std::unique_pt
     : DataReductionTab(idrUI, std::move(algorithmRunner)), m_view(view), m_model(std::move(model)) {
   m_view->subscribePresenter(this);
   m_algorithmRunner->subscribe(this);
-
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_view->getRunView()));
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptionsView(), PlotWidget::SpectraSliceSurface));
 }
 
-void IETPresenter::setup() {}
-
-bool IETPresenter::validateInstrumentDetails() {
+void IETPresenter::validateInstrumentDetails(IUserInputValidator *validator) const {
   auto const instrument = getInstrumentName().toStdString();
   if (instrument.empty()) {
-    m_view->showMessageBox("Please select a valid facility and/or instrument.");
-    return false;
+    validator->addErrorMessage("Please select a valid facility and/or instrument.");
   }
 
   QMap<QString, QString> instrumentDetails = getInstrumentDetails();
@@ -73,16 +70,14 @@ bool IETPresenter::validateInstrumentDetails() {
   for (const auto &key : keys) {
     if (!instrumentDetails.contains(QString::fromStdString(key)) ||
         instrumentDetails[QString::fromStdString(key)].isEmpty()) {
-      m_view->showMessageBox("Could not find " + key + " for the " + instrument +
-                             " instrument. Please select a valid instrument.");
-      return false;
+      validator->addErrorMessage("Could not find " + key + " for the " + instrument +
+                                 " instrument. Please select a valid instrument.");
+      break;
     }
   }
-
-  return true;
 }
 
-InstrumentData IETPresenter::getInstrumentData() {
+InstrumentData IETPresenter::getInstrumentData() const {
   QMap<QString, QString> instrumentDetails = getInstrumentDetails();
 
   return InstrumentData(
@@ -94,58 +89,72 @@ InstrumentData IETPresenter::getInstrumentData() {
 }
 
 void IETPresenter::updateInstrumentConfiguration() {
-  if (validateInstrumentDetails()) {
-    InstrumentData instrumentDetails = getInstrumentData();
-    auto const instrumentName = instrumentDetails.getInstrument();
-
-    // spectraRange & Efixed
-    auto const specMin = instrumentDetails.getDefaultSpectraMin();
-    auto const specMax = instrumentDetails.getDefaultSpectraMax();
-    m_view->setInstrumentSpectraRange(specMin, specMax);
-    m_view->setInstrumentEFixed(instrumentName, instrumentDetails.getDefaultEfixed());
-
-    // Rebinning
-    auto const rebinDefault = instrumentDetails.getDefaultRebin();
-    std::vector<double> rebinParams;
-    if (!rebinDefault.empty()) {
-      std::vector<std::string> rebinParamsStr;
-      boost::split(rebinParamsStr, rebinDefault, boost::is_any_of(","));
-      std::for_each(rebinParamsStr.begin(), rebinParamsStr.end(),
-                    [&rebinParams](auto &param) { rebinParams.push_back(std::stod(param)); });
-    } else
-      rebinParams = {0, 0, 0};
-
-    int rebinTab = (int)(rebinParams.size() != 3);
-    std::string rebinString = !rebinDefault.empty() ? rebinDefault : "";
-    m_view->setInstrumentRebinning(rebinParams, rebinString, rebinDefault.empty(), rebinTab);
-
-    // Grouping
-    m_view->setInstrumentGrouping(instrumentName);
-
-    // Instrument spec defaults
-    bool irsORosiris = std::regex_search(instrumentName, std::regex("(^OSIRIS$)|(^IRIS$)"));
-    bool toscaORtfxa = std::regex_search(instrumentName, std::regex("(^TOSCA$)|(^TFXA$)"));
-    m_idrUI->showAnalyserAndReflectionOptions(!toscaORtfxa);
-    std::map<std::string, bool> specMap{{"irsORosiris", !irsORosiris},
-                                        {"toscaORtfxa", !toscaORtfxa},
-                                        {"defaultEUnits", instrumentDetails.getDefaultUseDeltaEInWavenumber()},
-                                        {"defaultSaveNexus", instrumentDetails.getDefaultSaveNexus()},
-                                        {"defaultSaveASCII", instrumentDetails.getDefaultSaveASCII()},
-                                        {"defaultFoldMultiple", instrumentDetails.getDefaultFoldMultipleFrames()}};
-    m_view->setInstrumentSpecDefault(specMap);
+  auto validator = std::make_unique<UserInputValidator>();
+  validateInstrumentDetails(validator.get());
+  const auto error = validator->generateErrorMessage();
+  if (!error.empty()) {
+    m_view->displayWarning(error);
+    return;
   }
+
+  InstrumentData instrumentDetails = getInstrumentData();
+  auto const instrumentName = instrumentDetails.getInstrument();
+
+  // spectraRange & Efixed
+  auto const specMin = instrumentDetails.getDefaultSpectraMin();
+  auto const specMax = instrumentDetails.getDefaultSpectraMax();
+  m_view->setInstrumentSpectraRange(specMin, specMax);
+  m_view->setInstrumentEFixed(instrumentName, instrumentDetails.getDefaultEfixed());
+
+  // Rebinning
+  auto const rebinDefault = instrumentDetails.getDefaultRebin();
+  std::vector<double> rebinParams;
+  if (!rebinDefault.empty()) {
+    std::vector<std::string> rebinParamsStr;
+    boost::split(rebinParamsStr, rebinDefault, boost::is_any_of(","));
+    std::for_each(rebinParamsStr.begin(), rebinParamsStr.end(),
+                  [&rebinParams](auto &param) { rebinParams.push_back(std::stod(param)); });
+  } else
+    rebinParams = {0, 0, 0};
+
+  int rebinTab = (int)(rebinParams.size() != 3);
+  std::string rebinString = !rebinDefault.empty() ? rebinDefault : "";
+  m_view->setInstrumentRebinning(rebinParams, rebinString, rebinDefault.empty(), rebinTab);
+
+  // Grouping
+  m_view->setInstrumentGrouping(instrumentName);
+
+  // Instrument spec defaults
+  bool irsORosiris = std::regex_search(instrumentName, std::regex("(^OSIRIS$)|(^IRIS$)"));
+  bool toscaORtfxa = std::regex_search(instrumentName, std::regex("(^TOSCA$)|(^TFXA$)"));
+  m_idrUI->showAnalyserAndReflectionOptions(!toscaORtfxa);
+  std::map<std::string, bool> specMap{{"irsORosiris", !irsORosiris},
+                                      {"toscaORtfxa", !toscaORtfxa},
+                                      {"defaultEUnits", instrumentDetails.getDefaultUseDeltaEInWavenumber()},
+                                      {"defaultSaveNexus", instrumentDetails.getDefaultSaveNexus()},
+                                      {"defaultSaveASCII", instrumentDetails.getDefaultSaveASCII()},
+                                      {"defaultFoldMultiple", instrumentDetails.getDefaultFoldMultipleFrames()}};
+  m_view->setInstrumentSpecDefault(specMap);
 }
 
-bool IETPresenter::validate() {
+void IETPresenter::handleRun() {
+  InstrumentData instrumentData = getInstrumentData();
   IETRunData runData = m_view->getRunData();
-  auto uiv = std::make_unique<UserInputValidator>();
+
+  m_view->setEnableOutputOptions(false);
+
+  m_algorithmRunner->execute(m_model->energyTransferAlgorithm(instrumentData, runData));
+}
+
+void IETPresenter::handleValidation(IUserInputValidator *validator) const {
+  IETRunData runData = m_view->getRunData();
 
   if (!m_view->isRunFilesValid()) {
-    uiv->addErrorMessage("Run file range is invalid.");
+    validator->addErrorMessage("Run file range is invalid.");
   }
 
   if (runData.getInputData().getUseCalibration()) {
-    m_view->validateCalibrationFileType(uiv.get());
+    m_view->validateCalibrationFileType(validator);
   }
 
   auto rebinDetails = runData.getRebinData();
@@ -157,11 +166,11 @@ bool IETPresenter::validate() {
         if (response)
           rebinWidth = std::abs(rebinWidth);
 
-        bool rebinValid = !uiv->checkBins(rebinDetails.getRebinLow(), rebinWidth, rebinDetails.getRebinHigh());
+        bool rebinValid = !validator->checkBins(rebinDetails.getRebinLow(), rebinWidth, rebinDetails.getRebinHigh());
         m_view->setSingleRebin(rebinValid);
       }
     } else {
-      m_view->validateRebinString(uiv.get());
+      m_view->validateRebinString(validator);
     }
   } else {
     m_view->setSingleRebin(false);
@@ -177,31 +186,17 @@ bool IETPresenter::validate() {
 
   for (auto const &error : errors) {
     if (!error.empty())
-      uiv->addErrorMessage(error);
+      validator->addErrorMessage(error);
   }
 
-  auto const error = uiv->generateErrorMessage();
-  if (!error.empty())
-    m_view->showMessageBox(error);
-
-  return validateInstrumentDetails() && uiv->isAllInputValid();
+  validateInstrumentDetails(validator);
 }
 
-void IETPresenter::notifyRunClicked() { runTab(); }
-
-void IETPresenter::run() {
-  InstrumentData instrumentData = getInstrumentData();
-  IETRunData runData = m_view->getRunData();
-
-  m_view->setRunButtonText("Running...");
-  m_view->setEnableOutputOptions(false);
-
-  m_algorithmRunner->execute(m_model->energyTransferAlgorithm(instrumentData, runData));
-}
+void IETPresenter::notifyFindingRun() { m_runPresenter->setRunText("Finding files..."); }
 
 void IETPresenter::notifyBatchComplete(API::IConfiguredAlgorithm_sptr &lastAlgorithm, bool error) {
+  m_runPresenter->setRunEnabled(true);
   if (!lastAlgorithm || error) {
-    m_view->setRunButtonText("Run");
     m_view->setEnableOutputOptions(false);
     m_view->setPlotTimeIsPlotting(false);
     return;
@@ -219,14 +214,15 @@ void IETPresenter::notifyBatchComplete(API::IConfiguredAlgorithm_sptr &lastAlgor
 }
 
 void IETPresenter::handleReductionComplete() {
-  m_view->setRunButtonText("Run");
+  m_runPresenter->setRunEnabled(true);
   m_view->setEnableOutputOptions(true);
 
   InstrumentData instrumentData = getInstrumentData();
   auto const outputWorkspaceNames =
       m_model->groupWorkspaces(m_model->outputGroupName(), instrumentData.getInstrument(),
                                m_view->getGroupOutputOption(), m_view->getGroupOutputCheckbox());
-  m_pythonExportWsName = outputWorkspaceNames[0];
+  if (!outputWorkspaceNames.empty())
+    m_pythonExportWsName = outputWorkspaceNames[0];
 
   setOutputPlotOptionsWorkspaces(outputWorkspaceNames);
   m_view->setSaveEnabled(!outputWorkspaceNames.empty());
@@ -283,11 +279,11 @@ void IETPresenter::notifySaveCustomGroupingClicked(std::string const &customGrou
 
 void IETPresenter::notifyRunFinished() {
   if (!m_view->isRunFilesValid()) {
-    m_view->setRunButtonText("Invalid Run(s)");
+    m_runPresenter->setRunText("Invalid Run(s)");
   } else {
     double detailedBalance = m_model->loadDetailedBalance(m_view->getFirstFilename());
     m_view->setDetailedBalance(detailedBalance);
-    m_view->setRunButtonText("Run");
+    m_runPresenter->setRunEnabled(true);
   }
   m_view->setRunFilesEnabled(true);
 }

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "Common/RunWidget/IRunSubscriber.h"
 #include "DataReductionTab.h"
 #include "DllConfig.h"
 #include "ISISEnergyTransferData.h"
@@ -19,8 +20,8 @@ namespace CustomInterfaces {
 
 class MANTIDQT_INDIRECT_DLL IIETPresenter {
 public:
+  virtual void notifyFindingRun() = 0;
   virtual void notifySaveClicked() = 0;
-  virtual void notifyRunClicked() = 0;
   virtual void notifyPlotRawClicked() = 0;
   virtual void notifySaveCustomGroupingClicked(std::string const &customGrouping) = 0;
   virtual void notifyRunFinished() = 0;
@@ -28,32 +29,32 @@ public:
 
 class MANTIDQT_INDIRECT_DLL IETPresenter : public DataReductionTab,
                                            public IIETPresenter,
+                                           public IRunSubscriber,
                                            public API::IAlgorithmRunnerSubscriber {
 
 public:
   IETPresenter(IDataReduction *idrUI, IIETView *view, std::unique_ptr<IIETModel> model,
                std::unique_ptr<API::IAlgorithmRunner> algorithmRunner);
 
-  void setup() override;
-  void run() override;
-  bool validate() override;
-
+  void notifyFindingRun() override;
   void notifySaveClicked() override;
-  void notifyRunClicked() override;
   void notifyPlotRawClicked() override;
   void notifySaveCustomGroupingClicked(std::string const &customGrouping) override;
   void notifyRunFinished() override;
 
   void notifyBatchComplete(API::IConfiguredAlgorithm_sptr &lastAlgorithm, bool error) override;
 
+  void handleRun() override;
+  void handleValidation(IUserInputValidator *validator) const override;
+
 private:
-  bool validateInstrumentDetails();
+  void validateInstrumentDetails(IUserInputValidator *validator) const;
   void updateInstrumentConfiguration() override;
 
   void handleReductionComplete();
   void handlePlotRawPreProcessComplete();
 
-  InstrumentData getInstrumentData();
+  InstrumentData getInstrumentData() const;
 
   void setFileExtensionsByName(bool filter) override;
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
@@ -8,6 +8,7 @@
 #include "ISISEnergyTransferView.h"
 #include "Common/DataValidationHelper.h"
 #include "Common/DetectorGroupingOptions.h"
+#include "Common/RunWidget/RunView.h"
 #include "ISISEnergyTransferPresenter.h"
 
 #include "MantidQtWidgets/Common/AlgorithmDialog.h"
@@ -24,11 +25,9 @@ IETView::IETView(QWidget *parent) {
   m_uiForm.setupUi(parent);
 
   connect(m_uiForm.pbPlotTime, SIGNAL(clicked()), this, SLOT(plotRawClicked()));
-  connect(m_uiForm.dsRunFiles, SIGNAL(fileTextChanged(const QString &)), this, SLOT(pbRunEditing()));
   connect(m_uiForm.dsRunFiles, SIGNAL(findingFiles()), this, SLOT(pbRunFinding()));
   connect(m_uiForm.dsRunFiles, SIGNAL(fileFindingFinished()), this, SLOT(pbRunFinished()));
   connect(m_uiForm.dsCalibrationFile, SIGNAL(dataReady(QString const &)), this, SLOT(handleDataReady()));
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
 
   m_uiForm.dsCalibrationFile->isOptional(true);
@@ -96,17 +95,19 @@ std::string IETView::getGroupOutputOption() const { return m_uiForm.cbGroupOutpu
 
 bool IETView::getGroupOutputCheckbox() const { return m_uiForm.ckGroupOutput->isChecked(); }
 
+IRunView *IETView::getRunView() const { return m_uiForm.runWidget; }
+
 IOutputPlotOptionsView *IETView::getPlotOptionsView() const { return m_uiForm.ipoPlotOptions; }
 
 std::string IETView::getFirstFilename() const { return m_uiForm.dsRunFiles->getFirstFilename().toStdString(); }
 
 bool IETView::isRunFilesValid() const { return m_uiForm.dsRunFiles->isValid(); }
 
-void IETView::validateCalibrationFileType(UserInputValidator *uiv) const {
+void IETView::validateCalibrationFileType(IUserInputValidator *uiv) const {
   validateDataIsOfType(uiv, m_uiForm.dsCalibrationFile, "Calibration", DataType::Calib);
 }
 
-void IETView::validateRebinString(UserInputValidator *uiv) const {
+void IETView::validateRebinString(IUserInputValidator *uiv) const {
   uiv->checkFieldIsNotEmpty("Rebin string", m_uiForm.leRebinString, m_uiForm.valRebinString);
 }
 
@@ -272,13 +273,6 @@ void IETView::setInstrumentSpecDefault(std::map<std::string, bool> &specMap) {
   m_uiForm.ckFold->setChecked(specMap["defaultFoldMultiple"]);
 }
 
-void IETView::setRunButtonText(std::string const &runText) {
-  m_uiForm.pbRun->setText(QString::fromStdString(runText));
-  m_uiForm.pbRun->setEnabled(runText == "Run");
-  m_uiForm.pbRun->setToolTip(runText == "Invalid Run(s)" ? "Cannot find data files for some of the run numbers entered."
-                                                         : "");
-}
-
 void IETView::setEnableOutputOptions(bool const enable) {
   setPlotTimeEnabled(enable);
   setSaveEnabled(enable);
@@ -289,8 +283,6 @@ void IETView::showMessageBox(std::string const &message) {
 }
 
 void IETView::saveClicked() { m_presenter->notifySaveClicked(); }
-
-void IETView::runClicked() { m_presenter->notifyRunClicked(); }
 
 void IETView::plotRawClicked() { m_presenter->notifyPlotRawClicked(); }
 
@@ -309,10 +301,8 @@ void IETView::handleDataReady() {
     showMessageBox(errorMessage);
 }
 
-void IETView::pbRunEditing() { setRunButtonText("Editing..."); }
-
 void IETView::pbRunFinding() {
-  setRunButtonText("Finding files...");
+  m_presenter->notifyFindingRun();
   m_uiForm.dsRunFiles->setEnabled(false);
 }
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
@@ -17,6 +17,7 @@ namespace CustomInterfaces {
 
 class DetectorGroupingOptions;
 class IIETPresenter;
+class IRunView;
 
 class MANTIDQT_INDIRECT_DLL IIETView {
 public:
@@ -29,14 +30,15 @@ public:
   virtual IETSaveData getSaveData() const = 0;
 
   virtual std::string getGroupOutputOption() const = 0;
+  virtual IRunView *getRunView() const = 0;
   virtual IOutputPlotOptionsView *getPlotOptionsView() const = 0;
   virtual bool getGroupOutputCheckbox() const = 0;
 
   virtual std::string getFirstFilename() const = 0;
 
   virtual bool isRunFilesValid() const = 0;
-  virtual void validateCalibrationFileType(UserInputValidator *uiv) const = 0;
-  virtual void validateRebinString(UserInputValidator *uiv) const = 0;
+  virtual void validateCalibrationFileType(IUserInputValidator *uiv) const = 0;
+  virtual void validateRebinString(IUserInputValidator *uiv) const = 0;
   virtual std::optional<std::string> validateGroupingProperties(std::size_t const &spectraMin,
                                                                 std::size_t const &spectraMax) const = 0;
 
@@ -66,7 +68,6 @@ public:
   virtual void setSaveEnabled(bool enable) = 0;
   virtual void setPlotTimeIsPlotting(bool plotting) = 0;
   virtual void setFileExtensionsByName(QStringList calibrationFbSuffixes, QStringList calibrationWSSuffixes) = 0;
-  virtual void setRunButtonText(std::string const &runText) = 0;
   virtual void setEnableOutputOptions(bool const enable) = 0;
 
   virtual void setInstrumentSpectraRange(int specMin, int specMax) = 0;
@@ -92,14 +93,15 @@ public:
   IETSaveData getSaveData() const override;
 
   std::string getGroupOutputOption() const override;
+  IRunView *getRunView() const override;
   IOutputPlotOptionsView *getPlotOptionsView() const override;
   bool getGroupOutputCheckbox() const override;
 
   std::string getFirstFilename() const override;
 
   bool isRunFilesValid() const override;
-  void validateCalibrationFileType(UserInputValidator *uiv) const override;
-  void validateRebinString(UserInputValidator *uiv) const override;
+  void validateCalibrationFileType(IUserInputValidator *uiv) const override;
+  void validateRebinString(IUserInputValidator *uiv) const override;
   std::optional<std::string> validateGroupingProperties(std::size_t const &spectraMin,
                                                         std::size_t const &spectraMax) const override;
 
@@ -128,7 +130,6 @@ public:
   void setSaveEnabled(bool enable) override;
   void setPlotTimeIsPlotting(bool plotting) override;
   void setFileExtensionsByName(QStringList calibrationFbSuffixes, QStringList calibrationWSSuffixes) override;
-  void setRunButtonText(std::string const &runText) override;
   void setEnableOutputOptions(bool const enable) override;
 
   void setInstrumentSpectraRange(int specMin, int specMax) override;
@@ -142,14 +143,12 @@ public:
 
 private slots:
   void saveClicked();
-  void runClicked();
   void plotRawClicked();
   void saveCustomGroupingClicked(std::string const &customGrouping);
   void pbRunFinished();
 
   void handleDataReady();
 
-  void pbRunEditing();
   void pbRunFinding();
 
 private:

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.cpp
@@ -30,17 +30,14 @@ namespace MantidQt::CustomInterfaces {
  */
 Transmission::Transmission(IDataReduction *idrUI, QWidget *parent) : DataReductionTab(idrUI, parent) {
   m_uiForm.setupUi(parent);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::Spectra, "0-2"));
 
   // Update the preview plot when the algorithm is complete
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(transAlgDone(bool)));
 
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
-
-  connect(this, SIGNAL(updateRunButton(bool, std::string const &, QString const &, QString const &)), this,
-          SLOT(updateRunButton(bool, std::string const &, QString const &, QString const &)));
 
   m_uiForm.ppPlot->setCanvasColour(QColor(240, 240, 240));
 
@@ -48,14 +45,9 @@ Transmission::Transmission(IDataReduction *idrUI, QWidget *parent) : DataReducti
   m_uiForm.dsCanInput->setTypeSelectorVisible(false);
 }
 
-//----------------------------------------------------------------------------------------------
-/** Destructor
- */
 Transmission::~Transmission() = default;
 
-void Transmission::setup() {}
-
-void Transmission::run() {
+void Transmission::handleRun() {
   QString sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
   QString canWsName = m_uiForm.dsCanInput->getCurrentDataName();
   QString outWsName = sampleWsName.toLower() + "_transmission_group";
@@ -73,24 +65,24 @@ void Transmission::run() {
   m_pythonExportWsName = outWsName.toStdString();
 }
 
-bool Transmission::validate() {
+void Transmission::handleValidation(IUserInputValidator *validator) const {
   // Check if we have an appropriate instrument
   QString currentInst = getInstrumentName();
   if (currentInst != "IRIS" && currentInst != "OSIRIS")
-    return false;
+    validator->addErrorMessage("The selected instrument must be IRIS or OSIRIS");
 
   // Check for an invalid sample input
   if (!m_uiForm.dsSampleInput->isValid())
-    return false;
+    validator->addErrorMessage("Sample: " + m_uiForm.dsSampleInput->getProblem().toStdString());
 
   // Check for an invalid can input
   if (!m_uiForm.dsCanInput->isValid())
-    return false;
-
-  return true;
+    validator->addErrorMessage("Resolution: " + m_uiForm.dsCanInput->getProblem().toStdString());
 }
 
 void Transmission::transAlgDone(bool error) {
+  m_runPresenter->setRunEnabled(true);
+  m_uiForm.pbSave->setEnabled(!error);
   if (error)
     return;
 
@@ -108,9 +100,6 @@ void Transmission::transAlgDone(bool error) {
   m_uiForm.ppPlot->addSpectrum("Sample", sampleWsName + "_Sam", 0, Qt::red);
   m_uiForm.ppPlot->addSpectrum("Transmission", sampleWsName + "_Trans", 0, Qt::blue);
   m_uiForm.ppPlot->resizeX();
-
-  // Enable plot and save
-  m_uiForm.pbSave->setEnabled(true);
 }
 
 void Transmission::updateInstrumentConfiguration() {
@@ -127,11 +116,6 @@ void Transmission::setInstrument(QString const &instrumentName) {
 }
 
 /**
- * Handle when Run is clicked
- */
-void Transmission::runClicked() { runTab(); }
-
-/**
  * Handle saving of workspace
  */
 void Transmission::saveClicked() {
@@ -140,17 +124,6 @@ void Transmission::saveClicked() {
   m_batchAlgoRunner->executeBatchAsync();
 }
 
-void Transmission::setRunEnabled(bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
-
 void Transmission::setSaveEnabled(bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }
-
-void Transmission::updateRunButton(bool enabled, std::string const &enableOutputButtons, QString const &message,
-                                   QString const &tooltip) {
-  setRunEnabled(enabled);
-  m_uiForm.pbRun->setText(message);
-  m_uiForm.pbRun->setToolTip(tooltip);
-  if (enableOutputButtons != "unchanged")
-    setSaveEnabled(enableOutputButtons == "enable");
-}
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.h
@@ -23,8 +23,8 @@ public:
   Transmission(IDataReduction *idrUI, QWidget *parent = nullptr);
   ~Transmission() override;
 
-  void handleRun();
-  void handleValidation(IUserInputValidator *validator) const;
+  void handleRun() override;
+  void handleValidation(IUserInputValidator *validator) const override;
 
 private slots:
   void transAlgDone(bool error);

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "../DllConfig.h"
+#include "Common/RunWidget/IRunSubscriber.h"
 #include "DataReductionTab.h"
 #include "MantidKernel/System.h"
 #include "ui_Transmission.h"
@@ -15,27 +16,22 @@ namespace MantidQt {
 namespace CustomInterfaces {
 class IDataReduction;
 
-class MANTIDQT_INDIRECT_DLL Transmission : public DataReductionTab {
+class MANTIDQT_INDIRECT_DLL Transmission : public DataReductionTab, public IRunSubscriber {
   Q_OBJECT
 
 public:
   Transmission(IDataReduction *idrUI, QWidget *parent = nullptr);
   ~Transmission() override;
 
-  void setup() override;
-  void run() override;
-  bool validate() override;
+  void handleRun();
+  void handleValidation(IUserInputValidator *validator) const;
 
 private slots:
   void transAlgDone(bool error);
 
-  void runClicked();
   void saveClicked();
 
-  void setRunEnabled(bool enabled);
   void setSaveEnabled(bool enabled);
-  void updateRunButton(bool enabled = true, std::string const &enableOutputButtons = "unchanged",
-                       QString const &message = "Run", QString const &tooltip = "");
 
 private:
   void setInstrument(QString const &instrumentName);

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.ui
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>525</width>
-    <height>423</height>
+    <height>428</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -127,64 +127,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gbRun">
-     <property name="title">
-      <string>Run</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>7</number>
-      </property>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>197</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>180</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>197</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
+    <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">
@@ -245,6 +188,12 @@
    <class>MantidQt::MantidWidgets::PreviewPlot</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Plotting/PreviewPlot.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/qt/scientific_interfaces/Indirect/Simulation/DensityOfStates.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/DensityOfStates.cpp
@@ -26,7 +26,7 @@ enum class DensityOfStates::InputFormat : int { Unsupported = 0, Phonon, Castep,
 
 DensityOfStates::DensityOfStates(QWidget *parent) : SimulationTab(parent) {
   m_uiForm.setupUi(parent);
-  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::Spectra));
 

--- a/qt/scientific_interfaces/Indirect/Simulation/DensityOfStates.h
+++ b/qt/scientific_interfaces/Indirect/Simulation/DensityOfStates.h
@@ -8,7 +8,6 @@
 
 #include "../DllConfig.h"
 #include "Common/RunWidget/IRunSubscriber.h"
-#include "Common/RunWidget/RunPresenter.h"
 #include "SimulationTab.h"
 #include "ui_DensityOfStates.h"
 
@@ -40,7 +39,6 @@ private:
   std::string formatToFilePropName(InputFormat const &format) const;
   bool isPdosFile(InputFormat const &dosFileFormat) const;
 
-  std::unique_ptr<IRunPresenter> m_runPresenter;
   /// The ui form
   Ui::DensityOfStates m_uiForm;
   /// Name of output workspace

--- a/qt/scientific_interfaces/Indirect/Simulation/MolDyn.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/MolDyn.cpp
@@ -17,9 +17,9 @@
 using namespace Mantid::API;
 
 namespace MantidQt::CustomInterfaces {
-MolDyn::MolDyn(QWidget *parent) : SimulationTab(parent), m_runPresenter() {
+MolDyn::MolDyn(QWidget *parent) : SimulationTab(parent) {
   m_uiForm.setupUi(parent);
-  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface, "0"));
 

--- a/qt/scientific_interfaces/Indirect/Simulation/MolDyn.h
+++ b/qt/scientific_interfaces/Indirect/Simulation/MolDyn.h
@@ -8,7 +8,6 @@
 
 #include "../DllConfig.h"
 #include "Common/RunWidget/IRunSubscriber.h"
-#include "Common/RunWidget/RunPresenter.h"
 #include "SimulationTab.h"
 #include "ui_MolDyn.h"
 
@@ -34,7 +33,6 @@ private slots:
 private:
   void setSaveEnabled(bool enabled);
 
-  std::unique_ptr<IRunPresenter> m_runPresenter;
   std::string m_outputWsName;
   // The ui form
   Ui::MolDyn m_uiForm;

--- a/qt/scientific_interfaces/Indirect/Simulation/Sassena.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/Sassena.cpp
@@ -15,7 +15,7 @@
 namespace MantidQt::CustomInterfaces {
 Sassena::Sassena(QWidget *parent) : SimulationTab(parent) {
   m_uiForm.setupUi(parent);
-  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::Spectra));
 

--- a/qt/scientific_interfaces/Indirect/Simulation/Sassena.h
+++ b/qt/scientific_interfaces/Indirect/Simulation/Sassena.h
@@ -8,7 +8,6 @@
 
 #include "../DllConfig.h"
 #include "Common/RunWidget/IRunSubscriber.h"
-#include "Common/RunWidget/RunPresenter.h"
 #include "SimulationTab.h"
 #include "ui_Sassena.h"
 
@@ -34,7 +33,6 @@ private slots:
 private:
   void setSaveEnabled(bool enabled);
 
-  std::unique_ptr<IRunPresenter> m_runPresenter;
   /// The ui form
   Ui::Sassena m_uiForm;
   /// Name of the output workspace group

--- a/qt/scientific_interfaces/Indirect/Tools/Tools.cpp
+++ b/qt/scientific_interfaces/Indirect/Tools/Tools.cpp
@@ -86,18 +86,6 @@ void Tools::loadSettings() {
   settings.endGroup();
 }
 
-/**
- * Slot to run the underlying algorithm code based on the currently selected
- * tab.
- *
- * This method checks the tabs validate method is passing before calling
- * the run method.
- */
-void Tools::runClicked() {
-  int tabIndex = m_uiForm.ToolsTabs->currentIndex();
-  m_tabs[tabIndex]->runTab();
-}
-
 std::string Tools::documentationPage() const { return "Indirect Tools"; }
 
 Tools::~Tools() = default;

--- a/qt/scientific_interfaces/Indirect/Tools/Tools.cpp
+++ b/qt/scientific_interfaces/Indirect/Tools/Tools.cpp
@@ -32,7 +32,6 @@ void Tools::initLayout() {
   std::map<unsigned int, ToolsTab *>::iterator iter;
   for (iter = m_tabs.begin(); iter != m_tabs.end(); ++iter) {
     connect(iter->second, SIGNAL(showMessageBox(const std::string &)), this, SLOT(showMessageBox(const std::string &)));
-    iter->second->setupTab();
   }
 
   loadSettings();

--- a/qt/scientific_interfaces/Indirect/Tools/Tools.h
+++ b/qt/scientific_interfaces/Indirect/Tools/Tools.h
@@ -43,10 +43,6 @@ public: // public constructor, destructor and functions
 
   void initLayout() override;
 
-private slots:
-  /// Slot for clicking on the run button
-  void runClicked();
-
 private:
   std::string documentationPage() const override;
 

--- a/qt/scientific_interfaces/Indirect/Tools/TransmissionCalc.cpp
+++ b/qt/scientific_interfaces/Indirect/Tools/TransmissionCalc.cpp
@@ -31,12 +31,7 @@ TransmissionCalc::TransmissionCalc(QWidget *parent) : ToolsTab(parent) {
 
   m_uiForm.iicInstrumentConfiguration->updateInstrumentConfigurations(
       m_uiForm.iicInstrumentConfiguration->getInstrumentName());
-}
 
-/*
- * Run any tab setup code.
- */
-void TransmissionCalc::setup() {
   QRegExp chemicalFormulaRegex(R"([A-Za-z0-9\-\(\)]*)");
   QValidator *chemicalFormulaValidator = new QRegExpValidator(chemicalFormulaRegex, this);
   m_uiForm.leChemicalFormula->setValidator(chemicalFormulaValidator);

--- a/qt/scientific_interfaces/Indirect/Tools/TransmissionCalc.cpp
+++ b/qt/scientific_interfaces/Indirect/Tools/TransmissionCalc.cpp
@@ -25,7 +25,7 @@ Mantid::Kernel::Logger g_log("TransmissionCalc");
 namespace MantidQt::CustomInterfaces {
 TransmissionCalc::TransmissionCalc(QWidget *parent) : ToolsTab(parent) {
   m_uiForm.setupUi(parent);
-  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
 
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
 

--- a/qt/scientific_interfaces/Indirect/Tools/TransmissionCalc.h
+++ b/qt/scientific_interfaces/Indirect/Tools/TransmissionCalc.h
@@ -31,9 +31,6 @@ public:
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
 
-protected:
-  void setup() override;
-
 private slots:
   /// Handles completion of the algorithm
   void algorithmComplete(bool error);

--- a/qt/scientific_interfaces/Indirect/Tools/TransmissionCalc.h
+++ b/qt/scientific_interfaces/Indirect/Tools/TransmissionCalc.h
@@ -8,7 +8,6 @@
 
 #include "../DllConfig.h"
 #include "Common/RunWidget/IRunSubscriber.h"
-#include "Common/RunWidget/RunPresenter.h"
 #include "MantidAPI/ExperimentInfo.h"
 #include "ToolsTab.h"
 #include "ui_TransmissionCalc.h"
@@ -36,7 +35,6 @@ private slots:
   void algorithmComplete(bool error);
 
 private:
-  std::unique_ptr<IRunPresenter> m_runPresenter;
   /// The UI form
   Ui::TransmissionCalc m_uiForm;
   /// The name of the current instrument

--- a/qt/scientific_interfaces/Indirect/test/Reduction/ISISEnergyTransferPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/Reduction/ISISEnergyTransferPresenterTest.h
@@ -36,10 +36,12 @@ public:
     auto model = std::make_unique<NiceMock<MockIETModel>>();
     auto algorithmRunner = std::make_unique<NiceMock<MockAlgorithmRunner>>();
 
+    m_runView = std::make_unique<NiceMock<MockRunView>>();
     m_outputOptionsView = std::make_unique<NiceMock<MockOutputPlotOptionsView>>();
     m_instrumentConfig = std::make_unique<NiceMock<MockInstrumentConfig>>();
 
     m_view = std::make_unique<NiceMock<MockIETView>>();
+    ON_CALL(*m_view, getRunView()).WillByDefault(Return(m_runView.get()));
     ON_CALL(*m_view, getPlotOptionsView()).WillByDefault(Return(m_outputOptionsView.get()));
 
     m_model = model.get();
@@ -52,6 +54,7 @@ public:
   }
 
   void tearDown() override {
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&m_runView));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&m_outputOptionsView));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&m_instrumentConfig));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&m_view));
@@ -62,6 +65,7 @@ public:
     m_presenter.reset();
     m_idrUI.reset();
     m_view.reset();
+    m_runView.reset();
     m_outputOptionsView.reset();
     m_instrumentConfig.reset();
   }
@@ -94,7 +98,7 @@ public:
   void test_notifyRunFinished_sets_run_text_to_invalid_if_the_run_files_are_not_valid() {
     ON_CALL(*m_view, isRunFilesValid()).WillByDefault(Return(false));
 
-    EXPECT_CALL(*m_view, setRunButtonText("Invalid Run(s)")).Times(1);
+    EXPECT_CALL(*m_runView, setRunText("Invalid Run(s)")).Times(1);
     EXPECT_CALL(*m_view, setRunFilesEnabled(true)).Times(1);
 
     m_presenter->notifyRunFinished();
@@ -110,7 +114,7 @@ public:
     ON_CALL(*m_model, loadDetailedBalance(filename)).WillByDefault(Return(detailedBalance));
 
     EXPECT_CALL(*m_view, setDetailedBalance(detailedBalance)).Times(1);
-    EXPECT_CALL(*m_view, setRunButtonText("Run")).Times(1);
+    EXPECT_CALL(*m_runView, setRunText("Run")).Times(1);
     EXPECT_CALL(*m_view, setRunFilesEnabled(true)).Times(1);
 
     m_presenter->notifyRunFinished();
@@ -124,6 +128,7 @@ private:
   NiceMock<MockAlgorithmRunner> *m_algorithmRunner;
   std::unique_ptr<NiceMock<MockDataReduction>> m_idrUI;
 
+  std::unique_ptr<NiceMock<MockRunView>> m_runView;
   std::unique_ptr<NiceMock<MockOutputPlotOptionsView>> m_outputOptionsView;
   std::unique_ptr<NiceMock<MockInstrumentConfig>> m_instrumentConfig;
 };

--- a/qt/scientific_interfaces/Indirect/test/Reduction/MockObjects.h
+++ b/qt/scientific_interfaces/Indirect/test/Reduction/MockObjects.h
@@ -74,12 +74,13 @@ public:
   MOCK_CONST_METHOD0(getPlotData, IETPlotData());
   MOCK_CONST_METHOD0(getSaveData, IETSaveData());
   MOCK_CONST_METHOD0(getGroupOutputOption, std::string());
+  MOCK_CONST_METHOD0(getRunView, IRunView *());
   MOCK_CONST_METHOD0(getPlotOptionsView, IOutputPlotOptionsView *());
   MOCK_CONST_METHOD0(getGroupOutputCheckbox, bool());
   MOCK_CONST_METHOD0(getFirstFilename, std::string());
   MOCK_CONST_METHOD0(isRunFilesValid, bool());
-  MOCK_CONST_METHOD1(validateCalibrationFileType, void(UserInputValidator *uiv));
-  MOCK_CONST_METHOD1(validateRebinString, void(UserInputValidator *uiv));
+  MOCK_CONST_METHOD1(validateCalibrationFileType, void(IUserInputValidator *uiv));
+  MOCK_CONST_METHOD1(validateRebinString, void(IUserInputValidator *uiv));
   MOCK_CONST_METHOD2(validateGroupingProperties,
                      std::optional<std::string>(std::size_t const &spectraMin, std::size_t const &spectraMax));
   MOCK_CONST_METHOD0(showRebinWidthPrompt, bool());

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
@@ -26,7 +26,7 @@ namespace MantidQt::CustomInterfaces {
 Quasi::Quasi(QWidget *parent) : BayesFittingTab(parent), m_previewSpec(0) {
   m_uiForm.setupUi(parent);
 
-  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
 
   // Create range selector
   auto eRangeSelector = m_uiForm.ppPlot->addRangeSelector("QuasiERange");

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
@@ -8,7 +8,6 @@
 
 #include "BayesFittingTab.h"
 #include "Common/RunWidget/IRunSubscriber.h"
-#include "Common/RunWidget/RunPresenter.h"
 #include "DllConfig.h"
 #include "ui_Quasi.h"
 
@@ -59,8 +58,6 @@ private:
   void setSaveResultEnabled(bool enabled);
   void setButtonsEnabled(bool enabled);
   void setPlotResultIsPlotting(bool plotting);
-
-  std::unique_ptr<IRunPresenter> m_runPresenter;
 
   std::string m_outputBaseName;
   /// Current preview spectrum

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
@@ -27,7 +27,7 @@ namespace MantidQt::CustomInterfaces {
 ResNorm::ResNorm(QWidget *parent) : BayesFittingTab(parent), m_previewSpec(0) {
   m_uiForm.setupUi(parent);
 
-  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
 
   // Create range selector
   auto eRangeSelector = m_uiForm.ppPlot->addRangeSelector("ResNormERange");

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.h
@@ -8,7 +8,6 @@
 
 #include "BayesFittingTab.h"
 #include "Common/RunWidget/IRunSubscriber.h"
-#include "Common/RunWidget/RunPresenter.h"
 #include "DllConfig.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
@@ -66,8 +65,6 @@ private:
   void setSaveResultEnabled(bool enabled);
   void setButtonsEnabled(bool enabled);
   void setPlotResultIsPlotting(bool plotting);
-
-  std::unique_ptr<IRunPresenter> m_runPresenter;
 
   /// Current preview spectrum
   int m_previewSpec;

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
@@ -25,7 +25,7 @@ namespace MantidQt::CustomInterfaces {
 Stretch::Stretch(QWidget *parent) : BayesFittingTab(parent), m_previewSpec(0), m_save(false) {
   m_uiForm.setupUi(parent);
 
-  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
 
   // Create range selector
   auto eRangeSelector = m_uiForm.ppPlot->addRangeSelector("StretchERange");

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.h
@@ -8,7 +8,6 @@
 
 #include "BayesFittingTab.h"
 #include "Common/RunWidget/IRunSubscriber.h"
-#include "Common/RunWidget/RunPresenter.h"
 #include "DllConfig.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "ui_Stretch.h"
@@ -57,8 +56,6 @@ private:
   void setButtonsEnabled(bool enabled);
   void setPlotResultIsPlotting(bool plotting);
   void setPlotContourIsPlotting(bool plotting);
-
-  std::unique_ptr<IRunPresenter> m_runPresenter;
 
   /// Current preview spectrum
   int m_previewSpec;

--- a/qt/scientific_interfaces/Inelastic/Common/InelasticTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/InelasticTab.cpp
@@ -71,8 +71,6 @@ void InelasticTab::setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter
   m_runPresenter = std::move(presenter);
 }
 
-void InelasticTab::setupTab() { setup(); }
-
 bool InelasticTab::validateTab() { return validate(); }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/Common/InelasticTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/InelasticTab.cpp
@@ -71,18 +71,6 @@ void InelasticTab::setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter
   m_runPresenter = std::move(presenter);
 }
 
-//----------------------------------------------------------------------------------------------
-/** Destructor
- */
-void InelasticTab::runTab() {
-  if (validate()) {
-    m_tabStartTime = DateAndTime::getCurrentTime();
-    run();
-  } else {
-    g_log.warning("Failed to validate indirect tab input!");
-  }
-}
-
 void InelasticTab::setupTab() { setup(); }
 
 bool InelasticTab::validateTab() { return validate(); }

--- a/qt/scientific_interfaces/Inelastic/Common/InelasticTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/InelasticTab.cpp
@@ -71,8 +71,6 @@ void InelasticTab::setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter
   m_runPresenter = std::move(presenter);
 }
 
-bool InelasticTab::validateTab() { return validate(); }
-
 /**
  * Handles generating a Python script for the algorithms run on the current tab.
  */

--- a/qt/scientific_interfaces/Inelastic/Common/InelasticTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/InelasticTab.cpp
@@ -49,7 +49,7 @@ void setPropertyIf(const Algorithm_sptr &algorithm, std::string const &propName,
 namespace MantidQt::CustomInterfaces {
 
 InelasticTab::InelasticTab(QObject *parent)
-    : QObject(parent), m_properties(), m_dblManager(new QtDoublePropertyManager()),
+    : QObject(parent), m_runPresenter(), m_properties(), m_dblManager(new QtDoublePropertyManager()),
       m_blnManager(new QtBoolPropertyManager()), m_grpManager(new QtGroupPropertyManager()),
       m_dblEdFac(new DoubleEditorFactory()), m_tabStartTime(DateAndTime::getCurrentTime()),
       m_tabEndTime(DateAndTime::maximum()), m_plotter(std::make_unique<Widgets::MplCpp::ExternalPlotter>()),
@@ -65,6 +65,10 @@ InelasticTab::InelasticTab(QObject *parent)
   m_valPosDbl->setBottom(tolerance);
 
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmFinished(bool)));
+}
+
+void InelasticTab::setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter) {
+  m_runPresenter = std::move(presenter);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/qt/scientific_interfaces/Inelastic/Common/InelasticTab.h
+++ b/qt/scientific_interfaces/Inelastic/Common/InelasticTab.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "../DllConfig.h"
+#include "Common/RunWidget/RunPresenter.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/ITableWorkspace.h"
@@ -68,6 +69,9 @@ public:
   void displayWarning(std::string const &message);
 
 protected:
+  /// Set the presenter for the run widget
+  void setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter);
+
   /// Run the load algorithms
   bool loadFile(const std::string &filename, const std::string &outputName, const int specMin = -1,
                 const int specMax = -1, bool loadHistory = true);
@@ -105,6 +109,8 @@ protected:
   virtual void run() { throw std::logic_error("InelasticTab::run() called but is not implemented."); }
   /// Overidden by child class.
   virtual bool validate() { throw std::logic_error("InelasticTab::validate() called but is not implemented."); }
+
+  std::unique_ptr<RunPresenter> m_runPresenter;
 
   /// Parent QWidget (if applicable)
   QWidget *m_parentWidget;

--- a/qt/scientific_interfaces/Inelastic/Common/InelasticTab.h
+++ b/qt/scientific_interfaces/Inelastic/Common/InelasticTab.h
@@ -97,14 +97,10 @@ protected:
   /// Function to run an algorithm on a seperate thread
   void runAlgorithm(const Mantid::API::IAlgorithm_sptr &algorithm);
 
-  QString runPythonCode(const QString &code, bool no_output = false);
-
   /// Checks the ADS for a workspace named `workspaceName`,
   /// opens a warning box for plotting/saving if none found
   bool checkADSForPlotSaveWorkspace(const std::string &workspaceName, const bool plotting, const bool warn = true);
 
-  /// Overidden by child class.
-  virtual void setup() {}
   /// Overidden by child class.
   virtual void run() { throw std::logic_error("InelasticTab::run() called but is not implemented."); }
   /// Overidden by child class.
@@ -152,7 +148,6 @@ protected:
   Mantid::API::AnalysisDataServiceImpl &m_adsInstance;
 
 public slots:
-  void setupTab();
   bool validateTab();
   void exportPythonScript();
 

--- a/qt/scientific_interfaces/Inelastic/Common/InelasticTab.h
+++ b/qt/scientific_interfaces/Inelastic/Common/InelasticTab.h
@@ -152,7 +152,6 @@ protected:
   Mantid::API::AnalysisDataServiceImpl &m_adsInstance;
 
 public slots:
-  void runTab();
   void setupTab();
   bool validateTab();
   void exportPythonScript();

--- a/qt/scientific_interfaces/Inelastic/Common/InelasticTab.h
+++ b/qt/scientific_interfaces/Inelastic/Common/InelasticTab.h
@@ -148,7 +148,6 @@ protected:
   Mantid::API::AnalysisDataServiceImpl &m_adsInstance;
 
 public slots:
-  bool validateTab();
   void exportPythonScript();
 
 protected slots:

--- a/qt/scientific_interfaces/Inelastic/Common/InelasticTab.h
+++ b/qt/scientific_interfaces/Inelastic/Common/InelasticTab.h
@@ -101,11 +101,6 @@ protected:
   /// opens a warning box for plotting/saving if none found
   bool checkADSForPlotSaveWorkspace(const std::string &workspaceName, const bool plotting, const bool warn = true);
 
-  /// Overidden by child class.
-  virtual void run() { throw std::logic_error("InelasticTab::run() called but is not implemented."); }
-  /// Overidden by child class.
-  virtual bool validate() { throw std::logic_error("InelasticTab::validate() called but is not implemented."); }
-
   std::unique_ptr<RunPresenter> m_runPresenter;
 
   /// Parent QWidget (if applicable)

--- a/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Common/OutputPlotOptionsPresenter.cpp
@@ -105,7 +105,7 @@ void OutputPlotOptionsPresenter::replaceHandle(const std::string &wsName, const 
 void OutputPlotOptionsPresenter::setWorkspaces(std::vector<std::string> const &workspaces) {
   auto const workspaceNames = m_model->getAllWorkspaceNames(workspaces);
   m_view->setWorkspaces(workspaceNames);
-  handleWorkspaceChanged(workspaceNames.front());
+  handleWorkspaceChanged(!workspaceNames.empty() ? workspaceNames.front() : "");
 }
 
 void OutputPlotOptionsPresenter::setWorkspace(std::string const &plotWorkspace) {

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
@@ -111,7 +111,7 @@ AbsorptionCorrections::AbsorptionCorrections(QWidget *parent)
   std::map<std::string, std::string> actions;
   actions["Plot Spectra"] = "Plot Wavelength";
   actions["Plot Bins"] = "Plot Angle";
-  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraBin, "", actions));
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
@@ -33,10 +33,9 @@ Mantid::Kernel::Logger g_log("ApplyAbsorptionCorrections");
 } // namespace
 
 namespace MantidQt::CustomInterfaces {
-ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent)
-    : CorrectionsTab(parent), m_spectra(0u), m_runPresenter() {
+ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent) : CorrectionsTab(parent), m_spectra(0u) {
   m_uiForm.setupUi(parent);
-  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface));
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
@@ -575,7 +575,9 @@ void CalculatePaalmanPings::saveClicked() {
 
 void CalculatePaalmanPings::runClicked() {
   clearOutputPlotOptionsWorkspaces();
-  runTab();
+  if (validate()) {
+    run();
+  }
 }
 
 void CalculatePaalmanPings::setSampleDensityOptions(QString const &method) {

--- a/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
@@ -91,8 +91,6 @@ CalculatePaalmanPings::CalculatePaalmanPings(QWidget *parent)
   }
 }
 
-void CalculatePaalmanPings::setup() { doValidation(true); }
-
 void CalculatePaalmanPings::validateChemical() { doValidation(true); }
 
 void CalculatePaalmanPings::run() {

--- a/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
@@ -44,6 +44,7 @@ CalculatePaalmanPings::CalculatePaalmanPings(QWidget *parent)
     : CorrectionsTab(parent), m_sampleDensities(std::make_shared<Densities>()),
       m_canDensities(std::make_shared<Densities>()) {
   m_uiForm.setupUi(parent);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
   std::map<std::string, std::string> actions;
   actions["Plot Spectra"] = "Plot Wavelength";
   actions["Plot Bins"] = "Plot Angle";
@@ -59,11 +60,8 @@ CalculatePaalmanPings::CalculatePaalmanPings(QWidget *parent)
   QValidator *formulaValidator = new QRegExpValidator(regex, this);
   m_uiForm.leSampleChemicalFormula->setValidator(formulaValidator);
   m_uiForm.leCanChemicalFormula->setValidator(formulaValidator);
-  connect(m_uiForm.leSampleChemicalFormula, SIGNAL(editingFinished()), this, SLOT(validateChemical()));
-  connect(m_uiForm.leCanChemicalFormula, SIGNAL(editingFinished()), this, SLOT(validateChemical()));
   // Connect slots for run, plot and save
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
 
   // Connect slots for toggling the mass/number density unit
   connect(m_uiForm.cbSampleDensity, SIGNAL(currentIndexChanged(QString const &)), this,
@@ -91,10 +89,99 @@ CalculatePaalmanPings::CalculatePaalmanPings(QWidget *parent)
   }
 }
 
-void CalculatePaalmanPings::validateChemical() { doValidation(true); }
+void CalculatePaalmanPings::handleValidation(IUserInputValidator *validator) const {
+  validator->checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
+  const auto sampleWsName = m_uiForm.dsSample->getCurrentDataName();
+  const auto sampleWsNameStr = sampleWsName.toStdString();
+  bool sampleExists = AnalysisDataService::Instance().doesExist(sampleWsNameStr);
 
-void CalculatePaalmanPings::run() {
-  setRunIsRunning(true);
+  if (sampleExists && !AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(sampleWsNameStr)) {
+    validator->addErrorMessage("Invalid sample workspace. Ensure a MatrixWorkspace is provided.");
+  }
+
+  // Validate chemical formula
+  if (m_uiForm.cbSampleMaterialMethod->currentText() == "Chemical Formula") {
+    if (validator->checkFieldIsNotEmpty("Sample Chemical Formula", m_uiForm.leSampleChemicalFormula,
+                                        m_uiForm.valSampleChemicalFormula))
+      validator->checkFieldIsValid("Sample Chemical Formula", m_uiForm.leSampleChemicalFormula,
+                                   m_uiForm.valSampleChemicalFormula);
+
+    const auto sampleChem = m_uiForm.leSampleChemicalFormula->text().toStdString();
+    try {
+      Mantid::Kernel::Material::parseChemicalFormula(sampleChem);
+    } catch (std::runtime_error &ex) {
+      UNUSED_ARG(ex);
+      validator->addErrorMessage("Chemical Formula for Sample was not recognised.");
+      validator->setErrorLabel(m_uiForm.valSampleChemicalFormula, false);
+    }
+  }
+
+  if (m_uiForm.ckUseCan->isChecked()) {
+    validator->checkDataSelectorIsValid("Can", m_uiForm.dsContainer);
+
+    if (m_uiForm.cbCanMaterialMethod->currentText() == "Chemical Formula") {
+      // Validate chemical formula
+      if (validator->checkFieldIsNotEmpty("Can Chemical Formula", m_uiForm.leCanChemicalFormula,
+                                          m_uiForm.valCanChemicalFormula))
+        validator->checkFieldIsValid("Can Chemical Formula", m_uiForm.leCanChemicalFormula,
+                                     m_uiForm.valCanChemicalFormula);
+
+      const auto containerChem = m_uiForm.leCanChemicalFormula->text().toStdString();
+      try {
+        Mantid::Kernel::Material::parseChemicalFormula(containerChem);
+      } catch (std::runtime_error &ex) {
+        UNUSED_ARG(ex);
+        validator->addErrorMessage("Chemical Formula for Container was not recognised.");
+        validator->setErrorLabel(m_uiForm.valCanChemicalFormula, false);
+      }
+    }
+
+    const auto containerWsName = m_uiForm.dsContainer->getCurrentDataName();
+    const auto containerWsNameStr = containerWsName.toStdString();
+    bool containerExists = AnalysisDataService::Instance().doesExist(containerWsNameStr);
+
+    if (containerExists && !AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(containerWsNameStr)) {
+      validator->addErrorMessage("Invalid container workspace. Ensure a MatrixWorkspace is provided.");
+    }
+
+    // Ensure sample and container are the same kind of data
+    const auto sampleType = sampleWsName.right(sampleWsName.length() - sampleWsName.lastIndexOf("_"));
+    const auto containerType = containerWsName.right(containerWsName.length() - containerWsName.lastIndexOf("_"));
+
+    g_log.debug() << "Sample type is: " << sampleType.toStdString() << '\n';
+    g_log.debug() << "Can type is: " << containerType.toStdString() << '\n';
+
+    if (containerType != sampleType)
+      validator->addErrorMessage("Sample and can workspaces must contain the same type of data.");
+
+    // Shape validation
+
+    const auto shape = m_uiForm.cbSampleShape->currentIndex();
+    if (shape == 1 && m_uiForm.ckUseCan->isChecked()) {
+      auto sampleRadius = m_uiForm.spCylSampleOuterRadius->value();
+      auto containerRadius = m_uiForm.spCylCanOuterRadius->value();
+      if (containerRadius <= sampleRadius) {
+        validator->addErrorMessage("Container radius must be bigger than sample radius");
+      }
+    }
+    if (shape == 2) {
+      auto sampleInnerRadius = m_uiForm.spAnnSampleInnerRadius->value();
+      auto sampleOuterRadius = m_uiForm.spAnnSampleOuterRadius->value();
+      if (sampleOuterRadius <= sampleInnerRadius) {
+        validator->addErrorMessage("Sample outer radius must be bigger than sample inner radius");
+      }
+      if (m_uiForm.ckUseCan->isChecked()) {
+        auto containerRadius = m_uiForm.spAnnCanOuterRadius->value();
+        if (containerRadius <= sampleOuterRadius) {
+          validator->addErrorMessage("Container outer radius must be bigger than sample outer radius");
+        }
+      }
+    }
+  }
+}
+
+void CalculatePaalmanPings::handleRun() {
+  clearOutputPlotOptionsWorkspaces();
 
   // Get correct corrections algorithm
   auto sampleShape = m_uiForm.cbSampleShape->currentText();
@@ -131,7 +218,7 @@ void CalculatePaalmanPings::run() {
     if (convertedSampleWorkspace)
       absCorProps->setPropertyValue("SampleWorkspace", convertedSampleWorkspace.get());
     else {
-      setRunIsRunning(false);
+      m_runPresenter->setRunEnabled(true);
       return;
     }
 
@@ -171,7 +258,7 @@ void CalculatePaalmanPings::run() {
       if (convertedWorkspace)
         absCorProps->setPropertyValue("CanWorkspace", convertedWorkspace.get());
       else {
-        setRunIsRunning(false);
+        m_runPresenter->setRunEnabled(true);
         return;
       }
 
@@ -217,112 +304,6 @@ void CalculatePaalmanPings::run() {
   m_pythonExportWsName = outputWsName.toStdString();
 }
 
-bool CalculatePaalmanPings::validate() { return doValidation(); }
-
-/**
- * Does validation on the user input.
- *
- * @param silent Set to true to avoid creating an error message
- * @return True if all user input is valid
- */
-bool CalculatePaalmanPings::doValidation(bool silent) {
-  UserInputValidator uiv;
-
-  uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
-  const auto sampleWsName = m_uiForm.dsSample->getCurrentDataName();
-  const auto sampleWsNameStr = sampleWsName.toStdString();
-  bool sampleExists = AnalysisDataService::Instance().doesExist(sampleWsNameStr);
-
-  if (sampleExists && !AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(sampleWsNameStr)) {
-    uiv.addErrorMessage("Invalid sample workspace. Ensure a MatrixWorkspace is provided.");
-  }
-
-  // Validate chemical formula
-  if (m_uiForm.cbSampleMaterialMethod->currentText() == "Chemical Formula") {
-    if (uiv.checkFieldIsNotEmpty("Sample Chemical Formula", m_uiForm.leSampleChemicalFormula,
-                                 m_uiForm.valSampleChemicalFormula))
-      uiv.checkFieldIsValid("Sample Chemical Formula", m_uiForm.leSampleChemicalFormula,
-                            m_uiForm.valSampleChemicalFormula);
-
-    const auto sampleChem = m_uiForm.leSampleChemicalFormula->text().toStdString();
-    try {
-      Mantid::Kernel::Material::parseChemicalFormula(sampleChem);
-    } catch (std::runtime_error &ex) {
-      UNUSED_ARG(ex);
-      uiv.addErrorMessage("Chemical Formula for Sample was not recognised.");
-      uiv.setErrorLabel(m_uiForm.valSampleChemicalFormula, false);
-    }
-  }
-
-  if (m_uiForm.ckUseCan->isChecked()) {
-    uiv.checkDataSelectorIsValid("Can", m_uiForm.dsContainer);
-
-    if (m_uiForm.cbCanMaterialMethod->currentText() == "Chemical Formula") {
-      // Validate chemical formula
-      if (uiv.checkFieldIsNotEmpty("Can Chemical Formula", m_uiForm.leCanChemicalFormula,
-                                   m_uiForm.valCanChemicalFormula))
-        uiv.checkFieldIsValid("Can Chemical Formula", m_uiForm.leCanChemicalFormula, m_uiForm.valCanChemicalFormula);
-
-      const auto containerChem = m_uiForm.leCanChemicalFormula->text().toStdString();
-      try {
-        Mantid::Kernel::Material::parseChemicalFormula(containerChem);
-      } catch (std::runtime_error &ex) {
-        UNUSED_ARG(ex);
-        uiv.addErrorMessage("Chemical Formula for Container was not recognised.");
-        uiv.setErrorLabel(m_uiForm.valCanChemicalFormula, false);
-      }
-    }
-
-    const auto containerWsName = m_uiForm.dsContainer->getCurrentDataName();
-    const auto containerWsNameStr = containerWsName.toStdString();
-    bool containerExists = AnalysisDataService::Instance().doesExist(containerWsNameStr);
-
-    if (containerExists && !AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(containerWsNameStr)) {
-      uiv.addErrorMessage("Invalid container workspace. Ensure a MatrixWorkspace is provided.");
-    }
-
-    // Ensure sample and container are the same kind of data
-    const auto sampleType = sampleWsName.right(sampleWsName.length() - sampleWsName.lastIndexOf("_"));
-    const auto containerType = containerWsName.right(containerWsName.length() - containerWsName.lastIndexOf("_"));
-
-    g_log.debug() << "Sample type is: " << sampleType.toStdString() << '\n';
-    g_log.debug() << "Can type is: " << containerType.toStdString() << '\n';
-
-    if (containerType != sampleType)
-      uiv.addErrorMessage("Sample and can workspaces must contain the same type of data.");
-
-    // Shape validation
-
-    const auto shape = m_uiForm.cbSampleShape->currentIndex();
-    if (shape == 1 && m_uiForm.ckUseCan->isChecked()) {
-      auto sampleRadius = m_uiForm.spCylSampleOuterRadius->value();
-      auto containerRadius = m_uiForm.spCylCanOuterRadius->value();
-      if (containerRadius <= sampleRadius) {
-        uiv.addErrorMessage("Container radius must be bigger than sample radius");
-      }
-    }
-    if (shape == 2) {
-      auto sampleInnerRadius = m_uiForm.spAnnSampleInnerRadius->value();
-      auto sampleOuterRadius = m_uiForm.spAnnSampleOuterRadius->value();
-      if (sampleOuterRadius <= sampleInnerRadius) {
-        uiv.addErrorMessage("Sample outer radius must be bigger than sample inner radius");
-      }
-      if (m_uiForm.ckUseCan->isChecked()) {
-        auto containerRadius = m_uiForm.spAnnCanOuterRadius->value();
-        if (containerRadius <= sampleOuterRadius) {
-          uiv.addErrorMessage("Container outer radius must be bigger than sample outer radius");
-        }
-      }
-    }
-  }
-
-  // Show error message if needed
-  if (!uiv.isAllInputValid() && !silent)
-    emit showMessageBox(uiv.generateErrorMessage());
-
-  return uiv.isAllInputValid();
-}
-
 /**
  * Handles completion of the correction algorithm.
  *
@@ -330,7 +311,7 @@ bool CalculatePaalmanPings::doValidation(bool silent) {
  */
 void CalculatePaalmanPings::absCorComplete(bool error) {
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(absCorComplete(bool)));
-  setRunIsRunning(false);
+  m_runPresenter->setRunEnabled(true);
 
   if (!error) {
     // Convert the spectrum axis of correction factors to Q
@@ -375,7 +356,7 @@ void CalculatePaalmanPings::absCorComplete(bool error) {
  */
 void CalculatePaalmanPings::postProcessComplete(bool error) {
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(postProcessComplete(bool)));
-  setRunIsRunning(false);
+  m_runPresenter->setRunEnabled(true);
 
   if (!error) {
     auto const group = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(m_pythonExportWsName);
@@ -571,13 +552,6 @@ void CalculatePaalmanPings::saveClicked() {
   m_batchAlgoRunner->executeBatchAsync();
 }
 
-void CalculatePaalmanPings::runClicked() {
-  clearOutputPlotOptionsWorkspaces();
-  if (validate()) {
-    run();
-  }
-}
-
 void CalculatePaalmanPings::setSampleDensityOptions(QString const &method) {
   setComboBoxOptions(m_uiForm.cbSampleDensity, getDensityOptions(method));
 }
@@ -665,18 +639,6 @@ double CalculatePaalmanPings::getCanDensityValue(QString const &type) const {
   return type == "Mass Density" ? m_canDensities->getMassDensity() : m_canDensities->getNumberDensity();
 }
 
-void CalculatePaalmanPings::setRunEnabled(bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
-
 void CalculatePaalmanPings::setSaveResultEnabled(bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }
-
-void CalculatePaalmanPings::setButtonsEnabled(bool enabled) {
-  setRunEnabled(enabled);
-  setSaveResultEnabled(enabled);
-}
-
-void CalculatePaalmanPings::setRunIsRunning(bool running) {
-  m_uiForm.pbRun->setText(running ? "Running..." : "Run");
-  setButtonsEnabled(!running);
-}
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "Common/RunWidget/IRunSubscriber.h"
 #include "CorrectionsTab.h"
 #include "DllConfig.h"
 #include "ui_CalculatePaalmanPings.h"
@@ -18,20 +19,21 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-class MANTIDQT_INELASTIC_DLL CalculatePaalmanPings : public CorrectionsTab {
+class MANTIDQT_INELASTIC_DLL CalculatePaalmanPings : public CorrectionsTab, public IRunSubscriber {
   Q_OBJECT
 
 public:
   CalculatePaalmanPings(QWidget *parent = nullptr);
+
+  void handleRun();
+  void handleValidation(IUserInputValidator *validator) const;
 
 private slots:
   void absCorComplete(bool error);
   void postProcessComplete(bool error);
   void getBeamWidthFromWorkspace(const QString &wsName);
   void fillCorrectionDetails(const QString &wsName);
-  void validateChemical();
   void saveClicked();
-  void runClicked();
   void setSampleDensityOptions(QString const &method);
   void setCanDensityOptions(QString const &method);
   void setSampleDensityUnit(QString const &text);
@@ -44,12 +46,8 @@ private slots:
   void setCanDensity(double value);
 
 private:
-  void run() override;
-  bool validate() override;
   void loadSettings(const QSettings &settings) override;
   void setFileExtensionsByName(bool filter) override;
-
-  bool doValidation(bool silent = false);
 
   void addShapeSpecificSampleOptions(const Mantid::API::IAlgorithm_sptr &alg, const QString &shape);
   void addShapeSpecificCanOptions(const Mantid::API::IAlgorithm_sptr &alg, const QString &shape);
@@ -63,10 +61,7 @@ private:
   double getSampleDensityValue(QString const &type) const;
   double getCanDensityValue(QString const &type) const;
 
-  void setRunEnabled(bool enabled);
   void setSaveResultEnabled(bool enabled);
-  void setButtonsEnabled(bool enabled);
-  void setRunIsRunning(bool running);
 
   boost::optional<double> getInstrumentParameter(const Mantid::Geometry::Instrument_const_sptr &instrument,
                                                  const std::string &parameterName);

--- a/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.h
@@ -25,8 +25,8 @@ class MANTIDQT_INELASTIC_DLL CalculatePaalmanPings : public CorrectionsTab, publ
 public:
   CalculatePaalmanPings(QWidget *parent = nullptr);
 
-  void handleRun();
-  void handleValidation(IUserInputValidator *validator) const;
+  void handleRun() override;
+  void handleValidation(IUserInputValidator *validator) const override;
 
 private slots:
   void absCorComplete(bool error);

--- a/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.h
@@ -44,7 +44,6 @@ private slots:
   void setCanDensity(double value);
 
 private:
-  void setup() override;
   void run() override;
   bool validate() override;
   void loadSettings(const QSettings &settings) override;

--- a/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.ui
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.ui
@@ -24,11 +24,11 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>918</width>
-        <height>763</height>
+        <width>935</width>
+        <height>718</height>
        </rect>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0,0,1,1,1,0">
+      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,0,0,0,1,1,0,0">
        <item>
         <widget class="QTextEdit" name="textEdit">
          <property name="styleSheet">
@@ -1247,52 +1247,7 @@ p, li { white-space: pre-wrap; }
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="gbRun">
-         <property name="title">
-          <string>Run</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>3</number>
-          </property>
-          <item>
-           <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>265</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="pbRun">
-            <property name="text">
-             <string>Run</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>265</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
+        <widget class="MantidQt::CustomInterfaces::RunView" name="runWidget" native="true"/>
        </item>
        <item>
         <widget class="QGroupBox" name="gbOutput">
@@ -1351,6 +1306,12 @@ p, li { white-space: pre-wrap; }
    <class>MantidQt::CustomInterfaces::OutputPlotOptionsView</class>
    <extends>QWidget</extends>
    <header>Common/OutputPlotOptionsView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::CustomInterfaces::RunView</class>
+   <extends>QWidget</extends>
+   <header>Common/RunWidget/RunView.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
@@ -26,9 +26,9 @@ Mantid::Kernel::Logger g_log("ContainerSubtraction");
 }
 
 namespace MantidQt::CustomInterfaces {
-ContainerSubtraction::ContainerSubtraction(QWidget *parent) : CorrectionsTab(parent), m_spectra(0), m_runPresenter() {
+ContainerSubtraction::ContainerSubtraction(QWidget *parent) : CorrectionsTab(parent), m_spectra(0) {
   m_uiForm.setupUi(parent);
-  m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
+  setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface));
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/Corrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/Corrections.cpp
@@ -57,7 +57,6 @@ void Corrections::initLayout() {
 
   // Set up all tabs
   for (auto &tab : m_tabs) {
-    tab.second->setupTab();
     connect(tab.second, SIGNAL(showMessageBox(const std::string &)), this, SLOT(showMessageBox(const std::string &)));
   }
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
@@ -53,11 +53,6 @@ void CorrectionsTab::loadTabSettings(const QSettings &settings) { loadSettings(s
 void CorrectionsTab::filterInputData(bool filter) { setFileExtensionsByName(filter); }
 
 /**
- * Slot that can be called when a user edits an input.
- */
-void CorrectionsTab::inputChanged() { validate(); }
-
-/**
  * Check that the binning between two workspaces matches.
  *
  * @param left :: left hand workspace for the equality operator

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.h
@@ -97,10 +97,6 @@ protected:
   /// QtCheckBoxFactory
   QtCheckBoxFactory *m_blnEdFac;
 
-protected slots:
-  /// Slot that can be called when a user eidts an input.
-  void inputChanged();
-
 private:
   virtual void loadSettings(const QSettings &settings) = 0;
   virtual void setFileExtensionsByName(bool filter) = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
@@ -33,10 +33,6 @@ void DataProcessor::setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOpti
   m_plotOptionsPresenter = std::move(presenter);
 }
 
-void DataProcessor::setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter) {
-  m_runPresenter = std::move(presenter);
-}
-
 void DataProcessor::clearOutputPlotOptionsWorkspaces() { m_plotOptionsPresenter->clearWorkspaces(); }
 
 void DataProcessor::setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces) {

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
@@ -47,8 +47,6 @@ public:
 
   /// Set the presenter for the output plotting options
   void setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter);
-  /// Set the presenter for the run widget
-  void setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter);
 
   /// Clear the workspaces held by the output plotting options
   void clearOutputPlotOptionsWorkspaces();
@@ -63,7 +61,6 @@ private slots:
 
 protected:
   virtual void runComplete(bool error) { (void)error; };
-  std::unique_ptr<RunPresenter> m_runPresenter;
 
 private:
   virtual void setFileExtensionsByName(bool filter) { (void)filter; };

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessorInterface.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessorInterface.h
@@ -92,7 +92,6 @@ private:
     std::unique_ptr<TabModel> tabModel = std::make_unique<TabModel>();
     auto presenter = std::make_unique<TabPresenter>(tabContent, new TabView(tabContent), std::move(tabModel));
 
-    presenter->setupTab();
     tabContent->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
     connect(presenter.get(), SIGNAL(showMessageBox(const std::string &)), this,

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
@@ -25,8 +25,6 @@ FitTab::FitTab(QWidget *parent, std::string const &tabName)
   m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm->runWidget);
 }
 
-void FitTab::setup() { updateOutputOptions(false); }
-
 void FitTab::setupOutputOptionsPresenter(bool const editResults) {
   auto model = std::make_unique<FitOutputOptionsModel>();
   auto plotter = std::make_unique<Widgets::MplCpp::ExternalPlotter>();

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
@@ -19,7 +19,7 @@ namespace Inelastic {
 
 FitTab::FitTab(QWidget *parent, std::string const &tabName)
     : InelasticTab(parent), m_uiForm(new Ui::FitTab), m_dataPresenter(), m_fittingPresenter(), m_plotPresenter(),
-      m_runPresenter(), m_outOptionsPresenter() {
+      m_outOptionsPresenter() {
   m_uiForm->setupUi(parent);
   parent->setWindowTitle(QString::fromStdString(tabName));
   m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm->runWidget);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
@@ -113,8 +113,6 @@ public:
   void handleRun() override;
 
 private:
-  void setup() override;
-
   void updateParameterEstimationData();
   void updateDataReferences();
   void updateFitFunction();

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
@@ -8,7 +8,6 @@
 
 #include "Common/InelasticTab.h"
 #include "Common/RunWidget/IRunSubscriber.h"
-#include "Common/RunWidget/RunPresenter.h"
 #include "DllConfig.h"
 #include "FitDataPresenter.h"
 #include "FitOutputOptionsPresenter.h"
@@ -127,7 +126,6 @@ private:
   std::unique_ptr<FitDataPresenter> m_dataPresenter;
   std::unique_ptr<FittingPresenter> m_fittingPresenter;
   std::unique_ptr<FitPlotPresenter> m_plotPresenter;
-  std::unique_ptr<IRunPresenter> m_runPresenter;
   std::unique_ptr<FitOutputOptionsPresenter> m_outOptionsPresenter;
 };
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/QENSFitting.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/QENSFitting.cpp
@@ -31,7 +31,6 @@ QENSFitting::QENSFitting(QWidget *parent)
 void QENSFitting::initLayout() {
   // Set up all tabs
   for (auto &tab : m_tabs) {
-    tab.second->setupTab();
     connect(tab.second, SIGNAL(showMessageBox(const std::string &)), this, SLOT(showMessageBox(const std::string &)));
   }
 


### PR DESCRIPTION
### Description of work
This PR removes duplicate code from the Data Reduction interface and ensures it uses the new RunWidget. It also removes the `setup()`, `validate()` and `run()` functions from all remaining tab classes because we no longer require to use them. We also do not require `runTab` and `validateTab`.

Having the RunWidget will allow us to work on two new features detailed by #37418 and #37201 . It allows us to easily roll out these new features to all tabs in the Indirect and Inelastic interfaces.

Fixes #37381

### To test:
Follow the testing instructions on this page https://developer.mantidproject.org/Testing/Indirect/DataReductionTests.html

*This does not require release notes* because **it is a maintenance change**


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
