### PR TITLE
Update release notes template and generator

### DIFF
--- a/dev-docs/source/Standards/ReleaseNotesGuide.rst
+++ b/dev-docs/source/Standards/ReleaseNotesGuide.rst
@@ -73,6 +73,7 @@ Release note files need to be saved in the directory that best represents their 
 or ``Bugfixes`` directory. For example a Bugfix release note for Engineering Diffraction should sit within ``/Diffraction/Engineering/Bugfixes`` .
 
 Release notes should not be placed in any directory outside of ``New_features`` or ``Bugfixes`` e.g. do not place release notes in ``/Diffraction/Engineering``. You should also not save release notes in any directory titled ``Used`` as this is for notes that have already been collated into the release notes.
+The only exception to this is for Algorithms and Fit Functions in the Framework Directory that additionally have ``Deprecated`` and ``Removed``.
 
 If you are uncertain where your release note should be see the :ref:`Standard File Structure <ReleaseNoteFileStructure>`.
 
@@ -191,11 +192,15 @@ This is the basic directory structure that is available to you for release notes
 
 	  + New features
 	  + Bugfixes
+	  + Deprecated
+	  + Removed
 
   - Fit Functions (Sub-heading)
 
 	  + New features
 	  + Bugfixes
+	  + Deprecated
+	  + Removed
 
   - Data Objects (Sub-heading)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -237,4 +237,11 @@ intersphinx_mapping = {
 # Suppress build warnings of the type:
 # "WARNING: document isn't included in any toctree"
 # for individual release notes files.
-exclude_patterns = ["release/templates/*.rst", "release/**/Bugfixes/*.rst", "release/**/New_features/*.rst", "release/**/Used/*.rst"]
+exclude_patterns = [
+    "release/templates/*.rst",
+    "release/**/Bugfixes/*.rst",
+    "release/**/New_features/*.rst",
+    "release/**/Used/*.rst",
+    "release/**/Removed/*.rst",
+    "release/**/Deprecated/*.rst",
+]

--- a/docs/source/release/templates/framework.rst
+++ b/docs/source/release/templates/framework.rst
@@ -16,6 +16,14 @@ Bugfixes
 ############
 .. amalgamate:: Framework/Algorithms/Bugfixes
 
+Deprecated
+############
+.. amalgamate:: Framework/Algorithms/Deprecated
+
+Removed
+############
+.. amalgamate:: Framework/Algorithms/Removed
+
 Fit Functions
 -------------
 
@@ -26,6 +34,14 @@ New features
 Bugfixes
 ############
 .. amalgamate:: Framework/Fit_Functions/Bugfixes
+
+Deprecated
+############
+.. amalgamate:: Framework/Fit_Functions/Deprecated
+
+Removed
+############
+.. amalgamate:: Framework/Fit_Functions/Removed
 
 
 Data Objects

--- a/tools/release_generator/release.py
+++ b/tools/release_generator/release.py
@@ -131,6 +131,7 @@ inelastic = ["Algorithms"]
 muon = ["FDA", "Muon_Analysis", "MA_FDA", "ALC", "Elemental_Analysis", "Algorithms"]
 
 subfolders = ["Bugfixes", "New_features"]
+deprecated_subfolders = ["Bugfixes", "New_features", "Deprecated", "Removed"]
 muon_subfolders = ["Bugfixes"]
 #################################################################################
 
@@ -225,18 +226,29 @@ def makeSubDirectoriesFromList(directoryList, upperDirectory, HigherLevel):
         makeReleaseNoteSubfolders(combinedDirectory, HigherLevel)
 
 
+def subfolder_creation(directory, HigherLevel, folder):
+    subfolderName = HigherLevel / directory / folder
+    subfolderName.mkdir(parents=True, exist_ok=True)
+    makeGitkeep(subfolderName)
+
+
 def makeReleaseNoteSubfolders(directory, HigherLevel):
     directoryStr = str(directory)
     for folder in subfolders:
         if "Muon" in directoryStr:
             for single_folder in muon_subfolders:
-                subfolderName = HigherLevel / directory / single_folder
-                subfolderName.mkdir(parents=True, exist_ok=True)
-                makeGitkeep(subfolderName)
+                subfolder_creation(directory, HigherLevel, single_folder)
+        if "Framework" in directoryStr:
+            if "Algorithm" in directoryStr:
+                for single_folder in deprecated_subfolders:
+                    subfolder_creation(directory, HigherLevel, single_folder)
+            if "Fit_Functions" in directoryStr:
+                for single_folder in deprecated_subfolders:
+                    subfolder_creation(directory, HigherLevel, single_folder)
+            else:
+                subfolder_creation(directory, HigherLevel, folder)
         else:
-            subfolderName = HigherLevel / directory / folder
-            subfolderName.mkdir(parents=True, exist_ok=True)
-            makeGitkeep(subfolderName)
+            subfolder_creation(directory, HigherLevel, folder)
 
 
 def makeGitkeep(subfolderName):

--- a/tools/release_generator/release.py
+++ b/tools/release_generator/release.py
@@ -131,7 +131,7 @@ inelastic = ["Algorithms"]
 muon = ["FDA", "Muon_Analysis", "MA_FDA", "ALC", "Elemental_Analysis", "Algorithms"]
 
 subfolders = ["Bugfixes", "New_features"]
-deprecated_subfolders = ["Bugfixes", "New_features", "Deprecated", "Removed"]
+deprecated_subfolders = subfolders + ["Deprecated", "Removed"]
 muon_subfolders = ["Bugfixes"]
 #################################################################################
 
@@ -239,10 +239,7 @@ def makeReleaseNoteSubfolders(directory, HigherLevel):
             for single_folder in muon_subfolders:
                 subfolder_creation(directory, HigherLevel, single_folder)
         if "Framework" in directoryStr:
-            if "Algorithm" in directoryStr:
-                for single_folder in deprecated_subfolders:
-                    subfolder_creation(directory, HigherLevel, single_folder)
-            if "Fit_Functions" in directoryStr:
+            if "Algorithm" in directoryStr or "Fit_Functions" in directoryStr:
                 for single_folder in deprecated_subfolders:
                     subfolder_creation(directory, HigherLevel, single_folder)
             else:

--- a/tools/release_generator/release.py
+++ b/tools/release_generator/release.py
@@ -232,20 +232,21 @@ def subfolder_creation(directory, HigherLevel, folder):
     makeGitkeep(subfolderName)
 
 
-def makeReleaseNoteSubfolders(directory, HigherLevel):
+def getSubfoldersForDirectory(directory):
     directoryStr = str(directory)
-    for folder in subfolders:
-        if "Muon" in directoryStr:
-            for single_folder in muon_subfolders:
-                subfolder_creation(directory, HigherLevel, single_folder)
-        if "Framework" in directoryStr:
-            if "Algorithm" in directoryStr or "Fit_Functions" in directoryStr:
-                for single_folder in deprecated_subfolders:
-                    subfolder_creation(directory, HigherLevel, single_folder)
-            else:
-                subfolder_creation(directory, HigherLevel, folder)
-        else:
-            subfolder_creation(directory, HigherLevel, folder)
+
+    if "Muon" in directoryStr:
+        return muon_subfolders
+
+    if "Framework" in directoryStr and ("Algorithm" in directoryStr or "Fit_Functions" in directoryStr):
+        return deprecated_subfolders
+
+    return subfolders
+
+
+def makeReleaseNoteSubfolders(directory, HigherLevel):
+    for folder in getSubfoldersForDirectory(directory):
+        subfolder_creation(directory, HigherLevel, folder)
 
 
 def makeGitkeep(subfolderName):


### PR DESCRIPTION
### Description of work
Add Deprecated and Removed folders to the release notes templates and tools.

#### Summary of work
As a result of work on #37739 I have decided it would be good to add Deprecated and Removed to the templates for release notes under Framework. I also needed to update the conf file to ensure the toctree ignores the folders. I have also updated the Release Note Guide to explain about these new folders.

#### Purpose of work
To make it easier to write release notes for deprecated and removed algorithms and fit functions. It is likely that we will want to do this in v6.12 and possibly others going forward (see #37441). 

*There is no associated issue.*

#### Further detail of work
The template for the Framework release notes has been updated to include Deprecated and Removed headings as standard for Algorithms and Fit Functions. 

The release generator tool has been updated to create the folders for these in future release note generation. I have also added a new function to tidy up the code.

The conf file has been updated to ensure that any release notes added to these folders are exempt from the toctree (to avoid error messages).

The developer release note guidance has been updated in line with these changes.

### To test:

- Navigate to the ../tools/release_generator folder in your command line
- run python release.py --release 7.0.0 --milestone "Release 7.0"
- Check that v7.0.0 release notes have been created, including the new subfolders for Algorithms and Fit Functions in Framework
- Check that Framework page for the v7.0.0 release notes have the new Deprecated and Removed headings

*This does not require release notes* because **this is a change to how the release notes are generated and will only affect developers**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
