### PR TITLE
DiffractionFocussing2 bug with sorted events

### DIFF
--- a/Framework/Algorithms/test/DiffractionFocussing2Test.h
+++ b/Framework/Algorithms/test/DiffractionFocussing2Test.h
@@ -78,6 +78,126 @@ public:
     AnalysisDataService::Instance().remove("focusedWS");
   }
 
+  void test_preserve_compare() {
+    // processed nexus file in event mode
+    const std::string PG3_FILE("PG3_46577.nxs.h5");
+
+    const std::string inputWSname("PG3_46577");
+    const std::string groupWS("PG3_group");
+    { // load data from disk and get prepared for focussing
+      auto loader = AlgorithmFactory::Instance().create("Load", -1); // "LoadNexusProcessed", -1);
+      loader->initialize();
+      loader->setProperty("Filename", PG3_FILE);
+      loader->setProperty("OutputWorkspace", inputWSname);
+      loader->execute();
+      if (!loader->isExecuted())
+        throw std::runtime_error("Failed to load " + PG3_FILE);
+
+      auto cropworkspace = AlgorithmFactory::Instance().create("CropWorkspace", -1);
+      cropworkspace->initialize();
+      cropworkspace->setPropertyValue("InputWorkspace", inputWSname);
+      cropworkspace->setPropertyValue("OutputWorkspace", inputWSname);
+      cropworkspace->setProperty("XMin", 300.);
+      cropworkspace->execute();
+      if (!cropworkspace->isExecuted())
+        throw std::runtime_error("Failed to CropWorkspace");
+
+      auto compress = AlgorithmFactory::Instance().create("CompressEvents", -1);
+      compress->initialize();
+      compress->setPropertyValue("InputWorkspace", inputWSname);
+      compress->setPropertyValue("OutputWorkspace", inputWSname);
+      compress->execute();
+      if (!compress->isExecuted())
+        throw std::runtime_error("Failed to compress events");
+
+      auto resamplex = AlgorithmFactory::Instance().create("ResampleX", -1);
+      resamplex->initialize();
+      resamplex->setPropertyValue("InputWorkspace", inputWSname);
+      resamplex->setPropertyValue("OutputWorkspace", inputWSname);
+      resamplex->setProperty("NumberBins", 6000);
+      resamplex->setProperty("LogBinning", true);
+      resamplex->execute();
+      if (!resamplex->isExecuted())
+        throw std::runtime_error("Failed to resample x-axis in TOF");
+
+      auto convertunits = AlgorithmFactory::Instance().create("ConvertUnits", -1);
+      convertunits->initialize();
+      convertunits->setPropertyValue("InputWorkspace", inputWSname);
+      convertunits->setPropertyValue("OutputWorkspace", inputWSname);
+      convertunits->setProperty("Target", "dSpacing");
+      convertunits->execute();
+      if (!convertunits->isExecuted())
+        throw std::runtime_error("Failed to convert to dspacing");
+
+      auto creategroup = AlgorithmFactory::Instance().create("CreateGroupingWorkspace", -1);
+      creategroup->initialize();
+      creategroup->setPropertyValue("InputWorkspace", inputWSname);
+      creategroup->setPropertyValue("OutputWorkspace", groupWS);
+      creategroup->setProperty("GroupDetectorsBy", "All");
+      creategroup->execute();
+      if (!creategroup->isExecuted())
+        throw std::runtime_error("Failed to create grouping workspace");
+    }
+
+    const std::string outputFalse(inputWSname + "_false");
+    {
+      DiffractionFocussing2 focussing;
+      focussing.initialize();
+      TS_ASSERT_THROWS_NOTHING(focussing.setPropertyValue("InputWorkspace", inputWSname));
+      TS_ASSERT_THROWS_NOTHING(focussing.setPropertyValue("OutputWorkspace", outputFalse));
+      TS_ASSERT_THROWS_NOTHING(focussing.setPropertyValue("GroupingWorkspace", groupWS));
+      TS_ASSERT_THROWS_NOTHING(focussing.setProperty("PreserveEvents", false));
+      TS_ASSERT_THROWS_NOTHING(focussing.execute());
+      if (!focussing.isExecuted())
+        throw std::runtime_error("Failed to DiffractionFocus PreserveEvents=False");
+    }
+
+    const std::string outputTrue(inputWSname + "_true");
+    {
+      DiffractionFocussing2 focussing;
+      focussing.initialize();
+      TS_ASSERT_THROWS_NOTHING(focussing.setPropertyValue("InputWorkspace", inputWSname));
+      TS_ASSERT_THROWS_NOTHING(focussing.setPropertyValue("OutputWorkspace", outputTrue));
+      TS_ASSERT_THROWS_NOTHING(focussing.setPropertyValue("GroupingWorkspace", groupWS));
+      TS_ASSERT_THROWS_NOTHING(focussing.setProperty("PreserveEvents", true));
+      TS_ASSERT_THROWS_NOTHING(focussing.execute());
+      if (!focussing.isExecuted())
+        throw std::runtime_error("Failed to DiffractionFocus PreserveEvents=True");
+    }
+
+    // cleanup inputs
+    AnalysisDataService::Instance().remove(inputWSname);
+    AnalysisDataService::Instance().remove(groupWS);
+
+    // make sure workspace types do not match
+    MatrixWorkspace_const_sptr wsFalse = AnalysisDataService::Instance().retrieveWS<const MatrixWorkspace>(outputFalse);
+    MatrixWorkspace_const_sptr wsTrue = AnalysisDataService::Instance().retrieveWS<const MatrixWorkspace>(outputTrue);
+    TS_ASSERT_DIFFERS(wsFalse->id(), wsTrue->id()); // different workspace types
+
+    // check x-axis and total counts match - this is easier to debug than CompareWorkspaces
+    const size_t NUM_HISTO = wsFalse->getNumberHistograms();
+    for (size_t ws_index = 0; ws_index < NUM_HISTO; ++ws_index) {
+      TS_ASSERT_EQUALS(wsFalse->readX(ws_index), wsTrue->readX(ws_index));
+      const auto totalFalse = std::accumulate(wsFalse->readY(ws_index).cbegin(), wsFalse->readY(ws_index).cend(), 0.);
+      const auto totalTrue = std::accumulate(wsTrue->readY(ws_index).cbegin(), wsTrue->readY(ws_index).cend(), 0.);
+      TS_ASSERT_DELTA(totalFalse, totalTrue, .1);
+    }
+
+    // compare workspaces
+    auto comparator = AlgorithmFactory::Instance().create("CompareWorkspaces", -1);
+    comparator->initialize();
+    comparator->setProperty("Workspace1", outputFalse);
+    comparator->setProperty("Workspace2", outputTrue);
+    comparator->setProperty("CheckType", false);
+    comparator->execute();
+    bool result = comparator->getProperty("Result");
+    TS_ASSERT(result);
+
+    // cleanup outputs
+    AnalysisDataService::Instance().remove(outputFalse);
+    AnalysisDataService::Instance().remove(outputTrue);
+  }
+
   void test_EventWorkspace_SameOutputWS() { dotestEventWorkspace(true, 2); }
 
   void test_EventWorkspace_DifferentOutputWS() { dotestEventWorkspace(false, 2); }
