### PR TITLE
Fix cmake deprecation warning for Muon target

### DIFF
--- a/Framework/Muon/CMakeLists.txt
+++ b/Framework/Muon/CMakeLists.txt
@@ -81,8 +81,6 @@ if(COVERAGE)
   endforeach(loop_var)
 endif()
 
-# This policy setting allows a target to link to a target aliased to itself, but this behaviour is deprecated.
-cmake_policy(SET CMP0108 OLD)
 # Add a precompiled header where they are supported enable_precompiled_headers (inc/MantidAlgorithms/PrecompiledHeader.h
 # SRC_FILES ) Add the target for this directory
 add_library(Muon ${SRC_FILES} ${C_SRC_FILES} ${INC_FILES})
@@ -105,7 +103,7 @@ set_property(TARGET Muon PROPERTY FOLDER "MantidFramework")
 
 target_link_libraries(
   Muon
-  PUBLIC Mantid::API Mantid::Kernel Mantid::Muon Mantid::Geometry
+  PUBLIC Mantid::API Mantid::Kernel Mantid::Geometry
   PRIVATE Mantid::DataObjects Mantid::Indexing
 )
 # Add the unit tests directory


### PR DESCRIPTION
I added a policy change in #37687 after increasing the minimum `cmake` version to 3.21 in `CMakeLists.txt`, but this resulted in a deprecation warning. The Muon target was trying to link to itself using an alias, so I stopped it trying to do that and removed the policy change.

Fixes #37722. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

### To test:

Automated testing passes.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **it has no effect on the user**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
