### PR TITLE
Fix error causing grainsize to evaluate to 0 - `ornl-next`

### DIFF
--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -684,7 +684,7 @@ void EventWorkspace::sortAll(EventSortType sortType, Mantid::API::Progress *prog
   // Create the thread pool using tbb
   EventSortingTask task(this, sortType, prog);
   constexpr size_t GRAINSIZE_DEFAULT{100}; // somewhat arbitrary
-  const size_t grainsize = std::min<size_t>(GRAINSIZE_DEFAULT, this->getNumberHistograms() / GRAINSIZE_DEFAULT + 1);
+  const size_t grainsize = std::min<size_t>(GRAINSIZE_DEFAULT, (this->getNumberHistograms() / GRAINSIZE_DEFAULT) + 1);
   tbb::parallel_for(tbb::blocked_range<size_t>(0, data.size(), grainsize), task);
 }
 

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -684,7 +684,7 @@ void EventWorkspace::sortAll(EventSortType sortType, Mantid::API::Progress *prog
   // Create the thread pool using tbb
   EventSortingTask task(this, sortType, prog);
   constexpr size_t GRAINSIZE_DEFAULT{100}; // somewhat arbitrary
-  const size_t grainsize = std::min<size_t>(GRAINSIZE_DEFAULT, this->getNumberHistograms() / GRAINSIZE_DEFAULT);
+  const size_t grainsize = std::min<size_t>(GRAINSIZE_DEFAULT, this->getNumberHistograms() / GRAINSIZE_DEFAULT + 1);
   tbb::parallel_for(tbb::blocked_range<size_t>(0, data.size(), grainsize), task);
 }
 

--- a/docs/source/release/v6.11.0/Framework/Data_Objects/Bugfixes/37743.rst
+++ b/docs/source/release/v6.11.0/Framework/Data_Objects/Bugfixes/37743.rst
@@ -1,0 +1,1 @@
+- Added a `+ 1` to `EventWorkspace::sortAll` to prevent grainsize from being 0.


### PR DESCRIPTION
This is a sibling PR to #37743 into `ornl-next`
