### PR TITLE
Add ability to load A0 parameters to Function(Q) tab

### DIFF
--- a/docs/source/interfaces/inelastic/Inelastic QENS Fitting.rst
+++ b/docs/source/interfaces/inelastic/Inelastic QENS Fitting.rst
@@ -232,6 +232,8 @@ tab as seen in the :ref:`elwin-example-workflow`.
 8. In the **Output** section, select the **Msd** parameter and then click **Plot**. This plots the
    Msd parameter which can be found within the _Results group workspace.
 
+.. _iqtfit:
+
 I(Q, t)
 -------
 
@@ -437,9 +439,20 @@ This interface can be used for a jump diffusion fit as well as fitting across
 EISF. This is done by means of the
 :ref:`QENSFitSequential <algm-QENSFitSequential>` algorithm.
 
-The fit types available in Function(Q) are :ref:`ChudleyElliot <func-ChudleyElliot>`, :ref:`HallRoss <func-Hall-Ross>`,
-:ref:`FickDiffusion <func-FickDiffusion>`, :ref:`TeixeiraWater <func-TeixeiraWater>`, :ref:`EISFDiffCylinder <func-EISFDiffCylinder>`,
-:ref:`EISFDiffSphere <func-EISFDiffSphere>` and :ref:`EISFDiffSphereAlkyl <func-EISFDiffSphereAlkyl>`.
+This interface can load :math:`A0`, :math:`EISF`, :math:`Width` or :math:`FWHM` fitting
+parameters. The fit types available for each of these are listed below:
+
++----------------+---------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Fit Parameter  | Produced on         | Available fit types                                                                                                                                               |
++================+=====================+===================================================================================================================================================================+
+| A0             | :ref:`iqtfit` tab   | :ref:`EISFDiffCylinder <func-EISFDiffCylinder>`, :ref:`EISFDiffSphere <func-EISFDiffSphere>`, :ref:`EISFDiffSphereAlkyl <func-EISFDiffSphereAlkyl>`               |
++----------------+---------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| EISF           | :ref:`convfit` tab  | :ref:`EISFDiffCylinder <func-EISFDiffCylinder>`, :ref:`EISFDiffSphere <func-EISFDiffSphere>`, :ref:`EISFDiffSphereAlkyl <func-EISFDiffSphereAlkyl>`               |
++----------------+---------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Width          | :ref:`convfit` tab  | :ref:`ChudleyElliot <func-ChudleyElliot>`, :ref:`HallRoss <func-Hall-Ross>`, :ref:`FickDiffusion <func-FickDiffusion>`, :ref:`TeixeiraWater <func-TeixeiraWater>` |
++----------------+---------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| FWHM           | :ref:`convfit` tab  | :ref:`ChudleyElliot <func-ChudleyElliot>`, :ref:`HallRoss <func-Hall-Ross>`, :ref:`FickDiffusion <func-FickDiffusion>`, :ref:`TeixeiraWater <func-TeixeiraWater>` |
++----------------+---------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. interface:: QENS Fitting
   :width: 450