@@ -238,130 +358,6 @@ public:
                                        : double(bankWidthInPixels * bankWidthInPixels),
                       1e-4);
     }
-  }
-
-  void test_preserve_compare() {
-    // processed nexus file in event mode
-    const std::string PG3_FILE("PG3_46577.nxs.h5");
-    // const std::string PG3_FILE("/home/pf9/build/mantid/vulcanperf/VULCAN_218075.nxs.h5");
-    // const std::string PG3_FILE("/home/pf9/build/mantid/nom_ewm6535/NOM_198203.nxs.h5");
-
-    const std::string inputWSname("PG3_46577");
-    const std::string groupWS("PG3_group");
-    { // load data from disk and get prepared for focussing
-      auto loader = AlgorithmFactory::Instance().create("Load", -1); // "LoadNexusProcessed", -1);
-      loader->initialize();
-      loader->setProperty("Filename", PG3_FILE);
-      loader->setProperty("OutputWorkspace", inputWSname);
-      // loader->setProperty("NumberOfBins", 1);
-      // loader->setProperty("LoadLogs", false);
-      loader->execute();
-      if (!loader->isExecuted())
-        throw std::runtime_error("Failed to load " + PG3_FILE);
-
-      auto cropworkspace = AlgorithmFactory::Instance().create("CropWorkspace", -1);
-      cropworkspace->initialize();
-      cropworkspace->setProperty("InputWorkspace", inputWSname);
-      cropworkspace->setProperty("OutputWorkspace", inputWSname);
-      cropworkspace->setProperty("XMin", 300.);
-      cropworkspace->execute();
-      if (!cropworkspace->isExecuted())
-        throw std::runtime_error("Failed to CropWorkspace");
-
-      auto compress = AlgorithmFactory::Instance().create("CompressEvents", -1);
-      compress->initialize();
-      compress->setProperty("InputWorkspace", inputWSname);
-      compress->setProperty("OutputWorkspace", inputWSname);
-      compress->execute();
-      if (!compress->isExecuted())
-        throw std::runtime_error("Failed to compress events");
-
-      auto resamplex = AlgorithmFactory::Instance().create("ResampleX", -1);
-      resamplex->initialize();
-      resamplex->setProperty("InputWorkspace", inputWSname);
-      resamplex->setProperty("OutputWorkspace", inputWSname);
-      resamplex->setProperty("NumberBins", 6000);
-      resamplex->setProperty("LogBinning", true);
-      resamplex->execute();
-      if (!resamplex->isExecuted())
-        throw std::runtime_error("Failed to resample x-axis in TOF");
-
-      auto convertunits = AlgorithmFactory::Instance().create("ConvertUnits", -1);
-      convertunits->initialize();
-      convertunits->setProperty("InputWorkspace", inputWSname);
-      convertunits->setProperty("OutputWorkspace", inputWSname);
-      convertunits->setProperty("Target", "dSpacing");
-      convertunits->execute();
-      if (!convertunits->isExecuted())
-        throw std::runtime_error("Failed to convert to dspacing");
-
-      auto creategroup = AlgorithmFactory::Instance().create("CreateGroupingWorkspace", -1);
-      creategroup->initialize();
-      creategroup->setProperty("InputWorkspace", inputWSname);
-      creategroup->setProperty("OutputWorkspace", groupWS);
-      creategroup->setProperty("GroupDetectorsBy", "bank");
-      creategroup->execute();
-      if (!creategroup->isExecuted())
-        throw std::runtime_error("Failed to create grouping workspace");
-    }
-
-    const std::string outputFalse(inputWSname + "_false");
-    {
-      auto focus = AlgorithmFactory::Instance().create("DiffractionFocussing", 2);
-      focus->initialize();
-      TS_ASSERT_THROWS_NOTHING(focus->setProperty("InputWorkspace", inputWSname));
-      TS_ASSERT_THROWS_NOTHING(focus->setProperty("OutputWorkspace", outputFalse));
-      TS_ASSERT_THROWS_NOTHING(focus->setProperty("GroupingWorkspace", groupWS));
-      TS_ASSERT_THROWS_NOTHING(focus->setProperty("PreserveEvents", false));
-      TS_ASSERT_THROWS_NOTHING(focus->execute());
-      if (!focus->isExecuted())
-        throw std::runtime_error("Failed to DiffractionFocus PreserveEvents=False");
-    }
-
-    const std::string outputTrue(inputWSname + "_true");
-    {
-      auto focus = AlgorithmFactory::Instance().create("DiffractionFocussing", 2);
-      focus->initialize();
-      TS_ASSERT_THROWS_NOTHING(focus->setProperty("InputWorkspace", inputWSname));
-      TS_ASSERT_THROWS_NOTHING(focus->setProperty("OutputWorkspace", outputTrue));
-      TS_ASSERT_THROWS_NOTHING(focus->setProperty("GroupingWorkspace", groupWS));
-      TS_ASSERT_THROWS_NOTHING(focus->setProperty("PreserveEvents", true));
-      TS_ASSERT_THROWS_NOTHING(focus->execute());
-      if (!focus->isExecuted())
-        throw std::runtime_error("Failed to DiffractionFocus PreserveEvents=True");
-    }
-
-    // cleanup inputs
-    AnalysisDataService::Instance().remove(inputWSname);
-    AnalysisDataService::Instance().remove(groupWS);
-
-    // make sure workspace types do not match
-    MatrixWorkspace_const_sptr wsFalse = AnalysisDataService::Instance().retrieveWS<const MatrixWorkspace>(outputFalse);
-    MatrixWorkspace_const_sptr wsTrue = AnalysisDataService::Instance().retrieveWS<const MatrixWorkspace>(outputTrue);
-    TS_ASSERT_DIFFERS(wsFalse->id(), wsTrue->id()); // different workspace types
-
-    // check x-axis and total counts match - this is easier to debug than CompareWorkspaces
-    const size_t NUM_HISTO = wsFalse->getNumberHistograms();
-    for (size_t ws_index = 0; ws_index < NUM_HISTO; ++ws_index) {
-      TS_ASSERT_EQUALS(wsFalse->readX(ws_index), wsTrue->readX(ws_index));
-      const auto totalFalse = std::accumulate(wsFalse->readY(ws_index).cbegin(), wsFalse->readY(ws_index).cend(), 0.);
-      const auto totalTrue = std::accumulate(wsTrue->readY(ws_index).cbegin(), wsTrue->readY(ws_index).cend(), 0.);
-      TS_ASSERT_EQUALS(totalFalse, totalTrue);
-    }
-
-    // compare workspaces
-    auto comparator = AlgorithmFactory::Instance().create("CompareWorkspaces", -1);
-    comparator->initialize();
-    comparator->setProperty("Workspace1", outputFalse);
-    comparator->setProperty("Workspace2", outputTrue);
-    comparator->setProperty("CheckType", false);
-    comparator->execute();
-    bool result = comparator->getProperty("Result");
-    TS_ASSERT(result);
-
-    // cleanup outputs
-    AnalysisDataService::Instance().remove(outputFalse);
-    AnalysisDataService::Instance().remove(outputTrue);
   }
 
 private:

