### PR TITLE
Fixed unhandled exception with certain colourmaps in the sliceviewer

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/SliceViewer/Bugfixes/36723.rst
+++ b/docs/source/release/v6.11.0/Workbench/SliceViewer/Bugfixes/36723.rst
@@ -1,0 +1,1 @@
+- Fixed issue causing unhandled exception when changing normalisation with the "gist_rainbow" colourmap.

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -187,9 +187,10 @@ class ColorbarWidget(QWidget):
 
         if mappable_cmap.name.endswith("_r"):
             self.crev.setChecked(True)
+            self.cmap.setCurrentIndex(self.cmap_list.index(mappable_cmap.name.replace("_r", "")))
         else:
             self.crev.setChecked(False)
-        self.cmap.setCurrentIndex(self.cmap_list.index(mappable_cmap.name.replace("_r", "")))
+            self.cmap.setCurrentIndex(self.cmap_list.index(mappable_cmap.name))
 
         self.redraw()
 

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
@@ -4,10 +4,12 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from unittest.mock import patch
+
 import matplotlib.pyplot as plt
 import numpy as np
 
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.colorbar.colorbar import ColorbarWidget, NORM_OPTS
@@ -50,6 +52,14 @@ class ColorbarWidgetTest(TestCase):
 
             self.assertEqual(self.widget.cmin_value, expected_c_min)
             self.assertEqual(self.widget.cmax_value, c_max)
+
+    @patch("mantidqt.widgets.colorbar.colorbar.get_current_cmap")
+    def test_cmap_values_are_replaced_correctly(self, mocked_cmap):
+        image = plt.imshow(self.data, cmap="plasma", norm=Normalize(vmin=None, vmax=None))
+        mock_cmap = mock.MagicMock()
+        mock_cmap.name = "gist_rainbow"
+        mocked_cmap.return_value = mock_cmap
+        self.widget.set_mappable(image)
 
     def test_that_all_zero_slice_with_log_normalisation_gives_valid_clim(self):
         image = plt.imshow(self.data * 0, cmap="plasma", norm=Normalize(vmin=None, vmax=None))


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->Fixed issue causing unhandled exception when changing normalisation with the "gist_rainbow" colourmap, because the code was set to replace "_r"

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
--> 

Fixes #36723 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
--> **Report to:** @cailafinn, @jhaigh0 


#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
--> 

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
--> 

- Run the test called "test_cmap_values_are_replaced_correctly" located in test_colorbar.py.
- Recreate the issue to see if it still occurs

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
