### PR TITLE
GenerateGroupingPowder v2

### DIFF
--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -473,6 +473,7 @@ set(TEST_FILES
     FindDetectorsInShapeTest.h
     FindDetectorsParTest.h
     GenerateGroupingPowderTest.h
+    GenerateGroupingPowder2Test.h
     GroupDetectors2Test.h
     GroupDetectorsTest.h
     H5UtilTest.h

--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SRC_FILES
     src/FindDetectorsInShape.cpp
     src/FindDetectorsPar.cpp
     src/GenerateGroupingPowder.cpp
+    src/GenerateGroupingPowder2.cpp
     src/GroupDetectors.cpp
     src/GroupDetectors2.cpp
     src/H5Util.cpp
@@ -248,6 +249,7 @@ set(INC_FILES
     inc/MantidDataHandling/FindDetectorsInShape.h
     inc/MantidDataHandling/FindDetectorsPar.h
     inc/MantidDataHandling/GenerateGroupingPowder.h
+    inc/MantidDataHandling/GenerateGroupingPowder2.h
     inc/MantidDataHandling/GroupDetectors.h
     inc/MantidDataHandling/GroupDetectors2.h
     inc/MantidDataHandling/H5Util.h

--- a/Framework/DataHandling/inc/MantidDataHandling/GenerateGroupingPowder.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/GenerateGroupingPowder.h
@@ -31,6 +31,8 @@ public:
   static std::string parFilenameFromXmlFilename(const std::string &filename);
 
 protected:
+  void init() override;
+
   void createGroups();
   void saveAsNexus();
 
@@ -41,7 +43,6 @@ private:
   void saveAsXML();
   void saveAsPAR();
 
-  void init() override;
   void exec() override;
 
   std::map<std::string, std::string> validateInputs() override;

--- a/Framework/DataHandling/inc/MantidDataHandling/GenerateGroupingPowder.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/GenerateGroupingPowder.h
@@ -18,7 +18,7 @@ namespace DataHandling {
 
   @date 2012-07-16
 */
-class MANTID_DATAHANDLING_DLL GenerateGroupingPowder final : public API::Algorithm {
+class MANTID_DATAHANDLING_DLL GenerateGroupingPowder : public API::Algorithm {
 public:
   const std::string name() const override;
   /// Summary of algorithms purpose
@@ -30,15 +30,19 @@ public:
 
   static std::string parFilenameFromXmlFilename(const std::string &filename);
 
-private:
-  void saveAsXML();
+protected:
+  void createGroups();
   void saveAsNexus();
+
+  DataObjects::GroupingWorkspace_sptr m_groupWS;
+
+private:
+  void saveGroups();
+  void saveAsXML();
   void saveAsPAR();
 
   void init() override;
   void exec() override;
-
-  DataObjects::GroupingWorkspace_sptr m_groupWS;
 
   std::map<std::string, std::string> validateInputs() override;
 };

--- a/Framework/DataHandling/inc/MantidDataHandling/GenerateGroupingPowder2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/GenerateGroupingPowder2.h
@@ -22,6 +22,7 @@ private:
   void saveGroups();
   void saveAsXML();
   void saveAsPAR();
+  void init() override;
   void exec() override;
 };
 

--- a/Framework/DataHandling/inc/MantidDataHandling/GenerateGroupingPowder2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/GenerateGroupingPowder2.h
@@ -1,22 +1,18 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "MantidDataHandling/DllConfig.h"
 #include "MantidDataHandling/GenerateGroupingPowder.h"
-#include "MantidDataObjects/GroupingWorkspace.h"
 
 namespace Mantid {
 namespace DataHandling {
 
 /** GenerateGroupingPowder2 : Generate grouping file and par file, for powder
   scattering.
-
-  @date 2012-07-16
 */
 class MANTID_DATAHANDLING_DLL GenerateGroupingPowder2 : public GenerateGroupingPowder {
 public:

--- a/Framework/DataHandling/inc/MantidDataHandling/GenerateGroupingPowder2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/GenerateGroupingPowder2.h
@@ -1,0 +1,33 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidDataHandling/DllConfig.h"
+#include "MantidDataHandling/GenerateGroupingPowder.h"
+#include "MantidDataObjects/GroupingWorkspace.h"
+
+namespace Mantid {
+namespace DataHandling {
+
+/** GenerateGroupingPowder2 : Generate grouping file and par file, for powder
+  scattering.
+
+  @date 2012-07-16
+*/
+class MANTID_DATAHANDLING_DLL GenerateGroupingPowder2 : public GenerateGroupingPowder {
+public:
+  int version() const override;
+
+private:
+  void saveGroups();
+  void saveAsXML();
+  void saveAsPAR();
+  void exec() override;
+};
+
+} // namespace DataHandling
+} // namespace Mantid

--- a/Framework/DataHandling/inc/MantidDataHandling/SavePAR.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SavePAR.h
@@ -65,6 +65,11 @@ public:
    algorithm. */
   void set_resulting_workspace(const std::string &ws_name) { det_par_ws_name = ws_name; }
 
+  static void writePAR(const std::string &filename, const std::vector<double> &azimuthal,
+                       const std::vector<double> &polar, const std::vector<double> &azimuthal_width,
+                       const std::vector<double> &polar_width, const std::vector<double> &secondary_flightpath,
+                       const std::vector<size_t> &det_ID, const size_t nDetectors);
+
 private:
   /// Initialisation code
   void init() override;

--- a/Framework/DataHandling/src/GenerateGroupingPowder.cpp
+++ b/Framework/DataHandling/src/GenerateGroupingPowder.cpp
@@ -9,21 +9,16 @@
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/SpectrumInfo.h"
-#include "MantidDataHandling/SaveDetectorsGrouping.h"
-#include "MantidDataHandling/SavePAR.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidGeometry/Crystal/AngleUnits.h"
-#include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/DetectorGroup.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ListValidator.h"
-#include "MantidKernel/System.h"
 
 #include <Poco/DOM/AutoPtr.h>
 #include <Poco/DOM/DOMWriter.h>
 #include <Poco/DOM/Document.h>
-#include <Poco/DOM/Element.h>
 #include <Poco/DOM/Text.h>
 #include <Poco/XML/XMLWriter.h>
 
@@ -244,7 +239,7 @@ void GenerateGroupingPowder::init() {
   fileExtensionXMLorHDF5->addAllowedValue(std::string("nxs"));
   fileExtensionXMLorHDF5->addAllowedValue(std::string("nx5"));
   declareProperty("FileFormat", std::string("xml"), fileExtensionXMLorHDF5,
-                  "File extension/format for saving output: either xml (default) or nxs/nx5.", PropertyMode::Optional);
+                  "File extension/format for saving output: either xml (default) or nxs/nx5.");
   declareProperty(std::make_unique<FileProperty>("GroupingFilename", "", FileProperty::OptionalSave,
                                                  std::vector<std::string>{"xml", "nxs", "nx5"}),
                   "A grouping file that will be created.");
@@ -282,7 +277,11 @@ std::map<std::string, std::string> GenerateGroupingPowder::validateInputs() {
 /** Execute the algorithm.
  */
 void GenerateGroupingPowder::exec() {
+  createGroups();
+  saveGroups();
+}
 
+void GenerateGroupingPowder::createGroups() {
   MatrixWorkspace_const_sptr input_ws = getProperty("InputWorkspace");
   const auto &spectrumInfo = input_ws->spectrumInfo();
   const auto &detectorInfo = input_ws->detectorInfo();
@@ -336,6 +335,9 @@ void GenerateGroupingPowder::exec() {
       this->m_groupWS->setValue(ids, groupId);
     }
   }
+}
+
+void GenerateGroupingPowder::saveGroups() {
 
   // save if a filename was specified
   if (!isDefault("GroupingFilename")) {

--- a/Framework/DataHandling/src/GenerateGroupingPowder2.cpp
+++ b/Framework/DataHandling/src/GenerateGroupingPowder2.cpp
@@ -23,6 +23,15 @@ DECLARE_ALGORITHM(GenerateGroupingPowder2)
 /// Algorithm's version for identification. @see Algorithm::version
 int GenerateGroupingPowder2::version() const { return 2; }
 
+/** Initialize the algorithm's properties.
+ */
+void GenerateGroupingPowder2::init() {
+  GenerateGroupingPowder::init();
+
+  // This version will determine the file format from the extension of the GroupingFilename property
+  removeProperty("FileFormat");
+}
+
 /** Execute the algorithm.
  */
 void GenerateGroupingPowder2::exec() {
@@ -35,7 +44,8 @@ void GenerateGroupingPowder2::saveGroups() {
   // save if a filename was specified
   if (!isDefault("GroupingFilename")) {
 
-    std::string ext = this->getProperty("FileFormat");
+    std::string filename = this->getProperty("GroupingFilename");
+    std::string ext = filename.substr(filename.length() - 3);
     if (ext == "xml") {
       this->saveAsXML();
     } else if (ext == "nxs" || ext == "nx5") {

--- a/Framework/DataHandling/src/GenerateGroupingPowder2.cpp
+++ b/Framework/DataHandling/src/GenerateGroupingPowder2.cpp
@@ -1,0 +1,148 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataHandling/GenerateGroupingPowder2.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/SpectrumInfo.h"
+#include "MantidDataObjects/GroupingWorkspace.h"
+#include "MantidGeometry/Crystal/AngleUnits.h"
+#include "MantidGeometry/Instrument/DetectorGroup.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
+
+#include <Poco/DOM/AutoPtr.h>
+#include <Poco/DOM/DOMWriter.h>
+#include <Poco/DOM/Document.h>
+#include <Poco/DOM/Element.h>
+#include <Poco/DOM/Text.h>
+#include <Poco/XML/XMLWriter.h>
+
+#include <fstream>
+
+using namespace Mantid::API;
+using namespace Mantid::DataObjects;
+using namespace Mantid::Kernel;
+using namespace Mantid::Geometry;
+using namespace Poco::XML;
+
+namespace Mantid::DataHandling {
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(GenerateGroupingPowder2)
+
+/// Algorithm's version for identification. @see Algorithm::version
+int GenerateGroupingPowder2::version() const { return 2; }
+
+/** Execute the algorithm.
+ */
+void GenerateGroupingPowder2::exec() {
+  createGroups();
+  saveGroups();
+}
+
+void GenerateGroupingPowder2::saveGroups() {
+
+  // save if a filename was specified
+  if (!isDefault("GroupingFilename")) {
+
+    std::string ext = this->getProperty("FileFormat");
+    if (ext == "xml") {
+      this->saveAsXML();
+    } else if (ext == "nxs" || ext == "nx5") {
+      this->saveAsNexus();
+    } else {
+      throw std::invalid_argument("that file format doesn't exist: must be xml, nxs, nx5\n");
+    }
+
+    if (getProperty("GenerateParFile")) {
+      this->saveAsPAR();
+    }
+  }
+}
+
+// XML file
+void GenerateGroupingPowder2::saveAsXML() {
+  const std::string filename = this->getProperty("GroupingFilename");
+  auto saveDetectorsGrouping = createChildAlgorithm("SaveDetectorsGrouping");
+  saveDetectorsGrouping->setProperty("InputWorkspace", this->m_groupWS);
+  saveDetectorsGrouping->setProperty("OutputFile", filename);
+  saveDetectorsGrouping->setProperty("SaveUngroupedDetectors", false);
+  saveDetectorsGrouping->executeAsChildAlg();
+}
+
+// PAR file
+void GenerateGroupingPowder2::saveAsPAR() {
+  std::string PARfilename = getPropertyValue("GroupingFilename");
+  PARfilename = parFilenameFromXmlFilename(PARfilename);
+
+  std::ofstream outPAR_file(PARfilename.c_str());
+  if (!outPAR_file) {
+    g_log.error("Unable to create file: " + PARfilename);
+    throw Exception::FileError("Unable to create file: ", PARfilename);
+  }
+  MatrixWorkspace_const_sptr input_ws = getProperty("InputWorkspace");
+  const auto &spectrumInfo = input_ws->spectrumInfo();
+
+  const double step = getProperty("AngleStep");
+  const auto numSteps = static_cast<size_t>(180. / step + 1);
+
+  std::vector<std::vector<detid_t>> groups(numSteps);
+  std::vector<double> twoThetaAverage(numSteps, 0.);
+  std::vector<double> rAverage(numSteps, 0.);
+  // run through spectrums
+  for (size_t i = 0; i < spectrumInfo.size(); ++i) {
+    // skip invalid cases
+    if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMasked(i) || spectrumInfo.isMonitor(i)) {
+      continue;
+    }
+    const auto &det = spectrumInfo.detector(i);
+    // integer count angle slice
+    const double tt = spectrumInfo.twoTheta(i) * Geometry::rad2deg;
+    const auto where = static_cast<size_t>(tt / step);
+    // create these averages at this slice?
+    twoThetaAverage[where] += tt;
+    rAverage[where] += spectrumInfo.l2(i);
+    if (spectrumInfo.hasUniqueDetector(i)) {
+      groups[where].emplace_back(det.getID());
+    } else {
+      const auto &group = dynamic_cast<const DetectorGroup &>(det);
+      const auto idv = group.getDetectorIDs();
+      groups[where].insert(groups[where].end(), idv.begin(), idv.end());
+    }
+  }
+
+  size_t goodGroups(0);
+  for (size_t i = 0; i < numSteps; ++i) {
+    size_t gSize = groups.at(i).size();
+    if (gSize > 0)
+      ++goodGroups;
+  }
+
+  // Write the number of detectors to the file.
+  outPAR_file << " " << goodGroups << '\n';
+
+  for (size_t i = 0; i < numSteps; ++i) {
+    const size_t gSize = groups.at(i).size();
+    if (gSize > 0) {
+      outPAR_file << std::fixed << std::setprecision(3);
+      outPAR_file.width(10);
+      outPAR_file << rAverage.at(i) / static_cast<double>(gSize);
+      outPAR_file.width(10);
+      outPAR_file << twoThetaAverage.at(i) / static_cast<double>(gSize);
+      outPAR_file.width(10);
+      outPAR_file << 0.;
+      outPAR_file.width(10);
+      outPAR_file << step * Geometry::deg2rad * rAverage.at(i) / static_cast<double>(gSize);
+      outPAR_file.width(10);
+      outPAR_file << 0.01;
+      outPAR_file.width(10);
+      outPAR_file << (groups.at(i)).at(0) << '\n';
+    }
+  }
+
+  // Close the file
+  outPAR_file.close();
+}
+} // namespace Mantid::DataHandling

--- a/Framework/DataHandling/src/SaveDetectorsGrouping.cpp
+++ b/Framework/DataHandling/src/SaveDetectorsGrouping.cpp
@@ -37,6 +37,7 @@ void SaveDetectorsGrouping::init() {
       "GroupingWorkspace to output to XML file (GroupingWorkspace)");
   declareProperty(std::make_unique<FileProperty>("OutputFile", "", FileProperty::Save, ".xml"),
                   "File to save the detectors mask in XML format");
+  declareProperty("SaveUngroupedDetectors", true, "Whether to write out group number 0, the ungrouped group.");
 }
 
 /// Main body to execute algorithm
@@ -65,10 +66,15 @@ void SaveDetectorsGrouping::exec() {
  */
 void SaveDetectorsGrouping::createGroupDetectorIDMap(std::map<int, std::vector<detid_t>> &groupwkspmap) {
 
+  const bool excludeZero = !getProperty("SaveUngroupedDetectors");
+
   // 1. Create map
   for (size_t iws = 0; iws < mGroupWS->getNumberHistograms(); iws++) {
     // a) Group ID
     auto groupid = static_cast<int>(mGroupWS->y(iws)[0]);
+
+    if (excludeZero && groupid == 0)
+      continue;
 
     // b) Exist? Yes --> get handler on vector.  No --> create vector and
     auto it = groupwkspmap.find(groupid);

--- a/Framework/DataHandling/src/SavePAR.cpp
+++ b/Framework/DataHandling/src/SavePAR.cpp
@@ -10,13 +10,6 @@
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/InstrumentValidator.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidGeometry/Instrument.h"
-#include "MantidGeometry/Instrument/Detector.h"
-#include "MantidGeometry/Instrument/ObjComponent.h"
-#include "MantidGeometry/Objects/CSGObject.h"
-
-#include <cstdio>
-#include <fstream>
 
 namespace Mantid::DataHandling {
 
@@ -39,22 +32,11 @@ void SavePAR::init() {
 }
 
 void SavePAR::exec() {
-
   // Get the input workspace
   MatrixWorkspace_sptr inputWorkspace = getProperty("InputWorkspace");
 
   // Retrieve the filename from the properties
   const std::string filename = getProperty("Filename");
-
-  // Get a pointer to the sample
-  IComponent_const_sptr sample = inputWorkspace->getInstrument()->getSample();
-
-  std::ofstream outPAR_file(filename.c_str());
-
-  if (!outPAR_file) {
-    g_log.error("Failed to open (PAR) file:" + filename);
-    throw Kernel::Exception::FileError("Failed to open (PAR) file:", filename);
-  }
 
   // execute the ChildAlgorithm to calculate the detector's parameters;
   auto spCalcDetPar = createChildAlgorithm("FindDetectorsPar", 0, 1, true, 1);
@@ -68,11 +50,6 @@ void SavePAR::exec() {
     spCalcDetPar->setPropertyValue("OutputParTable", det_par_ws_name);
   }
 
-  // let's not do this for the time being
-  /* std::string parFileName = this->getPropertyValue("ParFile");
-      if(!(parFileName.empty()||parFileName=="not_used.par")){
-                spCalcDetPar->setPropertyValue("ParFile",parFileName);
-                    }*/
   spCalcDetPar->execute();
   //
   auto *pCalcDetPar = dynamic_cast<FindDetectorsPar *>(spCalcDetPar.get());
@@ -88,6 +65,18 @@ void SavePAR::exec() {
 
   size_t nDetectors = pCalcDetPar->getNDetectors();
 
+  writePAR(filename, azimuthal, polar, azimuthal_width, polar_width, secondary_flightpath, det_ID, nDetectors);
+}
+
+void SavePAR::writePAR(const std::string &filename, const std::vector<double> &azimuthal,
+                       const std::vector<double> &polar, const std::vector<double> &azimuthal_width,
+                       const std::vector<double> &polar_width, const std::vector<double> &secondary_flightpath,
+                       const std::vector<size_t> &det_ID, const size_t nDetectors) {
+  std::ofstream outPAR_file(filename.c_str());
+
+  if (!outPAR_file) {
+    throw Kernel::Exception::FileError("Failed to open (PAR) file:", filename);
+  }
   // Write the number of detectors to the file.
   outPAR_file << " " << nDetectors << '\n';
 

--- a/Framework/DataHandling/src/SavePAR.cpp
+++ b/Framework/DataHandling/src/SavePAR.cpp
@@ -52,7 +52,7 @@ void SavePAR::exec() {
 
   spCalcDetPar->execute();
   //
-  auto *pCalcDetPar = dynamic_cast<FindDetectorsPar *>(spCalcDetPar.get());
+  const auto *pCalcDetPar = dynamic_cast<FindDetectorsPar *>(spCalcDetPar.get());
   if (!pCalcDetPar) { // "can not get pointer to FindDetectorsPar algorithm"
     throw(std::bad_cast());
   }

--- a/Framework/DataHandling/test/GenerateGroupingPowder2Test.h
+++ b/Framework/DataHandling/test/GenerateGroupingPowder2Test.h
@@ -71,7 +71,6 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT(alg.isInitialized());
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", m_emptyInstrument));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FileFormat", "xml"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GroupingFilename", XML_OUT_FILE));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("AngleStep", step));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", GROUP_WS));
@@ -231,7 +230,6 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT(alg.isInitialized());
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", m_emptyInstrument));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FileFormat", "nxs"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GroupingFilename", NXS_OUT_FILE));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("AngleStep", step));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", GROUP_WS));
@@ -296,7 +294,6 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT(alg.isInitialized());
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", m_emptyInstrument));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FileFormat", "xml"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GroupingFilename", XML_OUT_FILE));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("AngleStep", step));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", GROUP_WS));
@@ -336,7 +333,6 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", GROUP_WS));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FileFormat", "xml"));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GroupingFilename", XML_OUT_FILE));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("AngleStep", angleStep));
     TS_ASSERT_THROWS_NOTHING(alg.execute());
@@ -386,7 +382,6 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT(alg.isInitialized());
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", INPUT_WS));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FileFormat", "nxs"));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("GenerateParFile", false));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GroupingFilename", NXS_OUT_FILE));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("AngleStep", TWO_THETA_STEP));

--- a/Framework/DataHandling/test/GenerateGroupingPowder2Test.h
+++ b/Framework/DataHandling/test/GenerateGroupingPowder2Test.h
@@ -1,0 +1,557 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/Axis.h"
+#include "MantidAPI/SpectrumInfo.h"
+#include "MantidDataHandling/GenerateGroupingPowder2.h"
+#include "MantidDataHandling/LoadDetectorsGroupingFile.h"
+#include "MantidDataHandling/LoadEmptyInstrument.h"
+#include "MantidDataHandling/LoadNexusProcessed.h"
+#include "MantidDataObjects/GroupingWorkspace.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidGeometry/Crystal/AngleUnits.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "MantidKernel/System.h"
+#include "MantidKernel/Timer.h"
+
+#include <Poco/DOM/DOMParser.h>
+#include <Poco/DOM/NodeFilter.h>
+#include <Poco/DOM/NodeIterator.h>
+#include <Poco/File.h>
+#include <Poco/SAX/InputSource.h>
+#include <cxxtest/TestSuite.h>
+#include <exception>
+#include <fstream>
+
+using namespace Mantid;
+using namespace Mantid::DataHandling;
+using namespace Mantid::DataObjects;
+using namespace Mantid::API;
+
+class GenerateGroupingPowder2Test : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static GenerateGroupingPowder2Test *createSuite() { return new GenerateGroupingPowder2Test(); }
+  static void destroySuite(GenerateGroupingPowder2Test *suite) { delete suite; }
+
+  GenerateGroupingPowder2Test() : CxxTest::TestSuite() {
+    LoadEmptyInstrument lei;
+    lei.initialize();
+    lei.setChild(true);
+    lei.setRethrows(true);
+    lei.setPropertyValue("Filename", "CNCS_Definition.xml");
+    lei.setPropertyValue("OutputWorkspace", "unused_for_child");
+    lei.execute();
+    m_emptyInstrument = lei.getProperty("OutputWorkspace");
+  }
+
+  void test_init() {
+    GenerateGroupingPowder2 alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+  }
+
+  void test_exec() {
+    const std::string XML_OUT_FILE("PowderGrouping_fulltest.xml");
+    const std::string PAR_OUT_FILE{GenerateGroupingPowder2::parFilenameFromXmlFilename(XML_OUT_FILE)};
+    const std::string GROUP_WS("plainExecTestWS");
+    constexpr double step = 10;
+
+    GenerateGroupingPowder2 alg;
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", m_emptyInstrument));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FileFormat", "xml"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GroupingFilename", XML_OUT_FILE));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("AngleStep", step));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", GROUP_WS));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    // Check the par file results
+    if (!fileExists(PAR_OUT_FILE)) {
+      throw std::runtime_error("par file was not created: " + PAR_OUT_FILE);
+    }
+    std::ifstream pf(PAR_OUT_FILE);
+    std::size_t nDet;
+    pf >> nDet;
+    TS_ASSERT_EQUALS(nDet, 14);
+    const auto &detectorInfo = m_emptyInstrument->detectorInfo();
+    for (std::size_t i = 0; i < nDet; ++i) {
+      double r, th, phi, dx, dy, tth;
+      detid_t detID;
+      pf >> r >> th >> phi >> dx >> dy >> detID;
+      TS_ASSERT_DELTA(r, 3.5, 0.2);
+      TS_ASSERT_DELTA(th, step * (static_cast<double>(i) + 0.5), 0.5 * step);
+      TS_ASSERT_EQUALS(phi, 0.00);
+      TS_ASSERT_DELTA(dx, r * step * Geometry::deg2rad, 0.01);
+      TS_ASSERT_EQUALS(dy, 0.01);
+      tth = detectorInfo.twoTheta(detectorInfo.indexOf(detID)) * Geometry::rad2deg;
+      TS_ASSERT_LESS_THAN(tth, static_cast<double>(i + 1) * step);
+      TS_ASSERT_LESS_THAN(static_cast<double>(i) * step, tth);
+    }
+    pf.close();
+
+    // check the xml grouping file
+    if (!fileExists(XML_OUT_FILE))
+      throw std::runtime_error("xml file was not created: " + XML_OUT_FILE);
+    LoadDetectorsGroupingFile load2;
+    load2.initialize();
+
+    TS_ASSERT(load2.setProperty("InputFile", XML_OUT_FILE));
+    TS_ASSERT(load2.setProperty("OutputWorkspace", "GroupPowder"));
+
+    load2.execute();
+    TS_ASSERT(load2.isExecuted());
+
+    DataObjects::GroupingWorkspace_sptr gws2 = std::dynamic_pointer_cast<DataObjects::GroupingWorkspace>(
+        API::AnalysisDataService::Instance().retrieve("GroupPowder"));
+
+    TS_ASSERT_DELTA(gws2->dataY(0)[0], 14.0, 1.0E-5);     // 130.6 degrees
+    TS_ASSERT_DELTA(gws2->dataY(10000)[0], 10.0, 1.0E-5); // 97.4 degrees
+    TS_ASSERT_DELTA(gws2->dataY(20000)[0], 7.0, 1.0E-5);  // 62.9 degrees
+    TS_ASSERT_DELTA(gws2->dataY(30000)[0], 3.0, 1.0E-5);  // 27.8 degrees
+    TS_ASSERT_DELTA(gws2->dataY(40000)[0], 2.0, 1.0E-5);  // 14.5 degrees
+    TS_ASSERT_DELTA(gws2->dataY(50000)[0], 5.0, 1.0E-5);  // 49.7 degrees
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(GROUP_WS);
+    // Delete files
+    remove(XML_OUT_FILE.c_str());
+    remove(PAR_OUT_FILE.c_str());
+  }
+
+  void test_turning_off_par_file_generation() {
+    const std::string XML_OUT_FILE("PowderGrouping_nopar.xml");
+    const std::string GROUP_WS("noParFileWS");
+    constexpr double step = 10;
+
+    GenerateGroupingPowder2 alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", m_emptyInstrument));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GroupingFilename", XML_OUT_FILE));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("AngleStep", step));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GenerateParFile", false));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", GROUP_WS));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    // make sure the xml exists and cleanup
+    if (fileExists(XML_OUT_FILE)) {
+      remove(XML_OUT_FILE.c_str());
+    } else {
+      TS_FAIL("xml file " + XML_OUT_FILE + " was not created");
+    }
+    // make sure the parfile does not exist and cleanup
+    const std::string parFilename(GenerateGroupingPowder2::parFilenameFromXmlFilename(XML_OUT_FILE));
+    if (fileExists(parFilename)) {
+      remove(parFilename.c_str());
+      TS_FAIL("par file " + parFilename + "exists and shouldn't");
+    }
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(GROUP_WS);
+  }
+
+  void test_ignore_detectors_without_spectra() {
+    const std::string XML_OUT_FILE("PowderGrouping_det_wo_spectra.xml");
+    const std::string GROUP_WS("noDetNoSpecWS");
+
+    auto histogram = m_emptyInstrument->histogram(0);
+    MatrixWorkspace_sptr ws = create<Workspace2D>(*m_emptyInstrument, 1, histogram);
+    ws->getSpectrum(0).copyInfoFrom(m_emptyInstrument->getSpectrum(8));
+    GenerateGroupingPowder2 alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    constexpr double step = 10;
+
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GroupingFilename", XML_OUT_FILE));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("AngleStep", step));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GenerateParFile", false));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", GROUP_WS));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    if (!fileExists(XML_OUT_FILE))
+      throw std::runtime_error("xml file was not created: " + XML_OUT_FILE);
+    std::ifstream in(XML_OUT_FILE);
+    Poco::XML::InputSource source{in};
+    Poco::XML::DOMParser parser;
+    Poco::AutoPtr<Poco::XML::Document> doc{parser.parse(&source)};
+    ShowDetIDsOnly filter;
+    Poco::XML::NodeIterator nodeIter{doc, Poco::XML::NodeFilter::SHOW_ELEMENT, &filter};
+    auto node = nodeIter.nextNode();
+    TS_ASSERT(node)
+    TS_ASSERT_EQUALS(node->nodeName(), "detids");
+    TS_ASSERT_EQUALS(node->innerText(), "4");
+    node = nodeIter.nextNode();
+    in.close();
+    TS_ASSERT(!node);
+
+    remove(XML_OUT_FILE.c_str());
+
+    // Just in case something went wrong.
+    std::string parFilename = GenerateGroupingPowder2::parFilenameFromXmlFilename(XML_OUT_FILE);
+    if (fileExists(parFilename)) {
+      remove(parFilename.c_str());
+      TS_FAIL("par file " + parFilename + "exists and shouldn't");
+    }
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(GROUP_WS);
+  }
+
+  // save as nexus, reload, and compare
+  void test_save_nexus_processed() {
+    const std::string NXS_OUT_FILE("PowderGrouping.nxs");
+    const std::string GROUP_WS("saveNXSWS");
+    constexpr double step = 10;
+
+    GenerateGroupingPowder2 alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", m_emptyInstrument));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FileFormat", "nxs"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GroupingFilename", NXS_OUT_FILE));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("AngleStep", step));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", GROUP_WS));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    GroupingWorkspace_sptr gws = alg.getProperty("GroupingWorkspace");
+    TS_ASSERT(gws);
+
+    if (!fileExists(NXS_OUT_FILE)) {
+      throw std::runtime_error("nexus file was not created: " + NXS_OUT_FILE);
+    }
+
+    LoadNexusProcessed load;
+    TS_ASSERT_THROWS_NOTHING(load.initialize());
+    TS_ASSERT(load.isInitialized());
+    load.setPropertyValue("Filename", NXS_OUT_FILE);
+    load.setPropertyValue("OutputWorkspace", GROUP_WS);
+
+    TS_ASSERT_THROWS_NOTHING(load.execute());
+
+    // Test some aspects of the file
+    Workspace_sptr workspace;
+    TS_ASSERT_THROWS_NOTHING(workspace = AnalysisDataService::Instance().retrieve(GROUP_WS));
+    TS_ASSERT(workspace);
+    TS_ASSERT(workspace.get());
+
+    MatrixWorkspace_sptr ows = std::dynamic_pointer_cast<MatrixWorkspace>(workspace);
+    TS_ASSERT(ows);
+    if (!ows)
+      return;
+
+    auto alg2 = AlgorithmManager::Instance().createUnmanaged("CompareWorkspaces");
+    alg2->initialize();
+    alg2->setProperty<MatrixWorkspace_sptr>("Workspace1", gws);
+    alg2->setProperty<MatrixWorkspace_sptr>("Workspace2", ows);
+    alg2->setProperty<double>("Tolerance", 0.0);
+    alg2->setProperty<bool>("CheckAxes", false);
+    alg2->execute();
+    if (alg2->isExecuted()) {
+      TS_ASSERT(alg2->getProperty("Result"));
+    } else {
+      TS_ASSERT(false);
+    }
+
+    // remove the output file
+    remove(NXS_OUT_FILE.c_str());
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(GROUP_WS);
+  }
+
+  // azimuthal grouping with a par file isn't currently supported
+  void test_azimuth_with_par_fail() {
+    const std::string XML_OUT_FILE("PowderGrouping_azi_with_par.xml");
+    const std::string PAR_OUT_FILE{GenerateGroupingPowder2::parFilenameFromXmlFilename(XML_OUT_FILE)};
+    const std::string GROUP_WS("aziWithParTestWS");
+    constexpr double step = 10;
+
+    GenerateGroupingPowder2 alg;
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", m_emptyInstrument));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FileFormat", "xml"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GroupingFilename", XML_OUT_FILE));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("AngleStep", step));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", GROUP_WS));
+    // these next two cannot coexist
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("AzimuthalStep", 180.));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GenerateParFile", true));
+    TS_ASSERT_THROWS(alg.execute(), std::runtime_error &); // TODO type may be something else
+    TS_ASSERT(!alg.isExecuted());
+
+    // cleanup in case things were created
+    if (fileExists(XML_OUT_FILE)) {
+      remove(XML_OUT_FILE.c_str());
+      TS_FAIL("The file " + XML_OUT_FILE + " should not exist");
+    }
+    // this will succeed if workspace doesn't exist
+    AnalysisDataService::Instance().remove(GROUP_WS);
+  }
+
+  void test_grouping_rectangular_instrument() {
+    const std::string XML_OUT_FILE("PowderGrouping_rectangular.xml");
+    const std::string GROUP_WS("_unused_for_child");
+    constexpr int numBanks{1};
+    constexpr int bankSize{6};
+    constexpr int numBins{13};
+    constexpr double angleStep{0.1};
+    API::MatrixWorkspace_sptr inputWS =
+        WorkspaceCreationHelper::create2DWorkspaceWithRectangularInstrument(numBanks, bankSize, numBins);
+
+    inputWS->getAxis(0)->setUnit("TOF");
+    inputWS->mutableRun().addProperty("wavelength", 1.0);
+    auto &paramMap = inputWS->instrumentParameters();
+    paramMap.addString(inputWS->getInstrument().get(), "l2", std::to_string(5.));
+
+    GenerateGroupingPowder2 alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", GROUP_WS));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FileFormat", "xml"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GroupingFilename", XML_OUT_FILE));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("AngleStep", angleStep));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    GroupingWorkspace_sptr outputWS = alg.getProperty("GroupingWorkspace");
+    TS_ASSERT(outputWS);
+    auto const &spectrumInfo = outputWS->spectrumInfo();
+    auto const nHist = spectrumInfo.size();
+    TS_ASSERT_EQUALS(nHist, numBanks * bankSize * bankSize);
+    double angleStepRad = angleStep * Mantid::Geometry::deg2rad;
+    // ensure each pixel angle is inside the range correspondng to its group ID
+    for (size_t i = 0; i < nHist; ++i) {
+      auto const twoTheta = spectrumInfo.twoTheta(i);
+      auto const groupID = outputWS->dataY(i)[0];
+      TS_ASSERT_LESS_THAN_EQUALS(angleStepRad * (groupID - 1), twoTheta);
+      TS_ASSERT_LESS_THAN(twoTheta, angleStepRad * (groupID));
+    }
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(GROUP_WS);
+    // Delete files
+    remove(XML_OUT_FILE.c_str());
+  }
+
+  /*
+   The angular range of the in-plane component of an in-plane detector is rougly 15 degrees. The angular step size is
+   chosen to be slightly larger than that to reduce the overall number of groups that will be generated. The
+   out-of-plane detector bank centers are roughly at the same two-theta angle as the in-plane, but your mileage may
+   vary.
+   */
+  void run_SNAPliteTest(const std::string &groupWSName, const double ang1, const double ang2, const bool numberByAngle,
+                        const bool splitSides, const std::vector<int> &groups_exp,
+                        const std::vector<double> &pixel_groups_exp) {
+    const std::string NXS_OUT_FILE("PowderGrouping.nxs");
+    constexpr double TWO_THETA_STEP{18};
+    const std::string INPUT_WS("SNAPlite");
+    const detid_t PIXELS_PER_BANK{32 * 32};
+
+    // create snap lite with default detector positions
+    WorkspaceCreationHelper::createSNAPLiteInstrument(INPUT_WS, ang1, ang2);
+
+    GenerateGroupingPowder2 alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", INPUT_WS));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FileFormat", "nxs"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GenerateParFile", false));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GroupingFilename", NXS_OUT_FILE));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("AngleStep", TWO_THETA_STEP));
+    if (splitSides) {
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("AzimuthalStep", 180.));
+      TS_ASSERT_THROWS_NOTHING(alg.setProperty("AzimuthalStart", -90.));
+    }
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("NumberByAngle", numberByAngle));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingWorkspace", groupWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    // make sure the output file exists
+    if (fileExists(NXS_OUT_FILE)) {
+      remove(NXS_OUT_FILE.c_str());
+    } else {
+      TS_FAIL("Output file does not exist: " + NXS_OUT_FILE);
+    }
+
+    // get the GroupingWorkspace
+    GroupingWorkspace_const_sptr outputws = alg.getProperty("GroupingWorkspace");
+    if (!outputws) {
+      throw std::runtime_error("Cannot get grouping workspace: " + groupWSName);
+    }
+
+    // verify the groups that were created
+    const auto groups_obs = outputws->getGroupIDs();
+    TS_ASSERT_EQUALS(groups_obs.size(), groups_exp.size());
+    TS_ASSERT_EQUALS(groups_obs, groups_exp);
+
+    // verify the group assigned to particular pixels in the center of each of the 18 banks
+    const double TOL{0.01}; // getValue returns a double
+    for (std::size_t i = 0; i < pixel_groups_exp.size(); ++i) {
+      const detid_t detID = static_cast<detid_t>((0.5 + double(i)) * PIXELS_PER_BANK);
+      TS_ASSERT_DELTA(outputws->getValue(detID), pixel_groups_exp[i], TOL);
+    }
+
+    // this will succeed if workspace doesn't exist
+    AnalysisDataService::Instance().remove(INPUT_WS);
+    AnalysisDataService::Instance().remove(groupWSName);
+  }
+
+  void test_SNAPlite_angle_numbering_at_zero() {
+    const double ang1 = 0.0;
+    const double ang2 = 0.0;
+    const bool numberByAngle{true};
+    const bool splitSides{false};
+    const std::vector<int> groups_exp{1, 2};
+    const std::vector<double> pixel_groups_exp{2, 2, 2, 2, 1, 1, 2, 2, 2, 2, 2, 2, 2, 1, 1, 2, 2, 2};
+
+    run_SNAPliteTest("PowderGrouping_no_azimuth_angle_numbering", ang1, ang2, numberByAngle, splitSides, groups_exp,
+                     pixel_groups_exp);
+  }
+
+  // make sure that the "old" behavior of numbering based on angle is still in place
+  void test_SNAPlite_no_azimuth_angle_numbering() {
+    // angles taken from SNAP_57514
+    /*
+     bank 12 approx 114-128 - center is group 6
+     bank 22 approx 97-113 - center is group 5
+     bank 32 approx 81-96 - center is group 4 or 5
+     bank 42 approx 41-55 - center is group 2
+     bank 52 approx 57-73 - center is group 3
+     bank 62 approx 75-89 - center is group 4
+     some pixels will make it into group 7
+     ** Must relabel the groups +1 to accound for change
+     */
+    const double ang1 = -65.3;
+    const double ang2 = 104.95;
+    const bool numberByAngle{true};
+    const bool splitSides{false};
+    const std::vector<int> groups_exp{3, 4, 5, 6, 7, 8}; // empty part of the instrument gets number 1,2
+    const std::vector<double> pixel_groups_exp{7, 7, 7, 6, 6, 6, 5, 5, 5, 3, 3, 3, 4, 4, 4, 5, 5, 5};
+    run_SNAPliteTest("PowderGrouping_no_azimuth_angle_numbering", ang1, ang2, numberByAngle, splitSides, groups_exp,
+                     pixel_groups_exp);
+  }
+
+  // test labeling by angle sectors, divided over entire sphere
+  void test_SNAPlite_split_sides_angle_numbering() {
+    const double ang1 = -90.0;
+    const double ang2 = 90.0;
+    const bool numberByAngle{true};
+    const bool splitSides{true};
+    const std::vector<int> groups_exp{7, 8, 9, 10, 11, 12, 13, 14};
+    const std::vector<double> pixel_groups_exp{11, 11, 11, 9, 9, 9, 9, 9, 9, 10, 10, 10, 12, 12, 12, 12, 12, 12};
+    run_SNAPliteTest("PowderGrouping_no_azimuth_angle_numbering", ang1, ang2, numberByAngle, splitSides, groups_exp,
+                     pixel_groups_exp);
+  }
+
+  // detectors centered at -65 and 105
+  void test_SNAPlite_no_azimuth() {
+    // angles taken from SNAP_57514
+    /*
+     bank 12 approx 114-128 - center is group 1
+     bank 22 approx 97-113 - center is group 2
+     bank 32 approx 81-96 - center is group 3
+     bank 42 approx 41-55 - center is group 5
+     bank 52 approx 57-73 - center is group 4
+     bank 62 approx 75-89 - center is group 3
+     */
+    const double ang1 = -65.3;
+    const double ang2 = 104.95;
+    const bool numberByAngle{false};
+    const bool splitSides{false};
+    const std::vector<int> groups_exp{1, 2, 3, 4, 5};
+    const std::vector<double> pixel_groups_exp{1, 1, 1, 2, 2, 2, 3, 3, 3, 5, 5, 5, 4, 4, 4, 3, 3, 3};
+    run_SNAPliteTest("PowderGrouping_no_azimuth", ang1, ang2, numberByAngle, splitSides, groups_exp, pixel_groups_exp);
+  }
+
+  // detectors centered at -30 and 140 - strange numbers but no overlap
+  void test_SNAPlite_no_azimuth_gaps() {
+    // angles invented so there is space in the middle of the range that is not covered
+    /*
+     bank 12 - center is group 1
+     bank 22 - center is group 2
+     bank 32 - center is group 3
+     bank 42 - center is group 5 or 6
+     bank 52 - center is group 5
+     bank 62 -  center is group 4
+     */
+    const double ang1 = -30;
+    const double ang2 = 140;
+    const bool numberByAngle{false};
+    const bool splitSides{false};
+    const std::vector<int> groups_exp{1, 2, 3, 4, 5, 6};
+    const std::vector<double> pixel_groups_exp{1, 1, 1, 2, 2, 2, 3, 3, 3, 5, 6, 6, 5, 5, 5, 4, 4, 4};
+    run_SNAPliteTest("PowderGrouping_no_azimuth_gaps", ang1, ang2, numberByAngle, splitSides, groups_exp,
+                     pixel_groups_exp);
+  }
+
+  // detectors centered at -65 and 105
+  void test_SNAPlite_with_azimuth() {
+    // angles taken from SNAP_57514
+    /*
+     bank 12 approx 114-128 - center is group 1
+     bank 22 approx 97-113 - center is group 2
+     bank 32 approx 81-96 - center is group 3
+     bank 42 approx 41-55 - center is group 6
+     bank 52 approx 57-73 - center is group 5
+     bank 62 approx 75-89 - center is group 4 (would overlap 3, but opposite side)
+     */
+    const double ang1 = -65.3;
+    const double ang2 = 104.95;
+    const bool numberByAngle{false};
+    const bool splitSides{true};
+    const std::vector<int> groups_exp{1, 2, 3, 4, 5, 6};
+    const std::vector<double> pixel_groups_exp{1, 1, 1, 2, 2, 2, 3, 3, 3, 6, 6, 6, 5, 5, 5, 4, 4, 4};
+    run_SNAPliteTest("PowderGrouping_no_azimuth", ang1, ang2, numberByAngle, splitSides, groups_exp, pixel_groups_exp);
+  }
+
+private:
+  struct ShowDetIDsOnly : Poco::XML::NodeFilter {
+    short acceptNode(Poco::XML::Node *node) override {
+      if (node->nodeName() == "detids") {
+        return FILTER_ACCEPT;
+      } else {
+        return FILTER_SKIP;
+      }
+    }
+  };
+
+  MatrixWorkspace_sptr m_emptyInstrument;
+
+  bool fileExists(const std::string &filename) {
+    Poco::File handle{filename};
+    return handle.exists();
+  }
+};