--- a/docs/source/release/v6.11.0/Inelastic/New_features/37657.rst
+++ b/docs/source/release/v6.11.0/Inelastic/New_features/37657.rst
@@ -1,0 +1,1 @@
+- Added the ability to load `A0` fit parameter data into the `Function (Q)` tab of the :ref:`QENS Fitting <interface-inelastic-qens-fitting>` interface.

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionModel.cpp
@@ -271,7 +271,12 @@ std::unordered_map<std::string, std::string> ConvolutionModel::mapDefaultParamet
 }
 
 void ConvolutionModel::addSampleLogs() {
-  AddSampleLogRunner addSampleLog(getResultWorkspace(), getResultGroup());
+  auto const result = getResultWorkspace();
+  auto const group = getResultGroup();
+  if (!result || !group) {
+    return;
+  }
+  AddSampleLogRunner addSampleLog(result, group);
   addSampleLog("resolution_filename", boost::algorithm::join(getNames(m_resolution), ","), "String");
 
   if (m_temperature && m_temperature.get() != 0.0) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
@@ -71,7 +71,7 @@ public:
   }
 
   template <typename FittingModel> void setupFittingPresenter() {
-    auto jobRunner = std::make_unique<MantidQt::API::QtJobRunner>();
+    auto jobRunner = std::make_unique<MantidQt::API::QtJobRunner>(true);
     auto algorithmRunner = std::make_unique<MantidQt::API::AlgorithmRunner>(std::move(jobRunner));
     auto model = std::make_unique<FittingModel>();
     m_fittingPresenter = std::make_unique<FittingPresenter>(this, m_uiForm->dockArea->m_fitPropertyBrowser,

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.cpp
@@ -205,7 +205,10 @@ IFunction_sptr extractFirstInnerFunction(const std::string &function) {
 
 template <typename WorkspaceType>
 std::shared_ptr<WorkspaceType> getWorkspaceOutput(const IAlgorithm_sptr &algorithm, const std::string &propertyName) {
-  return AnalysisDataService::Instance().retrieveWS<WorkspaceType>(algorithm->getProperty(propertyName));
+  auto &ads = AnalysisDataService::Instance();
+  if (ads.doesExist(algorithm->getProperty(propertyName)))
+    return ads.retrieveWS<WorkspaceType>(algorithm->getProperty(propertyName));
+  return nullptr;
 }
 
 WorkspaceGroup_sptr getOutputResult(const IAlgorithm_sptr &algorithm) {
@@ -619,7 +622,7 @@ void FittingModel::cleanFailedRun(const IAlgorithm_sptr &fittingAlgorithm) {
   const auto prefix = "__" + fittingAlgorithm->name() + "_ws";
 
   auto group = getOutputGroup(fittingAlgorithm);
-  if (group->size() == 1u) {
+  if (group && group->size() == 1u) {
     const auto base = prefix + std::to_string(m_fitPlotModel->getActiveWorkspaceID().value + 1);
     removeFromADSIfExists(base);
     cleanTemporaries(base + "_0");

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.cpp
@@ -440,6 +440,9 @@ void FittingModel::addOutput(IAlgorithm_sptr fitAlgorithm) {
   auto group = getOutputGroup(fitAlgorithm);
   auto parameters = getOutputParameters(fitAlgorithm);
   auto result = getOutputResult(fitAlgorithm);
+  if (!group || !parameters || !result) {
+    return;
+  }
   if (group->size() == 1u) {
     m_fitFunction = FunctionFactory::Instance().createInitialized(fitAlgorithm->getPropertyValue("Function"));
   } else {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.ui
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.ui
@@ -50,6 +50,11 @@
             <string>EISF</string>
            </property>
           </item>
+          <item>
+           <property name="text">
+            <string>A0</string>
+           </property>
+          </item>
          </widget>
         </item>
         <item row="1" column="0">

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.cpp
@@ -5,12 +5,12 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "FunctionQDataPresenter.h"
+
 #include "FitTab.h"
 #include "FitTabConstants.h"
-#include "MantidAPI/TextAxis.h"
 #include "ParameterEstimation.h"
 
-#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/TextAxis.h"
 
 namespace {
 using namespace MantidQt::CustomInterfaces::Inelastic;
@@ -23,114 +23,25 @@ std::string createSpectra(const std::vector<std::size_t> &spectrum) {
   return spectra;
 }
 
-std::string getHWHMName(const std::string &resultName) {
-  auto position = resultName.rfind("_FWHM");
-  if (position != std::string::npos)
-    return resultName.substr(0, position) + "_HWHM" + resultName.substr(position + 5, resultName.size());
-  return resultName + "_HWHM";
-}
-
-void deleteTemporaryWorkspaces(std::vector<std::string> const &workspaceNames) {
-  auto deleter = AlgorithmManager::Instance().create("DeleteWorkspace");
-  deleter->setLogging(false);
-  for (const auto &name : workspaceNames) {
-    deleter->setProperty("Workspace", name);
-    deleter->execute();
+void replaceAxisLabel(TextAxis *axis, std::size_t const index, std::string const &fromStr, std::string const &toStr) {
+  auto label = axis->label(index);
+  auto const position = label.find(fromStr);
+  if (position == std::string::npos) {
+    return;
   }
+  label.replace(position, fromStr.length(), toStr);
+  axis->setLabel(index, label);
 }
 
-std::string scaleWorkspace(std::string const &inputName, std::string const &outputName, double factor) {
-  auto scaleAlg = AlgorithmManager::Instance().create("Scale");
-  scaleAlg->initialize();
-  scaleAlg->setLogging(false);
-  scaleAlg->setProperty("InputWorkspace", inputName);
-  scaleAlg->setProperty("OutputWorkspace", outputName);
-  scaleAlg->setProperty("Factor", factor);
-  scaleAlg->execute();
-  return outputName;
-}
-
-std::string extractSpectra(std::string const &inputName, int startIndex, int endIndex, std::string const &outputName) {
-  auto extractAlg = AlgorithmManager::Instance().create("ExtractSpectra");
-  extractAlg->initialize();
-  extractAlg->setLogging(false);
-  extractAlg->setProperty("InputWorkspace", inputName);
-  extractAlg->setProperty("StartWorkspaceIndex", startIndex);
-  extractAlg->setProperty("EndWorkspaceIndex", endIndex);
-  extractAlg->setProperty("OutputWorkspace", outputName);
-  extractAlg->execute();
-  return outputName;
-}
-
-std::string extractSpectrum(const MatrixWorkspace_sptr &workspace, int index, std::string const &outputName) {
-  return extractSpectra(workspace->getName(), index, index, outputName);
-}
-
-std::string extractHWHMSpectrum(const MatrixWorkspace_sptr &workspace, int index) {
-  auto const scaledName = "__scaled_" + std::to_string(index);
-  auto const extractedName = "__extracted_" + std::to_string(index);
-  auto const outputName = scaleWorkspace(extractSpectrum(workspace, index, extractedName), scaledName, 0.5);
-  deleteTemporaryWorkspaces({extractedName});
-  return outputName;
-}
-
-std::string appendWorkspace(std::string const &lhsName, std::string const &rhsName, std::string const &outputName) {
-  auto appendAlg = AlgorithmManager::Instance().create("AppendSpectra");
-  appendAlg->initialize();
-  appendAlg->setLogging(false);
-  appendAlg->setProperty("InputWorkspace1", lhsName);
-  appendAlg->setProperty("InputWorkspace2", rhsName);
-  appendAlg->setProperty("OutputWorkspace", outputName);
-  appendAlg->execute();
-  return outputName;
-}
-
-MatrixWorkspace_sptr appendAll(std::vector<std::string> const &workspaces, std::string const &outputName) {
-  auto appended = workspaces[0];
-  for (auto i = 1u; i < workspaces.size(); ++i)
-    appended = appendWorkspace(appended, workspaces[i], outputName);
-  return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(appended);
-}
-
-std::vector<std::string> subdivideWidthWorkspace(const MatrixWorkspace_sptr &workspace,
-                                                 const std::vector<std::size_t> &widthSpectra) {
-  std::vector<std::string> subworkspaces;
-  subworkspaces.reserve(1 + 2 * widthSpectra.size());
-
-  int start = 0;
-  for (const auto &spectrum_number : widthSpectra) {
-    const auto spectrum = static_cast<int>(spectrum_number);
-    if (spectrum > start) {
-      auto const outputName = "__extracted_" + std::to_string(start) + "_to_" + std::to_string(spectrum);
-      subworkspaces.emplace_back(extractSpectra(workspace->getName(), start, spectrum - 1, outputName));
+void convertWidthToHWHM(MatrixWorkspace_sptr workspace, const std::vector<std::size_t> &widthSpectra) {
+  for (auto const &spectrumIndex : widthSpectra) {
+    if (auto axis = dynamic_cast<TextAxis *>(workspace->getAxis(1))) {
+      replaceAxisLabel(axis, spectrumIndex, "Width", "HWHM");
+      replaceAxisLabel(axis, spectrumIndex, "FWHM", "HWHM");
+      workspace->mutableY(spectrumIndex) *= 0.5;
+      workspace->mutableE(spectrumIndex) *= 0.5;
     }
-    subworkspaces.emplace_back(extractHWHMSpectrum(workspace, spectrum));
-    start = spectrum + 1;
   }
-
-  const int end = static_cast<int>(workspace->getNumberHistograms());
-  if (start < end) {
-    auto const outputName = "__extracted_" + std::to_string(start) + "_to_" + std::to_string(end);
-    subworkspaces.emplace_back(extractSpectra(workspace->getName(), start, end - 1, outputName));
-  }
-  return subworkspaces;
-}
-
-MatrixWorkspace_sptr createHWHMWorkspace(MatrixWorkspace_sptr workspace, const std::string &hwhmName,
-                                         const std::vector<std::size_t> &widthSpectra) {
-  if (widthSpectra.empty())
-    return workspace;
-  if (AnalysisDataService::Instance().doesExist(hwhmName))
-    return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(hwhmName);
-
-  const auto subworkspaces = subdivideWidthWorkspace(workspace, widthSpectra);
-  const auto hwhmWorkspace = appendAll(subworkspaces, hwhmName);
-  auto axis = dynamic_cast<TextAxis *>(workspace->getAxis(1)->clone(hwhmWorkspace.get()));
-  hwhmWorkspace->replaceAxis(1, std::unique_ptr<TextAxis>(axis));
-
-  deleteTemporaryWorkspaces(subworkspaces);
-
-  return hwhmWorkspace;
 }
 
 } // namespace
@@ -170,18 +81,17 @@ void FunctionQDataPresenter::addWorkspace(const std::string &workspaceName, cons
   if (workspace->y(0).size() == 1)
     throw std::invalid_argument("Workspace contains only one data point.");
 
-  const auto name = getHWHMName(workspace->getName());
-  const auto hwhmWorkspace = createHWHMWorkspace(workspace, name, parameters.spectra("Width"));
+  convertWidthToHWHM(workspace, parameters.spectra("Width"));
   m_tab->handleFunctionListChanged(chooseFunctionQFunctions(paramType == "Width"));
   const auto singleSpectra = FunctionModelSpectra(std::to_string(parameters.spectra(paramType)[spectrum_index]));
-  m_model->addWorkspace(hwhmWorkspace->getName(), singleSpectra);
+  m_model->addWorkspace(workspace->getName(), singleSpectra);
 }
 
 std::map<std::string, std::string> FunctionQDataPresenter::chooseFunctionQFunctions(bool paramWidth) const {
   if (m_view->isTableEmpty()) // when first data is added to table, it can only be either WIDTH or EISF
     return paramWidth ? FunctionQ::WIDTH_FITS : FunctionQ::EISF_FITS;
 
-  bool widthFuncs = paramWidth || m_view->dataColumnContainsText("FWHM");
+  bool widthFuncs = paramWidth || m_view->dataColumnContainsText("HWHM");
   bool eisfFuncs = !paramWidth || m_view->dataColumnContainsText("EISF") || m_view->dataColumnContainsText("A0");
   if (widthFuncs && eisfFuncs)
     return FunctionQ::ALL_FITS;
@@ -241,13 +151,12 @@ void FunctionQDataPresenter::setActiveWorkspaceIDToCurrentWorkspace(MantidWidget
   //  and the vector in m_fitDataModel which is in the base class
   //  FittingModel get table workspace index
   auto const &wsName = dialog->workspaceName();
-  auto const hwhmWsName = wsName + "_HWHM";
   // This a vector of workspace names currently loaded
   auto const wsVector = m_model->getWorkspaceNames();
   // this is an iterator pointing to the current wsName in wsVector
-  auto wsIt = std::find(wsVector.cbegin(), wsVector.cend(), hwhmWsName);
+  auto wsIt = std::find(wsVector.cbegin(), wsVector.cend(), wsName);
   if (wsIt == wsVector.cend()) {
-    wsIt = std::find(wsVector.cbegin(), wsVector.cend(), wsName);
+    return;
   }
   // this is the index of the workspace.
   auto const index = WorkspaceID(std::distance(wsVector.cbegin(), wsIt));

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.cpp
@@ -165,7 +165,7 @@ void FunctionQDataPresenter::addWorkspace(const std::string &workspaceName, cons
   const auto workspace = m_adsInstance.retrieveWS<MatrixWorkspace>(workspaceName);
   FunctionQParameters parameters(workspace);
   if (!parameters)
-    throw std::invalid_argument("Workspace contains no Width or EISF spectra.");
+    throw std::invalid_argument("Workspace contains no Width, EISF or A0 spectra.");
 
   if (workspace->y(0).size() == 1)
     throw std::invalid_argument("Workspace contains only one data point.");
@@ -182,7 +182,7 @@ std::map<std::string, std::string> FunctionQDataPresenter::chooseFunctionQFuncti
     return paramWidth ? FunctionQ::WIDTH_FITS : FunctionQ::EISF_FITS;
 
   bool widthFuncs = paramWidth || m_view->dataColumnContainsText("FWHM");
-  bool eisfFuncs = !paramWidth || m_view->dataColumnContainsText("EISF");
+  bool eisfFuncs = !paramWidth || m_view->dataColumnContainsText("EISF") || m_view->dataColumnContainsText("A0");
   if (widthFuncs && eisfFuncs)
     return FunctionQ::ALL_FITS;
   else if (widthFuncs)
@@ -245,7 +245,10 @@ void FunctionQDataPresenter::setActiveWorkspaceIDToCurrentWorkspace(MantidWidget
   // This a vector of workspace names currently loaded
   auto const wsVector = m_model->getWorkspaceNames();
   // this is an iterator pointing to the current wsName in wsVector
-  auto const wsIt = std::find(wsVector.cbegin(), wsVector.cend(), hwhmWsName);
+  auto wsIt = std::find(wsVector.cbegin(), wsVector.cend(), hwhmWsName);
+  if (wsIt == wsVector.cend()) {
+    wsIt = std::find(wsVector.cbegin(), wsVector.cend(), wsName);
+  }
   // this is the index of the workspace.
   auto const index = WorkspaceID(std::distance(wsVector.cbegin(), wsIt));
   updateActiveWorkspaceID(index);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQParameters.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQParameters.cpp
@@ -52,7 +52,8 @@ namespace MantidQt::CustomInterfaces::Inelastic {
 FunctionQParameters::FunctionQParameters() : m_widths(), m_eisfs() {}
 
 FunctionQParameters::FunctionQParameters(const MatrixWorkspace_sptr &workspace)
-    : m_widths(findAxisLabels(workspace, {".Width", ".FWHM"})), m_eisfs(findAxisLabels(workspace, {".EISF"})) {}
+    : m_widths(findAxisLabels(workspace, {".Width", ".FWHM"})), m_eisfs(findAxisLabels(workspace, {".EISF"})),
+      m_a0s(findAxisLabels(workspace, {".A0"})) {}
 
 std::vector<std::string> FunctionQParameters::names(std::string const &parameterType) const {
   auto const nameGetter = [](auto const &pair) { return pair.first; };
@@ -60,6 +61,8 @@ std::vector<std::string> FunctionQParameters::names(std::string const &parameter
     return extract<std::string>(m_widths, nameGetter);
   } else if (parameterType == "EISF") {
     return extract<std::string>(m_eisfs, nameGetter);
+  } else if (parameterType == "A0") {
+    return extract<std::string>(m_a0s, nameGetter);
   }
   return {};
 }
@@ -70,6 +73,8 @@ std::vector<std::size_t> FunctionQParameters::spectra(std::string const &paramet
     return extract<std::size_t>(m_widths, spectraGetter);
   } else if (parameterType == "EISF") {
     return extract<std::size_t>(m_eisfs, spectraGetter);
+  } else if (parameterType == "A0") {
+    return extract<std::size_t>(m_a0s, spectraGetter);
   }
   throw std::logic_error("An unexpected parameter type '" + parameterType + "'is active.");
 }
@@ -80,6 +85,8 @@ std::vector<std::string> FunctionQParameters::types() const {
     types.emplace_back("Width");
   if (!m_eisfs.empty())
     types.emplace_back("EISF");
+  if (!m_a0s.empty())
+    types.emplace_back("A0");
   return types;
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQParameters.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQParameters.h
@@ -27,11 +27,12 @@ public:
 
   std::vector<std::string> types() const;
 
-  operator bool() const { return !m_widths.empty() || !m_eisfs.empty(); }
+  operator bool() const { return !m_widths.empty() || !m_eisfs.empty() || !m_a0s.empty(); }
 
 private:
   std::vector<std::pair<std::string, std::size_t>> m_widths;
   std::vector<std::pair<std::string, std::size_t>> m_eisfs;
+  std::vector<std::pair<std::string, std::size_t>> m_a0s;
 };
 
 } // namespace Inelastic

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/ConvolutionModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/ConvolutionModelTest.h
@@ -152,13 +152,13 @@ public:
     TS_ASSERT_THROWS_NOTHING(m_model->addOutput(alg));
   }
 
-  void test_addOutput_throws_with_unexecuted_fit() {
+  void test_addOutput_does_not_throw_with_unexecuted_fit() {
     FunctionModelSpectra const spectra = FunctionModelSpectra("0-1");
     m_model->getFitDataModel()->addWorkspace(m_workspace, spectra);
     auto const modelWorkspace = m_model->getWorkspace(0);
 
     auto const alg = getSetupFitAlgorithm(m_model, std::move(modelWorkspace), "Name");
-    TS_ASSERT_THROWS_ANYTHING(m_model->addOutput(alg));
+    TS_ASSERT_THROWS_NOTHING(m_model->addOutput(alg));
   }
 
 private:

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/FunctionQDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/FunctionQDataPresenterTest.h
@@ -93,12 +93,12 @@ public:
   }
 
   void test_addWorkspace_does_not_throw_with_width() {
-    EXPECT_CALL(*m_model, addWorkspace("WorkspaceName_HWHM", FunctionModelSpectra("0"))).Times(Exactly(1));
+    EXPECT_CALL(*m_model, addWorkspace("WorkspaceName", FunctionModelSpectra("0"))).Times(Exactly(1));
     m_presenter->addWorkspace("WorkspaceName", "Width", 0);
   }
 
   void test_addWorkspace_does_not_throw_with_EISF() {
-    EXPECT_CALL(*m_model, addWorkspace("WorkspaceName_HWHM", FunctionModelSpectra("3"))).Times(Exactly(1));
+    EXPECT_CALL(*m_model, addWorkspace("WorkspaceName", FunctionModelSpectra("3"))).Times(Exactly(1));
     m_presenter->addWorkspace("WorkspaceName", "EISF", 0);
   }
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtJobRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtJobRunner.h
@@ -22,7 +22,7 @@ class JobRunnerSubscriber;
 class EXPORT_OPT_MANTIDQT_COMMON QtJobRunner : public QObject, public IJobRunner {
   Q_OBJECT
 public:
-  QtJobRunner();
+  QtJobRunner(bool const stopOnFailure = false);
   void subscribe(JobRunnerSubscriber *notifyee) override;
   void clearAlgorithmQueue() override;
   void setAlgorithmQueue(std::deque<MantidQt::API::IConfiguredAlgorithm_sptr> algorithms) override;

--- a/qt/widgets/common/src/QtJobRunner.cpp
+++ b/qt/widgets/common/src/QtJobRunner.cpp
@@ -15,9 +15,9 @@ using namespace MantidQt::API;
 
 namespace MantidQt::API {
 
-QtJobRunner::QtJobRunner() : QObject(), m_batchAlgoRunner(this) {
+QtJobRunner::QtJobRunner(bool const stopOnFailure) : QObject(), m_batchAlgoRunner(this) {
   qRegisterMetaType<API::IConfiguredAlgorithm_sptr>("MantidQt::API::IConfiguredAlgorithm_sptr");
-  m_batchAlgoRunner.stopOnFailure(false);
+  m_batchAlgoRunner.stopOnFailure(stopOnFailure);
   connectBatchAlgoRunnerSlots();
 }
 


### PR DESCRIPTION
### Description of work
This PR adds the ability to load a `_Result` workspace from the I(Q, t) fitting tab into the Function (Q) fitting tab if one of the fit parameters is `A0`. It is then possible to use one of the EISF fit functions to perform a fit.

This PR also changes the calculation of the HWHM. Rather than creating a new separate workspace containing the HWHM, the FWHM or Width spectra is changed in-place in the loaded workspace, and the label of the spectra is updated to read "HWHM". This keeps the ADS clean and leads to less confusion. It also means the code is greatly simplified.

Fixes #36349 

### To test:
1. Open Inelastic QENS Fitting interface
2. Go to Function(Q) tab
3. Load the following workspace containing `A0`
[irs26176_graphite002_iqt_Iqt_seq_1S_0-50__Result.zip](https://github.com/user-attachments/files/16232438/irs26176_graphite002_iqt_Iqt_seq_1S_0-50__Result.zip)

5. Select the `f1.A0` parameter, click `Add`, then `Close` the data selection dialog
6. The data should be plotted ok
7. Make sure only the EISF fit functions are visible.
8. Select a fit function and click `Run`
9. It should do a fit

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
