### PR TITLE
 Inelastic Settings option to turn off Load Workspace History 

### DIFF
--- a/docs/source/interfaces/indirect/Indirect Settings.rst
+++ b/docs/source/interfaces/indirect/Indirect Settings.rst
@@ -60,7 +60,7 @@ Load Workspace History
   workspace loading speeds.
   For many Indirect/Inelastic interfaces, workspaces to be processed by the interface are preloaded into the ADS.
   The history of a workspace is loaded by default when a workspace is loaded into the ADS from the interface.
-  In some cases, knowledge of the history may not be necessary for latter analysis.
+  In some cases, knowledge of the history may not be necessary for later analysis.
 
 
 Advanced

--- a/docs/source/interfaces/indirect/Indirect Settings.rst
+++ b/docs/source/interfaces/indirect/Indirect Settings.rst
@@ -55,6 +55,13 @@ Plot error bars for external plots
   If ticked, this will ensure that error bars are plotted on any plots which are plotted
   externally (i.e. in a separate window) from the indirect interfaces.
 
+Load Workspace History
+  If this option is unticked, the history of the workspace won't be loaded, resulting in faster
+  workspace loading speeds.
+  For many Indirect/Inelastic interfaces. Workspaces to be processed by the interface are preloaded into the ADS.
+  The history of a workspace is loaded by default when a workspace is loaded into the ADS from the interface.
+  In some cases, knowledge of the history may not be necessary for latter analysis.
+
 
 Advanced
 --------

--- a/docs/source/interfaces/indirect/Indirect Settings.rst
+++ b/docs/source/interfaces/indirect/Indirect Settings.rst
@@ -58,7 +58,7 @@ Plot error bars for external plots
 Load Workspace History
   If this option is unticked, the history of the workspace won't be loaded, resulting in faster
   workspace loading speeds.
-  For many Indirect/Inelastic interfaces. Workspaces to be processed by the interface are preloaded into the ADS.
+  For many Indirect/Inelastic interfaces, workspaces to be processed by the interface are preloaded into the ADS.
   The history of a workspace is loaded by default when a workspace is loaded into the ADS from the interface.
   In some cases, knowledge of the history may not be necessary for latter analysis.
 

--- a/docs/source/release/v6.11.0/Inelastic/New_features/37691.rst
+++ b/docs/source/release/v6.11.0/Inelastic/New_features/37691.rst
@@ -1,0 +1,1 @@
+- Add `Output Composite Members` option to I(Q, t) tab in :ref:`Inelastic QENS Fitting <interface-inelastic-qens-fitting>`

