### PR TITLE
Add output composite members option to Iqt

### DIFF
--- a/docs/source/release/v6.11.0/Inelastic/New_features/37677.rst
+++ b/docs/source/release/v6.11.0/Inelastic/New_features/37677.rst
@@ -1,0 +1,1 @@
+- Add `Output Composite Members` option to I(Q, t) tab in :ref:`Inelastic QENS Fitting <interface-inelastic-qens-fitting>`

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTabConstants.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTabConstants.h
@@ -65,8 +65,8 @@ static const auto ALL_FITS =
 namespace IqtFit {
 static const auto TAB_NAME = "I(Q, t)";
 static const auto HIDDEN_PROPS =
-    std::vector<std::string>({"CreateOutput", "LogValue", "PassWSIndexToFunction", "ConvolveMembers",
-                              "OutputCompositeMembers", "OutputWorkspace", "Output", "PeakRadius", "PlotParameter"});
+    std::vector<std::string>({"CreateOutput", "LogValue", "PassWSIndexToFunction", "ConvolveMembers", "OutputWorkspace",
+                              "Output", "PeakRadius", "PlotParameter"});
 
 inline auto templateSubTypes() {
   return packTemplateSubTypes(std::make_unique<IqtTypes::ExponentialSubType>(),


### PR DESCRIPTION
### Description of work
This PR adds `Output Composite Members` to the IQT fitting tab. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #31705. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->
### To test:
1. Go to `Interfaces->Inelastic->I(Q, T)`
2. Click `Add Workspace` and add [irs26176_graphite002_iqt.zip](https://github.com/user-attachments/files/16331874/irs26176_graphite002_iqt.zip)
3. Set the indices from 0-5
4. Add two Expontatials 
5. Click `Run`
6. Plot the output workspaces spectra suffixed with `_Workspace` and check that they have `Data`, `Calc` and `Diff` labels
7. Go back to the interface and mark `Output Composite Members` located at the end of the property browser
8. Plot the output workspaces spectra suffixed with `_Workspace` and check that they have now extra two`ExpDecay` labels


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
