### PR TITLE
Use original sample to normalise randomized sample

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CalculateIqt.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CalculateIqt.h
@@ -43,8 +43,7 @@ private:
   API::MatrixWorkspace_sptr replaceSpecialValues(const API::MatrixWorkspace_sptr &workspace);
 
   API::MatrixWorkspace_sptr removeInvalidData(API::MatrixWorkspace_sptr workspace);
-  API::MatrixWorkspace_sptr normalizedFourierTransform(API::MatrixWorkspace_sptr workspace,
-                                                       const std::string &rebinParams, const bool enforceNormalization);
+  API::MatrixWorkspace_sptr fourierTransform(API::MatrixWorkspace_sptr workspace, const std::string &rebinParams);
   API::MatrixWorkspace_sptr calculateIqt(API::MatrixWorkspace_sptr workspace,
                                          const API::MatrixWorkspace_sptr &resolutionWorkspace,
                                          const std::string &rebinParams, const bool enforceNormalization);
@@ -54,6 +53,9 @@ private:
   API::MatrixWorkspace_sptr
   setErrorsToStandardDeviation(const std::vector<API::MatrixWorkspace_sptr> &simulatedWorkspaces);
   API::MatrixWorkspace_sptr setErrorsToZero(const std::vector<API::MatrixWorkspace_sptr> &simulatedWorkspaces);
+
+  API::MatrixWorkspace_sptr m_sampleIntegral;
+  API::MatrixWorkspace_sptr m_resolutionIntegral;
 };
 
 } // namespace Algorithms

--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37653.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37653.rst
@@ -1,0 +1,1 @@
+- Fixed a bug in the Monte Carlo error calculation on the I(Q, t) tab of the :ref:`Data Processor Interface <interface-inelastic-data-processor>` where the first bin had an error of zero.


### PR DESCRIPTION
### Description of work
This PR fixes a bug where the error value for the first bin in the monte carlo error calculation was zero.

In the latest changes, the randomized sample used for calculating the errors is now normalised by the integral of the original sample. Previously, the randomized sample would be normalised by the integral of the current randomized sample, leading to a near-zero error bar for the first bin.

### To test:
1. Open Inelastic->Data Processor interface
2. Load the `irs26176_graphite002_red` as sample from the sample data
3. Load the `irs26173_graphite002_res` as resolution from the sample data
4. Tick `Enforce Normalisation`.
5. Click Run. Wait. Plot the first spectrum of the result `_iqt` workspace with error bars:
![image](https://github.com/mantidproject/mantid/assets/40830825/95a1ec32-84eb-4479-b148-f7ad1f40d18e)
6. Notice the error for the first bin is non-zero
7. Untick `Enforce Normalisation`.
8. Click Run. Wait. Plot the first spectrum of the result `_iqt` workspace with error bars:
![image](https://github.com/mantidproject/mantid/assets/40830825/acb5c2b0-fa27-4922-953b-d09ba2828156)


9. Tick `Enforce Normalisation`.
10. Click Run. 
11. Open Inelastic-> QENS Fitting
12. Load the `_iqt` workspace from the ADS
13. Select `Fit Type` to be Stretched Exp
14. Select `Background` to be `Flat Background`
15. Click Run and wait.
16. The Chi squared above the Function Browser should be roughly 1.28 . Previously this was higher

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
