### PR TITLE
Draw peak marker using cached position if no detector

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -108,6 +108,7 @@ public:
   double getAzimuthal() const override;
   double getDSpacing() const override;
   double getTOF() const override;
+  const Mantid::Kernel::V3D &getCachedDetectorPosition() const { return detPos; }
 
   double getInitialEnergy() const override;
   double getFinalEnergy() const override;

--- a/docs/source/release/v6.11.0/Workbench/InstrumentViewer/Bugfixes/37514.rst
+++ b/docs/source/release/v6.11.0/Workbench/InstrumentViewer/Bugfixes/37514.rst
@@ -1,0 +1,1 @@
+- Fixed crash in the instrument view when trying to overlay peaks that do not have a corresponding detector.

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
@@ -61,6 +61,8 @@ public:
   ~PanelsSurface() override;
   void init() override;
   void project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const override;
+  void project(const Mantid::Kernel::V3D &position, double &u, double &v, double &uscale,
+               double &vscale) const override;
   void resetInstrumentActor(const IInstrumentActor *rootActor) override;
 
 protected:

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedCylinder.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedCylinder.h
@@ -22,6 +22,8 @@ public:
 
 protected:
   void project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const override;
+  void project(const Mantid::Kernel::V3D &position, double &u, double &v, double &uscale,
+               double &vscale) const override;
   void rotate(const UnwrappedDetector &udet, Mantid::Kernel::Quat &R) const override;
 };
 } // namespace MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSphere.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSphere.h
@@ -23,6 +23,8 @@ public:
 protected:
   void rotate(const UnwrappedDetector &udet, Mantid::Kernel::Quat &R) const override;
   void project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const override;
+  void project(const Mantid::Kernel::V3D &position, double &u, double &v, double &uscale,
+               double &vscale) const override;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSurface.h
@@ -98,6 +98,24 @@ public:
   virtual void project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const = 0;
   //@}
 
