### PR TITLE
Fix crash from ROI banks

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/InstrumentViewer/Bugfixes/34378.rst
+++ b/docs/source/release/v6.11.0/Workbench/InstrumentViewer/Bugfixes/34378.rst
@@ -1,0 +1,1 @@
+- Fixed crash when selecting multiple ROI banks

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/MantidColorMap.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/MantidColorMap.h
@@ -42,11 +42,11 @@ public:
   double getNthPower() const { return m_gamma; }
   Colormap cmap() const { return m_mappable.cmap(); }
 
-  QRgb rgb(double vmin, double vmax, double value) const;
-  std::vector<QRgb> rgb(double vmin, double vmax, const std::vector<double> &values) const;
+  QRgb rgb(double vmin, double vmax, double value);
+  std::vector<QRgb> rgb(double vmin, double vmax, const std::vector<double> &values);
 
 private:
-  mutable ScalarMappable m_mappable;
+  ScalarMappable m_mappable;
   ScaleType m_scaleType;
   double m_gamma = {2.0};
 };

--- a/qt/widgets/mplcpp/src/MantidColorMap.cpp
+++ b/qt/widgets/mplcpp/src/MantidColorMap.cpp
@@ -146,7 +146,7 @@ void MantidColorMap::setNthPower(double gamma) {
  * @param value The value to be transformed
  * @return An instance QRgb describing the color
  */
-QRgb MantidColorMap::rgb(double vmin, double vmax, double value) const {
+QRgb MantidColorMap::rgb(double vmin, double vmax, double value) {
   m_mappable.setClim(vmin, vmax);
   return m_mappable.toRGBA(value);
 }
@@ -159,7 +159,7 @@ QRgb MantidColorMap::rgb(double vmin, double vmax, double value) const {
  * @param values The values to be transformed
  * @return An array of QRgb describing the colors
  */
-std::vector<QRgb> MantidColorMap::rgb(double vmin, double vmax, const std::vector<double> &values) const {
+std::vector<QRgb> MantidColorMap::rgb(double vmin, double vmax, const std::vector<double> &values) {
   m_mappable.setClim(vmin, vmax);
   return m_mappable.toRGBA(values);
 }


### PR DESCRIPTION
Use the existing `NDArrayToVector` converter to extract the RGBA values from `to_rgba`. The crash in #34378 was happening while the bytes were being extracted in this method, but using the existing converter is neater and prevents duplication. I also banished a `QString`.

The changes in `MantidColorMap` are to remove a use of `mutable` that was allowing methods to be marked as `const` when they actually change the state of a `MantidColorMap`.

Fixes #34378 

### To test:

See #34378 for how to reproduce.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
