### PR TITLE
35956 move verify and clear to tear down method in isis reflectometry unit tests

### DIFF
--- a/Framework/DataHandling/test/ISISJournalTest.h
+++ b/Framework/DataHandling/test/ISISJournalTest.h
@@ -84,12 +84,18 @@ private:
 
 class ISISJournalTest : public CxxTest::TestSuite {
 public:
+  void tearDown() override {
+    // Verifying and clearing of expectations happens when mock variables are destroyed.
+    // Some of our mocks are created as member variables and will exist until all tests have run, so we need to
+    // explicitly verify and clear them after each test.
+    verifyAndClear();
+  }
+
   void test_getRuns_requests_correct_url() {
     auto journal = makeJournal();
     auto url = std::string("http://data.isis.rl.ac.uk/journals/ndxinter/journal_19_4.xml");
     EXPECT_CALL(*m_internetHelper, sendRequestProxy(url, _)).Times(1);
     journal.getRuns();
-    verifyAndClear();
   }
 
   void test_getCycleNames_requests_correct_url() {
@@ -97,7 +103,6 @@ public:
     auto url = std::string("http://data.isis.rl.ac.uk/journals/ndxinter/journal_main.xml");
     EXPECT_CALL(*m_internetHelper, sendRequestProxy(url, _)).Times(1);
     journal.getCycleNames();
-    verifyAndClear();
   }
 
   void test_getRuns_when_server_returns_journalFile() {
@@ -106,7 +111,6 @@ public:
     auto const expected =
         std::vector<ISISJournal::RunData>{{{"name", "INTER22345"}}, {{"name", "INTER12345"}}, {{"name", "INTER12346"}}};
     TS_ASSERT_EQUALS(results, expected);
-    verifyAndClear();
   }
 
   void test_getCycleNames_when_server_returns_indexFile() {
@@ -114,40 +118,34 @@ public:
     auto results = journal.getCycleNames();
     auto const expected = std::vector<std::string>{"17_1", "18_1", "19_1", "19_2"};
     TS_ASSERT_EQUALS(results, expected);
-    verifyAndClear();
   }
 
   void test_getRuns_throws_if_url_not_found() {
     auto journal = makeJournal();
     expectURLNotFound();
     TS_ASSERT_THROWS(journal.getRuns(), InternetError const &);
-    verifyAndClear();
   }
 
   void test_getCycleNames_throws_if_url_not_found() {
     auto journal = makeJournal(indexFile);
     expectURLNotFound();
     TS_ASSERT_THROWS(journal.getCycleNames(), InternetError const &);
-    verifyAndClear();
   }
 
   void test_getRuns_with_empty_file_throws() {
     auto journal = makeJournal(emptyFile);
     TS_ASSERT_THROWS(journal.getRuns(), std::runtime_error const &);
-    verifyAndClear();
   }
 
   void test_getRuns_with_bad_xml_throws() {
     auto journal = makeJournal(badFile);
     TS_ASSERT_THROWS(journal.getRuns(), std::runtime_error const &);
-    verifyAndClear();
   }
 
   void test_getRuns_with_empty_xml_file_returns_empty_results() {
     auto journal = makeJournal(emptyJournalFile);
     auto results = journal.getRuns(valuesToLookup(), filters());
     TS_ASSERT_EQUALS(results, std::vector<ISISJournal::RunData>{});
-    verifyAndClear();
   }
 
   void test_getRuns_still_returns_run_names_when_requested_values_list_is_empty() {
@@ -161,7 +159,6 @@ public:
     auto results = journal.getRuns();
     auto const expected =
         std::vector<ISISJournal::RunData>{{{"name", "INTER22345"}}, {{"name", "INTER12345"}}, {{"name", "INTER12346"}}};
-    verifyAndClear();
   }
 
   void test_getRuns_returns_requested_values_filtered_by_one_filter() {
@@ -171,7 +168,6 @@ public:
         {{"name", "INTER12345"}, {"run_number", "12345"}, {"title", "Experiment 1 run 1"}},
         {{"name", "INTER12346"}, {"run_number", "12346"}, {"title", "Experiment 1 run 2"}}};
     TS_ASSERT_EQUALS(results, expected);
-    verifyAndClear();
   }
 
   void test_getRuns_returns_requested_values_filtered_by_multiple_filters() {
@@ -180,7 +176,6 @@ public:
     auto const expected = std::vector<ISISJournal::RunData>{
         {{"name", "INTER12346"}, {"run_number", "12346"}, {"title", "Experiment 1 run 2"}}};
     TS_ASSERT_EQUALS(results, expected);
-    verifyAndClear();
   }
 
   void test_getRuns_returns_requested_values_for_all_entries_when_no_filter_is_set() {
@@ -191,32 +186,27 @@ public:
         {{"name", "INTER12345"}, {"run_number", "12345"}, {"title", "Experiment 1 run 1"}},
         {{"name", "INTER12346"}, {"run_number", "12346"}, {"title", "Experiment 1 run 2"}}};
     TS_ASSERT_EQUALS(results, expected);
