### PR TITLE
Add signal to sigma post fitting check

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
@@ -217,8 +217,7 @@ private:
   void calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAlgorithm::PeakFitResult>> &fit_results);
 
   double calculateSignalToSigmaRatio(const size_t &iws, const std::pair<double, double> &peakWindow,
-                                     const API::IPeakFunction_sptr &peakFunction,
-                                     const API::IBackgroundFunction_sptr &backgroundFunction);
+                                     const API::IPeakFunction_sptr &peakFunction);
 
   /// Get the parameter name for peak height (I or height or etc)
   std::string getPeakHeightParameterName(const API::IPeakFunction_const_sptr &peak_function);

--- a/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
@@ -216,6 +216,10 @@ private:
   /// calculate peak+background for fitted
   void calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAlgorithm::PeakFitResult>> &fit_results);
 
+  double calculateSignalToSigmaRatio(const size_t &iws, const std::pair<double, double> &peakWindow,
+                                     const API::IPeakFunction_sptr &peakFunction,
+                                     const API::IBackgroundFunction_sptr &backgroundFunction);
+
   /// Get the parameter name for peak height (I or height or etc)
   std::string getPeakHeightParameterName(const API::IPeakFunction_const_sptr &peak_function);
 
@@ -328,6 +332,8 @@ private:
   // Criteria for rejecting non-peaks or weak peaks from fitting
   double m_minSignalToNoiseRatio;
   double m_minPeakTotalCount;
+
+  double m_minSignalToSigmaRatio;
 
   /// flag for high background
   bool m_highBackground;

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -33,6 +33,7 @@
 #include "MantidKernel/IValidator.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/StartsWithValidator.h"
+#include "MantidKernel/VectorHelper.h"
 
 #include "boost/algorithm/string.hpp"
 #include "boost/algorithm/string/trim.hpp"
@@ -82,6 +83,7 @@ const std::string OUTPUT_WKSP_PARAM_ERRS("OutputParameterFitErrorsWorkspace");
 const std::string RAW_PARAMS("RawPeakParameters");
 const std::string PEAK_MIN_SIGNAL_TO_NOISE_RATIO("MinimumSignalToNoiseRatio");
 const std::string PEAK_MIN_TOTAL_COUNT("MinimumPeakTotalCount");
+const std::string PEAK_MIN_SIGNAL_TO_SIGMA_RATIO("MinimumSignalToSigmaRatio");
 } // namespace PropertyNames
 } // namespace
 
@@ -430,6 +432,10 @@ void FitPeaks::init() {
   declareProperty(PropertyNames::PEAK_MIN_TOTAL_COUNT, EMPTY_DBL(),
                   "Used for validating peaks before fitting. If the total peak window Y-value count "
                   "is under this value, the peak will be excluded from fitting and calibration.");
+
+  declareProperty(PropertyNames::PEAK_MIN_SIGNAL_TO_SIGMA_RATIO, 0.,
+                  "Used for validating peaks before fitting. If the signal-to-sigma ratio is under this value, "
+                  "the peak will be excluded from fitting and calibration.");
 
   const std::string addoutgrp("Analysis");
   setPropertyGroup(PropertyNames::OUTPUT_WKSP_PARAMS, addoutgrp);
@@ -923,6 +929,11 @@ void FitPeaks::processInputPeakTolerance() {
   m_minSignalToNoiseRatio = getProperty(PropertyNames::PEAK_MIN_SIGNAL_TO_NOISE_RATIO);
   if (isEmpty(m_minSignalToNoiseRatio) || m_minSignalToNoiseRatio < 0.)
     m_minSignalToNoiseRatio = 0.;
+
+  // set the signal-to-sigma threshold to zero (default value) if not specified or invalid
+  m_minSignalToSigmaRatio = getProperty(PropertyNames::PEAK_MIN_SIGNAL_TO_SIGMA_RATIO);
+  if (isEmpty(m_minSignalToSigmaRatio) || m_minSignalToSigmaRatio < 0.)
+    m_minSignalToSigmaRatio = 0.;
 }
 
 //----------------------------------------------------------------------------------------------
@@ -1282,6 +1293,14 @@ void FitPeaks::fitSpectrumPeaks(size_t wi, const std::vector<double> &expected_p
                                bkgdfunction, peak_pre_check_result);
       if (peak_pre_check_result->isIndividualPeakRejected())
         fit_result->setBadRecord(peak_index, -1.);
+
+      if (m_minSignalToSigmaRatio > 0) {
+        if (calculateSignalToSigmaRatio(wi, peak_window_i, peakfunction, bkgdfunction); < m_minSignalToSigmaRatio) {
+          fit_result->setBadRecord(peak_index, -1.);
+          cost = DBL_MAX;
+        }
+      }
+
       *pre_check_result += *peak_pre_check_result; // keep track of the rejection count within the spectrum
     }
     pre_check_result->setNumberOfOutOfRangePeaks(number_of_out_of_range_peaks);
