### PR TITLE
Fix for the LoadIsawUB for MDWorkspaces

### DIFF
--- a/Framework/Crystal/src/LoadIsawUB.cpp
+++ b/Framework/Crystal/src/LoadIsawUB.cpp
@@ -181,6 +181,7 @@ void LoadIsawUB::readModulatedUB(std::ifstream &in, DblMatrix &ub) {
       ws = MDWS->getExperimentInfo(i);
       ws->mutableSample().setOrientedLattice(std::make_unique<OrientedLattice>(*latt));
     }
+    ws = MDWS->getExperimentInfo(0);
   }
   // Save it into the main workspace
   ws->mutableSample().setOrientedLattice(std::move(latt));

--- a/docs/source/release/v6.11.0/Framework/Algorithms/Bugfixes/37781.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/Bugfixes/37781.rst
@@ -1,2 +1,1 @@
-The :ref:`LoadIsawUB <algm-LoadIsawUB>` algorithm now correctly adds the UB to the first experiment info when the input workspace has more than one.
-
+- The :ref:`LoadIsawUB <algm-LoadIsawUB>` algorithm now correctly adds the UB to the first experiment info when the input workspace has more than one.

--- a/docs/source/release/v6.11.0/Framework/Algorithms/Bugfixes/37781.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/Bugfixes/37781.rst
@@ -1,0 +1,2 @@
+The :ref:`LoadIsawUB <algm-LoadIsawUB>` algorithm now correctly adds the UB to the first experiment info when the input workspace has more than one.
+


### PR DESCRIPTION
### Description of work

Fix for the LoadIsawUB for MDWorkspaces

#### Summary of work
The pointer to the first experiment info was reset.

Fixes #37781 

### To test:

Run script in the issue

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