-    verifyAndClear();
   }
 
   void test_getCycleList_with_empty_file_throws() {
     auto journal = makeJournal(emptyFile);
     TS_ASSERT_THROWS(journal.getCycleNames(), std::runtime_error const &);
-    verifyAndClear();
   }
 
   void test_getCycleList_with_bad_xml_throws() {
     auto journal = makeJournal(badFile);
     TS_ASSERT_THROWS(journal.getCycleNames(), std::runtime_error const &);
-    verifyAndClear();
   }
 
   void test_getCycleList_with_empty_xml_file_returns_empty_results() {
     auto journal = makeJournal(emptyIndexFile);
     auto results = journal.getCycleNames();
     TS_ASSERT_EQUALS(results, std::vector<std::string>{});
-    verifyAndClear();
   }
 
   void test_getCycleList_throws_when_invalid_element_names() {
     auto journal = makeJournal(invalidIndexFile);
     TS_ASSERT_THROWS(journal.getCycleNames(), std::invalid_argument const &);
-    verifyAndClear();
   }
 
   void test_getCycleList_returns_all_valid_cycles() {
@@ -224,7 +214,6 @@ public:
     auto results = journal.getCycleNames();
     auto const expected = std::vector<std::string>{"17_1", "18_1", "19_1", "19_2"};
     TS_ASSERT_EQUALS(results, expected);
-    verifyAndClear();
   }
 
 private:

--- a/qt/scientific_interfaces/ISISReflectometry/test/Options/OptionsDialogPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Options/OptionsDialogPresenterTest.h
@@ -31,12 +31,16 @@ public:
 
   void setUp() override {}
 
-  void tearDown() override {}
+  void tearDown() override {
+    // Verifying and clearing of expectations happens when mock variables are destroyed.
+    // Some of our mocks are created as member variables and will exist until all tests have run, so we need to
+    // explicitly verify and clear them after each test.
+    verifyAndClear();
+  }
 
   void testPresenterSubscribesToView() {
     EXPECT_CALL(m_view, subscribe(_)).Times(1);
     auto presenter = makePresenter();
-    verifyAndClear();
   }
 
   void testInitOptionsClearsVariables() {
@@ -45,8 +49,6 @@ public:
     presenter.initOptions();
     TS_ASSERT_EQUALS(presenter.m_boolOptions.size(), 0);
     TS_ASSERT_EQUALS(presenter.m_intOptions.size(), 0);
-    TS_ASSERT(Mock::VerifyAndClearExpectations(&m_view));
-    TS_ASSERT(Mock::VerifyAndClearExpectations(&m_modelUnsuccessfulLoad));
   }
 
   void testInitOptionsAttemptsToLoadFromModel() {
@@ -57,7 +59,6 @@ public:
     EXPECT_CALL(*m_model, loadSettingsProxy(presenter.m_boolOptions, presenter.m_intOptions)).WillOnce(Return());
     presenter.initOptions();
     assertLoadOptions(presenter);
-    verifyAndClear();
   }
 
   void testInitOptionsAppliesDefaultOptionsIfLoadUnsuccessful() {
@@ -67,8 +68,6 @@ public:
     EXPECT_CALL(*m_modelUnsuccessfulDefaults, applyDefaultOptionsProxy(_, _)).WillOnce(Return());
     presenter.initOptions();
     assertDefaultOptions(presenter);
-    TS_ASSERT(Mock::VerifyAndClearExpectations(&m_view));
-    TS_ASSERT(Mock::VerifyAndClearExpectations(&m_modelUnsuccessfulDefaults));
   }
 
   void testLoadOptionsQueriesModel() {
@@ -79,8 +78,6 @@ public:
     EXPECT_CALL(*m_model, loadSettingsProxy(presenter.m_boolOptions, presenter.m_intOptions)).Times(AtLeast(1));
     EXPECT_CALL(*mainWindowSubscriber.get(), notifyOptionsChanged()).Times(AtLeast(1));
     presenter.notifyLoadOptions();
-    verifyAndClear(std::move(mainWindowSubscriber));
-    verifyAndClear(std::move(mainWindowSubscriber));
   }
 
   void testLoadOptionsUpdatesView() {
@@ -92,7 +89,6 @@ public:
     EXPECT_CALL(*mainWindowSubscriber.get(), notifyOptionsChanged()).Times(AtLeast(1));
     presenter.notifyLoadOptions();
     assertLoadOptions(presenter);
-    verifyAndClear(std::move(mainWindowSubscriber));
   }
 
   void testLoadOptionsNotifiesMainWindow() {
@@ -102,7 +98,6 @@ public:
     presenter.subscribe(mainWindowSubscriber.get());
     presenter.notifyLoadOptions();
     assertLoadOptions(presenter);
-    verifyAndClear(std::move(mainWindowSubscriber));
   }
 
   void testSaveOptionsUpdatesModel() {
@@ -112,7 +107,6 @@ public:
     presenter.notifyLoadOptions();
     EXPECT_CALL(*m_model, saveSettings(presenter.m_boolOptions, presenter.m_intOptions)).Times(AtLeast(1));
     presenter.notifySaveOptions();
-    verifyAndClear();
   }
 
   void testSaveOptionsNotifiesMainWindow() {
@@ -121,7 +115,6 @@ public:
     EXPECT_CALL(*mainWindowSubscriber.get(), notifyOptionsChanged()).Times(AtLeast(1));
     presenter.subscribe(mainWindowSubscriber.get());
     presenter.notifySaveOptions();
-    verifyAndClear(std::move(mainWindowSubscriber));
   }
 
   void testSaveOptionsQueriesView() {
@@ -132,7 +125,6 @@ public:
     presenter.notifyLoadOptions();
     EXPECT_CALL(m_view, getOptions(presenter.m_boolOptions, presenter.m_intOptions)).Times(AtLeast(1));
     presenter.notifySaveOptions();
-    verifyAndClear();
   }
 
 private:
