### PR TITLE
37626 remove references to the ads from heliumanalyserefficiency algorithm

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/HeliumAnalyserEfficiency.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrections/HeliumAnalyserEfficiency.h
@@ -39,7 +39,6 @@ private:
   // Implement abstract Algorithm methods
   void init() override;
   void exec() override;
-  bool processGroups() override;
   void validateGroupInput();
   void calculateAnalyserEfficiency();
   MatrixWorkspace_sptr addTwoWorkspaces(MatrixWorkspace_sptr ws, MatrixWorkspace_sptr otherWs);

--- a/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
@@ -96,13 +96,16 @@ void HeliumAnalyserEfficiency::init() {
 }
 
 void validateInputWorkspace(MatrixWorkspace_sptr const &workspace, std::map<std::string, std::string> &errorList) {
+  if (workspace == nullptr) {
+    errorList[PropertyNames::INPUT_WORKSPACE] = "All input workspaces must be of type MatrixWorkspace.";
+    return;
+  }
+
   Kernel::Unit_const_sptr unit = workspace->getAxis(0)->unit();
   if (unit->unitID() != "Wavelength") {
     errorList[PropertyNames::INPUT_WORKSPACE] = "All input workspaces must be in units of Wavelength.";
-    return;
   }
 }
-
 /**
  * Tests that the inputs are all valid
  * @return A map containing the incorrect workspace
@@ -119,7 +122,7 @@ std::map<std::string, std::string> HeliumAnalyserEfficiency::validateInputs() {
         "The input group workspace must have four periods corresponding to the four spin configurations.";
   } else {
     for (size_t i = 0; i < wsGroup->size(); ++i) {
-      MatrixWorkspace_sptr const stateWs = std::dynamic_pointer_cast<MatrixWorkspace>(wsGroup->getItem(i));
+      const MatrixWorkspace_sptr stateWs = std::dynamic_pointer_cast<MatrixWorkspace>(wsGroup->getItem(i));
       validateInputWorkspace(stateWs, errorList);
     }
   }
@@ -130,7 +133,7 @@ void HeliumAnalyserEfficiency::exec() { calculateAnalyserEfficiency(); }
 
 void HeliumAnalyserEfficiency::calculateAnalyserEfficiency() {
   // First we extract the individual workspaces corresponding to each spin configuration from the group workspace
-  WorkspaceGroup_sptr groupWorkspace = getProperty(PropertyNames::INPUT_WORKSPACE);
+  const WorkspaceGroup_sptr groupWorkspace = getProperty(PropertyNames::INPUT_WORKSPACE);
   const std::string spinConfigurationInput = getProperty(PropertyNames::SPIN_STATES);
 
   const auto t11Ws = PolarizationCorrectionsHelpers::workspaceForSpinState(groupWorkspace, spinConfigurationInput,

--- a/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/HeliumAnalyserEfficiency.cpp
@@ -105,12 +105,6 @@ std::map<std::string, std::string> HeliumAnalyserEfficiency::validateInputs() {
   std::map<std::string, std::string> errorList;
   WorkspaceGroup_sptr ws = getProperty(PropertyNames::INPUT_WORKSPACE);
 
-  //  const std::string inputWorkspaceName = getProperty(PropertyNames::INPUT_WORKSPACE);
-  // if (!AnalysisDataService::Instance().doesExist(inputWorkspaceName)) {
-  // errorList[PropertyNames::INPUT_WORKSPACE] =
-  //      "The input workspace " + inputWorkspaceName + " does not exist in the ADS.";
-  // } else {
-  // const auto ws = AnalysisDataService::Instance().retrieve(getProperty(PropertyNames::INPUT_WORKSPACE));
   if (!ws->isGroup()) {
     errorList[PropertyNames::INPUT_WORKSPACE] = "The input workspace is not a group workspace";
   } else {
@@ -145,8 +139,6 @@ void HeliumAnalyserEfficiency::exec() { calculateAnalyserEfficiency(); }
 
 void HeliumAnalyserEfficiency::calculateAnalyserEfficiency() {
   // First we extract the individual workspaces corresponding to each spin configuration from the group workspace
-  // const auto groupWorkspace =
-  //     AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(getProperty(PropertyNames::INPUT_WORKSPACE));
   WorkspaceGroup_sptr groupWorkspace = getProperty(PropertyNames::INPUT_WORKSPACE);
   const std::string spinConfigurationInput = getProperty(PropertyNames::SPIN_STATES);
 

--- a/Framework/Algorithms/test/PolarizationCorrections/HeliumAnalyserEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/HeliumAnalyserEfficiencyTest.h
@@ -42,8 +42,8 @@ public:
     MatrixWorkspace_sptr ws1 = generateWorkspace("ws1", x, y);
     auto heliumAnalyserEfficiency = AlgorithmManager::Instance().create("HeliumAnalyserEfficiency");
     heliumAnalyserEfficiency->initialize();
-    TS_ASSERT_THROWS(heliumAnalyserEfficiency->setProperty("InputWorkspace", ws1), std::invalid_argument &);
     heliumAnalyserEfficiency->setProperty("OutputWorkspace", "P");
+    TS_ASSERT_THROWS(heliumAnalyserEfficiency->setProperty("InputWorkspace", ws1), std::invalid_argument &);
     TS_ASSERT_THROWS(heliumAnalyserEfficiency->execute(), const std::runtime_error &);
   }
 
@@ -75,8 +75,11 @@ public:
     heliumAnalyserEfficiency->initialize();
 
     heliumAnalyserEfficiency->setProperty("InputWorkspace", wsGrp);
+    heliumAnalyserEfficiency->setProperty("OutputWorkspace", "P");
 
-    TS_ASSERT_THROWS(heliumAnalyserEfficiency->execute(), std::runtime_error &);
+    TS_ASSERT_THROWS_EQUALS(
+        heliumAnalyserEfficiency->execute(), std::runtime_error const &e, std::string(e.what()),
+        "Some invalid Properties found: \n InputWorkspace: All input workspaces must be in units of Wavelength.");
   }
 
   void testZeroPdError() {

--- a/Framework/Algorithms/test/PolarizationCorrections/HeliumAnalyserEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/HeliumAnalyserEfficiencyTest.h
@@ -42,7 +42,7 @@ public:
     MatrixWorkspace_sptr ws1 = generateWorkspace("ws1", x, y);
     auto heliumAnalyserEfficiency = AlgorithmManager::Instance().create("HeliumAnalyserEfficiency");
     heliumAnalyserEfficiency->initialize();
-    heliumAnalyserEfficiency->setProperty("InputWorkspace", ws1->getName());
+    TS_ASSERT_THROWS(heliumAnalyserEfficiency->setProperty("InputWorkspace", ws1), std::invalid_argument &);
     heliumAnalyserEfficiency->setProperty("OutputWorkspace", "P");
     TS_ASSERT_THROWS(heliumAnalyserEfficiency->execute(), const std::runtime_error &);
   }
@@ -73,8 +73,10 @@ public:
     auto wsGrp = createExampleGroupWorkspace("wsGrp", e, "TOF");
     auto heliumAnalyserEfficiency = AlgorithmManager::Instance().create("HeliumAnalyserEfficiency");
     heliumAnalyserEfficiency->initialize();
-    TS_ASSERT_THROWS(heliumAnalyserEfficiency->setProperty("InputWorkspace", wsGrp->getName()),
-                     std::invalid_argument &);
+
+    heliumAnalyserEfficiency->setProperty("InputWorkspace", wsGrp);
+
+    TS_ASSERT_THROWS(heliumAnalyserEfficiency->execute(), std::runtime_error &);
   }
 
   void testZeroPdError() {
@@ -151,6 +153,23 @@ public:
     TS_ASSERT_EQUALS(outputWs->getNumberHistograms(), 1);
     const std::vector<std::string> &expectedColumns = {"Name", "Value", "Error"};
     TS_ASSERT_EQUALS(paramsWs->getColumnNames(), expectedColumns);
+  }
+
+  void testChildAlgorithmExecutesSuccessfully() {
+    MantidVec e;
+    auto wsGrp = createExampleGroupWorkspace("wsGrp", e);
+
+    auto heliumAnalyserEfficiency = createHeliumAnalyserEfficiencyAlgorithm(wsGrp, "E");
+    heliumAnalyserEfficiency->setChild(true);
+
+    heliumAnalyserEfficiency->execute();
+
+    TS_ASSERT(heliumAnalyserEfficiency->isExecuted());
+
+    MatrixWorkspace_sptr outputWorkspace = heliumAnalyserEfficiency->getProperty("OutputWorkspace");
+
+    TS_ASSERT_EQUALS(outputWorkspace->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(outputWorkspace->dataY(0).size(), e.size());
   }
 
 private:


### PR DESCRIPTION
### Description of work
Remove References to ADS from HeliumAnalyserEfficiencyAlgorithm

#### Summary of work
- Remove references from ADS, which previously handled validation and creation of the input workspace group. Now, the input workspace group from the GUI is validated and used directly in the algorithm.
- Adjust failing unit tests that relied on ADS to ensure they pass successfully.
- Add a test to ensure the algorithm works successfully when used as a child algorithm.

Fixes #37626 

### To test:
- Execute the HeliumAnalyserEfficiencyAlgorithm 
- Algorithm should execute successfully
- All Tests cases should pass 

This does not require release notes because it involves internal code changes that have no effect on the current functionality of the algorithm