### PR TITLE
Fix setuptools deprecations

### DIFF
--- a/Framework/PythonInterface/pyproject.toml
+++ b/Framework/PythonInterface/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/Framework/PythonInterface/setup.py
+++ b/Framework/PythonInterface/setup.py
@@ -14,6 +14,6 @@ from setuptools import find_packages, setup
 setup(
     name="mantid",
     version=os.environ["MANTID_VERSION_STR"],
-    packages=find_packages(exclude=["*.test", "plugins*"]),
+    packages=find_packages(exclude=["*.test"]),
     package_data={"": ["*.json", "*.ui"]},
 )

--- a/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
+++ b/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
@@ -32,11 +32,8 @@ class SimpleAPITest(unittest.TestCase):
     def test_simpleapi_does_not_import_qt(self):
         import sys
 
-        modules = [mod for mod in sys.modules]
-        qt_import = "qtpy"
-        matching_qtpy_imports = [mod for mod in modules if qt_import in mod]
         self.assertFalse(
-            len(matching_qtpy_imports) > 0,
+            "qtpy" in sys.modules,
             msg="The simpleapi shouldn't import qtpy, one or more of "
             "imports you've added includes a package which imports "
             "qtpy, please amend your imports.",
@@ -45,11 +42,8 @@ class SimpleAPITest(unittest.TestCase):
     def test_simpleapi_does_not_import_mantidqt(self):
         import sys
 
-        modules = [mod for mod in sys.modules]
-        mantidqt_import = "mantidqt"
-        matching_mantidqt_imports = [mod for mod in modules if mantidqt_import in mod]
         self.assertFalse(
-            len(matching_mantidqt_imports) > 0,
+            "mantidqt" in sys.modules,
             msg="The simpleapi shouldn't import mantidqt, one or more of "
             "imports you've added includes a package which imports "
             "mantidqt, please amend your imports.",

--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -103,7 +103,7 @@ set(LOCAL_PYPATH "${CMAKE_CURRENT_BINARY_DIR}/bin/")
 
 # used by mantidworkbench
 if(ENABLE_WORKBENCH)
-  set(MANTIDWORKBENCH_EXEC "${CMAKE_CURRENT_BINARY_DIR}/bin/workbench") # what the actual thing is called
+  set(MANTIDWORKBENCH_EXEC "-m workbench") # what the actual thing is called
   configure_file(
     ${CMAKE_MODULE_PATH}/Packaging/launch_mantidworkbench.sh.in
     ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/launch_mantidworkbench.sh @ONLY
@@ -129,13 +129,13 @@ if(ENABLE_WORKBENCH)
       set(LOCAL_PYPATH "\${CONDA_PREFIX}/bin:\${CONDA_PREFIX}/lib:\${CONDA_PREFIX}/plugins")
       set(PYTHON_EXEC_LOCAL "\${CONDA_PREFIX}/bin/python")
       set(PREAMBLE "${CONDA_PREAMBLE_TEXT}")
-      set(MANTIDWORKBENCH_EXEC "\${CONDA_PREFIX}/bin/workbench") # what the actual thing is called
+      set(MANTIDWORKBENCH_EXEC "-m workbench") # what the actual thing is called
       set(DEST_FILENAME_SUFFIX "")
     elseif(${install_type} STREQUAL "standalone")
       set(LOCAL_PYPATH "\${INSTALLDIR}/bin:\${INSTALLDIR}/lib:\${INSTALLDIR}/plugins")
       set(PYTHON_EXEC_LOCAL "\${INSTALLDIR}/bin/python")
       set(PREAMBLE "${SYS_PREAMBLE_TEXT}")
-      set(MANTIDWORKBENCH_EXEC "\${INSTALLDIR}/bin/workbench")
+      set(MANTIDWORKBENCH_EXEC "-m workbench")
       set(DEST_FILENAME_SUFFIX ".standalone")
     else()
       message(FATAL_ERROR "Unknown installation type '${install_type}' for workbench startup scripts")

--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -53,8 +53,9 @@ function(add_python_package pkg_name)
   set(_version_str ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_TWEAK})
   add_custom_command(
     OUTPUT ${_outputs}
-    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${_egg_link_dir} MANTID_VERSION_STR=${_version_str} ${Python_EXECUTABLE}
-            ${_setup_py} develop --install-dir ${_egg_link_dir} --script-dir ${_egg_link_dir}
+    COMMAND
+      ${CMAKE_COMMAND} -E env PYTHONPATH=${_egg_link_dir} PYTHONUSERBASE=${_egg_link_dir} PATH=${_egg_link_dir}:$PATH
+      MANTID_VERSION_STR=${_version_str} ${Python_EXECUTABLE} -m pip install --editable .
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${_setup_py}
   )

--- a/qt/applications/workbench/pyproject.toml
+++ b/qt/applications/workbench/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/qt/python/mantidqt/pyproject.toml
+++ b/qt/python/mantidqt/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/qt/python/mantidqtinterfaces/pyproject.toml
+++ b/qt/python/mantidqtinterfaces/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
See [here](https://packaging.python.org/en/latest/guides/modernize-setup-py-project/#modernize-setup-py-project) for details about the warning. We were calling `python setup.py develop`, but this now seems to be a faux pas, so I've changed it use the recommended alternative.

I changed the test because it was giving a false positive, when calling `pip install --editable` you will get something like `__editable ... mantidqt ...` in `sys.modules`, but that doesn't mean you've imported `mantidqt`. The test was trying to check that importing `mantid.simpleapi` doesn't import `mantidqt`, which it doesn't, you can check this manually pretty quickly at the REPL.

Fixes #37277 

https://builds.mantidproject.org/job/build_packages_from_branch/870/

### To test:

- Check package builds works fine
- Try importing `mantid.simpleapi` and check that `mantidqt` isn't imported
- When you build there should be no warnings in the output like the examples in #37277

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **it will have no effect on the user**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
