### PR TITLE
Add OutputSuffix to ISISIndirectEnergyTransfer

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -156,6 +156,12 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
             WorkspaceGroupProperty("OutputWorkspace", "", direction=Direction.Output), doc="Workspace group for the resulting workspaces."
         )
 
+        self.declareProperty(
+            name="OutputSuffix",
+            defaultValue="",
+            doc="A suffix that will be appended to each output workspace while preserving the naming convention",
+        )
+
     # pylint: disable=too-many-locals
     def PyExec(self):
         from IndirectReductionCommon import (
@@ -303,7 +309,9 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
                 ConvertUnits(InputWorkspace=c_ws_name, OutputWorkspace=c_ws_name, EMode="Indirect", Target=self._output_x_units)
 
         # Rename output workspaces
-        output_workspace_names = [rename_reduction(ws_name, self._sum_files) for ws_name in self._workspace_names]
+        output_workspace_names = [
+            rename_reduction(ws_name, self._sum_files, suffix=self._output_suffix) for ws_name in self._workspace_names
+        ]
 
         summary_prog = Progress(self, start=0.9, end=1.0, nreports=4)
 
@@ -406,6 +414,7 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
         self._output_x_units = self.getPropertyValue("UnitX")
 
         self._output_ws = self.getPropertyValue("OutputWorkspace")
+        self._output_suffix = self.getPropertyValue("OutputSuffix")
 
         # Disable sum files if there is only one file
         if len(self._data_files) == 1:

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferTest.py
@@ -409,6 +409,23 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
         red_ws = wks.getItem(0)
         self.assertEqual(red_ws.getSpectrum(0).getSpectrumNo(), 0)
 
+    def test_reduction_with_suffix(self):
+        """Check that the output suffix is appended at the end of output workspace names"""
+
+        wks = ISISIndirectEnergyTransfer(
+            InputFiles=["IRS26176.RAW"],
+            Instrument="IRIS",
+            Analyser="graphite",
+            Reflection="002",
+            SpectraRange=[3, 53],
+            OutputWorkspace="OutputGroup",
+            OutputSuffix="test",
+        )
+
+        self.assertTrue(isinstance(wks, WorkspaceGroup), "Result workspace should be a workspace group.")
+        self.assertEqual(wks.name(), "OutputGroup")
+        self.assertEqual(wks.getNames()[0], "iris26176_graphite002_test_red")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37820.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37820.rst
@@ -1,0 +1,1 @@
+- Add OutputSuffix parameter to :ref:`ISISIndirectEnergyTransfer <algm-ISISIndirectEnergyTransfer>` algorithm that will append a suffix to the end of output workspace names.

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -939,7 +939,7 @@ def fold_chopped(workspace_name):
 # -------------------------------------------------------------------------------
 
 
-def rename_reduction(workspace_name, multiple_files):
+def rename_reduction(workspace_name, multiple_files, suffix=None):
     """
     Renames a workspace according to the naming policy in the Workflow.NamingConvention parameter.
 
@@ -997,6 +997,9 @@ def rename_reduction(workspace_name, multiple_files):
 
     else:
         raise RuntimeError("No valid naming convention for workspace %s" % workspace_name)
+
+    if suffix:
+        new_name = "%s_%s" % (new_name, suffix)
 
     logger.information("New name for %s workspace: %s" % (workspace_name, new_name))
 

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -993,13 +993,13 @@ def rename_reduction(workspace_name, multiple_files, suffix=None):
     elif convention == "AnalyserReflection":
         analyser = instrument.getStringParameter("analyser")[0]
         reflection = instrument.getStringParameter("reflection")[0]
-        new_name = "%s%s%s_%s%s_red" % (inst_name.lower(), run_number, multi_run_marker, analyser, reflection)
+        if not suffix:
+            new_name = "%s%s%s_%s%s_red" % (inst_name.lower(), run_number, multi_run_marker, analyser, reflection)
+        else:
+            new_name = "%s%s%s_%s%s_%s_red" % (inst_name.lower(), run_number, multi_run_marker, analyser, reflection, suffix)
 
     else:
         raise RuntimeError("No valid naming convention for workspace %s" % workspace_name)
-
-    if suffix:
-        new_name = "%s_%s" % (new_name, suffix)
 
     logger.information("New name for %s workspace: %s" % (workspace_name, new_name))
 


### PR DESCRIPTION
### Description of work
This pull request introduces a new option to the ISISIndirectEnergyTransfer algorithm that appends each output workspace name with a suffix. This new feature addresses the issue of having the same output name when running the algorithm with different configurations. 


#### Purpose of work
Sam Jones reported this issue in one of his autoreduction scripts. The bug occurred because he was running the algorithm with two different grouping options, and the second run would always override the previous one as they both had the same output name.

*There is no associated issue.*

**Report to:** @Pasarus 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
-->

### To test:
1- Run the following script:
```
ISISIndirectEnergyTransfer(InputFiles='IRS21360.raw',
                           OutputWorkspace='IndirectReductions',
                           Instrument='IRIS',
                           Analyser='graphite',
                           Reflection='002',
                           SpectraRange=[3, 53],
                           OutputSuffix="test"
)
```
2- Check the output workspace and it should end with the specified suffix

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
