### PR TITLE
Fix for crash when opening instrument view with old Muon data

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/InstrumentViewer/Bugfixes/34544.rst
+++ b/docs/source/release/v6.11.0/Workbench/InstrumentViewer/Bugfixes/34544.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where opening the instrument viewer with old muon data (DEVA) would cause a crash.

--- a/qt/widgets/instrumentview/src/InstrumentRenderer.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentRenderer.cpp
@@ -38,6 +38,9 @@ InstrumentRenderer::InstrumentRenderer(const InstrumentActor &actor)
   const auto &componentInfo = actor.componentInfo();
 
   size_t textureIndex = 0;
+  if (componentInfo.size() <= 1) {
+    return;
+  }
   for (size_t i = componentInfo.root(); !componentInfo.isDetector(i); --i) {
     auto type = componentInfo.componentType(i);
     if (type == ComponentType::Rectangular || type == ComponentType::OutlineComposite || type == ComponentType::Grid) {

--- a/qt/widgets/instrumentview/test/CMakeLists.txt
+++ b/qt/widgets/instrumentview/test/CMakeLists.txt
@@ -1,8 +1,12 @@
 # Testing
 set(TEST_FILES
-    InstrumentRendererTest.h InstrumentWidgetDecoderTest.h InstrumentWidgetEncoderTest.h
-    InstrumentWidget/InstrumentDisplayTest.h InstrumentWidget/InstrumentWidgetTest.h
-    InstrumentWidget/PanelsSurfaceTest.h InstrumentWidget/ProjectionSurfaceTest.h
+    InstrumentRendererTest.h
+    InstrumentWidgetDecoderTest.h
+    InstrumentWidgetEncoderTest.h
+    InstrumentWidget/InstrumentDisplayTest.h
+    InstrumentWidget/InstrumentWidgetTest.h
+    InstrumentWidget/PanelsSurfaceTest.h
+    InstrumentWidget/ProjectionSurfaceTest.h
 )
 
 set(MOCK_HEADER_DIRS InstrumentWidget)

--- a/qt/widgets/instrumentview/test/CMakeLists.txt
+++ b/qt/widgets/instrumentview/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Testing
-set(TEST_FILES InstrumentWidgetDecoderTest.h InstrumentWidgetEncoderTest.h InstrumentWidget/InstrumentDisplayTest.h
-               InstrumentWidget/InstrumentWidgetTest.h InstrumentWidget/PanelsSurfaceTest.h
+set(TEST_FILES
+    InstrumentRendererTest.h InstrumentWidgetDecoderTest.h InstrumentWidgetEncoderTest.h
+    InstrumentWidget/InstrumentDisplayTest.h InstrumentWidget/InstrumentWidgetTest.h
+    InstrumentWidget/PanelsSurfaceTest.h
 )
 
 set(MOCK_HEADER_DIRS InstrumentWidget)

--- a/qt/widgets/instrumentview/test/InstrumentRendererTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentRendererTest.h
@@ -1,0 +1,39 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidQtWidgets/Common/MessageHandler.h"
+#include "MantidQtWidgets/InstrumentView/InstrumentActor.h"
+#include "MantidQtWidgets/InstrumentView/InstrumentRendererClassic.h"
+
+#include <cxxtest/TestSuite.h>
+
+using namespace Mantid::DataObjects;
+using namespace Mantid::Geometry;
+using namespace MantidQt::MantidWidgets;
+
+class InstrumentRendererTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static InstrumentRendererTest *createSuite() { return new InstrumentRendererTest(); }
+  static void destroySuite(InstrumentRendererTest *suite) { delete suite; }
+
+  void test_renderer_constructs_with_empty_instrument() {
+    auto ws = std::make_shared<Workspace2D>();
+    auto inst = std::make_shared<Instrument>();
+    inst->setName("DEVA");
+    ws->setInstrument(inst);
+    auto messageHandler = std::make_unique<MessageHandler>();
+
+    InstrumentActor actor(ws, *messageHandler);
+    TS_ASSERT(actor.componentInfo().size() <= 1);
+    TS_ASSERT_THROWS_NOTHING(auto renderer = std::make_unique<InstrumentRendererClassic>(actor));
+  }
+};


### PR DESCRIPTION
### Description of work

https://github.com/mantidproject/mantid/pull/16406 made it possible to load certain old data. As part of this, an empty instrument was added to the workspace by LoadEventMuon which caused a problem when opening the instrument viewer.

This PR adds a check when constructing the instrument renderer to check for an empty instrument.

Fixes #34544

### To test:

- Load `DEVA01360.nxs` from the unit test data (you may have to build the `StandardTestData` target if not already built)
- Attempt to open one of the workspace in the instrument viewer, there should be an appropriate warning and no crash

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
