### PR TITLE
Fix CombineDiffCal to not scale like $O(N^2)$

### DIFF
--- a/Framework/Algorithms/src/CombineDiffCal.cpp
+++ b/Framework/Algorithms/src/CombineDiffCal.cpp
@@ -120,6 +120,7 @@ std::map<std::string, std::string> CombineDiffCal::validateInputs() {
 
   const DataObjects::TableWorkspace_sptr groupedCalibrationWS = getProperty(PropertyNames::GROUP_CALIB);
   const DataObjects::TableWorkspace_sptr pixelCalibrationWS = getProperty(PropertyNames::PIXEL_CALIB);
+  Mantid::API::MatrixWorkspace_sptr calibrationWS = getProperty(PropertyNames::ARB_CALIB);
 
   const auto groupedResult = generateErrorString(groupedCalibrationWS);
   if (!groupedResult.empty()) {
@@ -148,6 +149,42 @@ std::map<std::string, std::string> CombineDiffCal::validateInputs() {
   if (!pixelResult.empty())
     results[PropertyNames::PIXEL_CALIB] = "The PixelCalibration Workspace is missing [ " + pixelResult + "]";
 
+  // Ensure compatible detector IDs in tables
+  // Ensure all detids in GroupedCalibration(detid_pd) and PixelCalibration(detid_prev)
+  // can be found in CalibrationWorkspace (detid_arb)
+
+  // put all detector IDs into sets, for easier searching
+  auto prev_col = pixelCalibrationWS->getColVector<detid_t>(ColNames::DETID);
+  auto pd_col = groupedCalibrationWS->getColVector<detid_t>(ColNames::DETID);
+  auto arb_col = calibrationWS->detectorInfo().detectorIDs();
+  std::set<detid_t> detid_pd(std::make_move_iterator(pd_col.begin()), std::make_move_iterator(pd_col.end()));
+  std::set<detid_t> detid_prev(std::make_move_iterator(prev_col.begin()), std::make_move_iterator(prev_col.end()));
+  std::set<detid_t> detid_arb(std::make_move_iterator(arb_col.begin()), std::make_move_iterator(arb_col.end()));
+
+  std::set<std::string> unmatched;
+  // check that all detector IDs from PixelCalibration are present in CalibrationWorkspace
+  if (!std::includes(detid_arb.begin(), detid_arb.end(), detid_prev.begin(), detid_prev.end())) {
+    unmatched.insert(PropertyNames::PIXEL_CALIB);
+    unmatched.insert(PropertyNames::ARB_CALIB);
+  }
+  // check that all detector IDs from GroupedCalibration are present in CalibrationWorkspace
+  if (!std::includes(detid_arb.begin(), detid_arb.end(), detid_pd.begin(), detid_pd.end())) {
+    unmatched.insert(PropertyNames::GROUP_CALIB);
+    unmatched.insert(PropertyNames::ARB_CALIB);
+  }
+  // if any workspaces do not match, throw an error
+  if (!unmatched.empty()) {
+    std::stringstream msg("");
+    msg << "Inconsistent detector IDs between";
+    for (std::string const &x : unmatched) {
+      msg << " " << x;
+    }
+    msg << ".";
+    for (std::string const &x : unmatched) {
+      results[x] = msg.str();
+    }
+  }
+
   return results;
 }
 
@@ -157,7 +194,7 @@ std::shared_ptr<Mantid::API::TableRow> binarySearchForRow(const API::ITableWorks
   size_t end = ws->rowCount() - 1;
 
   // looking at the detid column is faster
-  std::shared_ptr<const API::Column> detIdColumn = ws->getColumn("detid");
+  std::shared_ptr<const API::Column> detIdColumn = ws->getColumn(ColNames::DETID);
 
   // since both tables are already sorted, linear search the first two rows
   if (getDetId(detIdColumn, start) == detid) {
@@ -246,6 +283,11 @@ void CombineDiffCal::exec() {
   // in order to reduce the search space
   std::size_t lastStart = 0;
 
+  // get a map from detector ID to workspace index in the calibration WS
+  // there is no guarantee detectorIDs in GroupedWorkspace will be contiguous,
+  // and therefore a map and not a vector is necessary.
+  auto wkspIndices = calibrationWS->getDetectorIDToWorkspaceIndexMap();
+
   // loop through all rows in the grouped calibration table
   // this will calculate an updated row or copy the row if it is missing from the pixel calibration
   Mantid::API::TableRow groupedCalibrationRow = groupedCalibrationWS->getFirstRow();
@@ -261,8 +303,9 @@ void CombineDiffCal::exec() {
         // value from groupedCalibrationRow
         const double difcPD = groupedCalibrationWS->cell_cast<double>(groupedCalibrationRow.row(), 1);
 
-        // get value from groupedCalibrationWS
-        const auto wkspIndex = calibrationWS->getIndicesFromDetectorIDs({detid}).front();
+        // get workspace index from the map
+        const auto wkspIndex = wkspIndices[detid];
+
         double difcArb;
         const auto difcArbIter = difcArbMap.find(wkspIndex);
         if (difcArbIter == difcArbMap.end()) {

--- a/Framework/Algorithms/src/CombineDiffCal.cpp
+++ b/Framework/Algorithms/src/CombineDiffCal.cpp
@@ -288,6 +288,11 @@ void CombineDiffCal::exec() {
   // and therefore a map and not a vector is necessary.
   auto wkspIndices = calibrationWS->getDetectorIDToWorkspaceIndexMap();
 
+  // access the spectrum info outside of the loop
+  // this prevents constantly re-calling the method,
+  // which can have some O(N) behavior
+  auto spectrumInfo = calibrationWS->spectrumInfo();
+
   // loop through all rows in the grouped calibration table
   // this will calculate an updated row or copy the row if it is missing from the pixel calibration
   Mantid::API::TableRow groupedCalibrationRow = groupedCalibrationWS->getFirstRow();
@@ -309,7 +314,7 @@ void CombineDiffCal::exec() {
         double difcArb;
         const auto difcArbIter = difcArbMap.find(wkspIndex);
         if (difcArbIter == difcArbMap.end()) {
-          difcArb = calibrationWS->spectrumInfo().diffractometerConstants(wkspIndex)[Kernel::UnitParams::difc];
+          difcArb = spectrumInfo.diffractometerConstants(wkspIndex)[Kernel::UnitParams::difc];
           difcArbMap[wkspIndex] = difcArb;
         } else {
           difcArb = difcArbIter->second;

--- a/Framework/Algorithms/test/CombineDiffCalTest.h
+++ b/Framework/Algorithms/test/CombineDiffCalTest.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include <ctime>
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/AnalysisDataService.h"
@@ -15,7 +16,6 @@
 #include "MantidAlgorithms/CreateSampleWorkspace.h"
 #include "MantidDataObjects/MaskWorkspace.h"
 #include "MantidDataObjects/TableWorkspace.h"
-#include "MantidDataObjects/Workspace2D.h"
 
 #include "MantidAlgorithms/CreateSampleWorkspace.h"
 #include "MantidDataHandling/ApplyDiffCal.h"
@@ -270,7 +270,7 @@ public:
     auto alg = setupAlg(difCalPixelCalibration, difCalGroupedCalibration, diffCalCalibrationWs);
 
     // run the algorithm
-    TS_ASSERT_THROWS_NOTHING(alg->execute(););
+    TS_ASSERT_THROWS_NOTHING(alg->execute());
     TS_ASSERT(alg->isExecuted());
 
     DataObjects::TableWorkspace_sptr output = alg->getProperty("OutputWorkspace");
@@ -389,5 +389,314 @@ public:
     TS_ASSERT_EQUALS(difa->toDouble(2), ((1110. / 1100.) * (1110. / 1100.)) * 3.);
     TS_ASSERT_EQUALS(difa->toDouble(3), ((1110. / 1100.) * (1110. / 1100.)) * 4.);
     // detids 100 and 102 will be copied from the pixel calibration table
+  }
+
+  float doTimedRunWithPixels(std::size_t bank_width) {
+    // the detector panel will be square with bank_pixel_width X bank_pixel_width detectors
+    std::size_t Npixels = bank_width * bank_width;
+    double difcprev = 1.0, difcpd = 2.0, difcarb = 3.0;
+
+    // fake data to simulate the output of cross correlate PixelCalibration
+    DataObjects::TableWorkspace_sptr difCalPixelCalibration = createEmptyCalibrationTable();
+    for (std::size_t i = 0; i < Npixels; i++) {
+      TableRow newRow = difCalPixelCalibration->appendRow();
+      // adding i to the DIFC value ensures a proper order for combining
+      newRow << int(i + Npixels) << difcprev + double(i) << 0.0 << 0.0;
+    }
+
+    // fake data to simulate the output of PDCalibration GroupedCalibration
+    DataObjects::TableWorkspace_sptr difCalGroupedCalibration = createEmptyCalibrationTable();
+    for (std::size_t i = 0; i < Npixels; i++) {
+      TableRow newRow = difCalGroupedCalibration->appendRow();
+      // adding i to the DIFC value ensures a proper order for combining
+      newRow << int(i + Npixels) << difcpd + double(i) << 0.0 << 0.0;
+    }
+
+    // fake data to simulate CalibrationWorkspace
+    std::string calWsName = AnalysisDataService::Instance().uniqueName();
+    CreateSampleWorkspace createSampleWorkspaceAlgo;
+    createSampleWorkspaceAlgo.setChild(true);
+    createSampleWorkspaceAlgo.initialize();
+    createSampleWorkspaceAlgo.setPropertyValue("OutputWorkspace", calWsName);
+    createSampleWorkspaceAlgo.setProperty("NumBanks", 1);
+    createSampleWorkspaceAlgo.setProperty("BankPixelWidth", int(bank_width));
+    createSampleWorkspaceAlgo.execute();
+    // set the workspace's diffraction constants for comparison
+    MatrixWorkspace_sptr diffCalCalibrationWs = createSampleWorkspaceAlgo.getProperty("OutputWorkspace");
+    auto experimentInfo = std::dynamic_pointer_cast<API::ExperimentInfo>(diffCalCalibrationWs);
+    auto instrument = experimentInfo->getInstrument();
+    auto &paramMap = experimentInfo->instrumentParameters();
+    auto detids = instrument->getDetectorIDs();
+    std::sort(detids.begin(), detids.end());
+    for (std::size_t i = 0; i < Npixels; i++) {
+      auto det = instrument->getDetector(detids[i]);
+      // adding i to the DIFC value ensures a proper order for combining
+      paramMap.addDouble(det->getComponentID(), "DIFC", difcarb + double(i));
+      paramMap.addDouble(det->getComponentID(), "DIFA", 0.0);
+      paramMap.addDouble(det->getComponentID(), "TZERO", 0.0);
+    }
+
+    // set up and run the algorithm
+    auto alg = setupAlg(difCalPixelCalibration, difCalGroupedCalibration, diffCalCalibrationWs);
+    // run and time the algorithm
+    clock_t start = clock();
+    TS_ASSERT_THROWS_NOTHING(alg->execute(););
+    TS_ASSERT(alg->isExecuted());
+    clock_t end = clock();
+    float total = static_cast<float>(end - start);
+    TS_ASSERT_LESS_THAN(0.0, total);
+
+    // check the difcnew values
+    DataObjects::TableWorkspace_sptr output = alg->getProperty("OutputWorkspace");
+    std::vector<double> difcout = output->getColVector<double>("difc");
+    for (std::size_t i = 0; i < Npixels; i++) {
+      double I = double(i);
+      TS_ASSERT_EQUALS(difcout[i], (difcpd + I) / (difcarb + I) * (difcprev + I));
+    }
+
+    // return the measured time
+    return total;
+  }
+
+  void test_time_scaling() {
+    // run with increasing numbers of pixels
+    // check that the time scales better than quadratic, i.e. better than O(N^2)
+    constexpr std::size_t Npoints = 3;
+    std::size_t x[Npoints]; // the number of pixels
+    float y[Npoints];
+
+    for (std::size_t i = 0; i < Npoints; i++) {
+      std::size_t bank_width = (i + 1) * 100UL;
+      x[i] = bank_width * bank_width;
+      y[i] = doTimedRunWithPixels(bank_width);
+    }
+
+    // make a quadratic y = A(x-x0)^2 + C  (ignore linear term)
+    // use it to predict the final time under O(N^2) scaling
+    // ensure the final time is less than this
+    double deltax = double(x[1] - x[0]), deltay = (y[1] - y[0]);
+    double quadratic_C = y[0];
+    double quadratic_A = deltay / deltax / deltax;
+    deltax = double(x[Npoints - 1] - x[0]);
+    double quadratic_prediction = quadratic_A * deltax * deltax + quadratic_C;
+    TS_ASSERT_LESS_THAN(y[Npoints - 1], quadratic_prediction);
+  }
+
+  void test_correct_matching_detids() {
+    // Ensure the correct detector IDs are being matched up
+    // create workspaces with these detectors:
+    //  ARB: 4, 5, 6, 7
+    //   PD:    5,    7
+    // PREV: 4, 5, 6, 7
+    // in the result, we expect 5, 6, then the algo adds in 4, 7 from PREV
+
+    std::size_t bank_width = 2;
+
+    // Create the GroupedCalibration
+    DataObjects::TableWorkspace_sptr difCalGroupedCalibration = createEmptyCalibrationTable();
+    for (std::size_t i : {5, 7}) {
+      TableRow newRow = difCalGroupedCalibration->appendRow();
+      newRow << int(i) << double(i) << 0.0 << 0.0;
+    }
+
+    // Create the PixelCalibration
+    DataObjects::TableWorkspace_sptr difCalPixelCalibration = createEmptyCalibrationTable();
+    for (std::size_t i : {4, 5, 6, 7}) {
+      TableRow newRow = difCalPixelCalibration->appendRow();
+      newRow << int(i) << double(i) << 0.0 << 0.0;
+    }
+
+    // Create a CalibrationWorkspace
+    std::string calWsName = AnalysisDataService::Instance().uniqueName();
+    CreateSampleWorkspace createSampleWorkspaceAlgo;
+    createSampleWorkspaceAlgo.setChild(true);
+    createSampleWorkspaceAlgo.initialize();
+    createSampleWorkspaceAlgo.setPropertyValue("OutputWorkspace", calWsName);
+    createSampleWorkspaceAlgo.setProperty("NumBanks", 1);
+    createSampleWorkspaceAlgo.setProperty("BankPixelWidth", int(bank_width));
+    createSampleWorkspaceAlgo.execute();
+    MatrixWorkspace_sptr diffCalCalibrationWs = createSampleWorkspaceAlgo.getProperty("OutputWorkspace");
+    auto experimentInfo = std::dynamic_pointer_cast<API::ExperimentInfo>(diffCalCalibrationWs);
+    auto instrument = experimentInfo->getInstrument();
+    auto &paramMap = experimentInfo->instrumentParameters();
+    auto detids = instrument->getDetectorIDs();
+    std::sort(detids.begin(), detids.end());
+    for (detid_t detid : detids) {
+      auto det = instrument->getDetector(detid);
+      paramMap.addDouble(det->getComponentID(), "DIFC", double(detid));
+      paramMap.addDouble(det->getComponentID(), "DIFA", 0.0);
+      paramMap.addDouble(det->getComponentID(), "TZERO", 0.0);
+    }
+
+    // set up and run algorithm
+    auto alg = setupAlg(difCalPixelCalibration, difCalGroupedCalibration, diffCalCalibrationWs);
+    TS_ASSERT_THROWS_NOTHING(alg->execute());
+    TS_ASSERT(alg->isExecuted());
+
+    // check the difcnew values
+    // difc_new = (difc_pd / difc_arb) * difc_prev = (detid / detid) * detid = detid
+    DataObjects::TableWorkspace_sptr output = alg->getProperty("OutputWorkspace");
+    std::vector<detid_t> detid_out = output->getColVector<detid_t>("detid");
+    std::vector<detid_t> detid_exp{4, 5, 6, 7};
+    std::vector<double> difc_out = output->getColVector<double>("difc");
+    TS_ASSERT_EQUALS(detid_out.size(), detid_exp.size());
+    for (std::size_t i = 0; i < detid_out.size(); i++) {
+      TS_ASSERT_EQUALS(detid_out[i], detid_exp[i]);
+      TS_ASSERT_EQUALS(difc_out[i], double(detid_exp[i]));
+    }
+  }
+
+  void test_missing_pixel_cal_copies_group_cal() {
+    // Ensure the algorithm will simply copy missing rows from GroupedCalibration
+    // if they are not found inside PixelCalibraion
+    // create workspaces with these detectors:
+    //  ARB: 4, 5, 6, 7
+    //   PD: 4, 5, 6, 7
+    // PREV:    5, 6
+
+    std::size_t bank_width = 2;
+    double difc_pd = 2.0, difc_prev = 3.0, difc_arb = 4.0;
+    double difc_new = (difc_pd / difc_arb) * difc_prev;
+
+    // First create the GroupedCalibration
+    DataObjects::TableWorkspace_sptr difCalGroupedCalibration = createEmptyCalibrationTable();
+    for (std::size_t i : {4, 5, 6, 7}) {
+      TableRow newRow = difCalGroupedCalibration->appendRow();
+      newRow << int(i) << difc_pd << 0.0 << 0.0;
+    }
+
+    // Create a compatible PixelCalibration
+    DataObjects::TableWorkspace_sptr difCalPixelCalibration = createEmptyCalibrationTable();
+    for (std::size_t i : {5, 6}) {
+      TableRow newRow = difCalPixelCalibration->appendRow();
+      newRow << int(i) << difc_prev << 0.0 << 0.0;
+    }
+
+    // Create a CalibrationWorkspace
+    std::string calWsName = AnalysisDataService::Instance().uniqueName();
+    CreateSampleWorkspace createSampleWorkspaceAlgo;
+    createSampleWorkspaceAlgo.setChild(true);
+    createSampleWorkspaceAlgo.initialize();
+    createSampleWorkspaceAlgo.setPropertyValue("OutputWorkspace", calWsName);
+    createSampleWorkspaceAlgo.setProperty("NumBanks", 1);
+    createSampleWorkspaceAlgo.setProperty("BankPixelWidth", int(bank_width));
+    createSampleWorkspaceAlgo.execute();
+    MatrixWorkspace_sptr diffCalCalibrationWs = createSampleWorkspaceAlgo.getProperty("OutputWorkspace");
+    auto experimentInfo = std::dynamic_pointer_cast<API::ExperimentInfo>(diffCalCalibrationWs);
+    auto instrument = experimentInfo->getInstrument();
+    auto &paramMap = experimentInfo->instrumentParameters();
+    auto detids = instrument->getDetectorIDs();
+    std::sort(detids.begin(), detids.end());
+    for (detid_t detid : detids) {
+      auto det = instrument->getDetector(detid);
+      paramMap.addDouble(det->getComponentID(), "DIFC", difc_arb);
+      paramMap.addDouble(det->getComponentID(), "DIFA", 0.0);
+      paramMap.addDouble(det->getComponentID(), "TZERO", 0.0);
+    }
+
+    // set up and run algorithm
+    auto alg = setupAlg(difCalPixelCalibration, difCalGroupedCalibration, diffCalCalibrationWs);
+    TS_ASSERT_THROWS_NOTHING(alg->execute());
+    TS_ASSERT(alg->isExecuted());
+
+    // check the difcnew values
+    DataObjects::TableWorkspace_sptr output = alg->getProperty("OutputWorkspace");
+    std::vector<detid_t> detid_out = output->getColVector<detid_t>("detid");
+    std::vector<detid_t> detid_exp{4, 5, 6, 7};
+    std::vector<double> difc_out = output->getColVector<double>("difc");
+    std::vector<double> difc_exp{difc_pd, difc_new, difc_new, difc_pd};
+    TS_ASSERT_EQUALS(detid_out.size(), detid_exp.size());
+    for (std::size_t i = 0; i < detid_out.size(); i++) {
+      TS_ASSERT_EQUALS(detid_out[i], detid_exp[i]);
+      TS_ASSERT_EQUALS(difc_out[i], difc_exp[i]);
+    }
+  }
+
+  void test_validateInputs_in_pixel_not_cal() {
+    // Ensure the algorithm will fail early if the pixels in the PixelCalibration
+    // are not present in the CalibrationWorkspace
+    // create workspaces with these detectors:
+    //  ARB:    4, 5, 6, 7
+    //   PD:    4, 5, 6, 7
+    // PREV: 1, 4, 5, 6, 7
+
+    std::size_t bank_width = 2;
+
+    // First create the GroupedCalibration
+    DataObjects::TableWorkspace_sptr difCalGroupedCalibration = createEmptyCalibrationTable();
+    for (std::size_t i : {4, 5, 6, 7}) {
+      TableRow newRow = difCalGroupedCalibration->appendRow();
+      newRow << int(i) << 1.0 << 0.0 << 0.0;
+    }
+
+    // Create a compatible PixelCalibration
+    DataObjects::TableWorkspace_sptr difCalPixelCalibration = createEmptyCalibrationTable();
+    for (std::size_t i : {1, 4, 5, 6, 7}) {
+      TableRow newRow = difCalPixelCalibration->appendRow();
+      newRow << int(i) << 1.0 << 0.0 << 0.0;
+    }
+
+    // Create a CalibrationWorkspace
+    std::string calWsName = AnalysisDataService::Instance().uniqueName();
+    CreateSampleWorkspace createSampleWorkspaceAlgo;
+    createSampleWorkspaceAlgo.setChild(true);
+    createSampleWorkspaceAlgo.initialize();
+    createSampleWorkspaceAlgo.setPropertyValue("OutputWorkspace", calWsName);
+    createSampleWorkspaceAlgo.setProperty("NumBanks", 1);
+    createSampleWorkspaceAlgo.setProperty("BankPixelWidth", int(bank_width));
+    createSampleWorkspaceAlgo.execute();
+    MatrixWorkspace_sptr diffCalCalibrationWs = createSampleWorkspaceAlgo.getProperty("OutputWorkspace");
+
+    auto alg = setupAlg(difCalPixelCalibration, difCalGroupedCalibration, diffCalCalibrationWs);
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
+    TS_ASSERT(!alg->isExecuted());
+    auto result = alg->validateInputs();
+    TS_ASSERT(!result.count("GroupedCalibration"));
+    TS_ASSERT(result.count("PixelCalibration"));
+    TS_ASSERT(result.count("CalibrationWorkspace"));
+  }
+
+  void test_validateInputs_in_grouped_not_cal() {
+    // Ensure the algorithm will fail early if the pixels in the GroupedCalibration
+    // are not present in the CalibrationWorkspace
+    // create workspaces with these detectors:
+    //  ARB:    4, 5, 6, 7
+    //   PD: 1, 4, 5, 6, 7
+    // PREV:    4, 5, 6, 7
+
+    std::size_t bank_width = 2;
+
+    // First create the GroupedCalibration
+    DataObjects::TableWorkspace_sptr difCalGroupedCalibration = createEmptyCalibrationTable();
+    for (std::size_t i : {1, 4, 5, 6, 7}) {
+      TableRow newRow = difCalGroupedCalibration->appendRow();
+      newRow << int(i) << 1.0 << 0.0 << 0.0;
+    }
+
+    // Create a compatible PixelCalibration
+    DataObjects::TableWorkspace_sptr difCalPixelCalibration = createEmptyCalibrationTable();
+    for (std::size_t i : {4, 5, 6, 7}) {
+      TableRow newRow = difCalPixelCalibration->appendRow();
+      newRow << int(i) << 1.0 << 0.0 << 0.0;
+    }
+
+    // Create a CalibrationWorkspace with detector IDs 4, 5, 6, 7, and NOT 1
+    std::string calWsName = AnalysisDataService::Instance().uniqueName();
+    CreateSampleWorkspace createSampleWorkspaceAlgo;
+    createSampleWorkspaceAlgo.setChild(true);
+    createSampleWorkspaceAlgo.initialize();
+    createSampleWorkspaceAlgo.setPropertyValue("OutputWorkspace", calWsName);
+    createSampleWorkspaceAlgo.setProperty("NumBanks", 1);
+    createSampleWorkspaceAlgo.setProperty("BankPixelWidth", int(bank_width));
+    createSampleWorkspaceAlgo.execute();
+    MatrixWorkspace_sptr diffCalCalibrationWs = createSampleWorkspaceAlgo.getProperty("OutputWorkspace");
+
+    auto alg = setupAlg(difCalPixelCalibration, difCalGroupedCalibration, diffCalCalibrationWs);
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
+    TS_ASSERT(!alg->isExecuted());
+    auto result = alg->validateInputs();
+    TS_ASSERT(result.count("GroupedCalibration"));
+    TS_ASSERT(!result.count("PixelCalibration"));
+    TS_ASSERT(result.count("CalibrationWorkspace"));
   }
 };

--- a/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37731.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37731.rst
@@ -1,0 +1,1 @@
+- Improve time-scaling performance of CombineDiffCal, and add extra validations.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

Mantid's [`CombineDiffCal` algorithm](https://docs.mantidproject.org/nightly/algorithms/CombineDiffCal-v1.html) was accidentally setup so that it scaled like $O(N^2)$.  This meant for a machine like ORNL's SNAP, with over a million detectors, that the algorithm ran prohibitively slowly, taking between 2-4 hours.

Inside the primary `do-while` loop, the section to match rows in the tables called another method within `MatrixWorkspace` that is also $O(N)$.

The fix was to generate two items outside of the main `do-while` loop.  The first is to make a map from all detector IDs to spectrum indices, outside of the loop first and refer to that map inside the loop, lowering the scaling behavior down to something reasonable.  The second is to store the `spectrumInfo` object before the loop, as the call to get this object inside `ExperimentInfo` involves [an `any_of` call](https://github.com/mantidproject/mantid/blob/e4995f5353809892c6985c92893f5f144e6b499e/Framework/API/src/ExperimentInfo.cpp#L818) that can be $O(N)$.  

#### Purpose of work

The SNAP instrument has over a million pixels.  When trying to run calibration on SNAP,  it was taking over 17 hours to run a calculation.  This reduces that time significantly.

*There is no associated issue* in mantid, but at ORNL we had an issue, [EWM 5061](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=5061)

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

The work was very simple, a few-lines fix.

The call to `MatrixWorkspace::getIndicesFromDetectorIDs()` inside the `do-while` was removed.  It was replaced with a call before the `do-while` to `MatrixWorkspace::getDetectorIDToWorkspaceIndexMap()` which returns a map of *all* detector IDs to spectra indices.

In addition, I added validators that all of the detector IDs in the table workspaces can be found in the CalibrationWorkspace.  This prevents a vector out-of-range error that was occurring when the detector IDs did not match.

The additional tests check the scaling behavior, and the validation behavior.

Some context:
- original [PR](https://github.com/mantidproject/mantid/pull/31922) creating algorithm
- original [PR](https://github.com/mantidproject/mantid/pull/31924) into old `ornl-next`
- original [ORNL issue](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/276) for creating this algorithm
- related [ORNL issue](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/240)
- related [ORNL issue](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/108)

### To test:

Firstly, in workbench, verify this is a problem.  On `main`, run the following script (and grab a coffee or something...)
``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
import time
import random

bank_width = [2**j for j in range(5,10)]
num_pixels = [n*n for n in bank_width] 
times = []
for N in bank_width:
    NN = N*N
    detids = list(range(NN))
    
    # DIFCprev
    difcprev=CreateEmptyTableWorkspace()
    difcprev.addColumn("int", "detid")
    difcprev.addColumn("float", "difc")
    difcprev.addColumn("float", "difa")
    difcprev.addColumn("float", "tzero")
    # random.shuffle(detids)
    for i in detids:
        # NOTE detector IDs from CreateSampleWorkspace start at N^2
        difcprev.addRow({"detid": NN+i, "difc": 1.0, "difa": 1.0, "tzero": 0.0})
        
    # DIFCpd
    difcpd=CreateEmptyTableWorkspace()
    difcpd.addColumn("int", "detid")
    difcpd.addColumn("float", "difc")
    difcpd.addColumn("float", "difa")
    difcpd.addColumn("float", "tzero")
    # random.shuffle(detids)
    for i in detids:
        difcpd.addRow({"detid": NN+i, "difc": 2.0, "difa": 0.0, "tzero": 0.0})
        
    # DIFCarb
    CreateSampleWorkspace(
        OutputWorkspace='difcarb', 
        NumBanks=1, 
        BankPixelWidth=N,
    )
    
    # run the algorithm
    start = time.time()
    CombineDiffCal(
        PixelCalibration=difcprev,
        GroupedCalibration=difcpd,
        CalibrationWorkspace="difcarb",
        OutputWorkspace="outws",
    )
    end = time.time()
    times.append(end-start)

plt.plot(num_pixels, times, "bo-")
plt.xlabel("number of pixels")
plt.ylabel("time for completion")
plt.show()
     
```
and observe the plot of time-scaling.

**SAVE THE PLOT AND THE VALUES FOR LATER COMPARISON**

Also on `main`, attempt to run the following:
``` python
N = 2
detids = list(range(N*N))
    
# DIFCprev
difc=CreateEmptyTableWorkspace()
difc.addColumn("int", "detid")
difc.addColumn("float", "difc")
difc.addColumn("float", "difa")
difc.addColumn("float", "tzero")
for i in detids:
    difc.addRow({"detid": i, "difc": 1, "difa": 0, "tzero": 0})
     
# DIFCarb
CreateSampleWorkspace(
    OutputWorkspace='difcarb',
    NumBanks=1,
    BankPixelWidth=N,
)

# run the algorithm
CombineDiffCal(
    PixelCalibration=difc,
    GroupedCalibration=difc,
    CalibrationWorkspace="difcarb",
    OutputWorkspace="outws",
)
```
This will result in an out-of-range error message,
```
vector::_M_range_check: __n (which is 127275276773272) >= this->size() (which is 4)
```
which does not make it clear where things failed

Then pull and build this branch and run both scripts again.

The first script should run much faster, and its scaling be linear.  If you plot the two against one another, it should look something like this:
![image](https://github.com/user-attachments/assets/7f5ae978-f535-4911-a0c9-c06f13e0ddb3)

The second script should give a validation error, stating that the workspaces have incompatible detector IDs.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
