### PR TITLE
Fix GenerateGroupingPowder* test failures when run in parallel

### DIFF
--- a/Framework/DataHandling/test/GenerateGroupingPowder2Test.h
+++ b/Framework/DataHandling/test/GenerateGroupingPowder2Test.h
@@ -61,7 +61,7 @@ public:
   }
 
   void test_exec() {
-    const std::string XML_OUT_FILE("PowderGrouping_fulltest.xml");
+    const std::string XML_OUT_FILE("PowderGrouping2_fulltest.xml");
     const std::string PAR_OUT_FILE{GenerateGroupingPowder2::parFilenameFromXmlFilename(XML_OUT_FILE)};
     const std::string GROUP_WS("plainExecTestWS");
     constexpr double step = 10;
@@ -131,7 +131,7 @@ public:
   }
 
   void test_turning_off_par_file_generation() {
-    const std::string XML_OUT_FILE("PowderGrouping_nopar.xml");
+    const std::string XML_OUT_FILE("PowderGrouping2_nopar.xml");
     const std::string GROUP_WS("noParFileWS");
     constexpr double step = 10;
 
@@ -167,7 +167,7 @@ public:
   }
 
   void test_ignore_detectors_without_spectra() {
-    const std::string XML_OUT_FILE("PowderGrouping_det_wo_spectra.xml");
+    const std::string XML_OUT_FILE("PowderGrouping2_det_wo_spectra.xml");
     const std::string GROUP_WS("noDetNoSpecWS");
 
     auto histogram = m_emptyInstrument->histogram(0);
@@ -219,7 +219,7 @@ public:
 
   // save as nexus, reload, and compare
   void test_save_nexus_processed() {
-    const std::string NXS_OUT_FILE("PowderGrouping.nxs");
+    const std::string NXS_OUT_FILE("PowderGrouping2.nxs");
     const std::string GROUP_WS("saveNXSWS");
     constexpr double step = 10;
 
@@ -284,7 +284,7 @@ public:
 
   // azimuthal grouping with a par file isn't currently supported
   void test_azimuth_with_par_fail() {
-    const std::string XML_OUT_FILE("PowderGrouping_azi_with_par.xml");
+    const std::string XML_OUT_FILE("PowderGrouping2_azi_with_par.xml");
     const std::string PAR_OUT_FILE{GenerateGroupingPowder2::parFilenameFromXmlFilename(XML_OUT_FILE)};
     const std::string GROUP_WS("aziWithParTestWS");
     constexpr double step = 10;
@@ -313,7 +313,7 @@ public:
   }
 
   void test_grouping_rectangular_instrument() {
-    const std::string XML_OUT_FILE("PowderGrouping_rectangular.xml");
+    const std::string XML_OUT_FILE("PowderGrouping2_rectangular.xml");
     const std::string GROUP_WS("_unused_for_child");
     constexpr int numBanks{1};
     constexpr int bankSize{6};
@@ -367,7 +367,7 @@ public:
   void run_SNAPliteTest(const std::string &groupWSName, const double ang1, const double ang2, const bool numberByAngle,
                         const bool splitSides, const std::vector<int> &groups_exp,
                         const std::vector<double> &pixel_groups_exp) {
-    const std::string NXS_OUT_FILE("PowderGrouping.nxs");
+    const std::string NXS_OUT_FILE("PowderGrouping2.nxs");
     constexpr double TWO_THETA_STEP{18};
     const std::string INPUT_WS("SNAPlite");
     const detid_t PIXELS_PER_BANK{32 * 32};


### PR DESCRIPTION
The filenames were conflicting, `ctest -j2 -R GenerateGroupingPowder` should no longer fail. This was introduced by #37663

Failing tests here https://builds.mantidproject.org/job/pull_requests-conda-linux/8151/

### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

*There is no associated issue.*


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Check that to following no longer fails

```
ctest -j2 -R GenerateGroupingPowder
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because it just fixes a test that was added in this release, see  #37663

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