@@ -195,5 +187,7 @@ private:
     TS_ASSERT(Mock::VerifyAndClearExpectations(&m_view));
     TS_ASSERT(Mock::VerifyAndClearExpectations(m_model));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mainWindowSubscriber));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&m_modelUnsuccessfulDefaults));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&m_modelUnsuccessfulLoad));
   }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Options/OptionsDialogPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Options/OptionsDialogPresenterTest.h
@@ -182,11 +182,9 @@ private:
     TS_ASSERT_EQUALS(presenter.m_intOptions["RoundPrecision"], 5);
   }
 
-  void verifyAndClear(std::unique_ptr<NiceMock<MockOptionsDialogPresenterSubscriber>> mainWindowSubscriber =
-                          std::make_unique<NiceMock<MockOptionsDialogPresenterSubscriber>>()) {
+  void verifyAndClear() {
     TS_ASSERT(Mock::VerifyAndClearExpectations(&m_view));
     TS_ASSERT(Mock::VerifyAndClearExpectations(m_model));
-    TS_ASSERT(Mock::VerifyAndClearExpectations(&mainWindowSubscriber));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&m_modelUnsuccessfulDefaults));
     TS_ASSERT(Mock::VerifyAndClearExpectations(&m_modelUnsuccessfulLoad));
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -50,6 +50,9 @@ public:
 
   void tearDown() override {
     Mantid::Kernel::ConfigService::Instance().setString("default.facility", " ");
+    // Verifying and clearing of expectations happens when mock variables are destroyed.
+    // Some of our mocks are created as member variables and will exist until all tests have run, so we need to
+    // explicitly verify and clear them after each test.
     verifyAndClear();
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -48,7 +48,10 @@ class RunsPresenterTest : public CxxTest::TestSuite {
 public:
   void setUp() override { Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS"); }
 
-  void tearDown() override { Mantid::Kernel::ConfigService::Instance().setString("default.facility", " "); }
+  void tearDown() override {
+    Mantid::Kernel::ConfigService::Instance().setString("default.facility", " ");
+    verifyAndClear();
+  }
 
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
@@ -69,40 +72,34 @@ public:
   void testCreatePresenterSubscribesToView() {
     EXPECT_CALL(m_view, subscribe(_)).Times(1);
     auto presenter = makePresenter();
-    verifyAndClear();
   }
 
   void testCreatePresenterGetsRunsTableView() {
     EXPECT_CALL(m_view, table()).Times(1);
     auto presenter = makePresenter();
-    verifyAndClear();
   }
 
   void testInitInstrumentListUpdatesView() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, setInstrumentList(m_instruments, _)).Times(1);
     presenter.initInstrumentList();
-    verifyAndClear();
   }
 
   void testCreatePresenterUpdatesView() {
     expectUpdateViewWhenMonitorStopped();
     auto presenter = makePresenter();
-    verifyAndClear();
   }
 
   void testSettingsChanged() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, settingsChanged()).Times(1);
     presenter.settingsChanged();
-    verifyAndClear();
   }
 
   void testStartingSearchDoesNotClearPreviousResults() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_searcher, reset()).Times(0);
     presenter.notifySearch();
