### PR TITLE
Add usage reports for Indirect/Inelastic interfaces

### DIFF
--- a/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.h
+++ b/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.h
@@ -39,6 +39,7 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return "DiffractionReduction"; }
 
 public slots:
   void instrumentSelected(const QString &instrumentName, const QString &analyserName, const QString &reflectionName);

--- a/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ILLEnergyTransfer.h
@@ -25,6 +25,7 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return "ILLEnergyTransfer"; }
 
 private slots:
   void algorithmComplete(bool error);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.h
@@ -49,6 +49,7 @@ public:
 
   void handleRun() override;
   void handleValidation(IUserInputValidator *validator) const override;
+  const std::string getSubscriberName() const override { return "ISISCalibration"; }
 
 private slots:
   void algorithmComplete(bool error);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.h
@@ -50,6 +50,7 @@ public:
 
   void handleRun() override;
   void handleValidation(IUserInputValidator *validator) const override;
+  const std::string getSubscriberName() const override { return "ISISDiagnostics"; }
 
 private slots:
   void algorithmComplete(bool error);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.h
@@ -46,6 +46,7 @@ public:
 
   void handleRun() override;
   void handleValidation(IUserInputValidator *validator) const override;
+  const std::string getSubscriberName() const override { return "ISISEnergyTransfer"; }
 
 private:
   void validateInstrumentDetails(IUserInputValidator *validator) const;

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.h
@@ -25,6 +25,7 @@ public:
 
   void handleRun() override;
   void handleValidation(IUserInputValidator *validator) const override;
+  const std::string getSubscriberName() const override { return "Transmission"; }
 
 private slots:
   void transAlgDone(bool error);

--- a/qt/scientific_interfaces/Indirect/Simulation/DensityOfStates.h
+++ b/qt/scientific_interfaces/Indirect/Simulation/DensityOfStates.h
@@ -24,6 +24,7 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return "DensityOfStates"; }
 
 private slots:
   void dosAlgoComplete(bool error);

--- a/qt/scientific_interfaces/Indirect/Simulation/MolDyn.h
+++ b/qt/scientific_interfaces/Indirect/Simulation/MolDyn.h
@@ -24,6 +24,7 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return "MolDyn"; }
 
 private slots:
   void versionSelected(const QString & /*version*/);

--- a/qt/scientific_interfaces/Indirect/Simulation/Sassena.h
+++ b/qt/scientific_interfaces/Indirect/Simulation/Sassena.h
@@ -24,6 +24,7 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return "Sassena"; }
 
 private slots:
   /// Handle completion of the algorithm batch

--- a/qt/scientific_interfaces/Indirect/Tools/TransmissionCalc.h
+++ b/qt/scientific_interfaces/Indirect/Tools/TransmissionCalc.h
@@ -29,6 +29,7 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return "TransmissionCalc"; }
 
 private slots:
   /// Handles completion of the algorithm

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
@@ -24,6 +24,7 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return "Quasi"; }
 
   // Slot for when settings are changed
   void applySettings(std::map<std::string, QVariant> const &settings) override;

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.h
@@ -26,6 +26,7 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return "ResNorm"; }
 
 private slots:
   /// Handle completion of the algorithm

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.h
@@ -25,6 +25,8 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return "Stretch"; }
+
   // Slot for when settings are changed
   void applySettings(std::map<std::string, QVariant> const &settings) override;
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.h
@@ -31,6 +31,7 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return "AbsorptionCorrections"; }
 
 private slots:
   virtual void algorithmComplete(bool error);

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.h
@@ -27,6 +27,7 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return "ApplyAbsorptionCorrections"; }
 
 private slots:
   /// Handles a new sample being loaded

--- a/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.h
@@ -27,6 +27,7 @@ public:
 
   void handleRun() override;
   void handleValidation(IUserInputValidator *validator) const override;
+  const std::string getSubscriberName() const override { return "CalculatePaalmanPings"; }
 
 private slots:
   void absCorComplete(bool error);

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.h
@@ -26,6 +26,7 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return "ContainerSubtraction"; }
 
 private slots:
   /// Handles a new sample being loaded

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
@@ -53,6 +53,7 @@ public:
   // runWidget
   void handleRun() override;
   void handleValidation(IUserInputValidator *validator) const override;
