### PR TITLE
Prevent crash on Bayes Fitting Quasi

### DIFF
--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37642.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37642.rst
@@ -1,0 +1,2 @@
+- Fixed a crash on the Quasi tab of the :ref:`Inelastic Bayes Fitting <interface-inelastic-bayes-fitting>` interface caused by attempting to load a WorkspaceGroup rather than the expected Workspace2D.
+- Prevented a crash on the Quasi tab of the :ref:`Inelastic Bayes Fitting <interface-inelastic-bayes-fitting>` interface caused by clicking `Run` before data has finished loading.

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
@@ -65,9 +65,11 @@ Quasi::Quasi(QWidget *parent) : BayesFittingTab(parent), m_previewSpec(0) {
 
   // Connect the data selector for the sample to the mini plot
   connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this, SLOT(handleSampleInputReady(const QString &)));
+  connect(m_uiForm.dsSample, SIGNAL(filesAutoLoaded()), this, SLOT(enableView()));
 
   connect(m_uiForm.dsResolution, SIGNAL(dataReady(const QString &)), this,
           SLOT(handleResolutionInputReady(const QString &)));
+  connect(m_uiForm.dsResolution, SIGNAL(filesAutoLoaded()), this, SLOT(enableView()));
 
   // Connect the program selector to its handler
   connect(m_uiForm.cbProgram, SIGNAL(currentIndexChanged(int)), this, SLOT(handleProgramChange(int)));