--- a/docs/source/release/v6.11.0/Inelastic/New_features/37691.rst
+++ b/docs/source/release/v6.11.0/Inelastic/New_features/37691.rst
@@ -1,1 +1,1 @@
-- Add `Output Composite Members` option to I(Q, t) tab in :ref:`Inelastic QENS Fitting <interface-inelastic-qens-fitting>`
+- Add `Load Workspace History` option to the settings dialog for Indirect/Inelastic interfaces.

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReduction.cpp
@@ -103,6 +103,7 @@ void DataReduction::initLayout() {
 void DataReduction::applySettings(std::map<std::string, QVariant> const &settings) {
   for (auto tab = m_tabs.begin(); tab != m_tabs.end(); ++tab) {
     tab->second->filterInputData(settings.at("RestrictInput").toBool());
+    tab->second->enableLoadHistoryProperty(settings.at("LoadHistory").toBool());
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
@@ -236,4 +236,11 @@ std::map<std::string, double> DataReductionTab::getRangesFromInstrument(QString 
  */
 void DataReductionTab::filterInputData(bool filter) { setFileExtensionsByName(filter); }
 
+/**
+ * Workspaces loading from data selectors load the history of that workspace.
+ *
+ * @param doLoadHistory :: true if you want to load the history
+ */
+void DataReductionTab::enableLoadHistoryProperty(bool doLoadHistory) { setLoadHistory(doLoadHistory); }
+
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
@@ -58,6 +58,7 @@ public:
 
   /// Prevent loading of data with incorrect naming
   void filterInputData(bool filter);
+  void enableLoadHistoryProperty(bool doLoadHistory);
 
 public slots:
 
@@ -91,6 +92,7 @@ private slots:
 
 private:
   virtual void setFileExtensionsByName(bool filter) { UNUSED_ARG(filter); };
+  virtual void setLoadHistory(bool doLoadHistory) { (void)doLoadHistory; }
   virtual void updateInstrumentConfiguration() = 0;
 
   std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
@@ -12,6 +12,7 @@
 #include "MantidQtWidgets/Common/WorkspaceUtils.h"
 #include "MantidQtWidgets/Spectroscopy/InterfaceUtils.h"
 
+#include <MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h>
 #include <QFileInfo>
 
 using namespace Mantid::API;
@@ -261,7 +262,7 @@ void ISISDiagnostics::handleNewFile() {
   int specMin = static_cast<int>(m_dblManager->value(m_properties["SpecMin"]));
   int specMax = static_cast<int>(m_dblManager->value(m_properties["SpecMax"]));
 
-  if (!loadFile(filename.toStdString(), wsname.toStdString(), specMin, specMax)) {
+  if (!loadFile(filename.toStdString(), wsname.toStdString(), specMin, specMax, SettingsHelper::loadHistory())) {
     emit showMessageBox("Unable to load file.\nCheck whether your file exists "
                         "and matches the selected instrument in the "
                         "EnergyTransfer tab.");
@@ -430,6 +431,10 @@ void ISISDiagnostics::setFileExtensionsByName(bool filter) {
   auto const tabName("ISISDiagnostics");
   m_uiForm.dsCalibration->setFBSuffixes(filter ? getCalibrationFBSuffixes(tabName) : getCalibrationExtensions(tabName));
   m_uiForm.dsCalibration->setWSSuffixes(filter ? getCalibrationWSSuffixes(tabName) : noSuffices);
+}
+
+void ISISDiagnostics::setLoadHistory(bool doLoadHistory) {
+  m_uiForm.dsCalibration->setLoadProperty("LoadHistory", doLoadHistory);
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.h
@@ -73,6 +73,7 @@ private:
   void setDefaultInstDetails(QMap<QString, QString> const &instrumentDetails);
 
   void setFileExtensionsByName(bool filter) override;
+  void setLoadHistory(bool doLoadHistory) override;
 
   void setPeakRangeLimits(double peakMin, double peakMax);
   void setBackgroundRangeLimits(double backgroundMin, double backgroundMax);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
@@ -297,4 +297,6 @@ void IETPresenter::setFileExtensionsByName(bool filter) {
   m_view->setFileExtensionsByName(fbSuffixes, wsSuffixes);
 }
 
+void IETPresenter::setLoadHistory(bool doLoadHistory) { m_view->setLoadHistory(doLoadHistory); }
+
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.h
@@ -58,6 +58,7 @@ private:
   InstrumentData getInstrumentData() const;
 
   void setFileExtensionsByName(bool filter) override;
+  void setLoadHistory(bool doLoadHistory) override;
 
   IIETView *m_view;
   std::unique_ptr<IIETModel> m_model;

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
@@ -207,6 +207,10 @@ void IETView::setFileExtensionsByName(QStringList calibrationFbSuffixes, QString
   m_uiForm.dsCalibrationFile->setWSSuffixes(calibrationWSSuffixes);
 }
 
+void IETView::setLoadHistory(bool doLoadHistory) {
+  m_uiForm.dsCalibrationFile->setLoadProperty("LoadHistory", doLoadHistory);
+}
+
 void IETView::setInstrumentSpectraRange(int specMin, int specMax) {
   m_uiForm.spSpectraMin->setRange(specMin, specMax);
   m_uiForm.spSpectraMin->setValue(specMin);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
@@ -68,6 +68,7 @@ public:
   virtual void setSaveEnabled(bool enable) = 0;
   virtual void setPlotTimeIsPlotting(bool plotting) = 0;
   virtual void setFileExtensionsByName(QStringList calibrationFbSuffixes, QStringList calibrationWSSuffixes) = 0;
+  virtual void setLoadHistory(bool doLoadHistory) = 0;
   virtual void setEnableOutputOptions(bool const enable) = 0;
 
   virtual void setInstrumentSpectraRange(int specMin, int specMax) = 0;
@@ -130,6 +131,7 @@ public:
   void setSaveEnabled(bool enable) override;
   void setPlotTimeIsPlotting(bool plotting) override;
   void setFileExtensionsByName(QStringList calibrationFbSuffixes, QStringList calibrationWSSuffixes) override;
+  void setLoadHistory(bool doLoadHistory) override;
   void setEnableOutputOptions(bool const enable) override;
 
   void setInstrumentSpectraRange(int specMin, int specMax) override;

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.cpp
@@ -126,4 +126,9 @@ void Transmission::saveClicked() {
 
 void Transmission::setSaveEnabled(bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }
 
+void Transmission::setLoadHistory(bool doLoadHistory) {
+  m_uiForm.dsSampleInput->setLoadProperty("LoadHistory", doLoadHistory);
+  m_uiForm.dsCanInput->setLoadProperty("LoadHistory", doLoadHistory);
+};
+
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.h
@@ -35,6 +35,7 @@ private slots:
   void setSaveEnabled(bool enabled);
 
 private:
+  void setLoadHistory(bool doLoadHistory) override;
   void setInstrument(QString const &instrumentName);
   void updateInstrumentConfiguration() override;
 

--- a/qt/scientific_interfaces/Indirect/Simulation/MolDyn.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/MolDyn.cpp
@@ -108,6 +108,15 @@ void MolDyn::algorithmComplete(bool error) {
 void MolDyn::loadSettings(const QSettings &settings) { m_uiForm.mwRun->readSettings(settings.group()); }
 
 /**
+ * Selects wheter to load the history of a workspace for the resolution data selector loader
+ *
+ * @param doLoadHistory :: If true, the data selector loads the history of the added workspaces.
+ */
+void MolDyn::setLoadHistory(bool doLoadHistory) {
+  m_uiForm.dsResolution->setLoadProperty("LoadHistory", doLoadHistory);
+}
+
+/**
  * Handles the version of nMoldyn being selected.
  *
  * @param version The version as a string ("3" or "4")

--- a/qt/scientific_interfaces/Indirect/Simulation/MolDyn.h
+++ b/qt/scientific_interfaces/Indirect/Simulation/MolDyn.h
@@ -32,6 +32,7 @@ private slots:
   void algorithmComplete(bool error);
 
 private:
+  void setLoadHistory(bool doLoadHistory) override;
   void setSaveEnabled(bool enabled);
 
   std::string m_outputWsName;

--- a/qt/scientific_interfaces/Indirect/Simulation/Simulation.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/Simulation.cpp
@@ -91,4 +91,11 @@ void Simulation::loadSettings() {
   settings.endGroup();
 }
 
+void Simulation::applySettings(std::map<std::string, QVariant> const &settings) {
+  std::map<unsigned int, SimulationTab *>::iterator iter;
+  for (iter = m_simulationTabs.begin(); iter != m_simulationTabs.end(); ++iter) {
+    iter->second->enableLoadHistoryProperty(settings.at("LoadHistory").toBool());
+  }
+}
+
 std::string Simulation::documentationPage() const { return "Indirect Simulation"; }

--- a/qt/scientific_interfaces/Indirect/Simulation/Simulation.h
+++ b/qt/scientific_interfaces/Indirect/Simulation/Simulation.h
@@ -47,6 +47,8 @@ public: // public constructor, destructor and functions
 private:
   std::string documentationPage() const override;
 
+  void applySettings(std::map<std::string, QVariant> const &settings) override;
+
   /// Load default interface settings for each tab
   void loadSettings();
   /// Called upon a close event.

--- a/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.cpp
@@ -24,4 +24,6 @@ void SimulationTab::setOutputPlotOptionsWorkspaces(std::vector<std::string> cons
 
 void SimulationTab::clearOutputPlotOptionsWorkspaces() { m_plotOptionsPresenter->clearWorkspaces(); }
 
+void SimulationTab::enableLoadHistoryProperty(bool doLoadHistory) { setLoadHistory(doLoadHistory); }
+
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.h
+++ b/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.h
@@ -43,7 +43,7 @@ public:
   virtual void loadSettings(const QSettings &settings) = 0;
 
 private:
-  virtual void setLoadHistory(bool doLoadHistory){UNUSED_ARG(doLoadHistory)};
+  virtual void setLoadHistory(bool doLoadHistory) { UNUSED_ARG(doLoadHistory); }
   std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.h
+++ b/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.h
@@ -39,9 +39,11 @@ public:
   void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces);
   void clearOutputPlotOptionsWorkspaces();
 
+  void enableLoadHistoryProperty(bool doLoadHistory);
   virtual void loadSettings(const QSettings &settings) = 0;
 
 private:
+  virtual void setLoadHistory(bool doLoadHistory){UNUSED_ARG(doLoadHistory)};
   std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/test/Reduction/MockObjects.h
+++ b/qt/scientific_interfaces/Indirect/test/Reduction/MockObjects.h
@@ -107,6 +107,7 @@ public:
   MOCK_METHOD1(setSaveEnabled, void(bool enable));
   MOCK_METHOD1(setPlotTimeIsPlotting, void(bool plotting));
   MOCK_METHOD2(setFileExtensionsByName, void(QStringList calibrationFbSuffixes, QStringList calibrationWSSuffixes));
+  MOCK_METHOD1(setLoadHistory, void(bool doLoadHistory));
   MOCK_METHOD1(setRunButtonText, void(std::string const &runText));
   MOCK_METHOD1(setEnableOutputOptions, void(bool const enable));
 

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.cpp
@@ -25,6 +25,7 @@ void BayesFittingTab::filterInputData(bool filter) { setFileExtensionsByName(fil
 
 void BayesFittingTab::applySettings(std::map<std::string, QVariant> const &settings) {
   filterInputData(settings.at("RestrictInput").toBool());
+  setLoadHistory(settings.at("LoadHistory").toBool());
 }
 
 void BayesFittingTab::setFileExtensionsByName(bool filter) { (void)filter; }

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.h
@@ -79,6 +79,7 @@ protected:
 
 private:
   virtual void setFileExtensionsByName(bool filter);
+  virtual void setLoadHistory(bool doLoad) { (void)doLoad; }
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.h
@@ -79,7 +79,7 @@ protected:
 
 private:
   virtual void setFileExtensionsByName(bool filter);
-  virtual void setLoadHistory(bool doLoad) { (void)doLoad; }
+  virtual void setLoadHistory(bool doLoadHistory) { (void)doLoadHistory; }
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
@@ -213,10 +213,10 @@ void Quasi::setFileExtensionsByName(bool filter) {
   m_uiForm.dsResolution->setWSSuffixes(filter ? getResolutionWSSuffixes(tabName) : noSuffixes);
 }
 
-void Quasi::setLoadHistory(bool doLoad) {
-  m_uiForm.dsSample->setLoadProperty("LoadHistory", doLoad);
-  m_uiForm.dsResolution->setLoadProperty("LoadHistory", doLoad);
-  m_uiForm.dsResNorm->setLoadProperty("LoadHistory", doLoad);
+void Quasi::setLoadHistory(bool doLoadHistory) {
+  m_uiForm.dsSample->setLoadProperty("LoadHistory", doLoadHistory);
+  m_uiForm.dsResolution->setLoadProperty("LoadHistory", doLoadHistory);
+  m_uiForm.dsResNorm->setLoadProperty("LoadHistory", doLoadHistory);
 }
 
 void Quasi::handleValidation(IUserInputValidator *validator) const {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.cpp
@@ -104,7 +104,8 @@ void Quasi::applySettings(std::map<std::string, QVariant> const &settings) {
   setupFitOptions();
   setupPropertyBrowser();
   setupPlotOptions();
-  filterInputData(settings.at("RestrictInput").toBool());
+  setFileExtensionsByName(settings.at("RestrictInput").toBool());
+  setLoadHistory(settings.at("LoadHistory").toBool());
 }
 
 /**
@@ -210,6 +211,12 @@ void Quasi::setFileExtensionsByName(bool filter) {
   m_uiForm.dsSample->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
   m_uiForm.dsResolution->setFBSuffixes(filter ? getResolutionFBSuffixes(tabName) : getExtensions(tabName));
   m_uiForm.dsResolution->setWSSuffixes(filter ? getResolutionWSSuffixes(tabName) : noSuffixes);
+}
+
+void Quasi::setLoadHistory(bool doLoad) {
+  m_uiForm.dsSample->setLoadProperty("LoadHistory", doLoad);
+  m_uiForm.dsResolution->setLoadProperty("LoadHistory", doLoad);
+  m_uiForm.dsResNorm->setLoadProperty("LoadHistory", doLoad);
 }
 
 void Quasi::handleValidation(IUserInputValidator *validator) const {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
@@ -62,7 +62,7 @@ private:
   int displaySaveDirectoryMessage();
 
   void setFileExtensionsByName(bool filter) override;
-  void setLoadHistory(bool doLoad) override;
+  void setLoadHistory(bool doLoadHistory) override;
 
   void setPlotResultEnabled(bool enabled);
   void setSaveResultEnabled(bool enabled);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Quasi.h
@@ -62,6 +62,7 @@ private:
   int displaySaveDirectoryMessage();
 
   void setFileExtensionsByName(bool filter) override;
+  void setLoadHistory(bool doLoad) override;
 
   void setPlotResultEnabled(bool enabled);
   void setSaveResultEnabled(bool enabled);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
@@ -78,9 +78,9 @@ void ResNorm::setFileExtensionsByName(bool filter) {
   m_uiForm.dsResolution->setWSSuffixes(filter ? getResolutionWSSuffixes(tabName) : noSuffixes);
 }
 
-void ResNorm::setLoadHistory(bool doLoad) {
-  m_uiForm.dsVanadium->setLoadProperty("LoadHistory", doLoad);
-  m_uiForm.dsVanadium->setLoadProperty("LoadHistory", doLoad);
+void ResNorm::setLoadHistory(bool doLoadHistory) {
+  m_uiForm.dsVanadium->setLoadProperty("LoadHistory", doLoadHistory);
+  m_uiForm.dsVanadium->setLoadProperty("LoadHistory", doLoadHistory);
 }
 
 void ResNorm::handleValidation(IUserInputValidator *validator) const {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
@@ -78,6 +78,11 @@ void ResNorm::setFileExtensionsByName(bool filter) {
   m_uiForm.dsResolution->setWSSuffixes(filter ? getResolutionWSSuffixes(tabName) : noSuffixes);
 }
 
+void ResNorm::setLoadHistory(bool doLoad) {
+  m_uiForm.dsVanadium->setLoadProperty("LoadHistory", doLoad);
+  m_uiForm.dsVanadium->setLoadProperty("LoadHistory", doLoad);
+}
+
 void ResNorm::handleValidation(IUserInputValidator *validator) const {
   bool const vanValid = validator->checkDataSelectorIsValid("Vanadium", m_uiForm.dsVanadium);
   bool const resValid = validator->checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
@@ -80,7 +80,7 @@ void ResNorm::setFileExtensionsByName(bool filter) {
 
 void ResNorm::setLoadHistory(bool doLoadHistory) {
   m_uiForm.dsVanadium->setLoadProperty("LoadHistory", doLoadHistory);
-  m_uiForm.dsVanadium->setLoadProperty("LoadHistory", doLoadHistory);
+  m_uiForm.dsResolution->setLoadProperty("LoadHistory", doLoadHistory);
 }
 
 void ResNorm::handleValidation(IUserInputValidator *validator) const {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.h
@@ -50,7 +50,7 @@ private slots:
 
 private:
   void setFileExtensionsByName(bool filter) override;
-  void setLoadHistory(bool doLoad) override;
+  void setLoadHistory(bool doLoadHistory) override;
 
   void processLogs();
   void addAdditionalLogs(const Mantid::API::WorkspaceGroup_sptr &resultGroup) const;

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.h
@@ -50,6 +50,7 @@ private slots:
 
 private:
   void setFileExtensionsByName(bool filter) override;
+  void setLoadHistory(bool doLoad) override;
 
   void processLogs();
   void addAdditionalLogs(const Mantid::API::WorkspaceGroup_sptr &resultGroup) const;

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
@@ -69,6 +69,11 @@ void Stretch::setFileExtensionsByName(bool filter) {
   m_uiForm.dsResolution->setWSSuffixes(filter ? getResolutionWSSuffixes(tabName) : noSuffixes);
 }
 
+void Stretch::setLoadHistory(bool doLoad) {
+  m_uiForm.dsSample->setLoadProperty("LoadHistory", doLoad);
+  m_uiForm.dsResolution->setLoadProperty("LoadHistory", doLoad);
+}
+
 void Stretch::handleValidation(IUserInputValidator *validator) const {
   validator->checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
   validator->checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
@@ -250,7 +255,8 @@ void Stretch::applySettings(std::map<std::string, QVariant> const &settings) {
   setupFitOptions();
   setupPropertyBrowser();
   setupPlotOptions();
-  filterInputData(settings.at("RestrictInput").toBool());
+  setFileExtensionsByName(settings.at("RestrictInput").toBool());
+  setLoadHistory(settings.at("LoadHistory").toBool());
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
@@ -69,9 +69,9 @@ void Stretch::setFileExtensionsByName(bool filter) {
   m_uiForm.dsResolution->setWSSuffixes(filter ? getResolutionWSSuffixes(tabName) : noSuffixes);
 }
 
-void Stretch::setLoadHistory(bool doLoad) {
-  m_uiForm.dsSample->setLoadProperty("LoadHistory", doLoad);
-  m_uiForm.dsResolution->setLoadProperty("LoadHistory", doLoad);
+void Stretch::setLoadHistory(bool doLoadHistory) {
+  m_uiForm.dsSample->setLoadProperty("LoadHistory", doLoadHistory);
+  m_uiForm.dsResolution->setLoadProperty("LoadHistory", doLoadHistory);
 }
 
 void Stretch::handleValidation(IUserInputValidator *validator) const {

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.h
@@ -55,6 +55,7 @@ private slots:
 
 private:
   void setFileExtensionsByName(bool filter) override;
+  void setLoadHistory(bool doLoad) override;
 
   void populateContourWorkspaceComboBox();
   int displaySaveDirectoryMessage();

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.h
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.h
@@ -55,7 +55,7 @@ private slots:
 
 private:
   void setFileExtensionsByName(bool filter) override;
-  void setLoadHistory(bool doLoad) override;
+  void setLoadHistory(bool doLoadHistory) override;
 
   void populateContourWorkspaceComboBox();
   int displaySaveDirectoryMessage();

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
@@ -473,8 +473,8 @@ void AbsorptionCorrections::setFileExtensionsByName(bool filter) {
   m_uiForm.dsSampleInput->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
 }
 
-void AbsorptionCorrections::setLoadHistory(bool doLoad) {
-  m_uiForm.dsSampleInput->setLoadProperty("LoadHistory", doLoad);
+void AbsorptionCorrections::setLoadHistory(bool doLoadHistory) {
+  m_uiForm.dsSampleInput->setLoadProperty("LoadHistory", doLoadHistory);
 }
 
 void AbsorptionCorrections::processWavelengthWorkspace() {

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
@@ -473,6 +473,10 @@ void AbsorptionCorrections::setFileExtensionsByName(bool filter) {
   m_uiForm.dsSampleInput->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
 }
 
+void AbsorptionCorrections::setLoadHistory(bool doLoad) {
+  m_uiForm.dsSampleInput->setLoadProperty("LoadHistory", doLoad);
+}
+
 void AbsorptionCorrections::processWavelengthWorkspace() {
   auto correctionsWs = getADSWorkspace<WorkspaceGroup>(m_pythonExportWsName);
   if (correctionsWs) {

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.h
@@ -52,6 +52,7 @@ private slots:
 private:
   void loadSettings(const QSettings &settings) override;
   void setFileExtensionsByName(bool filter) override;
+  void setLoadHistory(bool doLoad) override;
 
   void validateSampleGeometryInputs(IUserInputValidator *uiv, const QString &shape) const;
   void validateContainerGeometryInputs(IUserInputValidator *uiv, const QString &shape) const;

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.h
@@ -52,7 +52,7 @@ private slots:
 private:
   void loadSettings(const QSettings &settings) override;
   void setFileExtensionsByName(bool filter) override;
-  void setLoadHistory(bool doLoad) override;
+  void setLoadHistory(bool doLoadHistory) override;
 
   void validateSampleGeometryInputs(IUserInputValidator *uiv, const QString &shape) const;
   void validateContainerGeometryInputs(IUserInputValidator *uiv, const QString &shape) const;

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
@@ -474,6 +474,12 @@ void ApplyAbsorptionCorrections::setFileExtensionsByName(bool filter) {
   m_uiForm.dsCorrections->setWSSuffixes(filter ? getCorrectionsWSSuffixes(tabName) : noSuffixes);
 }
 
+void ApplyAbsorptionCorrections::setLoadHistory(bool doLoad) {
+  m_uiForm.dsSample->setLoadProperty("LoadHistory", doLoad);
+  m_uiForm.dsContainer->setLoadProperty("LoadHistory", doLoad);
+  m_uiForm.dsCorrections->setLoadProperty("LoadHistory", doLoad);
+}
+
 /**
  * Replots the preview plot.
  *

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
@@ -474,10 +474,10 @@ void ApplyAbsorptionCorrections::setFileExtensionsByName(bool filter) {
   m_uiForm.dsCorrections->setWSSuffixes(filter ? getCorrectionsWSSuffixes(tabName) : noSuffixes);
 }
 
-void ApplyAbsorptionCorrections::setLoadHistory(bool doLoad) {
-  m_uiForm.dsSample->setLoadProperty("LoadHistory", doLoad);
-  m_uiForm.dsContainer->setLoadProperty("LoadHistory", doLoad);
-  m_uiForm.dsCorrections->setLoadProperty("LoadHistory", doLoad);
+void ApplyAbsorptionCorrections::setLoadHistory(bool doLoadHistory) {
+  m_uiForm.dsSample->setLoadProperty("LoadHistory", doLoadHistory);
+  m_uiForm.dsContainer->setLoadProperty("LoadHistory", doLoadHistory);
+  m_uiForm.dsCorrections->setLoadProperty("LoadHistory", doLoadHistory);
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.h
@@ -49,6 +49,7 @@ private slots:
 private:
   void loadSettings(const QSettings &settings) override;
   void setFileExtensionsByName(bool filter) override;
+  void setLoadHistory(bool doLoad) override;
 
   void addInterpolationStep(const Mantid::API::MatrixWorkspace_sptr &toInterpolate, std::string toMatch);
   void plotInPreview(const QString &curveName, Mantid::API::MatrixWorkspace_sptr &ws, const QColor &curveColor);

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.h
@@ -49,7 +49,7 @@ private slots:
 private:
   void loadSettings(const QSettings &settings) override;
   void setFileExtensionsByName(bool filter) override;
-  void setLoadHistory(bool doLoad) override;
+  void setLoadHistory(bool doLoadHistory) override;
 
   void addInterpolationStep(const Mantid::API::MatrixWorkspace_sptr &toInterpolate, std::string toMatch);
   void plotInPreview(const QString &curveName, Mantid::API::MatrixWorkspace_sptr &ws, const QColor &curveColor);

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
@@ -197,9 +197,9 @@ void ContainerSubtraction::setFileExtensionsByName(bool filter) {
   m_uiForm.dsContainer->setWSSuffixes(filter ? getContainerWSSuffixes(tabName) : noSuffixes);
 }
 
-void ContainerSubtraction::setLoadHistory(bool doLoad) {
-  m_uiForm.dsSample->setLoadProperty("LoadHistory", doLoad);
-  m_uiForm.dsContainer->setLoadProperty("LoadHistory", doLoad);
+void ContainerSubtraction::setLoadHistory(bool doLoadHistory) {
+  m_uiForm.dsSample->setLoadProperty("LoadHistory", doLoadHistory);
+  m_uiForm.dsContainer->setLoadProperty("LoadHistory", doLoadHistory);
 };
 
 /**

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
@@ -197,6 +197,11 @@ void ContainerSubtraction::setFileExtensionsByName(bool filter) {
   m_uiForm.dsContainer->setWSSuffixes(filter ? getContainerWSSuffixes(tabName) : noSuffixes);
 }
 
+void ContainerSubtraction::setLoadHistory(bool doLoad) {
+  m_uiForm.dsSample->setLoadProperty("LoadHistory", doLoad);
+  m_uiForm.dsContainer->setLoadProperty("LoadHistory", doLoad);
+};
+
 /**
  * Displays the sample data on the plot preview
  * @param dataName Name of new data source

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.h
@@ -47,7 +47,7 @@ private slots:
 private:
   void loadSettings(const QSettings &settings) override;
   void setFileExtensionsByName(bool filter) override;
-  void setLoadHistory(bool doLoad) override;
+  void setLoadHistory(bool doLoadHistory) override;
 
   void plotInPreview(const QString &curveName, Mantid::API::MatrixWorkspace_sptr &ws, const QColor &curveColor);
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.h
@@ -47,6 +47,7 @@ private slots:
 private:
   void loadSettings(const QSettings &settings) override;
   void setFileExtensionsByName(bool filter) override;
+  void setLoadHistory(bool doLoad) override;
 
   void plotInPreview(const QString &curveName, Mantid::API::MatrixWorkspace_sptr &ws, const QColor &curveColor);
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/Corrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/Corrections.cpp
@@ -97,6 +97,7 @@ void Corrections::loadSettings() {
 void Corrections::applySettings(std::map<std::string, QVariant> const &settings) {
   for (auto tab = m_tabs.begin(); tab != m_tabs.end(); ++tab) {
     tab->second->filterInputData(settings.at("RestrictInput").toBool());
+    tab->second->enableLoadHistoryProperty(settings.at("LoadHistory").toBool());
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
@@ -52,6 +52,8 @@ void CorrectionsTab::loadTabSettings(const QSettings &settings) { loadSettings(s
  */
 void CorrectionsTab::filterInputData(bool filter) { setFileExtensionsByName(filter); }
 
+void CorrectionsTab::enableLoadHistoryProperty(bool doLoad) { setLoadHistory(doLoad); }
+
 /**
  * Check that the binning between two workspaces matches.
  *

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
@@ -52,7 +52,7 @@ void CorrectionsTab::loadTabSettings(const QSettings &settings) { loadSettings(s
  */
 void CorrectionsTab::filterInputData(bool filter) { setFileExtensionsByName(filter); }
 
-void CorrectionsTab::enableLoadHistoryProperty(bool doLoad) { setLoadHistory(doLoad); }
+void CorrectionsTab::enableLoadHistoryProperty(bool doLoadHistory) { setLoadHistory(doLoadHistory); }
 
 /**
  * Check that the binning between two workspaces matches.

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.h
@@ -80,7 +80,7 @@ public:
 
   /// Prevent loading of data with incorrect naming
   void filterInputData(bool filter);
-  void enableLoadHistoryProperty(bool doLoad);
+  void enableLoadHistoryProperty(bool doLoadHistory);
 
 protected:
   /// Check the binning between two workspaces match
@@ -101,7 +101,7 @@ protected:
 private:
   virtual void loadSettings(const QSettings &settings) = 0;
   virtual void setFileExtensionsByName(bool filter) = 0;
-  virtual void setLoadHistory(bool doLoad) { (void)doLoad; };
+  virtual void setLoadHistory(bool doLoadHistory) { (void)doLoadHistory; };
 
   std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
 };

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.h
@@ -80,6 +80,7 @@ public:
 
   /// Prevent loading of data with incorrect naming
   void filterInputData(bool filter);
+  void enableLoadHistoryProperty(bool doLoad);
 
 protected:
   /// Check the binning between two workspaces match
@@ -100,6 +101,7 @@ protected:
 private:
   virtual void loadSettings(const QSettings &settings) = 0;
   virtual void setFileExtensionsByName(bool filter) = 0;
+  virtual void setLoadHistory(bool doLoad) { (void)doLoad; };
 
   std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
 };

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
@@ -72,4 +72,6 @@ void DataProcessor::setOutputPlotOptionsWorkspaces(std::vector<std::string> cons
  */
 void DataProcessor::filterInputData(bool filter) { setFileExtensionsByName(filter); }
 
+void DataProcessor::enableLoadHistoryProperty(bool doLoad) { setLoadHistory(doLoad); }
+
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
@@ -72,6 +72,6 @@ void DataProcessor::setOutputPlotOptionsWorkspaces(std::vector<std::string> cons
  */
 void DataProcessor::filterInputData(bool filter) { setFileExtensionsByName(filter); }
 
-void DataProcessor::enableLoadHistoryProperty(bool doLoad) { setLoadHistory(doLoad); }
+void DataProcessor::enableLoadHistoryProperty(bool doLoadHistory) { setLoadHistory(doLoadHistory); }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
@@ -43,6 +43,7 @@ public:
   virtual void clearOutputPlotOptionsWorkspaces() = 0;
   virtual void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces) = 0;
   virtual void filterInputData(bool filter) = 0;
+  virtual void enableLoadHistoryProperty(bool doLoad) = 0;
   virtual void exportPythonDialog() = 0;
   virtual API::IConfiguredAlgorithm_sptr setupSaveAlgorithm(const std::string &wsName,
                                                             const std::string &filename = "") = 0;
@@ -73,6 +74,7 @@ public:
                                                     const std::string &filename = "") override;
   /// Prevent loading of data with incorrect naming
   void filterInputData(bool filter) override;
+  void enableLoadHistoryProperty(bool doLoad) override;
 
   void exportPythonDialog() override;
 
@@ -82,6 +84,7 @@ protected:
 
 private:
   virtual void setFileExtensionsByName(bool filter) { (void)filter; };
+  virtual void setLoadHistory(bool doLoad) { (void)doLoad; }
   std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
@@ -43,7 +43,7 @@ public:
   virtual void clearOutputPlotOptionsWorkspaces() = 0;
   virtual void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces) = 0;
   virtual void filterInputData(bool filter) = 0;
-  virtual void enableLoadHistoryProperty(bool doLoad) = 0;
+  virtual void enableLoadHistoryProperty(bool doLoadHistory) = 0;
   virtual void exportPythonDialog() = 0;
   virtual API::IConfiguredAlgorithm_sptr setupSaveAlgorithm(const std::string &wsName,
                                                             const std::string &filename = "") = 0;
@@ -74,7 +74,7 @@ public:
                                                     const std::string &filename = "") override;
   /// Prevent loading of data with incorrect naming
   void filterInputData(bool filter) override;
-  void enableLoadHistoryProperty(bool doLoad) override;
+  void enableLoadHistoryProperty(bool doLoadHistory) override;
 
   void exportPythonDialog() override;
 
@@ -84,7 +84,7 @@ protected:
 
 private:
   virtual void setFileExtensionsByName(bool filter) { (void)filter; };
-  virtual void setLoadHistory(bool doLoad) { (void)doLoad; }
+  virtual void setLoadHistory(bool doLoadHistory) { (void)doLoadHistory; }
   std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessorInterface.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessorInterface.cpp
@@ -82,6 +82,7 @@ void DataProcessorInterface::initLayout() {
 void DataProcessorInterface::applySettings(std::map<std::string, QVariant> const &settings) {
   for (auto tab = m_presenters.begin(); tab != m_presenters.end(); ++tab) {
     tab->second->filterInputData(settings.at("RestrictInput").toBool());
+    tab->second->enableLoadHistoryProperty(settings.at("LoadHistory").toBool());
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
@@ -13,10 +13,13 @@
 #include "MantidQtWidgets/Common/WorkspaceUtils.h"
 #include "MantidQtWidgets/Plotting/RangeSelector.h"
 #include "MantidQtWidgets/Spectroscopy/InterfaceUtils.h"
+#include "MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h"
 
 #include <algorithm>
 
 #include "MantidQtWidgets/Common/AddWorkspaceMultiDialog.h"
+
+#include <MantidQtWidgets/Spectroscopy/SettingsWidget/Settings.h>
 
 using namespace Mantid::API;
 using namespace MantidQt::API;
@@ -152,6 +155,7 @@ void ElwinView::showAddWorkspaceDialog() {
   dialog->setAttribute(Qt::WA_DeleteOnClose);
   dialog->setWSSuffices(InterfaceUtils::getSampleWSSuffixes(tabName));
   dialog->setFBSuffices(InterfaceUtils::getSampleFBSuffixes(tabName));
+  dialog->setLoadProperty("LoadHistory", SettingsHelper::loadHistory());
   dialog->show();
 }
 

--- a/qt/scientific_interfaces/Inelastic/Processor/IIqtView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IIqtView.h
@@ -44,6 +44,7 @@ public:
   virtual void setSampleWSSuffixes(const QStringList &suffix) = 0;
   virtual void setResolutionFBSuffixes(const QStringList &suffix) = 0;
   virtual void setResolutionWSSuffixes(const QStringList &suffix) = 0;
+  virtual void setLoadHistory(bool doLoad) = 0;
   virtual void setSaveResultEnabled(bool enabled) = 0;
   virtual void setWatchADS(bool watch) = 0;
   virtual void setup() = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/IIqtView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IIqtView.h
@@ -44,7 +44,7 @@ public:
   virtual void setSampleWSSuffixes(const QStringList &suffix) = 0;
   virtual void setResolutionFBSuffixes(const QStringList &suffix) = 0;
   virtual void setResolutionWSSuffixes(const QStringList &suffix) = 0;
-  virtual void setLoadHistory(bool doLoad) = 0;
+  virtual void setLoadHistory(bool doLoadHistory) = 0;
   virtual void setSaveResultEnabled(bool enabled) = 0;
   virtual void setWatchADS(bool watch) = 0;
   virtual void setup() = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/IMomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IMomentsView.h
@@ -39,7 +39,7 @@ public:
 
   virtual void setFBSuffixes(QStringList const &suffix) = 0;
   virtual void setWSSuffixes(QStringList const &suffix) = 0;
-  virtual void setLoadHistory(bool doLoad) = 0;
+  virtual void setLoadHistory(bool doLoadHistory) = 0;
 
   /// Function to set the range limits of the plot
   virtual void setPlotPropertyRange(const QPair<double, double> &bounds) = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/IMomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IMomentsView.h
@@ -39,6 +39,7 @@ public:
 
   virtual void setFBSuffixes(QStringList const &suffix) = 0;
   virtual void setWSSuffixes(QStringList const &suffix) = 0;
+  virtual void setLoadHistory(bool doLoad) = 0;
 
   /// Function to set the range limits of the plot
   virtual void setPlotPropertyRange(const QPair<double, double> &bounds) = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/ISqwView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ISqwView.h
@@ -33,6 +33,7 @@ public:
 
   virtual void setFBSuffixes(QStringList const &suffix) = 0;
   virtual void setWSSuffixes(QStringList const &suffix) = 0;
+  virtual void setLoadHistory(bool doLoad) = 0;
   virtual std::tuple<double, double> getQRangeFromPlot() const = 0;
   virtual std::tuple<double, double> getERangeFromPlot() const = 0;
   virtual std::string getDataName() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/ISqwView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ISqwView.h
@@ -33,7 +33,7 @@ public:
 
   virtual void setFBSuffixes(QStringList const &suffix) = 0;
   virtual void setWSSuffixes(QStringList const &suffix) = 0;
-  virtual void setLoadHistory(bool doLoad) = 0;
+  virtual void setLoadHistory(bool doLoadHistory) = 0;
   virtual std::tuple<double, double> getQRangeFromPlot() const = 0;
   virtual std::tuple<double, double> getERangeFromPlot() const = 0;
   virtual std::string getDataName() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/ISymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ISymmetriseView.h
@@ -39,6 +39,7 @@ public:
 
   virtual void setFBSuffixes(QStringList const &suffix) = 0;
   virtual void setWSSuffixes(QStringList const &suffix) = 0;
+  virtual void setLoadHistory(bool doLoad) = 0;
 
   virtual double getElow() const = 0;
   virtual double getEhigh() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/ISymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ISymmetriseView.h
@@ -39,7 +39,7 @@ public:
 
   virtual void setFBSuffixes(QStringList const &suffix) = 0;
   virtual void setWSSuffixes(QStringList const &suffix) = 0;
-  virtual void setLoadHistory(bool doLoad) = 0;
+  virtual void setLoadHistory(bool doLoadHistory) = 0;
 
   virtual double getElow() const = 0;
   virtual double getEhigh() const = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.cpp
@@ -163,6 +163,8 @@ void IqtPresenter::setFileExtensionsByName(bool filter) {
   m_view->setResolutionWSSuffixes(filter ? InterfaceUtils::getResolutionWSSuffixes(tabName) : noSuffixes);
 }
 
+void IqtPresenter::setLoadHistory(bool doLoad) { m_view->setLoadHistory(doLoad); }
+
 /**
  * Retrieves the selected spectrum.
  *

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.cpp
@@ -163,7 +163,7 @@ void IqtPresenter::setFileExtensionsByName(bool filter) {
   m_view->setResolutionWSSuffixes(filter ? InterfaceUtils::getResolutionWSSuffixes(tabName) : noSuffixes);
 }
 
-void IqtPresenter::setLoadHistory(bool doLoad) { m_view->setLoadHistory(doLoad); }
+void IqtPresenter::setLoadHistory(bool doLoadHistory) { m_view->setLoadHistory(doLoadHistory); }
 
 /**
  * Retrieves the selected spectrum.

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.h
@@ -58,6 +58,7 @@ protected:
 
 private:
   void setFileExtensionsByName(bool filter) override;
+  void setLoadHistory(bool doLoad) override;
   /// Retrieve the selected spectrum
   int getSelectedSpectrum() const;
   /// Sets the selected spectrum

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.h
@@ -58,7 +58,7 @@ protected:
 
 private:
   void setFileExtensionsByName(bool filter) override;
-  void setLoadHistory(bool doLoad) override;
+  void setLoadHistory(bool doLoadHistory) override;
   /// Retrieve the selected spectrum
   int getSelectedSpectrum() const;
   /// Sets the selected spectrum

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
@@ -287,9 +287,9 @@ void IqtView::setResolutionFBSuffixes(const QStringList &suffix) { m_uiForm.dsRe
 
 void IqtView::setResolutionWSSuffixes(const QStringList &suffix) { m_uiForm.dsResolution->setWSSuffixes(suffix); }
 
-void IqtView::setLoadHistory(bool doLoad) {
-  m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoad);
-  m_uiForm.dsResolution->setLoadProperty("LoadHistory", doLoad);
+void IqtView::setLoadHistory(bool doLoadHistory) {
+  m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoadHistory);
+  m_uiForm.dsResolution->setLoadProperty("LoadHistory", doLoadHistory);
 }
 
 void IqtView::setSaveResultEnabled(bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
@@ -287,6 +287,11 @@ void IqtView::setResolutionFBSuffixes(const QStringList &suffix) { m_uiForm.dsRe
 
 void IqtView::setResolutionWSSuffixes(const QStringList &suffix) { m_uiForm.dsResolution->setWSSuffixes(suffix); }
 
+void IqtView::setLoadHistory(bool doLoad) {
+  m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoad);
+  m_uiForm.dsResolution->setLoadProperty("LoadHistory", doLoad);
+}
+
 void IqtView::setSaveResultEnabled(bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }
 
 void IqtView::setWatchADS(bool watch) { m_uiForm.ppPlot->watchADS(watch); }

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtView.h
@@ -44,6 +44,7 @@ public:
   void setSampleWSSuffixes(const QStringList &suffix) override;
   void setResolutionFBSuffixes(const QStringList &suffix) override;
   void setResolutionWSSuffixes(const QStringList &suffix) override;
+  void setLoadHistory(bool doLoad) override;
   void setSaveResultEnabled(bool enabled) override;
   void setWatchADS(bool watch) override;
   void setup() override;

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtView.h
@@ -44,7 +44,7 @@ public:
   void setSampleWSSuffixes(const QStringList &suffix) override;
   void setResolutionFBSuffixes(const QStringList &suffix) override;
   void setResolutionWSSuffixes(const QStringList &suffix) override;
-  void setLoadHistory(bool doLoad) override;
+  void setLoadHistory(bool doLoadHistory) override;
   void setSaveResultEnabled(bool enabled) override;
   void setWatchADS(bool watch) override;
   void setup() override;

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
@@ -117,7 +117,7 @@ void MomentsPresenter::setFileExtensionsByName(bool filter) {
   m_view->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
 }
 
-void MomentsPresenter::setLoadHistory(bool doLoad) { m_view->setLoadHistory(doLoad); }
+void MomentsPresenter::setLoadHistory(bool doLoadHistory) { m_view->setLoadHistory(doLoadHistory); }
 
 /**
  * Handle when Run is clicked

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
@@ -117,6 +117,8 @@ void MomentsPresenter::setFileExtensionsByName(bool filter) {
   m_view->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
 }
 
+void MomentsPresenter::setLoadHistory(bool doLoad) { m_view->setLoadHistory(doLoad); }
+
 /**
  * Handle when Run is clicked
  */

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.h
@@ -62,7 +62,7 @@ protected:
 private:
   void plotNewData(std::string const &filename);
   void setFileExtensionsByName(bool filter) override;
-  void setLoadHistory(bool doLoad) override;
+  void setLoadHistory(bool doLoadHistory) override;
 
   IMomentsView *m_view;
   std::unique_ptr<IMomentsModel> m_model;

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.h
@@ -62,6 +62,7 @@ protected:
 private:
   void plotNewData(std::string const &filename);
   void setFileExtensionsByName(bool filter) override;
+  void setLoadHistory(bool doLoad) override;
 
   IMomentsView *m_view;
   std::unique_ptr<IMomentsModel> m_model;

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
@@ -108,6 +108,8 @@ void MomentsView::setFBSuffixes(QStringList const &suffix) { m_uiForm.dsInput->s
 
 void MomentsView::setWSSuffixes(QStringList const &suffix) { m_uiForm.dsInput->setWSSuffixes(suffix); }
 
+void MomentsView::setLoadHistory(bool doLoad) { m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoad); }
+
 IOutputPlotOptionsView *MomentsView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
 
 MantidWidgets::DataSelector *MomentsView::getDataSelector() const { return m_uiForm.dsInput; }

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
@@ -108,7 +108,9 @@ void MomentsView::setFBSuffixes(QStringList const &suffix) { m_uiForm.dsInput->s
 
 void MomentsView::setWSSuffixes(QStringList const &suffix) { m_uiForm.dsInput->setWSSuffixes(suffix); }
 
-void MomentsView::setLoadHistory(bool doLoad) { m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoad); }
+void MomentsView::setLoadHistory(bool doLoadHistory) {
+  m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoadHistory);
+}
 
 IOutputPlotOptionsView *MomentsView::getPlotOptions() const { return m_uiForm.ipoPlotOptions; }
 

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.h
@@ -36,6 +36,7 @@ public:
   std::string getDataName() const override;
   void setFBSuffixes(QStringList const &suffix) override;
   void setWSSuffixes(QStringList const &suffix) override;
+  void setLoadHistory(bool doLoad) override;
 
   /// Function to set the range limits of the plot
   void setPlotPropertyRange(const QPair<double, double> &bounds) override;

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.h
@@ -36,7 +36,7 @@ public:
   std::string getDataName() const override;
   void setFBSuffixes(QStringList const &suffix) override;
   void setWSSuffixes(QStringList const &suffix) override;
-  void setLoadHistory(bool doLoad) override;
+  void setLoadHistory(bool doLoadHistory) override;
 
   /// Function to set the range limits of the plot
   void setPlotPropertyRange(const QPair<double, double> &bounds) override;

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.cpp
@@ -1,4 +1,5 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
+// Mantid Repository : https://github.com/mantidproject/mantid
 //
 // Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
@@ -101,6 +102,8 @@ void SqwPresenter::setFileExtensionsByName(bool filter) {
   m_view->setFBSuffixes(filter ? getSampleFBSuffixes(tabName) : getExtensions(tabName));
   m_view->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
 }
+
+void SqwPresenter::setLoadHistory(bool doLoadHistory) { m_view->setLoadHistory(doLoadHistory); }
 
 void SqwPresenter::handleRun() {
   clearOutputPlotOptionsWorkspaces();

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.cpp
@@ -1,5 +1,4 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
-// Mantid Repository : https://github.com/mantidproject/mantid
 //
 // Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.h
@@ -69,6 +69,7 @@ protected:
 private:
   void plotRqwContour();
   void setFileExtensionsByName(bool filter) override;
+  void setLoadHistory(bool doLoadHistory) override;
 
   ISqwView *m_view;
   std::unique_ptr<ISqwModel> m_model;

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
@@ -71,7 +71,7 @@ void SqwView::setFBSuffixes(QStringList const &suffix) { m_uiForm.dsInput->setFB
 
 void SqwView::setWSSuffixes(QStringList const &suffix) { m_uiForm.dsInput->setWSSuffixes(suffix); }
 
-void SqwView::setLoadHistory(bool doLoad) { m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoad); }
+void SqwView::setLoadHistory(bool doLoadHistory) { m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoadHistory); }
 
 bool SqwView::validate() {
   auto uiv = std::make_unique<UserInputValidator>();

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
@@ -71,6 +71,8 @@ void SqwView::setFBSuffixes(QStringList const &suffix) { m_uiForm.dsInput->setFB
 
 void SqwView::setWSSuffixes(QStringList const &suffix) { m_uiForm.dsInput->setWSSuffixes(suffix); }
 
+void SqwView::setLoadHistory(bool doLoad) { m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoad); }
+
 bool SqwView::validate() {
   auto uiv = std::make_unique<UserInputValidator>();
   validateDataIsOfType(uiv.get(), m_uiForm.dsInput, "Sample", DataType::Red);

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwView.h
@@ -35,6 +35,7 @@ public:
 
   void setFBSuffixes(QStringList const &suffix) override;
   void setWSSuffixes(QStringList const &suffix) override;
+  void setLoadHistory(bool doLoad) override;
   std::tuple<double, double> getQRangeFromPlot() const override;
   std::tuple<double, double> getERangeFromPlot() const override;
   std::string getDataName() const override;

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwView.h
@@ -35,7 +35,7 @@ public:
 
   void setFBSuffixes(QStringList const &suffix) override;
   void setWSSuffixes(QStringList const &suffix) override;
-  void setLoadHistory(bool doLoad) override;
+  void setLoadHistory(bool doLoadHistory) override;
   std::tuple<double, double> getQRangeFromPlot() const override;
   std::tuple<double, double> getERangeFromPlot() const override;
   std::string getDataName() const override;

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
@@ -117,7 +117,7 @@ void SymmetrisePresenter::setFileExtensionsByName(bool filter) {
   m_view->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
 }
 
-void SymmetrisePresenter::setLoadHistory(bool doLoad) { m_view->setLoadHistory(doLoad); }
+void SymmetrisePresenter::setLoadHistory(bool doLoadHistory) { m_view->setLoadHistory(doLoadHistory); }
 
 void SymmetrisePresenter::handleReflectTypeChanged(int value) {
   if (m_runPresenter->validate()) {

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
@@ -117,6 +117,8 @@ void SymmetrisePresenter::setFileExtensionsByName(bool filter) {
   m_view->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
 }
 
+void SymmetrisePresenter::setLoadHistory(bool doLoad) { m_view->setLoadHistory(doLoad); }
+
 void SymmetrisePresenter::handleReflectTypeChanged(int value) {
   if (m_runPresenter->validate()) {
     m_model->setIsPositiveReflect(value == 0);

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.h
@@ -76,7 +76,7 @@ protected:
 
 private:
   void setFileExtensionsByName(bool filter) override;
-  void setLoadHistory(bool doLoad) override;
+  void setLoadHistory(bool doLoadHistory) override;
 
   Mantid::API::AnalysisDataServiceImpl &m_adsInstance;
   ISymmetriseView *m_view;

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.h
@@ -76,6 +76,7 @@ protected:
 
 private:
   void setFileExtensionsByName(bool filter) override;
+  void setLoadHistory(bool doLoad) override;
 
   Mantid::API::AnalysisDataServiceImpl &m_adsInstance;
   ISymmetriseView *m_view;

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
@@ -282,6 +282,8 @@ void SymmetriseView::setFBSuffixes(QStringList const &suffix) { m_uiForm.dsInput
 
 void SymmetriseView::setWSSuffixes(QStringList const &suffix) { m_uiForm.dsInput->setWSSuffixes(suffix); }
 
+void SymmetriseView::setLoadHistory(bool doLoad) { return m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoad); }
+
 /**
  * Plots a new workspace in the mini plot when it is loaded form the data
  *selector.

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
@@ -283,7 +283,7 @@ void SymmetriseView::setFBSuffixes(QStringList const &suffix) { m_uiForm.dsInput
 void SymmetriseView::setWSSuffixes(QStringList const &suffix) { m_uiForm.dsInput->setWSSuffixes(suffix); }
 
 void SymmetriseView::setLoadHistory(bool doLoadHistory) {
-  return m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoadHistory);
+  m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoadHistory);
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
@@ -282,7 +282,9 @@ void SymmetriseView::setFBSuffixes(QStringList const &suffix) { m_uiForm.dsInput
 
 void SymmetriseView::setWSSuffixes(QStringList const &suffix) { m_uiForm.dsInput->setWSSuffixes(suffix); }
 
-void SymmetriseView::setLoadHistory(bool doLoad) { return m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoad); }
+void SymmetriseView::setLoadHistory(bool doLoadHistory) {
+  return m_uiForm.dsInput->setLoadProperty("LoadHistory", doLoadHistory);
+}
 
 /**
  * Plots a new workspace in the mini plot when it is loaded form the data

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.h
@@ -35,6 +35,7 @@ public:
 
   void setFBSuffixes(QStringList const &suffix) override;
   void setWSSuffixes(QStringList const &suffix) override;
+  void setLoadHistory(bool doLoad) override;
 
   double getElow() const override;
   double getEhigh() const override;

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.h
@@ -35,7 +35,7 @@ public:
 
   void setFBSuffixes(QStringList const &suffix) override;
   void setWSSuffixes(QStringList const &suffix) override;
-  void setLoadHistory(bool doLoad) override;
+  void setLoadHistory(bool doLoadHistory) override;
 
   double getElow() const override;
   double getEhigh() const override;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionAddWorkspaceDialog.cpp
@@ -50,6 +50,11 @@ void ConvolutionAddWorkspaceDialog::setFBSuffices(const QStringList &suffices) {
   m_uiForm.dsWorkspace->setFBSuffixes(suffices);
 }
 
+void ConvolutionAddWorkspaceDialog::setLoadProperty(const std::string &propName, bool enable) {
+  m_uiForm.dsWorkspace->setLoadProperty(propName, enable);
+  m_uiForm.dsResolution->setLoadProperty(propName, enable);
+}
+
 void ConvolutionAddWorkspaceDialog::setResolutionWSSuffices(const QStringList &suffices) {
   m_uiForm.dsResolution->setWSSuffixes(suffices);
 }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionAddWorkspaceDialog.h
@@ -27,6 +27,7 @@ public:
 
   void setWSSuffices(const QStringList &suffices) override;
   void setFBSuffices(const QStringList &suffices) override;
+  void setLoadProperty(const std::string &propname, bool enable) override;
   void setResolutionWSSuffices(const QStringList &suffices);
   void setResolutionFBSuffices(const QStringList &suffices);
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataView.cpp
@@ -9,6 +9,7 @@
 #include "FitDataPresenter.h"
 #include "MantidQtWidgets/Spectroscopy/InterfaceUtils.h"
 
+#include <MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h>
 #include <QComboBox>
 #include <QHeaderView>
 #include <QtGlobal>
@@ -46,6 +47,7 @@ void ConvolutionDataView::showAddWorkspaceDialog() {
   dialog->setFBSuffices(InterfaceUtils::getSampleFBSuffixes(tabName));
   dialog->setResolutionWSSuffices(InterfaceUtils::getResolutionWSSuffixes(tabName));
   dialog->setResolutionFBSuffices(InterfaceUtils::getResolutionFBSuffixes(tabName));
+  dialog->setLoadProperty("LoadHistory", SettingsHelper::loadHistory());
   dialog->updateSelectedSpectra();
   dialog->show();
 }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
@@ -10,6 +10,7 @@
 #include "MantidQtWidgets/Common/IndexTypes.h"
 #include "MantidQtWidgets/Common/TableWidgetValidators.h"
 #include "MantidQtWidgets/Spectroscopy/InterfaceUtils.h"
+#include "MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h"
 
 using namespace Mantid::API;
 using namespace MantidQt::MantidWidgets;
@@ -139,6 +140,7 @@ void FitDataView::showAddWorkspaceDialog() {
   dialog->setAttribute(Qt::WA_DeleteOnClose);
   dialog->setWSSuffices(InterfaceUtils::getSampleWSSuffixes(tabName));
   dialog->setFBSuffices(InterfaceUtils::getSampleFBSuffixes(tabName));
+  dialog->setLoadProperty("LoadHistory", SettingsHelper::loadHistory());
   dialog->updateSelectedSpectra();
   dialog->show();
 }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.cpp
@@ -14,7 +14,6 @@ namespace MantidQt::CustomInterfaces::Inelastic {
 
 FunctionQAddWorkspaceDialog::FunctionQAddWorkspaceDialog(QWidget *parent) : QDialog(parent) {
   m_uiForm.setupUi(this);
-  m_uiForm.dsWorkspace->setLoadProperty("LoadHistory", false);
 
   connect(m_uiForm.dsWorkspace, SIGNAL(dataReady(const QString &)), this, SLOT(emitWorkspaceChanged(const QString &)));
   connect(m_uiForm.dsWorkspace, SIGNAL(filesAutoLoaded()), this, SLOT(handleAutoLoaded()));
@@ -63,6 +62,10 @@ void FunctionQAddWorkspaceDialog::setWSSuffices(const QStringList &suffices) {
 
 void FunctionQAddWorkspaceDialog::setFBSuffices(const QStringList &suffices) {
   m_uiForm.dsWorkspace->setFBSuffixes(suffices);
+}
+
+void FunctionQAddWorkspaceDialog::setLoadProperty(const std::string &propName, bool enable) {
+  m_uiForm.dsWorkspace->setLoadProperty(propName, enable);
 }
 
 void FunctionQAddWorkspaceDialog::emitWorkspaceChanged(const QString &name) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.h
@@ -29,6 +29,7 @@ public:
   void setParameterNames(const std::vector<std::string> &names);
   void setWSSuffices(const QStringList &suffices) override;
   void setFBSuffices(const QStringList &suffices) override;
+  void setLoadProperty(const std::string &propname, bool enable) override;
 
   void enableParameterSelection();
   void disableParameterSelection();

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataView.cpp
@@ -51,6 +51,7 @@ void FunctionQDataView::showAddWorkspaceDialog() {
   dialog->setAttribute(Qt::WA_DeleteOnClose);
   dialog->setWSSuffices(InterfaceUtils::getSampleWSSuffixes(tabName));
   dialog->setFBSuffices(InterfaceUtils::getSampleFBSuffixes(tabName));
+  dialog->setLoadProperty("LoadHistory", SettingsHelper::loadHistory());
   dialog->updateSelectedSpectra();
   dialog->show();
 }

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/FitDataPresenterTest.h
@@ -60,6 +60,10 @@ public:
   virtual std::string workspaceName() const override { return "Name"; }
   virtual void setWSSuffices(const QStringList &suffices) override { (void)suffices; }
   virtual void setFBSuffices(const QStringList &suffices) override { (void)suffices; }
+  virtual void setLoadProperty(const std::string &propName, bool enabled) override {
+    (void)propName;
+    (void)enabled;
+  }
 
   virtual void updateSelectedSpectra() override {}
 };

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -521,6 +521,7 @@ public:
 
   MOCK_METHOD1(setFBSuffixes, void(QStringList const &suffix));
   MOCK_METHOD1(setWSSuffixes, void(QStringList const &suffix));
+  MOCK_METHOD1(setLoadHistory, void(bool doLoad));
 
   MOCK_METHOD1(setPlotPropertyRange, void(const QPair<double, double> &bounds));
   MOCK_METHOD1(setRangeSelector, void(const QPair<double, double> &bounds));

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -521,7 +521,7 @@ public:
 
   MOCK_METHOD1(setFBSuffixes, void(QStringList const &suffix));
   MOCK_METHOD1(setWSSuffixes, void(QStringList const &suffix));
-  MOCK_METHOD1(setLoadHistory, void(bool doLoad));
+  MOCK_METHOD1(setLoadHistory, void(bool doLoadHistory));
 
   MOCK_METHOD1(setPlotPropertyRange, void(const QPair<double, double> &bounds));
   MOCK_METHOD1(setRangeSelector, void(const QPair<double, double> &bounds));

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceDialog.h
@@ -28,6 +28,7 @@ public:
 
   void setWSSuffices(const QStringList &suffices) override;
   void setFBSuffices(const QStringList &suffices) override;
+  void setLoadProperty(const std::string &propName, bool enable) override;
 
   void updateSelectedSpectra() override;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
@@ -13,6 +13,7 @@
 
 #include <vector>
 
+#include <MantidAPI/AlgorithmRuntimeProps.h>
 #include <QDialog>
 
 namespace MantidQt {
@@ -31,6 +32,7 @@ public:
   bool isEmpty() const;
   void setWSSuffices(const QStringList &suffices) override;
   void setFBSuffices(const QStringList &suffices) override;
+  void setLoadProperty(const std::string &propname, bool enable) override;
   void setup();
 
   void notifyBatchComplete(bool error) override;
@@ -54,6 +56,7 @@ private:
   Ui::AddWorkspaceMultiDialog m_uiForm;
   /// Algorithm Runner used to run the load algorithm
   std::unique_ptr<MantidQt::API::QtJobRunner> m_algRunner;
+  Mantid::API::AlgorithmRuntimeProps m_loadProperties;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IAddWorkspaceDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IAddWorkspaceDialog.h
@@ -20,6 +20,7 @@ public:
   virtual std::string workspaceName() const = 0;
   virtual void setWSSuffices(const QStringList &suffices) = 0;
   virtual void setFBSuffices(const QStringList &suffices) = 0;
+  virtual void setLoadProperty(const std::string &propname, bool enable) = 0;
 
   virtual void updateSelectedSpectra() = 0;
 };

--- a/qt/widgets/common/src/AddWorkspaceDialog.cpp
+++ b/qt/widgets/common/src/AddWorkspaceDialog.cpp
@@ -38,6 +38,10 @@ void AddWorkspaceDialog::setWSSuffices(const QStringList &suffices) { m_uiForm.d
 
 void AddWorkspaceDialog::setFBSuffices(const QStringList &suffices) { m_uiForm.dsWorkspace->setFBSuffixes(suffices); }
 
+void AddWorkspaceDialog::setLoadProperty(const std::string &propName, bool enable) {
+  m_uiForm.dsWorkspace->setLoadProperty(propName, enable);
+}
+
 void AddWorkspaceDialog::updateSelectedSpectra() {
   auto const state = m_uiForm.ckAllSpectra->isChecked() ? Qt::Checked : Qt::Unchecked;
   selectAllSpectra(state);

--- a/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
+++ b/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/AddWorkspaceMultiDialog.h"
 #include "MantidAPI/AlgorithmManager.h"
+#include <MantidAPI/AlgorithmProperties.h>
 #include <MantidAPI/AlgorithmRuntimeProps.h>
 #include <MantidQtWidgets/Common/ConfiguredAlgorithm.h>
 #include <QFileInfo>
@@ -14,13 +15,16 @@
 namespace {
 using namespace Mantid::API;
 
-MantidQt::API::IConfiguredAlgorithm_sptr configureLoadAlgorithm(const QString &filename) {
+MantidQt::API::IConfiguredAlgorithm_sptr configureLoadAlgorithm(const QString &filename,
+                                                                const AlgorithmRuntimeProps &loadProps) {
   QFileInfo const fileinfo(filename);
   auto loader = AlgorithmManager::Instance().createUnmanaged("Load");
   loader->initialize();
+  loader->setProperty("Filename", filename.toStdString());
+  loader->setProperty("OutputWorkspace", fileinfo.baseName().toStdString());
+  loader->updatePropertyValues(loadProps);
   auto properties = std::make_unique<AlgorithmRuntimeProps>();
-  properties->setProperty("Filename", filename.toStdString());
-  properties->setProperty("OutputWorkspace", fileinfo.baseName().toStdString());
+
   return std::make_shared<MantidQt::API::ConfiguredAlgorithm>(loader, std::move(properties));
 }
 } // namespace
@@ -28,7 +32,7 @@ MantidQt::API::IConfiguredAlgorithm_sptr configureLoadAlgorithm(const QString &f
 namespace MantidQt::MantidWidgets {
 
 AddWorkspaceMultiDialog::AddWorkspaceMultiDialog(QWidget *parent)
-    : QDialog(parent), m_algRunner(std::make_unique<API::QtJobRunner>()) {
+    : QDialog(parent), m_algRunner(std::make_unique<API::QtJobRunner>()), m_loadProperties() {
   m_uiForm.setupUi(this);
   m_algRunner->subscribe(this);
   connect(m_uiForm.pbSelAll, SIGNAL(clicked()), this, SLOT(selectAllSpectra()));
@@ -61,6 +65,18 @@ void AddWorkspaceMultiDialog::setFBSuffices(const QStringList &suffices) {
   return m_uiForm.dsInputFiles->setFileExtensions(suffices);
 }
 
+/**
+ * Set an extra property on the load algorithm  of the workspace multi dialog
+ * before execution
+ *
+ * @param propertyName :: The name of the Load algorithm property to be set
+ * @param value :: The value of the Load algorithm property to be set
+ */
+
+void AddWorkspaceMultiDialog::setLoadProperty(const std::string &propName, bool enable) {
+  Mantid::API::AlgorithmProperties::update(propName, enable, m_loadProperties);
+}
+
 void AddWorkspaceMultiDialog::selectAllSpectra() { return m_uiForm.tbWorkspace->selectAll(); }
 
 void AddWorkspaceMultiDialog::emitAddData() { emit addData(this); }
@@ -74,7 +90,7 @@ void AddWorkspaceMultiDialog::handleFilesFound() {
   auto fileNames = m_uiForm.dsInputFiles->getFilenames();
   std::deque<API::IConfiguredAlgorithm_sptr> loadQueue;
   std::transform(fileNames.begin(), fileNames.end(), std::back_inserter(loadQueue),
-                 [](auto const &fileName) { return configureLoadAlgorithm(fileName); });
+                 [&](auto const &fileName) { return configureLoadAlgorithm(fileName, m_loadProperties); });
   m_algRunner->setAlgorithmQueue(loadQueue);
   m_algRunner->executeAlgorithmQueue();
 }

--- a/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
+++ b/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
@@ -69,8 +69,8 @@ void AddWorkspaceMultiDialog::setFBSuffices(const QStringList &suffices) {
  * Set an extra property on the load algorithm  of the workspace multi dialog
  * before execution
  *
- * @param propertyName :: The name of the Load algorithm property to be set
- * @param value :: The value of the Load algorithm property to be set
+ * @param propName :: The name of the Load algorithm property to be set
+ * @param enable :: The value of the Load algorithm property to be set
  */
 
 void AddWorkspaceMultiDialog::setLoadProperty(const std::string &propName, bool enable) {

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/MockObjects.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/MockObjects.h
@@ -116,6 +116,9 @@ public:
   MOCK_METHOD1(setPlotErrorBarsChecked, void(bool check));
   MOCK_CONST_METHOD0(isPlotErrorBarsChecked, bool());
 
+  MOCK_METHOD1(setLoadHistoryChecked, void(bool check));
+  MOCK_CONST_METHOD0(isLoadHistoryChecked, bool());
+
   MOCK_METHOD1(setDeveloperFeatureFlags, void(QStringList const &flags));
   MOCK_CONST_METHOD0(developerFeatureFlags, QStringList());
 

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/ISettingsView.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/ISettingsView.h
@@ -31,6 +31,9 @@ public:
   virtual void setPlotErrorBarsChecked(bool check) = 0;
   virtual bool isPlotErrorBarsChecked() const = 0;
 
+  virtual void setLoadHistoryChecked(bool check) = 0;
+  virtual bool isLoadHistoryChecked() const = 0;
+
   virtual void setDeveloperFeatureFlags(QStringList const &flags) = 0;
   virtual QStringList developerFeatureFlags() const = 0;
 

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/InterfaceSettings.ui
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/InterfaceSettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>495</width>
-    <height>283</height>
+    <height>313</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -89,6 +89,16 @@
           <widget class="QCheckBox" name="ckPlotErrorBars">
            <property name="text">
             <string>Plot error bars for external plots</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="ckLoadHistory">
+           <property name="text">
+            <string>Load History</string>
            </property>
            <property name="checked">
             <bool>true</bool>

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/InterfaceSettings.ui
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/InterfaceSettings.ui
@@ -98,7 +98,7 @@
          <item>
           <widget class="QCheckBox" name="ckLoadHistory">
            <property name="text">
-            <string>Load History</string>
+            <string>Load Workspace History (slower)</string>
            </property>
            <property name="checked">
             <bool>true</bool>

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h
@@ -25,6 +25,7 @@ MANTID_SPECTROSCOPY_DLL bool externalPlotErrorBars();
 MANTID_SPECTROSCOPY_DLL bool loadHistory();
 MANTID_SPECTROSCOPY_DLL QStringList developerFeatureFlags();
 MANTID_SPECTROSCOPY_DLL bool hasDevelopmentFlag(std::string const &flag);
+MANTID_SPECTROSCOPY_DLL bool indirectSettingsCreated();
 
 } // namespace SettingsHelper
 } // namespace CustomInterfaces

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h
@@ -17,10 +17,12 @@ namespace SettingsHelper {
 
 MANTID_SPECTROSCOPY_DLL void setRestrictInputDataByName(bool restricted);
 MANTID_SPECTROSCOPY_DLL void setExternalPlotErrorBars(bool errorBars);
+MANTID_SPECTROSCOPY_DLL void setLoadHistory(bool loadHistory);
 MANTID_SPECTROSCOPY_DLL void setDeveloperFeatureFlags(QStringList const &flags);
 
 MANTID_SPECTROSCOPY_DLL bool restrictInputDataByName();
 MANTID_SPECTROSCOPY_DLL bool externalPlotErrorBars();
+MANTID_SPECTROSCOPY_DLL bool loadHistory();
 MANTID_SPECTROSCOPY_DLL QStringList developerFeatureFlags();
 MANTID_SPECTROSCOPY_DLL bool hasDevelopmentFlag(std::string const &flag);
 

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h
@@ -25,8 +25,6 @@ MANTID_SPECTROSCOPY_DLL bool externalPlotErrorBars();
 MANTID_SPECTROSCOPY_DLL bool loadHistory();
 MANTID_SPECTROSCOPY_DLL QStringList developerFeatureFlags();
 MANTID_SPECTROSCOPY_DLL bool hasDevelopmentFlag(std::string const &flag);
-MANTID_SPECTROSCOPY_DLL bool indirectSettingsCreated();
-
 } // namespace SettingsHelper
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsPresenter.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsPresenter.h
@@ -24,7 +24,6 @@ public:
   QWidget *getView();
   void subscribeParent(ISettings *parent);
 
-  void iniSettings();
   void loadSettings();
 
   void notifyOkClicked();

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsPresenter.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsPresenter.h
@@ -24,6 +24,7 @@ public:
   QWidget *getView();
   void subscribeParent(ISettings *parent);
 
+  void iniSettings();
   void loadSettings();
 
   void notifyOkClicked();

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsView.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsView.h
@@ -39,6 +39,9 @@ public:
   void setPlotErrorBarsChecked(bool check) override;
   bool isPlotErrorBarsChecked() const override;
 
+  void setLoadHistoryChecked(bool check) override;
+  bool isLoadHistoryChecked() const override;
+
   void setDeveloperFeatureFlags(QStringList const &flags) override;
   QStringList developerFeatureFlags() const override;
 

--- a/qt/widgets/spectroscopy/src/InelasticTab.cpp
+++ b/qt/widgets/spectroscopy/src/InelasticTab.cpp
@@ -19,6 +19,7 @@
 #include "MantidQtWidgets/Common/InterfaceManager.h"
 #include "MantidQtWidgets/Plotting/RangeSelector.h"
 
+#include <MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h>
 #include <QDomDocument>
 #include <QFile>
 #include <QMessageBox>

--- a/qt/widgets/spectroscopy/src/SettingsWidget/Settings.cpp
+++ b/qt/widgets/spectroscopy/src/SettingsWidget/Settings.cpp
@@ -40,6 +40,7 @@ std::map<std::string, QVariant> Settings::getSettings() {
   std::map<std::string, QVariant> interfaceSettings;
   interfaceSettings["RestrictInput"] = SettingsHelper::restrictInputDataByName();
   interfaceSettings["ErrorBars"] = SettingsHelper::externalPlotErrorBars();
+  interfaceSettings["LoadHistory"] = SettingsHelper::loadHistory();
   return interfaceSettings;
 }
 

--- a/qt/widgets/spectroscopy/src/SettingsWidget/SettingsHelper.cpp
+++ b/qt/widgets/spectroscopy/src/SettingsWidget/SettingsHelper.cpp
@@ -10,7 +10,6 @@
 #include <QString>
 #include <QStringList>
 #include <QVariant>
-#include <iostream>
 
 namespace {
 

--- a/qt/widgets/spectroscopy/src/SettingsWidget/SettingsHelper.cpp
+++ b/qt/widgets/spectroscopy/src/SettingsWidget/SettingsHelper.cpp
@@ -14,6 +14,9 @@
 
 namespace {
 
+QMap<std::string, QVariant> defaultSettings = {
+    {"restrict-input-by-name", true}, {"plot-error-bars-external", false}, {"load-history", true}};
+
 template <typename T> void setSetting(std::string const &settingGroup, std::string const &settingName, T const &value) {
   QSettings settings;
   settings.beginGroup(QString::fromStdString(settingGroup));
@@ -24,7 +27,7 @@ template <typename T> void setSetting(std::string const &settingGroup, std::stri
 QVariant getSetting(std::string const &settingGroup, std::string const &settingName) {
   QSettings settings;
   settings.beginGroup(QString::fromStdString(settingGroup));
-  auto const settingValue = settings.value(QString::fromStdString(settingName));
+  auto const settingValue = settings.value(QString::fromStdString(settingName), defaultSettings[settingName]);
   settings.endGroup();
 
   return settingValue;
@@ -65,11 +68,4 @@ void setExternalPlotErrorBars(bool errorBars) { setSetting(INDIRECT_SETTINGS_GRO
 void setDeveloperFeatureFlags(QStringList const &flags) {
   setSetting(INDIRECT_SETTINGS_GROUP, FEATURE_FLAGS_PROPERTY, flags);
 }
-
-bool indirectSettingsCreated() {
-  // Any Indirect Settings path will suffice, as all indirect settings are created in the same function call.
-  auto const settingPath = QString::fromStdString(INDIRECT_SETTINGS_GROUP + "/" + LOAD_HISTORY_PROPERTY);
-  return QSettings().contains(settingPath);
-}
-
 } // namespace MantidQt::CustomInterfaces::SettingsHelper

--- a/qt/widgets/spectroscopy/src/SettingsWidget/SettingsHelper.cpp
+++ b/qt/widgets/spectroscopy/src/SettingsWidget/SettingsHelper.cpp
@@ -10,6 +10,7 @@
 #include <QString>
 #include <QStringList>
 #include <QVariant>
+#include <iostream>
 
 namespace {
 
@@ -28,6 +29,7 @@ QVariant getSetting(std::string const &settingGroup, std::string const &settingN
 
   return settingValue;
 }
+
 } // namespace
 
 namespace MantidQt::CustomInterfaces::SettingsHelper {
@@ -62,6 +64,12 @@ void setExternalPlotErrorBars(bool errorBars) { setSetting(INDIRECT_SETTINGS_GRO
 
 void setDeveloperFeatureFlags(QStringList const &flags) {
   setSetting(INDIRECT_SETTINGS_GROUP, FEATURE_FLAGS_PROPERTY, flags);
+}
+
+bool indirectSettingsCreated() {
+  // Any Indirect Settings path will suffice, as all indirect settings are created in the same function call.
+  auto const settingPath = QString::fromStdString(INDIRECT_SETTINGS_GROUP + "/" + LOAD_HISTORY_PROPERTY);
+  return QSettings().contains(settingPath);
 }
 
 } // namespace MantidQt::CustomInterfaces::SettingsHelper

--- a/qt/widgets/spectroscopy/src/SettingsWidget/SettingsHelper.cpp
+++ b/qt/widgets/spectroscopy/src/SettingsWidget/SettingsHelper.cpp
@@ -35,11 +35,14 @@ namespace MantidQt::CustomInterfaces::SettingsHelper {
 static std::string const INDIRECT_SETTINGS_GROUP("Indirect Settings");
 static std::string const RESTRICT_DATA_PROPERTY("restrict-input-by-name");
 static std::string const ERROR_BARS_PROPERTY("plot-error-bars-external");
+static std::string const LOAD_HISTORY_PROPERTY("load-history");
 static std::string const FEATURE_FLAGS_PROPERTY("developer-feature-flags");
 
 bool restrictInputDataByName() { return getSetting(INDIRECT_SETTINGS_GROUP, RESTRICT_DATA_PROPERTY).toBool(); }
 
 bool externalPlotErrorBars() { return getSetting(INDIRECT_SETTINGS_GROUP, ERROR_BARS_PROPERTY).toBool(); }
+
+bool loadHistory() { return getSetting(INDIRECT_SETTINGS_GROUP, LOAD_HISTORY_PROPERTY).toBool(); }
 
 QStringList developerFeatureFlags() {
   return getSetting(INDIRECT_SETTINGS_GROUP, FEATURE_FLAGS_PROPERTY).toStringList();
@@ -52,6 +55,8 @@ bool hasDevelopmentFlag(std::string const &flag) {
 void setRestrictInputDataByName(bool restricted) {
   setSetting(INDIRECT_SETTINGS_GROUP, RESTRICT_DATA_PROPERTY, restricted);
 }
+
+void setLoadHistory(bool loadHistory) { setSetting(INDIRECT_SETTINGS_GROUP, LOAD_HISTORY_PROPERTY, loadHistory); }
 
 void setExternalPlotErrorBars(bool errorBars) { setSetting(INDIRECT_SETTINGS_GROUP, ERROR_BARS_PROPERTY, errorBars); }
 

--- a/qt/widgets/spectroscopy/src/SettingsWidget/SettingsPresenter.cpp
+++ b/qt/widgets/spectroscopy/src/SettingsWidget/SettingsPresenter.cpp
@@ -39,6 +39,7 @@ void SettingsPresenter::loadSettings() {
 
   m_view->setRestrictInputByNameChecked(restrictInputDataByName());
   m_view->setPlotErrorBarsChecked(externalPlotErrorBars());
+  m_view->setLoadHistoryChecked(loadHistory());
 
   m_view->setDeveloperFeatureFlags(developerFeatureFlags());
 }
@@ -48,6 +49,7 @@ void SettingsPresenter::saveSettings() {
 
   setRestrictInputDataByName(m_view->isRestrictInputByNameChecked());
   setExternalPlotErrorBars(m_view->isPlotErrorBarsChecked());
+  setLoadHistory(m_view->isLoadHistoryChecked());
 
   setDeveloperFeatureFlags(m_view->developerFeatureFlags());
 

--- a/qt/widgets/spectroscopy/src/SettingsWidget/SettingsPresenter.cpp
+++ b/qt/widgets/spectroscopy/src/SettingsWidget/SettingsPresenter.cpp
@@ -14,12 +14,21 @@ using namespace SettingsHelper;
 SettingsPresenter::SettingsPresenter(std::unique_ptr<SettingsModel> model, ISettingsView *view)
     : m_model(std::move(model)), m_view(view) {
   m_view->subscribePresenter(this);
+  iniSettings();
   loadSettings();
 }
 
 QWidget *SettingsPresenter::getView() { return m_view->getView(); }
 
 void SettingsPresenter::subscribeParent(ISettings *parent) { m_parent = parent; }
+
+void SettingsPresenter::iniSettings() {
+  if (!indirectSettingsCreated()) {
+    setRestrictInputDataByName(true);
+    setExternalPlotErrorBars(false);
+    setLoadHistory(true);
+  }
+}
 
 void SettingsPresenter::notifyOkClicked() {
   saveSettings();

--- a/qt/widgets/spectroscopy/src/SettingsWidget/SettingsPresenter.cpp
+++ b/qt/widgets/spectroscopy/src/SettingsWidget/SettingsPresenter.cpp
@@ -14,21 +14,12 @@ using namespace SettingsHelper;
 SettingsPresenter::SettingsPresenter(std::unique_ptr<SettingsModel> model, ISettingsView *view)
     : m_model(std::move(model)), m_view(view) {
   m_view->subscribePresenter(this);
-  iniSettings();
   loadSettings();
 }
 
 QWidget *SettingsPresenter::getView() { return m_view->getView(); }
 
 void SettingsPresenter::subscribeParent(ISettings *parent) { m_parent = parent; }
-
-void SettingsPresenter::iniSettings() {
-  if (!indirectSettingsCreated()) {
-    setRestrictInputDataByName(true);
-    setExternalPlotErrorBars(false);
-    setLoadHistory(true);
-  }
-}
 
 void SettingsPresenter::notifyOkClicked() {
   saveSettings();

--- a/qt/widgets/spectroscopy/src/SettingsWidget/SettingsView.cpp
+++ b/qt/widgets/spectroscopy/src/SettingsWidget/SettingsView.cpp
@@ -51,6 +51,10 @@ void SettingsView::setPlotErrorBarsChecked(bool check) { m_uiForm->ckPlotErrorBa
 
 bool SettingsView::isPlotErrorBarsChecked() const { return m_uiForm->ckPlotErrorBars->isChecked(); }
 
+void SettingsView::setLoadHistoryChecked(bool check) { m_uiForm->ckLoadHistory->setChecked(check); }
+
+bool SettingsView::isLoadHistoryChecked() const { return m_uiForm->ckLoadHistory->isChecked(); }
+
 void SettingsView::setDeveloperFeatureFlags(QStringList const &flags) {
   m_uiForm->leDeveloperFeatureFlags->setText(flags.join(" "));
 }

--- a/qt/widgets/spectroscopy/test/SettingsWidget/SettingsPresenterTest.h
+++ b/qt/widgets/spectroscopy/test/SettingsWidget/SettingsPresenterTest.h
@@ -95,6 +95,7 @@ private:
     ON_CALL(*m_view, getSelectedFacility()).WillByDefault(Return(QString::fromStdString(facility)));
     ON_CALL(*m_view, isRestrictInputByNameChecked()).WillByDefault(Return(true));
     ON_CALL(*m_view, isPlotErrorBarsChecked()).WillByDefault(Return(true));
+    ON_CALL(*m_view, isLoadHistoryChecked()).WillByDefault(Return(true));
     ON_CALL(*m_view, developerFeatureFlags()).WillByDefault(Return(QStringList{""}));
 
     Expectation expectation = EXPECT_CALL(*m_view, getSelectedFacility()).Times(1);


### PR DESCRIPTION
### Description of work
This PR adds an option to the Indirect Settings dialog to load the history of a workspace, for details see #37691 . This will allow for faster workflows as sometimes loading the history can slog the loading algorithm #36769. 
This setting is now available in most indirect/inelastic interfaces that preload data using 'LoadNexusProcessed' algorithm to the ADS (as the ones having data selectors or workspace dialogs for selecting input data). It won't be available for loaders that load raw files (like in diffraction or data reduction interfaces). 



Fixes #37691 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
As there are many affected interfaces, the instructions are slightly tedious, I'm sorry for that. 

- First, make sure to delete the `[Indirect Settings]` and any setting in that group from the `mantidworkbench.ini` file that stores the settings in your machine. (You can find 'mantidworkbench.ini' either in `%APPDATA/../mantidproject` on Windows or in `.config/mantidproject` on MacOS  and Linux.) . Then save the file. 
- Open Mantid Workbench, and then any Indirect/Inelastic interface. Once on the interface, click on the cog icon for the settings, which should be located at the bottom left corner of the interface. The settings dialog will open. 
- On the settings dialog, the options: `Restrict allowed input files by name` and `Load Workspace History` should be ticked by default. Close the dialog. 

Now, for every Inelastic Interface, do the following for each tab (except  on `Calculate Paalman Pings` which is deprecated): 

- Open the settings dialog and tick on the `Load Workspace History` setting. 
- Load sample data for the respective interface (either with a dialog, or from the data selector)
- Once the sample data is loaded onto the ADS, right-click on the workspace and select `Show History`. You should see the history log for that workspace. 
- Clear the ADS. 
- Open the Settings dialog again and untick the `Load Workspace History` setting.
- Load the same sample data as before. 
- Once the sample data is loaded onto the ADS, right-click on the workspace and select `Show History`. You should see only 1 entry on the history log (the load algorithm). 
- Move onto the next interface. 

For the Indirect Interfaces, it is only necessary to do the loading history check with the Calibration Data Selector of the `ISIS Energy Transfer` and `ISIS Diagnostics` tabs (the one allowing to load calibration files) and with the Transmission tab. 

Finally, build the docs and check that the `Interfaces/Indirect Settings` section contains and entry for the load history settings. Check that is well formatted and understandable. 


*A release note has been added and the documentation entry for settings dialog updated*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
