### PR TITLE
Add link to NXevent_data in LoadEventNexus algorithm docs

### DIFF
--- a/docs/source/algorithms/LoadEventNexus-v1.rst
+++ b/docs/source/algorithms/LoadEventNexus-v1.rst
@@ -9,12 +9,11 @@
 Description
 -----------
 
-The LoadEventNeXus algorithm loads data from an EventNexus file into an
-:ref:`EventWorkspace <EventWorkspace>`. The histogram bin
-boundaries depend on the setting of NumberOfBins, which by default will be the whole range of time of flight able to hold all events (in all
-pixels) split into NumberOfBins linear bins, and will have their :ref:`units <Unit Factory>` set to time-of-flight.
-Since it is an :ref:`EventWorkspace <EventWorkspace>`, it can be rebinned
-to finer bins with no loss of data.
+The LoadEventNeXus algorithm loads data from an `EventNexus file <https://manual.nexusformat.org/classes/base_classes/NXevent_data.html>`_ into an :ref:`EventWorkspace <EventWorkspace>`.
+The histogram bin boundaries depend on the setting of NumberOfBins,
+which by default will be the whole range of time of flight able to hold all events (in all pixels) split into NumberOfBins linear bins,
+and will have their :ref:`units <Unit Factory>` set to time-of-flight.
+Since it is an :ref:`EventWorkspace <EventWorkspace>`, it can be rebinned to finer bins with no loss of data.
 
 Child algorithms used
 #####################


### PR DESCRIPTION
Since the description of the various fields is something that is frequently repeated, add a link in the algorithm documentation. This adds a link to the text and changes the description paragraph to use [semantic line breaks](https://sembr.org/).

*There is no associated issue.*

### To test:

Build the docs and test the new link in the `LoadEventNexus` algorithm page.

*This does not require release notes* because it adds a single link to the algorithm docs.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
