### PR TITLE
Fix No found object warning on Elwin Interface

### DIFF
--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37770.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37770.rst
@@ -1,0 +1,1 @@
+- Adding new data to the  :ref:`Elwin data table <elwin>` after clearing the Analysis Data Service no longer raises a *No data found* warning.

--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37787.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37787.rst
@@ -1,0 +1,1 @@
+- Mantid no longer crashes when trying to plot a preview of the selected workspace on the :ref:`Elwin tab <elwin>` after that workspace has been deleted from the ADS.

--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37788.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37788.rst
@@ -1,0 +1,2 @@
+- It is possible to see the Spectrum number 0 on the widget plot of the selected preview workspace on :ref:`Elwin interface <elwin>`
+- Changing the preview spectrum above the plot widget combo box plots the correct spectrum for the selected index  :ref:`Elwin interface <elwin>`

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
@@ -41,6 +41,7 @@ public:
   virtual void handleRemoveSelectedData() = 0;
   virtual void handleRowModeChanged() = 0;
   virtual void updateAvailableSpectra() = 0;
+  virtual MatrixWorkspace_sptr getInputWorkspace() const = 0;
 };
 
 class MANTIDQT_INELASTIC_DLL ElwinPresenter : public DataProcessor, public IElwinPresenter, public IRunSubscriber {
@@ -68,10 +69,10 @@ public:
   void handleRowModeChanged() override;
   void updateAvailableSpectra() override;
 
-  void setInputWorkspace(MatrixWorkspace_sptr inputWorkspace);
+  void setInputWorkspace(const MatrixWorkspace_sptr &inputWorkspace);
   virtual void setSelectedSpectrum(int spectrum);
   int getSelectedSpectrum() const;
-  MatrixWorkspace_sptr getInputWorkspace() const;
+  MatrixWorkspace_sptr getInputWorkspace() const override;
   MatrixWorkspace_sptr getPreviewPlotWorkspace();
   void setPreviewPlotWorkspace(const MatrixWorkspace_sptr &previewPlotWorkspace);
 
@@ -87,8 +88,7 @@ private:
   std::vector<std::string> getOutputWorkspaceNames();
   std::string getOutputBasename();
   bool checkForELTWorkspace();
-  void newPreviewFileSelected(const std::string &workspaceName, const std::string &filename);
-  void newPreviewWorkspaceSelected(const std::string &workspaceName);
+  void newPreviewWorkspaceSelected(int index);
   WorkspaceID findWorkspaceID();
 
   IElwinView *m_view;

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.h
@@ -103,10 +103,6 @@ private:
   void newPreviewWorkspaceSelected(int index);
   std::optional<WorkspaceID> findWorkspaceID(std::string const &name) const;
 
-  void handleRemoveEvent(Mantid::API::WorkspacePreDeleteNotification_ptr pNf);
-  void handleClearEvent(Mantid::API::ClearADSNotification_ptr pNf);
-  void handleRenameEvent(Mantid::API::WorkspaceRenameNotification_ptr pNf);
-
   IElwinView *m_view;
   std::unique_ptr<IElwinModel> m_model;
   std::unique_ptr<IDataModel> m_dataModel;

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
@@ -210,11 +210,9 @@ void ElwinView::addTableEntry(int row, std::string const &name, std::string cons
 }
 
 void ElwinView::updatePreviewWorkspaceNames(const std::vector<std::string> &names) {
-  disconnectSignals();
   m_uiForm.cbPreviewFile->clear();
   m_uiForm.cbPreviewFile->addItems(stdVectorToQStringList(names));
-  m_uiForm.cbPreviewFile->setCurrentIndex(0);
-  connectSignals();
+  m_uiForm.cbPreviewFile->setCurrentIndex(static_cast<int>(names.size()) - 1);
 }
 
 void ElwinView::setCell(std::unique_ptr<QTableWidgetItem> cell, int row, int column) {

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinView.h
@@ -39,18 +39,19 @@ public:
                            const std::vector<WorkspaceIndex>::const_iterator &to) override;
 
   void plotInput(MatrixWorkspace_sptr inputWS, int spectrum) override;
-  void newInputDataFromDialog(std::vector<std::string> const &names) override;
-  void clearPreviewFile() override;
   void setRunIsRunning(const bool running) override;
   void setSaveResultEnabled(const bool enabled) override;
   int getPreviewSpec() const override;
   std::string getPreviewWorkspaceName(int index) const override;
-  std::string getPreviewFilename(int index) const override;
+  void setPreviewWorkspaceName(int index) override;
   std::string getCurrentPreview() const override;
+  void updateSelectorRange(const MatrixWorkspace_sptr &inputWS) override;
 
   // controls for dataTable
   void clearDataTable() override;
   void addTableEntry(int row, std::string const &name, std::string const &wsIndexes) override;
+  void updatePreviewWorkspaceNames(const std::vector<std::string> &names) override;
+
   QModelIndexList getSelectedData() override;
   void selectAllRows() override;
 
@@ -83,7 +84,7 @@ private slots:
   void notifyCheckboxValueChanged(QtProperty *, bool);
   void notifyPlotPreviewClicked();
   void notifySaveClicked();
-  void notifySelectedSpectrumChanged(int);
+  void notifySelectedSpectrumChanged();
   void notifyPreviewIndexChanged(int);
   void notifyRowModeChanged();
   void notifyAddWorkspaceDialog();
@@ -95,8 +96,8 @@ private:
   void setHorizontalHeaders();
   void setDefaultSampleLog(const Mantid::API::MatrixWorkspace_const_sptr &ws);
 
-  void disconnectSignals();
-  void connectSignals();
+  void disconnectSignals() const;
+  void connectSignals() const;
 
   /// Function to set the range selector on the mini plot
   void setRangeSelector(MantidWidgets::RangeSelector *rs, QtProperty *lower, QtProperty *upper,

--- a/qt/scientific_interfaces/Inelastic/Processor/IElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IElwinView.h
@@ -42,19 +42,19 @@ public:
                                    const std::vector<MantidWidgets::WorkspaceIndex>::const_iterator &to) = 0;
 
   virtual void plotInput(Mantid::API::MatrixWorkspace_sptr inputWS, int spectrum) = 0;
-  virtual void newInputDataFromDialog(std::vector<std::string> const &names) = 0;
-  virtual void clearPreviewFile() = 0;
   virtual void setRunIsRunning(const bool running) = 0;
   virtual void setSaveResultEnabled(const bool enabled) = 0;
   virtual int getPreviewSpec() const = 0;
 
   virtual std::string getPreviewWorkspaceName(int index) const = 0;
-  virtual std::string getPreviewFilename(int index) const = 0;
+  virtual void setPreviewWorkspaceName(int index) = 0;
   virtual std::string getCurrentPreview() const = 0;
+  virtual void updateSelectorRange(const MatrixWorkspace_sptr &inputWS) = 0;
 
   // controls for dataTable
   virtual void clearDataTable() = 0;
   virtual void addTableEntry(int row, std::string const &name, std::string const &wsIndexes) = 0;
+  virtual void updatePreviewWorkspaceNames(const std::vector<std::string> &names) = 0;
 
   virtual QModelIndexList getSelectedData() = 0;
   virtual void selectAllRows() = 0;

--- a/qt/scientific_interfaces/Inelastic/test/Processor/ElwinPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Processor/ElwinPresenterTest.h
@@ -121,9 +121,9 @@ public:
   void test_handleAddData_sets_preview_workspace_and_spectrum() {
     auto dialog = new MantidQt::MantidWidgets::AddWorkspaceDialog(nullptr);
     m_presenter->setSelectedSpectrum(0);
+    m_presenter->setInputWorkspace(m_workspace);
 
     ON_CALL(*m_dataModel, getNumberOfWorkspaces()).WillByDefault(Return(1));
-    ON_CALL(*m_dataModel, getWorkspace(WorkspaceID(0))).WillByDefault(Return(m_workspace));
     EXPECT_CALL(*m_view, updatePreviewWorkspaceNames(m_dataModel->getWorkspaceNames())).Times(Exactly(1));
     EXPECT_CALL(*m_view, plotInput(m_workspace, 0)).Times(Exactly(1));
     m_presenter->handleAddData(dialog);

--- a/qt/scientific_interfaces/Inelastic/test/Processor/ElwinPresenterTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Processor/ElwinPresenterTest.h
@@ -122,9 +122,9 @@ public:
     auto dialog = new MantidQt::MantidWidgets::AddWorkspaceDialog(nullptr);
     m_presenter->setSelectedSpectrum(0);
 
-    ON_CALL(*m_view, getPreviewWorkspaceName(0)).WillByDefault(Return("workspace_test"));
-    EXPECT_CALL(*m_view, clearPreviewFile()).Times(Exactly(1));
-    EXPECT_CALL(*m_view, newInputDataFromDialog(m_dataModel->getWorkspaceNames())).Times(Exactly(1));
+    ON_CALL(*m_dataModel, getNumberOfWorkspaces()).WillByDefault(Return(1));
+    ON_CALL(*m_dataModel, getWorkspace(WorkspaceID(0))).WillByDefault(Return(m_workspace));
+    EXPECT_CALL(*m_view, updatePreviewWorkspaceNames(m_dataModel->getWorkspaceNames())).Times(Exactly(1));
     EXPECT_CALL(*m_view, plotInput(m_workspace, 0)).Times(Exactly(1));
     m_presenter->handleAddData(dialog);
   }

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -440,16 +440,16 @@ public:
                void(const std::vector<MantidQt::MantidWidgets::WorkspaceIndex>::const_iterator &from,
                     const std::vector<MantidQt::MantidWidgets::WorkspaceIndex>::const_iterator &to));
   MOCK_METHOD2(plotInput, void(Mantid::API::MatrixWorkspace_sptr inputWS, int spectrum));