@@ -1531,6 +1550,38 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
 
   return;
 }
+
+double FitPeaks::calculateSignalToSigmaRatio(const size_t &iws, const std::pair<double, double> &peakWindow,
+                                             const API::IPeakFunction_sptr &peakFunction,
+                                             const API::IBackgroundFunction_sptr &backgroundFunction) {
+  const auto &vecX = m_fittedPeakWS->points(iws);
+  auto startX = std::lower_bound(vecX.begin(), vecX.end(), peakWindow.first);
+  auto stopX = std::lower_bound(vecX.begin(), vecX.end(), peakWindow.second);
+
+  FunctionDomain1DVector domain(startX, stopX);
+  FunctionValues values(domain);
+  CompositeFunction_sptr compFunc = std::make_shared<API::CompositeFunction>();
+
+  compFunc->addFunction(backgroundFunction);
+  compFunc->function(domain, values);
+  auto bkgdValues = values.toVector();
+
+  compFunc->addFunction(peakFunction);
+  compFunc->function(domain, values);
+  auto fittedValues = values.toVector();
+
+  const auto &errors = m_fittedPeakWS->readE(iws);
+  auto startE = std::lower_bound(errors.begin(), errors.end(), peakWindow.first);
+  auto stopE = std::lower_bound(errors.begin(), errors.end(), peakWindow.second);
+  std::vector<double> peakErrors(startE, stopE);
+
+  double fittedSum = std::accumulate(fittedValues.cbegin(), fittedValues.cend(), 0.0);
+  double bkgdSum = std::accumulate(bkgdValues.cbegin(), bkgdValues.cend(), 0.0);
+  double sigma = sqrt(std::accumulate(peakErrors.cbegin(), peakErrors.cend(), 0.0, VectorHelper::SumSquares<double>()));
+
+  return (fittedSum - bkgdSum) / ((sigma == 0) ? 1 : sigma);
+}
+
 namespace {
 bool estimateBackgroundParameters(const Histogram &histogram, const std::pair<size_t, size_t> &peak_window,
                                   const API::IBackgroundFunction_sptr &bkgd_function) {

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1553,7 +1553,7 @@ void FitPeaks::calculateFittedPeaks(const std::vector<std::shared_ptr<FitPeaksAl
 
 double FitPeaks::calculateSignalToSigmaRatio(const size_t &iws, const std::pair<double, double> &peakWindow,
                                              const API::IPeakFunction_sptr &peakFunction) {
-  const auto &vecX = m_fittedPeakWS->points(iws);
+  const auto &vecX = m_inputMatrixWS->points(iws);
   auto startX = std::lower_bound(vecX.begin(), vecX.end(), peakWindow.first);
   auto stopX = std::lower_bound(vecX.begin(), vecX.end(), peakWindow.second);
 
@@ -1563,9 +1563,9 @@ double FitPeaks::calculateSignalToSigmaRatio(const size_t &iws, const std::pair<
   peakFunction->function(domain, values);
   auto peakValues = values.toVector();
 
-  const auto &errors = m_fittedPeakWS->readE(iws);
-  auto startE = std::lower_bound(errors.begin(), errors.end(), peakWindow.first);
-  auto stopE = std::lower_bound(errors.begin(), errors.end(), peakWindow.second);
+  const auto &errors = m_inputMatrixWS->readE(iws);
+  auto startE = errors.begin() + (startX - vecX.begin());
+  auto stopE = errors.begin() + (stopX - vecX.begin());
   std::vector<double> peakErrors(startE, stopE);
 
   double peakSum = std::accumulate(peakValues.cbegin(), peakValues.cend(), 0.0);

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -73,7 +73,7 @@ DECLARE_ALGORITHM(PDCalibration)
 
 namespace { // anonymous
 const auto isNonZero = [](const double value) { return value != 0.; };
-}
+} // namespace
 
 /// private inner class
 class PDCalibration::FittedPeaks {
@@ -315,6 +315,10 @@ void PDCalibration::init() {
                   "Used for validating peaks before fitting. If the total peak window Y-value count "
                   "is under this value, the peak will be excluded from fitting and calibration.");
 
+  declareProperty("MinimumSignalToSigmaRatio", 0.,
+                  "Used for validating peaks before fitting. If the signal-to-sigma ratio is under this value, "
+                  "the peak will be excluded from fitting and calibration.");
+
   // make group for Input properties
   std::string inputGroup("Input Options");
   setPropertyGroup("InputWorkspace", inputGroup);
@@ -336,6 +340,7 @@ void PDCalibration::init() {
   setPropertyGroup("MinimumPeakHeight", fitPeaksGroup);
   setPropertyGroup("MinimumSignalToNoiseRatio", fitPeaksGroup);
   setPropertyGroup("MinimumPeakTotalCount", fitPeaksGroup);
+  setPropertyGroup("MinimumSignalToSigmaRatio", fitPeaksGroup);
   setPropertyGroup("HighBackground", fitPeaksGroup);
   setPropertyGroup("MaxChiSq", fitPeaksGroup);
   setPropertyGroup("ConstrainPeakPositions", fitPeaksGroup);
@@ -489,6 +494,7 @@ void PDCalibration::exec() {
   const double minPeakHeight = getProperty("MinimumPeakHeight");
   const double minPeakTotalCount = getProperty("MinimumPeakTotalCount");
   const double minSignalToNoiseRatio = getProperty("MinimumSignalToNoiseRatio");
+  const double minSignalToSigmaRatio = getProperty("MinimumSignalToSigmaRatio");
   const double maxChiSquared = getProperty("MaxChiSq");
 
   const std::string calParams = getPropertyValue("CalibrationParameters");
@@ -578,6 +584,7 @@ void PDCalibration::exec() {
   algFitPeaks->setProperty("MinimumPeakHeight", minPeakHeight);
   algFitPeaks->setProperty("MinimumPeakTotalCount", minPeakTotalCount);
   algFitPeaks->setProperty("MinimumSignalToNoiseRatio", minSignalToNoiseRatio);
+  algFitPeaks->setProperty("MinimumSignalToSigmaRatio", minSignalToSigmaRatio);
   // some fitting strategy
   algFitPeaks->setProperty("FitFromRight", true);
   const bool highBackground = getProperty("HighBackground");

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -316,7 +316,7 @@ void PDCalibration::init() {
                   "is under this value, the peak will be excluded from fitting and calibration.");
 
   declareProperty("MinimumSignalToSigmaRatio", 0.,
-                  "Used for validating peaks before fitting. If the signal-to-sigma ratio is under this value, "
+                  "Used for validating peaks after fitting. If the signal-to-sigma ratio is under this value, "
                   "the peak will be excluded from fitting and calibration.");
 
   // make group for Input properties

--- a/Framework/Algorithms/test/FitPeaksTest.h
+++ b/Framework/Algorithms/test/FitPeaksTest.h
@@ -1488,7 +1488,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakCentersWorkspace", peak_center_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("FitPeakWindowWorkspace", fit_window_ws_name));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("HighBackground", false));
-    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MinimumSignalToSigmaRatio", 50.));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("MinimumSignalToSigmaRatio", 25.));
 
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3"));
     TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3"));

--- a/docs/source/release/v6.11.0/Diffraction/Powder/New_features/37826.rst
+++ b/docs/source/release/v6.11.0/Diffraction/Powder/New_features/37826.rst
@@ -1,0 +1,1 @@
+- Add a minimum signal-to-sigma post-fitting check to :ref:`FitPeaks <algm-FitPeaks>` and :ref:`PDCalibration <algm-PDCalibration>`, where peaks with a signal below the provided threshold will be rejected.


### PR DESCRIPTION
### Description of work
This pull request introduces a new property to FitPeaks and PDCalibration: the option to set a minimum signal-to-sigma ratio for post-fitting. When this property is provided, peaks with a signal-to-sigma ratio below the specified minimum will be rejected. The signal-to-sigma ratio is calculated as the integrated fitted peak minus the integrated background, divided by the sigma, which is calculated using the quadrature sum of the errors.
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #35224. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
1- Run the following script:
```
from mantid.simpleapi import *

ws = CreateSampleWorkspace(Function="User Defined",
                           UserDefinedFunction="name=LinearBackground, A0=0.3;name=Gaussian, PeakCentre=5, Height=10, Sigma=0.7",
                           NumBanks=1, BankPixelWidth=1, XMin=0, XMax=10, BinWidth=0.1)

FitPeaks(InputWorkspace='ws', PeakCenters='5.1', FitWindowBoundaryList='0,10', OutputPeakParametersWorkspace='fitted_params',
         BackgroundType='Linear', FittedPeaksWorkspace='fitted', OutputWorkspace='peakpositions', MinimumSignalToSigmaRatio='200')
```
2- Check the fitted data and params, you will notice the peak has been rejected.
3- Rerun the same script but with MinimumSignalToSigmaRatio='150', then you will see the expected fitted peak.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
