### PR TITLE
Add ragged workspace support for binary operations 

### DIFF
--- a/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -198,6 +198,9 @@ public:
     mutableHistogramRef().setSharedE(e);
   }
 
+  void resize(size_t n) { mutableHistogramRef().resize(n); }
+  size_t size() const { return histogramRef().size(); }
+
   void setMatrixWorkspace(MatrixWorkspace *matrixWorkspace, const size_t index);
 
   virtual void copyDataInto(DataObjects::EventList &) const;

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -233,6 +233,8 @@ public:
   void setSharedE(const size_t index, const Kernel::cow_ptr<HistogramData::HistogramE> &e) & {
     getSpectrumWithoutInvalidation(index).setSharedE(e);
   }
+  void resizeHistogram(const size_t index, size_t n) & { getSpectrum(index).resize(n); }
+  size_t histogramSize(const size_t index) const { return getSpectrum(index).size(); }
   // Methods for getting read-only access to the data.
   // Just passes through to the virtual dataX/Y/E function (const version)
   /// Deprecated, use x() instead. Returns a read-only (i.e. const) reference to

--- a/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
@@ -190,6 +190,10 @@ protected:
   /// Cache for RHS workspace's blocksize
   size_t m_rhsBlocksize;
 
+  /// Cache for if LHS workspace's is ragged
+  bool m_lhsRagged{false};
+  /// Cache for if RHS workspace's is ragged
+  bool m_rhsRagged{false};
   //------ Requirements -----------
 
   /// matchXSize set to true if the X sizes of histograms must match.

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -219,8 +219,7 @@ void BinaryOperation::exec() {
 
     // Always clear the MRUs.
     m_eout->clearMRU();
-    if (m_elhs)
-      m_elhs->clearMRU();
+    m_elhs->clearMRU();
     if (m_erhs)
       m_erhs->clearMRU();
 

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -237,8 +237,6 @@ void BinaryOperation::exec() {
       auto specialRHS = dynamic_cast<const SpecialWorkspace2D *>(m_rhs.get());
       if (specialLHS && specialRHS) {
         m_out = create<SpecialWorkspace2D>(*specialLHS);
-      } else if (m_lhsRagged) {
-        m_out = createRagged<HistoWorkspace>(*m_lhs);
       } else {
         m_out = create<HistoWorkspace>(*m_lhs);
       }

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -136,12 +136,16 @@ void BinaryOperation::exec() {
 
   try {
     m_lhsBlocksize = m_lhs->blocksize();
+    m_lhsRagged = false;
   } catch (std::length_error &) {
+    m_lhsBlocksize = 0;
     m_lhsRagged = true;
   }
   try {
     m_rhsBlocksize = m_rhs->blocksize();
+    m_rhsRagged = false;
   } catch (std::length_error &) {
+    m_rhsBlocksize = 0;
     m_rhsRagged = true;
   }
 

--- a/Framework/Algorithms/src/Divide.cpp
+++ b/Framework/Algorithms/src/Divide.cpp
@@ -200,8 +200,8 @@ std::string Divide::checkSizeCompatibility(const API::MatrixWorkspace_const_sptr
 
   if (m_matchXSize) {
     // Past this point, for a 2D WS operation, we require the X arrays to match.
-    // Note this only checks the first spectrum
-    if (!WorkspaceHelpers::matchingBins(*lhs, *rhs, true)) {
+    // Note this only checks the first spectrum except for ragged workspaces
+    if (!WorkspaceHelpers::matchingBins(*lhs, *rhs, !m_lhsRagged && !m_rhsRagged)) {
       return "X arrays must match when dividing 2D workspaces.";
     }
   }

--- a/Framework/Algorithms/src/Multiply.cpp
+++ b/Framework/Algorithms/src/Multiply.cpp
@@ -170,8 +170,8 @@ std::string Multiply::checkSizeCompatibility(const API::MatrixWorkspace_const_sp
 
     if (m_matchXSize) {
       // Past this point, for a 2D WS operation, we require the X arrays to
-      // match. Note this only checks the first spectrum
-      if (!WorkspaceHelpers::matchingBins(*lhs, *rhs, true)) {
+      // match. Note this only checks the first spectrum except for ragged workspaces
+      if (!WorkspaceHelpers::matchingBins(*lhs, *rhs, !m_lhsRagged && !m_rhsRagged)) {
         return "X arrays must match when multiplying 2D workspaces.";
       }
     }

--- a/Framework/Algorithms/test/PlusMinusTest.in.h
+++ b/Framework/Algorithms/test/PlusMinusTest.in.h
@@ -788,7 +788,6 @@ public:
   void checkData( MatrixWorkspace_sptr work_in1,  MatrixWorkspace_sptr work_in2, MatrixWorkspace_sptr work_out1,
       int loopOrientation, double expectedValue=-1.0, double expectedError=-1.0  )
   {
-    std::cout << "hello world!\n";
     TSM_ASSERT_LESS_THAN( message, 0, work_out1->getNumberHistograms());
     if (work_out1->isRaggedWorkspace()) {
       TSM_ASSERT_LESS_THAN( message, 0, work_out1->y(0).size());

--- a/Framework/Algorithms/test/PlusMinusTest.in.h
+++ b/Framework/Algorithms/test/PlusMinusTest.in.h
@@ -13,6 +13,7 @@
 #include "MantidAlgorithms/Minus.h"
 #include "MantidAlgorithms/Plus.h"
 #include "MantidAlgorithms/Rebin.h"
+#include "MantidHistogramData/HistogramBuilder.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidAPI/WorkspaceProperty.h"
@@ -597,8 +598,12 @@ public:
       mess << "Event";
     else
       mess << "2D";
-    mess << "(" << ws->getNumberHistograms() << " spectra," << ws->blocksize() << " bins,";
-    mess << "Y[0][0] = " << ws->y(0)[0] << ")";
+    mess << "(" << ws->getNumberHistograms() << " spectra, ";
+    if (ws->isRaggedWorkspace())
+      mess << "Ragged";
+    else
+      mess << ws->blocksize();
+    mess << " bins," << "Y[0][0] = " << ws->y(0)[0] << ")";
     return mess.str();
   }
 
@@ -783,12 +788,21 @@ public:
   void checkData( MatrixWorkspace_sptr work_in1,  MatrixWorkspace_sptr work_in2, MatrixWorkspace_sptr work_out1,
       int loopOrientation, double expectedValue=-1.0, double expectedError=-1.0  )
   {
+    std::cout << "hello world!\n";
     TSM_ASSERT_LESS_THAN( message, 0, work_out1->getNumberHistograms());
-    TSM_ASSERT_LESS_THAN( message, 0, work_out1->blocksize());
+    if (work_out1->isRaggedWorkspace()) {
+      TSM_ASSERT_LESS_THAN( message, 0, work_out1->y(0).size());
+    } else {
+      TSM_ASSERT_LESS_THAN( message, 0, work_out1->blocksize());
+    }
     TSM_ASSERT_EQUALS( message, work_in1->getNumberHistograms(), work_out1->getNumberHistograms());
     // Number of histograms/bins is unchanged (relative to LHS argument)
     TSM_ASSERT_EQUALS( message, work_out1->getNumberHistograms(), work_in1->getNumberHistograms());
-    TSM_ASSERT_EQUALS( message, work_out1->blocksize(), work_in1->blocksize());
+    if (work_out1->isRaggedWorkspace()) {
+      TSM_ASSERT_EQUALS( message, work_out1->y(0).size(), work_in1->y(0).size());
+    } else {
+      TSM_ASSERT_EQUALS( message, work_out1->blocksize(), work_in1->blocksize());
+    }
 
     if (expectedValue == -1.0 && expectedError == -1.0)
     {
@@ -1081,6 +1095,62 @@ public:
   }
 
 
+  MatrixWorkspace_sptr create_RaggedWorkspace()
+  {
+    // create workspace with 2 histograms
+    MatrixWorkspace_sptr raggedWS = WorkspaceCreationHelper::create2DWorkspace(2, 1);
+
+    // create and replace histograms with ragged ones
+    MantidVec x_data{100., 200., 300., 400.};
+    MantidVec y_data{1., 1., 1.};
+    MantidVec e_data{1., 1., 1.};
+    Mantid::HistogramData::HistogramBuilder builder;
+    builder.setX(x_data);
+    builder.setY(y_data);
+    builder.setE(e_data);
+    raggedWS->setHistogram(0, builder.build());
+
+    MantidVec x_data2{200., 400., 600.};
+    MantidVec y_data2{1., 1.};
+    MantidVec e_data2{1., 1.};
+    Mantid::HistogramData::HistogramBuilder builder2;
+    builder2.setX(x_data2);
+    builder2.setY(y_data2);
+    builder2.setE(e_data2);
+    raggedWS->setHistogram(1, builder2.build());
+
+    // quick check of the workspace
+    TS_ASSERT(raggedWS->isRaggedWorkspace());
+    TS_ASSERT_EQUALS(raggedWS->getNumberHistograms(), 2);
+    TS_ASSERT_EQUALS(raggedWS->x(0).size(), 4);
+    TS_ASSERT_EQUALS(raggedWS->x(1).size(), 3);
+    TS_ASSERT_EQUALS(raggedWS->y(0).size(), 3);
+    TS_ASSERT_EQUALS(raggedWS->y(1).size(), 2);
+    return raggedWS;
+  }
+
+  void test_RaggedWorkspace()
+  {
+    auto lhs = create_RaggedWorkspace();
+    auto rhs = create_RaggedWorkspace();
+    auto result = performTest(lhs, rhs, false, false, DO_PLUS ? 2.0 : 0.0, 1.4142135625);
+    TS_ASSERT(result->isRaggedWorkspace());
+  }
+
+  void test_RaggedWorkspace_and_single_value()
+  {
+    auto lhs = create_RaggedWorkspace();
+    auto rhs = WorkspaceCreationHelper::createWorkspaceSingleValue(2);
+    auto result = performTest(lhs, rhs, false, false, DO_PLUS ? 3.0 : -1.0, 1.7320508071);
+    TS_ASSERT(result->isRaggedWorkspace());
+  }
+
+  void test_RaggedWorkspace_not_compatible_x()
+  {
+    auto lhs = create_RaggedWorkspace();
+    auto rhs = WorkspaceCreationHelper::create2DWorkspace(2, 4);
+    performTest_fails(lhs, rhs);
+  }
 
 }; // end of class @PLUSMINUSTEST_CLASS@
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -169,7 +169,6 @@ knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/AbsorptionC
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/AbsorptionCorrection.cpp:445
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CalculateEfficiency.cpp:158
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CalculateEfficiency.cpp:159
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/BinaryOperation.cpp:213
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CalculateCarpenterSampleCorrection.cpp:162
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/Algorithms/inc/MantidAlgorithms/SpectrumAlgorithm.h:97
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/FunctionDomain1D.h:89
@@ -465,7 +464,7 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/FindClusterFace
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/FindClusterFaces.cpp:117
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/IndexSXPeaks.cpp:88
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/IndexSXPeaks.cpp:181
-returnByReference:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/MatrixWorkspace.h:335
+returnByReference:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/MatrixWorkspace.h:337
 variableScope:${CMAKE_SOURCE_DIR}/Framework/API/src/MatrixWorkspace.cpp:1635
 variableScope:${CMAKE_SOURCE_DIR}/Framework/API/src/MatrixWorkspace.cpp:1636
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MatrixWorkspace.cpp:383

--- a/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37793.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37793.rst
@@ -1,0 +1,1 @@
+- Add support for :ref:`Ragged Workspaces <Ragged_Workspace>` to binary operations. :ref:`Plus <algm-Plus>`, :ref:`Minus <algm-Minus>`, :ref:`Divide <algm-Divide>` and :ref:`Multiply <algm-Multiply>`.


### PR DESCRIPTION
### Description of work

You should now be added to do binary operations with Ragged Workspaces

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [4790: Math operations on mantid ragged workspaces](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/4790)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

The are 4 algorithms to test, Plus, Minus, Divide and Multiply. And you should test with EventWorkspace and Histogram workspaces, also with a constant (_e.g._ `ws+2`).

#### real data example

```python
filename="SNAP_45874"  # from systemtest data
LoadEventNexus(Filename=filename, OutputWorkspace='left')
LoadEventNexus(Filename=filename, OutputWorkspace='right')

CreateGroupingWorkspace(InputWorkspace='left', GroupDetectorsBy='Column', OutputWorkspace='SNAPFocGrp_Column')
for name in 'left', 'right':
    ConvertUnits(InputWorkspace=name, OutputWorkspace=name, Target='dSpacing')
    DiffractionFocussing(InputWorkspace=name, OutputWorkspace=name, GroupingWorkspace='SNAPFocGrp_Column')
    RebinRagged(InputWorkspace=name, OutputWorkspace=name+"_hist", XMin=(0.5,0.6,0.7,0.8,0.9,1), XMax=(2,2.2,2.4,2.6,2.8,3), Delta=(-0.001,-0.0015,-0.002,-0.0025,-0.003,-0.0035), PreserveEvents=False)
    RebinRagged(InputWorkspace=name, OutputWorkspace=name, XMin=(0.5,0.6,0.7,0.8,0.9,1), XMax=(2,2.2,2.4,2.6,2.8,3), Delta=(-0.001,-0.0015,-0.002,-0.0025,-0.003,-0.0035), PreserveEvents=True)

divisor = mtd['left']/mtd['right']
minusor = mtd['left'] - mtd['right']
```

#### fake data example

```python
left = CreateSampleWorkspace("Event", NumBanks=1, BankPixelWidth=2)
right = CreateSampleWorkspace("Event", NumBanks=1, BankPixelWidth=2)

left=RebinRagged(InputWorkspace=left, XMin=(100,200,300,400), XMax=(20000,15000,10000,5000), Delta=-1, PreserveEvents=True)
right=RebinRagged(InputWorkspace=right, XMin=(100,200,300,400), XMax=(20000,15000,10000,5000), Delta=-1, PreserveEvents=True)

out = left + right
out = left * right
out = left * 5
left =/ 10
# and many more combinations to try
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
