### PR TITLE
Compression options for AlignAndFocusPowderFromFiles

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -222,6 +222,11 @@ class AlignAndFocusPowderFromFiles(DataProcessorAlgorithm):
         loader.setPropertyValue("Filename", filename)
         loader.setPropertyValue("OutputWorkspace", wkspname)
 
+        if self.do_compression:
+            self.kwargs = self.__getAlignAndFocusArgs()
+            loader.setPropertyValue("CompressTolerance", str(self.kwargs["CompressTolerance"]))
+            loader.setPropertyValue("CompressBinningMode", self.kwargs["CompressBinningMode"])
+
         if skipLoadingLogs:
             if self.__loaderName != "LoadEventNexus":
                 raise RuntimeError("Cannot set LoadLogs=False in {}".format(self.__loaderName))
@@ -554,7 +559,7 @@ class AlignAndFocusPowderFromFiles(DataProcessorAlgorithm):
         return wkspname, unfocusname
 
     def __compressEvents(self, wkspname):
-        if self.kwargs["PreserveEvents"] and self.kwargs["CompressTolerance"] != 0.0 or self.do_compression:
+        if self.kwargs["PreserveEvents"] and self.kwargs["CompressTolerance"] != 0.0:
             CompressEvents(
                 InputWorkspace=wkspname,
                 OutputWorkspace=wkspname,

--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -224,7 +224,7 @@ class AlignAndFocusPowderFromFiles(DataProcessorAlgorithm):
 
         if self.do_compression:
             self.kwargs = self.__getAlignAndFocusArgs()
-            loader.setPropertyValue("CompressTolerance", str(self.kwargs["CompressTolerance"]))
+            loader.setProperty("CompressTolerance", self.kwargs["CompressTolerance"])
             loader.setPropertyValue("CompressBinningMode", self.kwargs["CompressBinningMode"])
 
         if skipLoadingLogs:

--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -673,7 +673,7 @@ class AlignAndFocusPowderFromFiles(DataProcessorAlgorithm):
         self.__loaderName = "Load"  # set the loader to be generic on first load
         self.filterBadPulses = self.getProperty("FilterBadPulses").value
         self.chunkSize = self.getProperty("MaxChunkSize").value
-        self.comression = self.getProperty("MinSizeCompressOnLoad").value
+        self.compression_threshold = self.getProperty("MinSizeCompressOnLoad").value
         self.absorption = self.getProperty("AbsorptionWorkspace").value
         self.charac = self.getProperty("Characterizations").value
         self.useCaching = len(self.getProperty("CacheDir").value) > 0
@@ -689,7 +689,7 @@ class AlignAndFocusPowderFromFiles(DataProcessorAlgorithm):
 
         # determing compression
         if determineCompression(
-            filename=self._filenames[0], compression=self.compression, chunking=(self.chunkSize > 0.0), absorption=self.absorption
+            filename=self._filenames[0], compression=self.compression_threshold, chunking=(self.chunkSize > 0.0), absorption=self.absorption
         ):
             self.do_compression = True
         else:

--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -554,7 +554,7 @@ class AlignAndFocusPowderFromFiles(DataProcessorAlgorithm):
         return wkspname, unfocusname
 
     def __compressEvents(self, wkspname):
-        if self.kwargs["PreserveEvents"] and self.kwargs["CompressTolerance"] != 0.0 and self.do_compression:
+        if self.kwargs["PreserveEvents"] and self.kwargs["CompressTolerance"] != 0.0 or self.do_compression:
             CompressEvents(
                 InputWorkspace=wkspname,
                 OutputWorkspace=wkspname,

--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -79,7 +79,7 @@ PROPS_FOR_PD_CHARACTER = ["FrequencyLogNames", "WaveLengthLogNames"]
 
 
 def determineCompression(filename, compression, chunking, absorption):
-    if compression == 0.0 or chunking or absorption:
+    if compression == 0.0 or chunking > 0.0 or absorption:
         return False
     sizeGiB = os.path.getsize(filename) / 1024.0 / 1024.0 / 1024.0
     if sizeGiB > compression:
@@ -688,12 +688,9 @@ class AlignAndFocusPowderFromFiles(DataProcessorAlgorithm):
         finalunfocusname = self.getPropertyValue("UnfocussedWorkspace")
 
         # determing compression
-        if determineCompression(
-            filename=self._filenames[0], compression=self.compression_threshold, chunking=(self.chunkSize > 0.0), absorption=self.absorption
-        ):
-            self.do_compression = True
-        else:
-            self.do_compression = False
+        self.do_compression = determineCompression(
+            filename=self._filenames[0], compression=self.compression_threshold, chunking=self.chunkSize, absorption=self.absorption
+        )
         if self.useCaching:
             # unfocus check only matters if caching is requested
             if finalunfocusname != "":

--- a/Testing/SystemTests/tests/framework/AlignAndFocusPowderFromFilesTest.py
+++ b/Testing/SystemTests/tests/framework/AlignAndFocusPowderFromFilesTest.py
@@ -236,7 +236,7 @@ class CompressedCompare(systemtesting.MantidSystemTest):
         return None
 
     def validate(self):
-        None
+        return None
 
 
 class UseCache(systemtesting.MantidSystemTest):

--- a/Testing/SystemTests/tests/framework/AlignAndFocusPowderFromFilesTest.py
+++ b/Testing/SystemTests/tests/framework/AlignAndFocusPowderFromFilesTest.py
@@ -213,6 +213,32 @@ class ChunkingCompare(systemtesting.MantidSystemTest):
         return ("with_chunks", "no_chunks")
 
 
+class CompressedCompare(systemtesting.MantidSystemTest):
+    # this test is very similar to SNAPRedux.Simple
+
+    def requiredMemoryMB(self):
+        return 24 * 1024  # GiB
+
+    def runTest(self):
+        GRP_WKSP = "SNAP_compress_params"
+
+        # 11MB file
+        kwargs = {"Filename": "SNAP_45874", "Params": (0.5, -0.004, 7), "GroupingWorkspace": GRP_WKSP}
+
+        # create grouping for two output spectra
+        CreateGroupingWorkspace(InstrumentFilename="SNAP_Definition.xml", GroupDetectorsBy="Group", OutputWorkspace=GRP_WKSP)
+
+        AlignAndFocusPowderFromFiles(
+            OutputWorkspace="compress1", MaxChunkSize=0.0, CompressTolerance=1e-2, MinSizeCompressOnLoad=1e-14, **kwargs
+        )
+
+    def validateMethod(self):
+        return None
+
+    def validate(self):
+        None
+
+
 class UseCache(systemtesting.MantidSystemTest):
     cal_file = "PG3_FERNS_d4832_2011_08_24.cal"
     char_file = "PG3_characterization_2012_02_23-HR-ILL.txt"

--- a/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37831.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37831.rst
@@ -1,0 +1,1 @@
+- Added a load compression parameter ``MinSizeCompressOnLoad`` for ref: :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles>`.


### PR DESCRIPTION
[6060: Add load w/ compression parameters to AlignAndFocusPowderFromFiles](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/6060)
### Description of work
Added an additional parameter  AlignAndFocusPowderFromFiles to determine whether its call to LoadEventNexus should enable compressing events during load. The parameter is called "MinSizeCompressOnLoad" which is a floating point number of Gbytes. 
. 
