### PR TITLE
Update available fit functions on Function Q interface according to data

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/Strings.h
+++ b/Framework/Kernel/inc/MantidKernel/Strings.h
@@ -250,6 +250,9 @@ MANTID_KERNEL_DLL std::string toLower(const std::string &input);
 /// Converts string to all uppercase
 MANTID_KERNEL_DLL std::string toUpper(const std::string &input);
 
+/// Checks if string ends with a suffix
+MANTID_KERNEL_DLL bool endsWith(std::string const &str, std::string const &suffix);
+
 /// determine if a character group exists in a string
 MANTID_KERNEL_DLL int confirmStr(const std::string &S, const std::string &fullPhrase);
 /// Get a word from a string

--- a/Framework/Kernel/src/Strings.cpp
+++ b/Framework/Kernel/src/Strings.cpp
@@ -127,6 +127,15 @@ MANTID_KERNEL_DLL std::string toUpper(const std::string &input) {
   return output;
 }
 
+/** Checks if string ends with a suffix
+ */
+MANTID_KERNEL_DLL bool endsWith(std::string const &str, std::string const &suffix) {
+  if (str.size() >= suffix.size()) {
+    return str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+  }
+  return false;
+}
+
 //------------------------------------------------------------------------------------------------
 /**
  * Function to convert a number into hex

--- a/Framework/Kernel/test/StringsTest.h
+++ b/Framework/Kernel/test/StringsTest.h
@@ -599,6 +599,13 @@ public:
       TS_ASSERT_EQUALS(text.length(), length);
     }
   }
+
+  void test_endsWith_when_the_suffix_is_smaller_than_the_str() {
+    TS_ASSERT(endsWith("ATestString", "String"));
+    TS_ASSERT(!endsWith("AStringTest", "String"));
+  }
+
+  void test_endsWith_when_the_suffix_is_too_large() { TS_ASSERT(!endsWith("SmallText", "AVeryLongSuffix")); }
 };
 
 class StringsTestPerformance : public CxxTest::TestSuite {

--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37671.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37671.rst
@@ -1,0 +1,1 @@
+- Available fit functions in the `Function (Q)` tab of the :ref:`QENS Fitting <interface-inelastic-qens-fitting>` interface are updated according to the type of data (`EISF`, `A0` or `Width`) loaded on the table.

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.cpp
@@ -148,11 +148,11 @@ void FitDataPresenter::addTableEntry(FitDomainIndex row) {
 }
 
 void FitDataPresenter::handleCellChanged(int row, int column) {
-  if (m_view->getColumnIndexFromName("StartX") == column) {
+  if (m_view->columnIndex("StartX") == column) {
     setTableStartXAndEmit(m_view->getText(row, column).toDouble(), row, column);
-  } else if (m_view->getColumnIndexFromName("EndX") == column) {
+  } else if (m_view->columnIndex("EndX") == column) {
     setTableEndXAndEmit(m_view->getText(row, column).toDouble(), row, column);
-  } else if (m_view->getColumnIndexFromName("Mask X Range") == column) {
+  } else if (m_view->columnIndex("Mask X Range") == column) {
     setModelExcludeAndEmit(m_view->getText(row, column).toStdString(), row);
   }
 }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataPresenter.h
@@ -56,6 +56,8 @@ public:
   std::vector<std::string> createDisplayNames() const;
   void validate(IUserInputValidator *validator);
 
+  virtual void updateFitFunctionList() const {};
+
   virtual void addWorkspace(const std::string &workspaceName, const std::string &paramType, const int &spectrum_index) {
     UNUSED_ARG(workspaceName);
     UNUSED_ARG(paramType);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
@@ -121,7 +121,7 @@ void FitDataView::setCell(std::unique_ptr<QTableWidgetItem> cell, size_t row, si
 
 bool FitDataView::columnContains(std::string const &columnHeader, std::string const &text) const {
   auto const column = columnIndex(columnHeader);
-  for (auto row = 0u; row < m_uiForm->tbFitData->rowCount(); ++row) {
+  for (auto row = 0; row < m_uiForm->tbFitData->rowCount(); ++row) {
     auto const itemText = m_uiForm->tbFitData->item(row, column)->text();
     if (itemText.contains(QString::fromStdString(text))) {
       return true;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
@@ -59,11 +59,11 @@ void FitDataView::setHorizontalHeaders(const QStringList &headers) {
   auto header = m_uiForm->tbFitData->horizontalHeader();
   header->setSectionResizeMode(0, QHeaderView::Stretch);
 
-  m_uiForm->tbFitData->setItemDelegateForColumn(getColumnIndexFromName("StartX"),
+  m_uiForm->tbFitData->setItemDelegateForColumn(columnIndex("StartX"),
                                                 new NumericInputDelegate(m_uiForm->tbFitData, NUMERICAL_PRECISION));
-  m_uiForm->tbFitData->setItemDelegateForColumn(getColumnIndexFromName("EndX"),
+  m_uiForm->tbFitData->setItemDelegateForColumn(columnIndex("EndX"),
                                                 new NumericInputDelegate(m_uiForm->tbFitData, NUMERICAL_PRECISION));
-  m_uiForm->tbFitData->setItemDelegateForColumn(getColumnIndexFromName("Mask X Range"),
+  m_uiForm->tbFitData->setItemDelegateForColumn(columnIndex("Mask X Range"),
                                                 new RegexInputDelegate(m_uiForm->tbFitData, MASK_LIST));
 
   m_uiForm->tbFitData->verticalHeader()->setVisible(false);
@@ -89,16 +89,16 @@ void FitDataView::addTableEntry(size_t row, FitDataRow const &newRow) {
 
   cell = std::make_unique<QTableWidgetItem>(QString::number(newRow.workspaceIndex));
   cell->setFlags(flags);
-  setCell(std::move(cell), row, getColumnIndexFromName("WS Index"));
+  setCell(std::move(cell), row, columnIndex("WS Index"));
 
   cell = std::make_unique<QTableWidgetItem>(makeQStringNumber(newRow.startX, NUMERICAL_PRECISION));
-  setCell(std::move(cell), row, getColumnIndexFromName("StartX"));
+  setCell(std::move(cell), row, columnIndex("StartX"));
 
   cell = std::make_unique<QTableWidgetItem>(makeQStringNumber(newRow.endX, NUMERICAL_PRECISION));
-  setCell(std::move(cell), row, getColumnIndexFromName("EndX"));
+  setCell(std::move(cell), row, columnIndex("EndX"));
 
   cell = std::make_unique<QTableWidgetItem>(QString::fromStdString(newRow.exclude));
-  setCell(std::move(cell), row, getColumnIndexFromName("Mask X Range"));
+  setCell(std::move(cell), row, columnIndex("Mask X Range"));
 }
 
 void FitDataView::updateNumCellEntry(double numEntry, size_t row, size_t column) {
@@ -109,8 +109,8 @@ void FitDataView::updateNumCellEntry(double numEntry, size_t row, size_t column)
 
 bool FitDataView::isTableEmpty() const { return m_uiForm->tbFitData->rowCount() == 0; }
 
-int FitDataView::getColumnIndexFromName(std::string const &ColName) {
-  return m_HeaderLabels.indexOf(QString::fromStdString(ColName));
+int FitDataView::columnIndex(std::string const &name) const {
+  return m_HeaderLabels.indexOf(QString::fromStdString(name));
 }
 
 void FitDataView::clearTable() { m_uiForm->tbFitData->setRowCount(0); }
@@ -119,8 +119,15 @@ void FitDataView::setCell(std::unique_ptr<QTableWidgetItem> cell, size_t row, si
   m_uiForm->tbFitData->setItem(static_cast<int>(row), static_cast<int>(column), cell.release());
 }
 
-bool FitDataView::dataColumnContainsText(std::string const &columnText) const {
-  return !m_uiForm->tbFitData->findItems(QString::fromStdString(columnText), Qt::MatchContains).isEmpty();
+bool FitDataView::columnContains(std::string const &columnHeader, std::string const &text) const {
+  auto const column = columnIndex(columnHeader);
+  for (auto row = 0u; row < m_uiForm->tbFitData->rowCount(); ++row) {
+    auto const itemText = m_uiForm->tbFitData->item(row, column)->text();
+    if (itemText.contains(QString::fromStdString(text))) {
+      return true;
+    }
+  }
+  return false;
 }
 
 QString FitDataView::getText(int row, int column) const {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.h
@@ -39,11 +39,11 @@ public:
   void validate(IUserInputValidator *validator) override;
   virtual void addTableEntry(size_t row, FitDataRow const &newRow) override;
   virtual void updateNumCellEntry(double numEntry, size_t row, size_t column) override;
-  int getColumnIndexFromName(std::string const &ColName) override;
+  int columnIndex(std::string const &name) const override;
   void clearTable() override;
   QString getText(int row, int column) const override;
   QModelIndexList getSelectedIndexes() const override;
-  bool dataColumnContainsText(std::string const &columnText) const override;
+  bool columnContains(std::string const &columnHeader, std::string const &text) const override;
 
   void displayWarning(const std::string &warning) override;
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitTab.cpp
@@ -111,6 +111,7 @@ void FitTab::handleDataRemoved() {
   updateDataReferences();
   m_plotPresenter->updateDataSelection(m_dataPresenter->createDisplayNames());
   updateParameterEstimationData();
+  m_dataPresenter->updateFitFunctionList();
 }
 
 void FitTab::handlePlotSpectrumChanged() {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.cpp
@@ -11,6 +11,7 @@
 #include "ParameterEstimation.h"
 
 #include "MantidAPI/TextAxis.h"
+#include "MantidKernel/Strings.h"
 
 namespace {
 using namespace MantidQt::CustomInterfaces::Inelastic;
@@ -33,9 +34,10 @@ void replaceAxisLabel(TextAxis *axis, std::size_t const index, std::string const
   axis->setLabel(index, label);
 }
 
-void convertWidthToHWHM(MatrixWorkspace_sptr workspace, const std::vector<std::size_t> &widthSpectra) {
+void convertWidthToHWHM(MatrixWorkspace_sptr workspace, std::vector<std::size_t> const &widthSpectra) {
   for (auto const &spectrumIndex : widthSpectra) {
-    if (auto axis = dynamic_cast<TextAxis *>(workspace->getAxis(1))) {
+    auto axis = dynamic_cast<TextAxis *>(workspace->getAxis(1));
+    if (axis && !Mantid::Kernel::Strings::endsWith(axis->label(spectrumIndex), "HWHM")) {
       replaceAxisLabel(axis, spectrumIndex, "Width", "HWHM");
       replaceAxisLabel(axis, spectrumIndex, "FWHM", "HWHM");
       workspace->mutableY(spectrumIndex) *= 0.5;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.cpp
@@ -97,8 +97,9 @@ FunctionQDataPresenter::chooseFunctionQFunctions(std::optional<bool> paramWidth)
     return (paramWidth == std::nullopt) ? FunctionQ::ALL_FITS
            : *paramWidth                ? FunctionQ::WIDTH_FITS
                                         : FunctionQ::EISF_FITS;
-  auto widthFuncs = m_view->dataColumnContainsText("HWHM");
-  auto eisfFuncs = m_view->dataColumnContainsText("EISF") || m_view->dataColumnContainsText("A0");
+  auto const columnHeader = "Parameter";
+  auto widthFuncs = m_view->columnContains(columnHeader, "HWHM");
+  auto eisfFuncs = m_view->columnContains(columnHeader, "EISF") || m_view->columnContains(columnHeader, "A0");
   if (paramWidth != std::nullopt) {
     widthFuncs = widthFuncs || *paramWidth;
     eisfFuncs = eisfFuncs || !*paramWidth;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataPresenter.h
@@ -35,6 +35,7 @@ public:
   void handleAddClicked() override;
   void handleWorkspaceChanged(FunctionQAddWorkspaceDialog *dialog, const std::string &workspace) override;
   void handleParameterTypeChanged(FunctionQAddWorkspaceDialog *dialog, const std::string &type) override;
+  void updateFitFunctionList() const override;
 
 protected:
   void addTableEntry(FitDomainIndex row) override;
@@ -44,7 +45,7 @@ private:
   void updateActiveWorkspaceID(WorkspaceID index);
   void updateParameterOptions(FunctionQAddWorkspaceDialog *dialog, const FunctionQParameters &parameters);
   void updateParameterTypes(FunctionQAddWorkspaceDialog *dialog, FunctionQParameters const &parameters);
-  std::map<std::string, std::string> chooseFunctionQFunctions(bool paramWidth) const;
+  std::map<std::string, std::string> chooseFunctionQFunctions(std::optional<bool> paramWidth) const;
   void setActiveWorkspaceIDToCurrentWorkspace(MantidWidgets::IAddWorkspaceDialog const *dialog);
 
   std::string m_activeParameterType;

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQParameters.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQParameters.cpp
@@ -51,7 +51,7 @@ namespace MantidQt::CustomInterfaces::Inelastic {
 FunctionQParameters::FunctionQParameters() : m_widths(), m_eisfs() {}
 
 FunctionQParameters::FunctionQParameters(const MatrixWorkspace_sptr &workspace)
-    : m_widths(findAxisLabels(workspace, {".Width", ".FWHM"})), m_eisfs(findAxisLabels(workspace, {".EISF"})),
+    : m_widths(findAxisLabels(workspace, {".Width", ".FWHM", ".HWHM"})), m_eisfs(findAxisLabels(workspace, {".EISF"})),
       m_a0s(findAxisLabels(workspace, {".A0"})) {}
 
 std::vector<std::string> FunctionQParameters::names(std::string const &parameterType) const {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/IFitDataView.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/IFitDataView.h
@@ -39,11 +39,11 @@ public:
   virtual void validate(IUserInputValidator *validator) = 0;
   virtual void addTableEntry(size_t row, FitDataRow const &newRow) = 0;
   virtual void updateNumCellEntry(double numEntry, size_t row, size_t column) = 0;
-  virtual int getColumnIndexFromName(std::string const &ColName) = 0;
+  virtual int columnIndex(std::string const &name) const = 0;
   virtual void clearTable() = 0;
   virtual QString getText(int row, int column) const = 0;
   virtual QModelIndexList getSelectedIndexes() const = 0;
-  virtual bool dataColumnContainsText(std::string const &columnText) const = 0;
+  virtual bool columnContains(std::string const &columnHeader, std::string const &text) const = 0;
 
   virtual void displayWarning(std::string const &warning) = 0;
 };

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -292,11 +292,11 @@ public:
   MOCK_METHOD1(validate, void(MantidQt::CustomInterfaces::IUserInputValidator *validator));
   MOCK_METHOD2(addTableEntry, void(size_t row, FitDataRow const &newRow));
   MOCK_METHOD3(updateNumCellEntry, void(double numEntry, size_t row, size_t column));
-  MOCK_METHOD1(getColumnIndexFromName, int(std::string const &ColName));
+  MOCK_CONST_METHOD1(columnIndex, int(std::string const &name));
   MOCK_METHOD0(clearTable, void());
   MOCK_CONST_METHOD2(getText, QString(int row, int column));
   MOCK_CONST_METHOD0(getSelectedIndexes, QModelIndexList());
-  MOCK_CONST_METHOD1(dataColumnContainsText, bool(const std::string &columnText));
+  MOCK_CONST_METHOD2(columnContains, bool(const std::string &columnHeader, const std::string &text));
 
   MOCK_METHOD1(setSampleWSSuffices, void(const QStringList &suffices));
   MOCK_METHOD1(setSampleFBSuffices, void(const QStringList &suffices));


### PR DESCRIPTION
### Description of work
Fixes the issue described in #37671 . Whenever new data is added to  the data table in the Function (Q) tab of the QENS Fitting interface, the list of available fit functions in the fit property browser should be updated dynamically to show which functions are available to fit according to the data on the table. This should be updated also whenever data is removed from the table. 

#### Summary of work
In order to add this feature, I have added a virtual function to the FitDataPresenter class that is redefined in the derived classes (in this case `FunctionQDataPresenter`) and that updates the available functions list from the remove handle in the `FitTab` class when the signal for removing data is sent. 
I have refactored the function `chooseFunctionQFunctions` on the `FunctionQDataPresenter` to be able to update properly when data is removed from the table (it was only implemented for added data). 


<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37671 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
Follow the test instructions of #37671, making sure now that the available functions are updated appropiately (the available functions for `EISF` data all start with the prefix `EISF`). 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
