### PR TITLE
Block libopenblas v0.3.28

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -87,7 +87,7 @@ gsl:
 
 # v0.3.23 causes a hang on osx for some systemtests, v0.3.24 causes a unit test failure that needs investigation, v0.3.25 causes a system test failure on linux
 libopenblas:
-  - '!=0.3.23,!=0.3.24,!=0.3.25'
+  - '!=0.3.23,!=0.3.24,!=0.3.25, !=0.3.28'
 
 euphonic:
   - '>=1.2.1,<2.0'

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -18,7 +18,7 @@ dependencies:
   - jsoncpp>=1.9.4,<2
   - libboost-devel=1.84.* # Use the same version as conda-forge
   - libboost-python-devel=1.84.* # Use the same version as conda-forge
-  - libopenblas!=0.3.23,!=0.3.24,!=0.3.25 # v0.3.25 causing system test failures on linux. Others are for macOS consistency.
+  - libopenblas!=0.3.23,!=0.3.24,!=0.3.25, !=0.3.28 # v0.3.25 causing system test failures on linux. Others are for macOS consistency.
   - librdkafka>=1.6.0
   - matplotlib=3.7.*
   - muparser>=2.3.2

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -16,7 +16,7 @@ dependencies:
   - jsoncpp>=1.9.4,<2
   - libboost-devel=1.84.* # Use the same version as conda-forge
   - libboost-python-devel=1.84.* # Use the same version as conda-forge
-  - libopenblas!=0.3.23,!=0.3.24,!=0.3.25 # v0.3.23 causes a hang for the system tests on OSX, v0.3.24 causing unit test failure - investigation needed, v0.3.25 causing a system test failure.
+  - libopenblas!=0.3.23,!=0.3.24,!=0.3.25, !=0.3.28 # v0.3.23 causes a hang for the system tests on OSX, v0.3.24 causing unit test failure - investigation needed, v0.3.25 causing a system test failure.
   - librdkafka>=1.6.0
   - matplotlib=3.7.*
   - muparser>=2.3.2


### PR DESCRIPTION
### Description of work

#### Summary of work
Have made it so that the build will no longer use v0.3.28 of `libopenblas` 

#### Purpose of work
Lots of PRs failing on unrelated tests as well as the nightly. The only dependency change has been `libopenblas`. Blocking this newest version seems to have allowed all tests to pass on this PR.

*There is no associated issue.*

#### Further detail of work
Changes to the conda recipe to avoid v0.3.28 of `libopenblas`

### To test:
- all CI tests should pass
- Check that v0.3.28 of `libopenblas` is no longer being used 

*This does not require release notes* because **it is a dependency pin*

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