+  const std::string getSubscriberName() const override { return "Elwin"; }
 
   // Elwin interface methods
   void handleValueChanged(std::string const &propName, double) override;

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.h
@@ -39,6 +39,7 @@ public:
   // runWidget
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return "IQT Data Processor"; }
 
   void handleSampDataReady(const std::string &wsname) override;
   void handleResDataReady(const std::string &resWorkspace) override;

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.h
@@ -45,6 +45,7 @@ public:
   // runWidget
   void handleRun() override;
   void handleValidation(IUserInputValidator *validator) const override;
+  const std::string getSubscriberName() const override { return "Moments"; }
 
   void handleDataReady(std::string const &dataName) override;
 

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.h
@@ -47,6 +47,7 @@ public:
   // runSubscriber
   void handleRun() override;
   void handleValidation(IUserInputValidator *validator) const override;
+  const std::string getSubscriberName() const override { return "Sqw"; }
 
   void handleDataReady(std::string const &dataName) override;
 

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.h
@@ -60,6 +60,7 @@ public:
   // run widget
   void handleRun() override;
   void handleValidation(IUserInputValidator *validator) const override;
+  const std::string getSubscriberName() const override { return "Symmetrise"; }
 
   void handleReflectTypeChanged(int value) override;
   void handleDoubleValueChanged(std::string const &propname, double value) override;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.h
@@ -111,6 +111,7 @@ public:
 
   void handleValidation(IUserInputValidator *validator) const override;
   void handleRun() override;
+  const std::string getSubscriberName() const override { return tabName(); }
 
 private:
   void updateParameterEstimationData();

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/MockObjects.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/MockObjects.h
@@ -216,6 +216,7 @@ public:
 
   MOCK_CONST_METHOD1(handleValidation, void(IUserInputValidator *validator));
   MOCK_METHOD0(handleRun, void());
+  MOCK_CONST_METHOD0(getSubscriberName, const std::string());
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/RunWidget/IRunSubscriber.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/RunWidget/IRunSubscriber.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "../DllConfig.h"
+#include <string>
 
 namespace MantidQt {
 namespace CustomInterfaces {

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/RunWidget/IRunSubscriber.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/RunWidget/IRunSubscriber.h
@@ -18,6 +18,7 @@ public:
 
   virtual void handleValidation(IUserInputValidator *validator) const = 0;
   virtual void handleRun() = 0;
+  virtual const std::string getSubscriberName() const = 0;
 };
 
 } // namespace CustomInterfaces

--- a/qt/widgets/spectroscopy/src/RunWidget/RunPresenter.cpp
+++ b/qt/widgets/spectroscopy/src/RunWidget/RunPresenter.cpp
@@ -9,6 +9,7 @@
 #include "MantidQtWidgets/Spectroscopy/RunWidget/IRunSubscriber.h"
 #include "MantidQtWidgets/Spectroscopy/RunWidget/RunView.h"
 
+#include "MantidKernel/UsageService.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 
 namespace MantidQt {
@@ -27,6 +28,8 @@ void RunPresenter::handleRunClicked() {
       m_view->displayWarning(ex.what());
       setRunEnabled(true);
     }
+    Mantid::Kernel::UsageService::Instance().registerFeatureUsage(Mantid::Kernel::FeatureType::Interface,
+                                                                  m_subscriber->getSubscriberName(), false);
   }
 }
 


### PR DESCRIPTION
### Description of work
This PR adds usage reports for all indirect/inelastic interfaces. It has been implemented by adding a new name method to the common run widget. After each time the run widget is used, a new usage request will be sent to the usage reports service.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37418. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
1. Open mantid
2. Make sure the "Report Usage Data" is checked in the starting about screen or go to `Help->About Mantid Workbench`
3. Change the log level in the log to "Debug"
4. Try few different interfaces from the indirect and inelastic features
5. You should see a request has been send with after clicking run in every interface
6. Send a GET request to https://reports.mantidproject.org/api/feature and you will get the usages from the reports service, you can use https://restninja.io/ for that and search for the feature in the response text
7. Make sure the name of each interface is correct 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **internal usage reporting**
<!-- delete this if you added release notes

If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
