### PR TITLE
Remove uses of load_module()

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/plugins.py
+++ b/Framework/PythonInterface/mantid/kernel/plugins.py
@@ -14,6 +14,7 @@ algorithms, fit functions etc.
 
 import os as _os
 from traceback import format_exc
+import importlib.util
 from importlib.machinery import SourceFileLoader
 from . import logger, Logger, config
 
@@ -45,7 +46,11 @@ class PluginLoader(object):
         name = _os.path.basename(pathname)  # Including extension
         name = _os.path.splitext(name)[0]
         self._logger.debug("Loading python plugin %s" % pathname)
-        return SourceFileLoader(name, pathname).load_module()
+        loader = SourceFileLoader(name, pathname)
+        spec = importlib.util.spec_from_loader(name, loader)
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
+        return module
 
 
 # ======================================================================================================================

--- a/Framework/PythonInterface/mantid/kernel/plugins.py
+++ b/Framework/PythonInterface/mantid/kernel/plugins.py
@@ -14,6 +14,7 @@ algorithms, fit functions etc.
 
 import os as _os
 from traceback import format_exc
+import sys
 import importlib.util
 from importlib.machinery import SourceFileLoader
 from . import logger, Logger, config
@@ -50,6 +51,11 @@ class PluginLoader(object):
         spec = importlib.util.spec_from_loader(name, loader)
         module = importlib.util.module_from_spec(spec)
         loader.exec_module(module)
+        # It's better to let import handle editing sys.modules, but this code used to call
+        # load_module, which would edit sys.modules, but now load_module is deprecated.
+        # We edit sys.modules here so that legacy user scripts will not have to be
+        # edited in order to keep working.
+        sys.modules[name] = module
         return module
 
 

--- a/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
@@ -5,7 +5,6 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-import inspect
 import os
 import sys
 import testhelpers
@@ -136,7 +135,7 @@ class ConfigServiceTest(unittest.TestCase):
 
     def test_properties_documented(self):
         # location of the rst file relative to this file this will break if either moves
-        doc_filename = os.path.split(inspect.getfile(self.__class__))[0]
+        doc_filename = os.path.split(__file__)[0]
         doc_filename = os.path.join(doc_filename, "../../../../../../docs/source/concepts/PropertiesFile.rst")
         doc_filename = os.path.abspath(doc_filename)
 

--- a/Framework/PythonInterface/test/testhelpers/testrunner.py
+++ b/Framework/PythonInterface/test/testhelpers/testrunner.py
@@ -11,6 +11,7 @@ once qtpy is universally used.
 It is intended to be used as a launcher script for a given unit test file.
 The reports are output to the current working directory.
 """
+import importlib.util
 from importlib.machinery import SourceFileLoader
 import os
 import sys
@@ -33,7 +34,12 @@ def main(argv):
 
     # Load the test and copy over any module variables so that we have
     # the same environment defined here
-    test_module = SourceFileLoader(module_name(pathname), pathname).load_module()
+
+    test_module_name = module_name(pathname)
+    test_loader = SourceFileLoader(test_module_name, pathname)
+    test_spec = importlib.util.spec_from_loader(test_module_name, test_loader)
+    test_module = importlib.util.module_from_spec(test_spec)
+    test_loader.exec_module(test_module)
     test_module_globals = dir(test_module)
     this_globals = globals()
     for key in test_module_globals:

--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -1153,18 +1153,14 @@ class TestManager(object):
         modname = modname.split(".py")[0]
         tests = []
         try:
-            spec = importlib.util.spec_from_file_location("", filename)
+            spec = importlib.util.spec_from_file_location(modname, filename)
             mod = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(mod)
 
-            mod_attrs = dir(mod)
-            for key in mod_attrs:
-                value = getattr(mod, key)
-                if key == "MantidSystemTest" or not inspect.isclass(value):
-                    continue
-                if self.isValidTestClass(value):
-                    test_name = key
-                    tests.append(TestSuite(self._runner.getTestDir(), modname, test_name, filename))
+            module_classes = dict(inspect.getmembers(mod, inspect.isclass))
+            module_classes = [x for x in module_classes if self.isValidTestClass(module_classes[x]) and x != "MantidSystemTest"]
+            for test_name in module_classes:
+                tests.append(TestSuite(self._runner.getTestDir(), modname, test_name, filename))
             module_loaded = True
         except Exception:
             print("Error importing module '{}':".format(modname))

--- a/Testing/Tools/cxxtest/sample/SCons/SConstruct
+++ b/Testing/Tools/cxxtest/sample/SCons/SConstruct
@@ -6,8 +6,14 @@ cxxtest_path = '../..'
 # without having to copy it into a particular path.
 # for nicer examples you *should* use, see the cxxtest builder tests in the
 # build_tools/SCons/test directory.
+import importlib.util
 from importlib.machinery import SourceFileLoader
-cxxtest = SourceFileLoader('cxxtest', cxxtestbuilder_path).load_module()
+
+cxxtest_name = 'cxxtest'
+loader = SourceFileLoader(cxxtest_name, cxxtestbuilder_path)
+spec = importlib.util.spec_from_loader(cxxtest_name, loader)
+cxxtest = importlib.util.module_from_spec(spec)
+loader.exec_module(cxxtest)
 
 # First build the 'real' library, when working on an embedded system
 # this may involve a cross compiler.

--- a/Testing/Tools/cxxtest/test/unit/SConstruct
+++ b/Testing/Tools/cxxtest/test/unit/SConstruct
@@ -2,8 +2,14 @@ CxxTestBuilder_path = '../../build_tools/SCons/cxxtest.py'
 CxxTest_dir = '../..'
 
 # First a little python magic to pull in CxxTestBuilder
+import importlib.util
 from importlib.machinery import SourceFileLoader
-cxxtest = SourceFileLoader('cxxtest', CxxTestBuilder_path).load_module()
+
+cxxtest_name = 'cxxtest'
+loader = SourceFileLoader(cxxtest_name, CxxTestBuilder_path)
+spec = importlib.util.spec_from_loader(cxxtest_name, loader)
+cxxtest = importlib.util.module_from_spec(spec)
+loader.exec_module(cxxtest)
 env = Environment()
 cxxtest.generate(env, CXXTEST_INSTALL_DIR=CxxTest_dir)
 

--- a/docs/source/release/v6.11.0/Framework/Python/Bugfixes/37031.rst
+++ b/docs/source/release/v6.11.0/Framework/Python/Bugfixes/37031.rst
@@ -1,0 +1,1 @@
+- Fixed error in the log about `load_module()` being deprecated in Python 3.12.


### PR DESCRIPTION
The `load_module()` method will be deprecated in Python 3.12, and uses of `load_module()` were generating error messages in the log warning about this deprecation. I've replaced these uses with the recommended `exec_module()`. See [here](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module) for more details.

In `systemtesting.py::loadTestsFromModule` I switched out a loop for a list comprehension and swapped in `inspect.getmembers`. Should do the same but easier to read I think.

In `plugins.py::run` the plugin is added to `sys.modules` purely to maintain existing behaviour. The old `load_module` would add the module to `sys.modules`, but `exec_module` does not. The `importlib` docs say  "The import machinery takes care of all the other responsibilities of [load_module()](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module) when [exec_module()](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.exec_module) is implemented"

Fixes #37031 

### To test:

See #37031 for the message you get on startup. Probably the easiest way to check is to download some plugins from the Script Repository in Workbench. When you restart Workbench you shouldn't get an error about `load_module()` being deprecated. I would check you can get the error in #37031 before trying out this fix. 

Also, double check no tests have gone missing, since I changed the system test discovery code.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
