### PR TITLE
Move from boost::optional to std::optional

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmFactory.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmFactory.h
@@ -12,7 +12,6 @@
 #include "MantidAPI/DllConfig.h"
 #include "MantidKernel/DynamicFactory.h"
 #include "MantidKernel/SingletonHolder.h"
-#include <boost/optional.hpp>
 #include <memory>
 #include <optional>
 #include <sstream>

--- a/Framework/API/inc/MantidAPI/AlgorithmProperties.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmProperties.h
@@ -16,6 +16,7 @@
 
 #include <boost/optional.hpp>
 #include <map>
+#include <optional>
 #include <string>
 
 namespace Mantid::API::AlgorithmProperties {
@@ -24,7 +25,10 @@ namespace Mantid::API::AlgorithmProperties {
 // strings to set the relevant property in an AlgorithmRuntimeProps
 
 void MANTID_API_DLL update(std::string const &property, std::string const &value, IAlgorithmRuntimeProps &properties);
+// TODO this method should no longer exist - migrate code to std::optional
 void MANTID_API_DLL update(std::string const &property, boost::optional<std::string> const &value,
+                           IAlgorithmRuntimeProps &properties);
+void MANTID_API_DLL update(std::string const &property, std::optional<std::string> const &value,
                            IAlgorithmRuntimeProps &properties);
 
 void MANTID_API_DLL update(std::string const &property, bool value, IAlgorithmRuntimeProps &properties);
@@ -35,7 +39,10 @@ void MANTID_API_DLL update(std::string const &property, size_t value, IAlgorithm
 
 void MANTID_API_DLL update(std::string const &property, double value, IAlgorithmRuntimeProps &properties);
 
+// TODO this method should no longer exist - migrate code to std::optional
 void MANTID_API_DLL update(std::string const &property, boost::optional<double> const &value,
+                           IAlgorithmRuntimeProps &properties);
+void MANTID_API_DLL update(std::string const &property, std::optional<double> const &value,
                            IAlgorithmRuntimeProps &properties);
 
 void MANTID_API_DLL update(std::string const &property, Workspace_sptr const &workspace,

--- a/Framework/API/inc/MantidAPI/BoxController.h
+++ b/Framework/API/inc/MantidAPI/BoxController.h
@@ -14,8 +14,8 @@
 #include "MantidKernel/ThreadPool.h"
 #include <nexus/NeXusFile.hpp>
 
-#include <boost/optional.hpp>
 #include <numeric>
+#include <optional>
 #include <vector>
 
 namespace Mantid {
@@ -38,7 +38,7 @@ public:
    * @param nd :: number of dimensions
    */
   BoxController(size_t nd)
-      : nd(nd), m_maxId(0), m_SplitThreshold(1024), m_splitTopInto(boost::none), m_numSplit(1), m_numTopSplit(1),
+      : nd(nd), m_maxId(0), m_SplitThreshold(1024), m_splitTopInto(std::nullopt), m_numSplit(1), m_numTopSplit(1),
         m_fileIO(std::shared_ptr<API::IBoxControllerIO>()) {
     // TODO: Smarter ways to determine all of these values
     m_maxDepth = 5;
@@ -134,7 +134,7 @@ public:
    *
    * @return the splits in each dimesion for the top level
    */
-  boost::optional<std::vector<size_t>> getSplitTopInto() const {
+  std::optional<std::vector<size_t>> getSplitTopInto() const {
     //      if (dim >= nd)
     //        throw std::invalid_argument("BoxController::setSplitInto() called
     //        with too high of a dimension index.");
@@ -182,7 +182,7 @@ public:
     if (!m_splitTopInto) {
       m_splitTopInto = std::vector<size_t>(nd, 1);
     }
-    m_splitTopInto.get()[dim] = num;
+    m_splitTopInto.value()[dim] = num;
     calcNumTopSplit();
   }
 
@@ -314,7 +314,7 @@ public:
     // We need to account for optional top level splitting
     if (depth == 0 && m_splitTopInto) {
 
-      const auto &splitTopInto = m_splitTopInto.get();
+      const auto &splitTopInto = m_splitTopInto.value();
       size_t numSplitTop =
           std::accumulate(splitTopInto.cbegin(), splitTopInto.cend(), size_t{1}, std::multiplies<size_t>());
       m_numMDBoxes[depth + 1] += numSplitTop;
@@ -413,7 +413,7 @@ private:
   void calcNumTopSplit() {
     m_numTopSplit = 1;
     for (size_t d = 0; d < nd; d++) {
-      m_numTopSplit *= m_splitTopInto.get()[d];
+      m_numTopSplit *= m_splitTopInto.value()[d];
     }
     /// And this changes the max # of boxes too
     resetMaxNumBoxes();
@@ -473,7 +473,7 @@ private:
   std::vector<size_t> m_splitInto;
 
   /// Splittin # for all dimensions in the top level
-  boost::optional<std::vector<size_t>> m_splitTopInto;
+  std::optional<std::vector<size_t>> m_splitTopInto;
 
   /// When you split a MDBox, it becomes this many sub-boxes
   size_t m_numSplit;

--- a/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -14,7 +14,7 @@
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace Mantid {
 namespace Geometry {
@@ -101,7 +101,7 @@ public:
    * @return a pointer to a new Peak object.
    */
   virtual std::unique_ptr<Geometry::IPeak> createPeak(const Mantid::Kernel::V3D &QLabFrame,
-                                                      boost::optional<double> detectorDistance = boost::none) const = 0;
+                                                      std::optional<double> detectorDistance = std::nullopt) const = 0;
 
   //---------------------------------------------------------------------------------------------
   /** Create an instance of a Peak

--- a/Framework/API/src/AlgorithmProperties.cpp
+++ b/Framework/API/src/AlgorithmProperties.cpp
@@ -20,10 +20,16 @@ void update(std::string const &property, std::string const &value, IAlgorithmRun
     properties.setPropertyValue(property, value);
 }
 
-void update(std::string const &property, boost::optional<std::string> const &value,
-            IAlgorithmRuntimeProps &properties) {
+// TODO code that uses this should move to std::optional
+[[deprecated("use version with std::optional instead")]] void
+update(std::string const &property, boost::optional<std::string> const &value, IAlgorithmRuntimeProps &properties) {
   if (value)
     update(property, value.get(), properties);
+}
+
+void update(std::string const &property, std::optional<std::string> const &value, IAlgorithmRuntimeProps &properties) {
+  if (value)
+    update(property, value.value(), properties);
 }
 
 void update(std::string const &property, bool value, IAlgorithmRuntimeProps &properties) {
@@ -42,9 +48,16 @@ void update(std::string const &property, double value, IAlgorithmRuntimeProps &p
   properties.setProperty(property, value);
 }
 
-void update(std::string const &property, boost::optional<double> const &value, IAlgorithmRuntimeProps &properties) {
+// TODO code that uses this should move to std::optional
+[[deprecated("use version with std::optional instead")]] void
+update(std::string const &property, boost::optional<double> const &value, IAlgorithmRuntimeProps &properties) {
   if (value)
     update(property, value.get(), properties);
+}
+
+void update(std::string const &property, std::optional<double> const &value, IAlgorithmRuntimeProps &properties) {
+  if (value)
+    update(property, value.value(), properties);
 }
 
 void update(std::string const &property, Workspace_sptr const &workspace, IAlgorithmRuntimeProps &properties) {

--- a/Framework/API/src/BoxController.cpp
+++ b/Framework/API/src/BoxController.cpp
@@ -21,7 +21,7 @@
 #include <Poco/DOM/Text.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 using namespace Mantid::Kernel;
 using Mantid::Kernel::Strings::convert;
@@ -77,11 +77,11 @@ bool BoxController::operator==(const BoxController &other) const {
   }
 
   if (m_splitTopInto && other.m_splitTopInto) {
-    if (m_splitTopInto.get().size() != other.m_splitTopInto.get().size()) {
+    if (m_splitTopInto.value().size() != other.m_splitTopInto.value().size()) {
       return false;
     } else {
-      for (size_t i = 0; i < m_splitTopInto.get().size(); i++) {
-        if (m_splitTopInto.get()[i] != other.m_splitTopInto.get()[i])
+      for (size_t i = 0; i < m_splitTopInto.value().size(); i++) {
+        if (m_splitTopInto.value()[i] != other.m_splitTopInto.value()[i])
           return false;
       }
     }
@@ -162,7 +162,7 @@ std::string BoxController::toXMLString() const {
 
   element = pDoc->createElement("SplitTopInto");
   if (m_splitTopInto) {
-    vecStr = Kernel::Strings::join(this->m_splitTopInto.get().begin(), this->m_splitTopInto.get().end(), ",");
+    vecStr = Kernel::Strings::join(this->m_splitTopInto.value().begin(), this->m_splitTopInto.value().end(), ",");
   } else {
     vecStr = "";
   }
@@ -238,12 +238,12 @@ void BoxController::fromXMLString(const std::string &xml) {
   if (nodes->length() > 0) {
     s = pBoxElement->getChildElement("SplitTopInto")->innerText();
     if (s.empty()) {
-      this->m_splitTopInto = boost::none;
+      this->m_splitTopInto = std::nullopt;
     } else {
       this->m_splitTopInto = splitStringIntoVector<size_t>(s);
     }
   } else {
-    this->m_splitTopInto = boost::none;
+    this->m_splitTopInto = std::nullopt;
   }
 
   s = pBoxElement->getChildElement("NumMDBoxes")->innerText();

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -74,7 +74,7 @@ FileFinderImpl::FileFinderImpl() {
 #ifdef _WIN32
   m_globOption = Poco::Glob::GLOB_DEFAULT;
 #else
-  setCaseSensitive(Kernel::ConfigService::Instance().getValue<bool>("filefinder.casesensitive").get_value_or(false));
+  setCaseSensitive(Kernel::ConfigService::Instance().getValue<bool>("filefinder.casesensitive").value_or(false));
 #endif
 }
 

--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -152,8 +152,8 @@ void FrameworkManagerImpl::loadPlugins() { loadPluginsUsingKey(PLUGINS_DIR_KEY, 
 void FrameworkManagerImpl::setNumOMPThreadsToConfigValue() {
   // Set the number of threads to use for this process
   auto maxCores = Kernel::ConfigService::Instance().getValue<int>("MultiThreaded.MaxCores");
-  if (maxCores.get_value_or(0) > 0) {
-    setNumOMPThreads(maxCores.get());
+  if (maxCores.value_or(0) > 0) {
+    setNumOMPThreads(maxCores.value());
   }
 }
 
@@ -346,7 +346,7 @@ void FrameworkManagerImpl::disableNexusOutput() { NXMSetError(nullptr, NexusErro
 void FrameworkManagerImpl::asynchronousStartupTasks() {
   auto instrumentUpdates = Kernel::ConfigService::Instance().getValue<bool>("UpdateInstrumentDefinitions.OnStartup");
 
-  if (instrumentUpdates.get_value_or(false)) {
+  if (instrumentUpdates.value_or(false)) {
     updateInstrumentDefinitions();
   } else {
     g_log.information() << "Instrument updates disabled - cannot update "
@@ -354,7 +354,7 @@ void FrameworkManagerImpl::asynchronousStartupTasks() {
   }
 
   auto newVersionCheck = Kernel::ConfigService::Instance().getValue<bool>("CheckMantidVersion.OnStartup");
-  if (newVersionCheck.get_value_or(false)) {
+  if (newVersionCheck.value_or(false)) {
     checkIfNewerVersionIsAvailable();
   } else {
     g_log.information() << "Version check disabled.\n";
@@ -367,11 +367,11 @@ void FrameworkManagerImpl::setupUsageReporting() {
   auto &configSvc = ConfigService::Instance();
   auto interval = configSvc.getValue<int>("Usage.BufferCheckInterval");
   auto &usageSvc = UsageService::Instance();
-  if (interval.get_value_or(0) > 0) {
-    usageSvc.setInterval(interval.get());
+  if (interval.value_or(0) > 0) {
+    usageSvc.setInterval(interval.value());
   }
   auto enabled = configSvc.getValue<bool>("usagereports.enabled");
-  usageSvc.setEnabled(enabled.get_value_or(false));
+  usageSvc.setEnabled(enabled.value_or(false));
   usageSvc.registerStartup();
 }
 

--- a/Framework/API/src/IPowderDiffPeakFunction.cpp
+++ b/Framework/API/src/IPowderDiffPeakFunction.cpp
@@ -31,8 +31,8 @@ IPowderDiffPeakFunction::IPowderDiffPeakFunction()
       mHKLSet(false), LATTICEINDEX(9999), HEIGHTINDEX(9999) {
   // Set peak's radius from configuration
   auto peakRadius = Kernel::ConfigService::Instance().getValue<int>("curvefitting.peakRadius");
-  if (peakRadius.is_initialized() && peakRadius.get() != s_peakRadius) {
-    setPeakRadius(peakRadius.get());
+  if (peakRadius.has_value() && peakRadius.value() != s_peakRadius) {
+    setPeakRadius(peakRadius.value());
   }
 }
 

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -84,7 +84,7 @@ MultipleFileProperty::MultipleFileProperty(const std::string &name, unsigned int
     m_action = action;
   }
 
-  m_multiFileLoadingEnabled = Kernel::ConfigService::Instance().getValue<bool>("loading.multifile").get_value_or(false);
+  m_multiFileLoadingEnabled = Kernel::ConfigService::Instance().getValue<bool>("loading.multifile").value_or(false);
   std::copy_if(exts.cbegin(), exts.cend(), std::back_inserter(m_exts), doesNotContainWildCard);
 }
 

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -10,8 +10,8 @@
 #include "MantidAPI/AlgorithmFactory.h"
 #include "MantidKernel/Instantiator.h"
 #include <algorithm>
-#include <boost/optional.hpp>
 #include <cxxtest/TestSuite.h>
+#include <optional>
 
 class AlgorithmFactoryTest : public CxxTest::TestSuite {
 public:

--- a/Framework/API/test/BoxControllerTest.h
+++ b/Framework/API/test/BoxControllerTest.h
@@ -10,10 +10,10 @@
 #include "MantidAPI/IBoxControllerIO.h"
 #include "MantidFrameworkTestHelpers/BoxControllerDummyIO.h"
 #include "MantidKernel/DiskBuffer.h"
-#include <boost/optional.hpp>
 #include <cxxtest/TestSuite.h>
 #include <map>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 
@@ -105,12 +105,12 @@ public:
     sc.setSplitTopInto(1, 20);
     sc.setSplitTopInto(2, 30);
 
-    boost::optional<std::vector<size_t>> splitTopInto = sc.getSplitTopInto();
+    std::optional<std::vector<size_t>> splitTopInto = sc.getSplitTopInto();
 
-    TSM_ASSERT_EQUALS("Should have three dimensions", splitTopInto.get().size(), 3);
-    TSM_ASSERT_EQUALS("Should have a value of 10 in the first dimension", splitTopInto.get()[0], 10);
-    TSM_ASSERT_EQUALS("Should have a value of 20 in the second dimension", splitTopInto.get()[1], 20);
-    TSM_ASSERT_EQUALS("Should have a value of 30 in the third dimension", splitTopInto.get()[2], 30);
+    TSM_ASSERT_EQUALS("Should have three dimensions", splitTopInto.value().size(), 3);
+    TSM_ASSERT_EQUALS("Should have a value of 10 in the first dimension", splitTopInto.value()[0], 10);
+    TSM_ASSERT_EQUALS("Should have a value of 20 in the second dimension", splitTopInto.value()[1], 20);
+    TSM_ASSERT_EQUALS("Should have a value of 30 in the third dimension", splitTopInto.value()[2], 30);
   }
 
   void test_setSplitTopIntoThrowsForWrongDimension() {
@@ -234,7 +234,7 @@ public:
     // Check for top level splitting
     if (a.getSplitTopInto() && b.getSplitTopInto()) {
       for (size_t d = 0; d < a.getNDims(); d++) {
-        TS_ASSERT_EQUALS(a.getSplitTopInto().get()[d], b.getSplitTopInto().get()[d]);
+        TS_ASSERT_EQUALS(a.getSplitTopInto().value()[d], b.getSplitTopInto().value()[d]);
       }
     } else {
       TS_ASSERT_EQUALS(a.getSplitTopInto(), b.getSplitTopInto());
@@ -341,7 +341,7 @@ public:
     // Check the constructor defaults.
     BoxController box_controller(2);
 
-    boost::optional<std::vector<size_t>> splitTopInto = box_controller.getSplitTopInto();
+    std::optional<std::vector<size_t>> splitTopInto = box_controller.getSplitTopInto();
     TS_ASSERT(!splitTopInto)
     TS_ASSERT_EQUALS(2, box_controller.getNDims());
     TS_ASSERT_EQUALS(1, box_controller.getNumSplit());

--- a/Framework/Algorithms/inc/MantidAlgorithms/MergeRuns.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MergeRuns.h
@@ -13,7 +13,7 @@
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace Mantid {
 namespace API {
@@ -122,7 +122,7 @@ private:
   // Methods called by exec()
   using Mantid::API::Algorithm::validateInputs;
   bool validateInputsForEventWorkspaces(const std::vector<std::string> &inputWorkspaces);
-  boost::optional<std::vector<double>> checkRebinning();
+  std::optional<std::vector<double>> checkRebinning();
   static std::vector<double> calculateRebinParams(const std::vector<double> &bins1, const std::vector<double> &bins2);
   static void noOverlapParams(const HistogramData::HistogramX &X1, const HistogramData::HistogramX &X2,
                               std::vector<double> &params);

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrectionFredrikze.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrectionFredrikze.h
@@ -8,8 +8,8 @@
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAlgorithms/DllConfig.h"
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 namespace Mantid {
 namespace API {

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
@@ -39,8 +39,8 @@ public:
 
 private:
   int getComponentIndex(Kernel::PseudoRandomNumberGenerator &rng) const;
-  boost::optional<Kernel::V3D> generatePointInObjectByIndex(int componentIndex,
-                                                            Kernel::PseudoRandomNumberGenerator &rng) const;
+  std::optional<Kernel::V3D> generatePointInObjectByIndex(int componentIndex,
+                                                          Kernel::PseudoRandomNumberGenerator &rng) const;
   const std::shared_ptr<Geometry::IObject> m_sample;
   const Geometry::SampleEnvironment *m_env;
   Geometry::BoundingBox m_activeRegion;

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/SparseInstrument.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/SparseInstrument.h
@@ -10,7 +10,7 @@
 #include "MantidAlgorithms/DllConfig.h"
 
 #include <array>
-#include <boost/optional/optional.hpp>
+#include <optional>
 #include <tuple>
 #include <utility>
 
@@ -50,7 +50,7 @@ MANTID_ALGORITHMS_DLL HistogramData::Histogram interpolateFromDetectorGrid(const
                                                                            const std::array<size_t, 4> &indices);
 MANTID_ALGORITHMS_DLL HistogramData::Histogram
 bilinearInterpolateFromDetectorGrid(const double lat, const double lon, const API::MatrixWorkspace &ws,
-                                    const std::vector<std::vector<boost::optional<size_t>>> &indices);
+                                    const std::vector<std::vector<std::optional<size_t>>> &indices);
 MANTID_ALGORITHMS_DLL std::unique_ptr<const Algorithms::DetectorGridDefinition>
 createDetectorGridDefinition(const API::MatrixWorkspace &modelWS, const size_t rows, const size_t columns);
 } // namespace SparseInstrument

--- a/Framework/Algorithms/src/CreateUserDefinedBackground.cpp
+++ b/Framework/Algorithms/src/CreateUserDefinedBackground.cpp
@@ -163,7 +163,7 @@ CreateUserDefinedBackground::createBackgroundWorkspace(const API::ITableWorkspac
     histogram.setFrequencyStandardDeviations(eBackground);
   } else {
     if (data->isHistogramData() &&
-        Kernel::ConfigService::Instance().getValue<bool>(AUTODISTRIBUTIONKEY).get_value_or(false)) {
+        Kernel::ConfigService::Instance().getValue<bool>(AUTODISTRIBUTIONKEY).value_or(false)) {
       // Background data is actually frequencies, we put it into temporary to
       // benefit from automatic conversion in setCounts(), etc.
       histogram.setCounts(Frequencies(yBackground), xBinEdges);

--- a/Framework/Algorithms/src/MergeRuns.cpp
+++ b/Framework/Algorithms/src/MergeRuns.cpp
@@ -432,7 +432,7 @@ bool MergeRuns::validateInputsForEventWorkspaces(const std::vector<std::string> 
  *  @return :: An optional object containing the rebinning params or none
  *  if rebinning is not needed.
  */
-boost::optional<std::vector<double>> MergeRuns::checkRebinning() {
+std::optional<std::vector<double>> MergeRuns::checkRebinning() {
   const std::string rebinBehaviour = getProperty("RebinBehaviour");
   const std::string sampleLogsFailBehaviour = getProperty("FailBehaviour");
   // To properly cover all X spans of the input workspaces, one needs to
@@ -444,7 +444,7 @@ boost::optional<std::vector<double>> MergeRuns::checkRebinning() {
             });
   auto it = inputsSortedByX.cbegin();
   g_log.notice() << "Using run '" << (*it)->getName() << "' as a reference to determine possible rebinning.\n";
-  boost::optional<std::vector<double>> rebinParams{boost::none};
+  std::optional<std::vector<double>> rebinParams{std::nullopt};
   std::vector<double> bins{(*it)->x(0).rawData()};
   for (++it; it != inputsSortedByX.cend(); ++it) {
     if (!WorkspaceHelpers::matchingBins(*inputsSortedByX.front(), **it, true)) {

--- a/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
@@ -105,9 +105,9 @@ int MCInteractionVolume::getComponentIndex(Kernel::PseudoRandomNumberGenerator &
  * @return The generated point
  */
 
-boost::optional<Kernel::V3D>
+std::optional<Kernel::V3D>
 MCInteractionVolume::generatePointInObjectByIndex(int componentIndex, Kernel::PseudoRandomNumberGenerator &rng) const {
-  boost::optional<Kernel::V3D> pointGenerated{boost::none};
+  std::optional<Kernel::V3D> pointGenerated{std::nullopt};
   if (componentIndex == -1) {
     pointGenerated = m_sample->generatePointInObject(rng, m_activeRegion, 1);
   } else {
@@ -129,7 +129,7 @@ MCInteractionVolume::generatePointInObjectByIndex(int componentIndex, Kernel::Ps
 ComponentScatterPoint MCInteractionVolume::generatePoint(Kernel::PseudoRandomNumberGenerator &rng) const {
   for (size_t i = 0; i < m_maxScatterAttempts; i++) {
     int componentIndex = getComponentIndex(rng);
-    boost::optional<Kernel::V3D> pointGenerated = generatePointInObjectByIndex(componentIndex, rng);
+    std::optional<Kernel::V3D> pointGenerated = generatePointInObjectByIndex(componentIndex, rng);
     if (pointGenerated) {
       return {componentIndex, *pointGenerated};
     }

--- a/Framework/Catalog/inc/MantidCatalog/OAuth.h
+++ b/Framework/Catalog/inc/MantidCatalog/OAuth.h
@@ -9,7 +9,7 @@
 #include "MantidCatalog/DllConfig.h"
 #include "MantidKernel/DateAndTime.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace Mantid {
 namespace Catalog {
@@ -35,14 +35,14 @@ class MANTID_CATALOG_DLL OAuthToken {
 public:
   OAuthToken() = delete;
   OAuthToken(std::string tokenType, int expiresIn, std::string accessToken, std::string scope,
-             boost::optional<std::string> refreshToken);
+             std::optional<std::string> refreshToken);
   ~OAuthToken();
 
   std::string tokenType() const;
   int expiresIn() const;
   std::string accessToken() const;
   std::string scope() const;
-  boost::optional<std::string> refreshToken() const;
+  std::optional<std::string> refreshToken() const;
 
   bool isExpired() const;
   bool isExpired(const DateAndTime &currentTime) const;
@@ -56,13 +56,13 @@ private:
   int m_expiresIn;
   std::string m_accessToken;
   std::string m_scope;
-  boost::optional<std::string> m_refreshToken;
+  std::optional<std::string> m_refreshToken;
 };
 
 class MANTID_CATALOG_DLL IOAuthTokenStore {
 public:
-  virtual void setToken(const boost::optional<OAuthToken> &token) = 0;
-  virtual boost::optional<OAuthToken> getToken() = 0;
+  virtual void setToken(const std::optional<OAuthToken> &token) = 0;
+  virtual std::optional<OAuthToken> getToken() = 0;
   virtual ~IOAuthTokenStore() = default;
 };
 
@@ -72,8 +72,8 @@ public:
   ConfigServiceTokenStore &operator=(const ConfigServiceTokenStore &other) = default;
   ~ConfigServiceTokenStore() override;
 
-  void setToken(const boost::optional<OAuthToken> &token) override;
-  boost::optional<OAuthToken> getToken() override;
+  void setToken(const std::optional<OAuthToken> &token) override;
+  std::optional<OAuthToken> getToken() override;
 };
 
 using IOAuthTokenStore_uptr = std::unique_ptr<IOAuthTokenStore>;

--- a/Framework/Catalog/inc/MantidCatalog/ONCat.h
+++ b/Framework/Catalog/inc/MantidCatalog/ONCat.h
@@ -14,7 +14,7 @@
 #include <memory>
 #include <vector>
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace Mantid {
 
@@ -120,8 +120,8 @@ public:
   // Exposed publicly for testing purposes only.
   //////////////////////////////////////////////////////////////////////
   ONCat(const std::string &url);
-  ONCat(std::string url, IOAuthTokenStore_uptr tokenStore, OAuthFlow flow, boost::optional<std::string> clientId,
-        boost::optional<std::string> clientSecret = boost::none);
+  ONCat(std::string url, IOAuthTokenStore_uptr tokenStore, OAuthFlow flow, std::optional<std::string> clientId,
+        std::optional<std::string> clientSecret = std::nullopt);
   void refreshTokenIfNeeded();
   void refreshTokenIfNeeded(const DateAndTime &currentTime);
   void setInternetHelper(const std::shared_ptr<Mantid::Kernel::InternetHelper> &internetHelper);
@@ -132,8 +132,8 @@ private:
 
   std::string m_url;
   IOAuthTokenStore_sptr m_tokenStore;
-  boost::optional<std::string> m_clientId;
-  boost::optional<std::string> m_clientSecret;
+  std::optional<std::string> m_clientId;
+  std::optional<std::string> m_clientSecret;
 
   OAuthFlow m_flow;
   std::shared_ptr<Mantid::Kernel::InternetHelper> m_internetHelper;

--- a/Framework/Catalog/inc/MantidCatalog/ONCatEntity.h
+++ b/Framework/Catalog/inc/MantidCatalog/ONCatEntity.h
@@ -13,8 +13,8 @@
 #include <string>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include <json/json.h>
+#include <optional>
 
 namespace Mantid {
 namespace Catalog {
@@ -41,13 +41,13 @@ using Mantid::Catalog::Exception::ContentError;
  * forces you to deal with the case where the field in question is not there.
  * There are two ways of doing this: the first is to specify a default value
  * to be used when a value is not present, and the second is to check for a
- * result on a boost::optional.
+ * result on a std::optional.
  *
  * However, if your projection is such that you *know* a field will be present
  * (note that most fields on API resources will always be returned as long
  * as they are requested as part of a projection, for example the "location"
  * field of the Datafile resource), then feel free to assume it will be
- * there and resolve the boost::optional without checking for a result.
+ * there and resolve the std::optional without checking for a result.
  *
  * @author Peter Parker
  * @date 2018
@@ -75,11 +75,11 @@ public:
   }
 
   // ... or, write conditional logic around boost's optional results.
-  template <typename T> boost::optional<T> get(const std::string &path) const {
+  template <typename T> std::optional<T> get(const std::string &path) const {
     try {
-      return boost::make_optional(getNestedContentValueAsType<T>(*m_content, path));
+      return std::make_optional(getNestedContentValueAsType<T>(*m_content, path));
     } catch (ContentError &) {
-      return boost::none;
+      return std::nullopt;
     }
   }
 

--- a/Framework/Catalog/src/ONCat.cpp
+++ b/Framework/Catalog/src/ONCat.cpp
@@ -87,7 +87,7 @@ static const std::string DEFAULT_CLIENT_ID = "d16ea847-41ce-4b30-9167-40298588e7
  */
 ONCat_uptr ONCat::fromMantidSettings(bool authenticate) {
   if (!authenticate) {
-    return std::make_unique<ONCat>(DEFAULT_ONCAT_URL, nullptr, OAuthFlow::NONE, boost::none, boost::none);
+    return std::make_unique<ONCat>(DEFAULT_ONCAT_URL, nullptr, OAuthFlow::NONE, std::nullopt, std::nullopt);
   }
 
   auto &config = Mantid::Kernel::ConfigService::Instance();
@@ -103,14 +103,17 @@ ONCat_uptr ONCat::fromMantidSettings(bool authenticate) {
                   << "Falling back to default -- user login required." << std::endl;
   }
 
-  return std::make_unique<ONCat>(
-      DEFAULT_ONCAT_URL, std::make_unique<ConfigServiceTokenStore>(),
-      hasClientCredentials ? OAuthFlow::CLIENT_CREDENTIALS : OAuthFlow::RESOURCE_OWNER_CREDENTIALS,
-      hasClientCredentials ? client_id : DEFAULT_CLIENT_ID, boost::make_optional(hasClientCredentials, client_secret));
+  std::optional<std::string> client_secret_option =
+      hasClientCredentials ? std::make_optional(client_secret) : std::nullopt;
+
+  return std::make_unique<ONCat>(DEFAULT_ONCAT_URL, std::make_unique<ConfigServiceTokenStore>(),
+                                 hasClientCredentials ? OAuthFlow::CLIENT_CREDENTIALS
+                                                      : OAuthFlow::RESOURCE_OWNER_CREDENTIALS,
+                                 hasClientCredentials ? client_id : DEFAULT_CLIENT_ID, client_secret_option);
 }
 
-ONCat::ONCat(std::string url, IOAuthTokenStore_uptr tokenStore, OAuthFlow flow, boost::optional<std::string> clientId,
-             boost::optional<std::string> clientSecret)
+ONCat::ONCat(std::string url, IOAuthTokenStore_uptr tokenStore, OAuthFlow flow, std::optional<std::string> clientId,
+             std::optional<std::string> clientSecret)
     : m_url(std::move(url)), m_tokenStore(std::move(tokenStore)), m_clientId(std::move(clientId)),
       m_clientSecret(std::move(clientSecret)), m_flow(flow), m_internetHelper(new Mantid::Kernel::InternetHelper()) {}
 
@@ -167,7 +170,7 @@ bool ONCat::isUserLoggedIn() const {
     return false;
   }
 
-  return m_tokenStore->getToken().is_initialized();
+  return m_tokenStore->getToken().has_value();
 }
 
 std::string ONCat::url() const { return m_url; }
@@ -178,7 +181,7 @@ void ONCat::logout() {
   // spec).  A "logout", then, is simply throwing away whatever token we
   // previously stored client-side.
   if (m_tokenStore) {
-    m_tokenStore->setToken(boost::none);
+    m_tokenStore->setToken(std::nullopt);
     g_log.debug() << "Logging out." << std::endl;
   }
 }
@@ -204,9 +207,9 @@ void ONCat::login(const std::string &username, const std::string &password) {
   Poco::Net::HTMLForm form(Poco::Net::HTMLForm::ENCODING_MULTIPART);
   form.set("username", username);
   form.set("password", password);
-  form.set("client_id", m_clientId.get());
+  form.set("client_id", m_clientId.value());
   if (m_clientSecret) {
-    form.set("client_secret", m_clientSecret.get());
+    form.set("client_secret", m_clientSecret.value());
   }
   form.set("grant_type", "password");
 
@@ -311,9 +314,9 @@ void ONCat::refreshTokenIfNeeded(const DateAndTime &currentTime) {
     }
 
     Poco::Net::HTMLForm form(Poco::Net::HTMLForm::ENCODING_MULTIPART);
-    form.set("client_id", m_clientId.get());
+    form.set("client_id", m_clientId.value());
     if (m_clientSecret) {
-      form.set("client_secret", m_clientSecret.get());
+      form.set("client_secret", m_clientSecret.value());
     }
     form.set("grant_type", "client_credentials");
 
@@ -333,7 +336,7 @@ void ONCat::refreshTokenIfNeeded(const DateAndTime &currentTime) {
       throw CatalogError(ie.what());
     }
   } else if (m_flow == OAuthFlow::RESOURCE_OWNER_CREDENTIALS) {
-    if (!currentToken.is_initialized()) {
+    if (!currentToken.has_value()) {
       return;
     }
     if (!currentToken->isExpired(currentTime)) {
@@ -345,12 +348,12 @@ void ONCat::refreshTokenIfNeeded(const DateAndTime &currentTime) {
     }
 
     Poco::Net::HTMLForm form(Poco::Net::HTMLForm::ENCODING_MULTIPART);
-    form.set("client_id", m_clientId.get());
+    form.set("client_id", m_clientId.value());
     if (m_clientSecret) {
-      form.set("client_secret", m_clientSecret.get());
+      form.set("client_secret", m_clientSecret.value());
     }
     form.set("grant_type", "refresh_token");
-    form.set("refresh_token", currentRefreshToken.get());
+    form.set("refresh_token", currentRefreshToken.value());
 
     m_internetHelper->reset();
     m_internetHelper->setBody(form);

--- a/Framework/Catalog/test/ONCatTest.h
+++ b/Framework/Catalog/test/ONCatTest.h
@@ -168,7 +168,7 @@ public:
   }
 
   void test_retrieve_entity_unauthenticated() {
-    ONCat oncat(DUMMY_URL, nullptr, OAuthFlow::NONE, boost::none, boost::none);
+    ONCat oncat(DUMMY_URL, nullptr, OAuthFlow::NONE, std::nullopt, std::nullopt);
 
     TS_ASSERT(!oncat.isUserLoggedIn());
 
@@ -267,7 +267,7 @@ public:
 
   void test_client_credentials_flow_with_refresh() {
     ONCat oncat(DUMMY_URL, make_mock_token_store(), OAuthFlow::CLIENT_CREDENTIALS, DUMMY_CLIENT_ID,
-                boost::make_optional<std::string>("9a2ad07a-a139-438b-8116-08c5452f96ad"));
+                std::make_optional<std::string>("9a2ad07a-a139-438b-8116-08c5452f96ad"));
 
     auto mock_oncat_api = make_mock_oncat_api(
         {{DUMMY_URL + "/oauth/token",
@@ -303,9 +303,9 @@ public:
   void test_config_service_token_store_roundtrip() {
     ConfigServiceTokenStore tokenStore;
 
-    const auto testToken = boost::make_optional(
+    const auto testToken = std::make_optional(
         OAuthToken("Bearer", 3600, "2KSL5aEnLvIudMHIjc7LcBWBCfxOHZ", "api:read data:read settings:read",
-                   boost::make_optional<std::string>("eZEiz7LbgFrkL5ZHv7R4ck9gOzXexb")));
+                   std::make_optional<std::string>("eZEiz7LbgFrkL5ZHv7R4ck9gOzXexb")));
 
     tokenStore.setToken(testToken);
 

--- a/Framework/Crystal/inc/MantidCrystal/CompositeCluster.h
+++ b/Framework/Crystal/inc/MantidCrystal/CompositeCluster.h
@@ -9,8 +9,8 @@
 #include "MantidCrystal/DllConfig.h"
 #include "MantidCrystal/ICluster.h"
 #include "MantidKernel/System.h"
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 namespace Mantid {
 namespace Crystal {
@@ -62,7 +62,7 @@ private:
   // void validateNoRepeat(CompositeCluster*const other) const;
 
   /// Label used by cluster
-  mutable boost::optional<size_t> m_label;
+  mutable std::optional<size_t> m_label;
   /// Attached clusters.
   std::vector<std::shared_ptr<ICluster>> m_ownedClusters;
 };

--- a/Framework/Crystal/inc/MantidCrystal/ConnectedComponentLabeling.h
+++ b/Framework/Crystal/inc/MantidCrystal/ConnectedComponentLabeling.h
@@ -47,7 +47,7 @@ class MANTID_CRYSTAL_DLL ConnectedComponentLabeling {
 
 public:
   /// Constructor
-  ConnectedComponentLabeling(const size_t &startId = 1, std::optional<int> nThreads = std::nullopt);
+  ConnectedComponentLabeling(const size_t &startId = 1, const std::optional<int> &nThreads = std::nullopt);
 
   /// Getter for the start label id
   size_t getStartLabelId() const;

--- a/Framework/Crystal/inc/MantidCrystal/ConnectedComponentLabeling.h
+++ b/Framework/Crystal/inc/MantidCrystal/ConnectedComponentLabeling.h
@@ -11,10 +11,10 @@
 #include "MantidCrystal/DllConfig.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/V3D.h"
-#include <boost/optional.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <map>
 #include <memory>
+#include <optional>
 #include <unordered_set>
 
 namespace Mantid {
@@ -47,7 +47,7 @@ class MANTID_CRYSTAL_DLL ConnectedComponentLabeling {
 
 public:
   /// Constructor
-  ConnectedComponentLabeling(const size_t &startId = 1, boost::optional<int> nThreads = boost::none);
+  ConnectedComponentLabeling(const size_t &startId = 1, std::optional<int> nThreads = std::nullopt);
 
   /// Getter for the start label id
   size_t getStartLabelId() const;
@@ -81,7 +81,7 @@ private:
   size_t m_startId;
 
   /// Run multithreaded
-  const boost::optional<int> m_nThreads;
+  const std::optional<int> m_nThreads;
 };
 
 } // namespace Crystal

--- a/Framework/Crystal/inc/MantidCrystal/ConnectedComponentLabeling.h
+++ b/Framework/Crystal/inc/MantidCrystal/ConnectedComponentLabeling.h
@@ -69,9 +69,6 @@ public:
   virtual ~ConnectedComponentLabeling();
 
 private:
-  /// Get the number of threads to use.
-  int getNThreads() const;
-
   /// Calculate the disjoint element tree across the image.
   ConnectedComponentMappingTypes::ClusterMap calculateDisjointTree(const Mantid::API::IMDHistoWorkspace_sptr &ws,
                                                                    BackgroundStrategy *const baseStrategy,
@@ -81,7 +78,7 @@ private:
   size_t m_startId;
 
   /// Run multithreaded
-  const std::optional<int> m_nThreads;
+  int m_nThreadsToUse;
 };
 
 } // namespace Crystal

--- a/Framework/Crystal/inc/MantidCrystal/FindSXPeaksHelper.h
+++ b/Framework/Crystal/inc/MantidCrystal/FindSXPeaksHelper.h
@@ -15,8 +15,8 @@
 #include "MantidKernel/System.h"
 #include "MantidKernel/Unit.h"
 
-#include <boost/optional.hpp>
 #include <iterator>
+#include <optional>
 #include <vector>
 
 namespace Mantid {
@@ -102,7 +102,7 @@ private:
 using yIt = Mantid::HistogramData::HistogramY::const_iterator;
 using Bound = HistogramData::HistogramX::const_iterator;
 using BoundsIterator = std::pair<Bound, Bound>;
-using PeakList = boost::optional<std::vector<SXPeak>>;
+using PeakList = std::optional<std::vector<SXPeak>>;
 
 class PeakContainer {
 public:

--- a/Framework/Crystal/src/CompositeCluster.cpp
+++ b/Framework/Crystal/src/CompositeCluster.cpp
@@ -96,7 +96,7 @@ void CompositeCluster::addIndex(const size_t & /*index*/) {
  */
 void CompositeCluster::findMinimum() const {
   if (!m_ownedClusters.empty()) {
-    ICluster *minCluster = m_ownedClusters.front().get();
+    ICluster const *minCluster = m_ownedClusters.front().get();
     size_t minLabel = minCluster->getLabel();
     for (size_t i = 1; i < m_ownedClusters.size(); ++i) {
       size_t temp = m_ownedClusters[i]->getLabel();
@@ -114,7 +114,7 @@ void CompositeCluster::findMinimum() const {
  */
 void CompositeCluster::toUniformMinimum(std::vector<DisjointElement> &disjointSet) {
   if (!m_ownedClusters.empty()) {
-    ICluster *minCluster = m_ownedClusters.front().get();
+    ICluster const *minCluster = m_ownedClusters.front().get();
     size_t minLabel = minCluster->getLabel();
     for (size_t i = 1; i < m_ownedClusters.size(); ++i) {
       size_t temp = m_ownedClusters[i]->getLabel();

--- a/Framework/Crystal/src/CompositeCluster.cpp
+++ b/Framework/Crystal/src/CompositeCluster.cpp
@@ -6,7 +6,9 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidCrystal/CompositeCluster.h"
 
+#include <algorithm>
 #include <numeric>
+#include <stdexcept>
 
 namespace {
 /**
@@ -61,10 +63,10 @@ void CompositeCluster::writeTo(std::shared_ptr<Mantid::API::IMDHistoWorkspace> w
  */
 size_t CompositeCluster::getLabel() const {
   findMinimum();
-  if (!m_label.is_initialized()) {
+  if (!m_label.has_value()) {
     throw std::runtime_error("No child IClusters. CompositeCluster::getLabel() is not supported.");
   } else {
-    return m_label.get(); // Assumes all are uniform.
+    return m_label.value(); // Assumes all are uniform.
   }
 }
 

--- a/Framework/Crystal/src/ConnectedComponentLabeling.cpp
+++ b/Framework/Crystal/src/ConnectedComponentLabeling.cpp
@@ -212,9 +212,9 @@ void memoryCheck(size_t nPoints) {
  * @param startId : Start Id to use for labeling
  * @param nThreads : Optional argument of number of threads to use.
  */
-ConnectedComponentLabeling::ConnectedComponentLabeling(const size_t &startId, boost::optional<int> nThreads)
+ConnectedComponentLabeling::ConnectedComponentLabeling(const size_t &startId, std::optional<int> nThreads)
     : m_startId(startId), m_nThreads(std::move(nThreads)) {
-  if (m_nThreads.is_initialized() && m_nThreads.get() < 0) {
+  if (m_nThreads.has_value() && m_nThreads.value() < 0) {
     throw std::invalid_argument("Cannot request that CCL runs with less than one thread!");
   }
 }
@@ -242,8 +242,8 @@ ConnectedComponentLabeling::~ConnectedComponentLabeling() = default;
  * @return : Number of available threads
  */
 int ConnectedComponentLabeling::getNThreads() const {
-  if (m_nThreads.is_initialized()) {
-    return m_nThreads.get(); // Follow explicit instructions if provided.
+  if (m_nThreads.has_value()) {
+    return m_nThreads.value(); // Follow explicit instructions if provided.
   } else {
     return API::FrameworkManager::Instance().getNumOMPThreads(); // Figure it out.
   }

--- a/Framework/Crystal/src/ConnectedComponentLabeling.cpp
+++ b/Framework/Crystal/src/ConnectedComponentLabeling.cpp
@@ -212,7 +212,7 @@ void memoryCheck(size_t nPoints) {
  * @param startId : Start Id to use for labeling
  * @param nThreads : Optional argument of number of threads to use.
  */
-ConnectedComponentLabeling::ConnectedComponentLabeling(const size_t &startId, std::optional<int> nThreads)
+ConnectedComponentLabeling::ConnectedComponentLabeling(const size_t &startId, const std::optional<int> &nThreads)
     : m_startId(startId) {
   if (nThreads.has_value()) {
     if (nThreads.value() < 0) {

--- a/Framework/Crystal/src/FindClusterFaces.cpp
+++ b/Framework/Crystal/src/FindClusterFaces.cpp
@@ -30,7 +30,7 @@ using namespace Mantid::Crystal;
 // Map of label ids to peak index in peaks workspace.
 using LabelMap = std::map<int, int>;
 // Optional set of labels
-using OptionalLabelPeakIndexMap = boost::optional<LabelMap>;
+using OptionalLabelPeakIndexMap = std::optional<LabelMap>;
 
 /**
  * Create an optional label set for filtering.
@@ -302,10 +302,10 @@ void FindClusterFaces::exec() {
   const auto nIterators = static_cast<int>(mdIterators.size());                      // Number of iterators yielded.
   VecClusterFaces clusterFaces(nIterators);
   size_t nSteps = 1000;
-  if (optionalAllowedLabels.is_initialized()) {
+  if (optionalAllowedLabels.has_value()) {
     nSteps = optionalAllowedLabels->size();
   }
-  const bool usingFiltering = optionalAllowedLabels.is_initialized();
+  const bool usingFiltering = optionalAllowedLabels.has_value();
 
   Progress progress(this, 0.0, 1.0, nSteps);
   PARALLEL_FOR_NO_WSP_CHECK()

--- a/Framework/Crystal/src/FindGoniometerAngles.cpp
+++ b/Framework/Crystal/src/FindGoniometerAngles.cpp
@@ -194,7 +194,7 @@ void FindGoniometerAngles::exec() {
       auto &peak = peakWS->getPeak(i);
       const auto q_lab = peak.getQLabFrame();
       peak.setGoniometerMatrix(R);
-      peak.setQLabFrame(q_lab, boost::none);
+      peak.setQLabFrame(q_lab, std::nullopt);
     }
   }
 }

--- a/Framework/Crystal/src/FindSXPeaksHelper.cpp
+++ b/Framework/Crystal/src/FindSXPeaksHelper.cpp
@@ -392,7 +392,7 @@ PeakList PeakFindingStrategy::convertToSXPeaks(const HistogramData::HistogramX &
     return peaks;
   }
 
-  // Add a vector to the boost optional
+  // Add a vector to the std::optional
   peaks = std::vector<FindSXPeaksHelper::SXPeak>();
 
   for (const auto &peak : foundPeaks) {

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -16,7 +16,7 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 
-#include <boost/optional/optional.hpp>
+#include <optional>
 
 #include <algorithm>
 
@@ -231,9 +231,9 @@ using IndexedSatelliteInfo = std::tuple<V3D, V3D, V3D, double>;
  * @return (IntHKL, IntMNP, error) if a peak was indexed, otherwise none
  */
 
-boost::optional<IndexedSatelliteInfo> indexSatellite(const V3D &mainHKL, const int maxOrder,
-                                                     const std::vector<V3D> &modVectors, const double tolerance,
-                                                     const bool crossTerms) {
+std::optional<IndexedSatelliteInfo> indexSatellite(const V3D &mainHKL, const int maxOrder,
+                                                   const std::vector<V3D> &modVectors, const double tolerance,
+                                                   const bool crossTerms) {
   const auto offsets = generateOffsetVectors(modVectors, maxOrder, crossTerms);
   bool foundSatellite{false};
   V3D indexedIntHKL, indexedMNP, fractionalOffset;
@@ -252,7 +252,7 @@ boost::optional<IndexedSatelliteInfo> indexSatellite(const V3D &mainHKL, const i
   if (foundSatellite)
     return std::make_tuple(fractionalOffset, indexedIntHKL, indexedMNP, indexedIntHKL.hklError());
   else
-    return boost::none;
+    return std::nullopt;
 }
 
 /**
@@ -295,7 +295,7 @@ CombinedIndexingStats indexPeaks(const std::vector<IPeak *> &peaks, DblMatrix ub
       auto result = indexSatellite(nominalHKL, satelliteArgs.maxOrder, satelliteArgs.modVectors,
                                    satelliteArgs.tolerance, satelliteArgs.crossTerms);
       if (result) {
-        const auto &satelliteInfo = result.get();
+        const auto &satelliteInfo = result.value();
         V3D hkl;
         ;
         if (roundHKLs) {

--- a/Framework/Crystal/src/IntegratePeaksHybrid.cpp
+++ b/Framework/Crystal/src/IntegratePeaksHybrid.cpp
@@ -204,8 +204,8 @@ void IntegratePeaksHybrid::exec() {
 
     HardThresholdBackground backgroundStrategy(threshold, normalization);
     // CCL. Multi-processor version.
-    const size_t startId = 1;
-    const size_t nThreads = 1;
+    constexpr size_t startId{1};
+    constexpr int nThreads{1};
     ConnectedComponentLabeling analysis(startId, nThreads); // CCL executed single threaded.
 
     Progress dummyProgress;

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -597,7 +597,7 @@ void PredictPeaks::calculateQAndAddToOutput(const V3D &hkl, const DblMatrix &ori
 
     // The exit point is the vector to the place that we hit a detector
     const auto magnitude = track.back().exitPoint.norm();
-    peak = std::make_unique<Peak>(m_inst, q, boost::optional<double>(magnitude));
+    peak = std::make_unique<Peak>(m_inst, q, std::optional<double>(magnitude));
   }
 
   if (m_edge > 0 && edgePixel(m_inst, peak->getBankName(), peak->getCol(), peak->getRow(), m_edge))

--- a/Framework/Crystal/test/FindSXPeaksHelperTest.h
+++ b/Framework/Crystal/test/FindSXPeaksHelperTest.h
@@ -138,9 +138,9 @@ public:
     auto peaks = peakFindingStrategy->findSXPeaks(x, y, e, workspaceIndex);
 
     // THEN
-    TSM_ASSERT("There should be two peaks that are found.", peaks.get().size() == 2);
-    TSM_ASSERT("The first peak should have a signal value of 7.", peaks.get()[0].getIntensity() == 7.);
-    TSM_ASSERT("The second peak should have a signal value of 11.", peaks.get()[1].getIntensity() == 11.);
+    TSM_ASSERT("There should be two peaks that are found.", peaks.value().size() == 2);
+    TSM_ASSERT("The first peak should have a signal value of 7.", peaks.value()[0].getIntensity() == 7.);
+    TSM_ASSERT("The second peak should have a signal value of 11.", peaks.value()[1].getIntensity() == 11.);
   }
 
   PeakList runFindAllPeaksWithMinBinWidth(const std::unique_ptr<BackgroundStrategy> backgroundStrategy,
@@ -167,14 +167,14 @@ public:
   void testWhenFindsAllPeaksWithMinimumBinWidthSpecified() {
     auto peaks = runFindAllPeaksWithMinBinWidth(std::make_unique<AbsoluteBackgroundStrategy>(3.0), 4);
 
-    TSM_ASSERT("There should be only one peak found.", peaks.get().size() == 1);
-    TSM_ASSERT("The only peak should have a signal value of 7.", peaks.get()[0].getIntensity() == 7.);
+    TSM_ASSERT("There should be only one peak found.", peaks.value().size() == 1);
+    TSM_ASSERT("The only peak should have a signal value of 7.", peaks.value()[0].getIntensity() == 7.);
   }
 
   void testAllPeaksWithMinimumBinWidthSpecifiedFindsNoPeaks() {
     auto peaks = runFindAllPeaksWithMinBinWidth(std::make_unique<AbsoluteBackgroundStrategy>(3.0), 5);
 
-    ETS_ASSERT_EQUALS(peaks.is_initialized(), false);
+    ETS_ASSERT_EQUALS(peaks.has_value(), false);
   }
 
   void testThatFindAllPeaksNSigmaFindPeaks() {
@@ -184,9 +184,9 @@ public:
     auto peaks = runAllPeaksNSigma(newYValues, newErrorValues, 3.0);
 
     // THEN
-    TSM_ASSERT("There should be two peaks that are found.", peaks.get().size() == 2);
-    TSM_ASSERT("The first peak should have a signal value of 14.", peaks.get()[0].getIntensity() == 14.);
-    TSM_ASSERT("The second peak should have a signal value of 21.5", peaks.get()[1].getIntensity() == 21.5);
+    TSM_ASSERT("There should be two peaks that are found.", peaks.value().size() == 2);
+    TSM_ASSERT("The first peak should have a signal value of 14.", peaks.value()[0].getIntensity() == 14.);
+    TSM_ASSERT("The second peak should have a signal value of 21.5", peaks.value()[1].getIntensity() == 21.5);
   }
 
   void testThatFindAllPeaksNSigmaFindPeaksWithMinBinWidthRequired() {
@@ -198,8 +198,8 @@ public:
     auto peaks = runAllPeaksNSigma(newYValues, newErrorValues, 3.0, 4);
 
     // THEN
-    TSM_ASSERT("There should be two peaks that are found.", peaks.get().size() == 1);
-    TSM_ASSERT("The first peak should have a signal value of 14.", peaks.get()[0].getIntensity() == 14.);
+    TSM_ASSERT("There should be two peaks that are found.", peaks.value().size() == 1);
+    TSM_ASSERT("The first peak should have a signal value of 14.", peaks.value()[0].getIntensity() == 14.);
   }
 
   void testThatFindAllPeaksNSigmaFindPeaksAtBoundary() {
@@ -209,8 +209,8 @@ public:
     auto peaks = runAllPeaksNSigma(newYValues, newErrorValues, 3.0);
 
     // THEN
-    TSM_ASSERT("There should be two peaks that are found.", peaks.get().size() == 1);
-    TSM_ASSERT("The second peak should have a signal value of 21.5", peaks.get()[0].getIntensity() == 23.5);
+    TSM_ASSERT("There should be two peaks that are found.", peaks.value().size() == 1);
+    TSM_ASSERT("The second peak should have a signal value of 21.5", peaks.value()[0].getIntensity() == 23.5);
   }
 
   void testWhenAllPeaksNSigmaFindsNoPeaks() {
@@ -218,7 +218,7 @@ public:
     std::vector<double> newErrorValues = {1.5, 2.0, 5.0, 5.0, 7.0, 1.5, 1.5, 1.5, 1.5, 3.0, 2.0, 4.0, 6.5, 2.5, 1.5};
     auto peaks = runAllPeaksNSigma(newYValues, newErrorValues, 3.0);
 
-    ETS_ASSERT_EQUALS(peaks.is_initialized(), false);
+    ETS_ASSERT_EQUALS(peaks.has_value(), false);
   }
 
   PeakList runAllPeaksNSigma(const std::vector<double> &newYValues, const std::vector<double> &newEValues,
@@ -286,7 +286,7 @@ public:
     EXPECT_CALL(progress, doReport(_)).Times(0); // We only report if there are more than 50 peaks
 
     // WHEN
-    auto reducedPeaks = simpleStrategy->reduce(peakList.get(), progress);
+    auto reducedPeaks = simpleStrategy->reduce(peakList.value(), progress);
 
     // THEN
     const double tolerance = 1e-6;
@@ -322,7 +322,7 @@ public:
     EXPECT_CALL(progress, doReport(_)).Times(0); // We only report if there are more than 50 peaks
 
     // WHEN
-    const auto reducedPeaks = findMaxReduceStrategy->reduce(peakList.get(), progress);
+    const auto reducedPeaks = findMaxReduceStrategy->reduce(peakList.value(), progress);
 
     // THEN
     const double tolerance = 1e-6;
@@ -445,8 +445,8 @@ private:
     auto peaks = peakFindingStrategy->findSXPeaks(x, y, e, workspaceIndex);
 
     // THEN
-    TSM_ASSERT("There should only be one peak that is found.", peaks.get().size() == 1);
-    TSM_ASSERT("The peak should have a signal value of 11.", peaks.get()[0].getIntensity() == 11.);
+    TSM_ASSERT("There should only be one peak that is found.", peaks.value().size() == 1);
+    TSM_ASSERT("The peak should have a signal value of 11.", peaks.value()[0].getIntensity() == 11.);
   }
 
   void doAddDoublePeakToData(Mantid::HistogramData::HistogramY &y) {

--- a/Framework/Crystal/test/IndexSXPeaksTest.h
+++ b/Framework/Crystal/test/IndexSXPeaksTest.h
@@ -114,9 +114,9 @@ public:
     for (int i = 0; i < m_masterPeaks->getNumberPeaks(); i++) {
       IPeak &peak = m_masterPeaks->getPeak(i);
       Mantid::Kernel::V3D v(1, 0, 0);
-      peak.setQSampleFrame(v, boost::none); // Overwrite all Q
-                                            // samples to be
-                                            // co-linear.
+      peak.setQSampleFrame(v, std::nullopt); // Overwrite all Q
+                                             // samples to be
+                                             // co-linear.
     }
 
     TS_ASSERT_THROWS(doTest(6, "1, 2, 3, 4, 5, 6", 14.131, 19.247, 8.606, 90.0, 105.071, 90.0),

--- a/Framework/Crystal/test/OptimizeLatticeForCellTypeTest.h
+++ b/Framework/Crystal/test/OptimizeLatticeForCellTypeTest.h
@@ -198,7 +198,7 @@ public:
       // peak.setHKL(hkl + modHKL * mnp);
       peak.setIntHKL(hkl);
       peak.setIntMNP(mnp);
-      peak.setQSampleFrame(peak.getQSampleFrame() + modUB * mnp * 2 * M_PI, boost::none);
+      peak.setQSampleFrame(peak.getQSampleFrame() + modUB * mnp * 2 * M_PI, std::nullopt);
     }
 
     OptimizeLatticeForCellType alg;

--- a/Framework/Crystal/test/SelectCellOfTypeTest.h
+++ b/Framework/Crystal/test/SelectCellOfTypeTest.h
@@ -209,7 +209,7 @@ public:
         peak.setHKL(hkl + modHKL * mnp);
         peak.setIntHKL(hkl);
         peak.setIntMNP(mnp);
-        peak.setQSampleFrame(peak.getQSampleFrame() + modUB * mnp * 2 * M_PI, boost::none);
+        peak.setQSampleFrame(peak.getQSampleFrame() + modUB * mnp * 2 * M_PI, std::nullopt);
       }
     }
 

--- a/Framework/Crystal/test/SelectCellWithFormTest.h
+++ b/Framework/Crystal/test/SelectCellWithFormTest.h
@@ -207,7 +207,7 @@ public:
         peak.setHKL(hkl + modHKL * mnp);
         peak.setIntHKL(hkl);
         peak.setIntMNP(mnp);
-        peak.setQSampleFrame(peak.getQSampleFrame() + modUB * mnp * 2 * M_PI, boost::none);
+        peak.setQSampleFrame(peak.getQSampleFrame() + modUB * mnp * 2 * M_PI, std::nullopt);
       }
     }
 
@@ -331,7 +331,7 @@ public:
         peak.setHKL(hkl + modHKL * mnp);
         peak.setIntHKL(hkl);
         peak.setIntMNP(mnp);
-        peak.setQSampleFrame(peak.getQSampleFrame() + modUB * mnp * 2 * M_PI, boost::none);
+        peak.setQSampleFrame(peak.getQSampleFrame() + modUB * mnp * 2 * M_PI, std::nullopt);
       }
     }
 

--- a/Framework/Crystal/test/TransformHKLTest.h
+++ b/Framework/Crystal/test/TransformHKLTest.h
@@ -179,7 +179,7 @@ public:
       peak.setHKL(hkl + modHKL * mnp);
       peak.setIntHKL(hkl);
       peak.setIntMNP(mnp);
-      peak.setQSampleFrame(peak.getQSampleFrame() + modUB * mnp * 2 * M_PI, boost::none);
+      peak.setQSampleFrame(peak.getQSampleFrame() + modUB * mnp * 2 * M_PI, std::nullopt);
     }
 
     TransformHKL alg;
@@ -243,7 +243,7 @@ public:
       peak.setHKL(hkl + modHKL * mnp);
       peak.setIntHKL(hkl);
       peak.setIntMNP(mnp);
-      peak.setQSampleFrame(peak.getQSampleFrame() + modUB * mnp * 2 * M_PI, boost::none);
+      peak.setQSampleFrame(peak.getQSampleFrame() + modUB * mnp * 2 * M_PI, std::nullopt);
     }
 
     TransformHKL alg;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValueHelper.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValueHelper.h
@@ -13,7 +13,7 @@
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidCurveFitting/DllConfig.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -35,7 +35,7 @@ struct InputSpectraToFit {
 /// Get a workspace
 MANTID_CURVEFITTING_DLL std::vector<int> getWorkspaceIndicesFromAxes(API::MatrixWorkspace &ws, int workspaceIndex,
                                                                      int spectrumNumber, double start, double end);
-MANTID_CURVEFITTING_DLL boost::optional<API::Workspace_sptr> getWorkspace(const std::string &name, int period);
+MANTID_CURVEFITTING_DLL std::optional<API::Workspace_sptr> getWorkspace(const std::string &name, int period);
 
 /// Create a list of input workspace names
 MANTID_CURVEFITTING_DLL std::vector<InputSpectraToFit> makeNames(const std::string &inputList, int default_wi,

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValueHelper.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValueHelper.cpp
@@ -71,7 +71,7 @@ void parseValueRange(const std::string &index, double &start, double &end, int &
 void addGroupWorkspace(std::vector<InputSpectraToFit> &nameList, double start, double end, int wi, int spec, int period,
                        const std::shared_ptr<API::WorkspaceGroup> &wsg);
 void addMatrixworkspace(std::vector<InputSpectraToFit> &nameList, double start, double end, std::string &name, int wi,
-                        int spec, int period, const boost::optional<API::Workspace_sptr> &workspaceOptional,
+                        int spec, int period, const std::optional<API::Workspace_sptr> &workspaceOptional,
                         const std::shared_ptr<API::MatrixWorkspace> &wsMatrix);
 /// Create a list of input workspace names
 std::vector<InputSpectraToFit> makeNames(const std::string &inputList, int default_wi, int default_spec) {
@@ -122,7 +122,7 @@ std::vector<InputSpectraToFit> makeNames(const std::string &inputList, int defau
   return nameList;
 }
 void addMatrixworkspace(std::vector<InputSpectraToFit> &nameList, double start, double end, std::string &name, int wi,
-                        int spec, int period, const boost::optional<API::Workspace_sptr> &workspaceOptional,
+                        int spec, int period, const std::optional<API::Workspace_sptr> &workspaceOptional,
                         const std::shared_ptr<API::MatrixWorkspace> &wsMatrix) {
   auto workspaceIndices = getWorkspaceIndicesFromAxes(*wsMatrix, wi, spec, start, end);
 
@@ -199,7 +199,7 @@ std::vector<int> getWorkspaceIndicesFromAxes(API::MatrixWorkspace &ws, int works
   return out;
 }
 
-boost::optional<API::Workspace_sptr> getWorkspace(const std::string &workspaceName, int period) {
+std::optional<API::Workspace_sptr> getWorkspace(const std::string &workspaceName, int period) {
   if (API::AnalysisDataService::Instance().doesExist(workspaceName)) {
     return API::AnalysisDataService::Instance().retrieve(workspaceName);
   } else {

--- a/Framework/CurveFitting/src/Functions/CrystalFieldFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldFunction.cpp
@@ -22,10 +22,10 @@
 
 #include "MantidKernel/Exception.h"
 
-#include <boost/optional.hpp>
 #include <boost/regex.hpp>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <utility>
 
 namespace Mantid::CurveFitting::Functions {

--- a/Framework/CurveFitting/src/Functions/PawleyFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/PawleyFunction.cpp
@@ -302,7 +302,7 @@ PawleyFunction::PawleyFunction()
     : IPawleyFunction(), m_compositeFunction(), m_pawleyParameterFunction(), m_peakProfileComposite(), m_hkls(),
       m_dUnit(), m_wsUnit(), m_peakRadius(5) {
   auto peakRadius = Kernel::ConfigService::Instance().getValue<int>("curvefitting.peakRadius");
-  m_peakRadius = peakRadius.get_value_or(5);
+  m_peakRadius = peakRadius.value_or(5);
 }
 
 void PawleyFunction::setMatrixWorkspace(std::shared_ptr<const MatrixWorkspace> workspace, size_t wi, double startX,

--- a/Framework/DataHandling/inc/MantidDataHandling/CompressEventAccumulator.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/CompressEventAccumulator.h
@@ -34,7 +34,7 @@ public:
 
 protected:
   template <typename INT_TYPE> double getBinCenter(const INT_TYPE bin) const;
-  boost::optional<size_t> findBin(const float tof) const;
+  std::optional<size_t> findBin(const float tof) const;
   /// shared pointer for the histogram bin boundaries
   const std::shared_ptr<std::vector<double>> m_histogram_edges;
 
@@ -45,7 +45,7 @@ private:
   double m_divisor;
   double m_offset;
   /// function pointer on how to find the bin boundaries
-  boost::optional<size_t> (*m_findBin)(const MantidVec &, const double, const double, const double, const bool);
+  std::optional<size_t> (*m_findBin)(const MantidVec &, const double, const double, const double, const bool);
 
 protected:
   /// track whether this has allocated the "big" memory objects

--- a/Framework/DataHandling/inc/MantidDataHandling/CreatePolarizationEfficienciesBase.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/CreatePolarizationEfficienciesBase.h
@@ -9,8 +9,8 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/DataBlockGenerator.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/DataBlockGenerator.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "MantidDataHandling/DataBlock.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace Mantid {
 namespace DataHandling {
@@ -32,7 +32,7 @@ public:
   std::vector<SpectrumPair> m_intervals;
   specnum_t m_currentSpectrum;
 
-  boost::optional<size_t> m_currentIntervalIndex;
+  std::optional<size_t> m_currentIntervalIndex;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNexusProcessed.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNexusProcessed.h
@@ -10,9 +10,9 @@
 #include "MantidAPI/Progress.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataObjects/EventWorkspace.h"
-#include <boost/optional.hpp>
 #include <climits>
 #include <nexus/NeXusFile.hpp>
+#include <optional>
 
 namespace Mantid {
 namespace NeXus {
@@ -84,7 +84,7 @@ private:
   void setOtherProperties(IAlgorithm *alg, const std::string &propertyName, const std::string &propertyValue,
                           int perioidNum) override;
   void doExec(const Mantid::API::Workspace_sptr &inputWorkspace, std::shared_ptr<Mantid::NeXus::NexusFileIO> &nexusFile,
-              const bool keepFile = false, boost::optional<size_t> entryNumber = boost::optional<size_t>());
+              const bool keepFile = false, std::optional<size_t> entryNumber = std::optional<size_t>());
 
   /// Pointer to the local workspace
   API::MatrixWorkspace_const_sptr m_inputWorkspace;

--- a/Framework/DataHandling/src/CompressEventAccumulator.cpp
+++ b/Framework/DataHandling/src/CompressEventAccumulator.cpp
@@ -43,7 +43,7 @@ template <typename INT_TYPE> double CompressEventAccumulator::getBinCenter(const
   return 0.5 * ((*binIter) + *(std::next(binIter)));
 }
 
-boost::optional<size_t> CompressEventAccumulator::findBin(const float tof) const {
+std::optional<size_t> CompressEventAccumulator::findBin(const float tof) const {
   // last parameter being false means don't find exact bin for raw events coming out of the file
   return m_findBin(*m_histogram_edges.get(), static_cast<double>(tof), m_divisor, m_offset, false);
 }
@@ -132,7 +132,7 @@ public:
       // this finds the bin for the current event, then moves the iterator until an event that is out of range is
       // encountered at that point, an event is added to the output and the iterators are moved
       const auto optional_bin_first = this->findBin(m_tof.front());
-      size_t lastBin = optional_bin_first.get();
+      size_t lastBin = optional_bin_first.value();
       double nextTof = m_histogram_edges->at(lastBin + 1);
       uint32_t counts = 0;
       for (const auto &tof : m_tof) {
@@ -159,7 +159,7 @@ public:
           } else {
             // find the bin to use
             const auto optional_bin = this->findBin(tof);
-            lastBin = optional_bin.get();
+            lastBin = optional_bin.value();
           }
           nextTof = m_histogram_edges->operator[](lastBin + 1);
         }
@@ -209,7 +209,7 @@ public:
     // add events
     const auto &bin_optional = this->findBin(tof);
     if (bin_optional) {
-      m_tof_bin.push_back(static_cast<uint32_t>(bin_optional.get()));
+      m_tof_bin.push_back(static_cast<uint32_t>(bin_optional.value()));
     }
   }
 
@@ -327,7 +327,7 @@ public:
     // add events
     const auto &bin_optional = this->findBin(tof);
     if (bin_optional) {
-      m_count[bin_optional.get()]++;
+      m_count[bin_optional.value()]++;
     }
   }
 

--- a/Framework/DataHandling/src/DataBlockGenerator.cpp
+++ b/Framework/DataHandling/src/DataBlockGenerator.cpp
@@ -23,10 +23,10 @@ DataBlockGenerator::DataBlockGenerator(std::vector<SpectrumPair> intervals) : m_
   // the sorted container
   if (!m_intervals.empty()) {
     m_currentIntervalIndex = 0;
-    m_currentSpectrum = m_intervals[m_currentIntervalIndex.get()].first;
+    m_currentSpectrum = m_intervals[m_currentIntervalIndex.value()].first;
 
   } else {
-    m_currentIntervalIndex = boost::none;
+    m_currentIntervalIndex = std::nullopt;
     m_currentSpectrum = -1;
   }
 }
@@ -44,18 +44,18 @@ DataBlockGenerator &DataBlockGenerator::operator++() {
     // We need to check if this index is still in the current interval
     // If not we need to increment the interval or set the interval index
     // to a final state
-    auto isinCurrentInterval = m_intervals[m_currentIntervalIndex.get()].first <= m_currentSpectrum &&
-                               m_currentSpectrum <= m_intervals[m_currentIntervalIndex.get()].second;
+    auto isinCurrentInterval = m_intervals[m_currentIntervalIndex.value()].first <= m_currentSpectrum &&
+                               m_currentSpectrum <= m_intervals[m_currentIntervalIndex.value()].second;
 
     if (!isinCurrentInterval) {
       ++(*m_currentIntervalIndex);
 
       // Check if we are past the last interval or else set it to the
       // first element of the new interval
-      if (m_currentIntervalIndex.get() > (m_intervals.size() - 1)) {
-        m_currentIntervalIndex = boost::none;
+      if (m_currentIntervalIndex.value() > (m_intervals.size() - 1)) {
+        m_currentIntervalIndex = std::nullopt;
       } else {
-        m_currentSpectrum = m_intervals[m_currentIntervalIndex.get()].first;
+        m_currentSpectrum = m_intervals[m_currentIntervalIndex.value()].first;
       }
     }
   }

--- a/Framework/DataHandling/src/LoadInstrumentFromNexus.cpp
+++ b/Framework/DataHandling/src/LoadInstrumentFromNexus.cpp
@@ -78,7 +78,7 @@ void LoadInstrumentFromNexus::exec() {
   // Otherwise try and get it from the nexus file - but not there at present!
   // l1 = nxload.ivpb.i_l1;
   // Default to 10 if the file doesn't have it set
-  double l1 = l1ConfigVal.get_value_or(10.0);
+  double l1 = l1ConfigVal.value_or(10.0);
 
   source->setPos(0.0, -1.0 * l1, 0.0);
   localWorkspace->setInstrument(instrument);

--- a/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
+++ b/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
@@ -85,7 +85,7 @@ void LoadInstrumentFromRaw::exec() {
   // If user has provided an L1, use that
   auto l1ConfigValue = Kernel::ConfigService::Instance().getValue<double>("instrument.L1");
   // Otherwise try and get it from the raw file
-  double l1 = l1ConfigValue.get_value_or(iraw.ivpb.i_l1);
+  double l1 = l1ConfigValue.value_or(iraw.ivpb.i_l1);
   // Default to 10 if the raw file doesn't have it set
   if (l1 == 0)
     l1 = 10.0;

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -80,7 +80,7 @@ struct SpectraInfo {
 };
 
 // Helper typdef.
-using SpectraInfo_optional = boost::optional<SpectraInfo>;
+using SpectraInfo_optional = std::optional<SpectraInfo>;
 
 /**
  * Extract ALL the detector, spectrum number and workspace index mapping

--- a/Framework/DataHandling/src/LoadRaw/isisraw2.cpp
+++ b/Framework/DataHandling/src/LoadRaw/isisraw2.cpp
@@ -24,11 +24,11 @@ ISISRAW2::ISISRAW2() : ISISRAW(nullptr, false), ndes(0), outbuff(nullptr), m_buf
   g_log.debug("Determining ioRaw buffer size\n");
   auto bufferSizeConfigVal = Mantid::Kernel::ConfigService::Instance().getValue<int>("loadraw.readbuffer.size");
 
-  if (!bufferSizeConfigVal.is_initialized()) {
+  if (!bufferSizeConfigVal.has_value()) {
     m_bufferSize = 200000;
     g_log.debug() << "loadraw.readbuffer.size not found, setting to " << m_bufferSize << "\n";
   } else {
-    m_bufferSize = bufferSizeConfigVal.get();
+    m_bufferSize = bufferSizeConfigVal.value();
     g_log.debug() << "loadraw.readbuffer.size set to " << m_bufferSize << "\n";
   }
 }

--- a/Framework/DataHandling/src/SaveGDA.cpp
+++ b/Framework/DataHandling/src/SaveGDA.cpp
@@ -14,7 +14,7 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/Unit.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <cmath>
 #include <fstream>
@@ -56,7 +56,7 @@ std::string generateBankHeader(int bank, int minT, size_t numberBins, double del
   return stream.str();
 }
 
-boost::optional<std::vector<std::string>> getParamLinesFromGSASFile(const std::string &paramsFilename) {
+std::optional<std::vector<std::string>> getParamLinesFromGSASFile(const std::string &paramsFilename) {
   // ICONS signifies that a line contains TOF to D conversion factors
   const static std::string paramLineDelimiter = "ICONS";
   std::ifstream paramsFile;
@@ -72,7 +72,7 @@ boost::optional<std::vector<std::string>> getParamLinesFromGSASFile(const std::s
     }
     return paramLines;
   } else {
-    return boost::none;
+    return std::nullopt;
   }
 }
 
@@ -187,7 +187,7 @@ void SaveGDA::exec() {
 
 std::map<std::string, std::string> SaveGDA::validateInputs() {
   std::map<std::string, std::string> issues;
-  boost::optional<std::string> inputWSIssue;
+  std::optional<std::string> inputWSIssue;
 
   const API::WorkspaceGroup_sptr inputWS = getProperty(PROP_INPUT_WS);
   for (const auto &ws : *inputWS) {

--- a/Framework/DataHandling/test/SavePARTest.h
+++ b/Framework/DataHandling/test/SavePARTest.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cxxtest/TestSuite.h>
+#include <filesystem>
 #include <fstream>
 
 #include "MantidDataHandling/SavePAR.h"
@@ -128,7 +129,7 @@ private:
     API::AnalysisDataService::Instance().remove(WSName);
     API::AnalysisDataService::Instance().remove(TestOutputParTableWSName);
     // delete test output file from the hdd;
-    unlink(TestOutputFile.c_str());
+    std::filesystem::remove(TestOutputFile);
   }
 
   MatrixWorkspace_sptr makeWorkspace(const std::string &input) {

--- a/Framework/DataHandling/test/SavePHXTest.h
+++ b/Framework/DataHandling/test/SavePHXTest.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cxxtest/TestSuite.h>
+#include <filesystem>
 #include <fstream>
 
 #include "MantidDataHandling/SavePHX.h"
@@ -158,7 +159,7 @@ private:
     // delete test ws from ds after the test ends
     AnalysisDataService::Instance().remove(WSName);
     // delete test output file from the hdd;
-    unlink(TestOutputFile.c_str());
+    std::filesystem::remove(TestOutputFile);
   }
 
   MatrixWorkspace_sptr makeWorkspace(const std::string &input) {

--- a/Framework/DataObjects/inc/MantidDataObjects/BasePeak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/BasePeak.h
@@ -14,8 +14,8 @@
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/PhysicalConstants.h"
 #include "MantidKernel/V3D.h"
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 namespace Mantid {
 

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -359,13 +359,13 @@ private:
   void generateCountsHistogram(const double step, const MantidVec &X, MantidVec &Y) const;
 
 public:
-  static boost::optional<size_t> findLinearBin(const MantidVec &X, const double tof, const double divisor,
-                                               const double offset, const bool findExact = true);
-  static boost::optional<size_t> findLogBin(const MantidVec &X, const double tof, const double divisor,
-                                            const double offset, const bool findExact = true);
+  static std::optional<size_t> findLinearBin(const MantidVec &X, const double tof, const double divisor,
+                                             const double offset, const bool findExact = true);
+  static std::optional<size_t> findLogBin(const MantidVec &X, const double tof, const double divisor,
+                                          const double offset, const bool findExact = true);
 
 private:
-  static boost::optional<size_t> findExactBin(const MantidVec &X, const double tof, size_t n_bin);
+  static std::optional<size_t> findExactBin(const MantidVec &X, const double tof, size_t n_bin);
 
   void generateCountsHistogramPulseTime(const MantidVec &X, MantidVec &Y) const;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeak.h
@@ -13,8 +13,8 @@
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/PhysicalConstants.h"
 #include "MantidKernel/V3D.h"
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 namespace Mantid {
 
@@ -32,7 +32,7 @@ public:
   LeanElasticPeak();
   LeanElasticPeak(const Mantid::Kernel::V3D &QSampleFrame);
   LeanElasticPeak(const Mantid::Kernel::V3D &QSampleFrame, const Mantid::Kernel::Matrix<double> &goniometer,
-                  boost::optional<std::shared_ptr<const Geometry::ReferenceFrame>> refFrame = boost::none);
+                  std::optional<std::shared_ptr<const Geometry::ReferenceFrame>> refFrame = std::nullopt);
   LeanElasticPeak(const Mantid::Kernel::V3D &QSampleFrame, double wavelength);
 
   /// Copy constructor
@@ -64,9 +64,9 @@ public:
   Mantid::Kernel::V3D getQLabFrame() const override;
   Mantid::Kernel::V3D getQSampleFrame() const override;
 
-  void setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame, boost::optional<double> = boost::none) override;
+  void setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame, std::optional<double> = std::nullopt) override;
   void setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame, const Mantid::Kernel::Matrix<double> &goniometer);
-  void setQLabFrame(const Mantid::Kernel::V3D &qLab, boost::optional<double> = boost::none) override;
+  void setQLabFrame(const Mantid::Kernel::V3D &qLab, std::optional<double> = std::nullopt) override;
 
   void setWavelength(double wavelength) override;
   double getWavelength() const override;

--- a/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeaksWorkspace.h
@@ -87,7 +87,7 @@ public:
   const LeanElasticPeak &getPeak(int peakNum) const override;
 
   std::unique_ptr<Geometry::IPeak> createPeak(const Kernel::V3D &QLabFrame,
-                                              boost::optional<double> detectorDistance = boost::none) const override;
+                                              std::optional<double> detectorDistance = std::nullopt) const override;
 
   std::unique_ptr<Geometry::IPeak> createPeak(const Kernel::V3D &Position,
                                               const Kernel::SpecialCoordinateSystem &frame) const override;

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -207,7 +207,7 @@ TMDE(std::vector<coord_t> MDEventWorkspace)::estimateResolution() const {
     size_t finestSplit = 1;
     size_t i = 0;
     if (splitTop) {
-      finestSplit *= splitTop.get()[d];
+      finestSplit *= splitTop.value()[d];
       i = 1;
     }
     for (; i < realDepth; i++)
@@ -822,7 +822,7 @@ TMDE(Kernel::SpecialCoordinateSystem MDEventWorkspace)::getSpecialCoordinateSyst
   auto coordinates = m_coordSystem;
 
   if (coordinatesFromMDFrames) {
-    coordinates = coordinatesFromMDFrames.get();
+    coordinates = coordinatesFromMDFrames.value();
   }
   return coordinates;
 }

--- a/Framework/DataObjects/inc/MantidDataObjects/MDFramesToSpecialCoordinateSystem.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDFramesToSpecialCoordinateSystem.h
@@ -10,7 +10,7 @@
 #include "MantidDataObjects/DllConfig.h"
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
-#include "boost/optional.hpp"
+#include <optional>
 namespace Mantid {
 namespace DataObjects {
 
@@ -19,11 +19,11 @@ namespace DataObjects {
 */
 class MANTID_DATAOBJECTS_DLL MDFramesToSpecialCoordinateSystem {
 public:
-  boost::optional<Mantid::Kernel::SpecialCoordinateSystem> operator()(const Mantid::API::IMDWorkspace *workspace) const;
+  std::optional<Mantid::Kernel::SpecialCoordinateSystem> operator()(const Mantid::API::IMDWorkspace *workspace) const;
 
 private:
   void checkQCompatibility(Mantid::Kernel::SpecialCoordinateSystem specialCoordinateSystem,
-                           boost::optional<Mantid::Kernel::SpecialCoordinateSystem> qFrameType) const;
+                           std::optional<Mantid::Kernel::SpecialCoordinateSystem> qFrameType) const;
   bool isUnknownFrame(const Mantid::Geometry::IMDDimension_const_sptr &dimension) const;
 };
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
@@ -18,7 +18,7 @@
 #include "MantidKernel/Utils.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include <boost/math/special_functions/round.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include <ostream>
 
 // These pragmas ignores the warning in the ctor where "d<nd-1" for nd=1.
@@ -69,10 +69,10 @@ template <typename MDE, size_t nd> size_t MDGridBox<MDE, nd>::initGridBox() {
   // How many is it split?
   // If we are at the top level and we have a specific top level split, then set
   // it.
-  boost::optional<std::vector<size_t>> splitTopInto = this->m_BoxController->getSplitTopInto();
+  std::optional<std::vector<size_t>> splitTopInto = this->m_BoxController->getSplitTopInto();
   if (this->getDepth() == 0 && splitTopInto) {
     for (size_t d = 0; d < nd; d++)
-      split[d] = splitTopInto.get()[d];
+      split[d] = splitTopInto.value()[d];
   } else {
     for (size_t d = 0; d < nd; d++)
       split[d] = this->m_BoxController->getSplitInto(d);

--- a/Framework/DataObjects/inc/MantidDataObjects/NoShape.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/NoShape.h
@@ -29,7 +29,7 @@ public:
   std::string shapeName() const override;
   /// Get the coordinate frame
   Kernel::SpecialCoordinateSystem frame() const override;
-  boost::optional<double> radius(RadiusType) const override { return boost::optional<double>{}; }
+  std::optional<double> radius(RadiusType) const override { return std::optional<double>{}; }
   /// Return the shape name
   static const std::string noShapeName();
 };

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -14,8 +14,8 @@
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/PhysicalConstants.h"
 #include "MantidKernel/V3D.h"
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 namespace Mantid {
 
@@ -35,9 +35,9 @@ class MANTID_DATAOBJECTS_DLL Peak : public BasePeak {
 public:
   Peak();
   Peak(const Geometry::Instrument_const_sptr &m_inst, const Mantid::Kernel::V3D &QLabFrame,
-       boost::optional<double> detectorDistance = boost::none);
+       std::optional<double> detectorDistance = std::nullopt);
   Peak(const Geometry::Instrument_const_sptr &m_inst, const Mantid::Kernel::V3D &QSampleFrame,
-       const Mantid::Kernel::Matrix<double> &goniometer, boost::optional<double> detectorDistance = boost::none);
+       const Mantid::Kernel::Matrix<double> &goniometer, std::optional<double> detectorDistance = std::nullopt);
   Peak(const Geometry::Instrument_const_sptr &m_inst, int m_detectorID, double m_Wavelength);
   Peak(const Geometry::Instrument_const_sptr &m_inst, int m_detectorID, double m_Wavelength,
        const Mantid::Kernel::V3D &HKL);
@@ -68,7 +68,7 @@ public:
 
   // Construct a peak from LeanPeak
   Peak(const Mantid::DataObjects::LeanElasticPeak &lpeak, const Geometry::Instrument_const_sptr &inst,
-       boost::optional<double> detectorDistance = boost::none);
+       std::optional<double> detectorDistance = std::nullopt);
 
   void setDetectorID(int id);
   int getDetectorID() const override;
@@ -99,8 +99,8 @@ public:
   Mantid::Kernel::V3D getDetectorPositionNoCheck() const;
 
   void setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame,
-                       boost::optional<double> detectorDistance = boost::none) override;
-  void setQLabFrame(const Mantid::Kernel::V3D &qLab, boost::optional<double> detectorDistance = boost::none) override;
+                       std::optional<double> detectorDistance = std::nullopt) override;
+  void setQLabFrame(const Mantid::Kernel::V3D &qLab, std::optional<double> detectorDistance = std::nullopt) override;
 
   void setWavelength(double wavelength) override;
   double getWavelength() const override;

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
@@ -46,7 +46,7 @@ public:
   std::string shapeName() const override;
 
   /// PeakBase interface
-  boost::optional<double> radius(RadiusType type = RadiusType::Radius) const override;
+  std::optional<double> radius(RadiusType type = RadiusType::Radius) const override;
   static const std::string ellipsoidShapeName();
 
 private:

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeSpherical.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeSpherical.h
@@ -8,7 +8,7 @@
 
 #include "MantidDataObjects/PeakShapeBase.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 
 namespace Mantid {
@@ -34,11 +34,11 @@ public:
   /// Equals operator
   bool operator==(const PeakShapeSpherical &other) const;
   /// Peak radius
-  boost::optional<double> radius(RadiusType type = RadiusType::Radius) const override;
+  std::optional<double> radius(RadiusType type = RadiusType::Radius) const override;
   /// Peak outer background radius
-  boost::optional<double> backgroundOuterRadius() const;
+  std::optional<double> backgroundOuterRadius() const;
   /// Peak inner background radius
-  boost::optional<double> backgroundInnerRadius() const;
+  std::optional<double> backgroundInnerRadius() const;
   /// Non-instance shape name
   static const std::string sphereShapeName();
 
@@ -46,9 +46,9 @@ private:
   /// Peak radius
   double m_radius;
   /// Background inner radius;
-  boost::optional<double> m_backgroundInnerRadius;
+  std::optional<double> m_backgroundInnerRadius;
   /// Background outer radius
-  boost::optional<double> m_backgroundOuterRadius;
+  std::optional<double> m_backgroundOuterRadius;
 };
 
 } // namespace DataObjects

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -83,7 +83,7 @@ public:
   const Peak &getPeak(int peakNum) const override;
 
   IPeak_uptr createPeak(const Kernel::V3D &QLabFrame,
-                        boost::optional<double> detectorDistance = boost::none) const override;
+                        std::optional<double> detectorDistance = std::nullopt) const override;
 
   IPeak_uptr createPeak(const Kernel::V3D &Position, const Kernel::SpecialCoordinateSystem &frame) const override;
 

--- a/Framework/DataObjects/src/LeanElasticPeak.cpp
+++ b/Framework/DataObjects/src/LeanElasticPeak.cpp
@@ -49,10 +49,10 @@ LeanElasticPeak::LeanElasticPeak(const Mantid::Kernel::V3D &QSampleFrame)
  */
 LeanElasticPeak::LeanElasticPeak(const Mantid::Kernel::V3D &QSampleFrame,
                                  const Mantid::Kernel::Matrix<double> &goniometer,
-                                 boost::optional<std::shared_ptr<const Geometry::ReferenceFrame>> refFrame)
+                                 std::optional<std::shared_ptr<const Geometry::ReferenceFrame>> refFrame)
     : BasePeak() {
-  if (refFrame.is_initialized())
-    setReferenceFrame(refFrame.get());
+  if (refFrame.has_value())
+    setReferenceFrame(refFrame.value());
   setQSampleFrame(QSampleFrame, goniometer);
 }
 
@@ -187,7 +187,7 @@ Mantid::Kernel::V3D LeanElasticPeak::getQSampleFrame() const { return m_Qsample;
  *        This is in inelastic convention: momentum transfer of the LATTICE!
  *        Also, q does NOT have a 2pi factor = it is equal to 1/wavelength.
  */
-void LeanElasticPeak::setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame, boost::optional<double>) {
+void LeanElasticPeak::setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame, std::optional<double>) {
   m_Qsample = QSampleFrame;
 }
 
@@ -216,7 +216,7 @@ void LeanElasticPeak::setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame,
  *        Also, q does have a 2pi factor = it is equal to 2pi/wavelength (in
  *        Angstroms).
  */
-void LeanElasticPeak::setQLabFrame(const Mantid::Kernel::V3D &qLab, boost::optional<double>) {
+void LeanElasticPeak::setQLabFrame(const Mantid::Kernel::V3D &qLab, std::optional<double>) {
   this->setQSampleFrame(getInverseGoniometerMatrix() * qLab);
 }
 

--- a/Framework/DataObjects/src/LeanElasticPeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/LeanElasticPeaksWorkspace.cpp
@@ -200,7 +200,7 @@ const LeanElasticPeak &LeanElasticPeaksWorkspace::getPeak(const int peakNum) con
  * @return a pointer to a new Peak object.
  */
 std::unique_ptr<Geometry::IPeak> LeanElasticPeaksWorkspace::createPeak(const Kernel::V3D &,
-                                                                       boost::optional<double>) const {
+                                                                       std::optional<double>) const {
   throw Exception::NotImplementedError("LeanElasticPeak should be create in q sample frame");
 }
 

--- a/Framework/DataObjects/src/MDFramesToSpecialCoordinateSystem.cpp
+++ b/Framework/DataObjects/src/MDFramesToSpecialCoordinateSystem.cpp
@@ -16,7 +16,7 @@ namespace Mantid::DataObjects {
  * @param workspace: the workspace which is being queried
  * @returns either a special coordinate or an empty optional
  */
-boost::optional<Mantid::Kernel::SpecialCoordinateSystem>
+std::optional<Mantid::Kernel::SpecialCoordinateSystem>
 MDFramesToSpecialCoordinateSystem::operator()(const Mantid::API::IMDWorkspace *workspace) const {
   // Make sure that the workspaces are either an MDHisto or MDEvent workspaces
   if (!dynamic_cast<const Mantid::API::IMDEventWorkspace *>(workspace) &&
@@ -31,7 +31,7 @@ MDFramesToSpecialCoordinateSystem::operator()(const Mantid::API::IMDWorkspace *w
   // This dimension will define the special coordinate system. Otherwise, we
   // don't have a special coordinate system
 
-  boost::optional<Mantid::Kernel::SpecialCoordinateSystem> qFrameType =
+  std::optional<Mantid::Kernel::SpecialCoordinateSystem> qFrameType =
       Mantid::Kernel::SpecialCoordinateSystem::None; // Set to none just to have
                                                      // it initialized
   auto hasQFrame = false;
@@ -40,7 +40,7 @@ MDFramesToSpecialCoordinateSystem::operator()(const Mantid::API::IMDWorkspace *w
     auto dimension = workspace->getDimension(dimIndex);
     auto &frame = dimension->getMDFrame();
     // Check for QCompatibility. This has gotten a bit more complicated than
-    // necessary since the boost optional
+    // necessary since the std::optional
     // caused a GCC error, when it was not initialized. Using -Wuninitialized
     // didn't make the compiler happy.
     if (frame.getMDUnit().isQUnit()) {
@@ -55,7 +55,7 @@ MDFramesToSpecialCoordinateSystem::operator()(const Mantid::API::IMDWorkspace *w
     isUnknown = isUnknownFrame(dimension);
   }
 
-  boost::optional<Mantid::Kernel::SpecialCoordinateSystem> output;
+  std::optional<Mantid::Kernel::SpecialCoordinateSystem> output;
   if (hasQFrame) {
     output = qFrameType;
   } else {
@@ -75,9 +75,9 @@ MDFramesToSpecialCoordinateSystem::operator()(const Mantid::API::IMDWorkspace *w
  */
 void MDFramesToSpecialCoordinateSystem::checkQCompatibility(
     Mantid::Kernel::SpecialCoordinateSystem specialCoordinateSystem,
-    boost::optional<Mantid::Kernel::SpecialCoordinateSystem> qFrameType) const {
+    std::optional<Mantid::Kernel::SpecialCoordinateSystem> qFrameType) const {
   if (qFrameType) {
-    if (specialCoordinateSystem != qFrameType.get()) {
+    if (specialCoordinateSystem != qFrameType.value()) {
       throw std::invalid_argument("Error in MDFrameFromWorkspace: Coordinate "
                                   "system in the different dimensions don't "
                                   "match.");

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -17,11 +17,11 @@
 #include "MantidKernel/VMD.h"
 #include "MantidKernel/WarningSuppressions.h"
 
-#include <boost/optional.hpp>
 #include <boost/scoped_array.hpp>
 #include <cmath>
 #include <map>
 #include <memory>
+#include <optional>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;
@@ -1265,7 +1265,7 @@ Kernel::SpecialCoordinateSystem MDHistoWorkspace::getSpecialCoordinateSystem() c
   auto coordinatesFromMDFrames = converter(this);
   auto coordinates = m_coordSystem;
   if (coordinatesFromMDFrames) {
-    coordinates = coordinatesFromMDFrames.get();
+    coordinates = coordinatesFromMDFrames.value();
   }
   return coordinates;
 }

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -41,7 +41,7 @@ Peak::Peak() : BasePeak(), m_row(-1), m_col(-1), m_detectorID(-1), m_initialEner
  *        Used to give a valid TOF. Default 1.0 meters.
  */
 Peak::Peak(const Geometry::Instrument_const_sptr &m_inst, const Mantid::Kernel::V3D &QLabFrame,
-           boost::optional<double> detectorDistance)
+           std::optional<double> detectorDistance)
     : BasePeak() {
   // Initialization of m_inst, sourcePos, m_samplePos
   setInstrument(m_inst);
@@ -63,7 +63,7 @@ Peak::Peak(const Geometry::Instrument_const_sptr &m_inst, const Mantid::Kernel::
  *        Used to give a valid TOF. Default 1.0 meters.
  */
 Peak::Peak(const Geometry::Instrument_const_sptr &m_inst, const Mantid::Kernel::V3D &QSampleFrame,
-           const Mantid::Kernel::Matrix<double> &goniometer, boost::optional<double> detectorDistance)
+           const Mantid::Kernel::Matrix<double> &goniometer, std::optional<double> detectorDistance)
     : BasePeak(goniometer) {
   // Initialization of m_inst, sourcePos, m_samplePos
   this->setInstrument(m_inst);
@@ -173,7 +173,7 @@ Peak::Peak(const Geometry::IPeak &ipeak)
 
 //----------------------------------------------------------------------------------------------
 Peak::Peak(const Mantid::DataObjects::LeanElasticPeak &lpeak, const Geometry::Instrument_const_sptr &inst,
-           boost::optional<double> detectorDistance)
+           std::optional<double> detectorDistance)
     : BasePeak(lpeak) {
   this->setInstrument(inst);
   this->setQLabFrame(lpeak.getQLabFrame(), std::move(detectorDistance));
@@ -499,7 +499,7 @@ Mantid::Kernel::V3D Peak::getQSampleFrame() const {
  * @param detectorDistance :: distance between the sample and the detector.
  *        Used to give a valid TOF. You do NOT need to explicitly set this.
  */
-void Peak::setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame, boost::optional<double> detectorDistance) {
+void Peak::setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame, std::optional<double> detectorDistance) {
   V3D Qlab = getGoniometerMatrix() * QSampleFrame;
   this->setQLabFrame(Qlab, detectorDistance);
 }
@@ -520,7 +520,7 @@ void Peak::setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame, boost::optio
  *this is provided. Then we do not
  * ray trace to find the intersecing detector.
  */
-void Peak::setQLabFrame(const Mantid::Kernel::V3D &qLab, boost::optional<double> detectorDistance) {
+void Peak::setQLabFrame(const Mantid::Kernel::V3D &qLab, std::optional<double> detectorDistance) {
   if (!this->m_inst) {
     throw std::invalid_argument("Setting QLab without an instrument would lead "
                                 "to an inconsistent state for the Peak");
@@ -571,8 +571,8 @@ void Peak::setQLabFrame(const Mantid::Kernel::V3D &qLab, boost::optional<double>
   detectorDir.normalize();
 
   // Use the given detector distance to find the detector position.
-  if (detectorDistance.is_initialized()) {
-    detPos = m_samplePos + detectorDir * detectorDistance.get();
+  if (detectorDistance.has_value()) {
+    detPos = m_samplePos + detectorDir * detectorDistance.value();
     // We do not-update the detector as by manually setting the distance the
     // client seems to know better.
   } else {

--- a/Framework/DataObjects/src/PeakColumn.cpp
+++ b/Framework/DataObjects/src/PeakColumn.cpp
@@ -90,8 +90,8 @@ PeakColumn<T>::PeakColumn(std::vector<T> &peaks, const std::string &name) : m_pe
   this->m_type = typeFromName(name); // Throws if the name is unknown
   const std::string key = "PeakColumn.hklPrec";
   auto hklPrec = ConfigService::Instance().getValue<int>(key);
-  this->m_hklPrec = hklPrec.get_value_or(2);
-  if (!hklPrec.is_initialized()) {
+  this->m_hklPrec = hklPrec.value_or(2);
+  if (!hklPrec.has_value()) {
     g_log.information() << "In PeakColumn constructor, did not find any value for '" << key
                         << "' from the Config Service. Using default: " << this->m_hklPrec << "\n";
   }

--- a/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
+++ b/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
@@ -99,7 +99,7 @@ PeakShapeEllipsoid *PeakShapeEllipsoid::clone() const { return new PeakShapeElli
 
 std::string PeakShapeEllipsoid::shapeName() const { return PeakShapeEllipsoid::ellipsoidShapeName(); }
 
-boost::optional<double> PeakShapeEllipsoid::radius(RadiusType type) const {
+std::optional<double> PeakShapeEllipsoid::radius(RadiusType type) const {
   std::vector<double>::const_iterator it;
   switch (type) {
   case (RadiusType::Radius):
@@ -112,7 +112,7 @@ boost::optional<double> PeakShapeEllipsoid::radius(RadiusType type) const {
     it = std::max_element(m_abc_radiiBackgroundInner.cbegin(), m_abc_radiiBackgroundInner.cend());
     break;
   }
-  return boost::optional<double>{*it};
+  return std::optional<double>{*it};
 }
 
 const std::string PeakShapeEllipsoid::ellipsoidShapeName() { return "ellipsoid"; }

--- a/Framework/DataObjects/src/PeakShapeSpherical.cpp
+++ b/Framework/DataObjects/src/PeakShapeSpherical.cpp
@@ -52,8 +52,8 @@ std::string PeakShapeSpherical::toJSON() const {
   root["radius"] = Json::Value(m_radius);
 
   if (m_backgroundInnerRadius && m_backgroundOuterRadius) {
-    root["background_outer_radius"] = Json::Value(m_backgroundOuterRadius.get());
-    root["background_inner_radius"] = Json::Value(m_backgroundInnerRadius.get());
+    root["background_outer_radius"] = Json::Value(m_backgroundOuterRadius.value());
+    root["background_inner_radius"] = Json::Value(m_backgroundInnerRadius.value());
   }
 
   return Mantid::JsonHelpers::jsonToString(root);
@@ -78,12 +78,12 @@ bool PeakShapeSpherical::operator==(const PeakShapeSpherical &other) const {
  * @param type Which radius to get.
  * @return radius
  */
-boost::optional<double> PeakShapeSpherical::radius(RadiusType type) const {
+std::optional<double> PeakShapeSpherical::radius(RadiusType type) const {
 
-  boost::optional<double> value;
+  std::optional<double> value;
   switch (type) {
   case (RadiusType::Radius):
-    value = boost::optional<double>{m_radius};
+    value = std::optional<double>{m_radius};
     break;
   case (RadiusType::OuterRadius):
     value = m_backgroundOuterRadius;
@@ -98,16 +98,16 @@ boost::optional<double> PeakShapeSpherical::radius(RadiusType type) const {
 /**
  * @brief Get the background outer radius. The outer radius may not be set, so
  * this is optional.
- * @return boost optional outer radius
+ * @return std::optional outer radius
  */
-boost::optional<double> PeakShapeSpherical::backgroundOuterRadius() const { return m_backgroundOuterRadius; }
+std::optional<double> PeakShapeSpherical::backgroundOuterRadius() const { return m_backgroundOuterRadius; }
 
 /**
  * @brief Get the background inner radius. The inner radius may not be set, so
  * this is optional.
- * @return boost optional inner radius.
+ * @return std::optional inner radius.
  */
-boost::optional<double> PeakShapeSpherical::backgroundInnerRadius() const { return m_backgroundInnerRadius; }
+std::optional<double> PeakShapeSpherical::backgroundInnerRadius() const { return m_backgroundInnerRadius; }
 
 /**
  * @brief PeakShapeSpherical::sphereShapeName

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -210,7 +210,7 @@ const Peak &PeaksWorkspace::getPeak(const int peakNum) const {
  * @return a pointer to a new Peak object.
  */
 std::unique_ptr<Geometry::IPeak> PeaksWorkspace::createPeak(const Kernel::V3D &QLabFrame,
-                                                            boost::optional<double> detectorDistance) const {
+                                                            std::optional<double> detectorDistance) const {
   // create a peak using the qLab frame
   std::unique_ptr<IPeak> peak = std::make_unique<Peak>(this->getInstrument(), QLabFrame, detectorDistance);
   // Set the goniometer

--- a/Framework/DataObjects/test/MDFramesToSpecialCoordinateSystemTest.h
+++ b/Framework/DataObjects/test/MDFramesToSpecialCoordinateSystemTest.h
@@ -19,7 +19,8 @@
 #include "MantidGeometry/MDGeometry/UnknownFrame.h"
 #include "MantidKernel/MDUnit.h"
 
-#include "boost/make_shared.hpp"
+#include <boost/make_shared.hpp>
+#include <optional>
 
 using namespace Mantid::Geometry;
 
@@ -64,7 +65,7 @@ public:
     Mantid::DataObjects::MDFramesToSpecialCoordinateSystem converter;
 
     // Act + Assert
-    auto coordinateSystem = boost::make_optional(false, Mantid::Kernel::SpecialCoordinateSystem::None);
+    std::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem;
     TSM_ASSERT_THROWS_NOTHING("Should throw nothing as coordinate system is "
                               "mixed only with one Q type.",
                               coordinateSystem = converter(ws.get()));
@@ -85,7 +86,7 @@ public:
     Mantid::DataObjects::MDFramesToSpecialCoordinateSystem converter;
 
     // Act + Assert
-    auto coordinateSystem = boost::make_optional(false, Mantid::Kernel::SpecialCoordinateSystem::None);
+    std::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem;
     TS_ASSERT_THROWS_NOTHING(coordinateSystem = converter(ws.get()));
     TSM_ASSERT_EQUALS("Should be Qlab", *coordinateSystem, Mantid::Kernel::SpecialCoordinateSystem::QLab);
   }
@@ -103,7 +104,7 @@ public:
     Mantid::DataObjects::MDFramesToSpecialCoordinateSystem converter;
 
     // Act + Assert
-    auto coordinateSystem = boost::make_optional(false, Mantid::Kernel::SpecialCoordinateSystem::None);
+    std::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem;
     TS_ASSERT_THROWS_NOTHING(coordinateSystem = converter(ws.get()));
     TSM_ASSERT_EQUALS("Should be QSample", *coordinateSystem, Mantid::Kernel::SpecialCoordinateSystem::QSample);
   }
@@ -121,7 +122,7 @@ public:
     Mantid::DataObjects::MDFramesToSpecialCoordinateSystem converter;
 
     // Act + Assert
-    auto coordinateSystem = boost::make_optional(false, Mantid::Kernel::SpecialCoordinateSystem::None);
+    std::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem;
     TS_ASSERT_THROWS_NOTHING(coordinateSystem = converter(ws.get()));
     TSM_ASSERT_EQUALS("Should be HKL", *coordinateSystem, Mantid::Kernel::SpecialCoordinateSystem::HKL);
   }
@@ -139,7 +140,7 @@ public:
     Mantid::DataObjects::MDFramesToSpecialCoordinateSystem converter;
 
     // Act + Assert
-    auto coordinateSystem = boost::make_optional(false, Mantid::Kernel::SpecialCoordinateSystem::None);
+    std::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem;
     TS_ASSERT_THROWS_NOTHING(coordinateSystem = converter(ws.get()));
     TSM_ASSERT_EQUALS("Should be None", *coordinateSystem, Mantid::Kernel::SpecialCoordinateSystem::None);
   }
@@ -157,7 +158,7 @@ public:
     Mantid::DataObjects::MDFramesToSpecialCoordinateSystem converter;
 
     // Act + Assert
-    boost::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem;
+    std::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem;
     TS_ASSERT_THROWS_NOTHING(coordinateSystem = converter(ws.get()));
     TSM_ASSERT("Should not be initialized", !coordinateSystem);
   }

--- a/Framework/DataObjects/test/MockObjects.h
+++ b/Framework/DataObjects/test/MockObjects.h
@@ -32,7 +32,7 @@ public:
   MOCK_CONST_METHOD0(algorithmName, std::string());
   MOCK_CONST_METHOD0(algorithmVersion, int());
   MOCK_CONST_METHOD0(shapeName, std::string());
-  MOCK_CONST_METHOD1(radius, boost::optional<double>(Mantid::Geometry::PeakShape::RadiusType));
+  MOCK_CONST_METHOD1(radius, std::optional<double>(Mantid::Geometry::PeakShape::RadiusType));
   ~MockPeakShape() override = default;
 };
 } // namespace DataObjects

--- a/Framework/DataObjects/test/PeakShapeSphericalTest.h
+++ b/Framework/DataObjects/test/PeakShapeSphericalTest.h
@@ -46,8 +46,8 @@ public:
     TS_ASSERT_EQUALS(frame, shape.frame());
     TS_ASSERT_EQUALS(algorithmName, shape.algorithmName());
     TS_ASSERT_EQUALS(algorithmVersion, shape.algorithmVersion());
-    TS_ASSERT(!shape.backgroundInnerRadius().is_initialized());
-    TS_ASSERT(!shape.backgroundOuterRadius().is_initialized());
+    TS_ASSERT(!shape.backgroundInnerRadius().has_value());
+    TS_ASSERT(!shape.backgroundOuterRadius().has_value());
   }
 
   void test_multiple_radii_constructor() {
@@ -70,15 +70,15 @@ public:
     TS_ASSERT_EQUALS(frame, shape.frame());
     TS_ASSERT_EQUALS(algorithmName, shape.algorithmName());
     TS_ASSERT_EQUALS(algorithmVersion, shape.algorithmVersion());
-    TS_ASSERT_EQUALS(backgroundInnerRadius, shape.backgroundInnerRadius().get());
-    TS_ASSERT_EQUALS(backgroundOuterRadius, shape.backgroundOuterRadius().get());
+    TS_ASSERT_EQUALS(backgroundInnerRadius, shape.backgroundInnerRadius().value());
+    TS_ASSERT_EQUALS(backgroundOuterRadius, shape.backgroundOuterRadius().value());
 
     PeakShapeSpherical badShape(radius, radius, radius, frame, algorithmName, algorithmVersion);
 
     TSM_ASSERT("Background inner radius should be set even when same as radius",
-               badShape.backgroundInnerRadius().is_initialized());
+               badShape.backgroundInnerRadius().has_value());
     TSM_ASSERT("Background outer radius should be unset since is same as radius",
-               !badShape.backgroundOuterRadius().is_initialized());
+               !badShape.backgroundOuterRadius().has_value());
   }
 
   void test_copy_constructor() {
@@ -98,8 +98,8 @@ public:
     TS_ASSERT_EQUALS(frame, b.frame());
     TS_ASSERT_EQUALS(algorithmName, b.algorithmName());
     TS_ASSERT_EQUALS(algorithmVersion, b.algorithmVersion());
-    TS_ASSERT_EQUALS(backgroundInnerRadius, b.backgroundInnerRadius().get());
-    TS_ASSERT_EQUALS(backgroundOuterRadius, b.backgroundOuterRadius().get());
+    TS_ASSERT_EQUALS(backgroundInnerRadius, b.backgroundInnerRadius().value());
+    TS_ASSERT_EQUALS(backgroundOuterRadius, b.backgroundOuterRadius().value());
   }
 
   void test_assignment() {
@@ -122,8 +122,8 @@ public:
     TS_ASSERT_EQUALS(a.frame(), b.frame());
     TS_ASSERT_EQUALS(a.algorithmName(), b.algorithmName());
     TS_ASSERT_EQUALS(a.algorithmVersion(), b.algorithmVersion());
-    TS_ASSERT_EQUALS(a.backgroundInnerRadius(), b.backgroundInnerRadius().get());
-    TS_ASSERT_EQUALS(a.backgroundOuterRadius(), b.backgroundOuterRadius().get());
+    TS_ASSERT_EQUALS(a.backgroundInnerRadius(), b.backgroundInnerRadius().value());
+    TS_ASSERT_EQUALS(a.backgroundOuterRadius(), b.backgroundOuterRadius().value());
   }
 
   void test_clone() {
@@ -142,8 +142,8 @@ public:
     TS_ASSERT_EQUALS(a.frame(), clone->frame());
     TS_ASSERT_EQUALS(a.algorithmName(), clone->algorithmName());
     TS_ASSERT_EQUALS(a.algorithmVersion(), clone->algorithmVersion());
-    TS_ASSERT_EQUALS(a.backgroundInnerRadius(), clone->backgroundInnerRadius().get());
-    TS_ASSERT_EQUALS(a.backgroundOuterRadius(), clone->backgroundOuterRadius().get());
+    TS_ASSERT_EQUALS(a.backgroundInnerRadius(), clone->backgroundInnerRadius().value());
+    TS_ASSERT_EQUALS(a.backgroundOuterRadius(), clone->backgroundOuterRadius().value());
     TS_ASSERT_DIFFERS(clone, &a);
     delete clone;
   }

--- a/Framework/DataObjects/test/PeakTest.h
+++ b/Framework/DataObjects/test/PeakTest.h
@@ -28,7 +28,7 @@ using namespace Mantid::Kernel;
 namespace boost {
 template <class CharType, class CharTrait>
 std::basic_ostream<CharType, CharTrait> &operator<<(std::basic_ostream<CharType, CharTrait> &out,
-                                                    optional<double> const &maybe) {
+                                                    std::optional<double> const &maybe) {
   if (maybe)
     out << maybe;
   return out;
@@ -396,7 +396,7 @@ public:
   /** Can't have Q = 0,0,0 or 0 in the Z direction when creating */
   void test_setQLabFrame_ThrowsIfQIsNull() {
     Peak p1(inst, 10000, 2.0);
-    const boost::optional<double> distance = 1.0;
+    const std::optional<double> distance = 1.0;
     TS_ASSERT_THROWS_ANYTHING(Peak p2(inst, V3D(0, 0, 0), distance));
     TS_ASSERT_THROWS_ANYTHING(Peak p2(inst, V3D(1, 2, 0), distance));
   }
@@ -425,7 +425,7 @@ public:
     V3D detPos1 = p1.getDetPos();
 
     // Construct using just Q
-    Peak p2(inst, Qlab1, boost::optional<double>(detPos1.norm()));
+    Peak p2(inst, Qlab1, std::optional<double>(detPos1.norm()));
     comparePeaks(p1, p2);
     TS_ASSERT_EQUALS(p2.getBankName(), "None");
     TS_ASSERT_EQUALS(p2.getRow(), -1);
@@ -605,7 +605,7 @@ public:
     V3D detPos1 = p1.getDetPos();
 
     // Construct using just Q
-    Peak p2(inst, Qlab1, boost::optional<double>(detPos1.norm()));
+    Peak p2(inst, Qlab1, std::optional<double>(detPos1.norm()));
     TS_ASSERT(p2.findDetector());
     comparePeaks(p1, p2);
     TS_ASSERT_EQUALS(p2.getBankName(), "bank1");

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
@@ -12,7 +12,7 @@
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/PhysicalConstants.h"
 #include "MantidKernel/V3D.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace Mantid {
 namespace Geometry {
@@ -52,8 +52,8 @@ public:
 
   virtual Mantid::Kernel::V3D getQLabFrame() const = 0;
   virtual Mantid::Kernel::V3D getQSampleFrame() const = 0;
-  virtual void setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame, boost::optional<double> detectorDistance) = 0;
-  virtual void setQLabFrame(const Mantid::Kernel::V3D &QLabFrame, boost::optional<double> detectorDistance) = 0;
+  virtual void setQSampleFrame(const Mantid::Kernel::V3D &QSampleFrame, std::optional<double> detectorDistance) = 0;
+  virtual void setQLabFrame(const Mantid::Kernel::V3D &QLabFrame, std::optional<double> detectorDistance) = 0;
 
   virtual void setWavelength(double wavelength) = 0;
   virtual double getWavelength() const = 0;

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h
@@ -18,6 +18,7 @@
 namespace Mantid {
 namespace Geometry {
 
+// TODO moving from boost::optional to std::optoinal in this file is non-trivial
 using ParsedRationalNumber = boost::fusion::vector<int, boost::optional<int>>;
 
 class MatrixVectorPairBuilder {

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/PeakShape.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/PeakShape.h
@@ -8,8 +8,8 @@
 
 #include "MantidGeometry/DllConfig.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace Mantid {
@@ -34,7 +34,7 @@ public:
   /// For selecting different radius types.
   enum RadiusType { Radius = 0, OuterRadius = 1, InnerRadius = 2 };
   /// Radius
-  virtual boost::optional<double> radius(RadiusType type) const = 0;
+  virtual std::optional<double> radius(RadiusType type) const = 0;
   /// Destructor
   virtual ~PeakShape() = default;
 };

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
@@ -68,12 +68,12 @@ public:
   }
 
   int getPointInObject(Kernel::V3D &point) const override { return m_shape->getPointInObject(point); }
-  boost::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
-                                                     const size_t i) const override {
+  std::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
+                                                   const size_t i) const override {
     return m_shape->generatePointInObject(rng, i);
   }
-  boost::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
-                                                     const BoundingBox &activeRegion, const size_t i) const override {
+  std::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
+                                                   const BoundingBox &activeRegion, const size_t i) const override {
     return m_shape->generatePointInObject(rng, activeRegion, i);
   }
 

--- a/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
@@ -15,9 +15,9 @@
 #include "MantidGeometry/Objects/Track.h"
 #include "MantidGeometry/Rendering/ShapeInfo.h"
 
-#include <boost/optional.hpp>
 #include <map>
 #include <memory>
+#include <optional>
 
 namespace Mantid {
 //----------------------------------------------------------------------
@@ -155,10 +155,10 @@ public:
   int getPointInObject(Kernel::V3D &point) const override;
 
   /// Select a random point within the object
-  boost::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
-                                                     const size_t) const override;
-  boost::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
-                                                     const BoundingBox &activeRegion, const size_t) const override;
+  std::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
+                                                   const size_t) const override;
+  std::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
+                                                   const BoundingBox &activeRegion, const size_t) const override;
 
   // Rendering member functions
   void draw() const override;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/IObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/IObject.h
@@ -9,9 +9,9 @@
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/Instrument/SolidAngleParams.h"
 #include "MantidGeometry/Rendering/ShapeInfo.h"
-#include <boost/optional.hpp>
 #include <map>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace Mantid {
@@ -68,10 +68,10 @@ public:
 
   virtual int getPointInObject(Kernel::V3D &point) const = 0;
 
-  virtual boost::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
-                                                             const size_t) const = 0;
-  virtual boost::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
-                                                             const BoundingBox &activeRegion, const size_t) const = 0;
+  virtual std::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
+                                                           const size_t) const = 0;
+  virtual std::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
+                                                           const BoundingBox &activeRegion, const size_t) const = 0;
 
   virtual detail::ShapeInfo::GeometryShape shape() const = 0;
   virtual const detail::ShapeInfo &shapeInfo() const = 0;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
@@ -105,10 +105,10 @@ public:
   int getPointInObject(Kernel::V3D &point) const override;
 
   /// Select a random point within the object
-  boost::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
-                                                     const size_t) const override;
-  boost::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
-                                                     const BoundingBox &activeRegion, const size_t) const override;
+  std::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
+                                                   const size_t) const override;
+  std::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
+                                                   const BoundingBox &activeRegion, const size_t) const override;
 
   // Rendering member functions
   void draw() const override;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject2D.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject2D.h
@@ -57,10 +57,10 @@ public:
                       double &zmin) const override;
   int getPointInObject(Kernel::V3D &point) const override;
 
-  boost::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
-                                                     const size_t) const override;
-  boost::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
-                                                     const BoundingBox &activeRegion, const size_t) const override;
+  std::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
+                                                   const size_t) const override;
+  std::optional<Kernel::V3D> generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
+                                                   const BoundingBox &activeRegion, const size_t) const override;
   detail::ShapeInfo::GeometryShape shape() const override;
   const detail::ShapeInfo &shapeInfo() const override;
   void GetObjectGeom(detail::ShapeInfo::GeometryShape &type, std::vector<Kernel::V3D> &vectors, double &innerRadius,

--- a/Framework/Geometry/inc/MantidGeometry/RandomPoint.h
+++ b/Framework/Geometry/inc/MantidGeometry/RandomPoint.h
@@ -10,7 +10,7 @@
 #include "MantidGeometry/Objects/BoundingBox.h"
 #include "MantidKernel/V3D.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace Mantid {
 namespace Kernel {
@@ -34,18 +34,18 @@ MANTID_GEOMETRY_DLL Kernel::V3D inHollowCylinder(const detail::ShapeInfo &shapeI
 
 MANTID_GEOMETRY_DLL Kernel::V3D inSphere(const detail::ShapeInfo &shapeInfo, Kernel::PseudoRandomNumberGenerator &rng);
 
-MANTID_GEOMETRY_DLL boost::optional<Kernel::V3D>
+MANTID_GEOMETRY_DLL std::optional<Kernel::V3D>
 inGenericShape(const IObject &object, Kernel::PseudoRandomNumberGenerator &rng, size_t maxAttempts);
 
 MANTID_GEOMETRY_DLL Kernel::V3D localPointInCylinder(const Kernel::V3D &basis, const Kernel::V3D &alongAxis,
                                                      double polarAngle, double radialLength);
 
 template <Kernel::V3D (*T)(const detail::ShapeInfo &, Kernel::PseudoRandomNumberGenerator &)>
-boost::optional<Kernel::V3D> bounded(const detail::ShapeInfo &shapeInfo, Kernel::PseudoRandomNumberGenerator &rng,
-                                     const BoundingBox &box, size_t maxAttempts);
+std::optional<Kernel::V3D> bounded(const detail::ShapeInfo &shapeInfo, Kernel::PseudoRandomNumberGenerator &rng,
+                                   const BoundingBox &box, size_t maxAttempts);
 
-MANTID_GEOMETRY_DLL boost::optional<Kernel::V3D>
-bounded(const IObject &object, Kernel::PseudoRandomNumberGenerator &rng, const BoundingBox &box, size_t maxAttempts);
+MANTID_GEOMETRY_DLL std::optional<Kernel::V3D> bounded(const IObject &object, Kernel::PseudoRandomNumberGenerator &rng,
+                                                       const BoundingBox &box, size_t maxAttempts);
 
 /**
  * Return a random point in a known shape restricted by a bounding box.
@@ -59,9 +59,9 @@ bounded(const IObject &object, Kernel::PseudoRandomNumberGenerator &rng, const B
  * @return a point or none if maxAttempts was exceeded
  */
 template <Kernel::V3D (*randomInShape)(const detail::ShapeInfo &, Kernel::PseudoRandomNumberGenerator &)>
-boost::optional<Kernel::V3D> bounded(const detail::ShapeInfo &shapeInfo, Kernel::PseudoRandomNumberGenerator &rng,
-                                     const BoundingBox &box, size_t maxAttempts) {
-  boost::optional<Kernel::V3D> point;
+std::optional<Kernel::V3D> bounded(const detail::ShapeInfo &shapeInfo, Kernel::PseudoRandomNumberGenerator &rng,
+                                   const BoundingBox &box, size_t maxAttempts) {
+  std::optional<Kernel::V3D> point;
   for (size_t attempt{0}; attempt < maxAttempts; ++attempt) {
     const Kernel::V3D pt{randomInShape(shapeInfo, rng)};
     if (box.isPointInside(pt)) {

--- a/Framework/Geometry/src/Objects/CSGObject.cpp
+++ b/Framework/Geometry/src/Objects/CSGObject.cpp
@@ -2001,9 +2001,9 @@ int CSGObject::getPointInObject(Kernel::V3D &point) const {
  * @param maxAttempts The maximum number of attempts at generating a point
  * @return whether a point was generated in the object or not
  */
-boost::optional<Kernel::V3D> CSGObject::generatePointInObject(PseudoRandomNumberGenerator &rng,
-                                                              const size_t maxAttempts) const {
-  boost::optional<V3D> point{boost::none};
+std::optional<Kernel::V3D> CSGObject::generatePointInObject(PseudoRandomNumberGenerator &rng,
+                                                            const size_t maxAttempts) const {
+  std::optional<V3D> point{std::nullopt};
   // If the shape fills its bounding box well enough then the most efficient
   // way to get the point is just brute force. We'll try that first with
   // just a few attempts.
@@ -2012,7 +2012,7 @@ boost::optional<Kernel::V3D> CSGObject::generatePointInObject(PseudoRandomNumber
   // within the box. So there is a sweet spot which depends on the actual
   // shape, its dimension and orientation.
   const size_t bruteForceAttempts{std::min(static_cast<size_t>(5), maxAttempts)};
-  boost::optional<V3D> maybePoint{RandomPoint::inGenericShape(*this, rng, bruteForceAttempts)};
+  std::optional<V3D> maybePoint{RandomPoint::inGenericShape(*this, rng, bruteForceAttempts)};
   if (maybePoint) {
     point = maybePoint;
   } else {
@@ -2047,10 +2047,10 @@ boost::optional<Kernel::V3D> CSGObject::generatePointInObject(PseudoRandomNumber
  * @param maxAttempts The maximum number of attempts at generating a point
  * @return whether a point was generated in the object or not
  */
-boost::optional<Kernel::V3D> CSGObject::generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
-                                                              const BoundingBox &activeRegion,
-                                                              const size_t maxAttempts) const {
-  boost::optional<V3D> point{boost::none};
+std::optional<Kernel::V3D> CSGObject::generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
+                                                            const BoundingBox &activeRegion,
+                                                            const size_t maxAttempts) const {
+  std::optional<V3D> point{std::nullopt};
   // We'll first try brute force. If the shape fills its bounding box
   // well enough, this should be the fastest method.
   // Increasing the brute force attemps speeds up the shapes that fill

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -374,8 +374,8 @@ int MeshObject::getPointInObject(Kernel::V3D &point) const {
  * @param maxAttempts The maximum number of attempts at generating a point
  * @return The generated point
  */
-boost::optional<Kernel::V3D> MeshObject::generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
-                                                               const size_t maxAttempts) const {
+std::optional<Kernel::V3D> MeshObject::generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
+                                                             const size_t maxAttempts) const {
   const auto &bbox = getBoundingBox();
   if (bbox.isNull()) {
     throw std::runtime_error("Object::generatePointInObject() - Invalid "
@@ -394,9 +394,9 @@ boost::optional<Kernel::V3D> MeshObject::generatePointInObject(Kernel::PseudoRan
  * @param maxAttempts The maximum number of attempts at generating a point
  * @return The generated point
  */
-boost::optional<Kernel::V3D> MeshObject::generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
-                                                               const BoundingBox &activeRegion,
-                                                               const size_t maxAttempts) const {
+std::optional<Kernel::V3D> MeshObject::generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
+                                                             const BoundingBox &activeRegion,
+                                                             const size_t maxAttempts) const {
 
   const auto point = RandomPoint::bounded(*this, rng, activeRegion, maxAttempts);
 

--- a/Framework/Geometry/src/Objects/MeshObject2D.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject2D.cpp
@@ -359,17 +359,17 @@ Try to find a point that lies within (or on) the object
 */
 int MeshObject2D::getPointInObject(Kernel::V3D &point) const { return this->isValid(point) ? 1 : 0; }
 
-boost::optional<Kernel::V3D> MeshObject2D::generatePointInObject(Kernel::PseudoRandomNumberGenerator & /*rng*/,
-                                                                 const size_t /*unused*/) const {
+std::optional<Kernel::V3D> MeshObject2D::generatePointInObject(Kernel::PseudoRandomNumberGenerator & /*rng*/,
+                                                               const size_t /*unused*/) const {
   // How this would work for a finite plane is not clear. Points within the
   // plane can of course be generated, but most implementations of this method
   // use the bounding box
   throw std::runtime_error("Not implemented.");
 }
 
-boost::optional<Kernel::V3D> MeshObject2D::generatePointInObject(Kernel::PseudoRandomNumberGenerator & /*rng*/,
-                                                                 const BoundingBox & /*activeRegion*/,
-                                                                 const size_t /*unused*/) const {
+std::optional<Kernel::V3D> MeshObject2D::generatePointInObject(Kernel::PseudoRandomNumberGenerator & /*rng*/,
+                                                               const BoundingBox & /*activeRegion*/,
+                                                               const size_t /*unused*/) const {
 
   // How this would work for a finite plane is not clear. Points within the
   // plane can of course be generated, but most implementations of this method

--- a/Framework/Geometry/src/RandomPoint.cpp
+++ b/Framework/Geometry/src/RandomPoint.cpp
@@ -129,8 +129,8 @@ Kernel::V3D inSphere(const detail::ShapeInfo &shapeInfo, Kernel::PseudoRandomNum
  * @param maxAttempts maximum number of random numbers to use before giving up
  * @return a point
  */
-boost::optional<Kernel::V3D> inGenericShape(const IObject &object, Kernel::PseudoRandomNumberGenerator &rng,
-                                            size_t maxAttempts) {
+std::optional<Kernel::V3D> inGenericShape(const IObject &object, Kernel::PseudoRandomNumberGenerator &rng,
+                                          size_t maxAttempts) {
   return bounded(object, rng, object.getBoundingBox(), maxAttempts);
 }
 
@@ -142,9 +142,9 @@ boost::optional<Kernel::V3D> inGenericShape(const IObject &object, Kernel::Pseud
  * @param maxAttempts number of attempts to find a suitable point
  * @return a point or none if maxAttempts was exceeded
  */
-boost::optional<Kernel::V3D> bounded(const IObject &object, Kernel::PseudoRandomNumberGenerator &rng,
-                                     const BoundingBox &box, size_t maxAttempts) {
-  boost::optional<Kernel::V3D> point{boost::none};
+std::optional<Kernel::V3D> bounded(const IObject &object, Kernel::PseudoRandomNumberGenerator &rng,
+                                   const BoundingBox &box, size_t maxAttempts) {
+  std::optional<Kernel::V3D> point{std::nullopt};
   if (box.isNull()) {
     throw std::invalid_argument("Invalid bounding box. Cannot generate random point.");
   }

--- a/Framework/Geometry/src/Surfaces/Line.cpp
+++ b/Framework/Geometry/src/Surfaces/Line.cpp
@@ -13,7 +13,7 @@
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/Tolerance.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace {
 Mantid::Kernel::Logger logger("Line");
@@ -122,7 +122,7 @@ cases exist.
   if (ix < 1)
     return 0;
 
-  boost::optional<Kernel::V3D> Ans1;
+  std::optional<Kernel::V3D> Ans1;
   if (SQ.first.imag() == 0.0 && SQ.first.real() >= 0.0) // +ve roots only
   {
     const double lambda = SQ.first.real();

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -675,7 +675,7 @@ public:
     // inside hole
     auto shell = ComponentCreationHelper::createHollowShell(0.5, 1.0);
     constexpr size_t maxAttempts{1};
-    boost::optional<V3D> point = shell->generatePointInObject(rng, maxAttempts);
+    std::optional<V3D> point = shell->generatePointInObject(rng, maxAttempts);
     TS_ASSERT_EQUALS(!point, false);
 
     constexpr double tolerance{1e-10};
@@ -702,7 +702,7 @@ public:
     constexpr double zLength{0.2};
     auto cuboid = ComponentCreationHelper::createCuboid(xLength, yLength, zLength);
     constexpr size_t maxAttempts{0};
-    boost::optional<V3D> point = cuboid->generatePointInObject(rng, maxAttempts);
+    std::optional<V3D> point = cuboid->generatePointInObject(rng, maxAttempts);
     TS_ASSERT_EQUALS(!point, false);
 
     constexpr double tolerance{1e-10};
@@ -734,7 +734,7 @@ public:
     };
     auto cylinder = ComponentCreationHelper::createCappedCylinder(radius, height, bottomCentre, axis, "cyl");
     constexpr size_t maxAttempts{0};
-    boost::optional<V3D> point = cylinder->generatePointInObject(rng, maxAttempts);
+    std::optional<V3D> point = cylinder->generatePointInObject(rng, maxAttempts);
     TS_ASSERT_EQUALS(!point, false);
     // Global->cylinder local coordinates
     *point -= bottomCentre;
@@ -772,7 +772,7 @@ public:
     auto hollowCylinder =
         ComponentCreationHelper::createHollowCylinder(innerRadius, radius, height, bottomCentre, axis, "hol-cyl");
     constexpr size_t maxAttempts{0};
-    boost::optional<V3D> point;
+    std::optional<V3D> point;
     point = hollowCylinder->generatePointInObject(rng, maxAttempts);
     TS_ASSERT_EQUALS(!point, false);
     // Global->cylinder local coordinates
@@ -1279,7 +1279,7 @@ public:
     constexpr double radius{0.23};
     auto sphere = ComponentCreationHelper::createSphere(radius);
     constexpr size_t maxAttempts{0};
-    boost::optional<V3D> point;
+    std::optional<V3D> point;
     point = sphere->generatePointInObject(rng, maxAttempts);
     TS_ASSERT_EQUALS(!point, false);
     // Global->cylinder local coordinates
@@ -1306,7 +1306,7 @@ public:
     // inside hole
     auto shell = ComponentCreationHelper::createHollowShell(0.5, 1.0);
     constexpr size_t maxAttempts{1};
-    boost::optional<V3D> point = shell->generatePointInObject(rng, maxAttempts);
+    std::optional<V3D> point = shell->generatePointInObject(rng, maxAttempts);
     TS_ASSERT_EQUALS(!point, true);
   }
 
@@ -1328,7 +1328,7 @@ public:
     // Create a thin infinite rectangular region to restrict point generation
     BoundingBox activeRegion(0.1, 0.1, 0.1, -0.1, -0.1, -0.1);
     constexpr size_t maxAttempts{1};
-    boost::optional<V3D> point = cuboid->generatePointInObject(rng, activeRegion, maxAttempts);
+    std::optional<V3D> point = cuboid->generatePointInObject(rng, activeRegion, maxAttempts);
     TS_ASSERT_EQUALS(!point, false);
     constexpr double tolerance{1e-10};
     TS_ASSERT_DELTA(-0.1 + randX * 0.2, point->X(), tolerance)
@@ -1356,7 +1356,7 @@ public:
     // Create a rectangular region to restrict point generation
     BoundingBox activeRegion(0.1, 0.1, 0.1, -0.1, -0.1, -0.1);
     constexpr size_t maxAttempts{1};
-    boost::optional<V3D> point = cuboid->generatePointInObject(rng, activeRegion, maxAttempts);
+    std::optional<V3D> point = cuboid->generatePointInObject(rng, activeRegion, maxAttempts);
     TS_ASSERT_EQUALS(!point, true);
   }
 

--- a/Framework/Geometry/test/MeshObject2DTest.h
+++ b/Framework/Geometry/test/MeshObject2DTest.h
@@ -306,7 +306,7 @@ public:
     // plane
     auto mesh = makeSimpleTriangleMesh();
     testing::NiceMock<MockRNG> generator;
-    boost::optional<V3D> point;
+    std::optional<V3D> point;
     TS_ASSERT_THROWS(point = mesh.generatePointInObject(generator, 10), std::runtime_error &);
   }
   // Characterisation test.
@@ -317,7 +317,7 @@ public:
     auto mesh = makeSimpleTriangleMesh();
     testing::NiceMock<MockRNG> generator;
     Mantid::Geometry::BoundingBox boundingBox;
-    boost::optional<V3D> point;
+    std::optional<V3D> point;
     TS_ASSERT_THROWS(point = mesh.generatePointInObject(generator, boundingBox, 10), std::runtime_error &);
   }
 

--- a/Framework/Geometry/test/MeshObjectTest.h
+++ b/Framework/Geometry/test/MeshObjectTest.h
@@ -17,7 +17,7 @@
 #include "MantidKernel/MersenneTwister.h"
 #include "MockRNG.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <cxxtest/TestSuite.h>
 
@@ -781,7 +781,7 @@ public:
     //  Random sequence set up so as to give point (0.90, 1.10, 0.65)
     auto geom_obj = createLShape();
     size_t maxAttempts(1);
-    boost::optional<Kernel::V3D> point;
+    std::optional<Kernel::V3D> point;
     TS_ASSERT_THROWS_NOTHING(point = geom_obj->generatePointInObject(rng, maxAttempts));
 
     const double tolerance(1e-10);
@@ -804,7 +804,7 @@ public:
     //  which is outside the octahedron
     auto geom_obj = createOctahedron();
     size_t maxAttempts(1);
-    boost::optional<V3D> point;
+    std::optional<V3D> point;
     point = geom_obj->generatePointInObject(rng, maxAttempts);
     TS_ASSERT_EQUALS(!point, true);
   }
@@ -998,7 +998,7 @@ public:
   void test_generatePointInside_Convex_Solid() {
     const size_t npoints(6000);
     const size_t maxAttempts(500);
-    boost::optional<V3D> point;
+    std::optional<V3D> point;
     for (size_t i = 0; i < npoints; ++i) {
       point = octahedron->generatePointInObject(rng, maxAttempts);
     }
@@ -1007,7 +1007,7 @@ public:
   void test_generatePointInside_NonConvex_Solid() {
     const size_t npoints(6000);
     const size_t maxAttempts(500);
-    boost::optional<V3D> point;
+    std::optional<V3D> point;
     for (size_t i = 0; i < npoints; ++i) {
       point = lShape->generatePointInObject(rng, maxAttempts);
     }

--- a/Framework/Geometry/test/MockObjects.h
+++ b/Framework/Geometry/test/MockObjects.h
@@ -85,9 +85,8 @@ public:
   MOCK_METHOD1(setSamplePos, void(const Mantid::Kernel::V3D &XYZ));
   MOCK_CONST_METHOD0(getQLabFrame, Mantid::Kernel::V3D());
   MOCK_CONST_METHOD0(getQSampleFrame, Mantid::Kernel::V3D());
-  MOCK_METHOD2(setQSampleFrame,
-               void(const Mantid::Kernel::V3D &QSampleFrame, boost::optional<double> detectorDistance));
-  MOCK_METHOD2(setQLabFrame, void(const Mantid::Kernel::V3D &QLabFrame, boost::optional<double> detectorDistance));
+  MOCK_METHOD2(setQSampleFrame, void(const Mantid::Kernel::V3D &QSampleFrame, std::optional<double> detectorDistance));
+  MOCK_METHOD2(setQLabFrame, void(const Mantid::Kernel::V3D &QLabFrame, std::optional<double> detectorDistance));
   MOCK_METHOD1(setWavelength, void(double wavelength));
   MOCK_CONST_METHOD0(getWavelength, double());
   MOCK_CONST_METHOD0(getScattering, double());

--- a/Framework/Geometry/test/PeakTransformHKLTest.h
+++ b/Framework/Geometry/test/PeakTransformHKLTest.h
@@ -18,7 +18,7 @@ using namespace testing;
 namespace boost {
 template <class CharType, class CharTrait>
 std::basic_ostream<CharType, CharTrait> &operator<<(std::basic_ostream<CharType, CharTrait> &out,
-                                                    optional<double> const &maybe) {
+                                                    std::optional<double> const &maybe) {
   if (maybe)
     out << maybe;
   return out;

--- a/Framework/Geometry/test/PeakTransformQLabTest.h
+++ b/Framework/Geometry/test/PeakTransformQLabTest.h
@@ -19,7 +19,7 @@ using namespace testing;
 namespace boost {
 template <class CharType, class CharTrait>
 std::basic_ostream<CharType, CharTrait> &operator<<(std::basic_ostream<CharType, CharTrait> &out,
-                                                    optional<double> const &maybe) {
+                                                    std::optional<double> const &maybe) {
   if (maybe)
     out << maybe;
   return out;

--- a/Framework/Geometry/test/PeakTransformQSampleTest.h
+++ b/Framework/Geometry/test/PeakTransformQSampleTest.h
@@ -19,7 +19,7 @@ using namespace testing;
 namespace boost {
 template <class CharType, class CharTrait>
 std::basic_ostream<CharType, CharTrait> &operator<<(std::basic_ostream<CharType, CharTrait> &out,
-                                                    optional<double> const &maybe) {
+                                                    std::optional<double> const &maybe) {
   if (maybe)
     out << maybe;
   return out;

--- a/Framework/Kernel/inc/MantidKernel/Chainable.h
+++ b/Framework/Kernel/inc/MantidKernel/Chainable.h
@@ -31,7 +31,7 @@ along the chain top to bottom.
 template <typename ChainableType> class DLLExport Chainable {
 protected:
   /// Successor factory
-  /// boost::optional<std::unique_ptr<ChainableType>> m_successor;
+  /// std::optional<std::unique_ptr<ChainableType>> m_successor;
   std::unique_ptr<ChainableType> m_successor;
   /// Provide option for derived classes to check successor and throw if bad
   virtual void checkSuccessor() const {}

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -12,7 +12,7 @@
 #include "MantidKernel/DllConfig.h"
 #include "MantidKernel/ProxyInfo.h"
 #include "MantidKernel/SingletonHolder.h"
-#include <boost/optional/optional.hpp>
+#include <optional>
 
 #include <map>
 #include <set>
@@ -125,7 +125,7 @@ public:
   /// Sets a configuration property
   void setString(const std::string &key, const std::string &value);
   // Searches for a configuration property and returns its value
-  template <typename T> boost::optional<T> getValue(const std::string &keyName);
+  template <typename T> std::optional<T> getValue(const std::string &keyName);
   /// Return the local properties filename.
   std::string getLocalFilename() const;
   /// Return the user properties filename

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -474,7 +474,7 @@ public:
 
   static bool showingHiddenObjects() {
     auto showingHiddenFlag = ConfigService::Instance().getValue<bool>("MantidOptions.InvisibleWorkspaces");
-    return showingHiddenFlag.get_value_or(false);
+    return showingHiddenFlag.value_or(false);
   }
 
   /// Sends notifications to observers. Observers can subscribe to

--- a/Framework/Kernel/inc/MantidKernel/ISaveable.h
+++ b/Framework/Kernel/inc/MantidKernel/ISaveable.h
@@ -10,7 +10,7 @@
 #include <list>
 #include <mutex>
 #ifndef Q_MOC_RUN
-#include <boost/optional.hpp>
+#include <optional>
 #endif
 
 namespace Mantid {
@@ -137,7 +137,7 @@ protected:
 private:
   // the iterator which describes the position of this object in the DiskBuffer.
   // Undefined if not placed to buffer
-  boost::optional<std::list<ISaveable *>::iterator> m_BufPosition;
+  std::optional<std::list<ISaveable *>::iterator> m_BufPosition;
   // the size of the object in the memory buffer, used to calculate the total
   // amount of memory the objects occupy
   size_t m_BufMemorySize;
@@ -159,7 +159,7 @@ private:
   size_t setBufferPosition(std::list<ISaveable *>::iterator bufPosition);
   /// returns the iterator pointing to the position of this object within the
   /// memory to-write buffer
-  boost::optional<std::list<ISaveable *>::iterator> &getBufPostion() { return m_BufPosition; }
+  std::optional<std::list<ISaveable *>::iterator> &getBufPostion() { return m_BufPosition; }
   /// return the amount of memory, this object had when it was stored in buffer
   /// last time;
   size_t getBufferSize() const { return m_BufMemorySize; }

--- a/Framework/Kernel/inc/MantidKernel/Material.h
+++ b/Framework/Kernel/inc/MantidKernel/Material.h
@@ -12,8 +12,8 @@
 #include "MantidKernel/AttenuationProfile.h"
 #include "MantidKernel/NeutronAtom.h"
 #include "MantidKernel/PhysicalConstants.h"
-#include <boost/optional/optional.hpp>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -196,8 +196,8 @@ private:
   double m_linearAbsorpXSectionByWL;
   double m_totalScatterXSection;
 
-  boost::optional<AttenuationProfile> m_attenuationOverride;
-  boost::optional<AttenuationProfile> m_xRayAttenuationProfile;
+  std::optional<AttenuationProfile> m_attenuationOverride;
+  std::optional<AttenuationProfile> m_xRayAttenuationProfile;
 };
 
 /// Typedef for a shared pointer

--- a/Framework/Kernel/inc/MantidKernel/MaterialBuilder.h
+++ b/Framework/Kernel/inc/MantidKernel/MaterialBuilder.h
@@ -8,7 +8,7 @@
 
 #include "MantidKernel/DllConfig.h"
 #include "MantidKernel/Material.h"
-#include <boost/optional/optional.hpp>
+#include <optional>
 
 namespace Mantid {
 // Forward declare
@@ -70,15 +70,15 @@ private:
 
   std::string m_name;
   Material::ChemicalFormula m_formula;
-  boost::optional<int> m_atomicNo;
+  std::optional<int> m_atomicNo;
   int m_massNo;
-  boost::optional<double> m_numberDensity, m_packingFraction;
-  boost::optional<double> m_numberDensityEff;
-  boost::optional<double> m_zParam, m_cellVol, m_massDensity;
-  boost::optional<double> m_totalXSection, m_cohXSection, m_incXSection, m_absSection;
+  std::optional<double> m_numberDensity, m_packingFraction;
+  std::optional<double> m_numberDensityEff;
+  std::optional<double> m_zParam, m_cellVol, m_massDensity;
+  std::optional<double> m_totalXSection, m_cohXSection, m_incXSection, m_absSection;
   NumberDensityUnit m_numberDensityUnit;
-  boost::optional<std::string> m_attenuationProfileFileName;
-  boost::optional<std::string> m_xRayAttenuationProfileFileName;
+  std::optional<std::string> m_attenuationProfileFileName;
+  std::optional<std::string> m_xRayAttenuationProfileFileName;
   std::string m_attenuationFileSearchPath;
 };
 

--- a/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
+++ b/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
@@ -201,8 +201,8 @@ template <typename T, typename BinaryOp> void AtomicOp(std::atomic<T> &f, T d, B
 
 inline void setMaxCoresToConfig() {
   const auto maxCores = Mantid::Kernel::ConfigService::Instance().getValue<int>("MultiThreaded.MaxCores");
-  if (maxCores.get_value_or(0) > 0) {
-    PARALLEL_SET_NUM_THREADS(maxCores.get());
+  if (maxCores.value_or(0) > 0) {
+    PARALLEL_SET_NUM_THREADS(maxCores.value());
   }
 }
 

--- a/Framework/Kernel/inc/MantidKernel/UserCatalogInfo.h
+++ b/Framework/Kernel/inc/MantidKernel/UserCatalogInfo.h
@@ -8,13 +8,13 @@
 
 #include "MantidKernel/DllConfig.h"
 #include "MantidKernel/ICatalogInfo.h"
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 namespace Mantid {
 namespace Kernel {
 
-using OptionalPath = boost::optional<std::string>;
+using OptionalPath = std::optional<std::string>;
 
 class CatalogConfigService {
 public:
@@ -36,7 +36,7 @@ CatalogConfigService *makeCatalogConfigServiceAdapter(const T &adaptee,
       auto const mountPoint = m_adaptee.getString(m_key);
       if (!mountPoint.empty())
         return OptionalPath(mountPoint);
-      return OptionalPath(boost::none);
+      return OptionalPath(std::nullopt);
     }
   };
   return new Adapter(adaptee, key);

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -50,7 +50,7 @@
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/trim.hpp>
-#include <boost/optional/optional.hpp>
+#include <optional>
 
 #include <algorithm>
 #include <cctype>
@@ -937,16 +937,16 @@ void ConfigServiceImpl::setString(const std::string &key, const std::string &val
  *value of.
  *  @returns An optional container with the value if found
  */
-template <typename T> boost::optional<T> ConfigServiceImpl::getValue(const std::string &keyName) {
+template <typename T> std::optional<T> ConfigServiceImpl::getValue(const std::string &keyName) {
   std::string strValue = getString(keyName);
   T output;
   int result = Mantid::Kernel::Strings::convert(strValue, output);
 
   if (result != 1) {
-    return boost::none;
+    return std::nullopt;
   }
 
-  return boost::optional<T>(output);
+  return std::optional<T>(output);
 }
 
 /** Searches for a string within the currently loaded configuration values and
@@ -956,13 +956,13 @@ template <typename T> boost::optional<T> ConfigServiceImpl::getValue(const std::
  *value of.
  *  @returns An optional container with the value if found
  */
-template <> boost::optional<bool> ConfigServiceImpl::getValue(const std::string &keyName) {
+template <> std::optional<bool> ConfigServiceImpl::getValue(const std::string &keyName) {
   auto returnedValue = getValue<std::string>(keyName);
-  if (!returnedValue.is_initialized()) {
-    return boost::none;
+  if (!returnedValue.has_value()) {
+    return std::nullopt;
   }
 
-  auto &configVal = returnedValue.get();
+  auto &configVal = returnedValue.value();
 
   std::transform(configVal.begin(), configVal.end(), configVal.begin(), ::tolower);
 
@@ -1840,9 +1840,9 @@ Kernel::ProxyInfo &ConfigServiceImpl::getProxy(const std::string &url) {
     auto proxyHost = getValue<std::string>("proxy.host");
     auto proxyPort = getValue<int>("proxy.port");
 
-    if (proxyHost.is_initialized() && proxyPort.is_initialized()) {
+    if (proxyHost.has_value() && proxyPort.has_value()) {
       // set it from the config values
-      m_proxyInfo = ProxyInfo(proxyHost.get(), proxyPort.get(), true);
+      m_proxyInfo = ProxyInfo(proxyHost.value(), proxyPort.value(), true);
     } else {
       // get the system proxy
       Poco::URI uri(url);
@@ -1934,12 +1934,12 @@ void ConfigServiceImpl::setLogLevel(std::string const &logLevel, bool quiet) {
 std::string ConfigServiceImpl::getLogLevel() { return g_log.getLevelName(); }
 
 /// \cond TEMPLATE
-template DLLExport boost::optional<double> ConfigServiceImpl::getValue(const std::string &);
-template DLLExport boost::optional<std::string> ConfigServiceImpl::getValue(const std::string &);
-template DLLExport boost::optional<int> ConfigServiceImpl::getValue(const std::string &);
-template DLLExport boost::optional<size_t> ConfigServiceImpl::getValue(const std::string &);
+template DLLExport std::optional<double> ConfigServiceImpl::getValue(const std::string &);
+template DLLExport std::optional<std::string> ConfigServiceImpl::getValue(const std::string &);
+template DLLExport std::optional<int> ConfigServiceImpl::getValue(const std::string &);
+template DLLExport std::optional<size_t> ConfigServiceImpl::getValue(const std::string &);
 #ifdef _MSC_VER
-template DLLExport boost::optional<bool> ConfigServiceImpl::getValue(const std::string &);
+template DLLExport std::optional<bool> ConfigServiceImpl::getValue(const std::string &);
 #endif
 
 /// \endcond TEMPLATE

--- a/Framework/Kernel/src/ErrorReporter.cpp
+++ b/Framework/Kernel/src/ErrorReporter.cpp
@@ -49,10 +49,10 @@ ErrorReporter::ErrorReporter(std::string application, Types::Core::time_duration
       m_share(share), m_name(std::move(name)), m_email(std::move(email)), m_textbox(std::move(textBox)),
       m_stacktrace(std::move(traceback)) {
   auto url = Mantid::Kernel::ConfigService::Instance().getValue<std::string>("errorreports.rooturl");
-  if (!url.is_initialized()) {
+  if (!url.has_value()) {
     g_log.debug() << "Failed to load error report url\n";
   } else {
-    m_url = url.get();
+    m_url = url.value();
   }
 }
 

--- a/Framework/Kernel/src/ISaveable.cpp
+++ b/Framework/Kernel/src/ISaveable.cpp
@@ -68,7 +68,7 @@ void ISaveable::saveAt(uint64_t newPos, uint64_t newSize) {
  */
 size_t ISaveable::setBufferPosition(std::list<ISaveable *>::iterator bufPosition) {
   std::lock_guard<std::mutex> lock(m_setter);
-  m_BufPosition = boost::optional<std::list<ISaveable *>::iterator>(bufPosition);
+  m_BufPosition = std::optional<std::list<ISaveable *>::iterator>(bufPosition);
   m_BufMemorySize = this->getDataMemorySize();
 
   return m_BufMemorySize;
@@ -80,7 +80,7 @@ void ISaveable::clearBufferState() {
   std::lock_guard<std::mutex> lock(m_setter);
 
   m_BufMemorySize = 0;
-  m_BufPosition = boost::optional<std::list<ISaveable *>::iterator>();
+  m_BufPosition = std::optional<std::list<ISaveable *>::iterator>();
 }
 
 } // namespace Mantid::Kernel

--- a/Framework/Kernel/src/InternetHelper.cpp
+++ b/Framework/Kernel/src/InternetHelper.cpp
@@ -441,7 +441,7 @@ void InternetHelper::throwNotConnected(const std::string &url, const HostNotFoun
 int InternetHelper::getTimeout() {
   if (!m_isTimeoutSet) {
     const auto timeout = ConfigService::Instance().getValue<int>("network.default.timeout");
-    m_timeout = timeout.is_initialized() ? timeout.get() : 30;
+    m_timeout = timeout.value_or(30);
   }
   return m_timeout;
 }

--- a/Framework/Kernel/src/MultiFileNameParser.cpp
+++ b/Framework/Kernel/src/MultiFileNameParser.cpp
@@ -535,7 +535,7 @@ std::vector<std::vector<unsigned int>> generateRange(unsigned int const from, un
 
   size_t limit;
   auto limitStr = ConfigService::Instance().getValue<std::string>("loading.multifilelimit");
-  if (!limitStr.is_initialized() || !Strings::convert(limitStr.get(), limit)) {
+  if (!limitStr.has_value() || !Strings::convert(limitStr.value(), limit)) {
     limit = ConfigService::Instance().getFacility().multiFileLimit();
   }
 

--- a/Framework/Kernel/src/ThreadPool.cpp
+++ b/Framework/Kernel/src/ThreadPool.cpp
@@ -74,8 +74,8 @@ size_t ThreadPool::getNumPhysicalCores() {
 
   auto maxCores = Kernel::ConfigService::Instance().getValue<int>("MultiThreaded.MaxCores");
 
-  if (!maxCores.is_initialized())
-    return std::min(maxCores.get_value_or(0), physicalCores);
+  if (!maxCores.has_value())
+    return std::min(maxCores.value_or(0), physicalCores);
   else
     return physicalCores;
 }

--- a/Framework/Kernel/src/UsageService.cpp
+++ b/Framework/Kernel/src/UsageService.cpp
@@ -93,10 +93,10 @@ UsageServiceImpl::UsageServiceImpl()
       m_featureActiveMethod(this, &UsageServiceImpl::sendFeatureAsyncImpl) {
   setInterval(60);
   auto url = Mantid::Kernel::ConfigService::Instance().getValue<std::string>("usagereports.rooturl");
-  if (!url.is_initialized()) {
+  if (!url.has_value()) {
     g_log.debug() << "Failed to load usage report url\n";
   } else {
-    m_url = url.get();
+    m_url = url.value();
     g_log.debug() << "Root usage reporting url is " << m_url << "\n";
   };
 }

--- a/Framework/Kernel/src/UserCatalogInfo.cpp
+++ b/Framework/Kernel/src/UserCatalogInfo.cpp
@@ -24,21 +24,21 @@ const std::string UserCatalogInfo::catalogPrefix() const { return m_catInfo->cat
 
 const std::string UserCatalogInfo::windowsPrefix() const {
   if (m_mountPoint) {
-    return m_mountPoint.get();
+    return m_mountPoint.value();
   }
   return m_catInfo->windowsPrefix();
 }
 
 const std::string UserCatalogInfo::macPrefix() const {
   if (m_mountPoint) {
-    return m_mountPoint.get();
+    return m_mountPoint.value();
   }
   return m_catInfo->macPrefix();
 }
 
 const std::string UserCatalogInfo::linuxPrefix() const {
   if (m_mountPoint) {
-    return m_mountPoint.get();
+    return m_mountPoint.value();
   }
   return m_catInfo->linuxPrefix();
 }

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -288,8 +288,8 @@ public:
 
   void testCustomPropertyAsValue() {
     // Mantid.legs is defined in the properties script as 6
-    int value = ConfigService::Instance().getValue<int>("projectRecovery.secondsBetween").get_value_or(0);
-    double dblValue = ConfigService::Instance().getValue<double>("projectRecovery.secondsBetween").get_value_or(0);
+    int value = ConfigService::Instance().getValue<int>("projectRecovery.secondsBetween").value_or(0);
+    double dblValue = ConfigService::Instance().getValue<double>("projectRecovery.secondsBetween").value_or(0);
 
     TS_ASSERT_EQUALS(value, 60);
     TS_ASSERT_EQUALS(dblValue, 60.0);

--- a/Framework/Kernel/test/UserCatalogInfoTest.h
+++ b/Framework/Kernel/test/UserCatalogInfoTest.h
@@ -17,7 +17,7 @@ using namespace testing;
 namespace boost {
 template <class CharType, class CharTrait>
 std::basic_ostream<CharType, CharTrait> &operator<<(std::basic_ostream<CharType, CharTrait> &out,
-                                                    optional<std::string> const &maybe) {
+                                                    std::optional<std::string> const &maybe) {
   if (maybe)
     out << maybe;
   return out;
@@ -177,7 +177,7 @@ public:
     CatalogConfigService *service = makeCatalogConfigServiceAdapter(usertype, std::string("my_key"));
     OptionalPath mountPoint = service->preferredMountPoint();
     TS_ASSERT(mountPoint);
-    TS_ASSERT_EQUALS("my_value", mountPoint.get());
+    TS_ASSERT_EQUALS("my_value", mountPoint.value());
     delete service;
   }
 };

--- a/Framework/LiveData/src/FakeEventDataListener.cpp
+++ b/Framework/LiveData/src/FakeEventDataListener.cpp
@@ -27,14 +27,14 @@ FakeEventDataListener::FakeEventDataListener()
       m_numExtractDataCalls(0), m_runNumber(1) {
 
   auto datarateConfigVal = ConfigService::Instance().getValue<int>("fakeeventdatalistener.datarate");
-  m_datarate = datarateConfigVal.get_value_or(200); // Default data rate. Low so that our lowest-powered
-                                                    // buildserver can cope.
-                                                    // For auto-ending and restarting runs
+  m_datarate = datarateConfigVal.value_or(200); // Default data rate. Low so that our lowest-powered
+                                                // buildserver can cope.
+                                                // For auto-ending and restarting runs
   auto endRunEveryConfigVal = ConfigService::Instance().getValue<int>("fakeeventdatalistener.endrunevery");
-  m_endRunEvery = endRunEveryConfigVal.get_value_or(0);
+  m_endRunEvery = endRunEveryConfigVal.value_or(0);
 
   auto notyettimesConfigVal = ConfigService::Instance().getValue<int>("fakeeventdatalistener.notyettimes");
-  m_notyettimes = notyettimesConfigVal.get_value_or(0);
+  m_notyettimes = notyettimesConfigVal.value_or(0);
 }
 
 /// Destructor

--- a/Framework/LiveData/src/FileEventDataListener.cpp
+++ b/Framework/LiveData/src/FileEventDataListener.cpp
@@ -58,8 +58,8 @@ FileEventDataListener::FileEventDataListener()
   }
 
   auto numChunks = ConfigService::Instance().getValue<int>("fileeventdatalistener.chunks");
-  m_numChunks = numChunks.get_value_or(0);
-  if (!numChunks.is_initialized()) {
+  m_numChunks = numChunks.value_or(0);
+  if (!numChunks.has_value()) {
     g_log.error("Configuration property fileeventdatalistener.chunks not "
                 "found. The algorithm will fail!");
   }

--- a/Framework/LiveData/src/ISIS/DAE/isisds_command.cpp
+++ b/Framework/LiveData/src/ISIS/DAE/isisds_command.cpp
@@ -156,7 +156,7 @@ SOCKET isisds_send_open(const char *host, ISISDSAccessMode access_type, uint16_t
   }
 
   auto timeoutInSecConfigVal = Mantid::Kernel::ConfigService::Instance().getValue<int>("ISISDAE.Timeout");
-  int timeoutinSec = timeoutInSecConfigVal.get_value_or(120); // Default to  120 seconds if not specified
+  int timeoutinSec = timeoutInSecConfigVal.value_or(120); // Default to  120 seconds if not specified
 
 #ifdef WIN32
   // WINDOWS

--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -96,7 +96,7 @@ SNSLiveEventDataListener::SNSLiveEventDataListener()
   auto keepPausedEvents = ConfigService::Instance().getValue<bool>("livelistener.keeppausedevents");
 
   // If the property hasn't been set, assume false
-  m_keepPausedEvents = keepPausedEvents.get_value_or(false);
+  m_keepPausedEvents = keepPausedEvents.value_or(false);
 }
 
 /// Destructor

--- a/Framework/LiveData/test/TestDataListener.cpp
+++ b/Framework/LiveData/test/TestDataListener.cpp
@@ -33,9 +33,9 @@ TestDataListener::TestDataListener()
 
   m_dataReset = false;
   m_timesCalled = 0;
-  m_resetAfter = ConfigService::Instance().getValue<int>("testdatalistener.reset_after").get_value_or(0);
-  m_changeStatusAfter = ConfigService::Instance().getValue<int>("testdatalistener.m_changeStatusAfter").get_value_or(0);
-  int temp = ConfigService::Instance().getValue<int>("testdatalistener.m_newStatus").get_value_or(0);
+  m_resetAfter = ConfigService::Instance().getValue<int>("testdatalistener.reset_after").value_or(0);
+  m_changeStatusAfter = ConfigService::Instance().getValue<int>("testdatalistener.m_changeStatusAfter").value_or(0);
+  int temp = ConfigService::Instance().getValue<int>("testdatalistener.m_newStatus").value_or(0);
 
   switch (temp) {
   case 0:

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
@@ -14,8 +14,8 @@
 #include "MantidKernel/NexusDescriptor.h"
 #include "MantidMDAlgorithms/DllConfig.h"
 
-#include <boost/optional.hpp>
 #include <boost/scoped_ptr.hpp>
+#include <optional>
 
 namespace Mantid {
 namespace MDAlgorithms {
@@ -69,7 +69,7 @@ private:
 
   void loadQConvention();
 
-  void loadVisualNormalization(const std::string &key, boost::optional<Mantid::API::MDNormalization> &normalization);
+  void loadVisualNormalization(const std::string &key, std::optional<Mantid::API::MDNormalization> &normalization);
 
   /// Load all the affine matricies
   void loadAffineMatricies(const API::IMDWorkspace_sptr &ws);
@@ -109,8 +109,8 @@ private:
   int m_saveMDVersion;
 
   /// Visual normalization
-  boost::optional<Mantid::API::MDNormalization> m_visualNormalization;
-  boost::optional<Mantid::API::MDNormalization> m_visualNormalizationHisto;
+  std::optional<Mantid::API::MDNormalization> m_visualNormalization;
+  std::optional<Mantid::API::MDNormalization> m_visualNormalizationHisto;
 
   /// Named entry
   static const std::string VISUAL_NORMALIZATION_KEY;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/SmoothMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/SmoothMD.h
@@ -8,8 +8,8 @@
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidMDAlgorithms/DllConfig.h"
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 namespace Mantid {
 namespace API {

--- a/Framework/MDAlgorithms/src/IntegratePeaksMDHKL.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMDHKL.cpp
@@ -85,7 +85,7 @@ void IntegratePeaksMDHKL::init() {
 void IntegratePeaksMDHKL::exec() {
   IMDWorkspace_sptr m_inputWS = getProperty("InputWorkspace");
   Mantid::DataObjects::MDFramesToSpecialCoordinateSystem converter;
-  boost::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem = converter(m_inputWS.get());
+  std::optional<Mantid::Kernel::SpecialCoordinateSystem> coordinateSystem = converter(m_inputWS.get());
   if (*coordinateSystem != Mantid::Kernel::SpecialCoordinateSystem::HKL) {
     std::stringstream errmsg;
     errmsg << "Input MDWorkspace's coordinate system is not HKL.";

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -198,8 +198,8 @@ void LoadMD::execLoader() {
     // Use the factory to make the workspace of the right type
     IMDEventWorkspace_sptr ws;
     if (m_visualNormalizationHisto && m_visualNormalization) {
-      ws = MDEventFactory::CreateMDWorkspace(m_numDims, eventType, m_visualNormalization.get(),
-                                             m_visualNormalizationHisto.get());
+      ws = MDEventFactory::CreateMDWorkspace(m_numDims, eventType, m_visualNormalization.value(),
+                                             m_visualNormalizationHisto.value());
     } else {
       ws = MDEventFactory::CreateMDWorkspace(m_numDims, eventType);
     }
@@ -285,7 +285,7 @@ void LoadMD::loadHisto() {
   MDHistoWorkspace_sptr ws;
   // If display normalization has been provided. Use that.
   if (m_visualNormalization) {
-    ws = std::make_shared<MDHistoWorkspace>(m_dims, m_visualNormalization.get());
+    ws = std::make_shared<MDHistoWorkspace>(m_dims, m_visualNormalization.value());
   } else {
     ws = std::make_shared<MDHistoWorkspace>(m_dims); // Whatever MDHistoWorkspace defaults to.
   }
@@ -406,7 +406,7 @@ void LoadMD::loadDimensions2() {
 }
 
 void LoadMD::loadVisualNormalization(const std::string &key,
-                                     boost::optional<Mantid::API::MDNormalization> &normalization) {
+                                     std::optional<Mantid::API::MDNormalization> &normalization) {
   try {
     uint32_t readVisualNormalization(0);
     m_file->readData(key, readVisualNormalization);

--- a/Framework/MDAlgorithms/src/SmoothMD.cpp
+++ b/Framework/MDAlgorithms/src/SmoothMD.cpp
@@ -41,7 +41,7 @@ using WidthVector = std::vector<double>;
 using KernelVector = std::vector<double>;
 
 // Typedef for an optional md histo workspace
-using OptionalIMDHistoWorkspace_const_sptr = boost::optional<IMDHistoWorkspace_const_sptr>;
+using OptionalIMDHistoWorkspace_const_sptr = std::optional<IMDHistoWorkspace_const_sptr>;
 
 // Typedef for a smoothing function
 using SmoothFunction =

--- a/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
@@ -1133,8 +1133,8 @@ public:
         dynamic_cast<PeakShapeSpherical *>(const_cast<PeakShape *>(&shape));
     TS_ASSERT(sphericalShape);
     TS_ASSERT_EQUALS(peakRadius, sphericalShape->radius());
-    TS_ASSERT_EQUALS(backgroundOuterRadius, sphericalShape->backgroundOuterRadius().get());
-    TS_ASSERT_EQUALS(backgroundInnerRadius, sphericalShape->backgroundInnerRadius().get());
+    TS_ASSERT_EQUALS(backgroundOuterRadius, sphericalShape->backgroundOuterRadius().value());
+    TS_ASSERT_EQUALS(backgroundInnerRadius, sphericalShape->backgroundInnerRadius().value());
   }
 
   void test_writes_out_peak_shape() {
@@ -1159,8 +1159,8 @@ public:
 
     // Check the shape is what we expect
     TS_ASSERT_EQUALS(peakRadius, sphericalShape->radius());
-    TS_ASSERT_EQUALS(backgroundOuterRadius, sphericalShape->backgroundOuterRadius().get());
-    TS_ASSERT_EQUALS(backgroundInnerRadius, sphericalShape->backgroundInnerRadius().get());
+    TS_ASSERT_EQUALS(backgroundOuterRadius, sphericalShape->backgroundOuterRadius().value());
+    TS_ASSERT_EQUALS(backgroundInnerRadius, sphericalShape->backgroundInnerRadius().value());
   }
 
   void test_exec_EllipsoidRadii_with_LeanElasticPeaks() {

--- a/Framework/MDAlgorithms/test/IntegratePeaksMDTest.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMDTest.h
@@ -373,8 +373,8 @@ public:
 
     // Check the shape is what we expect
     TS_ASSERT_EQUALS(peakRadius, sphericalShape->radius());
-    TS_ASSERT_EQUALS(backgroundOuterRadius, sphericalShape->backgroundOuterRadius().get());
-    TS_ASSERT_EQUALS(backgroundInnerRadius, sphericalShape->backgroundInnerRadius().get());
+    TS_ASSERT_EQUALS(backgroundOuterRadius, sphericalShape->backgroundOuterRadius().value());
+    TS_ASSERT_EQUALS(backgroundInnerRadius, sphericalShape->backgroundInnerRadius().value());
   }
 };
 

--- a/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
@@ -17,10 +17,10 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/scoped_array.hpp>
 
-#include <boost/optional.hpp>
 #include <climits>
 #include <memory>
 #include <nexus/NeXusFile.hpp>
+#include <optional>
 
 namespace Mantid {
 namespace NeXus {
@@ -39,7 +39,7 @@ class MANTID_NEXUS_DLL NexusFileIO {
 
 public:
   // Helper typedef
-  using optional_size_t = boost::optional<size_t>;
+  using optional_size_t = std::optional<size_t>;
 
   /// Default constructor
   NexusFileIO();

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -132,9 +132,9 @@ void NexusFileIO::openNexusWrite(const std::string &fileName, NexusFileIO::optio
   //
   if (mode == NXACC_RDWR) {
     size_t count = 0;
-    if (entryNumber.is_initialized()) {
+    if (entryNumber.has_value()) {
       // Use the entry number provided.
-      count = entryNumber.get();
+      count = entryNumber.value();
     } else {
       // Have to figure it our ourselves. Requires opening the exisitng file to
       // get the information via a search.

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometryUtilities.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometryUtilities.h
@@ -8,7 +8,7 @@
 
 #include "MantidNexusGeometry/DllConfig.h"
 #include <H5Cpp.h>
-#include <boost/optional.hpp>
+#include <optional>
 #include <vector>
 
 namespace Mantid {
@@ -24,15 +24,15 @@ template <typename T, typename R> std::vector<R> convertVector(const std::vector
   return target;
 }
 
-boost::optional<H5::DataSet> findDataset(const H5::Group &parentGroup, const H5std_string &name);
+std::optional<H5::DataSet> findDataset(const H5::Group &parentGroup, const H5std_string &name);
 
-boost::optional<H5::Group> findGroup(const H5::Group &parentGroup, const H5std_string &classType);
+std::optional<H5::Group> findGroup(const H5::Group &parentGroup, const H5std_string &classType);
 
 H5::Group findGroupOrThrow(const H5::Group &parentGroup, const H5std_string &classType);
 
 std::vector<H5::Group> findGroups(const H5::Group &parentGroup, const H5std_string &classType);
 
-boost::optional<H5::Group> findGroupByName(const H5::Group &parentGroup, const H5std_string &name);
+std::optional<H5::Group> findGroupByName(const H5::Group &parentGroup, const H5std_string &name);
 bool hasNXAttribute(const H5::Group &group, const std::string &attributeValue);
 bool isNamed(const H5::H5Object &obj, const std::string &name);
 } // namespace utilities

--- a/Framework/NexusGeometry/src/NexusGeometryUtilities.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometryUtilities.cpp
@@ -13,7 +13,7 @@ using namespace H5;
 
 /// Find a single dataset inside parent group (returns first match). Optional
 /// wrapped - empty to indicate nothing found.
-boost::optional<H5::DataSet> findDataset(const H5::Group &parentGroup, const H5std_string &name) {
+std::optional<H5::DataSet> findDataset(const H5::Group &parentGroup, const H5std_string &name) {
   // Iterate over children, and determine if a group
   for (hsize_t i = 0; i < parentGroup.getNumObjs(); ++i) {
     if (parentGroup.getObjTypeByIdx(i) == DATASET_TYPE) {
@@ -21,24 +21,24 @@ boost::optional<H5::DataSet> findDataset(const H5::Group &parentGroup, const H5s
       // Open the sub group
       if (childPath == name) {
         auto childDataset = parentGroup.openDataSet(childPath);
-        return boost::optional<DataSet>(childDataset);
+        return std::optional<DataSet>(childDataset);
       }
     }
   }
-  return boost::optional<DataSet>{}; // Empty
+  return std::optional<DataSet>{}; // Empty
 }
 
-boost::optional<H5::Group> findGroupByName(const H5::Group &parentGroup, const H5std_string &name) {
+std::optional<H5::Group> findGroupByName(const H5::Group &parentGroup, const H5std_string &name) {
 
   for (hsize_t i = 0; i < parentGroup.getNumObjs(); ++i) {
     if (parentGroup.getObjTypeByIdx(i) == GROUP_TYPE) {
       H5std_string childPath = parentGroup.getObjnameByIdx(i);
       if (childPath == name) {
-        return boost::optional<H5::Group>(parentGroup.openGroup(childPath));
+        return std::optional<H5::Group>(parentGroup.openGroup(childPath));
       }
     }
   }
-  return boost::optional<H5::Group>();
+  return std::optional<H5::Group>();
 }
 
 bool hasNXAttribute(const H5::Group &group, const std::string &attributeValue) {
@@ -70,7 +70,7 @@ bool isNamed(const H5::H5Object &object, const std::string &name) {
 
 /// Find a single group inside parent (returns first match). class type must
 /// match NX_class. Optional wrapped - empty to indicate nothing found.
-boost::optional<H5::Group> findGroup(const H5::Group &parentGroup, const H5std_string &classType) {
+std::optional<H5::Group> findGroup(const H5::Group &parentGroup, const H5std_string &classType) {
   // Iterate over children, and determine if a group
   for (hsize_t i = 0; i < parentGroup.getNumObjs(); ++i) {
     if (parentGroup.getObjTypeByIdx(i) == GROUP_TYPE) {
@@ -79,11 +79,11 @@ boost::optional<H5::Group> findGroup(const H5::Group &parentGroup, const H5std_s
       auto childGroup = parentGroup.openGroup(childPath);
       // Iterate through attributes to find NX_class
       if (hasNXAttribute(childGroup, classType)) {
-        return boost::optional<Group>(childGroup);
+        return std::optional<Group>(childGroup);
       }
     }
   }
-  return boost::optional<Group>{}; // Empty
+  return std::optional<Group>{}; // Empty
 } // namespace utilities
 
 /// Find all groups at the same level matching same class type. Returns first

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/PrecompiledHeader.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/PrecompiledHeader.h
@@ -13,7 +13,6 @@
 // Boost
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/if.hpp>
-#include <boost/optional.hpp>
 #include <boost/python/call_method.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>
@@ -28,3 +27,4 @@
 #include <boost/python/return_value_policy.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/wrapper.hpp>
+#include <optional>

--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -18,12 +18,12 @@
 #include "MantidPythonInterface/core/GetPointer.h"
 
 #include "MantidKernel/WarningSuppressions.h"
-#include <boost/optional.hpp>
 #include <boost/python/bases.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/dict.hpp>
 #include <boost/python/exception_translator.hpp>
 #include <boost/python/overloads.hpp>
+#include <optional>
 // As of boost 1.67 raw_function.hpp tries to pass
 // through size_t types through to make_function
 // which accepts int type, emitting a warning
@@ -111,23 +111,23 @@ void translateH5Exception(const H5::Exception &exc) {
   PyErr_SetString(PyExc_RuntimeError, ss.str().c_str());
 }
 
-template <typename T> boost::optional<T> extractArg(ssize_t index, const tuple &args) {
+template <typename T> std::optional<T> extractArg(ssize_t index, const tuple &args) {
   if (index < len(args)) {
-    return boost::optional<T>(extract<T>(args[index]));
+    return std::optional<T>(extract<T>(args[index]));
   }
-  return boost::none;
+  return std::nullopt;
 }
 
-template <typename T> void extractKwargs(const dict &kwargs, const std::string &keyName, boost::optional<T> &out) {
+template <typename T> void extractKwargs(const dict &kwargs, const std::string &keyName, std::optional<T> &out) {
   if (!kwargs.has_key(keyName)) {
     return;
   }
-  if (out != boost::none) {
+  if (out != std::nullopt) {
     throw std::invalid_argument("Parameter called '" + keyName +
                                 "' was specified twice."
                                 " This must be either positional or a kwarg, but not both.");
   }
-  out = boost::optional<T>(extract<T>(kwargs.get(keyName)));
+  out = std::optional<T>(extract<T>(kwargs.get(keyName)));
 }
 
 class SetPropertyVisitor final : public Mantid::PythonInterface::IPyTypeVisitor {
@@ -172,7 +172,7 @@ object createChildWithProps(tuple args, dict kwargs) {
   extractKwargs<bool>(kwargs, reservedNames[3], enableLogging);
   extractKwargs<int>(kwargs, reservedNames[4], version);
 
-  if (!name.is_initialized()) {
+  if (!name.has_value()) {
     throw std::invalid_argument("Please specify the algorithm name");
   }
   auto childAlg = parentAlg->createChildAlgorithm(name.value(), startProgress.value_or(-1), endProgress.value_or(-1),

--- a/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
@@ -44,8 +44,7 @@ void declareCPPAlgorithms() { AlgorithmFactory::Instance().subscribe<Mantid::Pyt
  */
 void updatePythonPaths() {
   auto packagesetup = import("mantid.kernel.packagesetup");
-  packagesetup.attr("update_sys_paths")(
-      ConfigService::Instance().getValue<std::string>(PYTHONPATHS_KEY).get_value_or(""));
+  packagesetup.attr("update_sys_paths")(ConfigService::Instance().getValue<std::string>(PYTHONPATHS_KEY).value_or(""));
 }
 
 /**

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -11,9 +11,9 @@
 #include "MantidPythonInterface/core/GetPointer.h"
 #include "MantidPythonInterface/core/Policies/MatrixToNumpy.h"
 #include "MantidPythonInterface/core/Policies/RemoveConst.h"
-#include <boost/optional.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
+#include <optional>
 
 using Mantid::Geometry::IPeak;
 using Mantid::Geometry::ReferenceFrame;
@@ -32,7 +32,7 @@ Mantid::Geometry::PeakShape_sptr getPeakShape(const IPeak &peak) {
 void setPeakShape(IPeak &peak, Mantid::Geometry::PeakShape_sptr shape) { peak.setPeakShape(shape->clone()); }
 void setQLabFrame1(IPeak &peak, Mantid::Kernel::V3D qLabFrame) {
   // Set the q lab frame. No explicit detector distance.
-  return peak.setQLabFrame(qLabFrame, boost::none);
+  return peak.setQLabFrame(qLabFrame, std::nullopt);
 }
 void setQLabFrame2(IPeak &peak, Mantid::Kernel::V3D qLabFrame, double distance) {
   // Set the q lab frame. Detector distance specified.
@@ -41,7 +41,7 @@ void setQLabFrame2(IPeak &peak, Mantid::Kernel::V3D qLabFrame, double distance) 
 
 void setQSampleFrame1(IPeak &peak, Mantid::Kernel::V3D qSampleFrame) {
   // Set the qsample frame. No explicit detector distance.
-  return peak.setQSampleFrame(qSampleFrame, boost::none);
+  return peak.setQSampleFrame(qSampleFrame, std::nullopt);
 }
 
 void setQSampleFrame2(IPeak &peak, Mantid::Kernel::V3D qSampleFrame, double distance) {

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
@@ -12,11 +12,11 @@
 #include "MantidPythonInterface/core/Converters/PyObjectToV3D.h"
 #include "MantidPythonInterface/core/GetPointer.h"
 #include <boost/none.hpp>
-#include <boost/optional.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/iterator.hpp>
 #include <boost/python/manage_new_object.hpp>
 #include <boost/python/return_internal_reference.hpp>
+#include <optional>
 #include <utility>
 
 using namespace boost::python;
@@ -41,7 +41,7 @@ IPeak *createPeakHKL(const IPeaksWorkspace &self, const object &data) {
 
 /// Create a peak via it's QLab value from a list or numpy array
 IPeak *createPeakQLab(const IPeaksWorkspace &self, const object &data) {
-  auto peak = self.createPeak(Mantid::PythonInterface::Converters::PyObjectToV3D(data)(), boost::none);
+  auto peak = self.createPeak(Mantid::PythonInterface::Converters::PyObjectToV3D(data)(), std::nullopt);
   // Python will manage it
   return peak.release();
 }
@@ -127,7 +127,7 @@ private:
   // type alias for the member function to wrap
   template <typename T> using MemberFunc = void (IPeak::*)(T value);
   // special type alias for V3D functions that take an addtional parameter
-  using MemberFuncV3D = void (IPeak::*)(const V3D &value, boost::optional<double>);
+  using MemberFuncV3D = void (IPeak::*)(const V3D &value, std::optional<double>);
   // type alias for the setter function
   using SetterType = std::function<void(IPeak &peak, const object)>;
 
@@ -164,7 +164,7 @@ private:
       if (!extractor.check()) {
         throw std::runtime_error("Cannot set value. Value was not of the expected type!");
       }
-      (peak.*func)(extractor(), boost::none);
+      (peak.*func)(extractor(), std::nullopt);
     };
   }
 

--- a/Framework/Reflectometry/inc/MantidReflectometry/CalculateSlits.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/CalculateSlits.h
@@ -9,7 +9,7 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/DataProcessorAlgorithm.h"
 #include "MantidReflectometry/DllConfig.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace Mantid {
 namespace Reflectometry {

--- a/Framework/Reflectometry/inc/MantidReflectometry/NRCalculateSlitResolution.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/NRCalculateSlitResolution.h
@@ -9,7 +9,7 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/DataProcessorAlgorithm.h"
 #include "MantidReflectometry/DllConfig.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace Mantid {
 namespace Reflectometry {

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto2.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto2.h
@@ -10,7 +10,7 @@
 #include "MantidReflectometry/DllConfig.h"
 #include "ReflectometryWorkflowBase2.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace Mantid {
 namespace Reflectometry {
@@ -44,7 +44,7 @@ private:
   class RebinParams {
   public:
     RebinParams(const double qMin, const bool qMinIsDefault, const double qMax, const bool qMaxIsDefault,
-                const boost::optional<double> &qStep)
+                const std::optional<double> &qStep)
         : m_qMin(qMin), m_qMinIsDefault(qMinIsDefault), m_qMax(qMax), m_qMaxIsDefault(qMaxIsDefault), m_qStep(qStep){};
 
     double qMin() const { return m_qMin; };
@@ -52,7 +52,7 @@ private:
     double qMax() const { return m_qMax; };
     bool qMaxIsDefault() const { return m_qMaxIsDefault; }
     double qStep() const { return *m_qStep; };
-    bool hasQStep() const { return m_qStep.is_initialized(); }
+    bool hasQStep() const { return m_qStep.has_value(); }
     std::vector<double> asVector() const { return std::vector<double>{qMin(), qStep(), qMax()}; };
 
   private:
@@ -60,7 +60,7 @@ private:
     bool m_qMinIsDefault;
     double m_qMax;
     bool m_qMaxIsDefault;
-    boost::optional<double> m_qStep;
+    std::optional<double> m_qStep;
   };
 
   void init() override;
@@ -77,7 +77,7 @@ private:
   double calculateTheta(const Mantid::API::MatrixWorkspace_sptr &inputWS);
   /// Find cropping and binning parameters
   RebinParams getRebinParams(const MatrixWorkspace_sptr &inputWS, const double theta);
-  boost::optional<double> getQStep(const MatrixWorkspace_sptr &inputWS, const double theta);
+  std::optional<double> getQStep(const MatrixWorkspace_sptr &inputWS, const double theta);
   /// Rebin and scale a workspace in Q
   Mantid::API::MatrixWorkspace_sptr rebinAndScale(const Mantid::API::MatrixWorkspace_sptr &inputWS,
                                                   RebinParams const &params);

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -10,7 +10,7 @@
 #include "MantidReflectometry/DllConfig.h"
 #include "ReflectometryWorkflowBase2.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace Mantid {
 namespace Reflectometry {
@@ -56,9 +56,9 @@ private:
     bool qMinIsDefault;
     double qMax;
     bool qMaxIsDefault;
-    boost::optional<double> qStep;
+    std::optional<double> qStep;
 
-    bool hasQStep() const { return qStep.is_initialized(); }
+    bool hasQStep() const { return qStep.has_value(); }
     std::vector<double> asVector() const { return {qMin, *qStep, qMax}; }
   };
 
@@ -76,7 +76,7 @@ private:
   double calculateTheta(const Mantid::API::MatrixWorkspace_sptr &inputWS);
   /// Find cropping and binning parameters
   RebinParams getRebinParams(const MatrixWorkspace_sptr &inputWS, const double theta);
-  boost::optional<double> getQStep(const MatrixWorkspace_sptr &inputWS, const double theta);
+  std::optional<double> getQStep(const MatrixWorkspace_sptr &inputWS, const double theta);
   // Optionally scale a workspace
   Mantid::API::MatrixWorkspace_sptr scale(Mantid::API::MatrixWorkspace_sptr inputWS);
   /// Rebin a workspace in Q

--- a/Framework/Reflectometry/src/ReflectometryBeamStatistics.cpp
+++ b/Framework/Reflectometry/src/ReflectometryBeamStatistics.cpp
@@ -17,7 +17,7 @@
 #include "MantidKernel/MandatoryValidator.h"
 
 #include <boost/math/special_functions/pow.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace {
 namespace Prop {
@@ -161,7 +161,7 @@ void ReflectometryBeamStatistics::exec() {
 double ReflectometryBeamStatistics::beamRMSVariation(API::MatrixWorkspace_sptr &ws, const size_t start,
                                                      const size_t end) {
   // det_fwhm and detdb_fwhm in COSMOS
-  boost::optional<double> rmsVariation;
+  std::optional<double> rmsVariation;
   if (ws->run().hasProperty(LogEntry::BEAM_RMS_VARIATION)) {
     try {
       rmsVariation = ws->run().getPropertyValueAsType<double>(LogEntry::BEAM_RMS_VARIATION);

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto2.cpp
@@ -610,8 +610,8 @@ auto ReflectometryReductionOneAuto2::getRebinParams(const MatrixWorkspace_sptr &
  * @param theta :: the angle of this run
  * @return :: the rebin step in Q, or none if it could not be found
  */
-boost::optional<double> ReflectometryReductionOneAuto2::getQStep(const MatrixWorkspace_sptr &inputWS,
-                                                                 const double theta) {
+std::optional<double> ReflectometryReductionOneAuto2::getQStep(const MatrixWorkspace_sptr &inputWS,
+                                                               const double theta) {
   Property *qStepProp = getProperty("MomentumTransferStep");
   double qstep;
   if (!qStepProp->isDefault()) {
@@ -631,7 +631,7 @@ boost::optional<double> ReflectometryReductionOneAuto2::getQStep(const MatrixWor
     calcRes->execute();
 
     if (!calcRes->isExecuted()) {
-      return boost::none;
+      return std::nullopt;
     }
     qstep = calcRes->getProperty("Resolution");
     qstep = -qstep;

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -622,8 +622,8 @@ auto ReflectometryReductionOneAuto3::getRebinParams(const MatrixWorkspace_sptr &
  * @param theta :: the angle of this run
  * @return :: the rebin step in Q, or none if it could not be found
  */
-boost::optional<double> ReflectometryReductionOneAuto3::getQStep(const MatrixWorkspace_sptr &inputWS,
-                                                                 const double theta) {
+std::optional<double> ReflectometryReductionOneAuto3::getQStep(const MatrixWorkspace_sptr &inputWS,
+                                                               const double theta) {
   Property *qStepProp = getProperty("MomentumTransferStep");
   double qstep;
   if (!qStepProp->isDefault()) {
@@ -643,7 +643,7 @@ boost::optional<double> ReflectometryReductionOneAuto3::getQStep(const MatrixWor
     calcRes->execute();
 
     if (!calcRes->isExecuted()) {
-      return boost::none;
+      return std::nullopt;
     }
     qstep = calcRes->getProperty("Resolution");
     qstep = -qstep;

--- a/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
@@ -88,14 +88,14 @@ std::vector<size_t> getProcessingInstructionsAsIndices(std::string const &instru
  *
  * @param instrument : the instrument containing the parameters
  * @param param : the parameter name
- * @return : the parameter value converted to an integer, or boost::none if it was not found
+ * @return : the parameter value converted to an integer, or std::nullopt if it was not found
  * @throw : if the detector index is invalid
  */
-boost::optional<size_t> getDetectorParamOrNone(const Instrument_const_sptr &instrument,
-                                               const MatrixWorkspace_sptr &inputWS, const std::string &param) {
+std::optional<size_t> getDetectorParamOrNone(const Instrument_const_sptr &instrument,
+                                             const MatrixWorkspace_sptr &inputWS, const std::string &param) {
   const std::vector<double> value = instrument->getNumberParameter(param);
   if (value.empty()) {
-    return boost::none;
+    return std::nullopt;
   }
   // Check it's a valid workspace index
   if (value[0] < 0) {
@@ -673,43 +673,43 @@ void ReflectometryWorkflowBase2::populateMonitorProperties(const IAlgorithm_sptr
 
   const auto startOverlap =
       checkForOptionalInstrumentDefault<double>(this, "StartOverlap", instrument, "TransRunStartOverlap");
-  if (startOverlap.is_initialized())
-    alg->setProperty("StartOverlap", startOverlap.get());
+  if (startOverlap.has_value())
+    alg->setProperty("StartOverlap", startOverlap.value());
 
   const auto endOverlap =
       checkForOptionalInstrumentDefault<double>(this, "EndOverlap", instrument, "TransRunEndOverlap");
-  if (endOverlap.is_initialized())
-    alg->setProperty("EndOverlap", endOverlap.get());
+  if (endOverlap.has_value())
+    alg->setProperty("EndOverlap", endOverlap.value());
 
   const auto monitorIndex =
       checkForOptionalInstrumentDefault<int>(this, "I0MonitorIndex", instrument, "I0MonitorIndex");
-  if (monitorIndex.is_initialized())
-    alg->setProperty("I0MonitorIndex", monitorIndex.get());
+  if (monitorIndex.has_value())
+    alg->setProperty("I0MonitorIndex", monitorIndex.value());
 
   const auto backgroundMin = checkForOptionalInstrumentDefault<double>(this, "MonitorBackgroundWavelengthMin",
                                                                        instrument, "MonitorBackgroundMin");
-  if (backgroundMin.is_initialized())
-    alg->setProperty("MonitorBackgroundWavelengthMin", backgroundMin.get());
+  if (backgroundMin.has_value())
+    alg->setProperty("MonitorBackgroundWavelengthMin", backgroundMin.value());
 
   const auto backgroundMax = checkForOptionalInstrumentDefault<double>(this, "MonitorBackgroundWavelengthMax",
                                                                        instrument, "MonitorBackgroundMax");
-  if (backgroundMax.is_initialized())
-    alg->setProperty("MonitorBackgroundWavelengthMax", backgroundMax.get());
+  if (backgroundMax.has_value())
+    alg->setProperty("MonitorBackgroundWavelengthMax", backgroundMax.value());
 
   const auto integrationMin = checkForOptionalInstrumentDefault<double>(this, "MonitorIntegrationWavelengthMin",
                                                                         instrument, "MonitorIntegralMin");
-  if (integrationMin.is_initialized())
-    alg->setProperty("MonitorIntegrationWavelengthMin", integrationMin.get());
+  if (integrationMin.has_value())
+    alg->setProperty("MonitorIntegrationWavelengthMin", integrationMin.value());
 
   const auto integrationMax = checkForOptionalInstrumentDefault<double>(this, "MonitorIntegrationWavelengthMax",
                                                                         instrument, "MonitorIntegralMax");
-  if (integrationMax.is_initialized())
-    alg->setProperty("MonitorIntegrationWavelengthMax", integrationMax.get());
+  if (integrationMax.has_value())
+    alg->setProperty("MonitorIntegrationWavelengthMax", integrationMax.value());
 
   const auto integrationBool = checkForOptionalInstrumentDefault<bool>(this, "NormalizeByIntegratedMonitors",
                                                                        instrument, "NormalizeByIntegratedMonitors");
-  if (integrationBool.is_initialized())
-    alg->setProperty("NormalizeByIntegratedMonitors", integrationBool.get());
+  if (integrationBool.has_value())
+    alg->setProperty("NormalizeByIntegratedMonitors", integrationBool.value());
 }
 
 /** Finding processing instructions from the parameters file
@@ -722,8 +722,8 @@ std::string ReflectometryWorkflowBase2::findProcessingInstructions(const Instrum
   assert(instrument && inputWS && inputWS->getNumberHistograms() > 0);
   const std::string analysisMode = getProperty("AnalysisMode");
 
-  boost::optional<size_t> maybeStart;
-  boost::optional<size_t> maybeStop;
+  std::optional<size_t> maybeStart;
+  std::optional<size_t> maybeStop;
   if (analysisMode == "PointDetectorAnalysis") {
     maybeStart = getDetectorParamOrNone(instrument, inputWS, "PointDetectorStart");
     maybeStop = getDetectorParamOrNone(instrument, inputWS, "PointDetectorStop");

--- a/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
@@ -91,7 +91,7 @@ public:
 
   void test_bad_input_workspace_units() {
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_notTOF, boost::none, "1");
+    setup_alg_on_workspace(alg, m_notTOF, std::nullopt, "1");
     alg.setProperty("WavelengthMin", 1.0);
     alg.setProperty("WavelengthMax", 15.0);
     TS_ASSERT_THROWS_ANYTHING(alg.execute());
@@ -99,7 +99,7 @@ public:
 
   void test_bad_wavelength_range() {
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "1");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "1");
     alg.setProperty("WavelengthMin", 15.0);
     alg.setProperty("WavelengthMax", 1.0);
     TS_ASSERT_THROWS_ANYTHING(alg.execute());
@@ -107,7 +107,7 @@ public:
 
   void test_bad_monitor_background_range() {
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "1");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "1");
     alg.setProperty("WavelengthMin", 1.0);
     alg.setProperty("WavelengthMax", 15.0);
     alg.setProperty("MonitorBackgroundWavelengthMin", 3.0);
@@ -117,7 +117,7 @@ public:
 
   void test_bad_monitor_integration_range() {
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "1");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "1");
     alg.setProperty("WavelengthMin", 1.0);
     alg.setProperty("WavelengthMax", 15.0);
     alg.setProperty("MonitorIntegrationWavelengthMin", 15.0);
@@ -127,7 +127,7 @@ public:
 
   void test_bad_first_transmission_run_units() {
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "1");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "1");
     alg.setChild(true);
     alg.initialize();
     alg.setProperty("FirstTransmissionRun", m_notTOF);
@@ -343,7 +343,7 @@ public:
 
     // Use theta from the logs to correct detector positions
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, inter, boost::none, "4");
+    setup_alg_on_workspace(alg, inter, std::nullopt, "4");
     alg.setProperty("ThetaLogName", "theta");
     alg.setProperty("CorrectDetectors", "1");
     alg.execute();
@@ -400,7 +400,7 @@ public:
   void test_IvsQ_linear_binning() {
 
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "2");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "2");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
     alg.setProperty("MomentumTransferMin", 1.0);
@@ -427,7 +427,7 @@ public:
   void test_IvsQ_logarithmic_binning() {
 
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "2");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "2");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
     alg.setProperty("MomentumTransferMin", 1.0);
@@ -445,7 +445,7 @@ public:
   void test_IvsLam_range() {
 
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "3");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
     alg.setProperty("MomentumTransferStep", 0.04);
@@ -466,7 +466,7 @@ public:
   void test_IvsQ_range() {
 
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "3");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
     alg.setProperty("MomentumTransferStep", 0.04);
@@ -492,7 +492,7 @@ public:
   void test_IvsQ_range_cropped() {
 
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "3");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
     alg.setProperty("MomentumTransferMin", 0.5);
@@ -514,7 +514,7 @@ public:
   void test_IvsQ_values() {
 
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "3");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
     alg.execute();
@@ -530,7 +530,7 @@ public:
   void test_IvsQ_values_scaled() {
 
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "3");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
     alg.setProperty("ScaleFactor", 0.1);
@@ -547,7 +547,7 @@ public:
   void test_IvsQ_binned_values() {
 
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "3");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
     alg.setProperty("MomentumTransferMin", 0.0);
@@ -571,7 +571,7 @@ public:
   void test_IvsQ_binned_values_scaled() {
 
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "3");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
     alg.setProperty("MomentumTransferMin", 0.0);
@@ -596,7 +596,7 @@ public:
   void test_IvsLam_values() {
 
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "3");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
     alg.execute();
@@ -612,7 +612,7 @@ public:
   void test_IvsLam_values_are_not_scaled() {
 
     ReflectometryReductionOneAuto3 alg;
-    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    setup_alg_on_workspace(alg, m_TOF, std::nullopt, "3");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
     alg.setProperty("ScaleFactor", 0.1);
@@ -1937,8 +1937,8 @@ private:
   }
 
   void setup_alg_on_workspace(ReflectometryReductionOneAuto3 &alg, MatrixWorkspace_sptr &inter,
-                              boost::optional<double> theta = boost::none,
-                              boost::optional<const char *> processingInstructions = boost::none) {
+                              std::optional<double> theta = std::nullopt,
+                              std::optional<const char *> processingInstructions = std::nullopt) {
     alg.initialize();
     alg.setChild(true);
     alg.setProperty("InputWorkspace", inter);

--- a/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -1332,7 +1332,7 @@ void ScriptRepositoryImpl::doDownloadFile(const std::string &url_file, const std
   try {
     Kernel::InternetHelper inetHelper;
     auto timeoutConfigVal = ConfigService::Instance().getValue<int>("network.scriptrepo.timeout");
-    int timeout = timeoutConfigVal.get_value_or(DEFAULT_TIMEOUT_SEC);
+    int timeout = timeoutConfigVal.value_or(DEFAULT_TIMEOUT_SEC);
     inetHelper.setTimeout(timeout);
 
     const auto status = inetHelper.downloadFile(url_file, local_file_path);

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FallbackBoostOptionalIO.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FallbackBoostOptionalIO.h
@@ -5,15 +5,24 @@
 #pragma once
 
 #include <boost/optional.hpp>
+#include <optional>
 #include <ostream>
 
-// Here we provide a printer for boost::optional that can be used
+// Here we provide a printer for std::optional that can be used
 // in cases where the output is not interesting, e.g.
 // it is a requirement by GoogleMock
 
 namespace boost {
 
 /// Simple prints the address of the optional object
+template <class CharType, class CharTrait, class OptionalValueType>
+inline std::basic_ostream<CharType, CharTrait> &operator<<(std::basic_ostream<CharType, CharTrait> &os,
+                                                           std::optional<OptionalValueType> const &value) {
+  return (os << "std::optional @ " << reinterpret_cast<const void *>(&value));
+}
+
+/// Simple prints the address of the optional object - this can be removed once boost::optional is converted to
+/// std::optional
 template <class CharType, class CharTrait, class OptionalValueType>
 inline std::basic_ostream<CharType, CharTrait> &operator<<(std::basic_ostream<CharType, CharTrait> &os,
                                                            boost::optional<OptionalValueType> const &value) {

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/ONCatHelper.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/ONCatHelper.h
@@ -53,11 +53,11 @@ class MockTokenStore : public IOAuthTokenStore {
 public:
   MockTokenStore();
 
-  void setToken(const boost::optional<OAuthToken> &token) override;
-  boost::optional<OAuthToken> getToken() override;
+  void setToken(const std::optional<OAuthToken> &token) override;
+  std::optional<OAuthToken> getToken() override;
 
 private:
-  boost::optional<OAuthToken> m_token;
+  std::optional<OAuthToken> m_token;
 };
 
 IOAuthTokenStore_uptr make_mock_token_store();

--- a/Framework/TestHelpers/src/ONCatHelper.cpp
+++ b/Framework/TestHelpers/src/ONCatHelper.cpp
@@ -75,18 +75,18 @@ std::unique_ptr<ONCat> make_oncat_with_mock_api(const std::shared_ptr<MockONCatA
   return oncat;
 }
 
-MockTokenStore::MockTokenStore() : m_token(boost::none) {}
+MockTokenStore::MockTokenStore() : m_token(std::nullopt) {}
 
-void MockTokenStore::setToken(const boost::optional<OAuthToken> &token) { m_token = token; }
+void MockTokenStore::setToken(const std::optional<OAuthToken> &token) { m_token = token; }
 
-boost::optional<OAuthToken> MockTokenStore::getToken() { return m_token; }
+std::optional<OAuthToken> MockTokenStore::getToken() { return m_token; }
 
 IOAuthTokenStore_uptr make_mock_token_store() { return std::make_unique<MockTokenStore>(); }
 
 IOAuthTokenStore_uptr make_mock_token_store_already_logged_in() {
   auto tokenStore = std::make_unique<MockTokenStore>();
   tokenStore->setToken(OAuthToken("Bearer", 3600, "2KSL5aEnLvIudMHIjc7LcBWBCfxOHZ", "api:read data:read settings:read",
-                                  boost::make_optional<std::string>("eZEiz7LbgFrkL5ZHv7R4ck9gOzXexb")));
+                                  std::make_optional<std::string>("eZEiz7LbgFrkL5ZHv7R4ck9gOzXexb")));
   return tokenStore;
 }
 

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -79,6 +79,8 @@ if(BUILD_MANTIDFRAMEWORK OR BUILD_MANTIDQT)
   add_definitions(-DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG)
   # Silence issues with deprecated allocator methods in boost regex
   add_definitions(-D_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING)
+  # The new interface is not available in Clang yet so we haven't migrated
+  add_definitions(-D_SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING)
 
   find_package(Poco 1.4.6 REQUIRED)
   add_definitions(-DPOCO_ENABLE_CPP11)

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -426,8 +426,6 @@ knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Beamline/src/ComponentInfo
 unsignedLessThanZero:${CMAKE_SOURCE_DIR}/Framework/Beamline/src/ComponentInfo.cpp:650
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/SpectraAxisValidator.cpp:26
 nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/API/src/MatrixWorkspaceMDIterator.cpp:33
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/CompositeCluster.cpp:97
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/CompositeCluster.cpp:115
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/Crystal/inc/MantidCrystal/ClearUB.h:25
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:91
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:151
@@ -1290,7 +1288,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/InstrumentSelec
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/ListPropertyWidget.cpp:46
 returnByReference:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h:35
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h:39
-iterateByValue:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/UserSubWindowFactory.h:96
 ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:318
 ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:320
 ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:329

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -432,8 +432,6 @@ constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWork
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:191
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:261
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/MultiPeriodGroupWorker.cpp:268
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/ConnectedComponentLabeling.cpp:337
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/ConnectedComponentLabeling.cpp:338
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/CalculateUMatrix.cpp:65
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/WorkspaceGroup.cpp:78
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/WorkspaceGroup.cpp:437

--- a/qt/scientific_interfaces/General/StepScan.cpp
+++ b/qt/scientific_interfaces/General/StepScan.cpp
@@ -606,7 +606,7 @@ void StepScan::generateCurve(const QString &var) {
 }
 
 namespace {
-auto get_fig_ax(boost::optional<int> fignum) {
+auto get_fig_ax(std::optional<int> fignum) {
   std::string pyCode = "import matplotlib.pyplot as plt\n"
                        "from mantid import plots\n"
                        "from workbench.plotting.globalfiguremanager import GlobalFigureManager\n"

--- a/qt/scientific_interfaces/General/StepScan.h
+++ b/qt/scientific_interfaces/General/StepScan.h
@@ -15,8 +15,6 @@
 #include "MantidQtWidgets/Common/UserSubWindow.h"
 #include "ui_StepScan.h"
 
-#include "boost/optional.hpp"
-
 namespace MantidQt {
 namespace CustomInterfaces {
 
@@ -79,7 +77,7 @@ private:
   API::QtAlgorithmRunner *m_algRunner; ///< Object for running algorithms asynchronously
   Poco::NObserver<StepScan, Mantid::API::WorkspaceAddNotification> m_addObserver;
   Poco::NObserver<StepScan, Mantid::API::WorkspaceAfterReplaceNotification> m_replObserver;
-  boost::optional<int> m_fignum;
+  std::optional<int> m_fignum;
   bool m_replaceObserverAdded;
 };
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
@@ -216,7 +216,7 @@ void CalculatePaalmanPings::handleRun() {
 
     auto const convertedSampleWorkspace = addConvertUnitsStep(sampleWs, "Wavelength", "UNIT", emode, efixed);
     if (convertedSampleWorkspace)
-      absCorProps->setPropertyValue("SampleWorkspace", convertedSampleWorkspace.get());
+      absCorProps->setPropertyValue("SampleWorkspace", convertedSampleWorkspace.value());
     else {
       m_runPresenter->setRunEnabled(true);
       return;
@@ -256,7 +256,7 @@ void CalculatePaalmanPings::handleRun() {
 
       auto const convertedWorkspace = addConvertUnitsStep(canWs, "Wavelength", "UNIT", emode);
       if (convertedWorkspace)
-        absCorProps->setPropertyValue("CanWorkspace", convertedWorkspace.get());
+        absCorProps->setPropertyValue("CanWorkspace", convertedWorkspace.value());
       else {
         m_runPresenter->setRunEnabled(true);
         return;
@@ -445,15 +445,15 @@ void CalculatePaalmanPings::getBeamWidthFromWorkspace(const QString &wsName) {
   const auto beamWidth = getInstrumentParameter(instrument, "Workflow.beam-width");
 
   if (beamWidth) {
-    m_uiForm.spCylBeamWidth->setValue(beamWidth.get());
-    m_uiForm.spAnnBeamWidth->setValue(beamWidth.get());
+    m_uiForm.spCylBeamWidth->setValue(beamWidth.value());
+    m_uiForm.spAnnBeamWidth->setValue(beamWidth.value());
   }
 
   const auto beamHeight = getInstrumentParameter(instrument, "Workflow.beam-height");
 
   if (beamHeight) {
-    m_uiForm.spCylBeamHeight->setValue(beamHeight.get());
-    m_uiForm.spAnnBeamHeight->setValue(beamHeight.get());
+    m_uiForm.spCylBeamHeight->setValue(beamHeight.value());
+    m_uiForm.spAnnBeamHeight->setValue(beamHeight.value());
   }
 }
 
@@ -465,9 +465,9 @@ void CalculatePaalmanPings::getBeamWidthFromWorkspace(const QString &wsName) {
  * @param parameterName The name of the parameter to extract.
  *
  * @return              The extracted parameter if it is found, else
- *                      boost::none.
+ *                      std::nullopt.
  */
-boost::optional<double>
+std::optional<double>
 CalculatePaalmanPings::getInstrumentParameter(const Mantid::Geometry::Instrument_const_sptr &instrument,
                                               const std::string &parameterName) {
 
@@ -475,7 +475,7 @@ CalculatePaalmanPings::getInstrumentParameter(const Mantid::Geometry::Instrument
     const auto parameterValue = QString::fromStdString(instrument->getStringParameter(parameterName)[0]);
     return parameterValue.toDouble();
   }
-  return boost::none;
+  return std::nullopt;
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.h
@@ -13,8 +13,8 @@
 
 #include "MantidGeometry/Instrument_fwd.h"
 
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -63,8 +63,8 @@ private:
 
   void setSaveResultEnabled(bool enabled);
 
-  boost::optional<double> getInstrumentParameter(const Mantid::Geometry::Instrument_const_sptr &instrument,
-                                                 const std::string &parameterName);
+  std::optional<double> getInstrumentParameter(const Mantid::Geometry::Instrument_const_sptr &instrument,
+                                               const std::string &parameterName);
 
   Ui::CalculatePaalmanPings m_uiForm;
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
@@ -85,9 +85,9 @@ bool CorrectionsTab::checkWorkspaceBinningMatches(const MatrixWorkspace_const_sp
  * @param eMode Emode to use (if not set will determine based on current X unit)
  * @return Name of output workspace
  */
-boost::optional<std::string> CorrectionsTab::addConvertUnitsStep(const MatrixWorkspace_sptr &ws,
-                                                                 std::string const &unitID, std::string const &suffix,
-                                                                 std::string eMode, double eFixed) {
+std::optional<std::string> CorrectionsTab::addConvertUnitsStep(const MatrixWorkspace_sptr &ws,
+                                                               std::string const &unitID, std::string const &suffix,
+                                                               std::string eMode, double eFixed) {
   std::string outputName = ws->getName();
 
   if (suffix != "UNIT")
@@ -112,7 +112,7 @@ boost::optional<std::string> CorrectionsTab::addConvertUnitsStep(const MatrixWor
       eFixed = *eFixedFromWs;
     } else {
       showMessageBox("Please enter an Efixed value.");
-      return boost::none;
+      return std::nullopt;
     }
   }
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.h
@@ -86,9 +86,9 @@ protected:
   bool checkWorkspaceBinningMatches(const Mantid::API::MatrixWorkspace_const_sptr &left,
                                     const Mantid::API::MatrixWorkspace_const_sptr &right);
   /// Adds a unit conversion step to the algorithm queue
-  boost::optional<std::string> addConvertUnitsStep(const Mantid::API::MatrixWorkspace_sptr &ws,
-                                                   const std::string &unitID, const std::string &suffix = "UNIT",
-                                                   std::string eMode = "", double eFixed = 0.0);
+  std::optional<std::string> addConvertUnitsStep(const Mantid::API::MatrixWorkspace_sptr &ws, const std::string &unitID,
+                                                 const std::string &suffix = "UNIT", std::string eMode = "",
+                                                 double eFixed = 0.0);
   /// Displays and logs the error for a workspace with an invalid type
   void displayInvalidWorkspaceTypeError(const std::string &workspaceName, Mantid::Kernel::Logger &log);
 

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
@@ -384,13 +384,14 @@ double ElwinView::getBackgroundEnd() { return m_dblManager->value(m_properties["
  */
 void ElwinView::setRangeSelector(RangeSelector *rs, QtProperty *lower, QtProperty *upper,
                                  const QPair<double, double> &range,
-                                 const boost::optional<QPair<double, double>> &bounds) {
+                                 const std::optional<QPair<double, double>> &bounds) {
   m_dblManager->setValue(lower, range.first);
   m_dblManager->setValue(upper, range.second);
   rs->setRange(range.first, range.second);
   if (bounds) {
     // clamp the bounds of the selector
-    rs->setBounds(bounds.get().first, bounds.get().second);
+    const auto value = bounds.value();
+    rs->setBounds(value.first, value.second);
   }
 }
 

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinView.h
@@ -101,7 +101,7 @@ private:
   /// Function to set the range selector on the mini plot
   void setRangeSelector(MantidWidgets::RangeSelector *rs, QtProperty *lower, QtProperty *upper,
                         const QPair<double, double> &range,
-                        const boost::optional<QPair<double, double>> &bounds = boost::none);
+                        const std::optional<QPair<double, double>> &bounds = std::nullopt);
   /// Sets the min of the range selector if it is less than the max
   void setRangeSelectorMin(QtProperty *minProperty, QtProperty *maxProperty,
                            MantidWidgets::RangeSelector *rangeSelector, double newValue);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionModel.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionModel.h
@@ -20,9 +20,9 @@ public:
   ConvolutionModel();
   ~ConvolutionModel() = default;
 
-  boost::optional<double> getInstrumentResolution(WorkspaceID workspaceID) const;
+  std::optional<double> getInstrumentResolution(WorkspaceID workspaceID) const;
 
-  void setTemperature(const boost::optional<double> &temperature);
+  void setTemperature(const std::optional<double> &temperature);
 
   void addOutput(Mantid::API::IAlgorithm_sptr fitAlgorithm) override;
 
@@ -34,11 +34,11 @@ private:
   std::unordered_map<std::string, std::string> mapDefaultParameterNames() const override;
   void addSampleLogs();
 
-  void setParameterNameChanges(const Mantid::API::IFunction &model, boost::optional<std::size_t> backgroundIndex);
+  void setParameterNameChanges(const Mantid::API::IFunction &model, std::optional<std::size_t> backgroundIndex);
 
   ResolutionCollectionType m_resolution;
   std::unordered_map<std::string, std::string> m_parameterNameChanges;
-  boost::optional<double> m_temperature;
+  std::optional<double> m_temperature;
 };
 
 } // namespace Inelastic

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/SingleFunctionTemplateModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/SingleFunctionTemplateModel.cpp
@@ -146,7 +146,7 @@ void SingleFunctionTemplateModel::setGlobal(std::string const &parameterName, bo
   setGlobalParameters(globalParameters);
 }
 
-boost::optional<std::string> SingleFunctionTemplateModel::findFitTypeForFunctionName(const std::string &name) const {
+std::optional<std::string> SingleFunctionTemplateModel::findFitTypeForFunctionName(const std::string &name) const {
   auto result = std::find_if(m_fitTypeToFunctionStore.constBegin(), m_fitTypeToFunctionStore.constEnd(),
                              [&name](const auto &function) -> bool {
                                if (function)
@@ -155,9 +155,9 @@ boost::optional<std::string> SingleFunctionTemplateModel::findFitTypeForFunction
                                  return false;
                              });
   if (result != std::end(m_fitTypeToFunctionStore)) {
-    return boost::optional<std::string>{result.key()};
+    return std::optional<std::string>{result.key()};
   }
-  return boost::none;
+  return std::nullopt;
 }
 
 } // namespace MantidQt::CustomInterfaces::Inelastic

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/SingleFunctionTemplateModel.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/SingleFunctionTemplateModel.h
@@ -15,7 +15,7 @@
 #include "MantidQtWidgets/Common/IndexTypes.h"
 
 #include <QMap>
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 
 namespace MantidQt {
@@ -51,7 +51,7 @@ private:
   QMap<std::string, IFunction_sptr> m_fitTypeToFunctionStore;
   QMap<std::string, std::vector<std::string>> m_globalParameterStore;
   std::vector<std::string> m_fitTypeList;
-  boost::optional<std::string> findFitTypeForFunctionName(const std::string &name) const;
+  std::optional<std::string> findFitTypeForFunctionName(const std::string &name) const;
   // Parameter estimation
   std::unique_ptr<FunctionParameterEstimation> m_parameterEstimation;
 };

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.cpp
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "FunctionQAddWorkspaceDialog.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <QSignalBlocker>
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/IFitOutput.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/IFitOutput.h
@@ -25,7 +25,7 @@ struct ParameterValue {
   explicit ParameterValue(double val) : value(val) {}
   ParameterValue(double val, double err) : value(val), error(err) {}
   double value;
-  boost::optional<double> error;
+  std::optional<double> error;
 };
 
 struct ResultLocationNew {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.h
@@ -22,7 +22,7 @@
 #include <QPair>
 #include <QString>
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <unordered_map>
 
 class QCheckBox;

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -152,9 +152,9 @@ std::string ALCDataLoadingView::greenPeriod() const { return m_ui.greenPeriod->c
 
 bool ALCDataLoadingView::subtractIsChecked() const { return m_ui.subtractCheckbox->isChecked(); }
 
-boost::optional<std::pair<double, double>> ALCDataLoadingView::timeRange() const {
+std::optional<std::pair<double, double>> ALCDataLoadingView::timeRange() const {
   auto range = std::make_pair(m_ui.minTime->value(), m_ui.maxTime->value());
-  return boost::make_optional(range);
+  return std::make_optional(range);
 }
 
 void ALCDataLoadingView::setDataCurve(MatrixWorkspace_sptr workspace, std::size_t const &workspaceIndex) {

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
@@ -50,7 +50,7 @@ public:
   std::string greenPeriod() const override;
   bool subtractIsChecked() const override;
   std::string calculationType() const override;
-  boost::optional<std::pair<double, double>> timeRange() const override;
+  std::optional<std::pair<double, double>> timeRange() const override;
   std::string getRunsText() const override;
   std::string getRunsFirstRunText() const override;
 

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingView.cpp
@@ -22,7 +22,7 @@ IFunction_const_sptr ALCPeakFittingView::function(std::string const &index) cons
   return m_ui.peaks->getFunctionByIndex(index);
 }
 
-boost::optional<std::string> ALCPeakFittingView::currentFunctionIndex() const {
+std::optional<std::string> ALCPeakFittingView::currentFunctionIndex() const {
   return m_ui.peaks->currentFunctionIndex();
 }
 

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingView.h
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingView.h
@@ -28,7 +28,7 @@ public:
   ~ALCPeakFittingView();
 
   Mantid::API::IFunction_const_sptr function(std::string const &index) const override;
-  boost::optional<std::string> currentFunctionIndex() const override;
+  std::optional<std::string> currentFunctionIndex() const override;
   Mantid::API::IPeakFunction_const_sptr peakPicker() const override;
   void emitFitRequested();
 

--- a/qt/scientific_interfaces/Muon/IALCDataLoadingView.h
+++ b/qt/scientific_interfaces/Muon/IALCDataLoadingView.h
@@ -13,7 +13,7 @@
 #include "MantidKernel/System.h"
 
 #include <QObject>
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -69,7 +69,7 @@ public:
 
   /// @return Selected integration time range, or nothing if limiting is
   /// disabled
-  virtual boost::optional<std::pair<double, double>> timeRange() const = 0;
+  virtual std::optional<std::pair<double, double>> timeRange() const = 0;
 
   /// Sets all available info to empty
   virtual void setAvailableInfoToEmpty() = 0;

--- a/qt/scientific_interfaces/Muon/IALCPeakFittingView.h
+++ b/qt/scientific_interfaces/Muon/IALCPeakFittingView.h
@@ -13,7 +13,7 @@
 #include "DllConfig.h"
 
 #include <QObject>
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -28,7 +28,7 @@ public:
   virtual Mantid::API::IFunction_const_sptr function(std::string const &index) const = 0;
 
   /// @return Index of the function currently seleted in the Function Browser
-  virtual boost::optional<std::string> currentFunctionIndex() const = 0;
+  virtual std::optional<std::string> currentFunctionIndex() const = 0;
 
   /// @return A peak currently represented by the peak picker
   virtual Mantid::API::IPeakFunction_const_sptr peakPicker() const = 0;

--- a/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
@@ -22,7 +22,7 @@ using namespace testing;
 namespace boost {
 template <class CharType, class CharTrait>
 std::basic_ostream<CharType, CharTrait> &operator<<(std::basic_ostream<CharType, CharTrait> &out,
-                                                    optional<std::pair<double, double>> const &maybe) {
+                                                    std::optional<std::pair<double, double>> const &maybe) {
   if (maybe)
     out << maybe->first << ", " << maybe->second;
   return out;
@@ -42,7 +42,7 @@ public:
   MOCK_CONST_METHOD0(log, std::string());
   MOCK_CONST_METHOD0(function, std::string());
   MOCK_CONST_METHOD0(calculationType, std::string());
-  MOCK_CONST_METHOD0(timeRange, boost::optional<PAIR_OF_DOUBLES>());
+  MOCK_CONST_METHOD0(timeRange, std::optional<PAIR_OF_DOUBLES>());
   MOCK_CONST_METHOD0(deadTimeType, std::string());
   MOCK_CONST_METHOD0(deadTimeFile, std::string());
   MOCK_CONST_METHOD0(detectorGroupingType, std::string());
@@ -146,7 +146,7 @@ public:
     ON_CALL(*m_view, calculationType()).WillByDefault(Return("Integral"));
     ON_CALL(*m_view, log()).WillByDefault(Return("sample_magn_field"));
     ON_CALL(*m_view, function()).WillByDefault(Return("Last"));
-    ON_CALL(*m_view, timeRange()).WillByDefault(Return(boost::make_optional(std::make_pair(-6.0, 32.0))));
+    ON_CALL(*m_view, timeRange()).WillByDefault(Return(std::make_optional(std::make_pair(-6.0, 32.0))));
     // Add range for integration
     ON_CALL(*m_view, deadTimeType()).WillByDefault(Return("None"));
     ON_CALL(*m_view, detectorGroupingType()).WillByDefault(Return("Auto"));
@@ -209,7 +209,7 @@ public:
 
   void test_load_timeLimits() {
     // Set time limit
-    ON_CALL(*m_view, timeRange()).WillByDefault(Return(boost::make_optional(std::make_pair(5.0, 10.0))));
+    ON_CALL(*m_view, timeRange()).WillByDefault(Return(std::make_optional(std::make_pair(5.0, 10.0))));
 
     EXPECT_CALL(*m_view, setLoadStatus(loadingString, "orange")).Times(1);
     EXPECT_CALL(*m_view, setLoadStatus(loadedString, "green")).Times(1);
@@ -224,7 +224,7 @@ public:
   void test_updateAvailableInfo() {
     // Test time limits
     auto timeRange = std::make_pair<double, double>(0.0, 0.0);
-    ON_CALL(*m_view, timeRange()).WillByDefault(Return(boost::make_optional(timeRange)));
+    ON_CALL(*m_view, timeRange()).WillByDefault(Return(std::make_optional(timeRange)));
 
     EXPECT_CALL(*m_view, getFirstFile()).WillRepeatedly(Return("MUSR00015189.nxs"));
     // Test logs
@@ -243,7 +243,7 @@ public:
   void test_updateAvailableInfo_NotFirstRun() {
     // Test time limits
     auto timeRange = std::make_pair<double, double>(0.1, 10.0); // not the first run loaded
-    ON_CALL(*m_view, timeRange()).WillByDefault(Return(boost::make_optional(timeRange)));
+    ON_CALL(*m_view, timeRange()).WillByDefault(Return(std::make_optional(timeRange)));
 
     EXPECT_CALL(*m_view, getFirstFile()).WillRepeatedly(Return("MUSR00015189.nxs"));
     // Test logs

--- a/qt/scientific_interfaces/Muon/test/ALCPeakFittingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCPeakFittingPresenterTest.h
@@ -19,8 +19,6 @@
 #include "../Muon/IALCPeakFittingModel.h"
 #include "../Muon/IALCPeakFittingView.h"
 
-#include <boost/optional/optional_io.hpp>
-
 using namespace Mantid;
 using namespace Mantid::API;
 using namespace MantidQt::CustomInterfaces;
@@ -29,7 +27,7 @@ using namespace testing;
 namespace boost {
 template <class CharType, class CharTrait>
 std::basic_ostream<CharType, CharTrait> &operator<<(std::basic_ostream<CharType, CharTrait> &out,
-                                                    optional<QString> const &maybe) {
+                                                    std::optional<QString> const &maybe) {
   if (maybe)
     out << maybe->toStdString();
   return out;
@@ -49,7 +47,7 @@ public:
   void plotGuess() override { emit plotGuessClicked(); }
 
   MOCK_CONST_METHOD1(function, IFunction_const_sptr(std::string const &));
-  MOCK_CONST_METHOD0(currentFunctionIndex, boost::optional<std::string>());
+  MOCK_CONST_METHOD0(currentFunctionIndex, std::optional<std::string>());
   MOCK_CONST_METHOD0(peakPicker, IPeakFunction_const_sptr());
 
   MOCK_METHOD0(initialize, void());
@@ -193,7 +191,7 @@ public:
   }
 
   void test_onCurrentFunctionChanged_nothing() {
-    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(boost::none));
+    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(std::nullopt));
 
     EXPECT_CALL(*m_view, setPeakPickerEnabled(false));
 
@@ -201,7 +199,7 @@ public:
   }
 
   void test_onCurrentFunctionChanged_peak() {
-    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(boost::optional<std::string>("f1")));
+    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(std::optional<std::string>("f1")));
     ON_CALL(*m_view, function(std::string("f1"))).WillByDefault(Return(createGaussian(1, 2, 3)));
 
     EXPECT_CALL(*m_view, setPeakPickerEnabled(true));
@@ -214,7 +212,7 @@ public:
   }
 
   void test_onCurrentFunctionChanged_nonPeak() {
-    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(boost::optional<std::string>("f1")));
+    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(std::optional<std::string>("f1")));
     ON_CALL(*m_view, function(std::string("f1")))
         .WillByDefault(Return(API::FunctionFactory::Instance().createFunction("LinearBackground")));
 
@@ -224,7 +222,7 @@ public:
   }
 
   void test_onPeakPickerChanged() {
-    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(boost::optional<std::string>("f1")));
+    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(std::optional<std::string>("f1")));
     ON_CALL(*m_view, peakPicker()).WillByDefault(Return(createGaussian(4, 5, 6)));
 
     EXPECT_CALL(*m_view, setParameter(std::string("f1"), std::string("PeakCentre"), 4));
@@ -235,7 +233,7 @@ public:
   }
 
   void test_onParameterChanged_peak() {
-    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(boost::optional<std::string>("f1")));
+    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(std::optional<std::string>("f1")));
     ON_CALL(*m_view, function(std::string("f1"))).WillByDefault(Return(createGaussian(4, 2, 6)));
     ON_CALL(*m_view, peakPicker()).WillByDefault(Return(createGaussian(4, 5, 6)));
 
@@ -252,7 +250,7 @@ public:
   // if it's thrown for currently selected peak function, because that's when
   // PeakPicker is displayed
   void test_onParameterChanged_notACurrentFunction() {
-    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(boost::optional<std::string>("f2")));
+    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(std::optional<std::string>("f2")));
 
     EXPECT_CALL(*m_view, setPeakPicker(_)).Times(0);
 
@@ -260,7 +258,7 @@ public:
   }
 
   void test_onParameterChanged_nonPeak() {
-    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(boost::optional<std::string>("f1")));
+    ON_CALL(*m_view, currentFunctionIndex()).WillByDefault(Return(std::optional<std::string>("f1")));
     ON_CALL(*m_view, function(std::string("f1")))
         .WillByDefault(Return(API::FunctionFactory::Instance().createFunction("LinearBackground")));
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
@@ -14,8 +14,8 @@
 
 #include <QWidget>
 
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 namespace Mantid {
 namespace API {
@@ -60,7 +60,7 @@ public:
   /// Return a function with specified index
   IFunction_sptr getFunctionByIndex(std::string const &index);
   /// Return index of the current function, if one is selected
-  boost::optional<std::string> currentFunctionIndex();
+  std::optional<std::string> currentFunctionIndex();
   /// Update the function parameter value
   void setParameter(std::string const &parameterName, double value);
   /// Update the function parameter error

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser/FunctionBrowserUtils.h
@@ -9,7 +9,6 @@
 #include "MantidQtWidgets/Common/DllOption.h"
 
 #include <QString>
-#include <boost/optional.hpp>
 
 #include <string>
 #include <vector>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
@@ -12,8 +12,8 @@
 #include "MantidQtWidgets/Common/FunctionModel.h"
 
 #include <QObject>
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace MantidQt {
@@ -47,7 +47,7 @@ public:
   void updateMultiDatasetParameters(const IFunction &fun);
   void updateMultiDatasetAttributes(const IFunction &fun);
   void clearErrors();
-  boost::optional<std::string> currentFunctionIndex() const;
+  std::optional<std::string> currentFunctionIndex() const;
   void setNumberOfDatasets(int);
   void setDatasets(const std::vector<std::string> &datasetNames);
   void setDatasets(const QList<FunctionModelDataset> &datasets);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -108,7 +108,7 @@ public:
   /// Clear all errors
   void clearErrors() override;
   /// Index of currently selected function.
-  boost::optional<std::string> currentFunctionIndex() const override;
+  std::optional<std::string> currentFunctionIndex() const override;
   /// Set a tie
   void setParameterTie(std::string const &parameterName, std::string const &tie) override;
   /// Set a constraint
@@ -376,7 +376,7 @@ protected:
   QAction *m_actionFunctionHelp;
   /// Index of currently selected function. Gets updated in
   /// updateCurrentFunctionIndex()
-  boost::optional<std::string> m_currentFunctionIndex;
+  std::optional<std::string> m_currentFunctionIndex;
   /// Set true if the constructed function is intended to be used in a
   /// multi-dataset fit
   bool m_multiDataset;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IFunctionView.h
@@ -12,7 +12,7 @@
 
 #include <QString>
 #include <QWidget>
-#include <boost/optional.hpp>
+#include <optional>
 #include <type_traits>
 
 namespace MantidQt {
@@ -38,7 +38,7 @@ public:
   virtual IFunction::Attribute getAttribute(std::string const &attrName) const = 0;
   virtual void setErrorsEnabled(bool enabled) = 0;
   virtual void clearErrors() = 0;
-  virtual boost::optional<std::string> currentFunctionIndex() const = 0;
+  virtual std::optional<std::string> currentFunctionIndex() const = 0;
   virtual void setParameterTie(std::string const &parameterName, std::string const &tie) = 0;
   virtual void setParameterConstraint(std::string const &parameterName, std::string const &constraint) = 0;
   virtual void setGlobalParameters(const std::vector<std::string> &) = 0;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IMuonFitDataSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IMuonFitDataSelector.h
@@ -9,7 +9,7 @@
 #include "DllOption.h"
 #include <QString>
 #include <QStringList>
-#include <boost/optional/optional.hpp>
+#include <optional>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -28,7 +28,7 @@ public:
   virtual double getEndTime() const = 0;
   virtual QStringList getPeriodSelections() const = 0;
   virtual void setWorkspaceDetails(const QString &runNumbers, const QString &instName,
-                                   const boost::optional<QString> &filePath) = 0;
+                                   const std::optional<QString> &filePath) = 0;
   virtual QStringList getChosenGroups() const = 0;
   virtual void setStartTime(double start) = 0;
   virtual void setEndTime(double end) = 0;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MuonFitDataSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MuonFitDataSelector.h
@@ -72,7 +72,7 @@ public:
 public slots:
   /// Set starting run number, instrument and (optionally) file path
   void setWorkspaceDetails(const QString &runNumbers, const QString &instName,
-                           const boost::optional<QString> &filePath) override;
+                           const std::optional<QString> &filePath) override;
   /// Set start time for fit
   void setStartTime(double start) override;
   /// Set end time for fit

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserSubWindowFactory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserSubWindowFactory.h
@@ -17,7 +17,6 @@
 #include <QHash>
 #include <QSetIterator>
 #include <QStringList>
-#include <boost/optional.hpp>
 #include <set>
 
 namespace MantidQt {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserSubWindowFactory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserSubWindowFactory.h
@@ -92,7 +92,7 @@ template <typename TYPE> void UserSubWindowFactoryImpl::subscribe() {
   // Make a record of each interface's categories.
   const QStringList interfaceCategories = TYPE::categoryInfo().split(";", Qt::SkipEmptyParts);
   QSet<QString> result;
-  foreach (const QString category, interfaceCategories) { result.insert(category.trimmed()); }
+  foreach (const QString &category, interfaceCategories) { result.insert(category.trimmed()); }
   m_categoryLookup[QString::fromStdString(realName)] = result;
 }
 

--- a/qt/widgets/common/src/FunctionBrowser.cpp
+++ b/qt/widgets/common/src/FunctionBrowser.cpp
@@ -296,7 +296,7 @@ void FunctionBrowser::setGlobalParameters(std::vector<std::string> const &global
   m_presenter->setGlobalParameters(globals);
 }
 
-boost::optional<std::string> FunctionBrowser::currentFunctionIndex() { return m_presenter->currentFunctionIndex(); }
+std::optional<std::string> FunctionBrowser::currentFunctionIndex() { return m_presenter->currentFunctionIndex(); }
 
 FunctionTreeView *FunctionBrowser::view() const { return dynamic_cast<FunctionTreeView *>(m_presenter->view()); }
 

--- a/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
+++ b/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
@@ -111,7 +111,7 @@ void FunctionMultiDomainPresenter::updateMultiDatasetAttributes(const IFunction 
 
 void FunctionMultiDomainPresenter::clearErrors() { m_view->clearErrors(); }
 
-boost::optional<std::string> FunctionMultiDomainPresenter::currentFunctionIndex() const {
+std::optional<std::string> FunctionMultiDomainPresenter::currentFunctionIndex() const {
   return m_view->currentFunctionIndex();
 }
 

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -2060,10 +2060,10 @@ void FunctionTreeView::setErrorsEnabled(bool enabled) { m_parameterManager->setE
  */
 void FunctionTreeView::clearErrors() { m_parameterManager->clearErrors(); }
 
-boost::optional<std::string> FunctionTreeView::currentFunctionIndex() const { return m_currentFunctionIndex; }
+std::optional<std::string> FunctionTreeView::currentFunctionIndex() const { return m_currentFunctionIndex; }
 
 void FunctionTreeView::updateCurrentFunctionIndex() {
-  boost::optional<std::string> newIndex;
+  std::optional<std::string> newIndex;
 
   if (auto item = m_browser->currentItem()) {
     auto prop = item->property();

--- a/qt/widgets/common/src/MuonFitDataSelector.cpp
+++ b/qt/widgets/common/src/MuonFitDataSelector.cpp
@@ -46,7 +46,7 @@ MuonFitDataSelector::MuonFitDataSelector(QWidget *parent, int runNumber, const Q
                                                                           const QStringList &groups)*/
     : MuonFitDataSelector(parent) {
   m_multiFit = false;
-  this->setWorkspaceDetails(QString::number(runNumber), instName, boost::optional<QString>{});
+  this->setWorkspaceDetails(QString::number(runNumber), instName, std::optional<QString>{});
   // not used in this case
   // but leave these here as a remainder
   // for future changes that may need to assign them
@@ -156,7 +156,7 @@ QStringList MuonFitDataSelector::getFilenames() const { return m_ui.runs->getFil
  * MUSRauto_E.tmp
  */
 void MuonFitDataSelector::setWorkspaceDetails(const QString &runNumbers, const QString &instName,
-                                              const boost::optional<QString> &filePath) {
+                                              const std::optional<QString> &filePath) {
   // Set the file finder to the correct instrument (not Mantid's default)
   m_ui.runs->setInstrumentOverride(instName);
 

--- a/qt/widgets/common/src/NotificationService.cpp
+++ b/qt/widgets/common/src/NotificationService.cpp
@@ -58,7 +58,7 @@ void NotificationService::showMessage(const QString &title, const QString &messa
 bool NotificationService::isEnabled() {
   bool retVal = false;
   try {
-    retVal = Mantid::Kernel::ConfigService::Instance().getValue<bool>(NOTIFICATIONS_ENABLED_KEY).get_value_or(true);
+    retVal = Mantid::Kernel::ConfigService::Instance().getValue<bool>(NOTIFICATIONS_ENABLED_KEY).value_or(true);
   } catch (const Mantid::Kernel::Exception::FileError &) {
     // The Config Service could not find the properties file
     // Disable notifications

--- a/qt/widgets/common/src/UserInputValidator.cpp
+++ b/qt/widgets/common/src/UserInputValidator.cpp
@@ -35,7 +35,7 @@ bool doesExistInADS(std::string const &workspaceName) {
   return AnalysisDataService::Instance().doesExist(workspaceName);
 }
 
-boost::optional<std::string> containsInvalidWorkspace(const WorkspaceGroup_const_sptr &group) {
+std::optional<std::string> containsInvalidWorkspace(const WorkspaceGroup_const_sptr &group) {
   if (group->isEmpty())
     return "The group workspace " + group->getName() + " is empty.";
 
@@ -43,7 +43,7 @@ boost::optional<std::string> containsInvalidWorkspace(const WorkspaceGroup_const
       std::find_if(std::cbegin(*group), std::cend(*group), [](const auto &workspace) { return !workspace; });
   if (it != std::cend(*group))
     return "The group workspace " + group->getName() + " contains an invalid workspace.";
-  return boost::none;
+  return std::nullopt;
 }
 
 } // anonymous namespace
@@ -372,7 +372,7 @@ bool UserInputValidator::checkWorkspaceGroupIsValid(QString const &groupName, QS
   if (checkWorkspaceType<WorkspaceGroup>(groupName, inputType, "WorkspaceGroup", silent)) {
     if (auto const group = WorkspaceUtils::getADSWorkspace<WorkspaceGroup>(groupName.toStdString())) {
       if (auto const error = containsInvalidWorkspace(group)) {
-        addErrorMessage(error.get(), silent);
+        addErrorMessage(error.value(), silent);
         return false;
       }
       return true;

--- a/qt/widgets/common/test/FunctionMultiDomainPresenterTest.h
+++ b/qt/widgets/common/test/FunctionMultiDomainPresenterTest.h
@@ -56,7 +56,7 @@ public:
       m_function->setError(i, 0.0);
     }
   }
-  boost::optional<QString> currentFunctionIndex() const override { return m_currentFunctionIndex; }
+  std::optional<QString> currentFunctionIndex() const override { return m_currentFunctionIndex; }
 
   void setParameterTie(const QString &paramName, const QString &tie) override {
     if (!tie.isEmpty()) {
@@ -113,7 +113,7 @@ public:
 
 private:
   IFunction_sptr m_function;
-  boost::optional<QString> m_currentFunctionIndex;
+  std::optional<QString> m_currentFunctionIndex;
   bool m_areErrorsEnabled{true};
   QStringList m_globals;
   MOCK_METHOD2(setDoubleAttribute, void(const QString &, double));

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
@@ -9,7 +9,7 @@
 #include "UnwrappedSurface.h"
 
 #include <QPolygonF>
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -70,7 +70,7 @@ protected:
 
   void processStructured(size_t rootIndex);
 
-  boost::optional<size_t> processTubes(size_t rootIndex);
+  std::optional<size_t> processTubes(size_t rootIndex);
 
   void processGrid(size_t rootIndex);
 

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -298,7 +298,7 @@ void InstrumentWidget::init(bool resetGeometry, bool setDefaultView) {
       QString defaultView = QString::fromStdString(m_instrumentActor->getDefaultView());
       if (defaultView == "3D" && !Mantid::Kernel::ConfigService::Instance()
                                       .getValue<bool>("MantidOptions.InstrumentView.UseOpenGL")
-                                      .get_value_or(true)) {
+                                      .value_or(true)) {
         // if OpenGL is switched off don't open the 3D view at start up
         defaultView = "CYLINDRICAL_Y";
       }
@@ -717,7 +717,7 @@ void InstrumentWidget::replaceWorkspace(const std::string &newWs, const std::str
   QString defaultView = QString::fromStdString(m_instrumentActor->getDefaultView());
   if (defaultView == "3D" && !Mantid::Kernel::ConfigService::Instance()
                                   .getValue<bool>("MantidOptions.InstrumentView.UseOpenGL")
-                                  .get_value_or(true)) {
+                                  .value_or(true)) {
     // if OpenGL is switched off we don't open the 3D view
     defaultView = "CYLINDRICAL_Y";
   }

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -394,8 +394,8 @@ void PanelsSurface::processGrid(size_t rootIndex) {
 /// and forming a flat surface.
 /// @param rootIndex :: Index of a component that is a tube
 /// @return Optional index of the bank that contains all of the tubes forming
-///   the surface. If the surface isn't flat return boost::none.
-boost::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
+///   the surface. If the surface isn't flat return std::nullopt.
+std::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
   const auto &componentInfo = m_instrActor->componentInfo();
   const auto bankIndex0 = componentInfo.parent(rootIndex);
   auto tubes = std::vector<size_t>();
@@ -441,7 +441,7 @@ boost::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
     addTubes(bankIndex, tubes);
     normal = tubes.size() > 1 ? calculateBankNormal(componentInfo, tubes) : V3D();
     if (normal.nullVector() || !isBankFlat(componentInfo, bankIndex, tubes, normal))
-      return boost::none;
+      return std::nullopt;
   }
 
   // save bank info
@@ -607,7 +607,7 @@ void PanelsSurface::findFlatPanels(size_t rootIndex, std::vector<bool> &visited)
   if (componentType == ComponentType::OutlineComposite) {
     const auto bankIndex = processTubes(rootIndex);
     if (bankIndex) {
-      setBankVisited(componentInfo, bankIndex.get(), visited);
+      setBankVisited(componentInfo, bankIndex.value(), visited);
     } else {
       setBankVisited(componentInfo, parentIndex, visited);
     }

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
@@ -60,7 +60,7 @@ public:
 
     m_glEnabledOriginal = Mantid::Kernel::ConfigService::Instance()
                               .getValue<bool>("MantidOptions.InstrumentView.UseOpenGL")
-                              .get_value_or(true);
+                              .value_or(true);
     setGl(true);
   }
 

--- a/qt/widgets/instrumentview/test/InstrumentWidget/PanelsSurfaceTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/PanelsSurfaceTest.h
@@ -34,7 +34,7 @@ public:
   Mantid::Kernel::Quat calcBankRotation(const Mantid::Kernel::V3D &detPos, Mantid::Kernel::V3D normal) {
     return PanelsSurface::calcBankRotation(detPos, normal);
   }
-  boost::optional<size_t> processTubes(size_t rootIndex) { return PanelsSurface::processTubes(rootIndex); }
+  std::optional<size_t> processTubes(size_t rootIndex) { return PanelsSurface::processTubes(rootIndex); }
   std::vector<UnwrappedDetector> getUnwrappedDetectors() { return m_unwrappedDetectors; };
   void addFlatBank(const Mantid::Kernel::Quat &rotation, const Mantid::Kernel::V3D &refPos) {
     auto *info = new FlatBankInfo(this);

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/ColorbarWidget.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/ColorbarWidget.h
@@ -35,7 +35,7 @@ public:
   ColorbarWidget(QWidget *parent = nullptr);
 
   void setNorm(const NormalizeBase &norm);
-  void setClim(boost::optional<double> vmin, boost::optional<double> vmax);
+  void setClim(std::optional<double> vmin, std::optional<double> vmax);
   std::tuple<double, double> clim() const;
 
   ///@name Legacy API to match DraggableColorBarWidget for instrument view

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/MantidAxes.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/MantidAxes.h
@@ -11,7 +11,7 @@
 #include "MantidQtWidgets/MplCpp/ErrorbarContainer.h"
 
 #include <boost/none_t.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <QHash>
 #include <QVariant>
@@ -30,12 +30,12 @@ public:
   /// @name Plot creation functions
   ///@{
   Line2D plot(const Mantid::API::MatrixWorkspace_sptr &workspace, const size_t wkspIndex, const QString &lineColour,
-              const QString &label, const boost::optional<QHash<QString, QVariant>> &otherKwargs = boost::none);
+              const QString &label, const std::optional<QHash<QString, QVariant>> &otherKwargs = std::nullopt);
   ErrorbarContainer errorbar(const Mantid::API::MatrixWorkspace_sptr &workspace, const size_t wkspIndex,
                              const QString &lineColour, const QString &label,
-                             const boost::optional<QHash<QString, QVariant>> &otherKwargs = boost::none);
+                             const std::optional<QHash<QString, QVariant>> &otherKwargs = std::nullopt);
   void pcolormesh(const Mantid::API::MatrixWorkspace_sptr &workspace,
-                  const boost::optional<QHash<QString, QVariant>> &otherKwargs = boost::none);
+                  const std::optional<QHash<QString, QVariant>> &otherKwargs = std::nullopt);
   ///@}
 
   /// @name Artist removal/replacement

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/ScalarMappable.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/ScalarMappable.h
@@ -10,7 +10,7 @@
 #include "MantidQtWidgets/MplCpp/Colors.h"
 #include "MantidQtWidgets/MplCpp/DllConfig.h"
 
-#include <boost/optional/optional.hpp>
+#include <optional>
 
 #include <QRgb>
 #include <QString>
@@ -34,7 +34,7 @@ public:
   void setCmap(const Colormap &cmap);
   void setCmap(const QString &cmap);
   void setNorm(const NormalizeBase &norm);
-  void setClim(boost::optional<double> vmin = boost::none, boost::optional<double> vmax = boost::none);
+  void setClim(std::optional<double> vmin = std::nullopt, std::optional<double> vmax = std::nullopt);
   QRgb toRGBA(double x, double alpha = 1.0) const;
   std::vector<QRgb> toRGBA(const std::vector<double> &x, double alpha = 1.0) const;
 };

--- a/qt/widgets/mplcpp/src/ColorbarWidget.cpp
+++ b/qt/widgets/mplcpp/src/ColorbarWidget.cpp
@@ -71,17 +71,17 @@ void ColorbarWidget::setNorm(const NormalizeBase &norm) {
  * @param vmin An optional new minimum of the scale
  * @param vmax An optional new maximum of the scale
  */
-void ColorbarWidget::setClim(boost::optional<double> vmin, boost::optional<double> vmax) {
+void ColorbarWidget::setClim(std::optional<double> vmin, std::optional<double> vmax) {
   m_mappable.setClim(vmin, vmax);
   m_canvas->draw();
 
-  if (vmin.is_initialized()) {
-    m_ui.scaleMinEdit->setText(QString::number(vmin.get()));
-    emit minValueChanged(vmin.get());
+  if (vmin.has_value()) {
+    m_ui.scaleMinEdit->setText(QString::number(vmin.value()));
+    emit minValueChanged(vmin.value());
   }
-  if (vmax.is_initialized()) {
-    m_ui.scaleMaxEdit->setText(QString::number(vmax.get()));
-    emit maxValueChanged(vmax.get());
+  if (vmax.has_value()) {
+    m_ui.scaleMaxEdit->setText(QString::number(vmax.value()));
+    emit maxValueChanged(vmax.value());
   }
 }
 
@@ -112,13 +112,13 @@ void ColorbarWidget::setupColorBarScaling(const MantidColorMap &mtdCMap) {
  * Update the minimum value of the normalization scale
  * @param vmin New minimum of the scale
  */
-void ColorbarWidget::setMinValue(double vmin) { setClim(vmin, boost::none); }
+void ColorbarWidget::setMinValue(double vmin) { setClim(vmin, std::nullopt); }
 
 /**
  * Update the maximum value of the normalization scale
  * @param vmin New maximum of the scale
  */
-void ColorbarWidget::setMaxValue(double vmax) { setClim(boost::none, vmax); }
+void ColorbarWidget::setMaxValue(double vmax) { setClim(std::nullopt, vmax); }
 
 /**
  * @return The minimum color scale value as a string
@@ -198,7 +198,7 @@ void ColorbarWidget::scaleMinimumEdited() {
   // The validator ensures the text is a double
   const double value = m_ui.scaleMinEdit->text().toDouble();
   emit minValueEdited(value);
-  setClim(value, boost::none);
+  setClim(value, std::nullopt);
 }
 
 /**
@@ -208,7 +208,7 @@ void ColorbarWidget::scaleMaximumEdited() {
   // The validator ensures the text is a double
   const double value = m_ui.scaleMaxEdit->text().toDouble();
   emit maxValueEdited(value);
-  setClim(boost::none, value);
+  setClim(std::nullopt, value);
 }
 
 /**

--- a/qt/widgets/mplcpp/src/Colors.cpp
+++ b/qt/widgets/mplcpp/src/Colors.cpp
@@ -9,16 +9,16 @@
 #include "MantidPythonInterface/core/ErrorHandling.h"
 #include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <algorithm>
 #include <numeric>
 #include <tuple>
 
-using boost::none;
-using boost::optional;
 using Mantid::PythonInterface::GlobalInterpreterLock;
 using Mantid::PythonInterface::PythonException;
+using std::nullopt;
+using std::optional;
 
 using OptionalTupleDouble = optional<std::tuple<double, double>>;
 
@@ -35,10 +35,10 @@ Python::Object colorsModule() { return Python::NewRef(PyImport_ImportModule("mat
 
 // Factory function for creating a Normalize instance
 // Holds the GIL
-Python::Object createNormalize(OptionalTupleDouble clim = none) {
+Python::Object createNormalize(OptionalTupleDouble clim = std::nullopt) {
   GlobalInterpreterLock lock;
-  if (clim.is_initialized()) {
-    const auto &range = clim.get();
+  if (clim.has_value()) {
+    const auto &range = clim.value();
     return colorsModule().attr("Normalize")(std::get<0>(range), std::get<1>(range));
   } else
     return colorsModule().attr("Normalize")();
@@ -46,10 +46,10 @@ Python::Object createNormalize(OptionalTupleDouble clim = none) {
 
 // Factory function for creating a SymLogNorm instance
 // Holds the GIL
-Python::Object createSymLog(double linthresh, double linscale, OptionalTupleDouble clim = none) {
+Python::Object createSymLog(double linthresh, double linscale, OptionalTupleDouble clim = std::nullopt) {
   GlobalInterpreterLock lock;
-  if (clim.is_initialized()) {
-    const auto &range = clim.get();
+  if (clim.has_value()) {
+    const auto &range = clim.value();
     return colorsModule().attr("SymLogNorm")(linthresh, linscale, std::get<0>(range), std::get<1>(range));
   } else
     return colorsModule().attr("SymLogNorm")(linthresh, linscale);
@@ -57,10 +57,10 @@ Python::Object createSymLog(double linthresh, double linscale, OptionalTupleDoub
 
 // Factory function for creating a SymLogNorm instance
 // Holds the GIL
-Python::Object createPowerNorm(double gamma, OptionalTupleDouble clim = none) {
+Python::Object createPowerNorm(double gamma, OptionalTupleDouble clim = std::nullopt) {
   GlobalInterpreterLock lock;
-  if (clim.is_initialized()) {
-    const auto &range = clim.get();
+  if (clim.has_value()) {
+    const auto &range = clim.value();
     return colorsModule().attr("PowerNorm")(gamma, std::get<0>(range), std::get<1>(range));
   } else {
     return colorsModule().attr("PowerNorm")(gamma);

--- a/qt/widgets/mplcpp/src/MantidAxes.cpp
+++ b/qt/widgets/mplcpp/src/MantidAxes.cpp
@@ -33,14 +33,14 @@ MantidAxes::MantidAxes(Python::Object pyObj) : Axes{std::move(pyObj)} {}
  */
 Line2D MantidAxes::plot(const Mantid::API::MatrixWorkspace_sptr &workspace, const size_t wkspIndex,
                         const QString &lineColour, const QString &label,
-                        const boost::optional<QHash<QString, QVariant>> &otherKwargs) {
+                        const std::optional<QHash<QString, QVariant>> &otherKwargs) {
   GlobalInterpreterLock lock;
   const auto wksp = Python::NewRef(MatrixWorkpaceToPython()(workspace));
   const auto args = Python::NewRef(Py_BuildValue("(O)", wksp.ptr()));
 
   Python::Dict kwargs;
   if (otherKwargs)
-    kwargs = Python::qHashToDict(otherKwargs.get());
+    kwargs = Python::qHashToDict(otherKwargs.value());
   kwargs["wkspIndex"] = wkspIndex;
   kwargs["color"] = lineColour.toLatin1().constData();
   kwargs["label"] = label.toLatin1().constData();
@@ -58,14 +58,14 @@ Line2D MantidAxes::plot(const Mantid::API::MatrixWorkspace_sptr &workspace, cons
  */
 ErrorbarContainer MantidAxes::errorbar(const Mantid::API::MatrixWorkspace_sptr &workspace, const size_t wkspIndex,
                                        const QString &lineColour, const QString &label,
-                                       const boost::optional<QHash<QString, QVariant>> &otherKwargs) {
+                                       const std::optional<QHash<QString, QVariant>> &otherKwargs) {
   GlobalInterpreterLock lock;
   const auto wksp = Python::NewRef(MatrixWorkpaceToPython()(workspace));
   const auto args = Python::NewRef(Py_BuildValue("(O)", wksp.ptr()));
 
   Python::Dict kwargs;
   if (otherKwargs)
-    kwargs = Python::qHashToDict(otherKwargs.get());
+    kwargs = Python::qHashToDict(otherKwargs.value());
   kwargs["wkspIndex"] = wkspIndex;
   kwargs["color"] = lineColour.toLatin1().constData();
   kwargs["label"] = label.toLatin1().constData();
@@ -74,14 +74,14 @@ ErrorbarContainer MantidAxes::errorbar(const Mantid::API::MatrixWorkspace_sptr &
 }
 
 void MantidAxes::pcolormesh(const Mantid::API::MatrixWorkspace_sptr &workspace,
-                            const boost::optional<QHash<QString, QVariant>> &otherKwargs) {
+                            const std::optional<QHash<QString, QVariant>> &otherKwargs) {
   GlobalInterpreterLock lock;
   const auto wksp = Python::NewRef(MatrixWorkpaceToPython()(workspace));
   const auto args = Python::NewRef(Py_BuildValue("(O)", wksp.ptr()));
 
   Python::Dict kwargs;
   if (otherKwargs)
-    kwargs = Python::qHashToDict(otherKwargs.get());
+    kwargs = Python::qHashToDict(otherKwargs.value());
 
   pyobj().attr("pcolormesh")(*args, **kwargs);
 }

--- a/qt/widgets/mplcpp/src/PeakMarker.cpp
+++ b/qt/widgets/mplcpp/src/PeakMarker.cpp
@@ -19,14 +19,14 @@ using Mantid::PythonInterface::PythonException;
 namespace {
 
 Python::Object newMarker(FigureCanvasQt *canvas, int peakID, double x, double height, double fwhm, double background,
-                         boost::optional<QHash<QString, QVariant>> const &otherKwargs) {
+                         std::optional<QHash<QString, QVariant>> const &otherKwargs) {
   GlobalInterpreterLock lock;
 
   Python::Object markersModule{Python::NewRef(PyImport_ImportModule("mantidqt.plotting.markers"))};
 
   auto const args =
       Python::NewRef(Py_BuildValue("(Oidddd)", canvas->pyobj().ptr(), peakID, x, height, fwhm, background));
-  Python::Dict kwargs = Python::qHashToDict(otherKwargs.get());
+  Python::Dict kwargs = Python::qHashToDict(otherKwargs.value());
 
   auto const marker = markersModule.attr("PeakMarker")(*args, **kwargs);
   return marker;

--- a/qt/widgets/mplcpp/src/RangeMarker.cpp
+++ b/qt/widgets/mplcpp/src/RangeMarker.cpp
@@ -18,14 +18,14 @@ using namespace MantidQt::Widgets::MplCpp;
 namespace {
 
 Python::Object newMarker(FigureCanvasQt *canvas, QString const &colour, double minimum, double maximum,
-                         QString const &rangeType, boost::optional<QHash<QString, QVariant>> const &otherKwargs) {
+                         QString const &rangeType, std::optional<QHash<QString, QVariant>> const &otherKwargs) {
   GlobalInterpreterLock lock;
 
   Python::Object markersModule{Python::NewRef(PyImport_ImportModule("mantidqt.plotting.markers"))};
 
   auto const args = Python::NewRef(Py_BuildValue("(Osdds)", canvas->pyobj().ptr(), colour.toLatin1().constData(),
                                                  minimum, maximum, rangeType.toLatin1().constData()));
-  Python::Dict kwargs = Python::qHashToDict(otherKwargs.get());
+  Python::Dict kwargs = Python::qHashToDict(otherKwargs.value());
 
   auto const marker = markersModule.attr("RangeMarker")(*args, **kwargs);
   return marker;

--- a/qt/widgets/mplcpp/src/ScalarMappable.cpp
+++ b/qt/widgets/mplcpp/src/ScalarMappable.cpp
@@ -87,16 +87,16 @@ void ScalarMappable::setNorm(const NormalizeBase &norm) {
  * @param vmin An optional new minmum value
  * @param vmax An optional new maximum value
  */
-void ScalarMappable::setClim(boost::optional<double> vmin, boost::optional<double> vmax) {
+void ScalarMappable::setClim(std::optional<double> vmin, std::optional<double> vmax) {
   GlobalInterpreterLock lock;
   Python::Object none;
   auto setClimAttr = pyobj().attr("set_clim");
-  if (vmin.is_initialized() && vmax.is_initialized()) {
-    setClimAttr(vmin.get(), vmax.get());
-  } else if (vmin.is_initialized()) {
-    setClimAttr(vmin.get(), none);
-  } else if (vmax.is_initialized()) {
-    setClimAttr(none, vmax.get());
+  if (vmin.has_value() && vmax.has_value()) {
+    setClimAttr(vmin.value(), vmax.value());
+  } else if (vmin.has_value()) {
+    setClimAttr(vmin.value(), none);
+  } else if (vmax.has_value()) {
+    setClimAttr(none, vmax.value());
   }
 }
 

--- a/qt/widgets/mplcpp/src/SingleMarker.cpp
+++ b/qt/widgets/mplcpp/src/SingleMarker.cpp
@@ -18,14 +18,14 @@ using namespace MantidQt::Widgets::MplCpp;
 namespace {
 
 Python::Object newMarker(FigureCanvasQt *canvas, QString const &colour, double position, double minimum, double maximum,
-                         QString const &markerType, boost::optional<QHash<QString, QVariant>> const &otherKwargs) {
+                         QString const &markerType, std::optional<QHash<QString, QVariant>> const &otherKwargs) {
   GlobalInterpreterLock lock;
 
   Python::Object markersModule{Python::NewRef(PyImport_ImportModule("mantidqt.plotting.markers"))};
 
   auto const args = Python::NewRef(Py_BuildValue("(Osddds)", canvas->pyobj().ptr(), colour.toLatin1().constData(),
                                                  position, minimum, maximum, markerType.toLatin1().constData()));
-  Python::Dict kwargs = Python::qHashToDict(otherKwargs.get());
+  Python::Dict kwargs = Python::qHashToDict(otherKwargs.value());
 
   auto const marker = markersModule.attr("SingleMarker")(*args, **kwargs);
   return marker;

--- a/qt/widgets/mplcpp/test/ScalarMappableTest.h
+++ b/qt/widgets/mplcpp/test/ScalarMappableTest.h
@@ -75,7 +75,7 @@ public:
 
   void testSetCLimSetsMaxOnlyWhenMinNotProvided() {
     ScalarMappable mappable(Normalize(-1, 1), "jet");
-    mappable.setClim(boost::none, 10);
+    mappable.setClim(std::nullopt, 10);
     auto norm = mappable.pyobj().attr("norm");
     TS_ASSERT_EQUALS(-1, norm.attr("vmin"));
     TS_ASSERT_EQUALS(10, norm.attr("vmax"));
@@ -83,7 +83,7 @@ public:
 
   void testSetCLimSetsNothingWhenNothingProvided() {
     ScalarMappable mappable(Normalize(-1, 1), "jet");
-    mappable.setClim(boost::none, boost::none);
+    mappable.setClim(std::nullopt, std::nullopt);
     auto norm = mappable.pyobj().attr("norm");
     TS_ASSERT_EQUALS(-1, norm.attr("vmin"));
     TS_ASSERT_EQUALS(1, norm.attr("vmax"));

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
@@ -133,7 +133,7 @@ private:
   void setScaleType(AxisID id, const QString &actionName);
   void toggleLegend(const bool checked);
 
-  boost::optional<char const *> overrideAxisLabel(AxisID const &axisID);
+  std::optional<char const *> overrideAxisLabel(AxisID const &axisID);
   void setAxisLabel(AxisID const &axisID, char const *const label);
 
   // Block redrawing from taking place

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -122,9 +122,9 @@ void PreviewPlot::addSpectrum(const QString &lineName, const Mantid::API::Matrix
       QSharedPointer<PlotCurveConfiguration>(new PlotCurveConfiguration(ws, lineName, wsIndex, lineColour, plotKwargs));
   m_plottedLines.insert(lineName, plotCurveConfig);
   if (auto const xLabel = overrideAxisLabel(AxisID::XBottom))
-    setAxisLabel(AxisID::XBottom, xLabel.get());
+    setAxisLabel(AxisID::XBottom, xLabel.value());
   if (auto const yLabel = overrideAxisLabel(AxisID::YLeft))
-    setAxisLabel(AxisID::YLeft, yLabel.get());
+    setAxisLabel(AxisID::YLeft, yLabel.value());
 
   regenerateLegend();
   axes.relim();
@@ -241,11 +241,11 @@ void PreviewPlot::setOverrideAxisLabel(AxisID const &axisID, char const *const l
  * @param axisID The axis ID (XBottom or YLeft).
  * @return True if the axis should display an axis label.
  */
-boost::optional<char const *> PreviewPlot::overrideAxisLabel(AxisID const &axisID) {
+std::optional<char const *> PreviewPlot::overrideAxisLabel(AxisID const &axisID) {
   auto const iter = m_axisLabels.find(axisID);
   if (iter != m_axisLabels.end())
     return iter.value();
-  return boost::none;
+  return std::nullopt;
 }
 
 /**

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/FitData.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/FitData.h
@@ -12,8 +12,8 @@
 #include "MantidQtWidgets/Common/FunctionModelSpectra.h"
 #include "MantidQtWidgets/Common/IndexTypes.h"
 
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 #include <cctype>
 #include <numeric>

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/InelasticTab.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/InelasticTab.h
@@ -21,7 +21,7 @@
 #include "MantidQtWidgets/Spectroscopy/RunWidget/RunPresenter.h"
 
 #include <boost/none_t.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <QDoubleValidator>
 #include <QMap>
@@ -86,7 +86,7 @@ protected:
   /// Function to set the range selector on the mini plot
   void setRangeSelector(MantidWidgets::RangeSelector *rs, QtProperty *lower, QtProperty *upper,
                         const QPair<double, double> &range,
-                        const boost::optional<QPair<double, double>> &bounds = boost::none);
+                        const std::optional<QPair<double, double>> &bounds = std::nullopt);
   /// Sets the min of the range selector if it is less than the max
   void setRangeSelectorMin(QtProperty *minProperty, QtProperty *maxProperty,
                            MantidWidgets::RangeSelector *rangeSelector, double newValue);

--- a/qt/widgets/spectroscopy/src/InelasticTab.cpp
+++ b/qt/widgets/spectroscopy/src/InelasticTab.cpp
@@ -196,13 +196,14 @@ void InelasticTab::setPlotPropertyRange(RangeSelector *rs, QtProperty *min, QtPr
  */
 void InelasticTab::setRangeSelector(RangeSelector *rs, QtProperty *lower, QtProperty *upper,
                                     const QPair<double, double> &range,
-                                    const boost::optional<QPair<double, double>> &bounds) {
+                                    const std::optional<QPair<double, double>> &bounds) {
   m_dblManager->setValue(lower, range.first);
   m_dblManager->setValue(upper, range.second);
   rs->setRange(range.first, range.second);
   if (bounds) {
     // clamp the bounds of the selector
-    rs->setBounds(bounds.get().first, bounds.get().second);
+    const auto values = bounds.value();
+    rs->setBounds(values.first, values.second);
   }
 }
 


### PR DESCRIPTION
~~Don't review until #37930 is merged.~~

### Description of work
Since `std::optional` is part of C++17, move the easy parts of mantid to use it. This does not modify [Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h](https://github.com/mantidproject/mantid/blob/main/Framework/Geometry/inc/MantidGeometry/Crystal/MatrixVectorPairParser.h) or the ISISReflectometryGUI code.

`Framework/API/inc/MantidAPI/AlgorithmProperties.h` was made to support both `std::optional` and `boost::optional` to handle the ISISReflectometryGUI not being moved.

#### Purpose of work
The preference for implementation (in order) is generally:
1. compiler feature
2. existing dependency / write in the repository
3. new dependency

This is moving from boost to c++17

Refs #37875.

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

This is a refactor and does not require anything other than the changes make sense and the tests continue to pass

*This does not require release notes* because it is an internal change to modernize the code.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