-    verifyAndClear();
   }
 
   void testStartingSearchClearsPreviousResultsIfSettingsChanged() {
@@ -111,7 +108,6 @@ public:
     expectSearchSettingsChanged();
     EXPECT_CALL(*m_searcher, reset()).Times(AtLeast(1));
     presenter.notifySearch();
-    verifyAndClear();
   }
 
   void testStartingSearchDoesNotClearPreviousResultsIfOverwritePrevented() {
@@ -121,7 +117,6 @@ public:
     expectOverwriteSearchResultsPrevented();
     EXPECT_CALL(*m_searcher, reset()).Times(0);
     presenter.notifySearch();
-    verifyAndClear();
   }
 
   void testStartingSearchDisablesSearchInputs() {
@@ -132,7 +127,6 @@ public:
     EXPECT_CALL(m_view, setSearchResultsEnabled(false)).Times(1);
     EXPECT_CALL(m_view, setAutoreduceButtonEnabled(false)).Times(1);
     presenter.notifySearch();
-    verifyAndClear();
   }
 
   void testNotifySearchResultsEnablesSearchInputs() {
@@ -143,7 +137,6 @@ public:
     EXPECT_CALL(m_view, setSearchResultsEnabled(true)).Times(1);
     EXPECT_CALL(m_view, setAutoreduceButtonEnabled(true)).Times(1);
     presenter.notifySearchComplete();
-    verifyAndClear();
   }
 
   void testSearchUsesCorrectSearchProperties() {
@@ -156,7 +149,6 @@ public:
     expectSearchCycle(cycle);
     EXPECT_CALL(*m_searcher, startSearchAsync(SearchCriteria{instrument, cycle, searchString})).Times(1);
     presenter.notifySearch();
-    verifyAndClear();
   }
 
   void testSearchWithEmptyStringDoesNotStartSearch() {
@@ -165,7 +157,6 @@ public:
     expectSearchString(searchString);
     EXPECT_CALL(*m_searcher, startSearchAsync(_)).Times(0);
     presenter.notifySearch();
-    verifyAndClear();
   }
 
   void testStartingSearchFails() {
@@ -176,7 +167,6 @@ public:
         .WillOnce(Return(false));
     EXPECT_CALL(m_messageHandler, giveUserCritical("Error starting search", "Error")).Times(1);
     presenter.notifySearch();
-    verifyAndClear();
   }
 
   void testStartingSearchSucceeds() {
@@ -188,35 +178,30 @@ public:
     EXPECT_CALL(m_messageHandler, giveUserCritical(_, _)).Times(0);
 
     presenter.notifySearch();
-    verifyAndClear();
   }
 
   void testNotifyReductionResumed() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifyResumeReductionRequested()).Times(AtLeast(1));
     presenter.notifyResumeReductionRequested();
-    verifyAndClear();
   }
 
   void testNotifyReductionPaused() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifyPauseReductionRequested());
     presenter.notifyPauseReductionRequested();
-    verifyAndClear();
   }
 
   void testNotifyAutoreductionResumed() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifyResumeAutoreductionRequested());
     presenter.notifyResumeAutoreductionRequested();
-    verifyAndClear();
   }
 
   void testNotifyAutoreductionPaused() {
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifyPauseAutoreductionRequested());
     presenter.notifyPauseAutoreductionRequested();
-    verifyAndClear();
   }
 
   void testNoCheckOnOverwritingBatchOnAutoreductionResumed() {
@@ -224,7 +209,6 @@ public:
     expectSearchString(m_searchString);
     EXPECT_CALL(m_mainPresenter, isOverwriteBatchPrevented()).Times(0);
     presenter.resumeAutoreduction();
-    verifyAndClear();
   }
 
   void testNoCheckOnDiscardChangesOnAutoreductionResumed() {
@@ -232,7 +216,6 @@ public:
     expectSearchString(m_searchString);
     EXPECT_CALL(m_mainPresenter, discardChanges(_)).Times(0);
     presenter.resumeAutoreduction();
-    verifyAndClear();
   }
 
   void testCheckDiscardChangesOnAutoreductionResumedIfUnsavedSearchResults() {
@@ -244,7 +227,6 @@ public:
                                                 "to be lost. Continue?"))
         .Times(AtLeast(1));
     presenter.resumeAutoreduction();
-    verifyAndClear();
   }
 
   void testCheckDiscardChangesOnAutoreductionResumedIfUnsavedTable() {
@@ -256,7 +238,6 @@ public:
                                                 "to be lost. Continue?"))
         .Times(AtLeast(1));
     presenter.resumeAutoreduction();
-    verifyAndClear();
   }
 
   void testCheckDiscardChangesOnAutoreductionResumedIfUnsavedTableAndSearchResults() {
@@ -269,7 +250,6 @@ public:
                                                 "and main table to be lost. Continue?"))
         .Times(AtLeast(1));
     presenter.resumeAutoreduction();