+  /*
+   * Project a point in the 3D space onto the surface. The method returns the u-
+   *and v- coordinates of the projection
+   * as well as the scaling factors along the u and v axes. The scaling factors
+   *help to draw an approximate projection
+   * of a 3D object on the surface which is an orthographic projection of the
+   *object onto the tagent plane to the
+   * surface at point (uv) and scaled along u and v by the corresponding factor.
+   *
+   * @param position :: The position of a detector
+   * @param u (output) :: u-coordinate of the projection.
+   * @param v (output) :: v-coordinate of the projection.
+   * @param uscale (output) :: The scaling factor along the u-coordinate.
+   * @param vscale (output) :: The scaling factor along the v-coordinate.
+   */
+  virtual void project(const Mantid::Kernel::V3D &position, double &u, double &v, double &uscale,
+                       double &vscale) const = 0;
+
   /** @name Public methods */
   //@{
   /// Toggle between the normal view and the "filpped" view (from behind)

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -313,6 +313,11 @@ void PanelsSurface::project(const size_t detIndex, double &u, double &v, double 
 
 void PanelsSurface::project(const Mantid::Kernel::V3D &position, double &u, double &v, double &uscale,
                             double &vscale) const {
+  UNUSED_ARG(position);
+  UNUSED_ARG(u);
+  UNUSED_ARG(v);
+  UNUSED_ARG(uscale);
+  UNUSED_ARG(vscale);
   throw std::runtime_error("A detector ID is required to project with a PanelsSurface.");
 }
 

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -311,6 +311,11 @@ void PanelsSurface::project(const size_t detIndex, double &u, double &v, double 
   uscale = vscale = 1.0;
 }
 
+void PanelsSurface::project(const Mantid::Kernel::V3D &position, double &u, double &v, double &uscale,
+                            double &vscale) const {
+  throw std::runtime_error("A detector ID is required to project with a PanelsSurface.");
+}
+
 void PanelsSurface::rotate(const UnwrappedDetector &udet, Mantid::Kernel::Quat &R) const {
   const auto &detectorInfo = m_instrActor->detectorInfo();
   const int index = m_detector2bankMap[udet.detIndex];

--- a/qt/widgets/instrumentview/src/PeakOverlay.cpp
+++ b/qt/widgets/instrumentview/src/PeakOverlay.cpp
@@ -264,7 +264,8 @@ void PeakOverlay::createMarkers(const PeakMarker2D::Style &style) {
       r->setPeak(peak, i);
       addMarker(r);
     } catch (const std::runtime_error &ex) {
-      g_log.error(ex.what());
+      g_log.error("Error creating marker for peak " + std::to_string(i) + " with detector ID " +
+                  std::to_string(peak.getDetectorID()) + ". " + ex.what());
       return;
     }
   }

--- a/qt/widgets/instrumentview/src/PeakOverlay.cpp
+++ b/qt/widgets/instrumentview/src/PeakOverlay.cpp
@@ -9,6 +9,8 @@
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidDataObjects/Peak.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidQtWidgets/InstrumentView/UnwrappedCylinder.h"
+#include "MantidQtWidgets/InstrumentView/UnwrappedSphere.h"
 #include "MantidQtWidgets/InstrumentView/UnwrappedSurface.h"
 
 #include <QList>
@@ -238,8 +240,9 @@ void PeakOverlay::createMarkers(const PeakMarker2D::Style &style) {
   for (int i = 0; i < nPeaks; ++i) {
     Mantid::Geometry::IPeak &peak = getPeak(i);
     int detID;
+    Mantid::DataObjects::Peak peakFull;
     try {
-      auto peakFull = dynamic_cast<Mantid::DataObjects::Peak &>(peak);
+      peakFull = dynamic_cast<Mantid::DataObjects::Peak &>(peak);
       detID = peakFull.getDetectorID();
     } catch (std::bad_cast &) {
       g_log.error("Cannot create markers for this type of peak");
@@ -249,8 +252,12 @@ void PeakOverlay::createMarkers(const PeakMarker2D::Style &style) {
     try {
       double u, v, uscale, vscale;
       auto &detInfo = m_peaksWorkspace->detectorInfo();
-      auto detIndex = detInfo.indexOf(detID);
-      m_surface->project(detIndex, u, v, uscale, vscale);
+      if (detID >= 0) {
+        auto detIndex = detInfo.indexOf(detID);
+        m_surface->project(detIndex, u, v, uscale, vscale);
+      } else {
+        m_surface->project(peakFull.getCachedDetectorPosition(), u, v, uscale, vscale);
+      }
       // Create a peak marker at this position
       PeakMarker2D *r =
           new PeakMarker2D(*this, u, v, m_peakIntensityScale->getScaledMarker(peak.getIntensity(), style));

--- a/qt/widgets/instrumentview/src/UnwrappedCylinder.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedCylinder.cpp
@@ -30,9 +30,14 @@ UnwrappedCylinder::UnwrappedCylinder(const InstrumentActor *rootActor, const Man
 void UnwrappedCylinder::project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const {
   const auto &componentInfo = m_instrActor->componentInfo();
   auto pos = componentInfo.position(detIndex) - m_pos;
-  double z = pos.scalar_prod(m_zaxis);
-  double x = pos.scalar_prod(m_xaxis);
-  double y = pos.scalar_prod(m_yaxis);
+  project(pos, u, v, uscale, vscale);
+}
+
+void UnwrappedCylinder::project(const Mantid::Kernel::V3D &position, double &u, double &v, double &uscale,
+                                double &vscale) const {
+  double z = position.scalar_prod(m_zaxis);
+  double x = position.scalar_prod(m_xaxis);
+  double y = position.scalar_prod(m_yaxis);
   // use equal area cylindrical projection with v = sin(latitude), u = longitude
   v = z / sqrt(x * x + y * y + z * z);
   u = applyUCorrection(-atan2(y, x));

--- a/qt/widgets/instrumentview/src/UnwrappedSphere.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedSphere.cpp
@@ -30,10 +30,15 @@ UnwrappedSphere::UnwrappedSphere(const InstrumentActor *rootActor, const Mantid:
 void UnwrappedSphere::project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const {
   const auto &componentInfo = m_instrActor->componentInfo();
   auto pos = componentInfo.position(detIndex) - m_pos;
+  project(pos, u, v, uscale, vscale);
+}
+
+void UnwrappedSphere::project(const Mantid::Kernel::V3D &position, double &u, double &v, double &uscale,
+                              double &vscale) const {
   // projection to cylinder axis
-  v = pos.scalar_prod(m_zaxis);
-  double x = pos.scalar_prod(m_xaxis);
-  double y = pos.scalar_prod(m_yaxis);
+  v = position.scalar_prod(m_zaxis);
+  double x = position.scalar_prod(m_xaxis);
+  double y = position.scalar_prod(m_yaxis);
 
   double r = sqrt(x * x + y * y + v * v);
   uscale = 1. / sqrt(x * x + y * y);

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
@@ -6,12 +6,14 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidQtWidgets/Common/MessageHandler.h"
 #include "MantidQtWidgets/InstrumentView/IGLDisplay.h"
 #include "MantidQtWidgets/InstrumentView/IQtDisplay.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidget.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h"
 
 #include "MockGLDisplay.h"
+#include "MockInstrumentActor.h"
 #include "MockInstrumentDisplay.h"
 #include "MockInstrumentWidgetMaskTab.h"
 #include "MockMessageHandler.h"
@@ -23,7 +25,10 @@
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/Workspace.h"
+#include "MantidDataObjects/Peak.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidKernel/V3D.h"
 
 #include <QObject>
 
@@ -71,7 +76,8 @@ public:
       auto displayMock = makeDisplay();
       EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(glMock.get()));
 
-      auto instance = construct("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 22, useLoadingThread);
+      auto instance = constructWithProjectionSurface("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 22,
+                                                     useLoadingThread);
 
       if (useLoadingThread) {
         InstrumentActor &actor = instance.getInstrumentActor();
@@ -89,7 +95,8 @@ public:
       auto glMock = makeGL();
       auto displayMock = makeDisplay();
       EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(qtMock.get()));
-      auto instance = construct("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 24, useLoadingThread);
+      auto instance = constructWithProjectionSurface("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 24,
+                                                     useLoadingThread);
 
       if (useLoadingThread) {
         InstrumentActor &actor = instance.getInstrumentActor();
@@ -111,7 +118,8 @@ public:
       auto displayMock = makeDisplay();
       EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(glMock.get()));
 
-      auto widget = construct("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 22, useLoadingThread);
+      auto widget = constructWithProjectionSurface("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 22,
+                                                   useLoadingThread);
 
       if (useLoadingThread) {
         InstrumentActor &actor = widget.getInstrumentActor();
@@ -135,7 +143,8 @@ public:
       auto displayMock = makeDisplay();
       EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(qtMock.get()));
 
-      auto widget = construct("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 24, useLoadingThread);
+      auto widget = constructWithProjectionSurface("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 24,
+                                                   useLoadingThread);
 
       if (useLoadingThread) {
         InstrumentActor &actor = widget.getInstrumentActor();
@@ -155,7 +164,8 @@ public:
       EXPECT_CALL(*glMock, updateDetectors()).Times(1);
       EXPECT_CALL(*displayMock, currentWidget()).Times(2).WillRepeatedly(Return(glMock.get()));
 
-      auto widget = construct("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 22, useLoadingThread);
+      auto widget = constructWithProjectionSurface("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 22,
+                                                   useLoadingThread);
 
       if (useLoadingThread) {
         InstrumentActor &actor = widget.getInstrumentActor();
@@ -175,7 +185,8 @@ public:
       auto displayMock = makeDisplay();
       EXPECT_CALL(*qtMock, updateDetectors()).Times(1);
       EXPECT_CALL(*displayMock, currentWidget()).Times(2).WillRepeatedly(Return(qtMock.get()));
-      auto widget = construct("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 22, useLoadingThread);
+      auto widget = constructWithProjectionSurface("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 22,
+                                                   useLoadingThread);
 
       if (useLoadingThread) {
         InstrumentActor &actor = widget.getInstrumentActor();
@@ -199,7 +210,8 @@ public:
       EXPECT_CALL(*glMock, updateDetectors()).Times(1);
       EXPECT_CALL(*displayMock, currentWidget()).Times(2).WillRepeatedly(Return(glMock.get()));
 
-      auto widget = construct("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 24, useLoadingThread);
+      auto widget = constructWithProjectionSurface("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 24,
+                                                   useLoadingThread);
 
       if (useLoadingThread) {
         InstrumentActor &actor = widget.getInstrumentActor();
@@ -221,7 +233,8 @@ public:
       EXPECT_CALL(*qtMock, updateDetectors()).Times(1);
       EXPECT_CALL(*displayMock, currentWidget()).Times(2).WillRepeatedly(Return(qtMock.get()));
 
-      auto widget = construct("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 24, useLoadingThread);
+      auto widget = constructWithProjectionSurface("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 24,
+                                                   useLoadingThread);
 
       if (useLoadingThread) {
         InstrumentActor &actor = widget.getInstrumentActor();
@@ -242,7 +255,8 @@ public:
         auto displayMock = makeDisplay();
         EXPECT_CALL(*displayMock, currentWidget()).Times(1).WillOnce(Return(glMock.get()));
         EXPECT_CALL(*displayMock, updateView(expected)).Times(1);
-        auto widget = construct("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 22, useLoadingThread);
+        auto widget = constructWithProjectionSurface("test_ws", std::move(displayMock), qtMock.get(), glMock.get(), 22,
+                                                     useLoadingThread);
 
         if (useLoadingThread) {
           InstrumentActor &actor = widget.getInstrumentActor();
@@ -263,7 +277,8 @@ public:
       auto displayMock = makeDisplay();
       EXPECT_CALL(*displayMock, currentWidget()).Times(3).WillRepeatedly(Return(qtMock.get()));
 
-      auto widget = construct(wsname, std::move(displayMock), qtMock.get(), glMock.get(), 46, useLoadingThread);
+      auto widget = constructWithProjectionSurface(wsname, std::move(displayMock), qtMock.get(), glMock.get(), 46,
+                                                   useLoadingThread);
 
       if (useLoadingThread) {
         InstrumentActor &actor = widget.getInstrumentActor();
@@ -299,6 +314,30 @@ public:
     draw_tab_save_actions("test_ws_d", 2);
   }
 
+  void test_peak_with_no_detector() {
+    for (const bool useLoadingThread : {true, false}) {
+      auto qtMock = makeQtDisplay();
+      auto glMock = makeGL();
+      auto displayMock = makeDisplay();
+      EXPECT_CALL(*displayMock, currentWidget()).WillRepeatedly(Return(qtMock.get()));
+
+      auto widget = constructWithUnwrappedSurface("test_ws", std::move(displayMock), qtMock.get(), glMock.get(),
+                                                  useLoadingThread);
+      widget.setViewType("CYLINDRICAL_X");
+
+      auto createPeaksWs = Mantid::API::AlgorithmManager::Instance().create("CreatePeaksWorkspace");
+      createPeaksWs->setRethrows(true);
+      createPeaksWs->setProperty("InstrumentWorkspace", "test_ws");
+      createPeaksWs->setProperty("OutputWorkspace", "peaks");
+      createPeaksWs->execute();
+      auto ws = AnalysisDataService::Instance().retrieve("peaks");
+      auto peaksWs = std::dynamic_pointer_cast<IPeaksWorkspace>(ws);
+      auto peak = Mantid::DataObjects::Peak(peaksWs->getInstrument(), Mantid::Kernel::V3D(1, 1, 1));
+      peaksWs->addPeak(peak);
+      TS_ASSERT_THROWS_NOTHING(widget.overlay("peaks"));
+    }
+  }
+
 private:
   bool m_glEnabledOriginal = true;
   bool m_glEnabled = true;
@@ -314,39 +353,56 @@ private:
     Mantid::Kernel::ConfigService::Instance().setString("MantidOptions.InstrumentView.UseOpenGL", stateStr);
   }
 
-  void mockConnect(MockQtConnect &mock, const char *signal, const char *slot) const {
-    EXPECT_CALL(mock, connect(_, StrEq(signal), _, StrEq(slot))).Times(1);
+  void mockConnect(MockQtConnect &mock, const char *signal, const char *slot, const bool checkNumberOfCalls) const {
+    if (checkNumberOfCalls) {
+      EXPECT_CALL(mock, connect(_, StrEq(signal), _, StrEq(slot))).Times(1);
+    } else {
+      EXPECT_CALL(mock, connect(_, StrEq(signal), _, StrEq(slot))).Times(testing::AtLeast(1));
+    }
   }
 
-  std::unique_ptr<ConnectMock> makeConnect(const bool useLoadingThread) const {
+  std::unique_ptr<ConnectMock> makeConnect(const bool useLoadingThread, const bool checkNumberOfCalls = true) const {
     auto mock = std::make_unique<ConnectMock>();
-    mockConnect(*mock, SIGNAL(enableLighting(bool)), SLOT(enableLighting(bool)));
+    mockConnect(*mock, SIGNAL(enableLighting(bool)), SLOT(enableLighting(bool)), checkNumberOfCalls);
 
-    mockConnect(*mock, SIGNAL(changed(double, double)), SLOT(setIntegrationRange(double, double)));
-    mockConnect(*mock, SIGNAL(clicked()), SLOT(helpClicked()));
-    mockConnect(*mock, SIGNAL(setAutoscaling(bool)), SLOT(setColorMapAutoscaling(bool)));
-    mockConnect(*mock, SIGNAL(rescaleColorMap()), SLOT(setupColorMap()));
+    mockConnect(*mock, SIGNAL(changed(double, double)), SLOT(setIntegrationRange(double, double)), checkNumberOfCalls);
+    mockConnect(*mock, SIGNAL(clicked()), SLOT(helpClicked()), checkNumberOfCalls);
+    mockConnect(*mock, SIGNAL(setAutoscaling(bool)), SLOT(setColorMapAutoscaling(bool)), checkNumberOfCalls);
+    mockConnect(*mock, SIGNAL(rescaleColorMap()), SLOT(setupColorMap()), checkNumberOfCalls);
     mockConnect(*mock, SIGNAL(executeAlgorithm(const QString &, const QString &)),
-                SLOT(executeAlgorithm(const QString &, const QString &)));
-    mockConnect(*mock, SIGNAL(changed(double, double)), SLOT(changedIntegrationRange(double, double)));
-    mockConnect(*mock, SIGNAL(currentChanged(int)), SLOT(tabChanged(int)));
-    mockConnect(*mock, SIGNAL(triggered()), SLOT(clearPeakOverlays()));
-    mockConnect(*mock, SIGNAL(triggered()), SLOT(clearAlignmentPlane()));
+                SLOT(executeAlgorithm(const QString &, const QString &)), checkNumberOfCalls);
+    mockConnect(*mock, SIGNAL(changed(double, double)), SLOT(changedIntegrationRange(double, double)),
+                checkNumberOfCalls);
+    mockConnect(*mock, SIGNAL(currentChanged(int)), SLOT(tabChanged(int)), checkNumberOfCalls);
+    mockConnect(*mock, SIGNAL(triggered()), SLOT(clearPeakOverlays()), checkNumberOfCalls);
+    mockConnect(*mock, SIGNAL(triggered()), SLOT(clearAlignmentPlane()), checkNumberOfCalls);
 
     EXPECT_CALL(*mock, connect(_, StrEq(SIGNAL(needSetIntegrationRange(double, double))), _,
                                StrEq(SLOT(setIntegrationRange(double, double))), Qt::QueuedConnection))
         .Times(1);
     mockConnect(*mock, SIGNAL(executeAlgorithm(Mantid::API::IAlgorithm_sptr)),
-                SLOT(executeAlgorithm(Mantid::API::IAlgorithm_sptr)));
+                SLOT(executeAlgorithm(Mantid::API::IAlgorithm_sptr)), checkNumberOfCalls);
 
     if (useLoadingThread) {
-      mockConnect(*mock, SIGNAL(initWidget(bool, bool)), SLOT(initWidget(bool, bool)));
-      EXPECT_CALL(*mock, connect(_, StrEq(SIGNAL(destroyed())), _, StrEq(SLOT(threadFinished())))).Times(2);
+      mockConnect(*mock, SIGNAL(initWidget(bool, bool)), SLOT(initWidget(bool, bool)), checkNumberOfCalls);
+      if (checkNumberOfCalls) {
+        EXPECT_CALL(*mock, connect(_, StrEq(SIGNAL(destroyed())), _, StrEq(SLOT(threadFinished())))).Times(2);
+      } else {
+        EXPECT_CALL(*mock, connect(_, StrEq(SIGNAL(destroyed())), _, StrEq(SLOT(threadFinished()))))
+            .Times(testing::AtLeast(1));
+      }
     }
 
-    EXPECT_CALL(*mock,
-                connect(_, StrEq(SIGNAL(updateInfoText())), _, StrEq(SLOT(updateInfoText())), Qt::QueuedConnection))
-        .Times(1);
+    if (checkNumberOfCalls) {
+
+      EXPECT_CALL(*mock,
+                  connect(_, StrEq(SIGNAL(updateInfoText())), _, StrEq(SLOT(updateInfoText())), Qt::QueuedConnection))
+          .Times(1);
+    } else {
+      EXPECT_CALL(*mock,
+                  connect(_, StrEq(SIGNAL(updateInfoText())), _, StrEq(SLOT(updateInfoText())), Qt::QueuedConnection))
+          .Times(testing::AtLeast(1));
+    }
     return mock;
   }
 
@@ -363,8 +419,9 @@ private:
     return mock;
   }
 
-  InstrumentWidget construct(QString wsname, std::unique_ptr<DisplayMock> displayMock, QtMock *qtMock, GLMock *glMock,
-                             const int getSurfaceCalls, const bool useLoadingThread) const {
+  InstrumentWidget constructWithProjectionSurface(QString wsname, std::unique_ptr<DisplayMock> displayMock,
+                                                  QtMock *qtMock, GLMock *glMock, const int getSurfaceCalls,
+                                                  const bool useLoadingThread) const {
 
     auto metaObjectMock = makeMetaObject(useLoadingThread);
     auto connectMock = makeConnect(useLoadingThread);
@@ -377,6 +434,34 @@ private:
 
     EXPECT_CALL(*displayMock, getSurface()).Times(getSurfaceCalls).WillRepeatedly(Return(surfaceMock));
     EXPECT_CALL(*displayMock, setSurfaceProxy(_)).Times(1);
+    EXPECT_CALL(*displayMock, installEventFilter(NotNull())).Times(1);
+
+    auto detIDs = std::vector<size_t>{0, 1};
+    EXPECT_CALL(*surfaceMock, getMaskedDetectors(_)).WillRepeatedly(SetArgReferee<0>(detIDs));
+    EXPECT_CALL(*surfaceMock, setInteractionMode(_)).Times(testing::AtLeast(1));
+
+    InstrumentWidget::Dependencies deps{std::move(displayMock),    nullptr,      nullptr, std::move(connectMock),
+                                        std::move(metaObjectMock), makeMessage()};
+
+    return InstrumentWidget(wsname, nullptr, true, true, 0.0, 0.0, true, std::move(deps), useLoadingThread);
+  }
+
+  InstrumentWidget constructWithUnwrappedSurface(QString wsname, std::unique_ptr<DisplayMock> displayMock,
+                                                 QtMock *qtMock, GLMock *glMock, const bool useLoadingThread) const {
+
+    auto metaObjectMock = makeMetaObject(useLoadingThread);
+    auto connectMock = makeConnect(useLoadingThread, false);
+
+    ON_CALL(*displayMock, getGLDisplay()).WillByDefault(Return(glMock));
+    ON_CALL(*displayMock, getQtDisplay()).WillByDefault(Return(qtMock));
+
+    auto messageHandler = MantidQt::MantidWidgets::MessageHandler();
+    auto instrumentActor = new InstrumentActor(wsname.toStdString(), messageHandler);
+    auto surfaceMock = std::make_shared<MockUnwrappedSphere>(instrumentActor);
+    EXPECT_CALL(*glMock, currentBackgroundColor()).Times(1);
+
+    EXPECT_CALL(*displayMock, getSurface()).Times(testing::AtLeast(1)).WillRepeatedly(Return(surfaceMock));
+    EXPECT_CALL(*displayMock, setSurfaceProxy(_)).Times(testing::AtLeast(1));
     EXPECT_CALL(*displayMock, installEventFilter(NotNull())).Times(1);
 
     auto detIDs = std::vector<size_t>{0, 1};

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockProjectionSurface.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockProjectionSurface.h
@@ -8,6 +8,7 @@
 
 #include "MantidQtWidgets/InstrumentView/GLDisplay.h"
 #include "MantidQtWidgets/InstrumentView/ProjectionSurface.h"
+#include "MantidQtWidgets/InstrumentView/UnwrappedSphere.h"
 
 #include <gmock/gmock.h>
 
@@ -16,6 +17,20 @@ class MockProjectionSurface : public ProjectionSurface {
 public:
   MockProjectionSurface() : ProjectionSurface(nullptr) {}
   virtual ~MockProjectionSurface() = default;
+  MOCK_METHOD(void, init, (), (override));
+  MOCK_METHOD(void, componentSelected, (size_t), (override));
+  MOCK_METHOD(void, getSelectedDetectors, (std::vector<size_t> &), (override));
+  MOCK_METHOD(void, getMaskedDetectors, (std::vector<size_t> &), (const, override));
+  MOCK_METHOD(void, drawSurface, (GLDisplay *, bool), (const, override));
+  MOCK_METHOD(void, changeColorMap, (), (override));
+  MOCK_METHOD(void, setInteractionMode, (int), (override));
+};
+
+class MockUnwrappedSphere : public UnwrappedSphere {
+public:
+  MockUnwrappedSphere(const InstrumentActor *rootActor)
+      : UnwrappedSphere(rootActor, Mantid::Kernel::V3D(), Mantid::Kernel::V3D(0, 0, 1), QSize(), true) {}
+  virtual ~MockUnwrappedSphere() = default;
   MOCK_METHOD(void, init, (), (override));
   MOCK_METHOD(void, componentSelected, (size_t), (override));
   MOCK_METHOD(void, getSelectedDetectors, (std::vector<size_t> &), (override));

--- a/qt/widgets/instrumentview/test/InstrumentWidget/PanelsSurfaceTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/PanelsSurfaceTest.h
@@ -27,6 +27,10 @@ public:
   void project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const override {
     PanelsSurface::project(detIndex, u, v, uscale, vscale);
   }
+  void project(const Mantid::Kernel::V3D &position, double &u, double &v, double &uscale,
+               double &vscale) const override {
+    PanelsSurface::project(position, u, v, uscale, vscale);
+  }
   Mantid::Kernel::Quat calcBankRotation(const Mantid::Kernel::V3D &detPos, Mantid::Kernel::V3D normal) {
     return PanelsSurface::calcBankRotation(detPos, normal);
   }


### PR DESCRIPTION
Peaks have a cached position, but they may not have a detector, so we can't just rely on the detector ID to draw the marker.

Fixes #37514 

Peaks have a cached position, which is where the position is stored when there's no corresponding detector. This can happen because it is possible to have peaks beyond the bounds of any detector, which is what is occurring the files in the linked issue. I added a method to the `UnwrappedSurface` base class to project a position onto the surface, so in `PeakOverlay::createMarkers()` we can use that method combined with the cached peak position. It's not possible to do this with a `PanelsSurface`, the code requires a detector, but in that case we shouldn't have a detectorless peak in the first place, plus there's a try-catch there just in case. Previously if this had happened it would have caused a sad mantid anyway.

### To test:
See #37514 for how to reproduce.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