@@ -86,6 +88,12 @@ Quasi::Quasi(QWidget *parent) : BayesFittingTab(parent), m_previewSpec(0) {
   m_uiForm.dsResolution->isOptional(true);
   m_uiForm.dsSample->setWorkspaceTypes({"Workspace2D"});
   m_uiForm.dsResolution->setWorkspaceTypes({"Workspace2D"});
+}
+
+void Quasi::enableView(bool const enable) {
+  m_uiForm.dsSample->setEnabled(enable);
+  m_uiForm.dsResolution->setEnabled(enable);
+  m_runPresenter->setRunText(enable ? "Run" : "Loading...");
 }
 
 /**
@@ -324,6 +332,7 @@ void Quasi::updateMiniPlot() {
  * @param filename :: The name of the workspace to plot
  */
 void Quasi::handleSampleInputReady(const QString &filename) {
+  enableView(true);
   auto &ads = AnalysisDataService::Instance();
   if (!ads.doesExist(filename.toStdString())) {
     return;
@@ -375,6 +384,8 @@ void Quasi::plotCurrentPreview() {
  * @param wsName The name of the workspace loaded
  */
 void Quasi::handleResolutionInputReady(const QString &wsName) {
+  enableView(true);
+
   bool isResolution(wsName.endsWith("_res"));
 
   m_uiForm.chkUseResNorm->setEnabled(isResolution);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
@@ -84,6 +84,8 @@ Quasi::Quasi(QWidget *parent) : BayesFittingTab(parent), m_previewSpec(0) {
   // Allows empty workspace selector when initially selected
   m_uiForm.dsSample->isOptional(true);
   m_uiForm.dsResolution->isOptional(true);
+  m_uiForm.dsSample->setWorkspaceTypes({"Workspace2D"});
+  m_uiForm.dsResolution->setWorkspaceTypes({"Workspace2D"});
 }
 
 /**
@@ -322,8 +324,15 @@ void Quasi::updateMiniPlot() {
  * @param filename :: The name of the workspace to plot
  */
 void Quasi::handleSampleInputReady(const QString &filename) {
-  MatrixWorkspace_sptr inWs = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(filename.toStdString());
-  int numHist = static_cast<int>(inWs->getNumberHistograms()) - 1;
+  auto &ads = AnalysisDataService::Instance();
+  if (!ads.doesExist(filename.toStdString())) {
+    return;
+  }
+  auto const sampleWs = ads.retrieveWS<MatrixWorkspace>(filename.toStdString());
+  if (!sampleWs) {
+    return;
+  }
+  int numHist = static_cast<int>(sampleWs->getNumberHistograms()) - 1;
   m_uiForm.spPreviewSpectrum->setMaximum(numHist);
   updateMiniPlot();
 

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
@@ -45,6 +45,7 @@ private slots:
   void updateMiniPlot();
   /// Handles what happen after the algorithm is run
   void algorithmComplete(bool error);
+  void enableView(bool const enable = false);
 
   void plotClicked();
   void plotCurrentPreview();

--- a/qt/widgets/common/src/DataSelector.cpp
+++ b/qt/widgets/common/src/DataSelector.cpp
@@ -181,6 +181,21 @@ bool DataSelector::isValid() {
                                                "missing from the analysis data "
                                                "service");
         }
+      } else {
+        auto &ads = AnalysisDataService::Instance();
+        if (!ads.doesExist(wsName)) {
+          return isValid;
+        }
+        auto const workspaceTypes = m_uiForm.wsWorkspaceInput->getWorkspaceTypes();
+        auto const workspace = ads.retrieveWS<Workspace>(wsName);
+        isValid = workspaceTypes.empty() || workspaceTypes.indexOf(QString::fromStdString(workspace->id())) != -1;
+        if (!isValid) {
+          m_uiForm.rfFileInput->setFileProblem("The specified workspace type (" +
+                                               QString::fromStdString(workspace->id()) +
+                                               ") is "
+                                               "not one of the allowed types: " +
+                                               workspaceTypes.join(", "));
+        }
       }
     }
   } else {

--- a/scripts/Inelastic/IndirectCommon.py
+++ b/scripts/Inelastic/IndirectCommon.py
@@ -293,13 +293,15 @@ def check_analysers_are_equal(in1WS, in2WS):
         analyser_1 = ws1.getInstrument().getStringParameter("analyser")[0]
         reflection_1 = ws1.getInstrument().getStringParameter("reflection")[0]
     except IndexError:
-        raise RuntimeError("Could not find analyser or reflection for workspace %s" % in1WS)
+        # Ignore this check if an analyser or reflection cannot be found
+        return
     ws2 = s_api.mtd[in2WS]
     try:
         analyser_2 = ws2.getInstrument().getStringParameter("analyser")[0]
         reflection_2 = ws2.getInstrument().getStringParameter("reflection")[0]
     except:
-        raise RuntimeError("Could not find analyser or reflection for workspace %s" % in2WS)
+        # Ignore this check if an analyser or reflection cannot be found
+        return
 
     if analyser_1 != analyser_2:
         raise ValueError("Workspace %s and %s have different analysers" % (ws1, ws2))

--- a/scripts/Inelastic/IndirectCommon.py
+++ b/scripts/Inelastic/IndirectCommon.py
@@ -133,6 +133,12 @@ def getEfixed(workspace):
         if analyser_comp is not None and analyser_comp.hasParameter("Efixed"):
             return analyser_comp.getNumberParameter("EFixed")[0]
 
+    if efixed_log := try_get_sample_log(workspace, "EFixed"):
+        return float(efixed_log)
+    # For Direct data, we can use "Ei" in the sample logs as EFixed
+    if ei_log := try_get_sample_log(workspace, "Ei"):
+        return float(ei_log)
+
     raise ValueError("No Efixed parameter found")
 
 
@@ -312,9 +318,8 @@ def check_analysers_are_equal(in1WS, in2WS):
 
 
 def get_sample_log(workspace, log_name):
-    table = s_api.CreateLogPropertyTable(workspace, log_name, EnableLogging=False)
+    table = s_api.CreateLogPropertyTable(workspace, log_name, EnableLogging=False, StoreInADS=False)
     log_value = table.cell(0, 0) if table else None
-    s_api.DeleteWorkspace(table, EnableLogging=False)
     return log_value
 
 

--- a/scripts/test/IndirectCommonTests.py
+++ b/scripts/test/IndirectCommonTests.py
@@ -73,6 +73,20 @@ class IndirectCommonTests(unittest.TestCase):
         ws = CreateSampleWorkspace()
         self.assertRaises(ValueError, indirect_common.getEfixed, ws.name())
 
+    def test_getEFixed_with_no_instrument_but_efixed_sample_log(self):
+        ws = self.make_dummy_workspace_without_instrument("test_ws1")
+        AddSampleLog(ws, LogName="EFixed", LogType="Number", LogText="1.83")
+
+        e_fixed = indirect_common.getEfixed(ws)
+        self.assertEqual(e_fixed, 1.83, "The EFixed value does not match the expected value")
+
+    def test_getEFixed_with_no_instrument_but_ei_sample_log(self):
+        ws = self.make_dummy_workspace_without_instrument("test_ws1")
+        AddSampleLog(ws, LogName="Ei", LogType="Number", LogText="1.83")
+
+        e_fixed = indirect_common.getEfixed(ws)
+        self.assertEqual(e_fixed, 1.83, "The EFixed value does not match the expected value")
+
     def test_getDefaultWorkingDirectory(self):
         path = os.path.join(os.path.expanduser("~"), "")
         config["defaultsave.directory"] = path

--- a/scripts/test/IndirectCommonTests.py
+++ b/scripts/test/IndirectCommonTests.py
@@ -12,6 +12,7 @@ Data Analysis, and Bayes.
 import unittest
 import numpy as np
 
+from mantid.api import AnalysisDataService
 from mantid.simpleapi import *
 import IndirectCommon as indirect_common
 
@@ -277,6 +278,27 @@ class IndirectCommonTests(unittest.TestCase):
 
         self.assert_table_workspace_dimensions(params_table, expected_row_count=26, expected_column_count=3)
         self.assert_table_workspace_dimensions(output_name, expected_row_count=5, expected_column_count=11)
+
+    def test_identify_non_zero_bin_range_returns_the_non_zero_bin_range(self):
+        ws = self.make_dummy_QENS_workspace()
+        e_min, e_max = indirect_common.identify_non_zero_bin_range(AnalysisDataService.retrieve(ws), 0)
+
+        self.assertEqual(0.0, e_min)
+        self.assertEqual(20000.0, e_max)
+
+    def test_identify_non_zero_bin_range_returns_the_expected_range_for_leading_zeros(self):
+        ws = CreateWorkspace(DataX="1,2,3,4,5", DataY="0,1,2,1,3", StoreInADS=False)
+        e_min, e_max = indirect_common.identify_non_zero_bin_range(ws, 0)
+
+        self.assertEqual(2.0, e_min)
+        self.assertEqual(5.0, e_max)
+
+    def test_identify_non_zero_bin_range_returns_the_expected_range_for_trailing_zeros(self):
+        ws = CreateWorkspace(DataX="1,2,3,4,5", DataY="4,1,2,0,0", StoreInADS=False)
+        e_min, e_max = indirect_common.identify_non_zero_bin_range(ws, 0)
+
+        self.assertEqual(1.0, e_min)
+        self.assertEqual(3.0, e_max)
 
     # -----------------------------------------------------------
     # Custom assertion functions

--- a/scripts/test/IndirectCommonTests.py
+++ b/scripts/test/IndirectCommonTests.py
@@ -139,10 +139,10 @@ class IndirectCommonTests(unittest.TestCase):
 
         self.assertRaises(ValueError, indirect_common.CheckAnalysersOrEFixed, ws1, ws2)
 
-    def test_CheckAnalysersOrEFixed_raises_runtimeError_with_no_inst_data(self):
+    def test_CheckAnalysersOrEFixed_does_not_raise_error_with_no_inst_data(self):
         ws1 = self.make_dummy_workspace_without_instrument("test_ws1")
         ws2 = self.make_dummy_workspace_without_instrument("test_ws2")
-        self.assertRaises(RuntimeError, indirect_common.CheckAnalysersOrEFixed, ws1, ws2)
+        self.assert_does_not_raise(RuntimeError, indirect_common.CheckAnalysersOrEFixed, ws1, ws2)
 
     def test_CheckHistZero(self):
         ws = self.make_dummy_QENS_workspace()


### PR DESCRIPTION
**Report to:** Mona Sarter and Spencer Howells

### Description of work
This PR fixes several issues on the Quasi tab of the Inelastic Bayes Fitting interface:
- The Sample and Resolution Data Selectors and Run button are now disabled while data is loading
- If a dataset does not have an "analyser" or "resolution", then a check to see if these two match for the sample and resolution is now skipped.  This is because we want to be able to use this interface for LET data, which do not have an equivalent for a instrument "analyser" or "resolution"
- The data selectors for Sample and Resolution will show a warning if you attempt to load a WorkspaceGroup (or anything that is not a Workspace2D) after clicking Run.

Fixes #37639

### To test:
Follow the Quasi test instructions here:
https://developer.mantidproject.org/Testing/Inelastic/BayesFittingTests.html#quasi-tab

1. Attempt to load the following files in Bayes Fitting Quasi tab:
Sample - [stv_01_inc_Subtract_EC_red.zip](https://github.com/user-attachments/files/16124479/stv_01_inc_Subtract_EC_red.zip)

Resolution - [res2_01_inc_Subtract_EC_red.zip](https://github.com/user-attachments/files/16124481/res2_01_inc_Subtract_EC_red.zip)

2. While loading, the Run button and Data Selector widgets should be disabled.
3. When loading is finished, they should be re-enabled
4. Click `Run`
8. It should run successfully - (but a poor fit)
9. Change the Emax to be around 0.4
10. Click Run. The fit should be better this time

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
