### PR TITLE
Fix 3d plot bug where zoom was toggled by context menu

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1342,6 +1342,10 @@ class MantidAxes3D(Axes3D):
     def __init__(self, *args, **kwargs):
         kwargs["auto_add_to_figure"] = False
         super().__init__(*args, **kwargs)
+        # By default, when right click is held the plot will zoom in and out.
+        # For Mantid plots right click will open a context menu instead
+        # Unassigning the zoom button avoids zoom becoming toggled after leaving the context menu
+        self.mouse_init(zoom_btn=None)
 
     def set_title(self, *args, **kwargs):
         # The set_title function in Axes3D also moves the title downwards for some reason so the Axes function is called

--- a/docs/source/release/v6.11.0/Workbench/Bugfixes/37585.rst
+++ b/docs/source/release/v6.11.0/Workbench/Bugfixes/37585.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where right-clicking a 3D plot to change the colour bar scale could toggle the zoom tool.


### PR DESCRIPTION
### Description of work

By default, holding right click and panning the mouse around on a Axes3D plot with zoom in and out.
In workbench, right-clicking a plot with bring up a context menu (for 3d plots its changing the colour bar scale).
Opening this QMenu seems to eat the mouse button release signal, so after you've used the menu the plot things right click is still held down.

I tried to fix the core problem of the release signal never getting caught but struggled to find a solution. Instead, I have just unassigned the zoom button on Mantid3D axis plots. We're already blocking the zoom behaviour with the context menu so this should be okay.

Fixes #37585

### To test:

- Follow instructions from the linked issue
- Should be able to change the colour bar scale through right-clicking without any weird zooming behaviour

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
