### PR TITLE
Speed improvement for ScaleX

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ScaleX.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ScaleX.h
@@ -10,6 +10,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidAlgorithms/DllConfig.h"
 
@@ -60,7 +61,8 @@ private:
   /// Create output workspace
   API::MatrixWorkspace_sptr createOutputWS(const API::MatrixWorkspace_sptr &input);
   /// Get the scale factor for the given spectrum
-  double getScaleFactor(const API::MatrixWorkspace_const_sptr &inputWS, const size_t index);
+  double getScaleFactor(const API::MatrixWorkspace_const_sptr &inputWS, const Mantid::API::SpectrumInfo &spectrumInfo,
+                        const size_t index);
 
   /// The progress reporting object
   std::unique_ptr<API::Progress> m_progress;

--- a/docs/source/release/v6.11.0/Framework/Algorithms/Bugfixes/37719.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/Bugfixes/37719.rst
@@ -1,0 +1,1 @@
+- The :ref:`ScaleX <algm-ScaleX>` algorithm has had a 95% speedup when using the "InstrumentParameter" property.


### PR DESCRIPTION
### Description of work
This PR makes a huge speed improvement to the ScaleX algorithm when using the "InstrumentParameter" property. The call to `ws->spectrumInfo()` was expensive, and this was being called thousands of times in a parallel for loop. The solution was simply to call it once before the for loop is run and re-use the variable.

**Report to:** Ross Stewart

In the DG Reduction script I was running, each call to ScaleX would take approximately 18 seconds. It now takes under 0.5 seconds for each call to ScaleX. In the DG Reduction script, the ScaleX algorithm is called 4 times per run. In a script with 1 run, this means a runtime improvement of approximately 30%. The red `X`'s show the ScaleX algorithm contribution to the script, and it is now negligible.

![image](https://github.com/user-attachments/assets/8b553a23-97a0-4da1-8d76-0af74d80af92)

The DG Reduction script is usually executed for many runs at a time. The runtime percentage improvement grows for a larger number of runs.

### To test:


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
