### PR TITLE
Update to C++ 20 standard

### DIFF
--- a/Framework/API/inc/MantidAPI/NumericAxis.h
+++ b/Framework/API/inc/MantidAPI/NumericAxis.h
@@ -41,6 +41,7 @@ public:
   /// Set the value at a specific index
   void setValue(const std::size_t &index, const double &value) override;
   size_t indexOfValue(const double value) const override;
+  bool operator==(const NumericAxis &) const;
   bool operator==(const Axis &) const override;
   virtual bool equalWithinTolerance(const Axis &axis2, const double tolerance) const;
   std::string label(const std::size_t &index) const override;

--- a/Framework/API/inc/MantidAPI/TextAxis.h
+++ b/Framework/API/inc/MantidAPI/TextAxis.h
@@ -47,6 +47,7 @@ public:
   void setValue(const std::size_t &index, const double &value) override;
   size_t indexOfValue(const double value) const override;
 
+  bool operator==(const TextAxis &) const;
   bool operator==(const Axis &) const override;
   /// Get the label at the specified index
   std::string label(const std::size_t &index) const override;
@@ -60,6 +61,7 @@ public:
 private:
   /// A vector holding the axis values for the axis.
   std::vector<std::string> m_values;
+  bool compareToTextAxis(const TextAxis &axis2) const;
 };
 
 } // namespace API

