### PR TITLE
Small speed improvement to Stitch1D

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/Stitch1D.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Stitch1D.h
@@ -52,15 +52,15 @@ private:
   /// Perform rebin
   Mantid::API::MatrixWorkspace_sptr rebin(Mantid::API::MatrixWorkspace_sptr &input, const std::vector<double> &params);
   /// Perform integration
-  Mantid::API::MatrixWorkspace_sptr integration(Mantid::API::MatrixWorkspace_sptr &input, const double start,
+  Mantid::API::MatrixWorkspace_sptr integration(Mantid::API::MatrixWorkspace_sptr const &input, const double start,
                                                 const double stop);
   Mantid::API::MatrixWorkspace_sptr singleValueWS(const double val);
   /// Calculate the weighted mean
-  Mantid::API::MatrixWorkspace_sptr weightedMean(Mantid::API::MatrixWorkspace_sptr &inOne,
-                                                 Mantid::API::MatrixWorkspace_sptr &inTwo);
+  Mantid::API::MatrixWorkspace_sptr weightedMean(Mantid::API::MatrixWorkspace_sptr const &inOne,
+                                                 Mantid::API::MatrixWorkspace_sptr const &inTwo);
   /// Conjoin x axis
-  Mantid::API::MatrixWorkspace_sptr conjoinXAxis(Mantid::API::MatrixWorkspace_sptr &inOne,
-                                                 Mantid::API::MatrixWorkspace_sptr &inTwo);
+  Mantid::API::MatrixWorkspace_sptr conjoinXAxis(Mantid::API::MatrixWorkspace_sptr const &inOne,
+                                                 Mantid::API::MatrixWorkspace_sptr const &inTwo);
   /// Find the start and end indexes
   boost::tuple<int, int> findStartEndIndexes(double startOverlap, double endOverlap,
                                              Mantid::API::MatrixWorkspace_sptr &workspace);

--- a/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Framework/Algorithms/src/Stitch1D.cpp
@@ -183,7 +183,7 @@ std::map<std::string, std::string> Stitch1D::validateInputs(void) {
  @return a double contianing the start of the overlapping region
  */
 double Stitch1D::getStartOverlap(const double intesectionMin, const double intesectionMax) const {
-  Property *startOverlapProp = this->getProperty("StartOverlap");
+  Property const *startOverlapProp = this->getProperty("StartOverlap");
   double startOverlapVal = this->getProperty("StartOverlap");
   startOverlapVal -= this->range_tolerance;
   const bool startOverlapBeyondRange = (startOverlapVal < intesectionMin) || (startOverlapVal > intesectionMax);
@@ -212,7 +212,7 @@ double Stitch1D::getStartOverlap(const double intesectionMin, const double intes
  @return a double contianing the end of the overlapping region
  */
 double Stitch1D::getEndOverlap(const double intesectionMin, const double intesectionMax) const {
-  Property *endOverlapProp = this->getProperty("EndOverlap");
+  Property const *endOverlapProp = this->getProperty("EndOverlap");
   double endOverlapVal = this->getProperty("EndOverlap");
   endOverlapVal += this->range_tolerance;
   const bool endOverlapBeyondRange = (endOverlapVal < intesectionMin) || (endOverlapVal > intesectionMax);
@@ -351,7 +351,7 @@ MatrixWorkspace_sptr Stitch1D::rebin(MatrixWorkspace_sptr &input, const std::vec
  @param stop :: a double defining the end of the region to integrate
  @return A shared pointer to the resulting MatrixWorkspace
  */
-MatrixWorkspace_sptr Stitch1D::integration(MatrixWorkspace_sptr &input, const double start, const double stop) {
+MatrixWorkspace_sptr Stitch1D::integration(MatrixWorkspace_sptr const &input, const double start, const double stop) {
   auto integration = this->createChildAlgorithm("Integration");
   integration->initialize();
   integration->setProperty("InputWorkspace", input);
@@ -368,7 +368,7 @@ MatrixWorkspace_sptr Stitch1D::integration(MatrixWorkspace_sptr &input, const do
  @param inTwo :: The second input workspace
  @return A shared pointer to the resulting MatrixWorkspace
  */
-MatrixWorkspace_sptr Stitch1D::weightedMean(MatrixWorkspace_sptr &inOne, MatrixWorkspace_sptr &inTwo) {
+MatrixWorkspace_sptr Stitch1D::weightedMean(MatrixWorkspace_sptr const &inOne, MatrixWorkspace_sptr const &inTwo) {
   auto weightedMean = this->createChildAlgorithm("WeightedMean");
   weightedMean->initialize();
   weightedMean->setProperty("InputWorkspace1", inOne);
@@ -382,7 +382,7 @@ MatrixWorkspace_sptr Stitch1D::weightedMean(MatrixWorkspace_sptr &inOne, MatrixW
  @param inTwo :: Second input workspace
  @return A shared pointer to the resulting MatrixWorkspace
  */
-MatrixWorkspace_sptr Stitch1D::conjoinXAxis(MatrixWorkspace_sptr &inOne, MatrixWorkspace_sptr &inTwo) {
+MatrixWorkspace_sptr Stitch1D::conjoinXAxis(MatrixWorkspace_sptr const &inOne, MatrixWorkspace_sptr const &inTwo) {
   const std::string in1 = "__Stitch1D_intermediate_workspace_1__";
   const std::string in2 = "__Stitch1D_intermediate_workspace_2__";
   Mantid::API::AnalysisDataService::Instance().addOrReplace(in1, inOne);

--- a/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Framework/Algorithms/src/Stitch1D.cpp
@@ -422,7 +422,7 @@ boost::tuple<int, int> Stitch1D::findStartEndIndexes(double startOverlap, double
 bool Stitch1D::hasNonzeroErrors(MatrixWorkspace_sptr &ws) {
   for (auto i = 0u; i < ws->getNumberHistograms(); ++i) {
     const auto &e = ws->e(i);
-    // Its faster to sum and then check the result is non-zero than to check each element is non-zero individually
+    // It's faster to sum and then check the result is non-zero than to check each element is non-zero individually
     if (std::accumulate(e.begin(), e.end(), 0.0) != 0.0) {
       return true;
     }

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -330,10 +330,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/SpatialGroup
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/Stitch.cpp:267
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/UpdateScriptRepository.cpp:51
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/Algorithms/inc/MantidAlgorithms/SofQWPolygon.h:55
-constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/Stitch1D.cpp:357
-constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/Stitch1D.cpp:374
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/Stitch1D.cpp:189
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/Stitch1D.cpp:218
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/AlgorithmHasProperty.cpp:36
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/SmoothNeighbours.cpp:382
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/SumEventsByLogValue.cpp:409


### PR DESCRIPTION
### Description of work
This PR makes a small change which results in a very slight speed improvement for the `Stitch1D` algorithm. The `hasNonzeroErrors` function was very slow for what it was doing.

The yellow scribble square indicates the amount of time that has been shaved off the execution of this algorithm (approximately 1/10th the original runtime).
![image](https://github.com/user-attachments/assets/499eaf4c-e2b2-4080-ad86-1a59f2f01c5d)

Its a very small improvement (0.05 seconds), but this algorithm is run many times when reducing hundreds of files.

### To test:
Code review and passing tests should be enough.

*This does not require release notes* because **speed improvement is so minimal it probably won't be noticed on its own**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
