### PR TITLE
Tie Peak Centres option for Convolution QENS Fitting

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1690,7 +1690,6 @@ missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Processor
 missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Processor/ElwinModel.h:50
 missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Processor/IqtModel.h:42
 missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/Processor/SymmetriseModel.h:39
-variableScope:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp:73
 missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.h:47
 missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionModel.h:21
 returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.h:99

--- a/docs/source/release/v6.11.0/Inelastic/New_features/37669.rst
+++ b/docs/source/release/v6.11.0/Inelastic/New_features/37669.rst
@@ -1,0 +1,1 @@
+- Added an option to "Tie Amplitudes" for two Lorentzians in the Convolution tab of the :ref:`Inelastic QENS Fitting <interface-inelastic-qens-fitting>` interface.

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTabConstants.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTabConstants.h
@@ -85,7 +85,7 @@ inline auto templateSubTypes() {
   return packTemplateSubTypes(
       std::make_unique<ConvTypes::LorentzianSubType>(), std::make_unique<ConvTypes::FitSubType>(),
       std::make_unique<ConvTypes::DeltaSubType>(), std::make_unique<ConvTypes::TempSubType>(),
-      std::make_unique<ConvTypes::BackgroundSubType>(), std::make_unique<ConvTypes::TieAmplitudesSubType>());
+      std::make_unique<ConvTypes::BackgroundSubType>(), std::make_unique<ConvTypes::TiePeakCentresSubType>());
 }
 
 } // namespace Convolution

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTabConstants.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTabConstants.h
@@ -82,10 +82,10 @@ static const auto HIDDEN_PROPS = std::vector<std::string>(
     {"CreateOutput", "LogValue", "PassWSIndexToFunction", "OutputWorkspace", "Output", "PeakRadius", "PlotParameter"});
 
 inline auto templateSubTypes() {
-  return packTemplateSubTypes(std::make_unique<ConvTypes::LorentzianSubType>(),
-                              std::make_unique<ConvTypes::FitSubType>(), std::make_unique<ConvTypes::DeltaSubType>(),
-                              std::make_unique<ConvTypes::TempSubType>(),
-                              std::make_unique<ConvTypes::BackgroundSubType>());
+  return packTemplateSubTypes(
+      std::make_unique<ConvTypes::LorentzianSubType>(), std::make_unique<ConvTypes::FitSubType>(),
+      std::make_unique<ConvTypes::DeltaSubType>(), std::make_unique<ConvTypes::TempSubType>(),
+      std::make_unique<ConvTypes::BackgroundSubType>(), std::make_unique<ConvTypes::TieHeightsSubType>());
 }
 
 } // namespace Convolution

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTabConstants.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTabConstants.h
@@ -85,7 +85,7 @@ inline auto templateSubTypes() {
   return packTemplateSubTypes(
       std::make_unique<ConvTypes::LorentzianSubType>(), std::make_unique<ConvTypes::FitSubType>(),
       std::make_unique<ConvTypes::DeltaSubType>(), std::make_unique<ConvTypes::TempSubType>(),
-      std::make_unique<ConvTypes::BackgroundSubType>(), std::make_unique<ConvTypes::TieHeightsSubType>());
+      std::make_unique<ConvTypes::BackgroundSubType>(), std::make_unique<ConvTypes::TieAmplitudesSubType>());
 }
 
 } // namespace Convolution

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
@@ -51,6 +51,7 @@ void ConvFunctionTemplateModel::clearData() {
   m_deltaType = DeltaType::None;
   m_tempCorrectionType = TempCorrectionType::None;
   m_backgroundType = BackgroundType::None;
+  m_tiePeakCentresType = TiePeakCentresType::False;
 
   m_model->clear();
 }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
@@ -63,7 +63,7 @@ void ConvFunctionTemplateModel::setModel() {
     m_globals.push_back(ParamID::TEMPERATURE);
   }
   m_model->setGlobalParameters(makeGlobalList());
-  tieHeights();
+  tieAmplitudes();
   estimateFunctionParameters();
 }
 
