### PR TITLE
New algorithm SaveMDHistoToVTK

### DIFF
--- a/Framework/PythonInterface/plugins/CMakeLists.txt
+++ b/Framework/PythonInterface/plugins/CMakeLists.txt
@@ -173,6 +173,7 @@ set(PYTHON_PLUGINS
     algorithms/SaveHKLCW.py
     algorithms/SaveINS.py
     algorithms/SaveISISReflectometryORSO.py
+    algorithms/SaveMDHistoToVTK.py
     algorithms/SaveNexusPD.py
     algorithms/SaveP2D.py
     algorithms/SavePlot1DAsJson.py

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDHistoToVTK.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDHistoToVTK.py
@@ -7,7 +7,7 @@
 
 import base64
 import numpy as np
-from lxml import etree
+import xml.etree.ElementTree as etree
 from mantid.api import AlgorithmFactory, PythonAlgorithm, FileAction, FileProperty, IMDHistoWorkspaceProperty, PropertyMode
 from mantid.kernel import Direction, SpecialCoordinateSystem
 from mantid.geometry import UnitCell
@@ -23,7 +23,7 @@ NUMPY_TYPE_TO_VTK = {
 
 class SaveMDHistoToVTK(PythonAlgorithm):
     def category(self):
-        return "DataHandling/XML"
+        return "DataHandling\\XML"
 
     def summary(self):
         """
@@ -115,7 +115,7 @@ class SaveMDHistoToVTK(PythonAlgorithm):
         root.append(grid)
 
         et = etree.ElementTree(root)
-        et.write(filename, pretty_print=True)
+        et.write(filename)
 
     def createSkewInformation(self, ws):
         # logic here is based on vtkDataSetToNonOrthogonalDataSet::createSkewInformation from mantid v5.1.1
@@ -196,7 +196,7 @@ def createDataArrayBinary(name, data, number_of_componets=1):
         RangeMax=str(np.nanmax(data)),
         NumberOfComponents=str(number_of_componets),
     )
-    dataArray.text = base64.b64encode(np.uint64(data.nbytes).tobytes() + data.tobytes())
+    dataArray.text = base64.b64encode(np.uint64(data.nbytes).tobytes() + data.tobytes()).decode()
     return dataArray
 
 

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDHistoToVTK.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDHistoToVTK.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
@@ -57,7 +57,7 @@ class SaveMDHistoToVTK(PythonAlgorithm):
         z = ws.getZDimension()
         Z = np.linspace(z.getMinimum(), z.getMaximum(), z.getNBoundaries())
 
-        boundingBoxInModelCoordinates = [x.getMinimum(), x.getMaximum(), y.getMinimum(), y.getMaximum(), z.getMinimum(), z.getMaximum()]
+        boundingBoxInModelCoordinates = (x.getMinimum(), x.getMaximum(), y.getMinimum(), y.getMaximum(), z.getMinimum(), z.getMaximum())
         extent = f"0 {x.getNBins()} 0 {y.getNBins()} 0 {z.getNBins()}"
         Xaxis = x.name
         Yaxis = y.name
@@ -111,7 +111,7 @@ class SaveMDHistoToVTK(PythonAlgorithm):
         fielddata = etree.Element("FieldData")
 
         change = etree.Element("DataArray", type="Float64", Name="ChangeOfBasisMatrix", NumberOfComponents="16", NumberOfTuples="1")
-        change.text = " ".join(f"{x:g}" for x in changeOfBasisMatrix.flatten())
+        change.text = " ".join(f"{x:.16g}" for x in changeOfBasisMatrix.flatten())
         fielddata.append(change)
 
         bb = etree.Element("DataArray", type="Float64", Name="BoundingBoxInModelCoordinates", NumberOfComponents="6", NumberOfTuples="1")

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDHistoToVTK.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDHistoToVTK.py
@@ -136,7 +136,14 @@ class SaveMDHistoToVTK(PythonAlgorithm):
         celldata = etree.Element("CellData", Scalers="Signal")
 
         signal_array = ws.getSignalArray()
-        signal = etree.Element("DataArray", Name="Signal", type=str(signal_array.dtype).capitalize(), format="binary")
+        signal = etree.Element(
+            "DataArray",
+            Name="Signal",
+            type=str(signal_array.dtype).capitalize(),
+            format="binary",
+            RangeMin=str(np.nanmin(signal_array)),
+            RangeMax=str(np.nanmax(signal_array)),
+        )
         signal.text = base64.b64encode(np.uint64(signal_array.nbytes).tobytes() + signal_array.ravel("F").tobytes())
 
         celldata.append(signal)

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDHistoToVTK.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDHistoToVTK.py
@@ -1,0 +1,139 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import numpy as np
+from mantid.api import AlgorithmFactory, PythonAlgorithm, FileAction, FileProperty, IMDHistoWorkspaceProperty, PropertyMode
+from mantid.kernel import Direction
+from lxml import etree
+
+
+class SaveMDHistoToVTK(PythonAlgorithm):
+    def category(self):
+        return "DataHandling/XML"
+
+    def summary(self):
+        """
+        summary of the algorithm
+        :return:
+        """
+        return "Save a MDHistoWorkspace to a VTK file"
+
+    def name(self):
+        return "SaveMDHistoToVTK"
+
+    def seeAlso(self):
+        return ["SaveNexus"]
+
+    def PyInit(self):
+        self.declareProperty(
+            IMDHistoWorkspaceProperty("InputWorkspace", "", optional=PropertyMode.Mandatory, direction=Direction.Input), "Input Workspace"
+        )
+        self.declareProperty(
+            FileProperty("Filename", "", action=FileAction.Save, extensions=["vts"], direction=Direction.Input), doc="Output filename."
+        )
+
+    def validateInputs(self):
+        issues = dict()
+        ws = self.getProperty("InputWorkspace").value
+        if ws.getNumDims() != 3:
+            issues["InputWorkspace"] = "Must have only 3 dimensions"
+
+        return issues
+
+    def PyExec(self):
+        ws = self.getProperty("InputWorkspace").value
+        filename = self.getPropertyValue("Filename")
+
+        B = ws.getExperimentInfo(0).sample().getOrientedLattice().getB()
+        B = B / np.linalg.norm(B, axis=0)
+
+        x = ws.getXDimension()
+        X = np.linspace(x.getMinimum(), x.getMaximum(), x.getNBoundaries())
+        y = ws.getYDimension()
+        Y = np.linspace(y.getMinimum(), y.getMaximum(), y.getNBoundaries())
+        z = ws.getZDimension()
+        Z = np.linspace(z.getMinimum(), z.getMaximum(), z.getNBoundaries())
+
+        boundingBoxInModelCoordinates = [x.getMinimum(), x.getMaximum(), y.getMinimum(), y.getMaximum(), z.getMinimum(), z.getMaximum()]
+        extent = f"0 {x.getNBins()} 0 {y.getNBins()} 0 {z.getNBins()} "
+        Xaxis = x.name
+        Yaxis = y.name
+        Zaxis = z.name
+
+        xyz = np.meshgrid(Z, Y, X, indexing="ij")
+        XYZ = np.stack((xyz[2].ravel(), xyz[1].ravel(), xyz[0].ravel()))
+
+        changeOfBasisMatrix = np.eye(4)
+        if x.getMDFrame().isQ() and y.getMDFrame().isQ() and z.getMDFrame().isQ():
+            changeOfBasisMatrix[:3, :3] = B
+            XYZ = np.dot(B, XYZ)
+
+        XYZ = XYZ.flatten("F")
+
+        root = etree.Element("VTKFile", type="StructuredGrid", version="2.2", byte_order="LittleEndian", header_type="UInt64")
+        grid = etree.Element("StructuredGrid", WholeExtent=extent)
+
+        fielddata = etree.Element("FieldData")
+
+        change = etree.Element("DataArray", type="Float64", Name="ChangeOfBasisMatrix", NumberOfComponents="16", NumberOfTuples="1")
+        change.text = " ".join(str(x) for x in changeOfBasisMatrix.flatten())
+        fielddata.append(change)
+
+        bb = etree.Element("DataArray", type="Float64", Name="BoundingBoxInModelCoordinates", NumberOfComponents="6", NumberOfTuples="1")
+        bb.text = " ".join(str(x) for x in boundingBoxInModelCoordinates)
+        fielddata.append(bb)
+
+        x_axis = etree.Element("Array", type="String", Name="AxisTitleForX", ComponentName0=Xaxis, NumberOfTuples="1", format="ascii")
+        x_axis.text = " ".join(str(ord(x)) for x in Xaxis) + " 0"
+        fielddata.append(x_axis)
+
+        y_axis = etree.Element("Array", type="String", Name="AxisTitleForY", ComponentName0=Yaxis, NumberOfTuples="1", format="ascii")
+        y_axis.text = " ".join(str(ord(x)) for x in Yaxis) + " 0"
+        fielddata.append(y_axis)
+
+        z_axis = etree.Element("Array", type="String", Name="AxisTitleForZ", ComponentName0=Zaxis, NumberOfTuples="1", format="ascii")
+        z_axis.text = " ".join(str(ord(x)) for x in Zaxis) + " 0"
+        fielddata.append(z_axis)
+
+        grid.append(fielddata)
+
+        piece = etree.Element("Piece", Extent=extent)
+        celldata = etree.Element("CellData", Scalers="Signal")
+
+        signal_array = ws.getSignalArray()
+        signal = etree.Element("DataArray", Name="Signal", type="Float64", format="ascii")
+        signal.text = " ".join(f"{x:g}" for x in signal_array.ravel("F"))
+
+        celldata.append(signal)
+
+        mask = np.isfinite(signal_array)
+        ghost_array = np.full_like(signal_array, 32, dtype=int)
+        ghost_array[mask] = 0
+
+        ghost = etree.Element("DataArray", Name="vtkGhostType", type="UInt8", format="ascii")
+        ghost.text = " ".join(f"{x:g}" for x in ghost_array.ravel("F"))
+
+        celldata.append(ghost)
+
+        piece.append(celldata)
+
+        points = etree.Element("Points")
+
+        xyz = etree.Element("DataArray", type="Float64", NumberOfComponents="3", format="ascii", Name="Points")
+        xyz.text = " ".join(f"{x:g}" for x in XYZ)
+
+        points.append(xyz)
+        piece.append(points)
+
+        grid.append(piece)
+        root.append(grid)
+
+        et = etree.ElementTree(root)
+        et.write(filename, pretty_print=True)
+
+
+AlgorithmFactory.subscribe(SaveMDHistoToVTK)

--- a/Framework/PythonInterface/plugins/algorithms/SaveMDHistoToVTK.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveMDHistoToVTK.py
@@ -12,6 +12,14 @@ from mantid.api import AlgorithmFactory, PythonAlgorithm, FileAction, FileProper
 from mantid.kernel import Direction, SpecialCoordinateSystem
 from mantid.geometry import UnitCell
 
+NUMPY_TYPE_TO_VTK = {
+    np.dtype("float32"): "Float32",
+    np.dtype("float64"): "Float64",
+    np.dtype("int32"): "Int32",
+    np.dtype("int64"): "Int64",
+    np.dtype("uint8"): "UInt8",
+}
+
 
 class SaveMDHistoToVTK(PythonAlgorithm):
     def category(self):
@@ -35,7 +43,7 @@ class SaveMDHistoToVTK(PythonAlgorithm):
             IMDHistoWorkspaceProperty("InputWorkspace", "", optional=PropertyMode.Mandatory, direction=Direction.Input), "Input Workspace"
         )
         self.declareProperty(
-            FileProperty("Filename", "", action=FileAction.Save, extensions=["vts"], direction=Direction.Input), doc="Output filename."
+            FileProperty("Filename", "", action=FileAction.Save, extensions=".vts", direction=Direction.Input), doc="Output filename."
         )
 
     def validateInputs(self):
@@ -50,121 +58,57 @@ class SaveMDHistoToVTK(PythonAlgorithm):
         ws = self.getProperty("InputWorkspace").value
         filename = self.getPropertyValue("Filename")
 
-        x = ws.getXDimension()
-        X = np.linspace(x.getMinimum(), x.getMaximum(), x.getNBoundaries())
-        y = ws.getYDimension()
-        Y = np.linspace(y.getMinimum(), y.getMaximum(), y.getNBoundaries())
-        z = ws.getZDimension()
-        Z = np.linspace(z.getMinimum(), z.getMaximum(), z.getNBoundaries())
+        # get dimension information
+        X = ws.getXDimension()
+        Y = ws.getYDimension()
+        Z = ws.getZDimension()
 
-        boundingBoxInModelCoordinates = (x.getMinimum(), x.getMaximum(), y.getMinimum(), y.getMaximum(), z.getMinimum(), z.getMaximum())
-        extent = f"0 {x.getNBins()} 0 {y.getNBins()} 0 {z.getNBins()}"
-        Xaxis = x.name
-        Yaxis = y.name
-        Zaxis = z.name
+        # get skew information
+        skew = self.createSkewInformation(ws)
 
-        xyz = np.meshgrid(Z, Y, X, indexing="ij")
-        XYZ = np.stack((xyz[2].ravel(), xyz[1].ravel(), xyz[0].ravel()))
-
-        changeOfBasisMatrix = np.eye(4)
-        if (
-            ws.getSpecialCoordinateSystem() == SpecialCoordinateSystem.HKL
-            and x.getMDFrame().isQ()
-            and y.getMDFrame().isQ()
-            and z.getMDFrame().isQ()
-            and ws.getNumExperimentInfo() > 0
-            and ws.getExperimentInfo(0).sample().hasOrientedLattice()
-        ):
-            B = ws.getExperimentInfo(0).sample().getOrientedLattice().getB()
-
-            skew = B
-
-            run = ws.getExperimentInfo(0).run()
-            if run.hasProperty("W_MATRIX"):
-                W = np.array(run.getProperty("W_MATRIX").value).reshape((3, 3))
-                B = B.dot(W)
-                uc = UnitCell()
-                uc.recalculateFromGstar(B.T.dot(B))
-                skew = uc.getB()
-            else:
-                basis = np.eye(3)
-
-                try:
-                    basis[0] = list(ws.getBasisVector(0))
-                    basis[1] = list(ws.getBasisVector(1))
-                    basis[2] = list(ws.getBasisVector(2))
-                except ValueError:
-                    # log error
-                    pass
-                else:
-                    if np.linalg.norm(basis) != 0:
-                        skew = basis.dot(B.dot(basis.T))
-
-            skew = skew / np.linalg.norm(skew, axis=0)
-
-            changeOfBasisMatrix[:3, :3] = skew
-            XYZ = np.dot(skew, XYZ)
-
+        # create xml tree
         root = etree.Element("VTKFile", type="StructuredGrid", version="2.2", byte_order="LittleEndian", header_type="UInt64")
+
+        extent = f"0 {X.getNBins()} 0 {Y.getNBins()} 0 {Z.getNBins()}"
         grid = etree.Element("StructuredGrid", WholeExtent=extent)
 
         fielddata = etree.Element("FieldData")
 
-        change = etree.Element("DataArray", type="Float64", Name="ChangeOfBasisMatrix", NumberOfComponents="16", NumberOfTuples="1")
-        change.text = " ".join(f"{x:.16g}" for x in changeOfBasisMatrix.flatten())
-        fielddata.append(change)
+        # create and add change-of-basis matrix
+        changeOfBasisMatrix = np.eye(4)
+        changeOfBasisMatrix[:3, :3] = skew
+        fielddata.append(createDataArray("ChangeOfBasisMatrix", changeOfBasisMatrix.ravel().tolist()))
 
-        bb = etree.Element("DataArray", type="Float64", Name="BoundingBoxInModelCoordinates", NumberOfComponents="6", NumberOfTuples="1")
-        bb.text = " ".join(str(x) for x in boundingBoxInModelCoordinates)
-        fielddata.append(bb)
+        # create and add bounding box coordinates
+        boundingBoxInModelCoordinates = (X.getMinimum(), X.getMaximum(), Y.getMinimum(), Y.getMaximum(), Z.getMinimum(), Z.getMaximum())
+        fielddata.append(createDataArray("BoundingBoxInModelCoordinates", boundingBoxInModelCoordinates))
 
-        x_axis = etree.Element("Array", type="String", Name="AxisTitleForX", ComponentName0=Xaxis, NumberOfTuples="1", format="ascii")
-        x_axis.text = " ".join(str(ord(x)) for x in Xaxis) + " 0"  # NULL terminated
-        fielddata.append(x_axis)
-
-        y_axis = etree.Element("Array", type="String", Name="AxisTitleForY", ComponentName0=Yaxis, NumberOfTuples="1", format="ascii")
-        y_axis.text = " ".join(str(ord(x)) for x in Yaxis) + " 0"  # NULL terminated
-        fielddata.append(y_axis)
-
-        z_axis = etree.Element("Array", type="String", Name="AxisTitleForZ", ComponentName0=Zaxis, NumberOfTuples="1", format="ascii")
-        z_axis.text = " ".join(str(ord(x)) for x in Zaxis) + " 0"  # NULL terminated
-        fielddata.append(z_axis)
+        # create and add axis titles
+        fielddata.append(createAxis("AxisTitleForX", X.name))
+        fielddata.append(createAxis("AxisTitleForY", Y.name))
+        fielddata.append(createAxis("AxisTitleForZ", Z.name))
 
         grid.append(fielddata)
 
         piece = etree.Element("Piece", Extent=extent)
         celldata = etree.Element("CellData", Scalers="Signal")
 
+        # add the signal array
         signal_array = ws.getSignalArray()
-        signal = etree.Element(
-            "DataArray",
-            Name="Signal",
-            type=str(signal_array.dtype).capitalize(),
-            format="binary",
-            RangeMin=str(np.nanmin(signal_array)),
-            RangeMax=str(np.nanmax(signal_array)),
-        )
-        signal.text = base64.b64encode(np.uint64(signal_array.nbytes).tobytes() + signal_array.ravel("F").tobytes())
+        celldata.append(createDataArrayBinary("Signal", signal_array.ravel("F")))
 
-        celldata.append(signal)
-
+        # create and add a mask array
         mask = np.isfinite(signal_array)
         ghost_array = np.full_like(signal_array, 32, dtype=np.uint8)  # 32 == CellGhostTypes::HIDDENCELL
         ghost_array[mask] = 0
-
-        ghost = etree.Element("DataArray", Name="vtkGhostType", type="UInt8", format="binary")
-        ghost.text = base64.b64encode(np.uint64(ghost_array.nbytes).tobytes() + ghost_array.ravel("F").tobytes())
-
-        celldata.append(ghost)
+        celldata.append(createDataArrayBinary("vtkGhostType", ghost_array.ravel("F")))
 
         piece.append(celldata)
 
+        # create and add cell boundary points
         points = etree.Element("Points")
-
-        xyz = etree.Element("DataArray", type="Float64", NumberOfComponents="3", format="binary", Name="Points")
-        xyz.text = base64.b64encode(np.uint64(XYZ.nbytes).tobytes() + XYZ.ravel("F").tobytes())
-
-        points.append(xyz)
+        XYZ = createPointsArray(ws, skew)
+        points.append(createDataArrayBinary("Points", XYZ.ravel("F"), 3))
         piece.append(points)
 
         grid.append(piece)
@@ -172,6 +116,88 @@ class SaveMDHistoToVTK(PythonAlgorithm):
 
         et = etree.ElementTree(root)
         et.write(filename, pretty_print=True)
+
+    def createSkewInformation(self, ws):
+        # logic here is based on vtkDataSetToNonOrthogonalDataSet::createSkewInformation from mantid v5.1.1
+        if (
+            ws.getSpecialCoordinateSystem() == SpecialCoordinateSystem.HKL
+            and ws.getXDimension().getMDFrame().isQ()
+            and ws.getYDimension().getMDFrame().isQ()
+            and ws.getZDimension().getMDFrame().isQ()
+            and ws.getNumExperimentInfo() > 0
+            and ws.getExperimentInfo(0).sample().hasOrientedLattice()
+        ):
+            self.log().information("Creating non-orthogonal skew matrix")
+
+            skew = B = ws.getExperimentInfo(0).sample().getOrientedLattice().getB()
+
+            run = ws.getExperimentInfo(0).run()
+            if run.hasProperty("W_MATRIX"):
+                self.log().information("Using W_MATRIX to calculate skew matrix")
+                W = np.array(run.getProperty("W_MATRIX").value).reshape((3, 3))
+                B = B.dot(W)
+                uc = UnitCell()
+                uc.recalculateFromGstar(B.T.dot(B))
+                skew = uc.getB()
+            else:
+                self.log().information("Using basis vectors to calculate skew matrix")
+                basis = np.eye(3)
+
+                try:
+                    basis[0] = list(ws.getBasisVector(0))
+                    basis[1] = list(ws.getBasisVector(1))
+                    basis[2] = list(ws.getBasisVector(2))
+                except ValueError:
+                    self.log().warning("Invalid basis vector found")
+                else:
+                    if np.linalg.norm(basis) != 0:
+                        skew = basis.dot(B.dot(basis.T))
+
+            skew = skew / np.linalg.norm(skew, axis=0)
+
+            return skew
+
+        return np.eye(3)
+
+
+def createPointsArray(ws, skew):
+    x = ws.getXDimension()
+    X = np.linspace(x.getMinimum(), x.getMaximum(), x.getNBoundaries())
+    y = ws.getYDimension()
+    Y = np.linspace(y.getMinimum(), y.getMaximum(), y.getNBoundaries())
+    z = ws.getZDimension()
+    Z = np.linspace(z.getMinimum(), z.getMaximum(), z.getNBoundaries())
+
+    xyz = np.meshgrid(Z, Y, X, indexing="ij")
+    XYZ = np.stack((xyz[2].ravel(), xyz[1].ravel(), xyz[0].ravel()))
+
+    return skew.dot(XYZ)
+
+
+def createDataArray(name, data):
+    dataArray = etree.Element("DataArray", type="Float64", Name=name, NumberOfComponents=str(len(data)), NumberOfTuples="1")
+    dataArray.text = " ".join(f"{x:.16g}" for x in data)
+    return dataArray
+
+
+def createAxis(name, title):
+    axis = etree.Element("Array", type="String", Name=name, ComponentName0=title, NumberOfTuples="1", format="ascii")
+    axis.text = " ".join(str(ord(x)) for x in title) + " 0"  # NULL terminated
+    return axis
+
+
+def createDataArrayBinary(name, data, number_of_componets=1):
+    dataArray = etree.Element(
+        "DataArray",
+        Name=name,
+        type=NUMPY_TYPE_TO_VTK[data.dtype],
+        format="binary",
+        RangeMin=str(np.nanmin(data)),
+        RangeMax=str(np.nanmax(data)),
+        NumberOfComponents=str(number_of_componets),
+    )
+    dataArray.text = base64.b64encode(np.uint64(data.nbytes).tobytes() + data.tobytes())
+    return dataArray
 
 
 AlgorithmFactory.subscribe(SaveMDHistoToVTK)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -116,6 +116,7 @@ set(TEST_PY_FILES
     SANSWideAngleCorrectionTest.py
     SaveGEMMAUDParamFileTest.py
     SaveNexusPDTest.py
+    SaveMDHistoToVTKTest.py
     SaveGSSCWTest.py
     SaveHKLCWTest.py
     SaveINSTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDHistoToVTKTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDHistoToVTKTest.py
@@ -10,7 +10,7 @@ import tempfile
 import os
 import unittest
 import numpy as np
-from lxml import etree
+import xml.etree.ElementTree as etree
 from mantid.simpleapi import SaveMDHistoToVTK, CreateMDHistoWorkspace, CreateMDWorkspace, AddSampleLog, SetUB, BinMD, FakeMDEventData
 
 
@@ -196,19 +196,19 @@ class SaveMDHistoToVTKTest(unittest.TestCase):
         root = etree.parse(filename)
 
         # check ChangeOfBasisMatrix
-        cob = root.xpath("//DataArray[@Name='ChangeOfBasisMatrix']")
+        cob = root.findall(".//DataArray[@Name='ChangeOfBasisMatrix']")
         assert len(cob) == 1
         cob = np.array(cob[0].text.split(), dtype=float)
         np.testing.assert_allclose(cob, expected_cob.flatten(), atol=1e-15)
 
         # check BoundingBoxInModelCoordinates
-        bb = root.xpath("//DataArray[@Name='BoundingBoxInModelCoordinates']")
+        bb = root.findall(".//DataArray[@Name='BoundingBoxInModelCoordinates']")
         assert len(bb) == 1
         bb = np.array(bb[0].text.split(), dtype=float)
         np.testing.assert_equal(bb, [-1.0, 1.0, -2.0, 2.0, -3.0, 3.0])
 
         # check axes labels
-        axes_labels = root.xpath("//Array")
+        axes_labels = root.findall(".//Array")
         assert len(axes_labels) == 3
 
         x = axes_labels[0]
@@ -227,7 +227,7 @@ class SaveMDHistoToVTKTest(unittest.TestCase):
         assert data == axes[2]
 
         # check signal array
-        signal = root.xpath("//DataArray[@Name='Signal']")
+        signal = root.findall(".//DataArray[@Name='Signal']")
         assert len(signal) == 1
         signal = signal[0]
         assert float(signal.attrib["RangeMin"]) == np.nanmin(expected_signal)
@@ -239,7 +239,7 @@ class SaveMDHistoToVTKTest(unittest.TestCase):
         np.testing.assert_equal(s, expected_signal)
 
         # check ghost array
-        ghost = root.xpath("//DataArray[@Name='vtkGhostType']")
+        ghost = root.findall(".//DataArray[@Name='vtkGhostType']")
         assert len(ghost) == 1
         ghost = ghost[0]
         data = base64.b64decode(ghost.text)
@@ -251,7 +251,7 @@ class SaveMDHistoToVTKTest(unittest.TestCase):
         np.testing.assert_equal(g, expected_ghost)
 
         # check boundary points
-        points = root.xpath("//DataArray[@Name='Points']")
+        points = root.findall(".//DataArray[@Name='Points']")
         assert len(points) == 1
         points = points[0]
         assert points.attrib["NumberOfComponents"] == "3"

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDHistoToVTKTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDHistoToVTKTest.py
@@ -261,6 +261,9 @@ class SaveMDHistoToVTKTest(unittest.TestCase):
         g = np.frombuffer(data[8:], dtype=np.float64)
         np.testing.assert_allclose(g, expected_points, atol=1e-15)
 
+        # cleanup
+        os.remove(filename)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDHistoToVTKTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveMDHistoToVTKTest.py
@@ -1,0 +1,266 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import base64
+import tempfile
+import os
+import unittest
+import numpy as np
+from lxml import etree
+from mantid.simpleapi import SaveMDHistoToVTK, CreateMDHistoWorkspace, CreateMDWorkspace, AddSampleLog, SetUB, BinMD, FakeMDEventData
+
+
+class SaveMDHistoToVTKTest(unittest.TestCase):
+    def test_simple(self):
+        tmp_filename = tempfile.mktemp(".vts")
+        input_data = [np.nan, 1, 2, 3, 4, 5, 6, 7]
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=3,
+            Extents="-1,1,-2,2,-3,3",
+            SignalInput=input_data,
+            ErrorInput=input_data,
+            NumberOfBins="2,2,2",
+            Names="[H,0,0],[0,K,0],[0,0,L]",
+            Units="r.l.u.,r.l.u.,r.l.u.",
+            Frames="HKL,HKL,HKL",
+        )
+
+        SaveMDHistoToVTK(ws, tmp_filename)
+
+        # manually calculate points
+        expected_points = []
+        for z in (-3, 0, 3):
+            for y in (-2, 0, 2):
+                for x in (-1, 0, 1):
+                    expected_points += [x, y, z]
+
+        self.check_result(tmp_filename, expected_points)
+
+    def test_non_orthogonal(self):
+        tmp_filename = tempfile.mktemp(".vts")
+        input_data = [np.nan, 1, 2, 3, 4, 5, 6, 7]
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=3,
+            Extents="-1,1,-2,2,-3,3",
+            SignalInput=input_data,
+            ErrorInput=input_data,
+            NumberOfBins="2,2,2",
+            Names="[H,0,0],[0,K,0],[0,0,L]",
+            Units="r.l.u.,r.l.u.,r.l.u.",
+            Frames="HKL,HKL,HKL",
+        )
+
+        AddSampleLog(ws, LogName="sample")  # easy was to create ExperimentInfo
+        SetUB(ws, gamma=120)
+
+        SaveMDHistoToVTK(ws, tmp_filename)
+
+        expected_cob = np.array([[1, 0.5, 0, 0], [0, np.sin(np.pi / 3), 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+
+        B = ws.getExperimentInfo(0).sample().getOrientedLattice().getB()
+        B = B / np.linalg.norm(B, axis=0)
+
+        # manually calculate points
+        expected_points = []
+        for z in (-3, 0, 3):
+            for y in (-2, 0, 2):
+                for x in (-1, 0, 1):
+                    expected_points += np.dot(B, [x, y, z]).tolist()
+
+        self.check_result(tmp_filename, expected_points, expected_cob=expected_cob)
+
+    def test_non_orthogonal_W_MATRIX(self):
+        tmp_filename = tempfile.mktemp(".vts")
+        input_data = [np.nan, 1, 2, 3, 4, 5, 6, 7]
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=3,
+            Extents="-1,1,-2,2,-3,3",
+            SignalInput=input_data,
+            ErrorInput=input_data,
+            NumberOfBins="2,2,2",
+            Names="[H,H,0],[H,-H,0],[0,0,L]",
+            Units="r.l.u.,r.l.u.,r.l.u.",
+            Frames="HKL,HKL,HKL",
+        )
+
+        AddSampleLog(ws, LogName="sample")  # easy was to create ExperimentInfo
+        SetUB(ws, gamma=120)
+
+        # aligning the W_MATRIX for a HH0 slice with a lattice with gamma=120 should result in an identity change of basis matrix
+        ws.getExperimentInfo(0).run().addProperty("W_MATRIX", [1.0, 1.0, 0.0, 1.0, -1.0, 0.0, 0.0, 0.0, 1.0], True)
+
+        SaveMDHistoToVTK(ws, tmp_filename)
+
+        # manually calculate points
+        expected_points = []
+        for z in (-3, 0, 3):
+            for y in (-2, 0, 2):
+                for x in (-1, 0, 1):
+                    expected_points += [x, y, z]
+
+        self.check_result(tmp_filename, expected_points, axes=("[H,H,0]", "[H,-H,0]", "[0,0,L]"))
+
+    def test_non_orthogonal_W_MATRIX2(self):
+        tmp_filename = tempfile.mktemp(".vts")
+        input_data = [np.nan, 1, 2, 3, 4, 5, 6, 7]
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=3,
+            Extents="-1,1,-2,2,-3,3",
+            SignalInput=input_data,
+            ErrorInput=input_data,
+            NumberOfBins="2,2,2",
+            Names="[H,0,0],[H,H,0],[0,0,L]",
+            Units="r.l.u.,r.l.u.,r.l.u.",
+            Frames="HKL,HKL,HKL",
+        )
+
+        AddSampleLog(ws, LogName="sample")  # easy was to create ExperimentInfo
+        SetUB(ws)
+
+        ws.getExperimentInfo(0).run().addProperty("W_MATRIX", [1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0], True)
+
+        SaveMDHistoToVTK(ws, tmp_filename)
+
+        expected_cob = np.array([[1, 1 / np.sqrt(2), 0, 0], [0, 1 / np.sqrt(2), 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
+
+        # manually calculate points
+        expected_points = []
+        for z in (-3, 0, 3):
+            for y in (-2, 0, 2):
+                for x in (-1, 0, 1):
+                    expected_points += [x + y / np.sqrt(2), y / np.sqrt(2), z]
+
+        self.check_result(tmp_filename, expected_points, expected_cob=expected_cob, axes=("[H,0,0]", "[H,H,0]", "[0,0,L]"))
+
+    def test_non_orthogonal_basis_vector(self):
+        tmp_filename = tempfile.mktemp(".vts")
+        ws = CreateMDWorkspace(
+            Dimensions=3,
+            Extents="-10,10,-10,10,-10,10",
+            Names="[H,0,0],[0,K,0],[0,0,L]",
+            Units="r.l.u.,r.l.u.,r.l.u.",
+            Frames="HKL,HKL,HKL",
+        )
+
+        AddSampleLog(ws, LogName="sample")  # easy was to create ExperimentInfo
+        SetUB(ws)
+
+        FakeMDEventData(ws, PeakParams="10,0.5,0.5,0.5,0.1")
+
+        ws_slice = BinMD(
+            InputWorkspace=ws,
+            AxisAligned=False,
+            BasisVector0="[H,0,0],r.l.u.,1,0,0",
+            BasisVector1="[H,H,0],r.l.u.,1,1,0",
+            BasisVector2="[0,0,L],r.l.u.,0,0,1",
+            OutputExtents="-1,1,-2,2,-3,3",
+            OutputBins="2,2,2",
+            NormalizeBasisVectors=False,
+        )
+
+        SaveMDHistoToVTK(ws_slice, tmp_filename)
+
+        expected_cob = np.array(
+            [[1 / np.sqrt(2), 1 / np.sqrt(5), 0, 0], [1 / np.sqrt(2), 2 / np.sqrt(5), 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]
+        )
+
+        # manually calculate points
+        expected_points = []
+        for z in (-3, 0, 3):
+            for y in (-2, 0, 2):
+                for x in (-1, 0, 1):
+                    expected_points += [x / np.sqrt(2) + y / np.sqrt(5), x / np.sqrt(2) + y * 2 / np.sqrt(5), z]
+
+        self.check_result(
+            tmp_filename,
+            expected_points,
+            expected_cob=expected_cob,
+            expected_signal=(0, 0, 0, 0, 0, 0, 3, 7),
+            axes=("[H,0,0]", "[H,H,0]", "[0,0,L]"),
+        )
+
+    def check_result(
+        self,
+        filename,
+        expected_points,
+        expected_signal=(np.nan, 1, 2, 3, 4, 5, 6, 7),
+        expected_cob=np.eye(4),
+        axes=("[H,0,0]", "[0,K,0]", "[0,0,L]"),
+    ):
+        assert os.path.isfile(filename)
+        # parse document
+        root = etree.parse(filename)
+
+        # check ChangeOfBasisMatrix
+        cob = root.xpath("//DataArray[@Name='ChangeOfBasisMatrix']")
+        assert len(cob) == 1
+        cob = np.array(cob[0].text.split(), dtype=float)
+        np.testing.assert_allclose(cob, expected_cob.flatten(), atol=1e-15)
+
+        # check BoundingBoxInModelCoordinates
+        bb = root.xpath("//DataArray[@Name='BoundingBoxInModelCoordinates']")
+        assert len(bb) == 1
+        bb = np.array(bb[0].text.split(), dtype=float)
+        np.testing.assert_equal(bb, [-1.0, 1.0, -2.0, 2.0, -3.0, 3.0])
+
+        # check axes labels
+        axes_labels = root.xpath("//Array")
+        assert len(axes_labels) == 3
+
+        x = axes_labels[0]
+        assert x.attrib["Name"] == "AxisTitleForX"
+        data = "".join(chr(int(c)) for c in x.text.split()[:-1])
+        assert data == axes[0]
+
+        y = axes_labels[1]
+        assert y.attrib["Name"] == "AxisTitleForY"
+        data = "".join(chr(int(c)) for c in y.text.split()[:-1])
+        assert data == axes[1]
+
+        z = axes_labels[2]
+        assert z.attrib["Name"] == "AxisTitleForZ"
+        data = "".join(chr(int(c)) for c in z.text.split()[:-1])
+        assert data == axes[2]
+
+        # check signal array
+        signal = root.xpath("//DataArray[@Name='Signal']")
+        assert len(signal) == 1
+        signal = signal[0]
+        assert float(signal.attrib["RangeMin"]) == np.nanmin(expected_signal)
+        assert float(signal.attrib["RangeMax"]) == np.nanmax(expected_signal)
+        data = base64.b64decode(signal.text)
+        byte_count = np.frombuffer(data[:8], dtype=np.uint64)
+        assert byte_count == 64
+        s = np.frombuffer(data[8:], dtype=np.float64)
+        np.testing.assert_equal(s, expected_signal)
+
+        # check ghost array
+        ghost = root.xpath("//DataArray[@Name='vtkGhostType']")
+        assert len(ghost) == 1
+        ghost = ghost[0]
+        data = base64.b64decode(ghost.text)
+        byte_count = np.frombuffer(data[:8], dtype=np.uint64)
+        assert byte_count == 8
+        g = np.frombuffer(data[8:], dtype=np.uint8)
+        expected_ghost = np.full_like(expected_signal, 0)
+        expected_ghost[np.isnan(expected_signal)] = 32
+        np.testing.assert_equal(g, expected_ghost)
+
+        # check boundary points
+        points = root.xpath("//DataArray[@Name='Points']")
+        assert len(points) == 1
+        points = points[0]
+        assert points.attrib["NumberOfComponents"] == "3"
+        data = base64.b64decode(points.text)
+        byte_count = np.frombuffer(data[:8], dtype=np.uint64)
+        assert byte_count == 648  # 3 x 3 x 3 x 3 X 8
+        g = np.frombuffer(data[8:], dtype=np.float64)
+        np.testing.assert_allclose(g, expected_points, atol=1e-15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/source/algorithms/SaveMDHistoToVTK-v1.rst
+++ b/docs/source/algorithms/SaveMDHistoToVTK-v1.rst
@@ -1,0 +1,44 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+This will save a 3 dimensional :ref:`MDHistoWorkspace` to a VTK file (``.vtu``, StructuredGrid XML VTK file) so that it can be visualized by software such as Paraview.
+
+If the workspace is in HKL space then the correct non-orthogonal transform will be included. To make use of the non-orthogonal transform in Paraview it is required to load the NonOrthogonalSource plugin. To set this plugin navigate to `Tools > Manage Plugins...` to open the Plugin Manager. Enable the Auto Load option on the plugin and press Load Selected.
+
+Usage
+-----
+
+.. testcode:: SaveMDHistoToVTK
+
+    import os
+    signalInput = [i for i in range(1,28)]
+    errorInput = [1 for i in range(1,28)]
+
+    ws = CreateMDHistoWorkspace(SignalInput=signalInput, ErrorInput=errorInput, Dimensionality='3',
+                                Extents='-1,1,-1,1,-1,1', NumberOfBins='3,3,3', Names='A,B,C', Units='U,T,W')
+
+    savefile = os.path.join(config["defaultsave.directory"], "mdhws.vts")
+    SaveMDHistoToVTK(InputWorkspace = ws, Filename = savefile)
+
+    print("File created: {}".format(os.path.exists(savefile)))
+
+.. testoutput:: SaveMDHistoToVTK
+
+    File created: True
+
+.. testcleanup:: SaveMDHistoToVTK
+
+    os.remove(savefile)
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.11.0/Diffraction/Single_Crystal/New_features/37748.rst
+++ b/docs/source/release/v6.11.0/Diffraction/Single_Crystal/New_features/37748.rst
@@ -1,0 +1,1 @@
+- New algorithm :ref:`SaveMDHistoToVTK <algm-SaveMDHistoToVTK>` that saves a MDHistoWorkspace as a VTK file so that it can be visualized by Paraview.


### PR DESCRIPTION
### Description of work

This restores some of the functionally lost when [SaveMDWorkspaceToVTK](https://docs.mantidproject.org/v5.1.1/algorithms/SaveMDWorkspaceToVTK-v1.html) was removed. This algorithm only does MDHistoWorkspace and not MDEventWorkspace hence the different name.

It was written without using the vtk library as that is a very large dependency.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [6222: New algorithm to write MDHistoWorkspace as a VTK file](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/6222) Also related to #29868

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Test with you own data, then open the file in Paraview and check the results.

Here is one example using a slightly modified usage example from [MDNorm](https://docs.mantidproject.org/nightly/algorithms/MDNorm-v1.html).

```python
Load(Filename='CORELLI_29782.nxs', OutputWorkspace='data')
Load(Filename='SingleCrystalDiffuseReduction_SA.nxs', OutputWorkspace='SolidAngle')
Load(Filename='SingleCrystalDiffuseReduction_Flux.nxs', OutputWorkspace= 'Flux')
MaskDetectors(Workspace='data', MaskedWorkspace='SolidAngle')
ConvertUnits(InputWorkspace='data',OutputWorkspace='data',Target='Momentum')
CropWorkspaceForMDNorm(InputWorkspace='data',
                       XMin=2.5,
                       XMax=10,
                       OutputWorkspace='data')
LoadIsawUB(InputWorkspace='data',Filename='SingleCrystalDiffuseReduction_UB.mat')
SetGoniometer(Workspace='data',Axis0='BL9:Mot:Sample:Axis1,0,1,0,1')
min_vals,max_vals=ConvertToMDMinMaxGlobal(InputWorkspace='data',
                                          QDimensions='Q3D',
                                          dEAnalysisMode='Elastic',
                                          Q3DFrames='Q')
ConvertToMD(InputWorkspace='data',
            QDimensions='Q3D',
            dEAnalysisMode='Elastic',
            Q3DFrames='Q_sample',
            OutputWorkspace='md',
            MinValues=min_vals,
            MaxValues=max_vals)
RecalculateTrajectoriesExtents(InputWorkspace= 'md', OutputWorkspace='md')

MDNorm(InputWorkspace='md',
       SolidAngleWorkspace='SolidAngle',
       FluxWorkspace='Flux',
       QDimension0='1,0,0',
       QDimension1='0,1,0',
       QDimension2='0,0,1',
       Dimension0Name='QDimension0',
       Dimension0Binning='-10.0,0.1,10.0',
       Dimension1Name='QDimension1',
       Dimension1Binning='-10.0,0.1,10.0',
       Dimension2Name='QDimension2',
       Dimension2Binning='-0.1,0.2,0.1',
       SymmetryOperations='P 31 2 1',
       OutputWorkspace='result',
       OutputDataWorkspace='dataMD',
       OutputNormalizationWorkspace='normMD')
       
SaveMDHistoToVTK("result", "result.vts")
```

When loaded into Paraview it looks like this

![test](https://github.com/user-attachments/assets/500b6466-ee82-4590-8f76-e7c7ce54d5c9)


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