-  MOCK_METHOD1(newInputDataFromDialog, void(std::vector<std::string> const &names));
-  MOCK_METHOD0(clearPreviewFile, void());
 
   MOCK_METHOD1(setRunIsRunning, void(const bool running));
   MOCK_METHOD1(setSaveResultEnabled, void(const bool enabled));
   MOCK_CONST_METHOD0(getPreviewSpec, int());
+  MOCK_METHOD1(updateSelectorRange, void(const MatrixWorkspace_sptr &inputWS));
 
   MOCK_CONST_METHOD1(getPreviewWorkspaceName, std::string(int index));
-  MOCK_CONST_METHOD1(getPreviewFilename, std::string(int index));
+  MOCK_METHOD1(setPreviewWorkspaceName, void(int index));
   MOCK_CONST_METHOD0(getCurrentPreview, std::string());
+  MOCK_METHOD1(updatePreviewWorkspaceNames, void(const std::vector<std::string> &names));
 
   MOCK_METHOD0(clearDataTable, void());
   MOCK_METHOD3(addTableEntry, void(int row, std::string const &name, std::string const &wsIndexes));

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AddWorkspaceMultiDialog.h
@@ -27,7 +27,7 @@ public:
   explicit AddWorkspaceMultiDialog(QWidget *parent);
 
   std::string workspaceName() const override;
