### PR TITLE
Unpin cmake to allow >3.26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake version check.
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.21)
 
 # Define the project name.
 project(Mantid)

--- a/Framework/Muon/CMakeLists.txt
+++ b/Framework/Muon/CMakeLists.txt
@@ -81,6 +81,8 @@ if(COVERAGE)
   endforeach(loop_var)
 endif()
 
+# This policy setting allows a target to link to a target aliased to itself, but this behaviour is deprecated.
+cmake_policy(SET CMP0108 OLD)
 # Add a precompiled header where they are supported enable_precompiled_headers (inc/MantidAlgorithms/PrecompiledHeader.h
 # SRC_FILES ) Add the target for this directory
 add_library(Muon ${SRC_FILES} ${C_SRC_FILES} ${INC_FILES})

--- a/Framework/PythonInterface/CMakeLists.txt
+++ b/Framework/PythonInterface/CMakeLists.txt
@@ -10,6 +10,9 @@ if(CMAKE_COMPILER_IS_GNUCXX
   add_definitions(-DBOOST_PYTHON_USE_GCC_SYMBOL_VISIBILITY)
 endif()
 
+# This allows the use of find_package(Boost ...), from cmake version 3.30 onwards
+cmake_policy(SET CMP0167 OLD)
+
 # Keep boost python separate from other boost
 set(_boost_libs_orig ${Boost_LIBRARIES})
 set(Boost_LIBRARIES)

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -72,6 +72,8 @@ if(BUILD_MANTIDFRAMEWORK OR BUILD_MANTIDQT)
     set(BOOST_INCLUDEDIR /usr/include/boost169)
     set(BOOST_LIBRARYDIR /usr/lib64/boost169)
   endif()
+  # This allows the use of find_package(Boost ...), from cmake version 3.30 onwards
+  cmake_policy(SET CMP0167 OLD)
   find_package(Boost ${BOOST_VERSION_REQUIRED} REQUIRED COMPONENTS date_time regex serialization filesystem system)
   add_definitions(-DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB -DBOOST_BIND_GLOBAL_PLACEHOLDERS)
   # Need this defined globally for our log time values

--- a/buildconfig/CMake/GoogleTest.cmake
+++ b/buildconfig/CMake/GoogleTest.cmake
@@ -18,6 +18,7 @@ fetchcontent_declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG b007c54f2944e193ac44fba1bc997cb65826a0b9
+  EXCLUDE_FROM_ALL
 )
 
 fetchcontent_makeavailable(googletest)
@@ -36,7 +37,7 @@ mark_as_advanced(
 
 # Hide targets from "all" and put them in the UnitTests folder in MSVS
 foreach(target_var gmock gtest gmock_main gtest_main)
-  set_target_properties(${target_var} PROPERTIES EXCLUDE_FROM_ALL TRUE FOLDER "UnitTests/gmock")
+  set_target_properties(${target_var} PROPERTIES FOLDER "UnitTests/gmock")
 endforeach()
 
 # W4 logging doesn't work with MSVC address sanitizer, turn off sanitizer since not our code

--- a/buildconfig/CMake/GoogleTest.cmake
+++ b/buildconfig/CMake/GoogleTest.cmake
@@ -20,11 +20,7 @@ fetchcontent_declare(
   GIT_TAG b007c54f2944e193ac44fba1bc997cb65826a0b9
 )
 
-fetchcontent_getproperties(googletest)
-if(NOT googletest_POPULATED)
-  fetchcontent_populate(googletest)
-  add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
+fetchcontent_makeavailable(googletest)
 
 mark_as_advanced(
   BUILD_GMOCK

--- a/buildconfig/CMake/Span.cmake
+++ b/buildconfig/CMake/Span.cmake
@@ -13,8 +13,4 @@ fetchcontent_declare(
                 "${CMAKE_SOURCE_DIR}/buildconfig/CMake/span_disable_testing.patch"
 )
 
-fetchcontent_getproperties(span)
-if(NOT span_POPULATED)
-  fetchcontent_populate(span)
-  add_subdirectory(${span_SOURCE_DIR} ${span_BINARY_DIR} EXCLUDE_FROM_ALL)
-endif()
+fetchcontent_makeavailable(span)

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -26,8 +26,8 @@ libboost_devel:
 libboost_python_devel:
   - 1.82 # Aim to follow conda-forge
 
-cmake: # Problem with fetching mslice repo in 3.27
-  - '>=3.21.0,<3.27'
+cmake:
+  - '>=3.21.0'
 
 hdf5: # this is to move to libcurl>=8.4
   - '>1.14.0,<1.15'

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   # Common packages
   - ccache
-  - cmake>=3.21.0,<3.27
+  - cmake>=3.21.0
   - doxygen=1.9.* # 1.10.0 Produces a warning in Framework/Geometry/src/Crystal/HKLFilter.cpp
   - eigen=3.4.*
   - euphonic>=1.2.1,<2.0

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   - ccache
-  - cmake>=3.21.0,<3.27
+  - cmake>=3.21.0
   - doxygen=1.9.* # 1.10.0 Produces a warning in Framework/Geometry/src/Crystal/HKLFilter.cpp
   - eigen=3.4.*
   - euphonic>=1.2.1,<2.0

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   - ccache
-  - cmake>=3.21.0,<3.27
+  - cmake>=3.21.0
   - conda-wrappers
   - doxygen=1.9.* # 1.10.0 Produces a warning in Framework/Geometry/src/Crystal/HKLFilter.cpp
   - eigen=3.4.*


### PR DESCRIPTION
Previously there was a problem with the UPDATE_DISCONNECTED option in cmake.

I disabled a warning about the `FindBoost` module by setting the `cmake` policy, see [here](https://cmake.org/cmake/help/latest/module/FindBoost.html). It recommends using the `BoostConfig.cmake` config file from the Boost repository, but the version of Boost that we're currently using doesn't appear to have that file. 

The pattern that we were using for including `googletest` and `span` is now deprecated, see [here](https://cmake.org/cmake/help/latest/module/FetchContent.html#command:fetchcontent_getproperties), so I've changed to use the newer method, i.e. using `FetchContent_MakeAvailable()`.

Updating the minimum `cmake` version in `CMakeLists.txt` from 3.16 to 3.21 sets policies for that version, so I had to disable policy [CMP0108](https://cmake.org/cmake/help/latest/policy/CMP0108.html) to allow for the Muon target to target itself via an alias. 

Fixes #37521 

### To test:
Try changing the mslice SHA and check that works.

To update `cmake` and clear the cache file, run `mamba env update -f mantid-developer-win.yml`, then delete `build/CMakeCache.txt`

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **these changes will not affect the user.**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