-    verifyAndClear();
   }
 
   void testDoNotStartAutoreductionWhenOverwritePreventedOnResumeAutoreductionWithNewSettings() {
@@ -279,7 +259,6 @@ public:
     expectOverwriteSearchResultsPrevented();
     expectDoNotStartAutoreduction();
     presenter.resumeAutoreduction();
-    verifyAndClear();
   }
 
   void testTableClearedWhenStartAutoreductionForFirstTime() {
@@ -287,7 +266,6 @@ public:
     expectSearchString(m_searchString);
     expectClearExistingTable();
     presenter.resumeAutoreduction();
-    verifyAndClear();
   }
 
   void testTableNotClearedWhenRestartAutoreduction() {
@@ -301,7 +279,6 @@ public:
     expectSearchSettingsDefault();
     expectDoNotClearExistingTable();
     presenter.resumeAutoreduction();
-    verifyAndClear();
   }
 
   void testTableClearedWhenResumeAutoreductionWithNewSettings() {
@@ -310,7 +287,6 @@ public:
     expectSearchSettingsChanged();
     expectClearExistingTable();
     presenter.resumeAutoreduction();
-    verifyAndClear();
   }
 
   void testTableNotClearedWhenOverwritePreventedOnResumeAutoreduction() {
@@ -320,7 +296,6 @@ public:
     expectOverwriteSearchResultsPrevented();
     expectDoNotClearExistingTable();
     presenter.resumeAutoreduction();
-    verifyAndClear();
   }
 
   void testResumeAutoreductionCancelledIfSearchStringIsEmpty() {
@@ -328,7 +303,6 @@ public:
     expectSearchString("");
     expectDoNotStartAutoreduction();
     presenter.resumeAutoreduction();
-    verifyAndClear();
   }
 
   void testAutoreductionResumed() {
@@ -336,7 +310,6 @@ public:
     expectWidgetsEnabledForAutoreducing();
     EXPECT_CALL(*m_runsTablePresenter, notifyAutoreductionResumed()).Times(1);
     presenter.notifyAutoreductionResumed();
-    verifyAndClear();
   }
 
   void testAutoreductionPaused() {
@@ -345,7 +318,6 @@ public:
     EXPECT_CALL(*m_runsTablePresenter, notifyAutoreductionPaused()).Times(1);
     expectWidgetsEnabledForPaused();
     presenter.notifyAutoreductionPaused();
-    verifyAndClear();
   }
 
   void testAutoreductionCompleted() {
@@ -353,84 +325,72 @@ public:
     EXPECT_CALL(*m_runNotifier, startPolling()).Times(1);
     expectWidgetsEnabledForAutoreducing();
     presenter.autoreductionCompleted();
-    verifyAndClear();
   }
 
   void testChildPresentersAreUpdatedWhenAnyBatchReductionResumed() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyAnyBatchReductionResumed()).Times(1);
     presenter.notifyAnyBatchReductionResumed();
-    verifyAndClear();
   }
 
   void testChildPresentersAreUpdatedWhenAnyBatchReductionPaused() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyAnyBatchReductionPaused()).Times(1);
     presenter.notifyAnyBatchReductionPaused();
-    verifyAndClear();
   }
 
   void testChildPresentersAreUpdatedWhenAnyBatchAutoreductionResumed() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyAnyBatchAutoreductionResumed()).Times(1);
     presenter.notifyAnyBatchAutoreductionResumed();
-    verifyAndClear();
   }
 
   void testChildPresentersAreUpdatedWhenAnyBatchAutoreductionPaused() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyAnyBatchAutoreductionPaused()).Times(1);
     presenter.notifyAnyBatchAutoreductionPaused();
