### PR TITLE
Fix crash when trying to run algorithms from Corrections interface

### DIFF
--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.h
@@ -96,8 +96,6 @@ private:
   std::shared_ptr<Densities> m_sampleDensities;
   std::shared_ptr<Densities> m_canDensities;
   Mantid::API::IAlgorithm_sptr m_absCorAlgo;
-
-  std::unique_ptr<IRunPresenter> m_runPresenter;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.h
@@ -67,8 +67,6 @@ private:
   Mantid::API::WorkspaceGroup_sptr m_ppCorrectionsGp;
 
   size_t m_spectra;
-
-  std::unique_ptr<IRunPresenter> m_runPresenter;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.h
@@ -90,8 +90,6 @@ private:
   Mantid::API::MatrixWorkspace_sptr m_transformedContainerWS;
 
   std::size_t m_spectra;
-
-  std::unique_ptr<IRunPresenter> m_runPresenter;
 };
 
 } // namespace CustomInterfaces


### PR DESCRIPTION
### Description of work
This PR fixes a crash ocurring in the tabs of the corrections interface for which there is a run widget implemented (all but ApplyPalmaanPings which will be soon deprecated). 
This was likely a missing delete on the  #37636 PR, which reimplemented the way to create the run presenter as being held by the parent inelastic tab class. There was a `runPresenter` memberr still on the declaration of the corrections tabs, which was being problematic. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37674 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Follow corrections testing (except PalmaanPings tab): https://developer.mantidproject.org/Testing/Inelastic/CorrectionsTests.html
- Clicking the run button when the algorithm is ready to run shouldn't crash mantid. 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
