### PR TITLE
Add tooltips to editor widget

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/New_features/37542.rst
+++ b/docs/source/release/v6.11.0/Workbench/New_features/37542.rst
@@ -1,0 +1,1 @@
+- Added tooltips to the run and abort buttons, displaying their functionality and shortcut keys.  Tooltips are displayed when hovering over the relevant buttons.

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
@@ -79,12 +79,14 @@ class CodeEditorTabWidget(QTabWidget):
         run_button.setObjectName(self.RUN_BUTTON_OBJECT_NAME)
         run_button.setIcon(get_icon("mdi.play", PLAY_BUTTON_GREEN_COLOR, 1.6))
         run_button.clicked.connect(parent.execute_current_async)
+        run_button.setToolTip("Run Ctrl+Enter")
         layout.addWidget(run_button)
 
         abort_button = QPushButton(container_widget)
         abort_button.setObjectName(self.ABORT_BUTTON_OBJECT_NAME)
         abort_button.setIcon(get_icon("mdi.square", ABORT_BUTTON_RED_COLOR, 1.1))
         abort_button.clicked.connect(parent.abort_current)
+        abort_button.setToolTip("Abort Ctrl+D")
         layout.addWidget(abort_button)
 
         options_button = QPushButton(container_widget)


### PR DESCRIPTION
### Description of work

#### Summary of work
Added tooltips to the run and abort buttons, displaying their functionality and shortcut keys.

Fixes #37542 
--> Tooltips are displayed when hovering over the buttons.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
--> **Report to:** @thomashampson

### To test:
--> Run Mantid Workbench and hover over the run and abort buttons.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