-    verifyAndClear();
   }
 
   void testChangingInstrumentIsDisabledWhenAnotherBatchReducing() {
     auto presenter = makePresenter();
     expectInstrumentComboIsDisabledWhenAnotherBatchReducing();
     presenter.notifyAnyBatchReductionResumed();
-    verifyAndClear();
   }
 
   void testChangingInstrumentIsEnabledWhenNoBatchesAreReducing() {
     auto presenter = makePresenter();
     expectInstrumentComboIsEnabledWhenNoBatchesAreReducing();
     presenter.notifyAnyBatchReductionPaused();
-    verifyAndClear();
   }
 
   void testChangingInstrumentIsDisabledWhenAnotherBatchAutoreducing() {
     auto presenter = makePresenter();
     expectInstrumentComboIsDisabledWhenAnotherBatchAutoreducing();
     presenter.notifyAnyBatchAutoreductionResumed();
-    verifyAndClear();
   }
 
   void testChangingInstrumentIsEnabledWhenNoBatchesAreAutoreducing() {
     auto presenter = makePresenter();
     expectInstrumentComboIsEnabledWhenNoBatchesAreAutoreducing();
     presenter.notifyAnyBatchAutoreductionPaused();
-    verifyAndClear();
   }
 
   void testAutoreductionDisabledWhenAnotherBatchAutoreducing() {
     auto presenter = makePresenter();
     expectAutoreduceButtonDisabledWhenAnotherBatchAutoreducing();
     presenter.notifyAnyBatchAutoreductionResumed();
-    verifyAndClear();
   }
 
   void testAutoreductionEnabledWhenAnotherBatchNotAutoreducing() {
     auto presenter = makePresenter();
     expectAutoreduceButtonEnabledWhenNoBatchesAreAutoreducing();
     presenter.notifyAnyBatchAutoreductionPaused();
-    verifyAndClear();
   }
 
   void testNotifyCheckForNewRuns() {
     auto presenter = makePresenter();
     expectCheckForNewRuns();
     presenter.notifyCheckForNewRuns();
-    verifyAndClear();
   }
 
   void testNotifySearchResultsResizesColumnsWhenNotAutoreducing() {
@@ -438,7 +398,6 @@ public:
     expectIsNotAutoreducing();
     EXPECT_CALL(m_view, resizeSearchResultsColumnsToContents()).Times(1);
     presenter.notifySearchComplete();
-    verifyAndClear();
   }
 
   void testNotifySearchResultsDoesNotResizeColumnsWhenAutoreducing() {
@@ -446,7 +405,6 @@ public:
     expectIsAutoreducing();
     EXPECT_CALL(m_view, resizeSearchResultsColumnsToContents()).Times(0);
     presenter.notifySearchComplete();
-    verifyAndClear();
   }
 
   void testNotifySearchResultsResumesReductionWhenAutoreducing() {
@@ -454,7 +412,6 @@ public:
     expectIsAutoreducing();
     EXPECT_CALL(m_mainPresenter, notifyResumeReductionRequested()).Times(AtLeast(1));
     presenter.notifySearchComplete();
-    verifyAndClear();
   }
 
   void testNotifySearchResultsTransfersRowsWhenAutoreducing() {
@@ -468,7 +425,6 @@ public:
       EXPECT_CALL(*m_searcher, getSearchResult(rowIndex)).Times(1).WillOnce(ReturnRef(searchResult));
     EXPECT_CALL(m_messageHandler, giveUserCritical(_, _)).Times(0);
     presenter.notifySearchComplete();
-    verifyAndClear();
   }
 
   void testTransferWithNoRowsSelected() {
@@ -478,7 +434,6 @@ public:
     EXPECT_CALL(m_messageHandler, giveUserCritical("Please select at least one run to transfer.", "No runs selected"))
         .Times(1);
     presenter.notifyTransfer();
-    verifyAndClear();
   }
 
   void testTransferWithAutoreductionRunning() {
@@ -487,7 +442,6 @@ public:
     expectIsAutoreducing();
     expectCreateEndlessProgressIndicator();
     presenter.notifyTransfer();
-    verifyAndClear();
   }
 
   void testTransferWithAutoreductionStopped() {
@@ -496,7 +450,6 @@ public:
     expectIsNotAutoreducing();
     expectCreatePercentageProgressIndicator();
     presenter.notifyTransfer();
-    verifyAndClear();
   }
 
   void testTransferUpdatesTablePresenter() {
@@ -504,7 +457,6 @@ public:
     auto expectedJobs = expectGetValidSearchResult();
     EXPECT_CALL(*m_runsTablePresenter, mergeAdditionalJobs(expectedJobs)).Times(1);
     presenter.notifyTransfer();
-    verifyAndClear();
   }
 
   void testTransferUpdatesLookupIndexes() {
@@ -512,7 +464,6 @@ public:
     auto expectedJobs = expectGetValidSearchResult();
     EXPECT_CALL(m_mainPresenter, notifyRunsTransferred()).Times(1);
     presenter.notifyTransfer();
-    verifyAndClear();
   }
 
   void testChangeInstrumentOnViewNotifiesMainPresenter() {
@@ -522,7 +473,6 @@ public:
     expectSearchInstrument(instrument);
     EXPECT_CALL(m_mainPresenter, notifyChangeInstrumentRequested(instrument)).Times(AtLeast(1));
     presenter.notifyChangeInstrumentRequested();
-    verifyAndClear();
   }
 
   void testChangeInstrumentOnViewPromptsToDiscardChangesIfUnsaved() {
@@ -535,7 +485,6 @@ public:
                                                 "lost. Continue?"))
         .Times(1);
     presenter.notifyChangeInstrumentRequested();
