### PR TITLE
Improve BayesFitting window support for quickbayes

### DIFF
--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
@@ -90,6 +90,7 @@ void BayesFitting::loadSettings() {
 void BayesFitting::applySettings(std::map<std::string, QVariant> const &settings) {
   for (auto tab = m_bayesTabs.begin(); tab != m_bayesTabs.end(); ++tab) {
     tab->second->filterInputData(settings.at("RestrictInput").toBool());
+    tab->second->applySettings(settings);
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
@@ -89,7 +89,6 @@ void BayesFitting::loadSettings() {
 
 void BayesFitting::applySettings(std::map<std::string, QVariant> const &settings) {
   for (auto tab = m_bayesTabs.begin(); tab != m_bayesTabs.end(); ++tab) {
-    tab->second->filterInputData(settings.at("RestrictInput").toBool());
     tab->second->applySettings(settings);
   }
 }

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.cpp
@@ -23,7 +23,9 @@ BayesFittingTab::~BayesFittingTab() { m_propTree->unsetFactoryForManager(m_dblMa
  */
 void BayesFittingTab::filterInputData(bool filter) { setFileExtensionsByName(filter); }
 
-void BayesFittingTab::applySettings(std::map<std::string, QVariant> const &settings) {}
+void BayesFittingTab::applySettings(std::map<std::string, QVariant> const &settings) {
+  filterInputData(settings.at("RestrictInput").toBool());
+}
 
 void BayesFittingTab::setFileExtensionsByName(bool filter) { (void)filter; }
 

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.cpp
@@ -23,6 +23,8 @@ BayesFittingTab::~BayesFittingTab() { m_propTree->unsetFactoryForManager(m_dblMa
  */
 void BayesFittingTab::filterInputData(bool filter) { setFileExtensionsByName(filter); }
 
+void BayesFittingTab::applySettings(std::map<std::string, QVariant> const &settings) {}
+
 void BayesFittingTab::setFileExtensionsByName(bool filter) { (void)filter; }
 
 void BayesFittingTab::updateProperties(QtProperty *prop, double val) {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.h
@@ -45,6 +45,13 @@ static const unsigned int NUM_DECIMALS = 6;
 /// precision for integer properties in bayes tabs
 static const unsigned int INT_DECIMALS = 0;
 
+struct BackgroundType {
+  inline static const std::string SLOPING = "Sloping";
+  inline static const std::string FLAT = "Flat";
+  inline static const std::string ZERO = "Zero";
+  inline static const std::string LINEAR = "Linear";
+};
+
 class MANTIDQT_INELASTIC_DLL BayesFittingTab : public InelasticTab {
   Q_OBJECT
 
@@ -57,6 +64,8 @@ public:
 
   /// Prevent loading of data with incorrect naming
   void filterInputData(bool filter);
+
+  virtual void applySettings(std::map<std::string, QVariant> const &settings);
 
 protected slots:
   /// Slot to update the guides when the range properties change

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
@@ -25,6 +25,13 @@ public:
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
 
+  // Slot for when settings are changed
+  void applySettings(std::map<std::string, QVariant> const &settings) override;
+  // Setup fit options, property browser, and plot options ui elements
+  void setupFitOptions();
+  void setupPropertyBrowser();
+  void setupPlotOptions();
+
 private slots:
   /// Slot for when the min range on the range selector changes
   void minValueChanged(double min);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
@@ -19,6 +19,12 @@ using namespace MantidQt::CustomInterfaces::InterfaceUtils;
 
 namespace {
 Mantid::Kernel::Logger g_log("Stretch");
+struct PlotType {
+  inline static const std::string ALL = "All";
+  inline static const std::string SIGMA = "Sigma";
+  inline static const std::string BETA = "Beta";
+  inline static const std::string FWHM = "FWHM";
+};
 } // namespace
 
 namespace MantidQt::CustomInterfaces {
@@ -32,38 +38,9 @@ Stretch::Stretch(QWidget *parent) : BayesFittingTab(parent), m_previewSpec(0), m
   connect(eRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(minValueChanged(double)));
   connect(eRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(maxValueChanged(double)));
 
-  // Add the properties browser to the ui form
-  m_uiForm.treeSpace->addWidget(m_propTree);
-
-  m_properties["EMin"] = m_dblManager->addProperty("EMin");
-  m_properties["EMax"] = m_dblManager->addProperty("EMax");
-  m_properties["SampleBinning"] = m_dblManager->addProperty("Sample Binning");
-  m_properties["Sigma"] = m_dblManager->addProperty("Sigma");
-  m_properties["Beta"] = m_dblManager->addProperty("Beta");
-
-  m_dblManager->setDecimals(m_properties["EMin"], NUM_DECIMALS);
-  m_dblManager->setDecimals(m_properties["EMax"], NUM_DECIMALS);
-  m_dblManager->setDecimals(m_properties["SampleBinning"], INT_DECIMALS);
-  m_dblManager->setDecimals(m_properties["Sigma"], INT_DECIMALS);
-  m_dblManager->setDecimals(m_properties["Beta"], INT_DECIMALS);
-
-  m_propTree->addProperty(m_properties["EMin"]);
-  m_propTree->addProperty(m_properties["EMax"]);
-  m_propTree->addProperty(m_properties["SampleBinning"]);
-  m_propTree->addProperty(m_properties["Sigma"]);
-  m_propTree->addProperty(m_properties["Beta"]);
-
-  formatTreeWidget(m_propTree, m_properties);
-
-  // default values
-  m_dblManager->setValue(m_properties["Sigma"], 50);
-  m_dblManager->setMinimum(m_properties["Sigma"], 1);
-  m_dblManager->setMaximum(m_properties["Sigma"], 200);
-  m_dblManager->setValue(m_properties["Beta"], 50);
-  m_dblManager->setMinimum(m_properties["Beta"], 1);
-  m_dblManager->setMaximum(m_properties["Beta"], 200);
-  m_dblManager->setValue(m_properties["SampleBinning"], 1);
-  m_dblManager->setMinimum(m_properties["SampleBinning"], 1);
+  setupFitOptions();
+  setupPropertyBrowser();
+  setupPlotOptions();
 
   // Connect the data selector for the sample to the mini plot
   connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this, SLOT(handleSampleInputReady(const QString &)));
@@ -95,11 +72,6 @@ void Stretch::setFileExtensionsByName(bool filter) {
 void Stretch::handleValidation(IUserInputValidator *validator) const {
   validator->checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
   validator->checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
-
-  auto const useQuickBayes = SettingsHelper::hasDevelopmentFlag("quickbayes");
-  if (useQuickBayes && m_uiForm.cbBackground->currentText() == "Sloping") {
-    validator->addErrorMessage("The 'quickBayes' package does not support a 'Sloping' background type.");
-  }
 }
 
 void Stretch::handleRun() {
@@ -125,12 +97,9 @@ void Stretch::handleRun() {
   auto const eMin = m_properties["EMin"]->valueText().toDouble();
   auto const eMax = m_properties["EMax"]->valueText().toDouble();
   auto const beta = m_properties["Beta"]->valueText().toInt();
-  auto const sigma = m_properties["Sigma"]->valueText().toInt();
-  auto const nBins = m_properties["SampleBinning"]->valueText().toInt();
 
   // Bool options
   auto const elasticPeak = m_uiForm.chkElasticPeak->isChecked();
-  auto const sequence = m_uiForm.chkSequentialFit->isChecked();
 
   // Construct OutputNames
   auto const cutIndex = sampleName.find_last_of("_");
@@ -152,10 +121,12 @@ void Stretch::handleRun() {
   stretch->setProperty("Elastic", elasticPeak);
   stretch->setProperty("OutputWorkspaceFit", m_fitWorkspaceName);
   stretch->setProperty("OutputWorkspaceContour", m_contourWorkspaceName);
-  if (useQuickBayes) {
-    stretch->setProperty("Background", background == "Flat" ? background : "None");
-  } else {
-    stretch->setProperty("Background", background);
+  stretch->setProperty("Background", background);
+  if (!useQuickBayes) {
+    auto const sigma = m_properties["Sigma"]->valueText().toInt();
+    auto const nBins = m_properties["SampleBinning"]->valueText().toInt();
+    auto const sequence = m_uiForm.chkSequentialFit->isChecked();
+
     stretch->setProperty("SampleBins", nBins);
     stretch->setProperty("NumberSigma", sigma);
     stretch->setProperty("Loop", sequence);
@@ -268,6 +239,105 @@ void Stretch::plotContourClicked() {
 void Stretch::loadSettings(const QSettings &settings) {
   m_uiForm.dsSample->readSettings(settings.group());
   m_uiForm.dsResolution->readSettings(settings.group());
+}
+
+/**
+ * Get called whenever the settings are updated
+ *
+ * @param settings :: The current settings
+ */
+void Stretch::applySettings(std::map<std::string, QVariant> const &settings) {
+  setupFitOptions();
+  setupPropertyBrowser();
+  setupPlotOptions();
+  filterInputData(settings.at("RestrictInput").toBool());
+}
+
+/**
+ * Setup the fit options based on the algorithm used
+ *
+ */
+void Stretch::setupFitOptions() {
+  auto const useQuickBayes = SettingsHelper::hasDevelopmentFlag("quickbayes");
+  m_uiForm.cbBackground->clear();
+  if (useQuickBayes) {
+    m_uiForm.cbBackground->addItem(QString::fromStdString(BackgroundType::LINEAR));
+    m_uiForm.cbBackground->addItem(QString::fromStdString(BackgroundType::FLAT));
+    m_uiForm.cbBackground->addItem(QString::fromStdString(BackgroundType::ZERO));
+    m_uiForm.chkSequentialFit->hide();
+  } else {
+    m_uiForm.cbBackground->addItem(QString::fromStdString(BackgroundType::SLOPING));
+    m_uiForm.cbBackground->addItem(QString::fromStdString(BackgroundType::FLAT));
+    m_uiForm.cbBackground->addItem(QString::fromStdString(BackgroundType::ZERO));
+    m_uiForm.chkSequentialFit->show();
+  }
+}
+
+/**
+ * Setup the property browser based on the algorithm used
+ *
+ */
+void Stretch::setupPropertyBrowser() {
+  auto const useQuickBayes = SettingsHelper::hasDevelopmentFlag("quickbayes");
+
+  m_properties.clear();
+  m_dblManager->clear();
+  m_propTree->clear();
+
+  m_uiForm.treeSpace->addWidget(m_propTree);
+
+  m_properties["EMin"] = m_dblManager->addProperty("EMin");
+  m_properties["EMax"] = m_dblManager->addProperty("EMax");
+  m_properties["Beta"] = m_dblManager->addProperty("Beta");
+
+  m_dblManager->setDecimals(m_properties["EMin"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["EMax"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["Beta"], INT_DECIMALS);
+
+  m_propTree->addProperty(m_properties["EMin"]);
+  m_propTree->addProperty(m_properties["EMax"]);
+  m_propTree->addProperty(m_properties["Beta"]);
+
+  m_dblManager->setValue(m_properties["Beta"], 50);
+  m_dblManager->setMinimum(m_properties["Beta"], 1);
+  m_dblManager->setMaximum(m_properties["Beta"], 200);
+
+  if (!useQuickBayes) {
+    m_properties["SampleBinning"] = m_dblManager->addProperty("Sample Binning");
+    m_properties["Sigma"] = m_dblManager->addProperty("Sigma");
+
+    m_dblManager->setDecimals(m_properties["SampleBinning"], INT_DECIMALS);
+    m_dblManager->setDecimals(m_properties["Sigma"], INT_DECIMALS);
+
+    m_propTree->addProperty(m_properties["SampleBinning"]);
+    m_propTree->addProperty(m_properties["Sigma"]);
+
+    m_dblManager->setValue(m_properties["Sigma"], 50);
+    m_dblManager->setMinimum(m_properties["Sigma"], 1);
+    m_dblManager->setMaximum(m_properties["Sigma"], 200);
+    m_dblManager->setValue(m_properties["SampleBinning"], 1);
+    m_dblManager->setMinimum(m_properties["SampleBinning"], 1);
+  }
+
+  formatTreeWidget(m_propTree, m_properties);
+}
+
+/**
+ * Setup the plot options based on the algorithm used
+ *
+ */
+void Stretch::setupPlotOptions() {
+  auto const useQuickBayes = SettingsHelper::hasDevelopmentFlag("quickbayes");
+  m_uiForm.cbPlot->clear();
+  if (useQuickBayes) {
+    m_uiForm.cbPlot->addItem(QString::fromStdString(PlotType::ALL));
+    m_uiForm.cbPlot->addItem(QString::fromStdString(PlotType::FWHM));
+    m_uiForm.cbPlot->addItem(QString::fromStdString(PlotType::BETA));
+  } else {
+    m_uiForm.cbPlot->addItem(QString::fromStdString(PlotType::ALL));
+    m_uiForm.cbPlot->addItem(QString::fromStdString(PlotType::SIGMA));
+    m_uiForm.cbPlot->addItem(QString::fromStdString(PlotType::BETA));
+  }
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.h
@@ -25,6 +25,13 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  // Slot for when settings are changed
+  void applySettings(std::map<std::string, QVariant> const &settings) override;
+
+  // Setup fit options, property browser, and plot options ui elements
+  void setupFitOptions();
+  void setupPropertyBrowser();
+  void setupPlotOptions();
 
 private slots:
   /// Slot for when the min range on the range selector changes


### PR DESCRIPTION
### Description of work
This pull request adds several improvements to the BayesFitting window to better support the `quickbayes` algorithm implementation. It introduces the following enhancements.:
- Change background option "Sloping" to "Linear" for quickbayes
- Remove any unsupported fit or property options by the `quickbayes` algorithms
- Change plot options "FWHM" to "Gamma" in the Quasi tab and "Sigma" to "FWHM" in the Stretch tab
- Output different names depending on the algorithm used

#### Summary of work
<!-- Please provide a short, high-level description of the work done.
-->
This PR refines the BayesFitting window to better support the new `quickbayes` algorithms. 

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37153. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->
### To test:
1. Open `Inelastic->Bayes fitting`
2. Check the layout of `Quasi` and `Stretch` tabs
3. Go to `Quasi` tab
4. Load these data sets from the SampleData
Sample `irs26176_graphite002_red`
Resolution `irs26173_graphite002_res`
5. Open the Settings widget in the bottom left corner
6. Type "quickbayes" (no capitals) in the developer flags box, and click `Ok`
7. The tabs should now be updated to reflect the relevant options for `quickbayes`
8. Check that the fit options are "Background" and "Elastic Peak"
9. Check that the background options are "Linear", "Flat", "Zero"
10. Check that the properties in the browser are "Emin" and "Emax"
11. Change Background to "Flat", Emin to -0.4, and Emax to 0.4
12. Click `Run`
13. Check that the plot options are "All", "Amplitude", "Gamma", and "Prob" and they are plotting the correct plots
14. Repeat the same steps for `Stretch`
15. For `Stretch` the fit options and background options are the same but the property browser has extra `Beta` property
16. The plot options are "All", "FWHM", and "Beta"


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
