### PR TITLE
Indirect Reduction avoid loading workspace into ADS during validation

### DIFF
--- a/docs/source/release/v6.11.0/Indirect/Bugfixes/37810.rst
+++ b/docs/source/release/v6.11.0/Indirect/Bugfixes/37810.rst
@@ -1,0 +1,1 @@
+- Fixed a bug on the Energy Transfer tab of the :ref:`Indirect Data Reduction <interface-indirect-data-reduction>` interface where the first raw file would be loaded into the ADS but never deleted.

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferValidator.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferValidator.cpp
@@ -44,9 +44,10 @@ std::string IETDataValidator::validateConversionData(IETConversionData conversio
   return "";
 }
 
-std::vector<std::string> IETDataValidator::validateBackgroundData(IETBackgroundData backgroundData,
-                                                                  IETConversionData conversionData,
-                                                                  std::string firstFileName, bool isRunFileValid) {
+std::vector<std::string> IETDataValidator::validateBackgroundData(IETBackgroundData const &backgroundData,
+                                                                  IETConversionData const &conversionData,
+                                                                  std::string const &firstFileName,
+                                                                  bool const isRunFileValid) {
   std::vector<std::string> errors;
 
   if (!isRunFileValid || !backgroundData.getRemoveBackground()) {

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferValidator.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferValidator.cpp
@@ -26,7 +26,8 @@ MatrixWorkspace_sptr load(std::string const &filename, int const specMin, int co
   loader->setPropertyValue("SpectrumMin", std::to_string(specMin));
   loader->setPropertyValue("SpectrumMax", std::to_string(specMax));
   loader->execute();
-  return loader->getProperty("OutputWorkspace");
+  Mantid::API::Workspace_sptr ws = loader->getProperty("OutputWorkspace");
+  return std::dynamic_pointer_cast<MatrixWorkspace>(ws);
 }
 } // namespace
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferValidator.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferValidator.cpp
@@ -15,12 +15,18 @@ using namespace Mantid::API;
 using namespace MantidQt::MantidWidgets::WorkspaceUtils;
 
 namespace {
-IAlgorithm_sptr loadAlgorithm(std::string const &filename, std::string const &outputName) {
+MatrixWorkspace_sptr load(std::string const &filename, int const specMin, int const specMax) {
   auto loader = AlgorithmManager::Instance().create("Load");
   loader->initialize();
+  loader->setAlwaysStoreInADS(false);
   loader->setProperty("Filename", filename);
-  loader->setProperty("OutputWorkspace", outputName);
-  return loader;
+  if (loader->existsProperty("LoadLogFiles")) {
+    loader->setProperty("LoadLogFiles", false);
+  }
+  loader->setPropertyValue("SpectrumMin", std::to_string(specMin));
+  loader->setPropertyValue("SpectrumMax", std::to_string(specMax));
+  loader->execute();
+  return loader->getProperty("OutputWorkspace");
 }
 } // namespace
 
@@ -43,42 +49,30 @@ std::vector<std::string> IETDataValidator::validateBackgroundData(IETBackgroundD
                                                                   std::string firstFileName, bool isRunFileValid) {
   std::vector<std::string> errors;
 
-  if (isRunFileValid) {
-    std::filesystem::path rawFileInfo(firstFileName);
-    std::string name = rawFileInfo.filename().string();
+  if (!isRunFileValid || !backgroundData.getRemoveBackground()) {
+    return errors;
+  }
 
-    int specMin = conversionData.getSpectraMin();
-    int specMax = conversionData.getSpectraMax();
+  const int backgroundStart = backgroundData.getBackgroundStart();
+  const int backgroundEnd = backgroundData.getBackgroundEnd();
 
-    auto loadAlg = loadAlgorithm(firstFileName, name);
-    if (loadAlg->existsProperty("LoadLogFiles")) {
-      loadAlg->setProperty("LoadLogFiles", false);
-    }
-    loadAlg->setPropertyValue("SpectrumMin", std::to_string(specMin));
-    loadAlg->setPropertyValue("SpectrumMax", std::to_string(specMax));
-    loadAlg->execute();
+  if (backgroundStart > backgroundEnd) {
+    errors.push_back("Background Start must be less than Background End");
+  }
 
-    if (backgroundData.getRemoveBackground()) {
-      const int backgroundStart = backgroundData.getBackgroundStart();
-      const int backgroundEnd = backgroundData.getBackgroundEnd();
+  int specMin = conversionData.getSpectraMin();
+  int specMax = conversionData.getSpectraMax();
+  const auto workspace = load(firstFileName, specMin, specMax);
 
-      if (backgroundStart > backgroundEnd) {
-        errors.push_back("Background Start must be less than Background End");
-      }
+  const double minBack = workspace->x(0).front();
+  const double maxBack = workspace->x(0).back();
 
-      auto tempWs = getADSWorkspace(name);
+  if (backgroundStart < minBack) {
+    errors.push_back("The Start of Background Removal is less than the minimum of the data range");
+  }
 
-      const double minBack = tempWs->x(0).front();
-      const double maxBack = tempWs->x(0).back();
-
-      if (backgroundStart < minBack) {
-        errors.push_back("The Start of Background Removal is less than the minimum of the data range");
-      }
-
-      if (backgroundEnd > maxBack) {
-        errors.push_back("The End of Background Removal is more than the maximum of the data range");
-      }
-    }
+  if (backgroundEnd > maxBack) {
+    errors.push_back("The End of Background Removal is more than the maximum of the data range");
   }
 
   return errors;

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferValidator.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferValidator.h
@@ -16,8 +16,9 @@ public:
   IETDataValidator() = default;
 
   std::string validateConversionData(IETConversionData conversionData);
-  std::vector<std::string> validateBackgroundData(IETBackgroundData backgroundData, IETConversionData conversionData,
-                                                  std::string firstFileName, bool isRunFileValid);
+  std::vector<std::string> validateBackgroundData(IETBackgroundData const &backgroundData,
+                                                  IETConversionData const &conversionData,
+                                                  std::string const &firstFileName, bool const isRunFileValid);
   std::string validateAnalysisData(IETAnalysisData analysisData);
 };
 


### PR DESCRIPTION
### Description of work
This PR fixes a bug where the first raw run in a Indirect Energy transfer reduction is loaded into the ADS for validation, but never gets deleted. The solution was to ensure the workspace is not loaded into the ADS, but only into memory while doing the validation. This ensures there is no left over workspace that needs to be deleted.

Fixes #37801 

### To test:
1. Open Indirect Data Reduction
2. Choose IRIS instrument (but happens also for other instruments)
3. Choose run 26176
4. Click `Run`
5. There should be a single reduced file in the ADS

Also follow the testing instructions here:
https://developer.mantidproject.org/Testing/Indirect/DataReductionTests.html

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