-    verifyAndClear();
   }
 
   void testChangeInstrumentOnViewDoesNotPromptToDiscardChangesIfSaved() {
@@ -546,7 +495,6 @@ public:
     expectNoUnsavedSearchResults();
     EXPECT_CALL(m_mainPresenter, discardChanges(_)).Times(0);
     presenter.notifyChangeInstrumentRequested();
-    verifyAndClear();
   }
 
   void testChangeInstrumentOnViewDoesNotNotifyMainPresenterIfPrevented() {
@@ -557,7 +505,6 @@ public:
     expectChangeInstrumentPrevented();
     EXPECT_CALL(m_mainPresenter, notifyChangeInstrumentRequested(_)).Times(0);
     presenter.notifyChangeInstrumentRequested();
-    verifyAndClear();
   }
 
   void testChangeInstrumentOnViewRevertsChangeIfPrevented() {
@@ -568,7 +515,6 @@ public:
     expectChangeInstrumentPrevented();
     EXPECT_CALL(m_view, setSearchInstrument("INTER")).Times(1);
     presenter.notifyChangeInstrumentRequested();
-    verifyAndClear();
   }
 
   void testChangeInstrumentOnChildNotifiesMainPresenter() {
@@ -577,7 +523,6 @@ public:
     expectPreviousInstrument("INTER");
     EXPECT_CALL(m_mainPresenter, notifyChangeInstrumentRequested(instrument)).Times(AtLeast(1));
     presenter.notifyChangeInstrumentRequested(instrument);
-    verifyAndClear();
   }
 
   void testChangeInstrumentOnChildDoesNotNotifyMainPresenterIfPrevented() {
@@ -587,7 +532,6 @@ public:
     expectChangeInstrumentPrevented();
     EXPECT_CALL(m_mainPresenter, notifyChangeInstrumentRequested(_)).Times(0);
     presenter.notifyChangeInstrumentRequested(instrument);
-    verifyAndClear();
   }
 
   void testChangeInstrumentOnChildReturnsTrueIfSuccess() {
@@ -596,7 +540,6 @@ public:
     expectPreviousInstrument("INTER");
     auto success = presenter.notifyChangeInstrumentRequested(instrument);
     TS_ASSERT_EQUALS(success, true);
-    verifyAndClear();
   }
 
   void testChangeInstrumentOnChildReturnsFalseIfPrevented() {
@@ -606,7 +549,6 @@ public:
     expectChangeInstrumentPrevented();
     auto success = presenter.notifyChangeInstrumentRequested(instrument);
     TS_ASSERT_EQUALS(success, false);
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesView() {
@@ -614,7 +556,6 @@ public:
     auto const instrument = std::string("TEST-instrumnet");
     EXPECT_CALL(m_view, setSearchInstrument(instrument)).Times(1);
     presenter.notifyInstrumentChanged(instrument);
-    verifyAndClear();
   }
 
   void testInstrumentChangedUpdatesChildPresenter() {
@@ -622,7 +563,6 @@ public:
     auto const instrument = std::string("TEST-instrumnet");
     EXPECT_CALL(*m_runsTablePresenter, notifyInstrumentChanged(instrument)).Times(1);
     presenter.notifyInstrumentChanged(instrument);
-    verifyAndClear();
   }
 
   void testInstrumentChangedClearsPreviousSearchResultsModel() {
@@ -630,14 +570,12 @@ public:
     auto const instrument = std::string("TEST-instrumnet");
     EXPECT_CALL(*m_searcher, reset()).Times(1);
     presenter.notifyInstrumentChanged(instrument);
-    verifyAndClear();
   }
 
   void testNotifyRowStateChanged() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowStateChanged()).Times(1);
     presenter.notifyRowStateChanged();
-    verifyAndClear();
   }
 
   void testNotifyRowStateChangedItem() {
@@ -645,42 +583,36 @@ public:
     auto row = makeRow();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowStateChanged(_)).Times(1);
     presenter.notifyRowStateChanged(row);
-    verifyAndClear();
   }
 
   void testRowStateChangedOnReductionResumed() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowStateChanged()).Times(1);
     presenter.notifyReductionResumed();
-    verifyAndClear();
   }
 
   void testRowStateChangedOnReductionPaused() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowStateChanged()).Times(1);
     presenter.notifyReductionPaused();
-    verifyAndClear();
   }
 
   void testRowStateChangedOnAutoreductionResumed() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowStateChanged()).Times(1);
     presenter.notifyAutoreductionResumed();
-    verifyAndClear();
   }
 
   void testRowStateChangedOnAutoreductionPaused() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowStateChanged()).Times(1);
     presenter.notifyAutoreductionPaused();
-    verifyAndClear();
   }
 
   void testNotifyRowModelChanged() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowModelChanged()).Times(1);
     presenter.notifyRowModelChanged();
-    verifyAndClear();
   }
 
   void testNotifyRowModelChangedItem() {
@@ -688,7 +620,6 @@ public:
     auto row = makeRow();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowModelChanged(_)).Times(1);
     presenter.notifyRowModelChanged(row);
