### PR TITLE
Fix a freeze in Elwin tab while the interface is running

### DIFF
--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37724.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37724.rst
@@ -1,0 +1,1 @@
+- Fix a freeze in :ref:`Elwin Tab <elwin>` of :ref:`Data Processor Interface <interface-inelastic-data-processor>` that happens when running the tab.

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinModel.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinModel.h
@@ -22,9 +22,12 @@ namespace CustomInterfaces {
 class MANTIDQT_INELASTIC_DLL IElwinModel {
 public:
   virtual ~IElwinModel() = default;
+
   virtual API::IConfiguredAlgorithm_sptr setupLoadAlgorithm(std::string const &filepath,
                                                             std::string const &outputName) const = 0;
-  virtual std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra const &spectra) = 0;
+  virtual API::IConfiguredAlgorithm_sptr setupExtractSpectra(MatrixWorkspace_sptr workspace,
+                                                             FunctionModelSpectra const &spectra,
+                                                             std::string const &outputName) const = 0;
   virtual API::IConfiguredAlgorithm_sptr setupGroupAlgorithm(std::string const &inputWorkspacesString,
                                                              std::string const &inputGroupWsName) const = 0;
   virtual API::IConfiguredAlgorithm_sptr setupElasticWindowMultiple(std::string const &workspaceBaseName,
@@ -50,7 +53,9 @@ public:
   ~ElwinModel() override = default;
   API::IConfiguredAlgorithm_sptr setupLoadAlgorithm(std::string const &filepath,
                                                     std::string const &outputName) const override;
-  std::string createGroupedWorkspaces(MatrixWorkspace_sptr workspace, FunctionModelSpectra const &spectra) override;
+  API::IConfiguredAlgorithm_sptr setupExtractSpectra(MatrixWorkspace_sptr workspace,
+                                                     FunctionModelSpectra const &spectra,
+                                                     std::string const &outputName) const override;
   API::IConfiguredAlgorithm_sptr setupGroupAlgorithm(std::string const &inputWorkspacesString,
                                                      std::string const &inputGroupWsName) const override;
   API::IConfiguredAlgorithm_sptr setupElasticWindowMultiple(std::string const &workspaceBaseName,

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.cpp
@@ -230,17 +230,17 @@ void ElwinPresenter::handleRun() {
   std::string const inputGroupWsName = "Elwin_Input";
   std::string outputWsBasename = WorkspaceUtils::parseRunNumbers(m_dataModel->getWorkspaceNames());
   // Load input files
+  std::deque<MantidQt::API::IConfiguredAlgorithm_sptr> algQueue = {};
   std::string inputWorkspacesString;
   for (WorkspaceID i = 0; i < m_dataModel->getNumberOfWorkspaces(); ++i) {
-
     auto workspace = m_dataModel->getWorkspace(i);
     auto spectra = m_dataModel->getSpectra(i);
-    auto spectraWS = m_model->createGroupedWorkspaces(workspace, spectra);
+    auto spectraWS = workspace->getName() + "_extracted_spectra";
+    algQueue.emplace_back(m_model->setupExtractSpectra(workspace, spectra, spectraWS));
     inputWorkspacesString += spectraWS + ",";
   }
 
   // Group input workspaces
-  std::deque<MantidQt::API::IConfiguredAlgorithm_sptr> algQueue = {};
   algQueue.emplace_back(m_model->setupGroupAlgorithm(inputWorkspacesString, inputGroupWsName));
   algQueue.emplace_back(m_model->setupElasticWindowMultiple(outputWsBasename, inputGroupWsName, m_view->getLogName(),
                                                             m_view->getLogValue()));

--- a/qt/scientific_interfaces/Inelastic/test/Processor/ElwinModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Processor/ElwinModelTest.h
@@ -154,10 +154,17 @@ public:
     TS_ASSERT(Mantid::API::AnalysisDataService::Instance().doesExist("LoadedWsName"));
   }
 
-  void test_createGroupedWorkspaces() {
+  void test_ExtractSpectra_set_up() {
+    MantidQt::API::BatchAlgorithmRunner batch;
+
     auto workspace1 = WorkspaceCreationHelper::create2DWorkspace(5, 4);
     Mantid::API::AnalysisDataService::Instance().addOrReplace("Workspace_name1_sqw", workspace1);
-    m_model->createGroupedWorkspaces(workspace1, FunctionModelSpectra("0,1"));
+
+    auto const extractSpectra =
+        m_model->setupExtractSpectra(workspace1, FunctionModelSpectra("0,1"), "Workspace_name1_sqw_extracted_spectra");
+    batch.setQueue(std::deque<MantidQt::API::IConfiguredAlgorithm_sptr>{extractSpectra});
+    batch.executeBatch();
+
     TS_ASSERT(Mantid::API::AnalysisDataService::Instance().doesExist("Workspace_name1_sqw_extracted_spectra"));
     TS_ASSERT_EQUALS(Mantid::API::AnalysisDataService::Instance()
                          .retrieveWS<MatrixWorkspace>("Workspace_name1_sqw_extracted_spectra")

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -485,8 +485,9 @@ public:
 
   MOCK_CONST_METHOD2(setupLoadAlgorithm, MantidQt::API::IConfiguredAlgorithm_sptr(std::string const &filepath,
                                                                                   std::string const &outputName));
-  MOCK_METHOD2(createGroupedWorkspaces,
-               std::string(MatrixWorkspace_sptr workspce, FunctionModelSpectra const &spectra));
+  MOCK_CONST_METHOD3(setupExtractSpectra, MantidQt::API::IConfiguredAlgorithm_sptr(MatrixWorkspace_sptr workspce,
+                                                                                   FunctionModelSpectra const &spectra,
+                                                                                   std::string const &outputName));
   MOCK_CONST_METHOD2(setupGroupAlgorithm,
                      MantidQt::API::IConfiguredAlgorithm_sptr(std::string const &inputWorkspacesString,
                                                               std::string const &inputGroupWsName));


### PR DESCRIPTION
### Description of work
This PR optimizes the processing speed of the Elwin tab. Previously, the tab ran many algorithms to extract and combine spectra. In addition, these processing steps were don in the UI thread so the interface will stop responding when running the tab. This PR replaces all these algorithm with ExtracSpectra algorithms and execute the algorithm using the batch algorithm runner which execute the algorithms in a background thread.
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
This PR optimizes Elwin tab processing speed

Fixes #37634. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1. Go to `Interfaces->Inelastic->Data Processor->Elwin`
2. Click on `Add Workspaces`
3. On `Input File` click on `Browse`
4. Select `irs26174_graphite002_red` and `irs26176_graphite002_red` from the usage dataset and click "Add Data"
5. Click `Run`
6. You will notice that the run button will switch quickly to `Running` state and the interface responds normally to different interactions (e.g. switching the tab)
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