--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -27,7 +27,7 @@ namespace Mantid::API {
 namespace {
 /// static logger
 Kernel::Logger g_log("CompositeFunction");
-constexpr char *ATTNUMDERIV = "NumDeriv";
+constexpr const char *ATTNUMDERIV = "NumDeriv";
 constexpr int NUMDEFAULTATTRIBUTES = 1;
 /**
  * Helper function called when we replace a function within the composite

--- a/Framework/API/src/NotebookBuilder.cpp
+++ b/Framework/API/src/NotebookBuilder.cpp
@@ -12,6 +12,7 @@
 #include "MantidAPI/HistoryItem.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/Property.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 #include <boost/utility.hpp>
 #include <utility>
@@ -143,6 +144,8 @@ const std::string NotebookBuilder::buildAlgorithmString(const AlgorithmHistory_c
   return name + "(" + propStr + ")";
 }
 
+GNU_DIAG_OFF("maybe-uninitialized")
+
 /**
  * Build the script output for a single property
  *
@@ -181,5 +184,7 @@ const std::string NotebookBuilder::buildPropertyString(const PropertyHistory_con
 
   return prop;
 }
+
+GNU_DIAG_ON("maybe-uninitialized")
 
 } // namespace Mantid::API

--- a/Framework/API/src/NumericAxis.cpp
+++ b/Framework/API/src/NumericAxis.cpp
@@ -107,6 +107,12 @@ void NumericAxis::setValue(const std::size_t &index, const double &value) {
   m_values[index] = value;
 }
 
+/** Check if two NumericAxis are equivalent
+ *  @param axis2 :: Reference to the axis to compare to
+ *  @return true if self and second axis are equal
+ */
+bool NumericAxis::operator==(const NumericAxis &axis2) const { return equalWithinTolerance(axis2, 1e-15); }
+
 /** Check if two axis defined as spectra or numeric axis are equivalent
  *  @param axis2 :: Reference to the axis to compare to
  *  @return true if self and second axis are equal

--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -17,6 +17,7 @@
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/Property.h"
 #include "MantidKernel/PropertyHistory.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
@@ -260,6 +261,8 @@ const std::string ScriptBuilder::buildAlgorithmString(const AlgorithmHistory &al
   return historyEntry;
 }
 
+GNU_DIAG_OFF("maybe-uninitialized")
+
 /**
  * Build the script output for a single property
  *
@@ -315,5 +318,7 @@ const std::string ScriptBuilder::buildPropertyString(const Mantid::Kernel::Prope
 
   return prop;
 }
+
+GNU_DIAG_ON("maybe-uninitialized")
 
 } // namespace Mantid::API

--- a/Framework/API/src/TextAxis.cpp
+++ b/Framework/API/src/TextAxis.cpp
@@ -74,19 +74,29 @@ size_t TextAxis::indexOfValue(const double value) const {
   return Mantid::Kernel::VectorHelper::indexOfValueFromCenters(spectraNumbers, value);
 }
 
+/** Check if two TextAxis are equivalent
+ *  @param axis2 :: Reference to the axis to compare to
+ *  @return true if self and other axis are equal
+ */
+bool TextAxis::operator==(const TextAxis &axis2) const { return compareToTextAxis(axis2); }
+
+bool TextAxis::compareToTextAxis(const TextAxis &axis2) const {
+  if (length() != axis2.length()) {
+    return false;
+  }
+  return std::equal(m_values.begin(), m_values.end(), axis2.m_values.begin());
+}
+
 /** Check if two axis defined as spectra or numeric axis are equivalent
  *  @param axis2 :: Reference to the axis to compare to
  *  @return true if self and other axis are equal
  */
 bool TextAxis::operator==(const Axis &axis2) const {
-  if (length() != axis2.length()) {
-    return false;
-  }
   const auto *spec2 = dynamic_cast<const TextAxis *>(&axis2);
   if (!spec2) {
     return false;
   }
-  return std::equal(m_values.begin(), m_values.end(), spec2->m_values.begin());
+  return compareToTextAxis(*spec2);
 }
 
 /** Returns a text label which shows the value at index and identifies the

--- a/Framework/API/test/MDFrameValidatorTest.h
+++ b/Framework/API/test/MDFrameValidatorTest.h
@@ -30,15 +30,15 @@ public:
   static void destroySuite(MDFrameValidatorTest *suite) { delete suite; }
 
   void testGetType() {
-    MDFrameValidator unitValidator(HKL::HKLName);
+    MDFrameValidator unitValidator(Mantid::Geometry::HKL::HKLName);
     TS_ASSERT_EQUALS(unitValidator.getType(), "mdframe");
   }
 
   void testHKLMDWorkspaceIsValidForValidatorWithHKLFrame() {
-    MDFrameValidator frameValidator(HKL::HKLName);
+    MDFrameValidator frameValidator(Mantid::Geometry::HKL::HKLName);
 
     HKLFrameFactory factory;
-    auto frame = factory.create(MDFrameArgument{HKL::HKLName, Units::Symbol::RLU});
+    auto frame = factory.create(MDFrameArgument{Mantid::Geometry::HKL::HKLName, Units::Symbol::RLU});
     auto dim = std::make_shared<MDHistoDimension>("x", "x", *frame, 0.0f, 100.0f, 10);
     auto ws = std::make_shared<MDHistoWorkspaceTester>(dim, dim, dim);
     TS_ASSERT_EQUALS(frameValidator.isValid(ws), "")
@@ -47,7 +47,7 @@ public:
   void testHKLMDWorkspaceIsNotValidForValidatorWithQLabFrame() {
     MDFrameValidator frameValidator(QLab::QLabName);
 
-    MDFrameArgument args{HKL::HKLName, Units::Symbol::RLU};
+    MDFrameArgument args{Mantid::Geometry::HKL::HKLName, Units::Symbol::RLU};
     auto frame = HKLFrameFactory().create(args);
     auto dim = std::make_shared<MDHistoDimension>("x", "x", *frame, 0.0f, 100.0f, 10);
     auto ws = std::make_shared<MDHistoWorkspaceTester>(dim, dim, dim);
@@ -57,7 +57,7 @@ public:
   void testMixedAxisMDWorkspaceIsNotValidForValidatorWithQLabFrame() {
     MDFrameValidator frameValidator(QLab::QLabName);
 
-    MDFrameArgument axisArgs1{HKL::HKLName, Units::Symbol::RLU};
+    MDFrameArgument axisArgs1{Mantid::Geometry::HKL::HKLName, Units::Symbol::RLU};
     MDFrameArgument axisArgs2{QLab::QLabName, Units::Symbol::InverseAngstrom};
 
     auto frame1 = HKLFrameFactory().create(axisArgs1);

--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrection.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrection.cpp
@@ -166,11 +166,11 @@ Kernel::IValidator_sptr MayersSampleCorrection::createInputWSValidator() const {
   using Kernel::CompositeValidator;
   auto validator = std::make_shared<CompositeValidator>();
 
-  unsigned int requires = (InstrumentValidator::SamplePosition | InstrumentValidator::SourcePosition);
-  validator->add<InstrumentValidator, unsigned int>(requires);
+  unsigned int require = (InstrumentValidator::SamplePosition | InstrumentValidator::SourcePosition);
+  validator->add<InstrumentValidator, unsigned int>(require);
 
-  requires = (SampleValidator::Shape | SampleValidator::Material);
-  validator->add<SampleValidator, unsigned int>(requires);
+  require = (SampleValidator::Shape | SampleValidator::Material);
+  validator->add<SampleValidator, unsigned int>(require);
 
   // NOTE: Mayers correction requires the input to be of TOF
   validator->add<WorkspaceUnitValidator>("TOF");

--- a/Framework/Crystal/test/FindClusterFacesTest.h
+++ b/Framework/Crystal/test/FindClusterFacesTest.h
@@ -110,7 +110,8 @@ class FindClusterFacesTest : public CxxTest::TestSuite {
 
 private:
   void verify_table_row(ITableWorkspace_sptr &outWS, int expectedClusterId, double expectedWorkspaceIndex,
-                        int expectedNormalDimensionIndex, bool expectedMaxExtent, double expectedRadius = -1) {
+                        int expectedNormalDimensionIndex, Mantid::API::Boolean expectedMaxExtent,
+                        double expectedRadius = -1) {
     for (size_t rowIndex = 0; rowIndex < outWS->rowCount(); ++rowIndex) {
       auto clusterId = outWS->cell<int>(rowIndex, 0);
       auto wsIndex = outWS->cell<double>(rowIndex, 1);

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProcessBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProcessBackground.h
@@ -32,8 +32,8 @@ private:
                                std::vector<double> &vec_peakfwhm);
 
   /// Exclude peak regions
-  size_t excludePeaks(std::vector<double> v_inX, std::vector<bool> &v_useX, std::vector<double> v_centre,
-                      std::vector<double> v_fwhm, double num_fwhm);
+  size_t excludePeaks(std::vector<double> v_inX, std::vector<bool> &v_useX, const std::vector<double> &v_centre,
+                      const std::vector<double> &v_fwhm, double num_fwhm);
 
   std::vector<double> m_vecPeakCentre;
   std::vector<double> m_vecPeakFWHM;

--- a/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
+++ b/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
@@ -908,7 +908,7 @@ void RefinePowderInstrumentParameters::importMonteCarloParametersFromTable(const
   for (size_t ir = 0; ir < numrows; ++ir) {
     TableRow row = tablews->getRow(ir);
     string parname;
-    double tmax, tmin, tstepsize;
+    double tmax = 0, tmin = 0, tstepsize = 0;
     row >> parname;
     for (size_t ic = 1; ic < colnames.size(); ++ic) {
       double tmpdbl = std::numeric_limits<float>::quiet_NaN();

--- a/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
+++ b/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
@@ -19,6 +19,7 @@
 #include "MantidKernel/System.h"
 #include "MantidKernel/VisibleWhenProperty.h"
 
+#include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>

--- a/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
+++ b/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
@@ -896,8 +896,8 @@ void RemovePeaks::parsePeakTableWorkspace(const TableWorkspace_sptr &peaktablews
 //----------------------------------------------------------------------------------------------
 /** Exclude peaks from
  */
-size_t RemovePeaks::excludePeaks(vector<double> v_inX, vector<bool> &v_useX, vector<double> v_centre,
-                                 vector<double> v_fwhm, double num_fwhm) {
+size_t RemovePeaks::excludePeaks(vector<double> v_inX, vector<bool> &v_useX, const vector<double> &v_centre,
+                                 const vector<double> &v_fwhm, double num_fwhm) {
   // Validate
   if (v_centre.size() != v_fwhm.size())
     throw runtime_error("Input different number of peak centres and fwhm.");

--- a/Framework/CurveFitting/test/Algorithms/ProfileChiSquared1DTest.h
+++ b/Framework/CurveFitting/test/Algorithms/ProfileChiSquared1DTest.h
@@ -19,8 +19,8 @@ using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 
 namespace {
-constexpr char *linearFunctionString = "name = LinearBackground, A0=0.8753627851076761,  A1 = "
-                                       "2.026706319695708 ";
+constexpr const char *linearFunctionString = "name = LinearBackground, A0=0.8753627851076761,  A1 = "
+                                             "2.026706319695708 ";
 }
 
 class ProfileChiSquared1DTest : public CxxTest::TestSuite {

--- a/Framework/DataHandling/src/ApplyDiffCal.cpp
+++ b/Framework/DataHandling/src/ApplyDiffCal.cpp
@@ -25,16 +25,6 @@ namespace Mantid::DataHandling {
 using Mantid::Kernel::Direction;
 using Mantid::Kernel::PropertyWithValue;
 
-namespace {
-namespace PropertyNames {
-const std::string CAL_FILE("Filename");
-const std::string GROUP_FILE("GroupFilename");
-const std::string MAKE_CAL("MakeCalWorkspace");
-const std::string MAKE_GRP("MakeGroupingWorkspace");
-const std::string MAKE_MSK("MakeMaskWorkspace");
-} // namespace PropertyNames
-} // namespace
-
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(ApplyDiffCal)
 

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -78,8 +78,6 @@ static const string EVENT_PARAM("EventFilename");
 static const string PULSEID_PARAM("PulseidFilename");
 static const string MAP_PARAM("MappingFilename");
 static const string PID_PARAM("SpectrumList");
-static const string PARALLEL_PARAM("UseParallelProcessing");
-static const string BLOCK_SIZE_PARAM("LoadingBlockSize");
 static const string OUT_PARAM("OutputWorkspace");
 /// All pixel ids with matching this mask are errors.
 static const PixelType ERROR_PID = 0x80000000;

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -76,8 +76,6 @@ static const string EVENT_PARAM("EventFilename");
 static const string PULSEID_PARAM("PulseidFilename");
 static const string MAP_PARAM("MappingFilename");
 static const string PID_PARAM("SpectrumList");
-static const string PARALLEL_PARAM("UseParallelProcessing");
-static const string BLOCK_SIZE_PARAM("LoadingBlockSize");
 static const string OUT_PARAM("OutputWorkspace");
 
 /// All pixel ids with matching this mask are errors.

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -577,14 +577,14 @@ void LoadEventPreNexus2::runLoadInstrument(const std::string &eventfilename,
   for (const auto &ending : eventExts) {
     size_t pos = instrument.find(ending);
     if (pos != string::npos) {
-      instrument = instrument.substr(0, pos);
+      instrument.resize(pos);
       break;
     }
   }
 
   // determine the instrument parameter file
   size_t pos = instrument.rfind('_'); // get rid of the run number
-  instrument = instrument.substr(0, pos);
+  instrument.resize(pos);
 
   // do the actual work
   auto loadInst = createChildAlgorithm("LoadInstrument");
@@ -667,7 +667,7 @@ void LoadEventPreNexus2::procEvents(DataObjects::EventWorkspace_sptr &workspace)
   loadOnlySomeSpectra = (!this->spectra_list.empty());
 
   // Turn the spectra list into a map, for speed of access
-  for (auto &spectrum : spectra_list)
+  for (const auto &spectrum : spectra_list)
     spectraLoadMap[spectrum] = true;
 
   // Pad all the pixels
@@ -937,7 +937,7 @@ void LoadEventPreNexus2::procEventsLinear(DataObjects::EventWorkspace_sptr & /*w
   std::stringstream dbss;
   // size_t numwrongpid = 0;
   for (size_t i = 0; i < current_event_buffer_size; i++) {
-    DasEvent &temp = *(event_buffer + i);
+    const DasEvent &temp = *(event_buffer + i);
     PixelType pid = temp.pid;
     bool iswrongdetid = false;
 
@@ -1103,11 +1103,6 @@ void LoadEventPreNexus2::procEventsLinear(DataObjects::EventWorkspace_sptr & /*w
       longest_tof = local_longest_tof;
   } // END_CRITICAL
 }
-
-//----------------------------------------------------------------------------------------------
-/** Comparator for sorting dasevent lists
- */
-bool vzintermediatePixelIDComp(IntermediateEvent x, IntermediateEvent y) { return (x.pid < y.pid); }
 
 //-----------------------------------------------------------------------------
 /**

--- a/Framework/DataHandling/src/LoadMuonNexusV2NexusHelper.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2NexusHelper.cpp
@@ -42,7 +42,6 @@ const std::string TIMEZERO{"time_zero"};
 const std::string SAMPLE{"sample"};
 const std::string TEMPERATURE{"temperature"};
 const std::string MAGNETICFIELD{"magnetic_field"};
-const std::string RAWDATA{"/raw_data_1"};
 const std::string SEQUENCES{"sequences"};
 const std::string TYPE{"type"};
 const std::string REQUESTED{"frames_requested"};

--- a/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
+++ b/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
@@ -74,7 +74,7 @@ void SaveSampleEnvironmentAndShape::exec() {
   size_t numVertices = 0;
 
   // Get the shape of the sample
-  auto &sampleShape = toMeshObject(inputWS->sample().getShape());
+  const auto &sampleShape = toMeshObject(inputWS->sample().getShape());
   if (!sampleShape.hasValidShape()) {
     throw std::invalid_argument("Sample Shape is not complete");
   }
@@ -129,7 +129,8 @@ void SaveSampleEnvironmentAndShape::exec() {
   } else {
 #ifdef ENABLE_LIB3MF
     Mantid3MFFileIO Mesh3MF;
-    Mesh3MF.writeMeshObjects(environmentPieces, MeshObject_const_sptr(&sampleShape), scaleType);
+    auto samplePtr = MeshObject_const_sptr(&sampleShape);
+    Mesh3MF.writeMeshObjects(environmentPieces, samplePtr, scaleType);
     Mesh3MF.saveFile(filename);
 #else
     throw std::runtime_error("3MF format not supported on this platform");

--- a/Framework/DataObjects/src/TableWorkspace.cpp
+++ b/Framework/DataObjects/src/TableWorkspace.cpp
@@ -141,7 +141,7 @@ API::Column_const_sptr TableWorkspace::getColumn(size_t index) const {
 void TableWorkspace::removeColumn(const std::string &name) {
   auto ci = std::find_if(m_columns.begin(), m_columns.end(), FindName(name));
   if (ci != m_columns.end()) {
-    if (!ci->unique()) {
+    if (ci->use_count() > 1) {
       g_log.error() << "Deleting column in use (" << name << ").\n";
     }
     m_columns.erase(ci);

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -381,7 +381,7 @@ public:
     // But you can still add a plain one
     TofEvent e(789, 654);
     el += e;
-    TS_ASSERT_EQUALS(el.getWeightedEvents()[NUMEVENTS + 1], e);
+    TS_ASSERT_EQUALS(el.getWeightedEvents()[NUMEVENTS + 1], static_cast<WeightedEvent>(e));
     TS_ASSERT_EQUALS(el.getEvent(NUMEVENTS + 1).weight(), 1.0);
   }
 

--- a/Framework/DataObjects/test/TableWorkspaceTest.h
+++ b/Framework/DataObjects/test/TableWorkspaceTest.h
@@ -27,7 +27,7 @@ using namespace std;
 
 template <class T> class TableColTestHelper : public TableColumn<T> {
 public:
-  TableColTestHelper<T>(T value) {
+  TableColTestHelper(T value) {
     std::vector<T> &dat = TableColumn<T>::data();
     dat.resize(1);
     dat[0] = value;

--- a/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
+++ b/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
@@ -99,6 +99,16 @@ public:
   bool operator==(const EnumeratedString &es) const { return value == es.value; }
   bool operator!=(const EnumeratedString &es) const { return value != es.value; }
 
+  template <typename OtherEnumType, const std::vector<std::string> *OtherEnumStrings>
+  bool operator==(const EnumeratedString<OtherEnumType, OtherEnumStrings> &) const {
+    return false; // Different enum types are always different
+  }
+
+  template <typename OtherEnumType, const std::vector<std::string> *OtherEnumStrings>
+  bool operator!=(const EnumeratedString<OtherEnumType, OtherEnumStrings> &other) const {
+    return !(*this == other);
+  }
+
   const char *c_str() const { return name.c_str(); }
   static size_t size() { return names->size(); }
 

--- a/Framework/Kernel/src/MultiFileNameParser.cpp
+++ b/Framework/Kernel/src/MultiFileNameParser.cpp
@@ -63,8 +63,8 @@ bool matchesFully(const std::string &stringToMatch, const std::string &regexStri
 std::string getMatchingString(const std::string &regexString, const std::string &toParse, const bool caseless = false);
 std::string pad(const unsigned int run, const std::string &instString);
 
-std::set<std::pair<unsigned int, unsigned int>> &
-mergeAdjacentRanges(std::set<std::pair<unsigned int, unsigned int>> &ranges,
+std::set<std::pair<unsigned int, unsigned int>>
+mergeAdjacentRanges(std::set<std::pair<unsigned int, unsigned int>> ranges,
                     const std::pair<unsigned int, unsigned int> &range);
 
 // Helper functor.
@@ -74,7 +74,7 @@ struct RangeContainsRun {
 };
 
 std::string toString(const RunRangeList &runRangeList);
-std::string &accumulateString(std::string &output, std::pair<unsigned int, unsigned int> runRange);
+std::string accumulateString(std::string output, std::pair<unsigned int, unsigned int> runRange);
 } // namespace
 
 /////////////////////////////////////////////////////////////////////////////
@@ -711,8 +711,8 @@ bool RangeContainsRun::operator()(const unsigned int run, const std::pair<unsign
  *
  * @returns the original ranges, with the extra range added/merged.
  */
-std::set<std::pair<unsigned int, unsigned int>> &
-mergeAdjacentRanges(std::set<std::pair<unsigned int, unsigned int>> &ranges,
+std::set<std::pair<unsigned int, unsigned int>>
+mergeAdjacentRanges(std::set<std::pair<unsigned int, unsigned int>> ranges,
                     const std::pair<unsigned int, unsigned int> &range) {
   // If ranges is empty, just insert the new range.
   if (ranges.empty()) {
@@ -747,7 +747,7 @@ mergeAdjacentRanges(std::set<std::pair<unsigned int, unsigned int>> &ranges,
  *
  * @returns the updated output
  */
-std::string &accumulateString(std::string &output, std::pair<unsigned int, unsigned int> runRange) {
+std::string accumulateString(std::string output, std::pair<unsigned int, unsigned int> runRange) {
   if (!output.empty())
     output += "_and_";
 

--- a/Framework/Kernel/test/BinaryStreamReaderTest.h
+++ b/Framework/Kernel/test/BinaryStreamReaderTest.h
@@ -33,7 +33,7 @@ public:
   //----------------------------------------------------------------------------
   void test_Constructor_With_Good_Stream_Does_Not_Touch_Stream() {
     BinaryStreamReader reader(m_bytes);
-    TS_ASSERT_EQUALS(std::ios_base::beg, m_bytes.tellg());
+    TS_ASSERT_EQUALS(std::streampos(0), m_bytes.tellg());
   }
 
   void test_Read_int16_t_Gives_Correct_Value() { doReadSingleValueTest<int16_t>(6, sizeof(int16_t)); }

--- a/Framework/Kernel/test/BinaryStreamWriterTest.h
+++ b/Framework/Kernel/test/BinaryStreamWriterTest.h
@@ -35,7 +35,7 @@ public:
   // single values
   void test_Constructor_With_Good_Stream_Does_Not_Touch_Stream() {
     BinaryStreamReader reader(m_bytes);
-    TS_ASSERT_EQUALS(std::ios_base::beg, m_bytes.tellg());
+    TS_ASSERT_EQUALS(std::streampos(0), m_bytes.tellg());
   }
 
   void test_Write_int16_t_Gives_Correct_Value() { doWriteSingleValueTest<int16_t>(6); }

--- a/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
@@ -18,6 +18,7 @@
 #include "MantidDataObjects/MDEventWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
+#include "MantidGeometry/MDGeometry/HKL.h"
 #include "MantidGeometry/MDGeometry/MDFrameFactory.h"
 #include "MantidGeometry/MDGeometry/MDHistoDimension.h"
 #include "MantidKernel/ArrayProperty.h"
@@ -363,7 +364,7 @@ void ConvertToDiffractionMDWorkspace::exec() {
     dimensionNames[1] = "K";
     dimensionNames[2] = "L";
     coordinateSystem = Mantid::Kernel::HKL;
-    MDFrameArgument frameArgQLab(HKL::HKLName, Units::Symbol::RLU.ascii());
+    MDFrameArgument frameArgQLab(Mantid::Geometry::HKL::HKLName, Units::Symbol::RLU.ascii());
     frame = frameFactory->create(frameArgQLab);
   } else {
     MDFrameArgument frameArgQLab(QLab::QLabName, "");

--- a/Framework/MDAlgorithms/test/MDEventWSWrapperTest.h
+++ b/Framework/MDAlgorithms/test/MDEventWSWrapperTest.h
@@ -43,7 +43,7 @@ public:
 
     TS_ASSERT_THROWS_NOTHING(pWSWrap->releaseWorkspace());
 
-    TSM_ASSERT("should be unique", pws.unique());
+    TSM_ASSERT("should be unique", pws.use_count() == 1);
   }
   void test_AddEventsData() {
 

--- a/Framework/Muon/src/PSIBackgroundSubtraction.cpp
+++ b/Framework/Muon/src/PSIBackgroundSubtraction.cpp
@@ -23,7 +23,7 @@ using namespace Mantid::DataObjects;
 namespace Mantid::Muon {
 
 namespace {
-constexpr char *MINIMISER = "Levenberg-Marquardt";
+constexpr const char *MINIMISER = "Levenberg-Marquardt";
 constexpr double FIT_TOLERANCE = 10;
 const std::string FIRST_GOOD = "First good spectra ";
 const std::string LAST_GOOD = "Last good spectra ";

--- a/Framework/Muon/test/PSIBackgroundSubtractionTest.h
+++ b/Framework/Muon/test/PSIBackgroundSubtractionTest.h
@@ -17,7 +17,7 @@ using namespace Mantid::Muon;
 
 namespace {
 
-constexpr char *WORKSPACE_NAME = "DummyWS";
+constexpr const char *WORKSPACE_NAME = "DummyWS";
 
 MatrixWorkspace_sptr createCountsTestWorkspace(const size_t numberOfHistograms, const size_t numberOfBins,
                                                bool addLogs = true) {

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
@@ -7,6 +7,7 @@
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidGeometry/Crystal/IPeak.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/api/RegisterWorkspacePtrToPython.h"
 #include "MantidPythonInterface/core/Converters/PyObjectToV3D.h"
 #include "MantidPythonInterface/core/GetPointer.h"
@@ -173,6 +174,8 @@ private:
   std::unordered_map<std::string, SetterType> m_setterMap;
 };
 
+GNU_DIAG_OFF("maybe-uninitialized")
+
 /**
  * Get the row index and column name from python types.
  *
@@ -201,6 +204,8 @@ std::pair<int, std::string> getRowAndColumnName(const IPeaksWorkspace &self, con
 
   return std::make_pair(rowIndex, columnName);
 }
+
+GNU_DIAG_ON("maybe-uninitialized")
 
 /**
  * Sets the value of the given cell

--- a/Framework/Reflectometry/src/SpecularReflectionCalculateTheta.cpp
+++ b/Framework/Reflectometry/src/SpecularReflectionCalculateTheta.cpp
@@ -17,12 +17,6 @@ using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;
 using namespace Mantid::API;
 
-namespace {
-const std::string multiDetectorAnalysis = "MultiDetectorAnalysis";
-const std::string lineDetectorAnalysis = "LineDetectorAnalysis";
-const std::string pointDetectorAnalysis = "PointDetectorAnalysis";
-} // namespace
-
 namespace Mantid::Reflectometry {
 
 // Register the algorithm into the AlgorithmFactory

--- a/Framework/Reflectometry/src/SpecularReflectionCalculateTheta2.cpp
+++ b/Framework/Reflectometry/src/SpecularReflectionCalculateTheta2.cpp
@@ -17,12 +17,6 @@ using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;
 using namespace Mantid::API;
 
-namespace {
-const std::string multiDetectorAnalysis = "MultiDetectorAnalysis";
-const std::string lineDetectorAnalysis = "LineDetectorAnalysis";
-const std::string pointDetectorAnalysis = "PointDetectorAnalysis";
-} // namespace
-
 namespace Mantid::Reflectometry {
 
 // Register the algorithm into the AlgorithmFactory

--- a/Framework/Reflectometry/src/SpecularReflectionPositionCorrect.cpp
+++ b/Framework/Reflectometry/src/SpecularReflectionPositionCorrect.cpp
@@ -19,8 +19,6 @@ using namespace Mantid::Kernel;
 
 namespace Mantid::Reflectometry {
 namespace {
-const std::string multiDetectorAnalysis = "MultiDetectorAnalysis";
-const std::string lineDetectorAnalysis = "LineDetectorAnalysis";
 const std::string pointDetectorAnalysis = "PointDetectorAnalysis";
 
 /**

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -126,9 +126,9 @@ if(OpenMP_CXX_FOUND)
 endif()
 
 # ######################################################################################################################
-# Set the c++ standard to 17 - cmake should do the right thing with msvc
+# Set the c++ standard to 20 - cmake should do the right thing with msvc
 # ######################################################################################################################
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ######################################################################################################################

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -616,8 +616,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/H5Util.cpp
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/ISISJournal.h:35
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/NexusClasses.h:107
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/DataBlockComposite.cpp:383
-passedByValue:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Functions/ProcessBackground.cpp:898
-passedByValue:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Functions/ProcessBackground.cpp:899
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/CreatePolarizationEfficienciesBase.h:30
 containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/CreatePolarizationEfficiencies.cpp:119
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/CreateChunkingFromInstrument.cpp:415
@@ -661,18 +659,7 @@ uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadFITS.cpp:5
 uninitMemberVarPrivate:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadHFIRSANS.h:124
 uninitMemberVarPrivate:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadHFIRSANS.h:125
 uninitMemberVarPrivate:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadHFIRSANS.h:126
-duplicateCondition:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp:1842
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp:1088
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp:1662
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp:1715
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadGSS.cpp:449
-uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp:731
-uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp:738
-passedByValue:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadEventPreNexus2.cpp:1112
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadEventPreNexus2.cpp:672
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadEventPreNexus2.cpp:942
-uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadEventPreNexus2.cpp:582
-uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadEventPreNexus2.cpp:589
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadFullprofResolution.cpp:324
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadFullprofResolution.cpp:299
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLIndirect2.cpp:181

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -567,9 +567,6 @@ passedByValue:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/RefinePo
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp:487
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp:772
 variableScope:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/FitPowderDiffPeaks.cpp:500
-uninitvar:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp:933
-uninitvar:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp:934
-uninitvar:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp:935
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/FitPowderDiffPeaks.cpp:1603
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/FitPowderDiffPeaks.cpp:1914
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/FitPowderDiffPeaks.cpp:2172

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -371,7 +371,7 @@ unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/WeightedMeanOfWorksp
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/IMDEventWorkspace.cpp:50
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/IMDEventWorkspace.cpp:85
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/IMDEventWorkspace.cpp:92
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/API/src/NumericAxis.cpp:154
+unreadVariable:${CMAKE_SOURCE_DIR}/Framework/API/src/NumericAxis.cpp:160
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/ParameterReference.cpp:52
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiDomainFunction.cpp:135
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiDomainFunction.cpp:174

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Map.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Map.h
@@ -17,7 +17,7 @@ namespace CustomInterfaces {
 namespace ISISReflectometry {
 
 template <typename Container, typename Transform,
-          typename Out = typename std::result_of<Transform(typename Container::value_type)>::type>
+          typename Out = typename std::invoke_result<Transform, typename Container::value_type>::type>
 std::vector<Out> map(Container const &in, Transform transform) {
   auto out = std::vector<Out>();
   out.reserve(in.size());
@@ -25,7 +25,7 @@ std::vector<Out> map(Container const &in, Transform transform) {
   return out;
 }
 
-template <typename In, typename Transform, typename Out = typename std::result_of<Transform(In)>::type>
+template <typename In, typename Transform, typename Out = typename std::invoke_result<Transform, In>::type>
 boost::optional<Out> map(boost::optional<In> const &in, Transform transform) {
   if (in.is_initialized())
     return transform(in.get());

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Parse.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Parse.h
@@ -27,9 +27,9 @@ MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<int> parseNonNegativeInt(std::str
 bool MANTIDQT_ISISREFLECTOMETRY_DLL isEntirelyWhitespace(std::string const &string);
 
 template <typename ParseItemFunction>
-boost::optional<std::vector<typename std::result_of<ParseItemFunction(std::string const &)>::type::value_type>>
+boost::optional<std::vector<typename std::invoke_result<ParseItemFunction, std::string const &>::type::value_type>>
 parseList(std::string commaSeparatedValues, ParseItemFunction parseItem) {
-  using ParsedItem = typename std::result_of<ParseItemFunction(std::string const &)>::type::value_type;
+  using ParsedItem = typename std::invoke_result<ParseItemFunction, std::string const &>::type::value_type;
   if (!commaSeparatedValues.empty()) {
     auto items = std::vector<std::string>();
     boost::algorithm::split(items, commaSeparatedValues, boost::is_any_of(","));

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/Subtree.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/Subtree.h
@@ -11,6 +11,8 @@ developer.mantidproject.org/BatchWidget/index.html
 #pragma once
 #include "MantidQtWidgets/Common/Batch/Row.h"
 
+#include <algorithm>
+
 namespace MantidQt {
 namespace MantidWidgets {
 namespace Batch {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Testing/QApplicationGlobalFixture.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Testing/QApplicationGlobalFixture.h
@@ -35,7 +35,7 @@ public:
 
   int m_argc = 1;
   GNU_DIAG_OFF("pedantic")
-  char *m_argv[1] = {"QAppForTesting"};
+  char *m_argv[1] = {const_cast<char *>("QAppForTesting")};
   GNU_DIAG_ON("pedantic")
   QApplication *m_app;
 };

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Axes.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Axes.h
@@ -46,7 +46,7 @@ public:
   void setXLabel(const char *label);
   void setYLabel(const char *label);
   void setTitle(const char *label);
-  void tickLabelFormat(const char *axis, const char *style, const bool useOffset);
+  void tickLabelFormat(const std::string &axis, const std::string &style, const bool useOffset);
   /// @}
 
   /// @name Drawing

--- a/qt/widgets/mplcpp/src/Axes.cpp
+++ b/qt/widgets/mplcpp/src/Axes.cpp
@@ -124,7 +124,7 @@ void Axes::setTitle(const char *label) { callMethodNoCheck<void, const char *>(p
  * @param bool useOffset :: True, the offset will be
  * calculated as needed, False no offset will be used
  */
-void Axes::tickLabelFormat(const char *axis, const char *style, const bool useOffset) {
+void Axes::tickLabelFormat(const std::string &axis, const std::string &style, const bool useOffset) {
   try {
     GlobalInterpreterLock lock;
     Python::List args;

--- a/qt/widgets/mplcpp/src/Plot.cpp
+++ b/qt/widgets/mplcpp/src/Plot.cpp
@@ -104,7 +104,7 @@ Python::Object constructKwargs(std::optional<std::vector<int>> spectrumNums,
   if (windowTitle)
     kwargs["window_title"] = *windowTitle;
 
-  return std::move(kwargs);
+  return kwargs;
 }
 
 Python::Object plot(const Python::Object &args, std::optional<std::vector<int>> spectrumNums,

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
@@ -75,7 +75,7 @@ public:
   bool hasCurve(const QString &lineName) const;
 
   void setOverrideAxisLabel(AxisID const &axisID, char const *const label);
-  void tickLabelFormat(char *axis, char *style, bool useOffset);
+  void tickLabelFormat(const std::string &axis, const std::string &style, bool useOffset);
   void setAxisRange(const QPair<double, double> &range, AxisID axisID = AxisID::XBottom);
   std::tuple<double, double> getAxisRange(AxisID axisID = AxisID::XBottom);
 
@@ -173,8 +173,8 @@ private:
   Widgets::MplCpp::PanZoomTool m_panZoomTool;
 
   // Tick label style
-  char *m_axis;
-  char *m_style;
+  std::string m_axis;
+  std::string m_style;
   bool m_useOffset;
 
   // Axis scales

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -741,10 +741,10 @@ void PreviewPlot::toggleLegend(const bool checked) {
  * @param bool useOffset :: True, the offset will be
  * calculated as needed, False no offset will be used
  */
-void PreviewPlot::tickLabelFormat(char *axis, char *style, bool useOffset) {
+void PreviewPlot::tickLabelFormat(const std::string &axis, const std::string &style, bool useOffset) {
   auto axes = m_canvas->gca();
-  const auto formatXTicks = *axis != 'y' && axes.getXScale().toStdString() == "linear";
-  const auto formatYTicks = *axis != 'x' && axes.getYScale().toStdString() == "linear";
+  const auto formatXTicks = axis != "y" && axes.getXScale().toStdString() == "linear";
+  const auto formatYTicks = axis != "x" && axes.getYScale().toStdString() == "linear";
 
   if (formatXTicks)
     axes.tickLabelFormat(std::string("x").c_str(), style, useOffset);


### PR DESCRIPTION
Update to C++ 20

A few things needed fixing to remove compilation errors and warnings:

- `requires` is now a keyword so we can't use it as a variable name
- The function in `Plot.cpp` that used `std::move` to return generated a warning for an unnecessary move
- The accumulate functions in `MultiFileNameParser.cpp` didn't compile unless they returned by value
- Ambiguous overload for `==` operator (`bool == Mantid::API::Boolean`) in `FindClusterFacesTest`
- Ambiguous == (`WeightedEvent == TofEvent`) in `EventListTest`
- Stricter class template checking meant remove `<T>` in `TableWorkspaceTest`
- `constexpr char*` now needs to be `constexpr const char*`
- Made `HKL` namespace explicit to avoid ambiguity
- `shared_ptr::unique` no longer exists, `use_count()==1` is closest equivalent
- Stricter rules around templated classes resulted in the need to make equality comparisons clearer for the compiler
- Changed some `char*` to `std::string` in a couple of methods

For the `cmake` variable see [here](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html)

For more C++ 20 info see [here](https://en.cppreference.com/w/cpp/20)

Fixes #37841

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **it should have no effect on the user**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
