### PR TITLE
Fix error when plotting live data

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/Bugfixes/36726.rst
+++ b/docs/source/release/v6.11.0/Workbench/Bugfixes/36726.rst
@@ -1,0 +1,1 @@
+- Fixed error when plotting a histogram of live data.

--- a/qt/python/mantidqt/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/functions.py
@@ -183,7 +183,7 @@ def plot_from_names(names, errors, overplot, fig=None, show_colorfill_btn=False,
         )
     else:
         return plot(
-            selection.workspaces,
+            names,
             spectrum_nums=selection.spectra,
             wksp_indices=selection.wksp_indices,
             errors=errors,


### PR DESCRIPTION
Instead of passing the workspaces references, pass the names of the workspaces to the plot function. With live data, after selecting which spectra to plot in the pop-up dialog, the workspace can be overwritten, at which point the reference is going to be invalid.

Fixes #36726

### To test:
See #36726 for details on how to reproduce.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
