### PR TITLE
Compression options for SNSPowderReduction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -160,6 +160,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
     _sampleFormula = None
     _massDensity = None
     _containerShape = None
+    _compressionThreshold = None
 
     def category(self):
         return "Diffraction\\Reduction"
@@ -178,7 +179,9 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         return "The algorithm used for reduction of powder diffraction data obtained on SNS instruments (e.g. PG3)"
 
     def PyInit(self):
-        self.copyProperties("AlignAndFocusPowderFromFiles", ["Filename", "PreserveEvents", "DMin", "DMax", "DeltaRagged"])
+        self.copyProperties(
+            "AlignAndFocusPowderFromFiles", ["Filename", "PreserveEvents", "DMin", "DMax", "DeltaRagged", "MinSizeCompressOnLoad"]
+        )
 
         self.declareProperty("Sum", False, "Sum the runs. Does nothing for characterization runs.")
         self.declareProperty(
@@ -437,6 +440,8 @@ class SNSPowderReduction(DataProcessorAlgorithm):
 
         self._info = None
         self._chunks = self.getProperty("MaxChunkSize").value
+
+        self._compressionThreshold = self.getProperty("MinSizeCompressOnLoad").value
 
         # define splitters workspace and filter wall time
         self._splittersWS = self.getProperty("SplittersWorkspace").value
@@ -928,7 +933,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             ReductionProperties="__snspowderreduction",
             LogAllowList=self.getPropertyValue("LogAllowList").strip(),
             LogBlockList=self.getPropertyValue("LogBlockList").strip(),
-            **otherArgs,
+            MinSizeCompressOnLoad=self._compressionThreshold**otherArgs,
         )
 
         # TODO make sure that this funny function is called

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -933,7 +933,8 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             ReductionProperties="__snspowderreduction",
             LogAllowList=self.getPropertyValue("LogAllowList").strip(),
             LogBlockList=self.getPropertyValue("LogBlockList").strip(),
-            MinSizeCompressOnLoad=self._compressionThreshold**otherArgs,
+            MinSizeCompressOnLoad=self._compressionThreshold,
+            **otherArgs,
         )
 
         # TODO make sure that this funny function is called

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SNSPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SNSPowderReductionTest.py
@@ -19,6 +19,18 @@ class SNSPowderReductionTest(unittest.TestCase):
             RuntimeError, SNSPowderReduction, Filename="PG3_46577", OutputDirectory="/tmp/", PushDataPositive="AddMinimum", OffsetData=42.0
         )
 
+    def testValidateInputsCompressLoad(self):
+        # PushDataPositive and OffsetData cannot be specified together
+        self.assertRaises(
+            RuntimeError,
+            SNSPowderReduction,
+            Filename="PG3_46577",
+            OutputDirectory="/tmp/",
+            PushDataPositive="AddMinimum",
+            OffsetData=42.0,
+            MinSizeCompressOnLoad=1e-14,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37831.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37831.rst
@@ -1,1 +1,2 @@
 - Added a load compression parameter ``MinSizeCompressOnLoad`` for ref: :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles>`.
+- Added a load compression parameter ``MinSizeCompressOnLoad`` for ref: :ref:`SNSPowderReduction <algm-SNSPowderReduction>`.

--- a/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37831.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37831.rst
@@ -1,2 +1,1 @@
-- Added a load compression parameter ``MinSizeCompressOnLoad`` for ref: :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles>`.
-- Added a load compression parameter ``MinSizeCompressOnLoad`` for ref: :ref:`SNSPowderReduction <algm-SNSPowderReduction>`.
+- Added a load compression parameter ``MinSizeCompressOnLoad`` for ref: :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles>` and ref: :ref:`SNSPowderReduction <algm-SNSPowderReduction>`


### PR DESCRIPTION
[6061: Add load w/ compression parameters to SNSPowderReduction](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/6061)

### Description of work

Added ``MinSizeCompressOnLoad parameterd`` to ``SNSPowderReuduction`` to determine whether its call to ``LoadEventNexus`` should enable compressing events during load. The parameter ``MinSizeCompressOnLoad``  is a floating point number of Gbytes.
.

