### PR TITLE
Added kwargs to pass parameters to Compare Workspaces function.

### DIFF
--- a/Framework/PythonInterface/mantid/_testing/AssertAlmostEqual.py
+++ b/Framework/PythonInterface/mantid/_testing/AssertAlmostEqual.py
@@ -31,7 +31,7 @@ def assert_almost_equal(Workspace1, Workspace2, rtol=Property.EMPTY_DBL, atol=Pr
 
     """
     # check arguments
-    if len(set(kwargs.keys()).intersection({"Workspace1", "Workspace2", "Tolerance", "ToleranceRelErr"})) > 0:
+    if not len(set(kwargs.keys()).intersection({"Workspace1", "Workspace2", "Tolerance", "ToleranceRelErr"})):
         raise ValueError("Workspace1, Workspace2, Tolerance, ToleranceRelErr cannot be in passed as additional parameters")
 
     if rtol == Property.EMPTY_DBL and atol == Property.EMPTY_DBL:

--- a/Framework/PythonInterface/mantid/_testing/AssertAlmostEqual.py
+++ b/Framework/PythonInterface/mantid/_testing/AssertAlmostEqual.py
@@ -8,7 +8,7 @@
 from mantid.simpleapi import CompareWorkspaces
 
 
-def assert_almost_equal(Workspace1, Workspace2, **kwargs):
+def assert_almost_equal(Workspace1, Workspace2, rtol=EMPTY_DBL, atol=EMPTY_DBL, **kwargs):
     """
     Raises an assertion error if two workspaces are not within specified tolerance.
 

--- a/Framework/PythonInterface/mantid/_testing/AssertAlmostEqual.py
+++ b/Framework/PythonInterface/mantid/_testing/AssertAlmostEqual.py
@@ -27,12 +27,12 @@ def assert_almost_equal(Workspace1, Workspace2, rtol=Property.EMPTY_DBL, atol=Pr
     AssertionError
         If Workspace1 and Workspace2 are not equal up to specified precision
     ValueError
-        If atol and rtol are both provided
+        If atol and rtol are both not provided
 
     """
     # check arguments
-    if not len(set(kwargs.keys()).intersection({"Workspace1", "Workspace2", "Tolerance", "ToleranceRelErr"})):
-        raise ValueError("Workspace1, Workspace2, Tolerance, ToleranceRelErr cannot be in passed as additional parameters")
+    if len(set(kwargs.keys()).intersection({"Workspace1", "Workspace2", "Tolerance", "ToleranceRelErr"})):
+        raise ValueError("Workspace1, Workspace2, Tolerance, ToleranceRelErr cannot be passed as additional parameters")
 
     if rtol == Property.EMPTY_DBL and atol == Property.EMPTY_DBL:
         raise ValueError("Specify rtol or atol")

--- a/Framework/PythonInterface/mantid/_testing/AssertAlmostEqual.py
+++ b/Framework/PythonInterface/mantid/_testing/AssertAlmostEqual.py
@@ -8,7 +8,7 @@
 from mantid.simpleapi import CompareWorkspaces
 
 
-def assert_almost_equal(Workspace1, Workspace2, rtol=0.0, atol=0.0):
+def assert_almost_equal(Workspace1, Workspace2, **kwargs):
     """
     Raises an assertion error if two workspaces are not within specified tolerance.
 
@@ -29,19 +29,24 @@ def assert_almost_equal(Workspace1, Workspace2, rtol=0.0, atol=0.0):
         If atol and rtol are both provided
 
     """
-
-    if rtol != 0.0 and atol != 0.0:
-        raise ValueError("Specify rtol or atol, not both")
+    rtol = kwargs.pop("rtol", None)
+    atol = kwargs.pop("atol", None)
     _rel = False
     tolerance = 1e-10
-    if atol:
-        tolerance = atol
 
-    if rtol:
-        tolerance = rtol
-        _rel = True
+    if rtol is not None and atol is not None:
+        raise ValueError("Specify rtol or atol, not both")
+    elif rtol in None and atol is None:
+        raise ValueError("Specify rtol or atol")
+    elif atol is not None:
+        if atol > 0.0:
+            tolerance = atol
+    elif rtol is not None:
+        if rtol > 0.0:
+            tolerance = rtol
+            _rel = True
 
-    result, message = CompareWorkspaces(Workspace1, Workspace2, Tolerance=tolerance, ToleranceRelErr=_rel)
+    result, message = CompareWorkspaces(Workspace1, Workspace2, Tolerance=tolerance, ToleranceRelErr=_rel, **kwargs)
     msg_dict = message.toDict()
     if not result:
         msg = ", ".join(msg_dict["Message"]) + f", Workspaces are not within tolerance ({tolerance})"

--- a/Framework/PythonInterface/mantid/_testing/AssertAlmostEqual.py
+++ b/Framework/PythonInterface/mantid/_testing/AssertAlmostEqual.py
@@ -36,7 +36,7 @@ def assert_almost_equal(Workspace1, Workspace2, **kwargs):
 
     if rtol is not None and atol is not None:
         raise ValueError("Specify rtol or atol, not both")
-    elif rtol in None and atol is None:
+    elif rtol is None and atol is None:
         raise ValueError("Specify rtol or atol")
     elif atol is not None:
         if atol > 0.0:

--- a/Framework/PythonInterface/test/python/mantid/_testing/AssertAlmostEqualTest.py
+++ b/Framework/PythonInterface/test/python/mantid/_testing/AssertAlmostEqualTest.py
@@ -22,7 +22,7 @@ class AssertAlmostEqualTest(unittest.TestCase):
         self.ws3 = ws3
 
     def test_simple(self):
-        assert_almost_equal(self.ws1, self.ws1)
+        assert_almost_equal(self.ws1, self.ws2, atol=1, rtol=1)
 
     def test_atol(self):
         # compare (ws1 - ws2) < atol
@@ -33,11 +33,8 @@ class AssertAlmostEqualTest(unittest.TestCase):
         assert_almost_equal(self.ws1, self.ws3, rtol=0.7)
 
     def test_raises(self):
-        with self.assertRaises(AssertionError):
-            assert_almost_equal(self.ws1, self.ws2)
-
         with self.assertRaises(ValueError):
-            assert_almost_equal(self.ws1, self.ws2, atol=1, rtol=1)
+            assert_almost_equal(self.ws1, self.ws2)
 
 
 if __name__ == "__main__":

--- a/docs/source/api/python/mantid/testing/assert_almost_equal.rst
+++ b/docs/source/api/python/mantid/testing/assert_almost_equal.rst
@@ -4,7 +4,12 @@
  assert_almost_equal
 =====================
 
-This is a Python function for testing if two modules are within a tolerance
+This is a Python function for testing if two modules are within a tolerance.
+At least ``rtol`` or ``atol`` parameters should be specified. Neither being
+specified generates a ``ValueError`` exception. Both being specified runs
+the underlying :ref:`algm-CompareWorkspaces` algorithm
+twice, with relative tolerance being first.
+
 
 
 .. module:`mantid.testing`

--- a/docs/source/release/v6.11.0/Framework/Python/New_features/37708.rst
+++ b/docs/source/release/v6.11.0/Framework/Python/New_features/37708.rst
@@ -1,0 +1,1 @@
+- The python function ``assert_almost_equal`` for testing if two modules are within a tolerance was reworked


### PR DESCRIPTION
### Description of work
Changed the method The method [mantid.testing.assert_almost_equal](https://github.com/mantidproject/mantid/blob/main/Framework/PythonInterface/mantid/_testing/AssertAlmostEqual.py#L11C5-L11C24)  to make it more useful for SNAPRed. The parameter rtol and etol got evaluated, the absence of both or presence of both generates an error. Additional parameters could be specified for the underlying mantid python function CompareWorkspaces

[EWM5931: [SNAPRed] assert_almost_equal improvements](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/5931)

