### PR TITLE
Add PearsonIV peak function

### DIFF
--- a/Framework/PythonInterface/plugins/CMakeLists.txt
+++ b/Framework/PythonInterface/plugins/CMakeLists.txt
@@ -375,6 +375,7 @@ set(PYTHON_PLUGINS
     functions/PCRmagnetZFKT.py
     functions/PCRmagnetfnorm.py
     functions/PEARLTransVoigt.py
+    functions/PearsonIV.py
     functions/Porod.py
     functions/PrimStretchedExpFT.py
     functions/RFresonance.py

--- a/Framework/PythonInterface/plugins/functions/PearsonIV.py
+++ b/Framework/PythonInterface/plugins/functions/PearsonIV.py
@@ -59,7 +59,8 @@ class PearsonIV(IPeakFunction):
         return self.functionLocal(self.getParameterValue("Centre"))
 
     def fwhm(self):
-        return (2 * self.getParameterValue("Sigma") + 1) / np.sqrt(self.getParameterValue("Exponent"))
+        # no exact form for FWHM - this is valid for skew=0
+        return 2 * self.getParameterValue("Sigma") * np.sqrt((2 ** (1 / self.getParameterValue("Exponent"))) - 1)
 
     def setCentre(self, new_centre):
         self.setParameter("Centre", new_centre)
@@ -74,8 +75,9 @@ class PearsonIV(IPeakFunction):
         return "Sigma"
 
     def setFwhm(self, new_fwhm):
-        height = self.height()
-        self.setParameter("Sigma", (np.sqrt(self.getParameterValue("Exponent")) * new_fwhm - 1) / 2)
+        height = self.height()  # to reset after
+        new_sigma = max(new_fwhm / (2 * np.sqrt((2 ** (1 / self.getParameterValue("Exponent"))) - 1)), 1e-10)
+        self.setParameter("Sigma", new_sigma)  # valid only for S > 0
         self.setHeight(height)
 
 

--- a/Framework/PythonInterface/plugins/functions/PearsonIV.py
+++ b/Framework/PythonInterface/plugins/functions/PearsonIV.py
@@ -1,0 +1,82 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+# pylint: disable=no-init,invalid-name
+
+import numpy as np
+from scipy.special import betaln, loggamma
+from mantid.api import IPeakFunction, FunctionFactory
+
+
+class PearsonIV(IPeakFunction):
+
+    def init(self):
+        self.declareParameter("Intensity", 1.0, "Area under the peak.")
+        self.declareParameter(
+            "Centre",
+            0.0,
+            "Position of the peak maximum (note this differs from the usual definition of the PearsonIV - "
+            "for which the 'location' parameter coincides with the maximum only for skew=0).",
+        )
+        self.declareParameter(
+            "Sigma",
+            1.0,
+            "One of the parameters controlling the width of peak (valid for Sigma > 0) - increasing Sigma increases the FWHM.",
+        )
+        self.declareParameter(
+            "Exponent",
+            1.5,
+            "One of the parameters controlling the width of peak (valid for Exponent > 0.5) - increasing Exponent decreases the FWHM.",
+        )
+        self.declareParameter(
+            "Skew",
+            0,
+            "Parameter determining the skew/asymmetry of the peak - a negative value of Skew produces a peak with "
+            "centre of mass at larger x value than the peak centre/maximum.",
+        )
+
+    def functionLocal(self, xvals):
+        intensity = self.getParameterValue("Intensity")
+        centre = self.getParameterValue("Centre")
+        sigma = self.getParameterValue("Sigma")
+        expon = self.getParameterValue("Exponent")
+        skew = self.getParameterValue("Skew")
+
+        dx = (xvals - centre - skew * sigma / (2 * expon)) / sigma  # adjusted centre to be at maximum of peak
+        logprefactor = 2 * (np.real(loggamma(expon + skew * 0.5j)) - loggamma(expon)) - betaln(expon - 0.5, 0.5)
+        return (intensity / sigma) * np.exp(logprefactor - expon * np.log1p(dx * dx) - skew * np.arctan(dx))
+
+    def centre(self):
+        return self.getParameterValue("Centre")
+
+    def intensity(self):
+        return self.getParameterValue("Intensity")
+
+    def height(self):
+        return self.functionLocal(self.getParameterValue("Centre"))
+
+    def fwhm(self):
+        return (2 * self.getParameterValue("Sigma") + 1) / np.sqrt(self.getParameterValue("Exponent"))
+
+    def setCentre(self, new_centre):
+        self.setParameter("Centre", new_centre)
+
+    def setHeight(self, new_height):
+        self.setParameter("Intensity", self.getParameterValue("Intensity") * new_height / self.height())
+
+    def setIntensity(self, new_intensity):
+        self.setParameter("Intensity", new_intensity)
+
+    def getWidthParameterName(self):
+        return "Sigma"
+
+    def setFwhm(self, new_fwhm):
+        height = self.height()
+        self.setParameter("Sigma", (np.sqrt(self.getParameterValue("Exponent")) * new_fwhm - 1) / 2)
+        self.setHeight(height)
+
+
+FunctionFactory.subscribe(PearsonIV)

--- a/Framework/PythonInterface/test/python/plugins/functions/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/functions/CMakeLists.txt
@@ -31,6 +31,7 @@ set(TEST_PY_FILES
     PCRmagnetRedfieldTest.py
     PCRmagnetfnormTest.py
     PEARLTransVoigtTest.py
+    PearsonIVTest.py
     PrimStretchedExpFTTest.py
     RedfieldTest.py
     RFresonanceTest.py

--- a/Framework/PythonInterface/test/python/plugins/functions/PearsonIVTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/PearsonIVTest.py
@@ -1,0 +1,46 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from mantid.simpleapi import FunctionWrapper
+from mantid.api import FunctionFactory
+
+import numpy as np
+import unittest
+
+
+class PearsonIVTest(unittest.TestCase):
+    def setUp(self):
+        self.func = FunctionFactory.Instance().createPeakFunction("PearsonIV")
+        pars = [1, 115, 1.0, 1.5, -5]  # intensity, centre, sigma, exponent, skew
+        [self.func.setParameter(ipar, par) for ipar, par in enumerate(pars)]
+
+    def test_exec_functionLocal(self):
+        x = np.linspace(100, 200, 101)
+        y = FunctionWrapper(self.func)(x)
+
+        # assert maximum and integral
+        self.assertAlmostEqual(y.max(), 0.2374, delta=1e-4)
+        intensity = np.sum(y) * (x[1] - x[0])
+        self.assertAlmostEqual(np.sum(y) * (x[1] - x[0]), 0.99, delta=1e-2)
+
+    def test_intensity(self):
+        self.assertAlmostEqual(self.func.intensity(), 1, delta=1e-3)
+
+    def test_set_intensity(self):
+        self.func.setIntensity(2)
+        self.assertAlmostEqual(self.func.intensity(), 2, delta=1e-3)
+
+    def test_fwhm(self):
+        fwhm = self.func.fwhm()
+        new_fwhm = 2 * fwhm
+        self.func.setFwhm(new_fwhm)
+
+        self.assertAlmostEqual(fwhm, 2.4494, delta=1e-3)
+        self.assertAlmostEqual(new_fwhm, 2 * 2.449, delta=1e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/functions/PearsonIVTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/PearsonIVTest.py
@@ -38,8 +38,12 @@ class PearsonIVTest(unittest.TestCase):
         new_fwhm = 2 * fwhm
         self.func.setFwhm(new_fwhm)
 
-        self.assertAlmostEqual(fwhm, 2.4494, delta=1e-3)
-        self.assertAlmostEqual(new_fwhm, 2 * 2.449, delta=1e-3)
+        self.assertAlmostEqual(fwhm, 1.5328, delta=1e-3)
+        self.assertAlmostEqual(new_fwhm, 2 * 1.5328, delta=1e-3)
+
+    def test_setFwhm_keep_sigma_grtrthn_zero(self):
+        self.func.setFwhm(0)
+        self.assertAlmostEqual(self.func.getParameterValue("Sigma"), 1e-10, delta=1e-10)
 
 
 if __name__ == "__main__":

--- a/docs/source/fitting/fitfunctions/PearsonIV.rst
+++ b/docs/source/fitting/fitfunctions/PearsonIV.rst
@@ -1,4 +1,4 @@
-.. _func-SpinDiffusion:
+.. _func-PearsonIV:
 
 =========
 PearsonIV
@@ -14,8 +14,7 @@ It differs from the traditional definition of the PearsonIV distribution [1]_ in
 centre (`Centre``) shifted so that it coincides with the peak maximum.
 
 The function is defined as
-.. math::
-    \frac{I}{\sigma}N\left[1 + \left(\frac{x - \lambda  - \nu\sigma/(2m)\right)^{2}}{\sigma}\right]^{-m}\exp\left(-\nu \arctan(\frac{x - \lambda - \nu\sigma/(2m)}{\sigma}) \right)
+.. math:: \frac{I}{\sigma}N\left[1 + \left(\frac{x - \lambda  - \nu\sigma/(2m)\right)^{2}}{\sigma}\right]^{-m}\exp\left(-\nu \arctan(\frac{x - \lambda - \nu\sigma/(2m)}{\sigma}) \right)
 
 where:
 

--- a/docs/source/fitting/fitfunctions/PearsonIV.rst
+++ b/docs/source/fitting/fitfunctions/PearsonIV.rst
@@ -1,0 +1,41 @@
+.. _func-SpinDiffusion:
+
+=========
+PearsonIV
+=========
+
+.. index:: PearsonIV
+
+Description
+-----------
+
+The PearsonIV peak shape is used to fit the prompt pulse in time-of-flight spectra.
+It differs from the traditional definition of the PearsonIV distribution [1]_ in that the Mantid definition has the peak
+centre (`Centre``) shifted so that it coincides with the peak maximum.
+
+The function is defined as
+.. math::
+    \frac{I}{\sigma}N\left[1 + \left(\frac{x - \lambda  - \nu\sigma/(2m)\right)^{2}}{\sigma}\right]^{-m}\exp\left(-\nu \arctan(\frac{x - \lambda - \nu\sigma/(2m)}{\sigma}) \right)
+
+where:
+
+- :math:`I` is the integrated intensity (area) of the peak (parameter name ``Intensity``)
+- :math:`\lambda` is the peak centre (parameter name ``Centre``).
+- :math:`\nu` is the parameter ``Skew``
+- :math:`m` is the parameter ``Exponent`` (valid for :math:`m > 0.5`)
+- :math:`\sigma` is the parameter ``Sigma`` (valid for :math:`\sigma > 0`)
+- :math:`N = \frac{2^{2m-2}\left|\Gamma(m+i\nu/2)\right|^2}{\pi\sigma\Gamma(2m-1)}` is the normalisation
+
+
+.. attributes::
+
+.. properties::
+
+References
+----------
+
+.. [1] Pearson, Karl. "X. Contributions to the mathematical theory of evolution.—II. Skew variation in homogeneous material." Philosophical Transactions of the Royal Society of London.(A.) 186 (1895): 343-414.
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.11.0/Framework/Fit_Functions/New_features/37800.rst
+++ b/docs/source/release/v6.11.0/Framework/Fit_Functions/New_features/37800.rst
@@ -1,0 +1,1 @@
+- Added the :ref:`PearsonIV <func-PearsonIV>` fit function to model prompt pulses.


### PR DESCRIPTION
### Description of work
Add `PearsonIV` function - will be used to model prompt pulse on HRPD.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Related to #37528 (but does not fix)


### To test:

(1) Load HRPD data and plot
```python
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from mantid.api import AnalysisDataService as ADS

ws =  Load(Filename='HRP81780.raw', OutputWorkspace='HRP81780')

fig, axes = plt.subplots(edgecolor='#ffffff', num='HRP81780-1', subplot_kw={'projection': 'mantid'})
axes.plot(ws, color='#1f77b4', label='HRP81780: spec 50', wkspIndex=49)
axes.set_title('HRP81780')
axes.set_xlabel('Time-of-flight ($\\mu s$)')
axes.set_ylabel('Counts ($\\mu s$)$^{-1}$')
axes.set_xlim([79917.0, 80270.0])
axes.set_ylim([0.083912, 22.081])
legend = axes.legend(fontsize=8.0).set_draggable(True).legend
fig.show()
```

(2) Click `Fit` on toolbar to open the fitbrowser
(3) Setup > Manage Setup > Load from string
(4) Copy/paste this function string and click OK
```
name=PearsonIV,Intensity=940.207,Centre=80004.8,Sigma=11.5146,Exponent=1.5,Skew=-5,constraints=(0.51<Exponent,1<Sigma);name=FlatBackground,A0=1.45373
```
(5) Fit - should execute without error
(6) Move red sliders to change FWHM
(7) Move red bar to change peak height and centre 


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
