### PR TITLE
Fix typo in IndirectResolution documentation

### DIFF
--- a/Framework/Algorithms/src/CalculateIqt.cpp
+++ b/Framework/Algorithms/src/CalculateIqt.cpp
@@ -205,7 +205,6 @@ MatrixWorkspace_sptr CalculateIqt::rebin(const MatrixWorkspace_sptr &workspace, 
   auto rebinAlgorithm = createChildAlgorithm("Rebin");
   rebinAlgorithm->initialize();
   rebinAlgorithm->setProperty("InputWorkspace", workspace);
-  rebinAlgorithm->setProperty("OutputWorkspace", "_");
   rebinAlgorithm->setProperty("Params", params);
   rebinAlgorithm->execute();
   return rebinAlgorithm->getProperty("OutputWorkspace");
@@ -215,7 +214,6 @@ MatrixWorkspace_sptr CalculateIqt::integration(const MatrixWorkspace_sptr &works
   auto integrationAlgorithm = createChildAlgorithm("Integration");
   integrationAlgorithm->initialize();
   integrationAlgorithm->setProperty("InputWorkspace", workspace);
-  integrationAlgorithm->setProperty("OutputWorkspace", "_");
   integrationAlgorithm->execute();
   return integrationAlgorithm->getProperty("OutputWorkspace");
 }
@@ -224,7 +222,6 @@ MatrixWorkspace_sptr CalculateIqt::convertToPointData(const MatrixWorkspace_sptr
   auto pointDataAlgorithm = createChildAlgorithm("ConvertToPointData");
   pointDataAlgorithm->initialize();
   pointDataAlgorithm->setProperty("InputWorkspace", workspace);
-  pointDataAlgorithm->setProperty("OutputWorkspace", "_");
   pointDataAlgorithm->execute();
   return pointDataAlgorithm->getProperty("OutputWorkspace");
 }
@@ -233,7 +230,6 @@ MatrixWorkspace_sptr CalculateIqt::extractFFTSpectrum(const MatrixWorkspace_sptr
   auto FFTAlgorithm = createChildAlgorithm("ExtractFFTSpectrum");
   FFTAlgorithm->initialize();
   FFTAlgorithm->setProperty("InputWorkspace", workspace);
-  FFTAlgorithm->setProperty("OutputWorkspace", "_");
   FFTAlgorithm->setProperty("FFTPart", 2);
   FFTAlgorithm->execute();
   return FFTAlgorithm->getProperty("OutputWorkspace");
@@ -245,7 +241,6 @@ MatrixWorkspace_sptr CalculateIqt::divide(const MatrixWorkspace_sptr &lhsWorkspa
   divideAlgorithm->initialize();
   divideAlgorithm->setProperty("LHSWorkspace", lhsWorkspace);
   divideAlgorithm->setProperty("RHSWorkspace", rhsWorkspace);
-  divideAlgorithm->setProperty("OutputWorkspace", "_");
   divideAlgorithm->execute();
   return divideAlgorithm->getProperty("OutputWorkspace");
 }
@@ -254,7 +249,6 @@ MatrixWorkspace_sptr CalculateIqt::cropWorkspace(const MatrixWorkspace_sptr &wor
   auto cropAlgorithm = createChildAlgorithm("CropWorkspace");
   cropAlgorithm->initialize();
   cropAlgorithm->setProperty("InputWorkspace", workspace);
-  cropAlgorithm->setProperty("OutputWorkspace", "_");
   cropAlgorithm->setProperty("XMax", xMax);
   cropAlgorithm->execute();
   return cropAlgorithm->getProperty("OutputWorkspace");
@@ -264,7 +258,6 @@ MatrixWorkspace_sptr CalculateIqt::replaceSpecialValues(const MatrixWorkspace_sp
   auto specialValuesAlgorithm = createChildAlgorithm("ReplaceSpecialValues");
   specialValuesAlgorithm->initialize();
   specialValuesAlgorithm->setProperty("InputWorkspace", workspace);
-  specialValuesAlgorithm->setProperty("OutputWorkspace", "_");
   specialValuesAlgorithm->setProperty("InfinityValue", 0.0);
   specialValuesAlgorithm->setProperty("BigNumberThreshold", 1.0001);
   specialValuesAlgorithm->setProperty("NaNValue", 0.0);

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectResolution.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectResolution.py
@@ -47,7 +47,7 @@ class IndirectResolution(DataProcessorAlgorithm):
         )
 
         self.declareProperty(
-            IntArrayProperty(name="DetectorRange", values=[0, 1]), doc="Range of detetcors to use in resolution calculation."
+            IntArrayProperty(name="DetectorRange", values=[0, 1]), doc="Range of detectors to use in resolution calculation."
         )
         self.declareProperty(FloatArrayProperty(name="BackgroundRange", values=[0.0, 0.0]), doc="Energy range to use as background.")
 


### PR DESCRIPTION
### Description of work
This PR does two things:
- It fixes a typo in the IndirectResolution documentation
- It removes setting the OutputWorkspace property in the child algorithm calls in CalculateIqt (for cleaner code).

Fixes #37771

### To test:
1. Open Inelastic->Data Processor interface
2. Go to the Iqt tab
3. Load the usual 26176 _red file as sample
4. Load the usual 26173 _res file as resolution
5. Untick `Enforce Normalisation`
6. Click `Run`
7. Plot the first spectrum. It should look something like this
![image](https://github.com/user-attachments/assets/9dd4c401-3295-424a-aa2e-54e745d041e0)

9. Tick `Enforce Normalisation`
10. Click `Run`
11. The first point in the plot should start at 1, and then exponentially decrease 

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
