### PR TITLE
FitPeaks - fixing check to be start/stop

### DIFF
--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -445,7 +445,7 @@ std::map<std::string, std::string> FitPeaks::validateInputs() {
   map<std::string, std::string> issues;
 
   // check that min/max spectra indices make sense - only matters if both are specified
-  if (!(isDefault(PropertyNames::START_WKSP_INDEX) && isDefault(PropertyNames::START_WKSP_INDEX))) {
+  if (!(isDefault(PropertyNames::START_WKSP_INDEX) && isDefault(PropertyNames::STOP_WKSP_INDEX))) {
     const int startIndex = getProperty(PropertyNames::START_WKSP_INDEX);
     const int stopIndex = getProperty(PropertyNames::STOP_WKSP_INDEX);
     if (startIndex > stopIndex) {

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -260,7 +260,6 @@ knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FindPeaks.c
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/InterpolatingRebin.cpp:69
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetEi2.cpp:213
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/Algorithms/inc/MantidAlgorithms/GetAllEi.h:32
-duplicateExpression:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/FitPeaks.cpp:448
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp:277
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp:501
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetTimeSeriesLogInformation.cpp:248


### PR DESCRIPTION
This was pointed out in #35837 and apparently by cppcheck (which was suppressed).

*There is no associated issue.*

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

A code review is probably the best way to verify this.

*This does not require release notes* because nothing appears to set only one of the values.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
