### PR TITLE
Add libopenblas v0.3.28 notes to build configs

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -85,7 +85,7 @@ tbb:
 gsl:
   - 2.7
 
-# v0.3.23 causes a hang on osx for some systemtests, v0.3.24 causes a unit test failure that needs investigation, v0.3.25 causes a system test failure on linux
+# v0.3.23 causes a hang on osx for some systemtests, v0.3.24 causes a unit test failure that needs investigation, v0.3.25 causes a system test failure on linux, v0.3.28 causes unit test failures on osx and system test failures on linux.
 libopenblas:
   - '!=0.3.23,!=0.3.24,!=0.3.25, !=0.3.28'
 

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -18,7 +18,7 @@ dependencies:
   - jsoncpp>=1.9.4,<2
   - libboost-devel=1.84.* # Use the same version as conda-forge
   - libboost-python-devel=1.84.* # Use the same version as conda-forge
-  - libopenblas!=0.3.23,!=0.3.24,!=0.3.25, !=0.3.28 # v0.3.25 causing system test failures on linux. Others are for macOS consistency.
+  - libopenblas!=0.3.23,!=0.3.24,!=0.3.25, !=0.3.28 # v0.3.25 causing system test failures on linux. v0.3.28 also causes some system test failures. Others are for macOS consistency.
   - librdkafka>=1.6.0
   - matplotlib=3.7.*
   - muparser>=2.3.2

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -16,7 +16,7 @@ dependencies:
   - jsoncpp>=1.9.4,<2
   - libboost-devel=1.84.* # Use the same version as conda-forge
   - libboost-python-devel=1.84.* # Use the same version as conda-forge
-  - libopenblas!=0.3.23,!=0.3.24,!=0.3.25, !=0.3.28 # v0.3.23 causes a hang for the system tests on OSX, v0.3.24 causing unit test failure - investigation needed, v0.3.25 causing a system test failure.
+  - libopenblas!=0.3.23,!=0.3.24,!=0.3.25, !=0.3.28 # v0.3.23 causes a hang for the system tests on OSX, v0.3.24 causing unit test failure - investigation needed, v0.3.25 causing a system test failure, v0.3.28 causes unit test failures on similar tests to v0.3.24.
   - librdkafka>=1.6.0
   - matplotlib=3.7.*
   - muparser>=2.3.2


### PR DESCRIPTION
### Description of work


#### Summary of work
Added explaination as to why we are avoiding using v0.3.28 of libopenblas on linux and osx.

Fixes #37835. 



#### Further detail of work
An addendum to the work undertaken in #37821 

### To test:
- all tests should pass
- explanations in files should make sense

*This does not require release notes* because **this affects developers only**


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
