### PR TITLE
Fix polarization corrections not being applied in ReflectometryReductionOneLiveData

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -37,6 +37,11 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
     def seeAlso(self):
         return ["ReflectometryISISLoadAndProcess", "StartLiveData"]
 
+    def checkGroups(self):
+        """Prevent the default behaviour when a workspace group is passed in so that we can pass the whole group
+        through to the reduction algorithm"""
+        return False
+
     def PyInit(self):
         instruments = ["CRISP", "INTER", "OFFSPEC", "POLREF", "SURF"]
         defaultInstrument = str(config.getInstrument())
@@ -171,12 +176,12 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
         """Set up instrument parameters for the slits"""
         s1 = liveValues[self._s1vg_name()].value
         s2 = liveValues[self._s2vg_name()].value
-        SetInstrumentParameter(
-            Workspace=self._temp_ws_name, ParameterName="vertical gap", ParameterType="Number", ComponentName="slit1", Value=str(s1)
-        )
-        SetInstrumentParameter(
-            Workspace=self._temp_ws_name, ParameterName="vertical gap", ParameterType="Number", ComponentName="slit2", Value=str(s2)
-        )
+        output_ws = AnalysisDataService.retrieve(self._temp_ws_name)
+
+        ws_list = output_ws if isinstance(output_ws, WorkspaceGroup) else [output_ws]
+        for ws in ws_list:
+            SetInstrumentParameter(Workspace=ws, ParameterName="vertical gap", ParameterType="Number", ComponentName="slit1", Value=str(s1))
+            SetInstrumentParameter(Workspace=ws, ParameterName="vertical gap", ParameterType="Number", ComponentName="slit2", Value=str(s2))
 
     def _copy_property_values_to(self, alg):
         for prop in self._child_properties:

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -136,6 +136,8 @@ AlgorithmFactory.subscribe(GetFakeLiveInstrumentValuesWithZeroTheta)
 
 
 class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
+    INPUT_WS_ERROR = "Invalid value for property InputWorkspace"
+
     def setUp(self):
         self._setup_environment()
         self._setup_workspaces()
@@ -173,16 +175,16 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         self.assertRaises(TypeError, ReflectometryReductionOneLiveData)
 
     def test_invalid_input_workspace(self):
-        self.assertRaises(ValueError, ReflectometryReductionOneLiveData, InputWorkspace="bad")
+        self.assertRaisesRegex(ValueError, self.INPUT_WS_ERROR, ReflectometryReductionOneLiveData, InputWorkspace="bad")
 
     def test_invalid_output_workspace(self):
