### PR TITLE
Add option to not delete subtracted workspace in container subtraction tab

### DIFF
--- a/docs/source/interfaces/inelastic/Inelastic Corrections.rst
+++ b/docs/source/interfaces/inelastic/Inelastic Corrections.rst
@@ -35,6 +35,8 @@ Manage Directories
   Opens the Manage Directories dialog allowing you to change your search directories
   and default save directory and enable/disable data archive search.
 
+.. _container-subtraction:
+
 Container Subtraction
 ---------------------
 

--- a/docs/source/release/v6.11.0/Inelastic/New_features/37763.rst
+++ b/docs/source/release/v6.11.0/Inelastic/New_features/37763.rst
@@ -1,0 +1,1 @@
+- Add option to not delete subtracted workspaces when adding new data in the :ref:`Container Subtraction <container-subtraction>` tab of the Corrections interface.

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
@@ -62,8 +62,12 @@ ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent) : Correc
 }
 
 ApplyAbsorptionCorrections::~ApplyAbsorptionCorrections() {
-  if (m_ppContainerWS)
+  if (m_ppContainerWS) {
+    (void)m_uiForm.dsSample->disconnect();
+    (void)m_uiForm.dsContainer->disconnect();
+    (void)m_uiForm.dsContainer->disconnect();
     AnalysisDataService::Instance().remove(m_containerWorkspaceName);
+  }
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
@@ -179,17 +179,6 @@ std::string ContainerSubtraction::createOutputName() {
   return outputWsName.toStdString();
 }
 
-/**
- * Removes the output workspace from the ADS if exists
- */
-void ContainerSubtraction::removeOutput() {
-  auto &ads = AnalysisDataService::Instance();
-  if (ads.doesExist(m_pythonExportWsName)) {
-    ads.remove(m_pythonExportWsName);
-  }
-  m_pythonExportWsName.clear();
-}
-
 void ContainerSubtraction::loadSettings(const QSettings &settings) {
   m_uiForm.dsContainer->readSettings(settings.group());
   m_uiForm.dsSample->readSettings(settings.group());

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
@@ -212,9 +212,6 @@ void ContainerSubtraction::newSample(const QString &dataName) {
   // Remove old sample and fit curves from plot
   m_uiForm.ppPreview->removeSpectrum("Subtracted");
   m_uiForm.ppPreview->removeSpectrum("Sample");
-  // Remove the subtracted workspace if option is checked
-  if (m_uiForm.ckRemoveSub->isChecked())
-    removeOutput();
 
   m_csSampleWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(dataName.toStdString());
   // Get new workspace
@@ -244,9 +241,6 @@ void ContainerSubtraction::newContainer(const QString &dataName) {
   // Remove old container and fit
   m_uiForm.ppPreview->removeSpectrum("Subtracted");
   m_uiForm.ppPreview->removeSpectrum("Container");
-  // Remove the subtracted workspace if option is checked
-  if (m_uiForm.ckRemoveSub->isChecked())
-    removeOutput();
 
   // Get new workspace
   m_csContainerWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(dataName.toStdString());

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.h
@@ -51,7 +51,6 @@ private:
   void plotInPreview(const QString &curveName, Mantid::API::MatrixWorkspace_sptr &ws, const QColor &curveColor);
 
   std::string createOutputName();
-  void removeOutput();
 
   Mantid::API::MatrixWorkspace_sptr requestRebinToSample(Mantid::API::MatrixWorkspace_sptr workspace) const;
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.ui
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.ui
@@ -146,6 +146,42 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="1">
+           <layout class="QHBoxLayout" name="loShift">
+            <item>
+             <widget class="QDoubleSpinBox" name="spShift">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="decimals">
+               <number>5</number>
+              </property>
+              <property name="minimum">
+               <double>-999.990000000000009</double>
+              </property>
+              <property name="maximum">
+               <double>999.990000000000009</double>
+              </property>
+              <property name="singleStep">
+               <double>0.010000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="ckShiftCan">
+            <property name="text">
+             <string>Shift x-values of container by adding:</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="1">
            <layout class="QHBoxLayout" name="loScaleFactor">
             <item>
@@ -172,41 +208,12 @@
             </item>
            </layout>
           </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="ckShiftCan">
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="ckRemoveSub">
             <property name="text">
-             <string>Shift x-values of container by adding:</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
+             <string>Remove subtracted workspace when new data is added</string>
             </property>
            </widget>
-          </item>
-          <item row="1" column="1">
-           <layout class="QHBoxLayout" name="loShift">
-            <item>
-             <widget class="QDoubleSpinBox" name="spShift">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="decimals">
-               <number>5</number>
-              </property>
-              <property name="minimum">
-               <double>-999.990000000000009</double>
-              </property>
-              <property name="maximum">
-               <double>999.990000000000009</double>
-              </property>
-              <property name="singleStep">
-               <double>0.010000000000000</double>
-              </property>
-              <property name="value">
-               <double>0.000000000000000</double>
-              </property>
-             </widget>
-            </item>
-           </layout>
           </item>
          </layout>
         </widget>
@@ -326,27 +333,27 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::CustomInterfaces::OutputPlotOptionsView</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsView.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>MantidQt::CustomInterfaces::RunView</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Spectroscopy/RunWidget/RunView.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <class>MantidQt::CustomInterfaces::OutputPlotOptionsView</class>
    <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
+   <header>MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsView.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>MantidQt::MantidWidgets::PreviewPlot</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Plotting/PreviewPlot.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.ui
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.ui
@@ -24,8 +24,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>970</width>
-        <height>745</height>
+        <width>966</width>
+        <height>796</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -207,13 +207,6 @@
              </widget>
             </item>
            </layout>
-          </item>
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="ckRemoveSub">
-            <property name="text">
-             <string>Remove subtracted workspace when new data is added</string>
-            </property>
-           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
### Description of work
This PR fixes a behavior of the container subtractions tab that causes the previously generated subtracted output workspace to be removed when new data is added on either of the data selectors. 
In this case, adding new data (Either from the ads or from file) won't delete the last generated output, and it will only override it if the new data that is added is the same as the one before (like in other Inelastic interfaces). 

When the last generated output was deleted upon selecting new data, it could happen that you select the last output to be the new data in the data selector for the container, causing a crash in Mantid as more signals than necessary are emitted when this happens. I think the container subtraction class could be refactored in the near future to avoid these kind of spurious interactions without having to be careful about disconnecting signals before deleting some workspaces. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37763. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Load `Interfaces->Inelastic->Corrections` interface. 
- On `Sample` select `irs26176_graphite002_red` from the SampleData-ISIS set and `irs26174_graphite002_red` ,from the same data set, as the `Container`. 
- Click on `Run`. 
- A workspace with suffix `_Subtract_` should be generated on the ads. 
- Click on the `Sample` data selector and change from `File` to `Workspace`. On the generated combobox, select the data set `irs26174_graphite002_red` from the list. 
- The `subtract` workspace shouldn't be deleted. 
- Closing the interface will remove the container workspace  (`irs26174_graphite002_red`), unless the container you used has a `subtract` suffix attach to its name. 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*Release notes added*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