-  stringPairVec selectedNameIndexPairs() const;
+  StringPairVec selectedNameIndexPairs() const;
 
   bool isEmpty() const;
   void setWSSuffices(const QStringList &suffices) override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
@@ -16,7 +16,7 @@
 #include <Poco/AutoPtr.h>
 #include <Poco/NObserver.h>
 
-typedef std::vector<std::pair<std::string, std::string>> stringPairVec;
+typedef std::vector<std::pair<std::string, std::string>> StringPairVec;
 namespace MantidQt {
 namespace MantidWidgets {
 /**
@@ -56,7 +56,7 @@ public:
 
   bool showWorkspaceGroups() const;
   void showWorkspaceGroups(bool show);
-  stringPairVec retrieveSelectedNameIndexPairs();
+  StringPairVec retrieveSelectedNameIndexPairs();
 
   QStringList getWorkspaceTypes() const;
   QStringList getWSSuffixes() const;

--- a/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
+++ b/qt/widgets/common/src/AddWorkspaceMultiDialog.cpp
@@ -48,7 +48,7 @@ std::string AddWorkspaceMultiDialog::workspaceName() const {
 
 void AddWorkspaceMultiDialog::setup() { m_uiForm.tbWorkspace->setupTable(); }
 
-stringPairVec AddWorkspaceMultiDialog::selectedNameIndexPairs() const {
+StringPairVec AddWorkspaceMultiDialog::selectedNameIndexPairs() const {
 
   return m_uiForm.tbWorkspace->retrieveSelectedNameIndexPairs();
 }

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -167,13 +167,12 @@ void WorkspaceMultiSelector::addItems(const std::vector<std::string> &names) {
   }
 }
 
-stringPairVec WorkspaceMultiSelector::retrieveSelectedNameIndexPairs() {
+StringPairVec WorkspaceMultiSelector::retrieveSelectedNameIndexPairs() {
 
-  auto selIndexes = selectedIndexes();
-  stringPairVec nameIndexPairVec;
-  nameIndexPairVec.reserve(static_cast<std::size_t>(selIndexes.size()));
-
-  for (auto const &index : selIndexes) {
+  auto selRows = selectionModel()->selectedRows();
+  StringPairVec nameIndexPairVec;
+  nameIndexPairVec.reserve(static_cast<std::size_t>(selRows.size()));
+  for (auto const &index : selRows) {
     std::string txt = item(index.row(), namesCol)->text().toStdString();
     if (!txt.empty()) {
       std::string idx = item(index.row(), indexCol)->text().toStdString();


### PR DESCRIPTION
### Description of work
This PR fixes issue #37770 and other related issues: #37787 and #37788. All three issues are related to the underlying problem of trying to retrieve loaded workspaces onto the elwin interface from the ADS. If for some reason the data on the ADS is modified, the interface tries to retrieve workspaces that don't exist, and depending on the actions on the interface can either crash mantid #37787 or give a warning #37770.  
Additionally, the preview plot is chosen by selecting the workspace to plot and the spectrum index on that workspace from two comboboxes. The spectrum combobox was not retrieving the correct index number, and could not plot spectrum number 0. 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

I have tried to refactor the Elwin Presenter and Elwin View classes to handle better the communication between view and presenter, and to reduce dependencies with the ADS. The elwin presenter already stores copies of the loaded workspaces in their data model, and it's not necessary to retrieve workspaces from the ADS in order to plot data.
Also, Elwin interface used to have a way to load data through a file finder or through a workspace dialog , but this was removed in #36953 in favor of a multiple file workspace dialog. So there are functions on the presenter and view that are not needed anymore, I have tried to remove these as well.


<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37770, #37787, #37788 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

 - Check that the test instructions for the issues #37770, #37787, #37788 are not happening anymore. 
 - Follow manual testing instructions for elwin tab: https://developer.mantidproject.org/Testing/Inelastic/DataProcessorTests.html . See there are no issues when running the instructions.
 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*Added release notes*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