-        self.assertRaises(RuntimeError, ReflectometryReductionOneLiveData, InputWorkspace=self.__class__._input_ws, OutputWorkspace="")
+        self.assertRaises(RuntimeError, ReflectometryReductionOneLiveData, InputWorkspace=self._input_ws, OutputWorkspace="")
 
     def test_invalid_property(self):
         self.assertRaises(
             TypeError,
             ReflectometryReductionOneLiveData,
-            InputWorkspace=self.__class__._input_ws,
+            InputWorkspace=self._input_ws,
             OutputWorkspace="output",
             Instrument="INTER",
             GetLiveValueAlgorithm="GetFakeLiveInstrumentValue",
@@ -220,7 +222,7 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
     def test_instrument_was_not_set_on_input_workspace(self):
         workspace = self._run_algorithm_with_defaults()
         # The input workspace should be unchanged
-        self.assertEqual(self.__class__._input_ws.getInstrument().getName(), "")
+        self.assertEqual(self._input_ws.getInstrument().getName(), "")
 
     def test_sample_log_values_were_set_on_output_workspace(self):
         workspace = self._run_algorithm_with_defaults()
@@ -259,7 +261,7 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
             RuntimeError,
             "Unknown algorithm 'GetFakeLiveInstrumentValueInvalidNames'",
             ReflectometryReductionOneLiveData,
-            InputWorkspace=self.__class__._input_ws,
+            InputWorkspace=self._input_ws,
             OutputWorkspace="output",
             Instrument="INTER",
             GetLiveValueAlgorithm="GetFakeLiveInstrumentValueInvalidNames",
@@ -302,9 +304,9 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         config["default.instrument"] = self._old_instrument
 
     def _setup_workspaces(self):
-        self.__class__._input_ws = self._create_test_workspace()
+        self._input_ws = self._create_test_workspace()
         self._default_args = {
-            "InputWorkspace": self.__class__._input_ws,
+            "InputWorkspace": self._input_ws,
             "OutputWorkspace": "output",
             "Instrument": "INTER",
             "GetLiveValueAlgorithm": "GetFakeLiveInstrumentValue",

--- a/docs/source/release/v6.11.0/Reflectometry/Bugfixes/34904.rst
+++ b/docs/source/release/v6.11.0/Reflectometry/Bugfixes/34904.rst
@@ -1,0 +1,1 @@
+- Fix a bug where :ref:`algm-ReflectometryReductionOneLiveData` was not applying polarization corrections because it did not handle WorkspaceGroup inputs correctly.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Algorithm `ReflectometryReductionOneLiveData` was not applying polarization corrections because these corrections are only applied when a workspace group has been passed through to the reduction algorithm (`ReflectometryReductionOneAuto`). This wasn't happening because `ReflectometryReductionOneLiveData` was not set up to override the default handling of workspace groups, so when passed a group it just looped through and passed each child workspace individually to the reduction algorithm. This PR makes use of the `checkGroups()` method to override this behaviour and allow us to handle the workspace group instead.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #34904. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

**Report to:** Becky in the Reflectometry Group at ISIS

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
As well as implementing the `checkGroups()` method, it was necessary to make a small change to the algorithm's calls to `SetInstrumentParameter`, as this doesn't seem to take the name of a workspace group and so we need to loop through the child workspaces instead.

I have added a test that fails if we're not handling workspace groups correctly. I also made a few very minor tidy-ups to the existing tests.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Running `ReflectometryReductionOneLiveData` normally requires us to be in cycle as information is picked up from the instrument. To override this behaviour for testing, amend the algorithm code as follows:

1) In method `_live_value_list`, edit the existing code to provide values for `_theta_name`, `_s1vg_name` and `_s2vg_name` to give:

```
self._theta_name(): LiveValue(2.3, "deg", self._alternative_theta_name(), LiveValue.LOG_TYPE_NUM_SERIES),
self._s1vg_name(): LiveValue(1.0, "m", self._alternative_s1vg_name(), LiveValue.LOG_TYPE_NUM_SERIES),
self._s2vg_name(): LiveValue(3.0, "m", self._alternative_s2vg_name(), LiveValue.LOG_TYPE_NUM_SERIES),
```

2) In method `_get_live_values_from_instrument`, edit the existing code to do nothing when an exception is raised after trying to look up values from the instrument:

```
try:
    liveValue.value = self._get_block_value_from_instrument(name)
except:
    pass
    # self.log().information("Failed to get value " + name + " from the instrument; trying " + liveValue.alternative_name)
    # liveValue.value = self._get_block_value_from_instrument(liveValue.alternative_name)
```

3) After making the above amendments to the `ReflectometryReductionOneLiveData` algorithm, start-up Mantid and run the following script:

```
grp = LoadISISNexus("POLREF00037125")
P1 = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=(1 + tanh(0.0733 * 12 * x * 0.2))/2',XUnit='Wavelength', xMin='1.0032467124235502',XMax='14.99788120223049', BinWidth='0.0035', NumBanks='1', BankPixelWidth='1')
P2 = P1.clone()
F1 = P1.clone()
F2 = P1.clone()
efficiencies = JoinISISPolarizationEfficiencies(P1=P1, P2=P2, F1=F1, F2=F2)
ReflectometryReductionOneLiveData(InputWorkspace="grp", Instrument='POLREF', PolarizationAnalysis=True, PolarizationEfficiencies=efficiencies)
```

There should be an `IvsLam_37125` workspace group in the workspaces list. Expand this and you should see that the child workspace names are suffixed with either `++` or `--`, which indicates that polarization corrections have been applied. 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
