### PR TITLE
Fix nightly version regex in delete nightly workflow

### DIFF
--- a/.github/workflows/delete_old_nightly_releases.yml
+++ b/.github/workflows/delete_old_nightly_releases.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           keep_latest: 3
           # Nightly tags are of the form v{major}.{minor}.{date}.{time}
-          delete_tag_regex: v\d\.\d\.\d{8}\.\d{4}
+          delete_tag_regex: v\d+\.\d+\.\d{8}\.\d{4}
           prerelease_only: true
           delete_tags: true
         env:


### PR DESCRIPTION
### Description of work
Generalise the regex for matching nightly release version numbers in the workflow that deletes old nightly releases and tags. Previously it was looking for nightly version numbers that only had a single digit for major and minor release numbers. Now the major and minor version number can have one or more digits.

#### Purpose of work
The workflow stopped working when we went to v6.10.0

*There is no associated issue.*

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Put the regex `v\d+\.\d+\.\d{8}\.\d{4}` into [regex101](https://regex101.com/) and try it out with different version numbers. Make sure it matches nightly-like version numbers (`v{major}.{minor}.{yyyymmdd}.{tttt}`) and nothing else.
- I have tested the new regex on a sandbox repo where I created a bunch of tags. You can look at the output [here](https://github.com/thomashampson/sandbox/actions/runs/9790449328/job/27032086003). Before running there were these tags:
![image](https://github.com/mantidproject/mantid/assets/8058899/cbf1e18a-2632-4c8b-90e5-52c2edd41097)
After running there were these tags:
![image](https://github.com/mantidproject/mantid/assets/8058899/5162b52e-d60c-4e82-955f-da948238b345)
The workflow is supposed to leave three nightly tags of the form `v{major}.{minor}.{yyyymmdd}.{tttt}`, and it has done that.



*This does not require release notes* because **it's a fix to a github action**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
