### PR TITLE
Skip PowderReduceP2DTest on macOS and re-enable on Windows

### DIFF
--- a/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
+++ b/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
@@ -17,8 +17,9 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
         self.setUp()
 
     def skipTests(self):
-        # Windows produces different outputs. Disable there for further investigation
-        return sys.platform.startswith("win")
+        # MacOS produces different results since moving from clang version 15 to 16.
+        # We skip it for now while investigation continues.
+        return sys.platform.startswith("darwin")
 
     def setUp(self):
         self.sample = self._sampleEventData()


### PR DESCRIPTION
### Description of work
clang update from 15 to 16 causes differences in the output file that are not understood yet, but the test is passing on Windows, so we don't need to skip it on there any more. Therefore we should swap the skip from Windows to mac while investigation continues, otherwise there will be no new nightly build.

*There is an associated issue but this doesn't fix it* #37720 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
I ran the test locally on Windows and it passed.

*This does not require release notes* because **it doesn't affect the functionality for users**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
