### PR TITLE
Fix the calibration diagnostics plot issue

### DIFF
--- a/docs/source/release/v6.11.0/Diffraction/Powder/Bugfixes/37791.rst
+++ b/docs/source/release/v6.11.0/Diffraction/Powder/Bugfixes/37791.rst
@@ -1,0 +1,1 @@
+- Fix bug in the calibration diagnostics plotting where the solid angle of detectors were not extracted successfully

--- a/scripts/Calibration/tofpd/diagnostics.py
+++ b/scripts/Calibration/tofpd/diagnostics.py
@@ -16,7 +16,7 @@ from mantid.dataobjects import TableWorkspace, Workspace2D
 from mantid.plots.datafunctions import get_axes_labels
 from mantid.plots.resampling_image.samplingimage import imshow_sampling
 from mantid.plots.utility import colormap_as_plot_color
-from mantid.simpleapi import CalculateDIFC, LoadDiffCal, mtd, SolidAngle
+from mantid.simpleapi import CalculateDIFC, LoadDiffCal, mtd, LoadEmptyInstrument, SolidAngle
 
 
 # Diamond peak positions in d-space which may differ from actual sample

--- a/scripts/Calibration/tofpd/diagnostics.py
+++ b/scripts/Calibration/tofpd/diagnostics.py
@@ -16,7 +16,7 @@ from mantid.dataobjects import TableWorkspace, Workspace2D
 from mantid.plots.datafunctions import get_axes_labels
 from mantid.plots.resampling_image.samplingimage import imshow_sampling
 from mantid.plots.utility import colormap_as_plot_color
-from mantid.simpleapi import CalculateDIFC, LoadDiffCal, mtd, LoadEmptyInstrument, SolidAngle
+from mantid.simpleapi import CalculateDIFC, LoadDiffCal, mtd, SolidAngle
 
 
 # Diamond peak positions in d-space which may differ from actual sample
@@ -265,10 +265,12 @@ def difc_plot2d(calib_new, calib_old=None, instr_ws=None, mask=None, vrange=(0, 
 
     # Use the largest solid angle for circle radius
     maximum_solid_angle = 0.0
-    LoadEmptyInstrument(InstrumentName=instr_name, OutputWorkspace=f"{instr_name}_instr")
-    det_tmp = SolidAngle(InputWorkspace=f"{instr_name}_instr", OutputWorkspace="detector_tmp")
-    for det_id in range(info.size()):
-        maximum_solid_angle = max(maximum_solid_angle, det_tmp.readY(det_id)[0])
+    if instr_ws is None:
+        LoadEmptyInstrument(InstrumentName=instr_name, OutputWorkspace=f"{instr_name}_instr")
+        instr_ws = f"{instr_name}_instr"
+    det_tmp = SolidAngle(InputWorkspace=instr_ws, OutputWorkspace="detector_tmp")
+    for wksp_index in range(info.size()):
+        maximum_solid_angle = max(maximum_solid_angle, det_tmp.readY(wksp_index)[0])
 
     # Convert to degrees for plotting
     theta_array = np.rad2deg(theta_array)

--- a/scripts/Calibration/tofpd/diagnostics.py
+++ b/scripts/Calibration/tofpd/diagnostics.py
@@ -16,7 +16,7 @@ from mantid.dataobjects import TableWorkspace, Workspace2D
 from mantid.plots.datafunctions import get_axes_labels
 from mantid.plots.resampling_image.samplingimage import imshow_sampling
 from mantid.plots.utility import colormap_as_plot_color
-from mantid.simpleapi import CalculateDIFC, LoadDiffCal, mtd
+from mantid.simpleapi import CalculateDIFC, LoadDiffCal, mtd, LoadEmptyInstrument, SolidAngle
 
 
 # Diamond peak positions in d-space which may differ from actual sample
@@ -264,10 +264,11 @@ def difc_plot2d(calib_new, calib_old=None, instr_ws=None, mask=None, vrange=(0, 
             value_array.append(percent)
 
     # Use the largest solid angle for circle radius
-    sample_position = info.samplePosition()
     maximum_solid_angle = 0.0
+    LoadEmptyInstrument(InstrumentName=instr_name, OutputWorkspace=f"{instr_name}_instr")
+    det_tmp = SolidAngle(InputWorkspace=f"{instr_name}_instr", OutputWorkspace="detector_tmp")
     for det_id in range(info.size()):
-        maximum_solid_angle = max(maximum_solid_angle, delta.getDetector(det_id).solidAngle(sample_position))
+        maximum_solid_angle = max(maximum_solid_angle, det_tmp.readY(det_id)[0])
 
     # Convert to degrees for plotting
     theta_array = np.rad2deg(theta_array)


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

With the calibration diagnostics tool, we are supposed to be able to generate a 2D plot showing the difference between the calibrated and engineering calibration constant, and also the masks will be shown as well.

However, seems that the new version of Mantid is killing the capability complaining something about the solid angle extraction from the instrument. Here we are fixing the issue by changing the way of extracting the solid angle.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

### To test:

Use the following script,

```python
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

LoadDiffCal(
    InstrumentName="NOM",
    Filename="/SNS/snfs1/instruments/NOM/shared/CALIBRATION/autoreduce/NOMAD_196808_2023-08-14_shifter.h5"
)

fig, ax = diagnostics.difc_plot2d("_cal", instr_ws="_group",
                                  mask="_mask", vrange=(0, 5))
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
