### PR TITLE
37659 fixing crash engdiff fit tab when fit is re run for a func having fwhm params

### DIFF
--- a/docs/source/release/v6.11.0/Diffraction/Engineering/Bugfixes/37659.rst
+++ b/docs/source/release/v6.11.0/Diffraction/Engineering/Bugfixes/37659.rst
@@ -1,0 +1,1 @@
+- Fixed a crash in :ref:`Fitting tab <ui engineering fitting>` of :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` when a fit is re-run for a function like PseudoVoigt that contains FWHM parameter as the peak function.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
@@ -94,10 +94,13 @@ class FittingPlotModel(object):
 
     def _setup_peak_func_and_extract_fwhm(self, ws_name, peak_func_names, fit_func):
         fit_func_name = fit_func.name()
+        key_fwhm = fit_func_name + "_fwhm"
+        if key_fwhm.lower() in set([k.lower() for k in self._fit_results[ws_name]["results"].keys()]):
+            return  # Avoid re-calculating of FWHM if the results already contain it
+
         if fit_func_name in peak_func_names:
             peak_func = FunctionFactory.Instance().createPeakFunction(fit_func_name)
             [peak_func.setParameter(i_param, fit_func.getParameterValue(i_param)) for i_param in range(fit_func.nParams())]
-            key_fwhm = fit_func_name + "_fwhm"
             self._fit_results[ws_name]["results"][key_fwhm].append([peak_func.fwhm(), 0.0])
 
     def _calculate_fwhm_values(self, ws_name, fit_functions):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
@@ -94,13 +94,13 @@ class FittingPlotModel(object):
 
     def _setup_peak_func_and_extract_fwhm(self, ws_name, peak_func_names, fit_func):
         fit_func_name = fit_func.name()
-        key_fwhm = fit_func_name + "_fwhm"
-        if key_fwhm.lower() in set([k.lower() for k in self._fit_results[ws_name]["results"].keys()]):
-            return  # Avoid re-calculating of FWHM if the results already contain it
+        if fit_func.hasParameter("FWHM"):
+            return  # Avoid re-calculating of FWHM if the fit function already has it
 
         if fit_func_name in peak_func_names:
             peak_func = FunctionFactory.Instance().createPeakFunction(fit_func_name)
             [peak_func.setParameter(i_param, fit_func.getParameterValue(i_param)) for i_param in range(fit_func.nParams())]
+            key_fwhm = fit_func_name + "_fwhm"
             self._fit_results[ws_name]["results"][key_fwhm].append([peak_func.fwhm(), 0.0])
 
     def _calculate_fwhm_values(self, ws_name, fit_functions):


### PR DESCRIPTION
### Description of work
In Engineering diffraction's fitting tab, after re-running a Fit, for a function such as PseudoVoigt that already contains fwhm parameter Mantid had crashed. This was because when implementing #36319 fwhm parameters were re calculated for the same function.

Fixes #37659. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->

### To test:

1. Open Engineering diffraction GUI
2. Go to Fitting tab 
3. Load any focused data with Add to Plot ticked (for more info https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html#test-4)
4. Click on Fit to open the fit property browser
5. On fit property browser click on Setup -> Manage Setup -> Load From String and paste below in the text box 
```
name=PseudoVoigt,Mixing=0.999999,Intensity=101.382,PeakCentre=25074.1,FWHM=98.7982;name=PseudoVoigt,Mixing=1,Intensity=0.834947,PeakCentre=25074.1,FWHM=0.939437
```
7. Click on Fit->Fit to do the first fit.
8. Use the Zoom tool bar button in the toolbar to zoom into a fitted peak.
9. Re run Fit->Fit to observe the changed in fit and Mantid should not crash.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.

