### PR TITLE
Change default Instrument View background colour to opaque black

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/InstrumentViewer/Bugfixes/37370.rst
+++ b/docs/source/release/v6.11.0/Workbench/InstrumentViewer/Bugfixes/37370.rst
@@ -1,0 +1,1 @@
+- Fixed drawing artifacts appearing (in some cases) when zooming in on the Instrument View with a 2D projection

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -584,7 +584,7 @@ void InstrumentWidget::setSurfaceType(int type) {
       showPeakLabels = settings.value("ShowPeakLabels", true).toBool();
       // By default this is should be off for now.
       showPeakRelativeIntensity = settings.value("ShowPeakRelativeIntensities", false).toBool();
-      backgroundColor = settings.value("BackgroundColor", QColor(0, 0, 0, 1.0)).value<QColor>();
+      backgroundColor = settings.value("BackgroundColor", QColor("black")).value<QColor>();
       settings.endGroup();
     }
 


### PR DESCRIPTION
If the background colour for the Instrument View is transparent, then when zooming in the previous image will still be visible, as well as the zoomed-in image, because the background is being used to paint over the previous image. Hence I've changed the background to be opaque black instead of (almost) transparent.

In `UnwrappedSurface.cpp::541`, the image is painted over with the background colour, which is why it must be opaque.

Fixes #37370. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->

### To test:
Follow the instructions in #37370 to reproduce. If you can't reproduce this initially, probably you've set the background colour in the Instrument View display settings at some point, which fixes the problem until something changes the `mantidworkbench.ini` file. In that case delete the line that starts `InstrumentWidget\BackgroundColor=` from `mantidworkbench.ini`.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