--- a/Framework/Algorithms/test/DiffractionFocussing2Test.h
+++ b/Framework/Algorithms/test/DiffractionFocussing2Test.h
@@ -240,6 +240,130 @@ public:
     }
   }
 
+  void test_preserve_compare() {
+    // processed nexus file in event mode
+    const std::string PG3_FILE("PG3_46577.nxs.h5");
+    // const std::string PG3_FILE("/home/pf9/build/mantid/vulcanperf/VULCAN_218075.nxs.h5");
+    // const std::string PG3_FILE("/home/pf9/build/mantid/nom_ewm6535/NOM_198203.nxs.h5");
+
+    const std::string inputWSname("PG3_46577");
+    const std::string groupWS("PG3_group");
+    { // load data from disk and get prepared for focussing
+      auto loader = AlgorithmFactory::Instance().create("Load", -1); // "LoadNexusProcessed", -1);
+      loader->initialize();
+      loader->setProperty("Filename", PG3_FILE);
+      loader->setProperty("OutputWorkspace", inputWSname);
+      // loader->setProperty("NumberOfBins", 1);
+      // loader->setProperty("LoadLogs", false);
+      loader->execute();
+      if (!loader->isExecuted())
+        throw std::runtime_error("Failed to load " + PG3_FILE);
+
+      auto cropworkspace = AlgorithmFactory::Instance().create("CropWorkspace", -1);
+      cropworkspace->initialize();
+      cropworkspace->setProperty("InputWorkspace", inputWSname);
+      cropworkspace->setProperty("OutputWorkspace", inputWSname);
+      cropworkspace->setProperty("XMin", 300.);
+      cropworkspace->execute();
+      if (!cropworkspace->isExecuted())
+        throw std::runtime_error("Failed to CropWorkspace");
+
+      auto compress = AlgorithmFactory::Instance().create("CompressEvents", -1);
+      compress->initialize();
+      compress->setProperty("InputWorkspace", inputWSname);
+      compress->setProperty("OutputWorkspace", inputWSname);
+      compress->execute();
+      if (!compress->isExecuted())
+        throw std::runtime_error("Failed to compress events");
+
+      auto resamplex = AlgorithmFactory::Instance().create("ResampleX", -1);
+      resamplex->initialize();
+      resamplex->setProperty("InputWorkspace", inputWSname);
+      resamplex->setProperty("OutputWorkspace", inputWSname);
+      resamplex->setProperty("NumberBins", 6000);
+      resamplex->setProperty("LogBinning", true);
+      resamplex->execute();
+      if (!resamplex->isExecuted())
+        throw std::runtime_error("Failed to resample x-axis in TOF");
+
+      auto convertunits = AlgorithmFactory::Instance().create("ConvertUnits", -1);
+      convertunits->initialize();
+      convertunits->setProperty("InputWorkspace", inputWSname);
+      convertunits->setProperty("OutputWorkspace", inputWSname);
+      convertunits->setProperty("Target", "dSpacing");
+      convertunits->execute();
+      if (!convertunits->isExecuted())
+        throw std::runtime_error("Failed to convert to dspacing");
+
+      auto creategroup = AlgorithmFactory::Instance().create("CreateGroupingWorkspace", -1);
+      creategroup->initialize();
+      creategroup->setProperty("InputWorkspace", inputWSname);
+      creategroup->setProperty("OutputWorkspace", groupWS);
+      creategroup->setProperty("GroupDetectorsBy", "bank");
+      creategroup->execute();
+      if (!creategroup->isExecuted())
+        throw std::runtime_error("Failed to create grouping workspace");
+    }
+
+    const std::string outputFalse(inputWSname + "_false");
+    {
+      auto focus = AlgorithmFactory::Instance().create("DiffractionFocussing", 2);
+      focus->initialize();
+      TS_ASSERT_THROWS_NOTHING(focus->setProperty("InputWorkspace", inputWSname));
+      TS_ASSERT_THROWS_NOTHING(focus->setProperty("OutputWorkspace", outputFalse));
+      TS_ASSERT_THROWS_NOTHING(focus->setProperty("GroupingWorkspace", groupWS));
+      TS_ASSERT_THROWS_NOTHING(focus->setProperty("PreserveEvents", false));
+      TS_ASSERT_THROWS_NOTHING(focus->execute());
+      if (!focus->isExecuted())
+        throw std::runtime_error("Failed to DiffractionFocus PreserveEvents=False");
+    }
+
+    const std::string outputTrue(inputWSname + "_true");
+    {
+      auto focus = AlgorithmFactory::Instance().create("DiffractionFocussing", 2);
+      focus->initialize();
+      TS_ASSERT_THROWS_NOTHING(focus->setProperty("InputWorkspace", inputWSname));
+      TS_ASSERT_THROWS_NOTHING(focus->setProperty("OutputWorkspace", outputTrue));
+      TS_ASSERT_THROWS_NOTHING(focus->setProperty("GroupingWorkspace", groupWS));
+      TS_ASSERT_THROWS_NOTHING(focus->setProperty("PreserveEvents", true));
+      TS_ASSERT_THROWS_NOTHING(focus->execute());
+      if (!focus->isExecuted())
+        throw std::runtime_error("Failed to DiffractionFocus PreserveEvents=True");
+    }
+
+    // cleanup inputs
+    AnalysisDataService::Instance().remove(inputWSname);
+    AnalysisDataService::Instance().remove(groupWS);
+
+    // make sure workspace types do not match
+    MatrixWorkspace_const_sptr wsFalse = AnalysisDataService::Instance().retrieveWS<const MatrixWorkspace>(outputFalse);
+    MatrixWorkspace_const_sptr wsTrue = AnalysisDataService::Instance().retrieveWS<const MatrixWorkspace>(outputTrue);
+    TS_ASSERT_DIFFERS(wsFalse->id(), wsTrue->id()); // different workspace types
+
+    // check x-axis and total counts match - this is easier to debug than CompareWorkspaces
+    const size_t NUM_HISTO = wsFalse->getNumberHistograms();
+    for (size_t ws_index = 0; ws_index < NUM_HISTO; ++ws_index) {
+      TS_ASSERT_EQUALS(wsFalse->readX(ws_index), wsTrue->readX(ws_index));
+      const auto totalFalse = std::accumulate(wsFalse->readY(ws_index).cbegin(), wsFalse->readY(ws_index).cend(), 0.);
+      const auto totalTrue = std::accumulate(wsTrue->readY(ws_index).cbegin(), wsTrue->readY(ws_index).cend(), 0.);
+      TS_ASSERT_EQUALS(totalFalse, totalTrue);
+    }
+
+    // compare workspaces
+    auto comparator = AlgorithmFactory::Instance().create("CompareWorkspaces", -1);
+    comparator->initialize();
+    comparator->setProperty("Workspace1", outputFalse);
+    comparator->setProperty("Workspace2", outputTrue);
+    comparator->setProperty("CheckType", false);
+    comparator->execute();
+    bool result = comparator->getProperty("Result");
+    TS_ASSERT(result);
+
+    // cleanup outputs
+    AnalysisDataService::Instance().remove(outputFalse);
+    AnalysisDataService::Instance().remove(outputTrue);
+  }
+
 private:
   DiffractionFocussing2 focus;
 };

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -267,9 +267,9 @@ public:
 
   void filterByPulseTime(Types::Core::DateAndTime start, Types::Core::DateAndTime stop, EventList &output) const;
 
