### PR TITLE
add ConfigService::remove to python API - `ornl-next`

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -104,6 +104,7 @@ void export_ConfigService() {
            "definitions")
       .def("getFacilityNames", &ConfigServiceImpl::getFacilityNames, arg("self"), "Returns the default facility")
       .def("getFacilities", &ConfigServiceImpl::getFacilities, arg("self"), "Returns the default facility")
+      .def("remove", &ConfigServiceImpl::remove, (arg("self"), arg("rootName")), "Remove the indicated key.")
       .def("getFacility", (const FacilityInfo &(ConfigServiceImpl::*)() const) & ConfigServiceImpl::getFacility,
            arg("self"), return_value_policy<reference_existing_object>(), "Returns the default facility")
       .def("getFacility",

--- a/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
@@ -221,6 +221,14 @@ class ConfigServiceTest(unittest.TestCase):
         # verify check for converting checked value to string
         self.assertFalse(1 in ConfigService)
 
+    def test_remove(self):
+        garbage = "garbage.truck"
+        assert garbage not in list(config.keys())
+        config.setString(garbage, "yes")
+        assert garbage in list(config.keys())
+        config.remove(garbage)
+        assert garbage not in list(config.keys())
+
     @unittest.skipIf(not _on_windows, "Windows only test, uses APPDATA")
     def test_get_app_data_dir(self):
         self.assertEqual(

--- a/docs/source/release/v6.11.0/Workbench/New_features/37852.rst
+++ b/docs/source/release/v6.11.0/Workbench/New_features/37852.rst
@@ -1,0 +1,1 @@
+- expose `ConfifService::remove()` to python API

--- a/docs/source/release/v6.11.0/Workbench/New_features/37852.rst
+++ b/docs/source/release/v6.11.0/Workbench/New_features/37852.rst
@@ -1,1 +1,1 @@
-- expose `ConfifService::remove()` to python API
+- expose :class:`ConfigService::remove() <mantid.kernel.ConfigServiceImpl.remove>` to python API


### PR DESCRIPTION
This is a sister PR to #37852, into `ornl-next`