### PR TITLE
Load() loads incorrect extension when specified

### DIFF
--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -458,11 +458,11 @@ const API::Result<std::string> FileFinderImpl::findRun(const std::string &hintst
   if (!extension.empty())
     uniqueExts.emplace_back(extension);
 
-  // If useExtsOnly and extension not in filename
+  // If no extension in filename and useExtsOnly
   if (extension.empty() || useExtsOnly) {
     getUniqueExtensions(exts, uniqueExts);
   }
-  // Majority of cases, no extension in filename
+  // If no extension in filename and useExtsOnly=Flase (most cases)
   if (extension.empty() && !useExtsOnly) {
     getUniqueExtensions(extensions, uniqueExts);
   }
@@ -476,8 +476,9 @@ const API::Result<std::string> FileFinderImpl::findRun(const std::string &hintst
     return path;
   }
 
-  if (!path && uniqueExts.size() == 1) {
-    uniqueExts.pop_back();
+  // Path not found
+  if (uniqueExts.size() == 1) {
+    uniqueExts.pop_back(); // No need to search for missing extension again
     getUniqueExtensions(exts, uniqueExts);
     getUniqueExtensions(extensions, uniqueExts);
 
@@ -490,7 +491,6 @@ const API::Result<std::string> FileFinderImpl::findRun(const std::string &hintst
       return path;
     }
   }
-  // Path not found
   g_log.information() << "Unable to find run with hint " << hint << "\n";
   return API::Result<std::string>("", path.errors());
 }

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -455,7 +455,9 @@ const API::Result<std::string> FileFinderImpl::findRun(const std::string &hintst
   // On Windows throw out ones that only vary in case
   std::vector<std::string> uniqueExts;
   uniqueExts.reserve(1 + exts.size() + extensions.size());
-  if (!extension.empty())
+
+  // If extension specified in filename
+  if (!extension.empty() && !useExtsOnly)
     uniqueExts.emplace_back(extension);
 
   // If no extension in filename and useExtsOnly

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -363,6 +363,17 @@ std::vector<IArchiveSearch_sptr> FileFinderImpl::getArchiveSearch(const Kernel::
   return archs;
 }
 
+/**
+ * Find a path to a single file from a hint.
+ * @param hintstr :: hint string to look for filename.
+ * @param extensionsProvided :: Vector of aditional file extensions to consider. Optional.
+ *                  If not provided, facility extensions used.
+ * @param useOnlyExtensionsProvided :: Optional bool.
+ *                  If it's true (and extensionsProvided is not empty),
+ *                  search for the file using extensionsProvided only.
+ *                  If it's false, use extensionsProvided AND facility extensions.
+ * @return A vector of full paths or empty vector
+ */
 const API::Result<std::string> FileFinderImpl::findRun(const std::string &hintstr,
                                                        const std::vector<std::string> &extensionsProvided,
                                                        const bool useOnlyExtensionsProvided) const {

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -280,18 +280,10 @@ std::string FileFinderImpl::makeFileName(const std::string &hint, const Kernel::
     filename = shortName + filename;
   }
 
-  std::pair<std::string, std::string> p = toInstrumentAndNumber(filename);
+  auto [instrumentName, runNumber] = toInstrumentAndNumber(filename);
 
-  filename = p.first;
-  if (!delimiter.empty()) {
-    filename += delimiter;
-  }
-  filename += p.second;
-
-  if (!suffix.empty()) {
-    filename += suffix;
-  }
-
+  // delimiter and suffix might be empty strings
+  filename = instrumentName + delimiter + runNumber + suffix;
   return filename;
 }
 

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -443,18 +443,17 @@ const API::Result<std::string> FileFinderImpl::findRun(const std::string &hintst
   std::vector<std::string> extensionsToSearch;
   extensionsToSearch.reserve(1 + extensionsProvided.size() + facilityExtensions.size());
 
-  // If extension specified in filename
-  if (!extension.empty() && !useOnlyExtensionsProvided)
-    extensionsToSearch.emplace_back(extension);
-
-  // If no extension in filename and useExtsOnly
-  if (extension.empty() || useOnlyExtensionsProvided) {
+  if (useOnlyExtensionsProvided) {
     getUniqueExtensions(extensionsProvided, extensionsToSearch);
-  }
-  // If no extension in filename and useExtsOnly=Flase (most cases)
-  if (extension.empty() && !useOnlyExtensionsProvided) {
-    g_log.debug() << "Add facility extensions defined in the Facility.xml file" << std::endl;
-    getUniqueExtensions(facilityExtensions, extensionsToSearch);
+
+  } else {
+    if (!extension.empty()) {
+      extensionsToSearch.emplace_back(extension);
+
+    } else {
+      getUniqueExtensions(extensionsProvided, extensionsToSearch);
+      getUniqueExtensions(facilityExtensions, extensionsToSearch);
+    }
   }
 
   // determine which archive search facilities to use
@@ -465,9 +464,11 @@ const API::Result<std::string> FileFinderImpl::findRun(const std::string &hintst
     g_log.information() << "Found path = " << path << '\n';
     return path;
   }
-
   // Path not found
+
+  // If only looked for extension in filename
   if (!useOnlyExtensionsProvided && extensionsToSearch.size() == 1) {
+
     extensionsToSearch.pop_back(); // No need to search for missing extension again
     getUniqueExtensions(extensionsProvided, extensionsToSearch);
     getUniqueExtensions(facilityExtensions, extensionsToSearch);

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -477,7 +477,7 @@ const API::Result<std::string> FileFinderImpl::findRun(const std::string &hintst
   }
 
   // Path not found
-  if (uniqueExts.size() == 1) {
+  if (!useExtsOnly && uniqueExts.size() == 1) {
     uniqueExts.pop_back(); // No need to search for missing extension again
     getUniqueExtensions(exts, uniqueExts);
     getUniqueExtensions(extensions, uniqueExts);

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -537,10 +537,10 @@ std::string FileFinderImpl::validateRuns(const std::string &searchText) const {
  * @param hintstr :: Comma separated list of hints to findRun method.
  *  Can also include ranges of runs, e.g. 123-135 or equivalently 123-35.
  *  Only the beginning of a range can contain an instrument name.
- * @param exts :: Vector of allowed file extensions. Optional.
+ * @param extensionsProvided :: Vector of allowed file extensions. Optional.
  *                If provided, this provides the only extensions searched for.
  *                If not provided, facility extensions used.
- * @param useExtsOnly :: Optional bool. If it's true (and exts is not empty),
+ * @param useOnlyExtensionsProvided:: Optional bool. If it's true (and exts is not empty),
                            search the for the file using exts only.
                            If it's false, use exts AND facility extensions.
  * @return A vector of full paths or empty vector

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -460,8 +460,10 @@ const API::Result<std::string> FileFinderImpl::findRun(const std::string &hintst
 
   // If provided exts are empty, or useExtsOnly is false,
   // we want to include facility exts as well
-  getUniqueExtensions(exts, uniqueExts);
-  if (exts.empty() || !useExtsOnly) {
+  if (extension.empty() || useExtsOnly) {
+    getUniqueExtensions(exts, uniqueExts);
+  }
+  if (extension.empty() && !useExtsOnly) {
     getUniqueExtensions(extensions, uniqueExts);
   }
 

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -458,11 +458,11 @@ const API::Result<std::string> FileFinderImpl::findRun(const std::string &hintst
   if (!extension.empty())
     uniqueExts.emplace_back(extension);
 
-  // If provided exts are empty, or useExtsOnly is false,
-  // we want to include facility exts as well
+  // If useExtsOnly and extension not in filename
   if (extension.empty() || useExtsOnly) {
     getUniqueExtensions(exts, uniqueExts);
   }
+  // Majority of cases, no extension in filename
   if (extension.empty() && !useExtsOnly) {
     getUniqueExtensions(extensions, uniqueExts);
   }

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -472,14 +472,26 @@ const API::Result<std::string> FileFinderImpl::findRun(const std::string &hintst
 
   auto path = getPath(archs, filenames, uniqueExts);
   if (path) {
-    g_log.information() << "found path = " << path << '\n';
+    g_log.information() << "Found path = " << path << '\n';
     return path;
-  } else {
-    g_log.information() << "Unable to find run with hint " << hint << "\n";
   }
 
-  g_log.information() << "Unable to find file path for " << hint << "\n";
+  if (!path && uniqueExts.size() == 1) {
+    uniqueExts.pop_back();
+    getUniqueExtensions(exts, uniqueExts);
+    getUniqueExtensions(extensions, uniqueExts);
 
+    g_log.warning() << "Extension ['" << extension << "'] not found.\n";
+    g_log.warning() << "Searching for other facility extensions." << std::endl;
+
+    path = getPath(archs, filenames, uniqueExts);
+    if (path) {
+      g_log.information() << "Found path = " << path << '\n';
+      return path;
+    }
+  }
+  // Path not found
+  g_log.information() << "Unable to find run with hint " << hint << "\n";
   return API::Result<std::string>("", path.errors());
 }
 

--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -350,11 +350,9 @@ public:
   }
 
   void testFindRunWithOverwriteExtensionsAndCorrectExtensionInFilename() {
-    std::string path;
-
     // This file is .nxs or .RAW
     const std::vector<std::string> incorrect_extension = {".txt"};
-    path = FileFinder::Instance().findRun("MUSR15189.nxs", incorrect_extension, true).result();
+    std::string path = FileFinder::Instance().findRun("MUSR15189.nxs", incorrect_extension, true).result();
     TS_ASSERT_EQUALS(path, "");
   }
 
@@ -365,16 +363,13 @@ public:
   }
 
   void testFindRunWithOverwriteExtensionsAndIncorrectExtensions() {
-    std::string path;
-
     // This file is .nxs or .RAW
     const std::vector<std::string> incorrect_extension = {".txt"};
-    path = FileFinder::Instance().findRun("MUSR15189", incorrect_extension, true).result();
+    std::string path = FileFinder::Instance().findRun("MUSR15189", incorrect_extension, true).result();
     TS_ASSERT_EQUALS(path, "");
   }
 
   void testFindRunWithNoOverwriteAndIncorrectExtensionInFilename() {
-
     // Displays warning to user but still finds path using facility extensions
     std::string path = FileFinder::Instance().findRun("MUSR15189.txt").result();
     std::string actualExtension = path.substr(path.size() - 4, 4);
@@ -382,12 +377,10 @@ public:
   }
 
   void testFindRunWithOverwriteExtensionsAndOneCorrectExtension() {
-    std::string path;
-
     // This file is .nxs or .RAW
     // returns a .nxs if no extensions passed in
     const std::vector<std::string> extensions = {".a", ".txt", ".nxs"};
-    path = FileFinder::Instance().findRun("MUSR15189", extensions, true).result();
+    std::string path = FileFinder::Instance().findRun("MUSR15189", extensions, true).result();
     std::string actualExtension = "";
     if (!path.empty()) {
       actualExtension = path.substr(path.size() - 4, 4);

--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -104,6 +104,7 @@ public:
 
     ConfigService::Instance().updateFacilities(m_facFile.path());
     ConfigService::Instance().setString("datacachesearch.directory", "");
+    // Update entire config to set search data directories
     const std::string propfile = ConfigService::Instance().getDirectoryOfExecutable() + "Mantid.properties";
     ConfigService::Instance().updateConfig(propfile);
   }

--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -104,6 +104,8 @@ public:
 
     ConfigService::Instance().updateFacilities(m_facFile.path());
     ConfigService::Instance().setString("datacachesearch.directory", "");
+    const std::string propfile = ConfigService::Instance().getDirectoryOfExecutable() + "Mantid.properties";
+    ConfigService::Instance().updateConfig(propfile);
   }
 
   ~FileFinderTest() override { m_facFile.remove(); }

--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -347,6 +347,21 @@ public:
     }
   }
 
+  void testFindRunWithOverwriteExtensionsAndCorrectExtensionInFilename() {
+    std::string path;
+
+    // This file is .nxs or .RAW
+    const std::vector<std::string> incorrect_extension = {".txt"};
+    path = FileFinder::Instance().findRun("MUSR15189.nxs", incorrect_extension, true).result();
+    TS_ASSERT_EQUALS(path, "");
+  }
+
+  void testFindRunWithNoOverwriteExtensionsAndCorrectExtensionInFilename() {
+    std::string path = FileFinder::Instance().findRun("MUSR15189.nxs").result();
+    std::string actualExtension = path.substr(path.size() - 4, 4);
+    TS_ASSERT_EQUALS(actualExtension, ".nxs");
+  }
+
   void testFindRunWithOverwriteExtensionsAndIncorrectExtensions() {
     std::string path;
 
@@ -354,6 +369,14 @@ public:
     const std::vector<std::string> incorrect_extension = {".txt"};
     path = FileFinder::Instance().findRun("MUSR15189", incorrect_extension, true).result();
     TS_ASSERT_EQUALS(path, "");
+  }
+
+  void testFindRunWithNoOverwriteAndIncorrectExtensionInFilename() {
+
+    // Displays warning to user but still finds path using facility extensions
+    std::string path = FileFinder::Instance().findRun("MUSR15189.txt").result();
+    std::string actualExtension = path.substr(path.size() - 4, 4);
+    TS_ASSERT_EQUALS(actualExtension, ".nxs");
   }
 
   void testFindRunWithOverwriteExtensionsAndOneCorrectExtension() {

--- a/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37857.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37857.rst
@@ -1,0 +1,3 @@
+- :ref:`algm-Load` will now give a warning if the extension specified on the filename, eg. `MUSR15189.txt`, is not found.
+  Loading files from interfaces or other algorithms should also give this warning.
+  The algorithm will still load the file by looking for other extensions, as was the case before.


### PR DESCRIPTION
### Description of work
As described in #35661 the Load() algorithm might load an incorrect file extension even when the extension is specified in the file name.

#### Summary of work
I have maintained the same behaviour for backwards compatibility, the only change I made is that if the file with the specified extension is not found, a warning is issued to let the user know that other extensions will be considered.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
Run the code in the original issue and check that a warning is displayed in the console log. Load the same file without an extension specified and check that no warning is displayed.

Turn on the debug level on the console log and run the code in the original issue again. Check that at first only the extension specified in the filename is considered and then all extensions are considered.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