-  void filterByPulseTime(Kernel::TimeROI *timeRoi, EventList *output) const;
+  void filterByPulseTime(Kernel::TimeROI const *timeRoi, EventList *output) const;
 
-  void filterInPlace(Kernel::TimeROI *timeRoi);
+  void filterInPlace(const Kernel::TimeROI *timeRoi);
 
   /// Initialize the detector ID's and event type of the destination event lists when splitting this list
   void initializePartials(std::map<int, EventList *> partials) const;
@@ -284,7 +284,7 @@ public:
 
   void divide(const MantidVec &X, const MantidVec &Y, const MantidVec &E) override;
 
-  void convertUnitsViaTof(Mantid::Kernel::Unit *fromUnit, Mantid::Kernel::Unit *toUnit);
+  void convertUnitsViaTof(Mantid::Kernel::Unit const *fromUnit, Mantid::Kernel::Unit const *toUnit);
   void convertUnitsQuickly(const double &factor, const double &power);
 
   /// Returns a copy of the Histogram associated with this spectrum.
@@ -421,7 +421,7 @@ private:
   static void filterByTimeROIHelper(std::vector<T> &events, const std::vector<Kernel::TimeInterval> &intervals,
                                     EventList *output);
 
-  template <class T> void filterInPlaceHelper(Kernel::TimeROI *timeRoi, typename std::vector<T> &events);
+  template <class T> void filterInPlaceHelper(Kernel::TimeROI const *timeRoi, typename std::vector<T> &events);
 
   template <class T> static void multiplyHelper(std::vector<T> &events, const double value, const double error = 0.0);
   template <class T>
