### PR TITLE
Hide the "Optimise Event Slices" Checkbox In the ISIS SANS GUI

### DIFF
--- a/docs/source/release/v6.11.0/SANS/Bugfixes/37846.rst
+++ b/docs/source/release/v6.11.0/SANS/Bugfixes/37846.rst
@@ -1,0 +1,3 @@
+- The ``Optimize Event Slices`` checkbox has been removed from the ``General, Scale, Event Slice, Sample`` settings on
+  the ISIS SANS :ref:`ISIS_SANS_Settings_Tab-ref` menu to avoid an issue with the ``SANSSingleReduction2`` algorithm
+  not working.

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -387,6 +387,11 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         self.hide_geometry()
         self.hide_background_subtraction()
 
+        # Hide broken functionality: https://github.com/mantidproject/mantid/issues/37836
+        self.event_slice_optimisation_checkbox.setChecked(False)
+        self.event_slice_optimisation_checkbox.setHidden(True)
+        self.event_slice_optimisation_label.setHidden(True)
+
         return True
 
     def _on_wavelength_step_type_changed(self):
@@ -1142,7 +1147,7 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
 
     @event_slice_optimisation.setter
     def event_slice_optimisation(self, value):
-        self.event_slice_optimisation_checkbox.setChecked(value)
+        pass
 
     @property
     def instrument(self):

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -1147,6 +1147,8 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
 
     @event_slice_optimisation.setter
     def event_slice_optimisation(self, value):
+        # Functionality is broken, so the checkbox for this setter is hidden. See here for more information:
+        # https://github.com/mantidproject/mantid/issues/37836
         pass
 
     @property


### PR DESCRIPTION
### Description of work


#### Summary of work
Hide and uncheck the Optimise Event Slices checkbox, which can cause the SANSSingleReduction2 algorithm to run, which doesn't work anymore. 

Fixes #37846 


#### Further detail of work
Hide the functionality rather than remove it, until we can determine if the algorithm needs to be used. The changes ensure that the checkbox cannot be checked in the background. 

### To test:
1. Load the User and Batch files from the `loqdemo`. 
2. Switch to the Settings tab. 
3. Check that the Optimise Event Slices checkbox is not present next to the `Slices` text entry. 
4. Enter 5-10 into the slices box. 
5. Ensure the Use Compatibility Mode checkbox is checked
6. Return to the Runs tab and run the reduction.
7. Check the history on the output workspaces and ensure the V1 version of SANSSingleReduction was used. 

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
