### PR TITLE
Use BoostConfig instead of deprecated cmake code

### DIFF
--- a/Framework/PythonInterface/CMakeLists.txt
+++ b/Framework/PythonInterface/CMakeLists.txt
@@ -10,14 +10,12 @@ if(CMAKE_COMPILER_IS_GNUCXX
   add_definitions(-DBOOST_PYTHON_USE_GCC_SYMBOL_VISIBILITY)
 endif()
 
-# This allows the use of find_package(Boost ...), from cmake version 3.30 onwards
-cmake_policy(SET CMP0167 OLD)
-
 # Keep boost python separate from other boost
 set(_boost_libs_orig ${Boost_LIBRARIES})
 set(Boost_LIBRARIES)
+set(Boost_VERBOSE "ON")
 find_package(
-  Boost ${BOOST_VERSION_REQUIRED}
+  Boost CONFIG
   COMPONENTS python${Python_VERSION_MAJOR}${Python_VERSION_MINOR}
   REQUIRED
 )

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -64,7 +64,6 @@ if(BUILD_MANTIDFRAMEWORK OR BUILD_MANTIDQT)
   # ####################################################################################################################
   # Look for dependencies Do NOT add include_directories commands here. They will affect every target.
   # ####################################################################################################################
-  set(BOOST_VERSION_REQUIRED 1.65.0)
   set(Boost_NO_BOOST_CMAKE TRUE)
   # Unless specified see if the boost169 package is installed
   if(EXISTS /usr/lib64/boost169 AND NOT (BOOST_LIBRARYDIR OR BOOST_INCLUDEDIR))
@@ -72,9 +71,9 @@ if(BUILD_MANTIDFRAMEWORK OR BUILD_MANTIDQT)
     set(BOOST_INCLUDEDIR /usr/include/boost169)
     set(BOOST_LIBRARYDIR /usr/lib64/boost169)
   endif()
-  # This allows the use of find_package(Boost ...), from cmake version 3.30 onwards
-  cmake_policy(SET CMP0167 OLD)
-  find_package(Boost ${BOOST_VERSION_REQUIRED} REQUIRED COMPONENTS date_time regex serialization filesystem system)
+
+  set(Boost_VERBOSE "ON")
+  find_package(Boost CONFIG REQUIRED COMPONENTS date_time regex serialization filesystem system)
   add_definitions(-DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB -DBOOST_BIND_GLOBAL_PLACEHOLDERS)
   # Need this defined globally for our log time values
   add_definitions(-DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG)


### PR DESCRIPTION
Use `Config` mode for `find_packages(Boost)`, because `Module` mode will use the `FindBoost` module that is deprecated, see #37714. Config mode will use the `BoostConfig.cmake` shipped with each version of Boost, and available in the conda environment (e.g. `\mambaforge\pkgs\libboost-devel-1.82.0-h91493d7_6\Library\lib\cmake\Boost-1.82.0`). I also removed the policy change code that allowed the use of `FindBoost` in `cmake`>=3.30, added in #37687.

See [here](https://cmake.org/cmake/help/latest/command/find_package.html) for more details on `Module` vs `Config` search modes.

The `FindBoost` deprecation is detailed [here](https://cmake.org/cmake/help/latest/module/FindBoost.html).

I deleted the Boost version specification because conda will handle that.

Setting `Boost_VERBOSE` prints out which version it has found, and where, otherwise you get no output.

Fixes #37714.

### To test:

Automated testing

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **it will have no effect on the user.**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