@@ -430,8 +430,8 @@ private:
   template <class T>
   static void divideHistogramHelper(std::vector<T> &events, const MantidVec &X, const MantidVec &Y, const MantidVec &E);
   template <class T>
-  void convertUnitsViaTofHelper(typename std::vector<T> &events, Mantid::Kernel::Unit *fromUnit,
-                                Mantid::Kernel::Unit *toUnit);
+  void convertUnitsViaTofHelper(typename std::vector<T> &events, Mantid::Kernel::Unit const *fromUnit,
+                                Mantid::Kernel::Unit const *toUnit);
   template <class T>
   void convertUnitsQuicklyHelper(typename std::vector<T> &events, const double &factor, const double &power);
 };

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -3522,9 +3522,8 @@ void EventList::setTofs(const MantidVec &tofs) {
  * @param error: error on 'value'. Can be 0.
  * */
 template <class T> void EventList::multiplyHelper(std::vector<T> &events, const double value, const double error) {
-  // Square of the value's error
-  double errorSquared = error * error;
-  double valueSquared = value * value;
+  // Square of the value
+  const double valueSquared = value * value;
 
   auto itev_end = events.end();
 
@@ -3536,6 +3535,7 @@ template <class T> void EventList::multiplyHelper(std::vector<T> &events, const 
     }
   } else {
     // Carry the scalar error
+    const double errorSquared = error * error; // Square of the value's error
     for (auto itev = events.begin(); itev != itev_end; itev++) {
       itev->m_errorSquared =
           static_cast<float>(itev->m_errorSquared * valueSquared + errorSquared * itev->m_weight * itev->m_weight);
@@ -3970,7 +3970,7 @@ void EventList::filterByPulseTime(Types::Core::DateAndTime start, Types::Core::D
  * @param output :: reference to an event list that will be output.
  * @throws std::invalid_argument If output is a reference to this EventList
  */
-void EventList::filterByPulseTime(Kernel::TimeROI *timeRoi, EventList *output) const {
+void EventList::filterByPulseTime(Kernel::TimeROI const *timeRoi, EventList *output) const {
 
   this->sortPulseTime();
   // Clear the output
@@ -4066,7 +4066,7 @@ void EventList::filterByTimeROIHelper(std::vector<T> &events, const std::vector<
  *
  * @param timeRoi :: a TimeROI that will be used to filter events
  */
-void EventList::filterInPlace(Kernel::TimeROI *timeRoi) {
+void EventList::filterInPlace(Kernel::TimeROI const *timeRoi) {
   if (timeRoi == nullptr) {
     throw std::runtime_error("TimeROI can not be a nullptr\n");
   }
@@ -4117,7 +4117,8 @@ void EventList::filterInPlace(Kernel::TimeROI *timeRoi) {
  *  in this helper function and is expected to be implicitly followed by the
  *  caller.
  */
-template <class T> void EventList::filterInPlaceHelper(Kernel::TimeROI *timeRoi, typename std::vector<T> &events) {
+template <class T>
+void EventList::filterInPlaceHelper(Kernel::TimeROI const *timeRoi, typename std::vector<T> &events) {
 
   const auto splitter = timeRoi->toTimeIntervals();
   // Iterate through the splitter at the same time
@@ -4244,8 +4245,8 @@ void getEventsFrom(const EventList &el, std::vector<WeightedEventNoTime> const *
  * @param toUnit the unit to convert to
  */
 template <class T>
-void EventList::convertUnitsViaTofHelper(typename std::vector<T> &events, Mantid::Kernel::Unit *fromUnit,
-                                         Mantid::Kernel::Unit *toUnit) {
+void EventList::convertUnitsViaTofHelper(typename std::vector<T> &events, Mantid::Kernel::Unit const *fromUnit,
+                                         Mantid::Kernel::Unit const *toUnit) {
   for (auto &itev : events) {
     // Conver to TOF
     const double tof = fromUnit->singleToTOF(itev.m_tof);
@@ -4262,7 +4263,7 @@ void EventList::convertUnitsViaTofHelper(typename std::vector<T> &events, Mantid
  * @param fromUnit :: the Unit describing the input unit. Must be initialized.
  * @param toUnit :: the Unit describing the output unit. Must be initialized.
  */
-void EventList::convertUnitsViaTof(Mantid::Kernel::Unit *fromUnit, Mantid::Kernel::Unit *toUnit) {
+void EventList::convertUnitsViaTof(Mantid::Kernel::Unit const *fromUnit, Mantid::Kernel::Unit const *toUnit) {
   // Check for initialized
   if (!fromUnit || !toUnit)
     throw std::runtime_error("EventList::convertUnitsViaTof(): one of the units is NULL!");

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1891,8 +1891,7 @@ void EventList::histogramForWeightsHelper(const std::vector<T> &events, const Ma
     return;
   }
 
-  // If the sizes are the same, then the "resize" command will NOT clear the
-  // original values.
+  // If the sizes are the same, then the "resize" command will NOT clear the original values.
   bool mustFill = (Y.size() == x_size - 1);
   // Clear the Y data, assign all to 0.
   Y.resize(x_size - 1, 0.0);
@@ -1987,8 +1986,15 @@ void EventList::histogramForWeightsHelper(const std::vector<T> &events, const do
     return;
   }
 
+  // If the sizes are the same, then the "resize" command will NOT clear the original values.
+  bool mustFill = (Y.size() == x_size - 1);
   Y.resize(x_size - 1, 0.0);
   E.resize(x_size - 1, 0.0);
+  if (mustFill) {
+    // We must make sure the starting point is 0.0
+    std::fill(Y.begin(), Y.end(), 0.0);
+    std::fill(E.begin(), E.end(), 0.0);
+  }
 
   if (events.empty())
     return;
@@ -2093,8 +2099,8 @@ void EventList::generateHistogramTimeAtSample(const MantidVec &X, MantidVec &Y, 
 }
 
 // --------------------------------------------------------------------------
-/** Generates both the Y and E (error) histograms w.r.t TOF
- * for an EventList with or without WeightedEvents.
+/** Generates both the Y and E (error) histograms w.r.t TOF for an EventList with or without WeightedEvents.
+ *  This will zero out the Y array as part of the process.
  *
  * @param X: x-bins supplied
  * @param Y: counts returned
@@ -2126,8 +2132,8 @@ void EventList::generateHistogram(const MantidVec &X, MantidVec &Y, MantidVec &E
 }
 
 // --------------------------------------------------------------------------
-/** Generates both the Y and E (error) histograms w.r.t TOF
- * for an EventList with or without WeightedEvents.
+/** Generates both the Y and E (error) histograms w.r.t TOF for an EventList with or without WeightedEvents.
+ *  This will zero out the Y array as part of the process.
  *
  * This calculates histogram without sorting the events by using the step size to estimate the bin number. This has been
  * made to only work for logarithmic or linear binning. This falls back to using the sorted histogram method if the
@@ -2466,8 +2472,12 @@ void EventList::generateCountsHistogram(const double step, const MantidVec &X, M
     return;
   }
 
+  // If the sizes are the same, then the "resize" command will NOT clear the original values.
+  bool mustFill = (Y.size() == x_size - 1);
   // Clear the Y data, assign all to 0.
   Y.resize(x_size - 1, 0);
+  if (mustFill) // starting point is no counts
+    std::fill(Y.begin(), Y.end(), 0.0);
 
   // Do we even have any events to do?
   if (this->events.empty())

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -2844,6 +2844,8 @@ public:
     VectorHelper::createAxisFromRebinParams(rebinParams, X, true);
 
     TS_ASSERT(!e.isSortedByTof());
+    // set the values of Y to be one so we can check that the values are zeroed out
+    Y.resize(X.size() - 1, 1.);
 
     // do unsorted histogram then compare and check still unsorted
     e.generateHistogram(rebinParams[1], X, Y, E);

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -216,7 +216,7 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DirectILLTu
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DirectILLTubeBackground.cpp:364
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/EditInstrumentGeometry.cpp:273
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:89
-containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:677
+containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:685
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ExportTimeSeriesLog.cpp:134
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ExportTimeSeriesLog.cpp:330
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp:54
@@ -871,13 +871,8 @@ constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNexusPr
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNexusProcessed.cpp:380
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/CenteringGroup.h:46
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNexusProcessed.cpp:410
-variableScope:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:3516
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/CompositeBraggScatterer.h:64
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp:189
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:3963
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4110
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4237
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:4238
 derefInvalidIterator:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1590
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/Group.h:148
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/MaskWorkspace.cpp:411

--- a/docs/source/release/v6.11.0/Diffraction/Powder/Bugfixes/37811.rst
+++ b/docs/source/release/v6.11.0/Diffraction/Powder/Bugfixes/37811.rst
@@ -1,0 +1,1 @@
+- Fix bug in :ref:`DiffractionFocussing <algm-DiffractionFocussing-v2>` not properly accumulating data when :ref:`CompressEvents <algm-CompressEvents-v1>` prior to it in ``PreserveEvents=False`` mode


### PR DESCRIPTION
### Description of work

There was a difference in the result of `DiffractionFocussing` with `PreserverEvents` being true/false for sorted and unsorted events. The issue was finally discovered when creating the histogram view of a tof sorted event list (from compression) versus an unsorted event list (from file), which went through two different details for generating the histogram. For the tof sorted the Y-vector passed in is zeroed out. For the unsorted, the Y-vector is accumulated. This only occured for `PreserveEvents=False` in `DiffractionFocusing`

Fixes [EWM6757](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6535). *There is no associated issue.*

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

For people with access to the original 17GB data file this was discovered with
```python
from mantid.simpleapi import *


direc = '/absolute/path/to/data/'
wkspname='diamond'

# load data
Load(Filename=direc+'NOM_198202.nxs.h5', OutputWorkspace=wkspname, NumberOfBins=1)
LoadDiffCal(InputWorkspace=wkspname, Filename=direc+'NOMAD_196808_2023-08-14_shifter.h5', GroupFilename=direc+'NOM_Texture_Grouping.xml', WorkspaceName='NOM', TofMin=300)

# process up to focussing
MaskDetectors(Workspace=wkspname, MaskedWorkspace='NOM_mask')
CropWorkspace(InputWorkspace=wkspname, OutputWorkspace=wkspname, XMin=300)
CompressEvents(InputWorkspace=wkspname, OutputWorkspace=wkspname)
ResampleX(InputWorkspace=wkspname, OutputWorkspace=wkspname, NumberBins=6000, LogBinning=True)
ApplyDiffCal(InstrumentWorkspace=wkspname, CalibrationWorkspace='NOM_cal')
ConvertUnits(InputWorkspace=wkspname, OutputWorkspacediamond_hist=wkspname, Target='dSpacing')
ApplyDiffCal(InstrumentWorkspace=wkspname, ClearCalibration=True)

# EVENTS=FALSE
DiffractionFocussing(InputWorkspace=wkspname, OutputWorkspace=wkspname+"_hist", GroupingWorkspace='NOM_group', PreserveEvents=False)

#EVENTS=TRUE
DiffractionFocussing(InputWorkspace=wkspname, OutputWorkspace=wkspname, GroupingWorkspace='NOM_group', PreserveEvents=True)

# compare, ignoring that they are different types
CompareWorkspaces(Workspace1=wkspname+"_hist", Workspace2=wkspname, Checktype=False)
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
