### PR TITLE
Expose `ConfigService::configureLogging()` to API, fix handling of removed properties not also in file

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -206,7 +206,9 @@ public:
   /// Sets the log level priority for all log channels
   void setLogLevel(int logLevel, bool quiet = false);
   /// Sets the log level priority for all log channels
-  void setLogLevel(std::string logLevel, bool quiet = false);
+  void setLogLevel(std::string const &logLevel, bool quiet = false);
+  // return the string name for the log level
+  std::string getLogLevel();
 
   /// Look for an instrument
   const InstrumentInfo &getInstrument(const std::string &instrumentName = "") const;

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -721,11 +721,16 @@ void ConfigServiceImpl::saveConfig(const std::string &filename) const {
   } // End while-loop
 
   // Any remaining keys within the changed key store weren't present in the
-  // current user properties so append them
+  // current user properties so append them IF they exist
   if (!m_changed_keys.empty()) {
     updated_file += "\n";
     auto key_end = m_changed_keys.end();
     for (auto key_itr = m_changed_keys.begin(); key_itr != key_end;) {
+      // if the key does not have a property, skip it
+      if (!hasProperty(*key_itr)) {
+        ++key_itr;
+        continue;
+      }
       updated_file += *key_itr + "=";
       std::string value = getString(*key_itr, false);
       Poco::replaceInPlace(value, "\\", "\\\\"); // replace single \ with double

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1921,7 +1921,7 @@ void ConfigServiceImpl::setLogLevel(int logLevel, bool quiet) {
   }
 }
 
-void ConfigServiceImpl::setLogLevel(std::string logLevel, bool quiet) {
+void ConfigServiceImpl::setLogLevel(std::string const &logLevel, bool quiet) {
   Mantid::Kernel::Logger::setLevelForAll(logLevel);
   // update the internal value to keep strings in sync
   m_pConf->setString(LOG_LEVEL_KEY, g_log.getLevelName());
@@ -1930,6 +1930,8 @@ void ConfigServiceImpl::setLogLevel(std::string logLevel, bool quiet) {
     g_log.log("logging set to " + logLevel + " priority", static_cast<Logger::Priority>(g_log.getLevel()));
   }
 }
+
+std::string ConfigServiceImpl::getLogLevel() { return g_log.getLevelName(); }
 
 /// \cond TEMPLATE
 template DLLExport boost::optional<double> ConfigServiceImpl::getValue(const std::string &);

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -110,6 +110,19 @@ public:
     TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().setLogLevel(4));
   }
 
