### PR TITLE
Load workspaces from MultiDialog (Elwin) in a background thread

### DIFF
--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37682.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37682.rst
@@ -1,0 +1,1 @@
+- The dialog window for adding data in the  :ref:`Elwin Tab <elwin>` of the ref:`Data Processor Interface <interface-inelastic-data-processor>` no longer freezes when adding data.

--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37682.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37682.rst
@@ -1,1 +1,1 @@
-- The dialog window for adding data in the  :ref:`Elwin Tab <elwin>` of the ref:`Data Processor Interface <interface-inelastic-data-processor>` no longer freezes when adding data.
+- The dialog window for adding data in the  :ref:`Elwin Tab <elwin>` of the :ref:`Data Processor Interface <interface-inelastic-data-processor>` no longer freezes when adding data.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
@@ -8,6 +8,7 @@
 
 #include "DllOption.h"
 #include "MantidQtWidgets/Common/IAddWorkspaceDialog.h"
+#include "QtJobRunner.h"
 #include "ui_AddWorkspaceMultiDialog.h"
 
 #include <vector>
@@ -17,7 +18,9 @@
 namespace MantidQt {
 namespace MantidWidgets {
 
-class EXPORT_OPT_MANTIDQT_COMMON AddWorkspaceMultiDialog : public QDialog, public IAddWorkspaceDialog {
+class EXPORT_OPT_MANTIDQT_COMMON AddWorkspaceMultiDialog : public QDialog,
+                                                           public IAddWorkspaceDialog,
+                                                           public API::JobRunnerSubscriber {
   Q_OBJECT
 public:
   explicit AddWorkspaceMultiDialog(QWidget *parent);
@@ -30,6 +33,12 @@ public:
   void setFBSuffices(const QStringList &suffices) override;
   void setup();
 
+  void notifyBatchComplete(bool error) override;
+  void notifyBatchCancelled() override{};
+  void notifyAlgorithmStarted(API::IConfiguredAlgorithm_sptr &algorithm) override { UNUSED_ARG(algorithm); };
+  void notifyAlgorithmComplete(API::IConfiguredAlgorithm_sptr &algorithm) override { UNUSED_ARG(algorithm); };
+  void notifyAlgorithmError(API::IConfiguredAlgorithm_sptr &algorithm, std::string const &message) override;
+
 signals:
   void addData(MantidWidgets::IAddWorkspaceDialog *dialog);
 
@@ -41,7 +50,10 @@ private slots:
   void emitAddData();
 
 private:
+  void updateAddButtonState(bool enabled) const;
   Ui::AddWorkspaceMultiDialog m_uiForm;
+  /// Algorithm Runner used to run the load algorithm
+  std::unique_ptr<MantidQt::API::QtJobRunner> m_algRunner;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
+++ b/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
@@ -6,30 +6,31 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/AddWorkspaceMultiDialog.h"
 #include "MantidAPI/AlgorithmManager.h"
+#include <MantidAPI/AlgorithmRuntimeProps.h>
+#include <MantidQtWidgets/Common/ConfiguredAlgorithm.h>
 #include <QFileInfo>
 #include <utility>
 
 namespace {
 using namespace Mantid::API;
 
-void loadFile(const QString &filename) {
-  QFileInfo fileinfo(filename);
-
+MantidQt::API::IConfiguredAlgorithm_sptr configureLoadAlgorithm(const QString &filename) {
+  QFileInfo const fileinfo(filename);
   auto loader = AlgorithmManager::Instance().createUnmanaged("Load");
   loader->initialize();
-  loader->setProperty("Filename", filename.toStdString());
-  loader->setProperty("OutputWorkspace", fileinfo.baseName().toStdString());
-  loader->execute();
-
-  return;
+  auto properties = std::make_unique<AlgorithmRuntimeProps>();
+  properties->setProperty("Filename", filename.toStdString());
+  properties->setProperty("OutputWorkspace", fileinfo.baseName().toStdString());
+  return std::make_shared<MantidQt::API::ConfiguredAlgorithm>(loader, std::move(properties));
 }
 } // namespace
 
 namespace MantidQt::MantidWidgets {
 
-AddWorkspaceMultiDialog::AddWorkspaceMultiDialog(QWidget *parent) : QDialog(parent) {
+AddWorkspaceMultiDialog::AddWorkspaceMultiDialog(QWidget *parent)
+    : QDialog(parent), m_algRunner(std::make_unique<API::QtJobRunner>()) {
   m_uiForm.setupUi(this);
-
+  m_algRunner->subscribe(this);
   connect(m_uiForm.pbSelAll, SIGNAL(clicked()), this, SLOT(selectAllSpectra()));
   connect(m_uiForm.pbResetDefault, SIGNAL(clicked()), this, SLOT(updateSelectedSpectra()));
   connect(m_uiForm.dsInputFiles, SIGNAL(filesFound()), this, SLOT(handleFilesFound()));
@@ -69,10 +70,30 @@ void AddWorkspaceMultiDialog::updateSelectedSpectra() { return m_uiForm.tbWorksp
 void AddWorkspaceMultiDialog::unifyRange() { return m_uiForm.tbWorkspace->unifyRange(); }
 
 void AddWorkspaceMultiDialog::handleFilesFound() {
+  updateAddButtonState(false);
   auto fileNames = m_uiForm.dsInputFiles->getFilenames();
+  std::deque<API::IConfiguredAlgorithm_sptr> loadQueue = {};
   for (auto const &fileName : fileNames) {
-    loadFile(fileName);
+    loadQueue.emplace_back(configureLoadAlgorithm(fileName));
   }
+  m_algRunner->setAlgorithmQueue(loadQueue);
+  m_algRunner->executeAlgorithmQueue();
 }
 
+void AddWorkspaceMultiDialog::notifyBatchComplete(bool error) {
+  UNUSED_ARG(error);
+  updateAddButtonState(true);
+}
+
+void AddWorkspaceMultiDialog::notifyAlgorithmError(API::IConfiguredAlgorithm_sptr &algorithm,
+                                                   std::string const &message) {
+  UNUSED_ARG(algorithm);
+  updateAddButtonState(true);
+  QMessageBox::warning(this, "Loading error", message.c_str());
+}
+
+void AddWorkspaceMultiDialog::updateAddButtonState(bool enabled) const {
+  enabled ? m_uiForm.pbAdd->setText("Add Data") : m_uiForm.pbAdd->setText("Loading");
+  m_uiForm.pbAdd->setEnabled(enabled);
+}
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
+++ b/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
@@ -72,10 +72,9 @@ void AddWorkspaceMultiDialog::unifyRange() { return m_uiForm.tbWorkspace->unifyR
 void AddWorkspaceMultiDialog::handleFilesFound() {
   updateAddButtonState(false);
   auto fileNames = m_uiForm.dsInputFiles->getFilenames();
-  std::deque<API::IConfiguredAlgorithm_sptr> loadQueue = {};
-  for (auto const &fileName : fileNames) {
-    loadQueue.emplace_back(configureLoadAlgorithm(fileName));
-  }
+  std::deque<API::IConfiguredAlgorithm_sptr> loadQueue;
+  std::transform(fileNames.begin(), fileNames.end(), std::back_inserter(loadQueue),
+                 [](auto const &fileName) { return configureLoadAlgorithm(fileName); });
   m_algRunner->setAlgorithmQueue(loadQueue);
   m_algRunner->executeAlgorithmQueue();
 }


### PR DESCRIPTION
Until recently, in the workspace dialogs used in few tabs of several Inelastic/Indirect classes (notably QENS Fitting), the algorithm loading the data was executed from the member functions of the dialog class. This could cause the GUI to freeze when the data to load is large or demanding. To not block the gui thread from the dialog windows is it necessary to: 
1. Create the dialog as non-modal. 
2. Run the load algorithms form a background thread. 

This was fixed in #37095 for the workspace dialog used in most tabs (`AddWokspaceDialog` base class). 
In this PR , I have additionally implemented the loading of workspace in a background thread in the workspace multi selector dialog window (`AddWorkspaceMultiDialog` class), which is currently used by the Elwin interface. 
I have used a QtJobRunner class as it is easy to run a batch of load algorithms (as when loading multiple files in sequence) in a background thread. 



Fixes  #37184. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

### To test:
- Go to `Interfaces->Inelastic->Data Processor->Elwin`
- Click on `Add Workspaces`
- On `Input File` click on `Browse`. 
- Select two suitable reduced files form the usage data set: 'irs26174_graphite002_red` and `irs26176_graphite002_red' and click `Open`
- When data is being loaded, the `Add` button on the dialog should grey out and the text now reads: `loading`. While this switches back to normal once the data is on the dialog table. 
- Try to load again incorrect data (for example open a file with `.irf` extension from the user data set. This should raise an error in the loading algorithm, which will prompt the notifier to send a warning message, appearing as a warning box dialog.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
