### PR TITLE
Fix for random phase value bug in PyChop

### DIFF
--- a/docs/source/interfaces/direct/PyChop.rst
+++ b/docs/source/interfaces/direct/PyChop.rst
@@ -66,6 +66,8 @@ If the *Instrument scientist mode* option is selected, a similar option is
 enabled for MERLIN if the G chopper is used. In this case, the phase (time
 delay) of the thick disk chopper can be adjusted. The time delay is the time-of-
 flight at which the chopper slit first opens (sweeps across the beam profile).
+In the event that this mode is then deselected, the time delay entered previously
+will be utilised for subsequent calculations instead of the default value.
 
 The Matplotlib axes showing the calculated data have the standard toolbars.
 

--- a/docs/source/release/v6.11.0/Direct_Geometry/General/Bugfixes/37805.rst
+++ b/docs/source/release/v6.11.0/Direct_Geometry/General/Bugfixes/37805.rst
@@ -1,1 +1,1 @@
-- Fix for random phase values on Merlin when using PyChop not in instrument scientist mode.
+- Random phase values are no longer used on Merlin when using :ref:`PyChop` with instrument scientist mode disabled.

--- a/docs/source/release/v6.11.0/Direct_Geometry/General/Bugfixes/37805.rst
+++ b/docs/source/release/v6.11.0/Direct_Geometry/General/Bugfixes/37805.rst
@@ -1,0 +1,1 @@
+- Fix for random phase values on Merlin when using PyChop not in instrument scientist mode.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
@@ -217,7 +217,7 @@ class PyChopGui(QMainWindow):
             if key.endswith("Phase"):
                 # Special case for MERLIN
                 # sets the default phase for Chopper0Phase if not in "Instrument Scientist Mode"
-                if not widget["Label"].isHidden() or "MERLIN" in str(self.engine.instname) and widget["Label"].isHidden():
+                if not widget["Label"].isHidden() or "MERLIN" in str(self.engine.instname) and key[7] == 0:
                     idx = int(key[7])
                     phase = widget["Edit"].text()
                     if isinstance(self.engine.chopper_system.defaultPhase[idx], str):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
@@ -214,22 +214,20 @@ class PyChopGui(QMainWindow):
         # Checks for independent phases
         phases = []
         for key, widget in self.widgets.items():
-            if "MERLIN" in str(self.engine.instname) and key.endswith("Phase") and widget["Label"].isHidden():
+            if key.endswith("Phase"):
                 # Special case for MERLIN
                 # sets the default phase for Chopper0Phase if not in "Instrument Scientist Mode"
-                phase = float(widget["Edit"].text())
-                phases.append(phase)
-            if key.endswith("Phase") and not widget["Label"].isHidden():
-                idx = int(key[7])
-                phase = widget["Edit"].text()
-                if isinstance(self.engine.chopper_system.defaultPhase[idx], str):
-                    phase = str(phase)
-                else:
-                    try:
-                        phase = float(phase) % (1e6 / self.engine.moderator.source_rep)
-                    except ValueError:
-                        raise ValueError(f'Incorrect phase value "{phase}" for {widget["Label"].text()}')
-                phases.append(phase)
+                if not widget["Label"].isHidden() or "MERLIN" in str(self.engine.instname) and widget["Label"].isHidden():
+                    idx = int(key[7])
+                    phase = widget["Edit"].text()
+                    if isinstance(self.engine.chopper_system.defaultPhase[idx], str):
+                        phase = str(phase)
+                    else:
+                        try:
+                            phase = float(phase) % (1e6 / self.engine.moderator.source_rep)
+                        except ValueError:
+                            raise ValueError(f'Incorrect phase value "{phase}" for {widget["Label"].text()}')
+                    phases.append(phase)
         if phases:
             self.engine.setFrequency(freq_in, phase=phases)
         else:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
@@ -214,6 +214,11 @@ class PyChopGui(QMainWindow):
         # Checks for independent phases
         phases = []
         for key, widget in self.widgets.items():
+            if "MERLIN" in str(self.engine.instname) and key.endswith("Phase") and widget["Label"].isHidden():
+                # Special case for MERLIN
+                # sets the default phase for Chopper0Phase if not in "Instrument Scientist Mode"
+                phase = float(widget["Edit"].text())
+                phases.append(phase)
             if key.endswith("Phase") and not widget["Label"].isHidden():
                 idx = int(key[7])
                 phase = widget["Edit"].text()
@@ -642,9 +647,9 @@ class PyChopGui(QMainWindow):
         txt += "# Ei = %8.2f meV\n" % (ei)
         txt += "# Flux = %8.2f n/cm2/s\n" % (flux)
         txt += "# Elastic resolution = %6.2f meV\n" % (res[0])
-        txt += "# Time width at sample = %6.2f us, of which:\n" % (1e6 * np.sqrt(tsqvan))
+        txt += "# Time width at sample = %6.2f us, of which:\n" % (1e6 * np.sqrt(tsqvan[0]))
         for ky, val in list(tsqdic.items()):
-            txt += "#     %20s : %6.2f us\n" % (ky, 1e6 * np.sqrt(val))
+            txt += "#     %20s : %6.2f us\n" % (ky, 1e6 * np.sqrt(val[0]))
         txt += "# %s distances:\n" % (obj.instname)
         txt += "#     x0 = %6.2f m (%s to Fermi)\n" % (x0, first_component)
         txt += "#     x1 = %6.2f m (Fermi to sample)\n" % (x1)

--- a/scripts/pychop/merlin.yaml
+++ b/scripts/pychop/merlin.yaml
@@ -21,7 +21,7 @@ chopper_system:
       radius: 300               # Disk radius
       isDouble: False           # Is this a double disk system?
       isPhaseIndependent: True  # Is this disk to be phased independently?
-      defaultPhase: 12800       # What is the default phase for this disk (either a time in microseconds
+      defaultPhase: 12400       # What is the default phase for this disk (either a time in microseconds
                                 #   or a slot index [as a string] for the desired rep to go through)
       phaseOffset: 11300        # Offset introduced after disk chopper controller update
       phaseName: 'Disk chopper phase delay time'


### PR DESCRIPTION
### Description of work

#### Summary of work
PyChop only allows in "Instrument Scientist Mode" to change the chopper phase and else needs to use the default phase value. For each calculation, the default phase value must be reset to avoid being overwritten by a temporary value when calculating the possible incident energies.

I have also fixed two NumPy deprecation warnings.

Fixes #37734. 

**Report to:** [Adroja / ISIS]

### To test:

Follow the instructions in the original issue and check that the bug is fixed.


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
