### PR TITLE
Correct bug of missing 'Hmag' field in CrystalField interface

### DIFF
--- a/docs/source/release/v6.11.0/Direct_Geometry/CrystalField/Bugfixes/37847.rst
+++ b/docs/source/release/v6.11.0/Direct_Geometry/CrystalField/Bugfixes/37847.rst
@@ -1,0 +1,2 @@
+- The method `cf.getMagneticMoment()` no longer ignores the `Hmag` field, which is now
+  correctly considered in the calculations of the magnetic moment.

--- a/scripts/Inelastic/CrystalField/function.py
+++ b/scripts/Inelastic/CrystalField/function.py
@@ -702,7 +702,7 @@ class PhysicalProperties(object):
                 out += ",Temperature=%s" % (self._physpropTemperature)
             else:  # either susceptibility or M(T)
                 out += ",inverse=%s" % (1 if self._suscInverseFlag else 0)
-                out += (",Hmag=%s" % (self._hmag)) if self._typeid == self.MAGNETISATION else ""
+                out += (",Hmag=%s" % (self._hmag)) if self._typeid == self.MAGNETICMOMENT else ""
                 if self._typeid == self.SUSCEPTIBILITY and self._lambda != 0:
                     out += ",Lambda=%s" % (self._lambda)
                 if self._typeid == self.SUSCEPTIBILITY and self._chi0 != 0:

--- a/scripts/test/CrystalFieldTest.py
+++ b/scripts/test/CrystalFieldTest.py
@@ -675,6 +675,16 @@ class CrystalFieldTests(unittest.TestCase):
         self.assertAlmostEqual(chi_powder[10] * 10, 1 / invmt_powder_SI[10], 2)
         self.assertAlmostEqual(chi_powder[15] * 10, 1 / invmt_powder_SI[15], 2)
 
+        # Test different Hmag
+        _, h_mag_10 = cf.getMagneticMoment(Hmag=10, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="bohr")
+        self.assertAlmostEqual(h_mag_10[5], 0.323607, 5)
+        self.assertAlmostEqual(h_mag_10[10], 0.182484, 5)
+        self.assertAlmostEqual(h_mag_10[15], 0.129909, 5)
+        _, h_mag_0p1 = cf.getMagneticMoment(Hmag=5, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="bohr")
+        self.assertAlmostEqual(h_mag_0p1[5], 0.16923426, 6)
+        self.assertAlmostEqual(h_mag_0p1[10], 0.09228022, 6)
+        self.assertAlmostEqual(h_mag_0p1[15], 0.06525625, 6)
+
         # Test M(H) calculations
         Hmag_SI, mag_SI = cf.getMagneticMoment(np.linspace(0, 30, 15), Temperature=10, Hdir=[0, 1, -1], Unit="SI")
         self.assertAlmostEqual(mag_SI[1], 1.8139, 3)

--- a/scripts/test/CrystalFieldTest.py
+++ b/scripts/test/CrystalFieldTest.py
@@ -680,10 +680,10 @@ class CrystalFieldTests(unittest.TestCase):
         self.assertAlmostEqual(h_mag_10[5], 0.323607, 5)
         self.assertAlmostEqual(h_mag_10[10], 0.182484, 5)
         self.assertAlmostEqual(h_mag_10[15], 0.129909, 5)
-        _, h_mag_0p1 = cf.getMagneticMoment(Hmag=5, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="bohr")
-        self.assertAlmostEqual(h_mag_0p1[5], 0.16923426, 6)
-        self.assertAlmostEqual(h_mag_0p1[10], 0.09228022, 6)
-        self.assertAlmostEqual(h_mag_0p1[15], 0.06525625, 6)
+        _, h_mag_5 = cf.getMagneticMoment(Hmag=5, Temperature=np.linspace(1, 300, 50), Hdir="powder", Unit="bohr")
+        self.assertAlmostEqual(h_mag_5[5], 0.16923426, 6)
+        self.assertAlmostEqual(h_mag_5[10], 0.09228022, 6)
+        self.assertAlmostEqual(h_mag_5[15], 0.06525625, 6)
 
         # Test M(H) calculations
         Hmag_SI, mag_SI = cf.getMagneticMoment(np.linspace(0, 30, 15), Temperature=10, Hdir=[0, 1, -1], Unit="SI")


### PR DESCRIPTION


### Description of work
Fixes #37823, where an incorrect if statement was preventing the Hmag field from being included in the calculations of getMagneticMoment.


#### Summary of work
The previous statement for introducing 'Hmag' into the function string never actually happened because it was inserted into the else part of the self.MAGNETISATION check. The logic was the following:
```
if MAGNETISATION:
  do something
else:
  # everything here is NOT MAGNETISATION
  if MAGNETISATION:
    # never happened
    out += 'Hmag'
``` 

I changed the if statement to MAGNETICMOMENT,
so that if not MAGNETISATION, but if MAGNETICMOMENT, then 'Hmag' gets added to the function string.

I assume this was the intended behaviour, which is also supported by the previous comments in the code.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->


#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Look at the if statement that I changed and check it makes physical sense.

Run the following script (which is just the two scripts @mducle provided in the original issue) and check that corrected workspaces match with the new workspaces by overplotting them:

```python
from mantid.simpleapi import CreateWorkspace
from CrystalField import CrystalField, PhysicalProperties
import numpy as np

cf = CrystalField('Ce', 'C4', Temperature=1, B20=0.2, B40=0.01, B44=-0.005)
T = np.linspace(1,300,100)
moment_T0p1 = CreateWorkspace(*cf.getMagneticMoment (0.1, Temperature = T , Hdir=[1,0,0], Hmag=0.1, Unit='bohr'))
moment_T1 = CreateWorkspace(*cf.getMagneticMoment (1, Temperature = T , Hdir=[1,0,0], Hmag=1, Unit='bohr'))
moment_T10 = CreateWorkspace(*cf.getMagneticMoment (10, Temperature = T , Hdir=[1,0,0], Hmag=10, Unit='bohr'))

def mymagmom(cf, **kwargs):
    Hmag = kwargs.pop('Hmag')
    if not isinstance(T, str) or 'mantid' in type(T):
        twksp = CreateWorkspace(kwargs['Temperature'], kwargs['Temperature'], OutputWorkspace='_twksp')
    else:
        twksp = kwargs['Temperature']
    funstr = cf.makePhysicalPropertiesFunction(PhysicalProperties("M(T)", **kwargs)) + f',Hmag={Hmag}'
    return cf._calcSpectrum(funstr, twksp, 0)

cf = CrystalField('Ce', 'C4', Temperature=1, B20=0.2, B40=0.01, B44=-0.005)
T = np.linspace(1,300,100)
moment_T0p1_correct = CreateWorkspace(*mymagmom(cf, Temperature = T , Hdir=[1,0,0], Hmag=0.1, Unit='bohr'))
moment_T1_correct = CreateWorkspace(*mymagmom(cf, Temperature = T , Hdir=[1,0,0], Hmag=1, Unit='bohr'))
moment_T10_correct = CreateWorkspace(*mymagmom(cf, Temperature = T , Hdir=[1,0,0], Hmag=10, Unit='bohr'))
``` 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