@@ -296,8 +296,8 @@ void ConvFunctionTemplateModel::setSubType(std::size_t subTypeIndex, int typeInd
   case ConvTypes::SubTypeIndex::Background:
     m_backgroundType = static_cast<ConvTypes::BackgroundType>(typeIndex);
     break;
-  case ConvTypes::SubTypeIndex::TieHeights:
-    m_tieHeightsType = static_cast<ConvTypes::TieHeightsType>(typeIndex);
+  case ConvTypes::SubTypeIndex::TieAmplitudes:
+    m_tieAmplitudesType = static_cast<ConvTypes::TieAmplitudesType>(typeIndex);
     break;
   default:
     throw std::logic_error("A matching ConvTypes::SubTypeIndex could not be found.");
@@ -314,16 +314,16 @@ std::map<std::size_t, int> ConvFunctionTemplateModel::getSubTypes() const {
   subTypes[ConvTypes::SubTypeIndex::Delta] = static_cast<int>(m_deltaType);
   subTypes[ConvTypes::SubTypeIndex::TempCorrection] = static_cast<int>(m_tempCorrectionType);
   subTypes[ConvTypes::SubTypeIndex::Background] = static_cast<int>(m_backgroundType);
-  subTypes[ConvTypes::SubTypeIndex::TieHeights] = static_cast<int>(m_tieHeightsType);
+  subTypes[ConvTypes::SubTypeIndex::TieAmplitudes] = static_cast<int>(m_tieAmplitudesType);
   return subTypes;
 }
 
-void ConvFunctionTemplateModel::tieHeights() {
+void ConvFunctionTemplateModel::tieAmplitudes() {
   auto const lor1AmplitudeName = getParameterName(ParamID::LOR1_AMPLITUDE);
   auto const lor2AmplitudeName = getParameterName(ParamID::LOR2_AMPLITUDE);
   if (!lor1AmplitudeName || !lor2AmplitudeName)
     return;
-  auto const tie = m_tieHeightsType == TieHeightsType::True ? *lor2AmplitudeName : "";
+  auto const tie = m_tieAmplitudesType == TieAmplitudesType::True ? *lor2AmplitudeName : "";
   for (auto i = 0; i < getNumberDomains(); ++i) {
     setLocalParameterTie(*lor1AmplitudeName, i, tie);
   }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
@@ -71,10 +71,10 @@ void ConvFunctionTemplateModel::setFunction(IFunction_sptr fun) {
   clearData();
   if (!fun)
     return;
-  bool isBackgroundSet = false;
   if (fun->name() == "Convolution") {
     checkConvolution(fun);
   } else if (fun->name() == "CompositeFunction") {
+    bool isBackgroundSet = false;
     for (size_t i = 0; i < fun->nFunctions(); ++i) {
       auto innerFunction = fun->getFunction(i);
       auto const name = innerFunction->name();

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
@@ -63,7 +63,7 @@ void ConvFunctionTemplateModel::setModel() {
     m_globals.push_back(ParamID::TEMPERATURE);
   }
   m_model->setGlobalParameters(makeGlobalList());
-  tieAmplitudes();
+  tiePeakCentres();
   estimateFunctionParameters();
 }
 
@@ -296,8 +296,8 @@ void ConvFunctionTemplateModel::setSubType(std::size_t subTypeIndex, int typeInd
   case ConvTypes::SubTypeIndex::Background:
     m_backgroundType = static_cast<ConvTypes::BackgroundType>(typeIndex);
     break;
-  case ConvTypes::SubTypeIndex::TieAmplitudes:
-    m_tieAmplitudesType = static_cast<ConvTypes::TieAmplitudesType>(typeIndex);
+  case ConvTypes::SubTypeIndex::TiePeakCentres:
+    m_tiePeakCentresType = static_cast<ConvTypes::TiePeakCentresType>(typeIndex);
     break;
   default:
     throw std::logic_error("A matching ConvTypes::SubTypeIndex could not be found.");
@@ -314,18 +314,18 @@ std::map<std::size_t, int> ConvFunctionTemplateModel::getSubTypes() const {
   subTypes[ConvTypes::SubTypeIndex::Delta] = static_cast<int>(m_deltaType);
   subTypes[ConvTypes::SubTypeIndex::TempCorrection] = static_cast<int>(m_tempCorrectionType);
   subTypes[ConvTypes::SubTypeIndex::Background] = static_cast<int>(m_backgroundType);
-  subTypes[ConvTypes::SubTypeIndex::TieAmplitudes] = static_cast<int>(m_tieAmplitudesType);
+  subTypes[ConvTypes::SubTypeIndex::TiePeakCentres] = static_cast<int>(m_tiePeakCentresType);
   return subTypes;
 }
 
-void ConvFunctionTemplateModel::tieAmplitudes() {
-  auto const lor1AmplitudeName = getParameterName(ParamID::LOR1_AMPLITUDE);
-  auto const lor2AmplitudeName = getParameterName(ParamID::LOR2_AMPLITUDE);
-  if (!lor1AmplitudeName || !lor2AmplitudeName)
+void ConvFunctionTemplateModel::tiePeakCentres() {
+  auto const lor1PeakCentreName = getParameterName(ParamID::LOR1_PEAKCENTRE);
+  auto const lor2PeakCentreName = getParameterName(ParamID::LOR2_PEAKCENTRE);
+  if (!lor1PeakCentreName || !lor2PeakCentreName)
     return;
-  auto const tie = m_tieAmplitudesType == TieAmplitudesType::True ? *lor2AmplitudeName : "";
+  auto const tie = m_tiePeakCentresType == TiePeakCentresType::True ? *lor1PeakCentreName : "";
   for (auto i = 0; i < getNumberDomains(); ++i) {
-    setLocalParameterTie(*lor1AmplitudeName, i, tie);
+    setLocalParameterTie(*lor2PeakCentreName, i, tie);
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.cpp
@@ -63,6 +63,7 @@ void ConvFunctionTemplateModel::setModel() {
     m_globals.push_back(ParamID::TEMPERATURE);
   }
   m_model->setGlobalParameters(makeGlobalList());
+  tieHeights();
   estimateFunctionParameters();
 }
 
@@ -295,6 +296,9 @@ void ConvFunctionTemplateModel::setSubType(std::size_t subTypeIndex, int typeInd
   case ConvTypes::SubTypeIndex::Background:
     m_backgroundType = static_cast<ConvTypes::BackgroundType>(typeIndex);
     break;
+  case ConvTypes::SubTypeIndex::TieHeights:
+    m_tieHeightsType = static_cast<ConvTypes::TieHeightsType>(typeIndex);
+    break;
   default:
     throw std::logic_error("A matching ConvTypes::SubTypeIndex could not be found.");
   }
@@ -310,7 +314,19 @@ std::map<std::size_t, int> ConvFunctionTemplateModel::getSubTypes() const {
   subTypes[ConvTypes::SubTypeIndex::Delta] = static_cast<int>(m_deltaType);
   subTypes[ConvTypes::SubTypeIndex::TempCorrection] = static_cast<int>(m_tempCorrectionType);
   subTypes[ConvTypes::SubTypeIndex::Background] = static_cast<int>(m_backgroundType);
+  subTypes[ConvTypes::SubTypeIndex::TieHeights] = static_cast<int>(m_tieHeightsType);
   return subTypes;
+}
+
+void ConvFunctionTemplateModel::tieHeights() {
+  auto const lor1AmplitudeName = getParameterName(ParamID::LOR1_AMPLITUDE);
+  auto const lor2AmplitudeName = getParameterName(ParamID::LOR2_AMPLITUDE);
+  if (!lor1AmplitudeName || !lor2AmplitudeName)
+    return;
+  auto const tie = m_tieHeightsType == TieHeightsType::True ? *lor2AmplitudeName : "";
+  for (auto i = 0; i < getNumberDomains(); ++i) {
+    setLocalParameterTie(*lor1AmplitudeName, i, tie);
+  }
 }
 
 int ConvFunctionTemplateModel::getNumberOfPeaks() const {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.h
@@ -56,7 +56,7 @@ private:
   void clearData();
   void setModel() override;
 
-  void tieAmplitudes();
+  void tiePeakCentres();
 
   std::optional<std::string> getLor1Prefix() const;
   std::optional<std::string> getLor2Prefix() const;
@@ -97,7 +97,7 @@ private:
   ConvTypes::DeltaType m_deltaType = ConvTypes::DeltaType::None;
   ConvTypes::TempCorrectionType m_tempCorrectionType = ConvTypes::TempCorrectionType::None;
   ConvTypes::BackgroundType m_backgroundType = ConvTypes::BackgroundType::None;
-  ConvTypes::TieAmplitudesType m_tieAmplitudesType = ConvTypes::TieAmplitudesType::False;
+  ConvTypes::TiePeakCentresType m_tiePeakCentresType = ConvTypes::TiePeakCentresType::False;
 
   BackgroundSubType m_backgroundSubtype;
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.h
@@ -56,6 +56,8 @@ private:
   void clearData();
   void setModel() override;
 
+  void tieHeights();
+
   std::optional<std::string> getLor1Prefix() const;
   std::optional<std::string> getLor2Prefix() const;
   std::optional<std::string> getFitTypePrefix() const;
@@ -95,6 +97,7 @@ private:
   ConvTypes::DeltaType m_deltaType = ConvTypes::DeltaType::None;
   ConvTypes::TempCorrectionType m_tempCorrectionType = ConvTypes::TempCorrectionType::None;
   ConvTypes::BackgroundType m_backgroundType = ConvTypes::BackgroundType::None;
+  ConvTypes::TieHeightsType m_tieHeightsType = ConvTypes::TieHeightsType::False;
 
   BackgroundSubType m_backgroundSubtype;
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/ConvFunctionTemplateModel.h
@@ -56,7 +56,7 @@ private:
   void clearData();
   void setModel() override;
 
-  void tieHeights();
+  void tieAmplitudes();
 
   std::optional<std::string> getLor1Prefix() const;
   std::optional<std::string> getLor2Prefix() const;
@@ -97,7 +97,7 @@ private:
   ConvTypes::DeltaType m_deltaType = ConvTypes::DeltaType::None;
   ConvTypes::TempCorrectionType m_tempCorrectionType = ConvTypes::TempCorrectionType::None;
   ConvTypes::BackgroundType m_backgroundType = ConvTypes::BackgroundType::None;
-  ConvTypes::TieHeightsType m_tieHeightsType = ConvTypes::TieHeightsType::False;
+  ConvTypes::TieAmplitudesType m_tieAmplitudesType = ConvTypes::TieAmplitudesType::False;
 
   BackgroundSubType m_backgroundSubtype;
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.cpp
@@ -144,9 +144,9 @@ std::map<ConvTypes::TempCorrectionType, TemplateSubTypeDescriptor>
     };
 
 template <>
-std::map<ConvTypes::TieHeightsType, TemplateSubTypeDescriptor>
-    TemplateSubTypeImpl<ConvTypes::TieHeightsType>::g_typeMap{
-        {ConvTypes::TieHeightsType::False, {"None", "", {ParamID::NONE, ParamID::NONE}}},
-        {ConvTypes::TieHeightsType::True, {"Tie Heights", "", {ParamID::NONE, ParamID::NONE}}},
+std::map<ConvTypes::TieAmplitudesType, TemplateSubTypeDescriptor>
+    TemplateSubTypeImpl<ConvTypes::TieAmplitudesType>::g_typeMap{
+        {ConvTypes::TieAmplitudesType::False, {"None", "", {ParamID::NONE, ParamID::NONE}}},
+        {ConvTypes::TieAmplitudesType::True, {"Tie Amplitudes", "", {ParamID::NONE, ParamID::NONE}}},
     };
 } // namespace MantidQt::CustomInterfaces::Inelastic

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.cpp
@@ -144,9 +144,9 @@ std::map<ConvTypes::TempCorrectionType, TemplateSubTypeDescriptor>
     };
 
 template <>
-std::map<ConvTypes::TieAmplitudesType, TemplateSubTypeDescriptor>
-    TemplateSubTypeImpl<ConvTypes::TieAmplitudesType>::g_typeMap{
-        {ConvTypes::TieAmplitudesType::False, {"None", "", {ParamID::NONE, ParamID::NONE}}},
-        {ConvTypes::TieAmplitudesType::True, {"Tie Amplitudes", "", {ParamID::NONE, ParamID::NONE}}},
+std::map<ConvTypes::TiePeakCentresType, TemplateSubTypeDescriptor>
+    TemplateSubTypeImpl<ConvTypes::TiePeakCentresType>::g_typeMap{
+        {ConvTypes::TiePeakCentresType::False, {"None", "", {ParamID::NONE, ParamID::NONE}}},
+        {ConvTypes::TiePeakCentresType::True, {"Tie Peak Centres", "", {ParamID::NONE, ParamID::NONE}}},
     };
 } // namespace MantidQt::CustomInterfaces::Inelastic

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.cpp
@@ -142,4 +142,11 @@ std::map<ConvTypes::TempCorrectionType, TemplateSubTypeDescriptor>
         {ConvTypes::TempCorrectionType::Exponential,
          {"Temp Correction", "ConvTempCorrection", {ParamID::TEMPERATURE, ParamID::TEMPERATURE}}},
     };
+
+template <>
+std::map<ConvTypes::TieHeightsType, TemplateSubTypeDescriptor>
+    TemplateSubTypeImpl<ConvTypes::TieHeightsType>::g_typeMap{
+        {ConvTypes::TieHeightsType::False, {"None", "", {ParamID::NONE, ParamID::NONE}}},
+        {ConvTypes::TieHeightsType::True, {"Tie Heights", "", {ParamID::NONE, ParamID::NONE}}},
+    };
 } // namespace MantidQt::CustomInterfaces::Inelastic

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.h
@@ -88,12 +88,15 @@ enum class TempCorrectionType { None, Exponential };
 
 enum class BackgroundType { None, Flat, Linear };
 
+enum class TieHeightsType { False, True };
+
 enum SubTypeIndex {
   Lorentzian = 0,
   Fit = 1,
   Delta = 2,
   TempCorrection = 3,
   Background = 4,
+  TieHeights = 5,
 };
 
 extern std::map<FitType, bool> FitTypeQDepends;
@@ -120,6 +123,11 @@ struct TempSubType : public TemplateSubTypeImpl<TempCorrectionType> {
 
 struct BackgroundSubType : public TemplateSubTypeImpl<BackgroundType> {
   std::string name() const override { return "Background"; }
+};
+
+struct TieHeightsSubType : public TemplateSubTypeImpl<TieHeightsType> {
+  std::string name() const override { return "Tie Heights"; }
+  bool isType(const std::type_info &type) const override { return type == typeid(bool); }
 };
 
 } // namespace ConvTypes

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.h
@@ -88,7 +88,7 @@ enum class TempCorrectionType { None, Exponential };
 
 enum class BackgroundType { None, Flat, Linear };
 
-enum class TieHeightsType { False, True };
+enum class TieAmplitudesType { False, True };
 
 enum SubTypeIndex {
   Lorentzian = 0,
@@ -96,7 +96,7 @@ enum SubTypeIndex {
   Delta = 2,
   TempCorrection = 3,
   Background = 4,
-  TieHeights = 5,
+  TieAmplitudes = 5,
 };
 
 extern std::map<FitType, bool> FitTypeQDepends;
@@ -125,8 +125,8 @@ struct BackgroundSubType : public TemplateSubTypeImpl<BackgroundType> {
   std::string name() const override { return "Background"; }
 };
 
-struct TieHeightsSubType : public TemplateSubTypeImpl<TieHeightsType> {
-  std::string name() const override { return "Tie Heights"; }
+struct TieAmplitudesSubType : public TemplateSubTypeImpl<TieAmplitudesType> {
+  std::string name() const override { return "Tie Amplitudes"; }
   bool isType(const std::type_info &type) const override { return type == typeid(bool); }
 };
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FitTypes.h
@@ -88,7 +88,7 @@ enum class TempCorrectionType { None, Exponential };
 
 enum class BackgroundType { None, Flat, Linear };
 
-enum class TieAmplitudesType { False, True };
+enum class TiePeakCentresType { False, True };
 
 enum SubTypeIndex {
   Lorentzian = 0,
@@ -96,7 +96,7 @@ enum SubTypeIndex {
   Delta = 2,
   TempCorrection = 3,
   Background = 4,
-  TieAmplitudes = 5,
+  TiePeakCentres = 5,
 };
 
 extern std::map<FitType, bool> FitTypeQDepends;
@@ -125,8 +125,8 @@ struct BackgroundSubType : public TemplateSubTypeImpl<BackgroundType> {
   std::string name() const override { return "Background"; }
 };
 
-struct TieAmplitudesSubType : public TemplateSubTypeImpl<TieAmplitudesType> {
-  std::string name() const override { return "Tie Amplitudes"; }
+struct TiePeakCentresSubType : public TemplateSubTypeImpl<TiePeakCentresType> {
+  std::string name() const override { return "Tie Peak Centres"; }
   bool isType(const std::type_info &type) const override { return type == typeid(bool); }
 };
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/IqtFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/IqtFunctionTemplateModel.cpp
@@ -59,6 +59,7 @@ void IqtFunctionTemplateModel::clearData() {
   m_exponentialType = ExponentialType::None;
   m_fitType = FitType::None;
   m_backgroundType = BackgroundType::None;
+  m_tieIntensitiesType = TieIntensitiesType::False;
 
   m_model->clear();
 }


### PR DESCRIPTION
### Description of work
This PR adds an option to the Convolution tab of the Inelastic QENS Fitting interface to "Tie Peak Centres" for the two lorentzians fitting functions. If there are two lorentzians selected, this option when ticked will tie their peak centres together.

If no lorentzians or one lorentzian is selected, this option is ignored.

Fixes #37200


### To test:
1. Open Inelastic QENS Fitting interface
2. Go to Convolution tab
3. Add the 26176 _red  as sample, and 26173 _res as resolution. Found in the Sample datasets
4. Tick "Tie Peak Centres" with no lorentzians selected. No crash should happen
4. Tick "Tie Peak Centres" with one lorentzians selected. No crash should happen
4. Tick "Tie Peak Centres" with two lorentzians selected
5. Click Run and wait. 
6. Check that the two Peak Centres have the same value at the end of the fit

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