-    verifyAndClear();
   }
 
   void testPercentCompleteIsRequestedFromMainPresenter() {
@@ -696,7 +627,6 @@ public:
     auto progress = 33;
     EXPECT_CALL(m_mainPresenter, percentComplete()).Times(1).WillOnce(Return(progress));
     TS_ASSERT_EQUALS(presenter.percentComplete(), progress);
-    verifyAndClear();
   }
 
   void testStartMonitorStartsAlgorithmRunner() {
@@ -705,7 +635,6 @@ public:
     auto algRunner = expectGetAlgorithmRunner();
     EXPECT_CALL(*algRunner, startAlgorithmImpl(_)).Times(1);
     presenter.notifyStartMonitor();
-    verifyAndClear();
   }
 
   void testStartMonitorUpdatesView() {
@@ -713,7 +642,6 @@ public:
     expectStartingLiveDataSucceeds();
     expectUpdateViewWhenMonitorStarting();
     presenter.notifyStartMonitor();
-    verifyAndClear();
   }
 
   void testStartMonitorSetsAlgorithmProperties() {
@@ -725,7 +653,6 @@ public:
     presenter.notifyStartMonitor();
     auto expected = defaultLiveMonitorAlgorithmOptions(instrument, updateInterval);
     assertAlgorithmPropertiesContainOptions(*expected, algRunner);
-    verifyAndClear();
   }
 
   void testStartMonitorSetsDefaultPostProcessingProperties() {
@@ -735,7 +662,6 @@ public:
     presenter.notifyStartMonitor();
     auto expected = defaultLiveMonitorReductionOptions();
     assertPostProcessingPropertiesContainOptions(*expected, algRunner);
-    verifyAndClear();
   }
 
   void testStartMonitorSetsUserSpecifiedPostProcessingProperties() {
@@ -748,7 +674,6 @@ public:
     auto algRunner = expectGetAlgorithmRunner();
     presenter.notifyStartMonitor();
     assertPostProcessingPropertiesContainOptions(*options, algRunner);
-    verifyAndClear();
   }
 
   void testStopMonitorUpdatesView() {
@@ -757,7 +682,6 @@ public:
     expectUpdateViewWhenMonitorStopped();
     presenter.notifyStopMonitor();
     TS_ASSERT_EQUALS(presenter.m_monitorAlg, nullptr);
-    verifyAndClear();
   }
 
   void testMonitorNotRunningAfterStartMonitorFails() {
@@ -771,14 +695,12 @@ public:
     EXPECT_CALL(*algRunner, getAlgorithm()).Times(1).WillOnce(Return(startMonitorAlg));
     expectUpdateViewWhenMonitorStopped();
     presenter.notifyStartMonitorComplete();
-    verifyAndClear();
   }
 
   void testNotifyTableChangedSetsUnsavedFlag() {
     auto presenter = makePresenter();
     presenter.notifyTableChanged();
     TS_ASSERT_EQUALS(presenter.hasUnsavedChanges(), true);
-    verifyAndClear();
   }
 
   void testNotifyChangsSavedClearsUnsavedFlag() {
@@ -786,21 +708,18 @@ public:
     presenter.notifyTableChanged();
     presenter.notifyChangesSaved();
     TS_ASSERT_EQUALS(presenter.hasUnsavedChanges(), false);
-    verifyAndClear();
   }
 
   void testNotifyChangsSavedUpdatesSearcher() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_searcher, setSaved()).Times(1);
     presenter.notifyChangesSaved();
-    verifyAndClear();
   }
 
   void testNotifyBatchLoaded() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_runsTablePresenter, notifyBatchLoaded()).Times(1);
     presenter.notifyBatchLoaded();
-    verifyAndClear();
   }
 
   void testNotifyRowContentChanged() {
@@ -808,7 +727,6 @@ public:
     auto row = makeRow(0.5);
     EXPECT_CALL(m_mainPresenter, notifyRowContentChanged(row));
     presenter.notifyRowContentChanged(row);
-    verifyAndClear();
   }
 
   void testNotifyGroupNameChanged() {
@@ -816,7 +734,6 @@ public:
     auto group = makeGroupWithOneRow();
     EXPECT_CALL(m_mainPresenter, notifyGroupNameChanged(group));
     presenter.notifyGroupNameChanged(group);
-    verifyAndClear();
   }
 
   void testNotifyExportSearchResultsWhenNoResults() {
@@ -830,7 +747,6 @@ public:
         .Times(1);
 
     presenter.notifyExportSearchResults();
-    verifyAndClear();
   }
 
   void testNotifyExportSearchResultsWithResultsAndCSVFileExtension() {
@@ -845,7 +761,6 @@ public:
     EXPECT_CALL(m_fileHandler, saveCSVToFile(filename, csv)).Times(1);
 
     presenter.notifyExportSearchResults();
-    verifyAndClear();
   }
 
   void testNotifyExportSearchResultsWithResultsAndNoCSVFileExtension() {
@@ -863,7 +778,6 @@ public:
     EXPECT_CALL(m_fileHandler, saveCSVToFile(filename_after_asking, csv)).Times(1);
 
     presenter.notifyExportSearchResults();
-    verifyAndClear();
   }
 
   void testNotifyExportSearchResultsWhenSavingFails() {
@@ -880,7 +794,6 @@ public:
     EXPECT_CALL(m_messageHandler, giveUserCritical("Could not open file at: test.csv", "Error")).Times(1);
 
     presenter.notifyExportSearchResults();
-    verifyAndClear();
   }
 
   void testNotifyExportSearchResultsDoesNotSaveWhenFileCancelled() {
@@ -895,7 +808,6 @@ public:
     EXPECT_CALL(m_fileHandler, saveCSVToFile(filename, csv)).Times(0);
 
     presenter.notifyExportSearchResults();
-    verifyAndClear();
   }
 
 private:


### PR DESCRIPTION
### Description of work
Move verify and clear to tear down method in isis reflectometry unit tests 
#### Summary of work
moved verify and clear to tear down method in the following files:
- OptionsDialogPresenterTest
- RunsPresenterTest
- ISISJournalTest

Closes: https://github.com/mantidproject/mantid/issues/35956

#### To test:

Tests should pass.

*This does not require release notes* because **it is a unit test refactor.**