### PR TITLE
Fix error causing grainsize to evaluate to 0

### DIFF
--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -684,7 +684,7 @@ void EventWorkspace::sortAll(EventSortType sortType, Mantid::API::Progress *prog
   // Create the thread pool using tbb
   EventSortingTask task(this, sortType, prog);
   constexpr size_t GRAINSIZE_DEFAULT{100}; // somewhat arbitrary
-  const size_t grainsize = std::min<size_t>(GRAINSIZE_DEFAULT, this->getNumberHistograms() / GRAINSIZE_DEFAULT + 1);
+  const size_t grainsize = std::min<size_t>(GRAINSIZE_DEFAULT, (this->getNumberHistograms() / GRAINSIZE_DEFAULT) + 1);
   tbb::parallel_for(tbb::blocked_range<size_t>(0, data.size(), grainsize), task);
 }
 

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -684,7 +684,7 @@ void EventWorkspace::sortAll(EventSortType sortType, Mantid::API::Progress *prog
   // Create the thread pool using tbb
   EventSortingTask task(this, sortType, prog);
   constexpr size_t GRAINSIZE_DEFAULT{100}; // somewhat arbitrary
-  const size_t grainsize = std::min<size_t>(GRAINSIZE_DEFAULT, this->getNumberHistograms() / GRAINSIZE_DEFAULT);
+  const size_t grainsize = std::min<size_t>(GRAINSIZE_DEFAULT, this->getNumberHistograms() / GRAINSIZE_DEFAULT + 1);
   tbb::parallel_for(tbb::blocked_range<size_t>(0, data.size(), grainsize), task);
 }
 

--- a/docs/source/release/v6.11.0/Framework/Data_Objects/Bugfixes/37743.rst
+++ b/docs/source/release/v6.11.0/Framework/Data_Objects/Bugfixes/37743.rst
@@ -1,0 +1,1 @@
+- Added a `+ 1` to `EventWorkspace::sortAll` to prevent grainsize from being 0.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

In `EventWorkspaces::sortAll`, changed how `grainsize` was calculated.  The method as it was written would always lead to a grainsize of `0` if the workspace contained fewer than 100 histograms, and a grainsize of `0` was considered an error (at least when built with Ubuntu 22.04.4 LTS.  Now it will always be at least `1`.

#### Purpose of work

The issue with `grainsize` calculation was causing errors when testing locally.

I have no idea why these errors did not also occur on Jenkins.

*There is no associated issue.*

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

There is no further detail.  That's it.  One line change.

### To test:

Try to reproduce the issue by building and running the `AlgorithmsTest` target on `main`.  Several tests should fail complaining about grainsize (or at least they did for me).

Build and run the same tests on this branch.  There should be no issues.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