+  void testLogLevelSetGet() {
+    Logger log1("testLogLevelGetSet");
+
+    for (std::string x : Logger::PriorityNames) {
+      TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().setLogLevel(x));
+      TS_ASSERT_EQUALS(log1.getLevelName(), x);
+      TS_ASSERT_EQUALS(ConfigService::Instance().getLogLevel(), x);
+    }
+
+    // return back to previous values
+    TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().setLogLevel(4));
+  }
+
   void testDefaultFacility() {
     TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().getFacility());
     //

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -146,10 +146,12 @@ void export_ConfigService() {
       .def("saveConfig", &ConfigServiceImpl::saveConfig, (arg("self"), arg("filename")),
            "Saves the keys that have changed from their default to the given "
            "filename")
+      .def("getLogLevel", &ConfigServiceImpl::getLogLevel, arg("self"),
+           "Return the string value for the log representation")
       .def("setLogLevel", (void (ConfigServiceImpl::*)(int, bool)) & ConfigServiceImpl::setLogLevel,
            (arg("self"), arg("logLevel"), arg("quiet") = false),
            "Sets the log level priority for all the log channels, logLevel 1 = Fatal, 6 = information, 7 = Debug")
-      .def("setLogLevel", (void (ConfigServiceImpl::*)(std::string, bool)) & ConfigServiceImpl::setLogLevel,
+      .def("setLogLevel", (void (ConfigServiceImpl::*)(std::string const &, bool)) & ConfigServiceImpl::setLogLevel,
            (arg("self"), arg("logLevel"), arg("quiet") = false),
            "Sets the log level priority for all the log channels. Allowed values are fatal, critical, error, warning, "
            "notice, information, debug, and trace.")

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -104,6 +104,8 @@ void export_ConfigService() {
            "definitions")
       .def("getFacilityNames", &ConfigServiceImpl::getFacilityNames, arg("self"), "Returns the default facility")
       .def("getFacilities", &ConfigServiceImpl::getFacilities, arg("self"), "Returns the default facility")
+      .def("configureLogging", &ConfigServiceImpl::configureLogging, arg("self"),
+           "Configure and start the logging framework")
       .def("remove", &ConfigServiceImpl::remove, (arg("self"), arg("rootName")), "Remove the indicated key.")
       .def("getFacility", (const FacilityInfo &(ConfigServiceImpl::*)() const) & ConfigServiceImpl::getFacility,
            arg("self"), return_value_policy<reference_existing_object>(), "Returns the default facility")

--- a/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
@@ -133,6 +133,12 @@ class ConfigServiceTest(unittest.TestCase):
         testhelpers.assertRaisesNothing(self, config.setLogLevel, 4, True)
         testhelpers.assertRaisesNothing(self, config.setLogLevel, "warning", True)
 
+    def test_log_level_get_set(self):
+        logLevels = ["fatal", "error", "warning", "information", "debug"]
+        for x in logLevels:
+            config.setLogLevel(x)
+            self.assertEqual(config.getLogLevel(), x)
+
     def test_properties_documented(self):
         # location of the rst file relative to this file this will break if either moves
         doc_filename = os.path.split(__file__)[0]

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -91,7 +91,6 @@ returnByReference:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ConfigSe
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ConfigService.h:197
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ThreadScheduler.h:174
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/ThreadScheduler.h:278
-passedByValue:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/ConfigService.cpp:1919
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/TopicInfo.cpp:38
 returnStdMoveLocal:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp:408
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/PropertyManagerProperty.cpp:149

--- a/docs/source/release/v6.11.0/Workbench/New_features/37873.rst
+++ b/docs/source/release/v6.11.0/Workbench/New_features/37873.rst
@@ -1,0 +1,3 @@
+- expose :class:`ConfigService::configureLogging() <mantid.kernel.ConfigServiceImpl.configureLogging>` to python API
+- expose :class:`ConfigService::getLogLevel() <mantid.kernel.ConfigServiceImpl.getLogLevel>` to python API
+- fix handling of removed propertyies in :class:`ConfigService::saveConfig() <mantid.kernel.ConfigServiceImpl.saveConfig>`


### PR DESCRIPTION
### Description of work

#### Summary of work
The function `ConfigService::configureLogging()` resets and rebuilds the logging framework.  This method was not exposed to the python API, meaning the logger could only be reset by calling some other function, like `ConfigService::setString("logging.channels.consoleChannel.class")`.    This simply exposes the method.

The `ConfigService::remove()` function adds the removed property to the `m_changed_keys` list.  This can lead to unexpected behavior if the removed property is not also inside the property file.  In particular, the property key was being printed with a blank value, which caused crashes the next time Mantid was loaded.

This adds an additional check to the `ConfigService::saveConfig()` method, to make sure all properties in the `m_changed_keys` list actually have values before writing them.

It was determined in the course of thinking of tests that since `ConfigService.setLogLevel()` is a function in the API, that it would be beneficial to also have `ConfigService.getLogLevel()` as well.  It has been configured to return the string name of the log level, instead of the numerical value.

#### Purpose of work
SNAPRed would really like to divert mantid workbench logs while it is running, then restore mantid logs when it closes.  

This will require being able to rebuild the mantid workbench logs.

This is related to the following ORNL EWMs:
- [EWM 6894](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=6894)
- [EWM 6854](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=6854)

Also follows on from PR #37852 

#### Further detail of work
In the Python interface file for `ConfigService`, added `ConfigService::configureLogging()` to the list of exposed methods.

In the `ConfigService` class, added a check
``` c++
      // if the key does not have a property, skip it
      if (!hasProperty(*key_itr)) {
        ++key_itr;
        continue;
      }
```
before writing the key to the config properties file.

### To test:

There is an added unit test for the behavior when removing a property not in the file and then saving.  There are also added tests to check the behavior of `ConfigService::getLogLevel()` in the C++ and Python APIs.

You can also test in workbench.  Pull this branch, build workbench.

From the terminal, run
``` bash
tail ~/.mantid/Mantid.user.properties 
```
and verify that `garbage.truck` is not in the file (would be really weird if it were).

Now build workbench, launch with `./bin/launch_mantidworkbench.sh`, and run the following script
``` python
from mantid.kernel import ConfigService
ConfigService.remove("garbage.truck")
```
and close workbench.  Run `tail` again, and there is still not any `garbage.truck`.

To see the necessity of this change, repeat the same steps in `main`.  In the last step, you will instead see `garbage.truck=` in the file.  If used on a real property like `logging.channels.consoleChannel.class`, this would cause mantid workbench to fail to open.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
