### PR TITLE
Fix segmentation fault in ExtractFFTSpectrum algorithm

### DIFF
--- a/Framework/Algorithms/src/ExtractFFTSpectrum.cpp
+++ b/Framework/Algorithms/src/ExtractFFTSpectrum.cpp
@@ -60,7 +60,6 @@ void ExtractFFTSpectrum::exec() {
 
   Progress prog(this, 0.0, 1.0, numHists);
 
-  Mantid::Kernel::Unit_sptr unit; // must retrieve this from the child FFT
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int i = 0; i < numHists; i++) {
     PARALLEL_START_INTERRUPT_REGION
@@ -77,7 +76,9 @@ void ExtractFFTSpectrum::exec() {
     childFFT->setProperty<bool>("AcceptXRoundingErrors", xRoundingErrs);
     childFFT->execute();
     MatrixWorkspace_const_sptr fftTemp = childFFT->getProperty("OutputWorkspace");
-    unit = fftTemp->getAxis(0)->unit();
+    if (i == 0) {
+      outputWS->getAxis(0)->unit() = fftTemp->getAxis(0)->unit();
+    }
     outputWS->setHistogram(i, fftTemp->histogram(fftPart));
 
     prog.report();
@@ -85,8 +86,6 @@ void ExtractFFTSpectrum::exec() {
     PARALLEL_END_INTERRUPT_REGION
   }
   PARALLEL_CHECK_INTERRUPT_REGION
-
-  outputWS->getAxis(0)->unit() = unit;
 
   if (!inputImagWS && fftPart <= 2) {
     // In this case, trim half of the workspace, as these are just zeros.

--- a/docs/source/algorithms/TransformToIqt-v1.rst
+++ b/docs/source/algorithms/TransformToIqt-v1.rst
@@ -99,7 +99,7 @@ Usage
 
 **Example - TransformToIqt with IRIS data.**
 
-.. code:: python
+.. testcode:: exTransformToIqtIRIS
 
     sample = Load('irs26176_graphite002_red.nxs')
     can = Load('irs26173_graphite002_red.nxs')

--- a/docs/source/release/v6.11.0/Framework/Algorithms/Bugfixes/37725.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/Bugfixes/37725.rst
@@ -1,0 +1,1 @@
+- Fixed an unreliable segmentation fault in the :ref:`ExtractFFTSpectrum <algm-ExtractFFTSpectrum>` algorithm.

--- a/qt/widgets/common/src/EditLocalParameterDialog.cpp
+++ b/qt/widgets/common/src/EditLocalParameterDialog.cpp
@@ -42,10 +42,10 @@ EditLocalParameterDialog::EditLocalParameterDialog(QWidget *parent, const std::s
                                                    const QStringList &ties, const QStringList &constraints)
     : MantidDialog(parent), m_parName(parName), m_values(values), m_fixes(fixes), m_ties(std::move(ties)),
       m_constraints(std::move(constraints)) {
-  assert(values.size() == datasetDomainNames.size());
-  assert(fixes.size() == datasetDomainNames.size());
-  assert(ties.size() == datasetDomainNames.size());
-  assert(constraints.size() == datasetDomainNames.size());
+  assert(static_cast<std::size_t>(values.size()) == datasetDomainNames.size());
+  assert(static_cast<std::size_t>(fixes.size()) == datasetDomainNames.size());
+  assert(static_cast<std::size_t>(ties.size()) == datasetDomainNames.size());
+  assert(static_cast<std::size_t>(constraints.size()) == datasetDomainNames.size());
   m_uiForm.setupUi(this);
   setAttribute(Qt::WA_DeleteOnClose);
   doSetup(parName, datasetNames, datasetDomainNames);


### PR DESCRIPTION
### Description of work
This PR fixes an unreliable segmentation fault in the `ExtractFFTSpectrum` algorithm. This was causing several failures in our system tests, including tests relating to IRIS and OSIRIS IqtFit. It is currently believe that this segmentation fault is the same fault recorded by this issue #35992 . This PR re-enables the disabled doc test.

I have also fixed a few warnings about comparison types in a few "assert" statements I have seen when building on linux:

```
/home/mlc47243/Documents/mantid-development/mantid-conda/mantid/qt/widgets/common/src/EditLocalParameterDialog.cpp:45:24: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   45 |   assert(values.size() == datasetDomainNames.size());
      |          ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/mlc47243/Documents/mantid-development/mantid-conda/mantid/qt/widgets/common/src/EditLocalParameterDialog.cpp:46:23: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   46 |   assert(fixes.size() == datasetDomainNames.size());
      |          ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/mlc47243/Documents/mantid-development/mantid-conda/mantid/qt/widgets/common/src/EditLocalParameterDialog.cpp:47:22: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   47 |   assert(ties.size() == datasetDomainNames.size());
      |          ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/mlc47243/Documents/mantid-development/mantid-conda/mantid/qt/widgets/common/src/EditLocalParameterDialog.cpp:48:29: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
   48 |   assert(constraints.size() == datasetDomainNames.size());
      |          ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Fixes #35992

### To test:
Code review and check all the tests are passing. I have run the system tests 10 times on linux and they haven't failed, yet.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
