### PR TITLE
Add warning on QENS Fitting interface for missing workspaces

### DIFF
--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37706.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37706.rst
@@ -1,0 +1,1 @@
+- If the ADS is cleared from workspaces that are used to run fits on an open :ref:`QENS Fitting interface <interface-inelastic-qens-fitting>`, a warning message pops up when clicking on the `Run` button.

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
@@ -73,7 +73,11 @@ std::vector<std::pair<std::string, size_t>> FitDataPresenter::getResolutionsForF
   return m_model->getResolutionsForFit();
 }
 
-void FitDataPresenter::validate(IUserInputValidator *validator) { m_view->validate(validator); }
+void FitDataPresenter::validate(IUserInputValidator *validator) {
+  m_view->validate(validator);
+  if (!MantidWidgets::WorkspaceUtils::doAllWsExistInADS(m_model->getWorkspaceNames()))
+    validator->addErrorMessage("No input data for fit : Some of the input workspaces have been removed from the ADS");
+}
 
 void FitDataPresenter::handleAddData(MantidWidgets::IAddWorkspaceDialog const *dialog) {
   try {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
@@ -36,7 +36,7 @@ public:
 class MANTIDQT_INELASTIC_DLL FitDataPresenter : public IFitDataPresenter, public AnalysisDataServiceObserver {
 public:
   FitDataPresenter(IFitTab *tab, IDataModel *model, IFitDataView *view);
-  ~FitDataPresenter();
+  ~FitDataPresenter() override;
   virtual bool addWorkspaceFromDialog(MantidWidgets::IAddWorkspaceDialog const *dialog);
   void addWorkspace(const std::string &workspaceName, const FunctionModelSpectra &workspaceIndices);
   void setResolution(const std::string &name);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
@@ -15,6 +15,7 @@
 #include "InelasticFitPropertyBrowser.h"
 #include "MantidAPI/AnalysisDataServiceObserver.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidQtWidgets/Common/WorkspaceUtils.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceUtils.h
@@ -39,6 +39,7 @@ EXPORT_OPT_MANTIDQT_COMMON std::optional<std::size_t> maximumIndex(const Mantid:
 EXPORT_OPT_MANTIDQT_COMMON std::string getIndexString(const std::string &workspaceName);
 
 EXPORT_OPT_MANTIDQT_COMMON bool doesExistInADS(std::string const &workspaceName);
+EXPORT_OPT_MANTIDQT_COMMON bool doAllWsExistInADS(std::vector<std::string> const &workspaceNames);
 
 template <typename T = Mantid::API::MatrixWorkspace>
 std::shared_ptr<T> getADSWorkspace(std::string const &workspaceName) {

--- a/qt/widgets/common/src/WorkspaceUtils.cpp
+++ b/qt/widgets/common/src/WorkspaceUtils.cpp
@@ -215,6 +215,10 @@ bool doesExistInADS(std::string const &workspaceName) {
   return AnalysisDataService::Instance().doesExist(workspaceName);
 }
 
+bool doAllWsExistInADS(std::vector<std::string> const &workspaceNames) {
+  return AnalysisDataService::Instance().doAllWsExist(workspaceNames);
+}
+
 std::vector<std::string> attachPrefix(std::vector<std::string> const &strings, std::string const &prefix) {
   return transformElements(strings.begin(), strings.end(), [&prefix](std::string const &str) { return prefix + str; });
 }


### PR DESCRIPTION
### Description of work
This PR fixes #37706. Although I haven't been able to reproduce the crash described in the issue neither on Windows nor MacOSX. I have reproduced a crash in the conditions described in #37706 on Mantid v6.10 when workspaces needed in the QENS interface are deleted from the ADS and the `Run` button is clicked. 
I think this crash was fixed during this sprint as a `Run` widget has been added in place of the `Run` button in most Inelastic interfaces. This widget catches exceptions thrown from the presenter or the model when  the `Run` button is clicked, and avoids the aforementioned crash. 
However, due to the way the ADS handles the workspaces when they are cleared vs. when they are deleted, the behaviour is different. In one case(Delete) the error is caught in the model, and shown as a warning dialog, while in the other case (Clear) the error is caught by the algorithm per-se, and gives an uninformative error message on the Messages center('_Algorithm Property does not exist_'). 

#### Summary of work
I have added a check in the validation stage of the data presenter that checks the workspaces in the data model against the workspaces in the ADS, and raise an error if any of the workspaces on the data model is not on the ADS. Now in both cases, Delete and Clear workspaces, error message will be the same, informing that the problem is that one of the target workspace has been deleted from the ADS. 


<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37706 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1. Open `Interfaces->Inelastic->QENS Fitting'
2. Go to `I(Q,t)` tab and load some sample data: 'irs26174_graphite002_iqt` from the Usage Data. 
3. On the property browser, add 1 exponential to fit. 
4. Delete the workspace: `irs26174_graphite002_iqt` from the ADS (click on delete). 
5. Click on `Run` button on the interface. 
6. A warning box with message : `No input data...` should appear. 
7. Close the `QENS Fitting` interface and repeat steps 1-6, but this time remove the workspace by clearing the ADS
instead of deleting. Same warning message should appear. 
---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
