### PR TITLE
Fix error from plot when cropping workspace

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/Bugfixes/37132.rst
+++ b/docs/source/release/v6.11.0/Workbench/Bugfixes/37132.rst
@@ -1,0 +1,1 @@
+- Fixed error when cropping a workspace after using the ``Plot All`` button

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -106,7 +106,7 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
 
     def on_plot_all_clicked(self):
         selection = SpectraSelection(self._workspaces)
-        selection.wksp_indices = range(self.wi_min, self.wi_max + 1)
+        selection.spectra = self._plottable_spectra
         selection.plot_type = self._ui.plotType.currentIndex()
 
         if self._advanced:

--- a/qt/python/mantidqt/mantidqt/dialogs/test/test_spectraselectiondialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/test/test_spectraselectiondialog.py
@@ -99,12 +99,12 @@ class SpectraSelectionDialogTest(unittest.TestCase):
         do_test(dlg._ui.wkspIndices)
         do_test(dlg._ui.specNums)
 
-    def test_plot_all_gives_only_workspaces_indices(self):
+    def test_plot_all_gives_only_spectra_numbers(self):
         dlg = SpectraSelectionDialog([self._multi_spec_ws])
         dlg._ui.buttonBox.button(QDialogButtonBox.YesToAll).click()
         self.assertNotEqual(dlg.selection, None)
-        self.assertEqual(dlg.selection.spectra, None)
-        self.assertEqual(range(200), dlg.selection.wksp_indices)
+        self.assertEqual(dlg.selection.spectra, list(range(1, 201)))
+        self.assertEqual(dlg.selection.wksp_indices, None)
 
     def test_entered_workspace_indices_gives_correct_selection_back(self):
         dlg = SpectraSelectionDialog([self._multi_spec_ws])
@@ -328,7 +328,8 @@ class SpectraSelectionDialogTest(unittest.TestCase):
         ssd._ui.plotType.setCurrentIndex(2)
         ssd._ui.buttonBox.button(QDialogButtonBox.YesToAll).click()
 
-        self.assertEqual(ssd.selection.wksp_indices, range(0, 200))
+        self.assertEqual(ssd.selection.wksp_indices, None)
+        self.assertEqual(ssd.selection.spectra, list(range(1, 201)))
         self.assertEqual(ssd.selection.plot_type, 2)
         self.assertEqual(ssd.selection.errors, False)
         self.assertEqual(ssd.selection.log_name, "Workspace name")


### PR DESCRIPTION
If you click `Plot All`, then crop the underlying workspace, this stops you getting an error. Plotting with workspace indices instead of spectra numbers will still give the original error, but that can be fixed separately because it looks a bit more involved.

The `_WorkspaceArtists` object relies on the mapping of a workspace to spectra number at the time it is created. So when the workspace is cropped, and you're plotting by workspace index, that index will then change the spectrum that is represents. If we just use the spectra numbers to plot when using `Plot All` then at least this problem can be avoided in that case.

This is part of dealing with #37132 

### To test:
- Load a workspace with more than one spectra (but not too many), e.g. `INTER13460`
- Hit `Plot All` in the `Plot 1D` dialog that pops up when you double-click the workspace in the ADS
- Run `CropWorkspace` on that workspace with e.g. `StartWorkspaceIndex` as 1
- Click the plot settings cog
- No error

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