--- a/Framework/DataHandling/test/SaveDetectorsGroupingTest.h
+++ b/Framework/DataHandling/test/SaveDetectorsGroupingTest.h
@@ -12,6 +12,7 @@
 #include "MantidKernel/Timer.h"
 #include <cxxtest/TestSuite.h>
 
+#include "MantidAPI/AlgorithmFactory.h"
 #include "MantidDataHandling/LoadDetectorsGroupingFile.h"
 #include "MantidDataHandling/SaveDetectorsGrouping.h"
 #include "Poco/File.h"
@@ -140,6 +141,59 @@ public:
 
     // Clean-up
     API::AnalysisDataService::Instance().remove(testWs);
+
+    Poco::File file(testFile);
+    file.remove();
+  }
+
+  void test_SaveUngroupedDetectors() {
+    // Create a grouping workspace with a single detector in a single group
+    auto alg = Mantid::API::AlgorithmFactory::Instance().create("CreateGroupingWorkspace", 1);
+    alg->initialize();
+    alg->setChild(true);
+    alg->setProperty("InstrumentName", "IRIS");
+    alg->setProperty("ComponentName", "graphite");
+    alg->setProperty("CustomGroupingString", "42");
+    alg->setProperty("OutputWorkspace", "unused");
+    alg->execute();
+
+    DataObjects::GroupingWorkspace_sptr output = alg->getProperty("OutputWorkspace");
+
+    // Save the test workspace, first saving ungrouped detectors
+    SaveDetectorsGrouping save;
+    save.initialize();
+    TS_ASSERT(save.setProperty("InputWorkspace", output));
+    TS_ASSERT(save.setProperty("OutputFile", "grouptemp.xml"));
+    save.execute();
+    TS_ASSERT(save.isExecuted());
+
+    // Get full path of the file
+    std::string testFile = save.getPropertyValue("OutputFile");
+
+    // Check that both group 0 and 1 are in the file
+    std::string xmlText = Kernel::Strings::loadFile(testFile);
+    TS_ASSERT_DIFFERS(xmlText.find("<group ID=\"0\">"), std::string::npos)             // group 0 found
+    TS_ASSERT_DIFFERS(xmlText.find("<detids>3-41,43-112</detids>"), std::string::npos) // group 0 found
+    TS_ASSERT_DIFFERS(xmlText.find("<group ID=\"1\">"), std::string::npos)             // group 1 found
+    TS_ASSERT_DIFFERS(xmlText.find("<detids>42</detids>"), std::string::npos)          // group 1 found
+
+    // Now repeat but don't save ungrouped detectors
+    SaveDetectorsGrouping save2;
+    save2.initialize();
+    TS_ASSERT(save2.setProperty("InputWorkspace", output));
+    TS_ASSERT(save2.setProperty("OutputFile", "grouptemp.xml"));
+    TS_ASSERT(save2.setProperty("SaveUngroupedDetectors", false));
+    save2.execute();
+    TS_ASSERT(save2.isExecuted());
+
+    testFile = save2.getPropertyValue("OutputFile");
+
+    // Check that only group 1 and not 0 is in the file
+    xmlText = Kernel::Strings::loadFile(testFile);
+    TS_ASSERT_EQUALS(xmlText.find("<group ID=\"0\">"), std::string::npos)             // group 0 NOT found
+    TS_ASSERT_EQUALS(xmlText.find("<detids>3-41,43-112</detids>"), std::string::npos) // group 0 NOT found
+    TS_ASSERT_DIFFERS(xmlText.find("<group ID=\"1\">"), std::string::npos)            // group 1 found
+    TS_ASSERT_DIFFERS(xmlText.find("<detids>42</detids>"), std::string::npos)         // group 1 found
 
     Poco::File file(testFile);
     file.remove();

--- a/Framework/DataHandling/test/SaveDetectorsGroupingTest.h
+++ b/Framework/DataHandling/test/SaveDetectorsGroupingTest.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Run.h"
+#include "MantidKernel/Strings.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/Timer.h"
 #include <cxxtest/TestSuite.h>

--- a/Testing/SystemTests/tests/framework/DirectILLAutoProcessTest.py
+++ b/Testing/SystemTests/tests/framework/DirectILLAutoProcessTest.py
@@ -30,7 +30,7 @@ class DirectILLAuto_PANTHER_Powder_Test(systemtesting.MantidSystemTest):
     def validate(self):
         self.tolerance = 1e-2
         self.tolerance_is_rel_err = True
-        self.disableChecking = ["Instrument"]
+        self.disableChecking = ["Instrument", "SpectraMap"]
         return ["He3C60", "ILL_PANTHER_Powder_Auto.nxs"]
 
     def runTest(self):
@@ -182,7 +182,7 @@ class DirectILLAuto_SHARP_Powder_Test(systemtesting.MantidSystemTest):
     def validate(self):
         self.tolerance = 1e-2
         self.tolerance_is_rel_err = True
-        self.disableChecking = ["Instrument"]
+        self.disableChecking = ["Instrument", "SpectraMap"]
         return ["PEO", "ILL_SHARP_Powder_Auto.nxs"]
 
     def runTest(self):

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -844,8 +844,6 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/CoordTransfor
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/CoordTransformAffine.cpp:368
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SavePHX.cpp:77
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SavePHX.cpp:50
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SavePAR.cpp:78
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SavePAR.cpp:50
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/SaveOpenGenieAscii.h:23
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNXcanSAS.cpp:412
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNXcanSAS.cpp:428

--- a/docs/source/algorithms/GenerateGroupingPowder-v2.rst
+++ b/docs/source/algorithms/GenerateGroupingPowder-v2.rst
@@ -1,0 +1,120 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+For powder samples, with no texture, the scattering consists only of
+rings. This algorithm reads a workspace and an angle step, then
+generates a grouping file (.xml or .nxs) and an optional par file (.par),
+by grouping detectors in one of several methods:
+
+* Divide ring into circular sectors labeled i\*step to (i+1)\*step (see note below).
+  The original and default behavior.
+* Divide sphere into spherical sectors, similarly to above but including azimuthal angles (see note below).
+  Use NumberByAngle set to true and specify AzimuthalStep and AzimuthalStart.
+* Divide ring into circular sectors labeled in order, from large 2theta to low 2theta.
+  Use NumberByAngle set to false and specify only AngleStep (or set AzimuthalStep to its default at 360).
+* Divide ring into circular sectors labeled in order, splitting left/right sides from large 2theta to low 2theta.
+  One side is labeled first, then the other.
+  Use NumberByAngle set to false, specify AngleStep, and specify AzimuthalStep as anything other than 360.
+
+The par file is required
+for saving in the NXSPE format, since Mantid does not correctly
+calculate the angles for detector groups. It will contain
+average distances to the detector groups, and average scattering angles.
+The x and y extents in the par file are radians(step)\*distance and
+0.01, and are not supposed to be accurate.  A par file can only be saved using the original default labeling scheme.
+
+The grouping file (.xml) can be used with :ref:`GroupDetectors
+<algm-GroupDetectors>` to perform the grouping.
+
+Usage
+-----
+
+.. include:: ../usagedata-note.txt
+
+.. testcode:: GenerateGroupingPowder_default
+
+    # create some grouping file
+    import mantid
+    outputFilename=mantid.config.getString("defaultsave.directory")+"powder.xml"
+
+    #load some file
+    ws=Load("CNCS_7860")
+
+    #generate the files
+    GenerateGroupingPowder(ws,10, GroupingFilename=outputFilename)
+
+    #check that it works
+    import os.path
+    if(os.path.isfile(outputFilename)):
+        print("Found file powder.xml")
+    if(os.path.isfile(mantid.config.getString("defaultsave.directory")+"powder.par")):
+        print("Found file powder.par")
+    wsg=GroupDetectors(ws,outputFilename)
+    print("The grouping workspace has {} histograms".format(wsg.getNumberHistograms()))
+
+.. testcleanup:: GenerateGroupingPowder_default
+
+   DeleteWorkspace(ws)
+   DeleteWorkspace(wsg)
+   import os,mantid
+   filename=mantid.config.getString("defaultsave.directory")+"powder.xml"
+   os.remove(filename)
+   filename=mantid.config.getString("defaultsave.directory")+"powder.par"
+   os.remove(filename)
+
+Output:
+
+.. testoutput:: GenerateGroupingPowder_default
+
+    Found file powder.xml
+    Found file powder.par
+    The grouping workspace has 14 histograms
+
+----
+
+Similarly, one could instead specify the grouping workspace:
+
+.. testcode:: GenerateGroupingPowder_GroupingWorkspace
+
+    #load some file
+    ws=Load("CNCS_7860")
+    gws_name= "a_nice_name_for_grouping_workspace"
+
+    #generate the files
+    GenerateGroupingPowder(ws,10, GroupingWorkspace=gws_name)
+
+    #check that it works
+    gws = mtd[gws_name]
+    print("The grouping workspace has {} histograms".format(gws.getNumberHistograms()))
+
+.. testcleanup:: GenerateGroupingPowder_GroupingWorkspace
+
+   DeleteWorkspace(ws)
+   DeleteWorkspace(gws)
+
+
+
+Output:
+
+.. testoutput:: GenerateGroupingPowder_GroupingWorkspace
+
+    The grouping workspace has 51200 histograms
+
+
+
+If one would use LoadDetectorsGroupingFile on powder.xml one would get a workspace that looks like
+
+.. figure:: /images/GenerateGroupingPowder.png
+   :alt: GenerateGroupingPowder.png
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37663.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37663.rst
@@ -1,1 +1,1 @@
-- New version 2 of :ref:`GenerateGroupingPowder <algm-GenerateGroupingPowder>` that will save the grouping file with groups starting at 1 instead of 0 to make them consisted with ``GroupingWorkspace``.
+- New version 2 of :ref:`GenerateGroupingPowder <algm-GenerateGroupingPowder>` that will save the grouping file with groups starting at 1 instead of 0 to make them consisted with ``GroupingWorkspace``. The ``FileFormat`` parameter has also been removed as it will now be determined from the extension of ``GroupingFilename``.

--- a/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37663.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37663.rst
@@ -1,0 +1,1 @@
+- New version 2 of :ref:`GenerateGroupingPowder <algm-GenerateGroupingPowder>` that will save the grouping file with groups starting at 1 instead of 0 to make them consisted with ``GroupingWorkspace``.


### PR DESCRIPTION
### Description of work
New version of `GenerateGroupingPowder`. This is a Version 2 because it now produces different xml grouping files. It will start groups from 1 instead of 0, thereby following the conversion from `GroupingWorkspace`. It will also create small sized xml files.


#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes Ref [1728: [40h] [Enabler] refactor SaveDetectorsGrouping, SavePAR, SaveNexusProcessed, GenerateGroupingPowder for less code reuse, more efficiency](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/1728)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

You can compare the two version by

```python
ws=Load("CNCS_7860", NumberOfBins=1)
GenerateGroupingPowder(ws,10, GroupingFilename="/tmp/powder1.xml", GroupingWorkspace="groups1", Version=1)
GenerateGroupingPowder(ws,10, GroupingFilename="/tmp/powder2.xml", GroupingWorkspace="groups2")
```

and look at the saved grouping files.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
