### PR TITLE
Fixed NumPy deprecation warning for alltrue

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/RebinRagged.py
+++ b/Framework/PythonInterface/plugins/algorithms/RebinRagged.py
@@ -83,13 +83,13 @@ class RebinRagged(PythonAlgorithm):
         if len(xmins) == 0 or len(xmaxs) == 1 or len(deltas) == 0:
             return False
         # is there (effectively) only one xmin?
-        if not (len(xmins) == 1 or np.alltrue(xmins == xmins[0])):
+        if not (len(xmins) == 1 or np.all(xmins == xmins[0])):
             return False
         # is there (effectively) only one xmin?
-        if not (len(xmaxs) == 1 or np.alltrue(xmaxs == xmaxs[0])):
+        if not (len(xmaxs) == 1 or np.all(xmaxs == xmaxs[0])):
             return False
         # is there (effectively) only one xmin?
-        if not (len(deltas) == 1 or np.alltrue(deltas == deltas[0])):
+        if not (len(deltas) == 1 or np.all(deltas == deltas[0])):
             return False
 
         # all of these point to 'just do rebin'

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MatchSpectraTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MatchSpectraTest.py
@@ -98,7 +98,7 @@ class MatchSpectraTest(unittest.TestCase):
         )
         self.__checkReference(results, 1)
         self.__checkValues(results, 0, 1.0, 10.0)
-        self.assertTrue(np.alltrue(mtd[outwsname].readY(0) == mtd[outwsname].readY(1)))
+        self.assertTrue(np.all(mtd[outwsname].readY(0) == mtd[outwsname].readY(1)))
 
         ##### scale only
         results = MatchSpectra(
@@ -106,7 +106,7 @@ class MatchSpectraTest(unittest.TestCase):
         )
         self.__checkReference(results, 2)
         self.__checkValues(results, 0, 10.0, 0.0)
-        self.assertTrue(np.alltrue(mtd[outwsname].readY(0) == mtd[outwsname].readY(2)))
+        self.assertTrue(np.all(mtd[outwsname].readY(0) == mtd[outwsname].readY(2)))
 
         ##### both
         results = MatchSpectra(
@@ -114,7 +114,7 @@ class MatchSpectraTest(unittest.TestCase):
         )
         self.__checkReference(results, 3)
         self.__checkValues(results, 0, 10.0, 10.0)
-        self.assertTrue(np.alltrue(mtd[outwsname].readY(0) == mtd[outwsname].readY(3)))
+        self.assertTrue(np.all(mtd[outwsname].readY(0) == mtd[outwsname].readY(3)))
 
         DeleteWorkspaces(WorkspaceList=[inwsname, outwsname])
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/InstrumentSetupWidget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/InstrumentSetupWidget.py
@@ -136,7 +136,7 @@ class GonioTableModel(QtCore.QAbstractTableModel):
     def validDir(self, dirstring):
         d = numpy.fromstring(dirstring, dtype=float, sep=",")
         if len(d) == 3:
-            return numpy.alltrue(numpy.isfinite(d))
+            return numpy.all(numpy.isfinite(d))
         return False
 
     def validateGon(self):


### PR DESCRIPTION
### Description of work

The `alltrue` function is deprecated and will be removed in NumPy 2.0. That is why it has been replaced with the `all` function.

Fixes #37586.

### To test:

Tests should pass.

Open the DGS Planner interface in the Direct menu. There should be no NumPy deprecation warning anymore.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
