### PR TITLE
Sphinx 9 deprecations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -206,7 +206,7 @@ epub_uid = "Mantid Reference: " + version
 
 # -- Options for selected builder output ---------------------------------------
 # Default is to use standard HTML theme unless the qthelp tag is specified
-html_theme_cfg = "conf-qthelp.py" if "qthelp" in [k.strip() for k in tags.tags] else "conf-html.py"
+html_theme_cfg = "conf-qthelp.py" if "qthelp" in [k.strip() for k in tags] else "conf-html.py"
 # Python 3 removed execfile...
 exec(compile(open(html_theme_cfg).read(), html_theme_cfg, "exec"))
 

--- a/docs/sphinxext/mantiddoc/directives/amalgamate.py
+++ b/docs/sphinxext/mantiddoc/directives/amalgamate.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantiddoc.directives.base import BaseDirective
-
+from pathlib import Path
 import os
 
 
@@ -36,7 +36,7 @@ class CompilationDirective(BaseDirective):
         if os.path.exists(script_dir):
             for file in os.listdir(script_dir):
                 if file.endswith(".rst"):
-                    with open(script_dir + "/" + file) as f:
+                    with open(script_dir.joinpath(file)) as f:
                         contents = f.read()
                         self.add_rst(contents)
 
@@ -44,7 +44,7 @@ class CompilationDirective(BaseDirective):
 
     def getPath(self):
         # the location of documentation
-        source_dir = self.state.document.settings.env.srcdir
+        source_dir = Path(self.state.document.settings.env.srcdir)
         # the location of the release notes for this version
         release_dir = self.source().rsplit("/", 1)[0]
         # argument provided to amalgamate directive
@@ -52,7 +52,7 @@ class CompilationDirective(BaseDirective):
         if args[0] != "/":
             args = "/" + args
         path_to_notes = release_dir + args
-        return os.path.abspath(os.path.join(source_dir, path_to_notes))
+        return source_dir.joinpath(path_to_notes)
 
 
 def setup(app):

--- a/docs/sphinxext/mantiddoc/directives/amalgamate.py
+++ b/docs/sphinxext/mantiddoc/directives/amalgamate.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantiddoc.directives.base import BaseDirective
-from pathlib import Path
+from pathlib import PurePosixPath
 import os
 
 
@@ -44,7 +44,7 @@ class CompilationDirective(BaseDirective):
 
     def getPath(self):
         # the location of documentation
-        source_dir = Path(self.state.document.settings.env.srcdir)
+        source_dir = PurePosixPath(self.state.document.settings.env.srcdir)
         # the location of the release notes for this version
         release_dir = self.source().rsplit("/", 1)[0]
         # argument provided to amalgamate directive

--- a/docs/sphinxext/mantiddoc/directives/base.py
+++ b/docs/sphinxext/mantiddoc/directives/base.py
@@ -11,6 +11,7 @@ import re
 from mantid.api import AlgorithmFactory, AlgorithmManager, FunctionFactory
 from mantiddoc import get_logger
 from typing import List
+from pathlib import Path
 
 ALG_DOCNAME_RE = re.compile(r"^([A-Z][a-zA-Z0-9]+)-v([0-9][0-9]*)$")
 FIT_DOCNAME_RE = re.compile(r"^([A-Z][a-zA-Z0-9]+)$")
@@ -77,7 +78,7 @@ class BaseDirective(Directive):
         if screenshots_dir is None or screenshots_dir == "":
             return None
         else:
-            return screenshots_dir
+            return Path(screenshots_dir)
 
     def add_rst(self, text):
         """

--- a/docs/sphinxext/mantiddoc/directives/base.py
+++ b/docs/sphinxext/mantiddoc/directives/base.py
@@ -11,7 +11,7 @@ import re
 from mantid.api import AlgorithmFactory, AlgorithmManager, FunctionFactory
 from mantiddoc import get_logger
 from typing import List
-from pathlib import Path
+from pathlib import PurePosixPath
 
 ALG_DOCNAME_RE = re.compile(r"^([A-Z][a-zA-Z0-9]+)-v([0-9][0-9]*)$")
 FIT_DOCNAME_RE = re.compile(r"^([A-Z][a-zA-Z0-9]+)$")
@@ -78,7 +78,7 @@ class BaseDirective(Directive):
         if screenshots_dir is None or screenshots_dir == "":
             return None
         else:
-            return Path(screenshots_dir)
+            return PurePosixPath(screenshots_dir)
 
     def add_rst(self, text):
         """

--- a/docs/sphinxext/mantiddoc/directives/categories.py
+++ b/docs/sphinxext/mantiddoc/directives/categories.py
@@ -16,7 +16,7 @@ creates "index" pages that lists the contents of each category. The display of e
 from mantiddoc.directives.base import AlgorithmBaseDirective, algorithm_name_and_version  # pylint: disable=unused-import
 from sphinx.util.osutil import relative_uri
 import os
-from pathlib import Path
+from pathlib import PurePosixPath
 
 CATEGORY_PAGE_TEMPLATE = "category.html"
 ALG_CATEGORY_PAGE_TEMPLATE = "algorithmcategories.html"
@@ -124,8 +124,8 @@ class Category(LinkItem):
           name (str): The name of the category
           docname (str): Relative path to document from root directory
         """
-        self.src_path = Path(src_path)
-        docname = Path(docname)
+        self.src_path = PurePosixPath(src_path)
+        docname = PurePosixPath(docname)
         self.section = docname.parts[0]
         dirpath = docname.parent
         html_dir = dirpath.joinpath(CATEGORIES_DIR)
@@ -379,7 +379,7 @@ def create_category_pages(app):
         # Now any additional index pages if required
         if category.name in INDEX_CATEGORIES:
             # index in categories directory
-            category_html_dir = Path(category.name.lower(), "categories")
+            category_html_dir = PurePosixPath(category.name.lower(), "categories")
             category_html_path_noext = category_html_dir.joinpath("index")
             yield (str(category_html_path_noext), context, template)
 
@@ -412,7 +412,7 @@ def create_top_algorithm_category(categories):
     # create a Top level algorithms category page
     # Initialise the lists
     all_top_categories = []
-    category_src_dir = Path("")
+    category_src_dir = PurePosixPath("")
     # If the category is a top category it will not contain "\\"
     for top_name, top_category in categories.items():
         # Add all the top level categories
@@ -440,7 +440,7 @@ def create_top_algorithm_category(categories):
 
     # create the page
     top_context = {}
-    top_category_html_path_noext = Path("algorithms", "index")
+    top_category_html_path_noext = PurePosixPath("algorithms", "index")
     top_context["outpath"] = str(top_category_html_path_noext.with_suffix(".html"))
     # set the content
     top_context["pages"] = []
@@ -448,7 +448,7 @@ def create_top_algorithm_category(categories):
     top_context["techniquecategories"] = sorted(technique_categories, key=lambda x: x.name)
     top_context["facilitycategories"] = sorted(facility_categories, key=lambda x: x.name)
     top_context["title"] = "Algorithm Contents"
-    top_html_path_noext = str(Path("algorithms", "index"))
+    top_html_path_noext = str(PurePosixPath("algorithms", "index"))
     return (top_html_path_noext, top_context, template)
 
 

--- a/docs/sphinxext/mantiddoc/directives/categories.py
+++ b/docs/sphinxext/mantiddoc/directives/categories.py
@@ -129,7 +129,10 @@ class Category(LinkItem):
         self.section = docname.parts[0]
         dirpath = docname.parent
         html_dir = dirpath.joinpath(CATEGORIES_DIR)
-        self.html_path = html_dir.joinpath(name + ".html")
+        # name can arrive with a format like "MyAlgorithmCategory\\NameOfAlgorithm", so we
+        # have to sort those slashes out
+        name_with_slashes_fixed = name.replace("\\", "/").replace("//", "/")
+        self.html_path = html_dir.joinpath(name_with_slashes_fixed + ".html")
         super(Category, self).__init__(name, self.html_path)
         self.pages = set([])
         self.subcategories = set([])
@@ -446,7 +449,7 @@ def create_top_algorithm_category(categories):
     top_context["facilitycategories"] = sorted(facility_categories, key=lambda x: x.name)
     top_context["title"] = "Algorithm Contents"
     top_html_path_noext = str(Path("algorithms", "index"))
-    return (str(top_html_path_noext), top_context, template)
+    return (top_html_path_noext, top_context, template)
 
 
 def extract_matching_categories(input_categories, filepath):

--- a/docs/sphinxext/mantiddoc/directives/categories.py
+++ b/docs/sphinxext/mantiddoc/directives/categories.py
@@ -16,7 +16,7 @@ creates "index" pages that lists the contents of each category. The display of e
 from mantiddoc.directives.base import AlgorithmBaseDirective, algorithm_name_and_version  # pylint: disable=unused-import
 from sphinx.util.osutil import relative_uri
 import os
-import posixpath
+from pathlib import Path
 
 CATEGORY_PAGE_TEMPLATE = "category.html"
 ALG_CATEGORY_PAGE_TEMPLATE = "algorithmcategories.html"
@@ -77,7 +77,7 @@ class LinkItem(object):
         Returns:
           str: A string containing the link to reach this item
         """
-        link = relative_uri(base=to_unix_style_path(base), to=self.location)
+        link = relative_uri(str(base), to=str(self.location))
         if not link.endswith(ext):
             link += ext
         return link
@@ -124,12 +124,12 @@ class Category(LinkItem):
           name (str): The name of the category
           docname (str): Relative path to document from root directory
         """
-        self.src_path = to_unix_style_path(src_path)
-        docname = to_unix_style_path(docname)
-        self.section = docname.lower().split("/")[0]
-        dirpath, filename = posixpath.split(docname)
-        html_dir = dirpath + "/" + CATEGORIES_DIR
-        self.html_path = html_dir + "/" + to_unix_style_path(name) + ".html"
+        self.src_path = Path(src_path)
+        docname = Path(docname)
+        self.section = docname.parts[0]
+        dirpath = docname.parent
+        html_dir = dirpath.joinpath(CATEGORIES_DIR)
+        self.html_path = html_dir.joinpath(name + ".html")
         super(Category, self).__init__(name, self.html_path)
         self.pages = set([])
         self.subcategories = set([])
@@ -312,20 +312,6 @@ class CategoriesDirective(AlgorithmBaseDirective):
 # ---------------------------------------------------------------------------------
 
 
-def to_unix_style_path(path):
-    """
-    Replaces any backslashes in the given string with forward slashes
-    and replace consecutive forward slashes with a single forward slash.
-
-    Arguments:
-      path: A string possibly containing backslashes
-    """
-    return path.replace("\\", "/").replace("//", "/")
-
-
-# ---------------------------------------------------------------------------------
-
-
 def html_collect_pages(app):
     """
     Callback for the 'html-collect-pages' Sphinx event. Adds category
@@ -384,21 +370,21 @@ def create_category_pages(app):
         context["outpath"] = category.html_path
 
         # jinja appends .html to output name
-        category_html_path_noext = posixpath.splitext(category.html_path)[0]
-        yield (category_html_path_noext, context, template)
+        category_html_path_noext = category.html_path.with_suffix("")
+        yield (str(category_html_path_noext), context, template)
 
         # Now any additional index pages if required
         if category.name in INDEX_CATEGORIES:
             # index in categories directory
-            category_html_dir = posixpath.join(category.name.lower(), "categories")
-            category_html_path_noext = posixpath.join(category_html_dir, "index")
-            yield (category_html_path_noext, context, template)
+            category_html_dir = Path(category.name.lower(), "categories")
+            category_html_path_noext = category_html_dir.joinpath("index")
+            yield (str(category_html_path_noext), context, template)
 
             # index in document directory
-            document_dir = posixpath.dirname(category_html_dir)
-            category_html_path_noext = posixpath.join(document_dir, "index")
-            context["outpath"] = category_html_path_noext + ".html"
-            yield (category_html_path_noext, context, template)
+            document_dir = category_html_dir.parent
+            category_html_path_noext = document_dir.joinpath("index")
+            context["outpath"] = str(category_html_path_noext.with_suffix(".html"))
+            yield (str(category_html_path_noext), context, template)
 
     # create the top level algorithm category
     yield create_top_algorithm_category(categories)
@@ -423,16 +409,16 @@ def create_top_algorithm_category(categories):
     # create a Top level algorithms category page
     # Initialise the lists
     all_top_categories = []
-    category_src_dir = ""
+    category_src_dir = Path("")
     # If the category is a top category it will not contain "\\"
     for top_name, top_category in categories.items():
         # Add all the top level categories
         if "\\" not in top_name and top_category.section == "algorithms":
             # get additional text for each category
             # if is exists it is in src_path/caterories/name.txt
-            alg_src_dir = posixpath.dirname(top_category.src_path)
-            category_src_dir = posixpath.join(alg_src_dir, "categories")
-            category_text_path = posixpath.join(category_src_dir, top_name) + ".txt"
+            alg_src_dir = top_category.src_path.parent
+            category_src_dir = alg_src_dir.joinpath("categories")
+            category_text_path = category_src_dir.joinpath(top_name).with_suffix(".txt")
             if os.path.isfile(category_text_path):
                 with open(category_text_path) as f:
                     top_category.additional_text = f.read()
@@ -442,21 +428,25 @@ def create_top_algorithm_category(categories):
 
     # split the full list into subsections
     general_categories = all_top_categories
-    technique_categories = extract_matching_categories(general_categories, posixpath.join(category_src_dir, "techniquecategories") + ".txt")
-    facility_categories = extract_matching_categories(general_categories, posixpath.join(category_src_dir, "facilitycategories") + ".txt")
+    technique_categories = extract_matching_categories(
+        general_categories, category_src_dir.joinpath("techniquecategories").with_suffix(".txt")
+    )
+    facility_categories = extract_matching_categories(
+        general_categories, category_src_dir.joinpath("facilitycategories").with_suffix(".txt")
+    )
 
     # create the page
     top_context = {}
-    top_category_html_path_noext = posixpath.join("algorithms", "index")
-    top_context["outpath"] = top_category_html_path_noext + ".html"
+    top_category_html_path_noext = Path("algorithms", "index")
+    top_context["outpath"] = str(top_category_html_path_noext.with_suffix(".html"))
     # set the content
     top_context["pages"] = []
     top_context["generalcategories"] = sorted(general_categories, key=lambda x: x.name)
     top_context["techniquecategories"] = sorted(technique_categories, key=lambda x: x.name)
     top_context["facilitycategories"] = sorted(facility_categories, key=lambda x: x.name)
     top_context["title"] = "Algorithm Contents"
-    top_html_path_noext = posixpath.join("algorithms", "index")
-    return (top_html_path_noext, top_context, template)
+    top_html_path_noext = str(Path("algorithms", "index"))
+    return (str(top_html_path_noext), top_context, template)
 
 
 def extract_matching_categories(input_categories, filepath):

--- a/docs/sphinxext/mantiddoc/directives/diagram.py
+++ b/docs/sphinxext/mantiddoc/directives/diagram.py
@@ -98,7 +98,8 @@ class DiagramDirective(BaseDirective):
         gviz.wait()
 
         # relative path to image, in unix style
-        rel_path = out_path.relative_to(env.srcdir)
+        # pathlib.Path.relative_to() will not work here, the method won't traverse up then down again
+        rel_path = os.path.relpath(out_path, env.srcdir).replace("\\", "/")
 
         self.add_rst(".. image:: /" + rel_path + "\n\n")
 

--- a/docs/sphinxext/mantiddoc/directives/diagram.py
+++ b/docs/sphinxext/mantiddoc/directives/diagram.py
@@ -9,7 +9,7 @@ from sphinx.locale import _  # noqa: F401
 import os
 from string import Template
 import subprocess
-from pathlib import Path
+from pathlib import PurePosixPath
 
 STYLE = dict()
 
@@ -48,7 +48,7 @@ class DiagramDirective(BaseDirective):
         if diagrams_dir is None or diagrams_dir == "":
             return None
         else:
-            return Path(diagrams_dir)
+            return PurePosixPath(diagrams_dir)
 
     def run(self):
         """
@@ -82,14 +82,14 @@ class DiagramDirective(BaseDirective):
         if diagram_name[-4:] != ".dot":
             raise RuntimeError("Diagrams need to be referred to by their filename, including '.dot' extension.")
 
-        in_path = Path(env.srcdir, "diagrams", diagram_name)
-        out_path = Path(diagrams_dir, diagram_name[:-4] + ".svg")
+        in_path = PurePosixPath(env.srcdir, "diagrams", diagram_name)
+        out_path = PurePosixPath(diagrams_dir, diagram_name[:-4] + ".svg")
 
         # Generate the diagram
         try:
             in_src = open(in_path, "r").read()
         except Exception:
-            raise RuntimeError("Cannot find dot-file: '" + diagram_name + "' in '" + Path(env.srcdir, "diagrams"))
+            raise RuntimeError("Cannot find dot-file: '" + diagram_name + "' in '" + PurePosixPath(env.srcdir, "diagrams"))
 
         out_src = Template(in_src).substitute(STYLE)
         out_src = out_src.encode()

--- a/docs/sphinxext/mantiddoc/directives/diagram.py
+++ b/docs/sphinxext/mantiddoc/directives/diagram.py
@@ -9,6 +9,7 @@ from sphinx.locale import _  # noqa: F401
 import os
 from string import Template
 import subprocess
+from pathlib import Path
 
 STYLE = dict()
 
@@ -47,7 +48,7 @@ class DiagramDirective(BaseDirective):
         if diagrams_dir is None or diagrams_dir == "":
             return None
         else:
-            return diagrams_dir
+            return Path(diagrams_dir)
 
     def run(self):
         """
@@ -81,14 +82,14 @@ class DiagramDirective(BaseDirective):
         if diagram_name[-4:] != ".dot":
             raise RuntimeError("Diagrams need to be referred to by their filename, including '.dot' extension.")
 
-        in_path = os.path.join(env.srcdir, "diagrams", diagram_name)
-        out_path = os.path.join(diagrams_dir, diagram_name[:-4] + ".svg")
+        in_path = Path(env.srcdir, "diagrams", diagram_name)
+        out_path = Path(diagrams_dir, diagram_name[:-4] + ".svg")
 
         # Generate the diagram
         try:
             in_src = open(in_path, "r").read()
         except Exception:
-            raise RuntimeError("Cannot find dot-file: '" + diagram_name + "' in '" + os.path.join(env.srcdir, "diagrams"))
+            raise RuntimeError("Cannot find dot-file: '" + diagram_name + "' in '" + Path(env.srcdir, "diagrams"))
 
         out_src = Template(in_src).substitute(STYLE)
         out_src = out_src.encode()
@@ -97,7 +98,7 @@ class DiagramDirective(BaseDirective):
         gviz.wait()
 
         # relative path to image, in unix style
-        rel_path = os.path.relpath(out_path, env.srcdir).replace("\\", "/")
+        rel_path = out_path.relative_to(env.srcdir)
 
         self.add_rst(".. image:: /" + rel_path + "\n\n")
 

--- a/docs/sphinxext/mantiddoc/directives/interface.py
+++ b/docs/sphinxext/mantiddoc/directives/interface.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantiddoc.directives.base import BaseDirective  # pylint: disable=unused-import
+import os
 from pathlib import Path
 
 
@@ -92,7 +93,8 @@ class InterfaceDirective(BaseDirective):
                 width = picture.width
 
             # relative path to image
-            rel_path = screenshots_dir.relative_to(env.srcdir)
+            # pathlib.Path.relative_to() will not work here, the method won't traverse up then down again
+            rel_path = os.path.relpath(screenshots_dir, env.srcdir).replace("\\", "/")
             # stick a "/" as the first character so Sphinx computes relative location from source directory
             path = Path("/").joinpath(rel_path).joinpath(filename)
             caption = ""

--- a/docs/sphinxext/mantiddoc/directives/interface.py
+++ b/docs/sphinxext/mantiddoc/directives/interface.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantiddoc.directives.base import BaseDirective  # pylint: disable=unused-import
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 
 class InterfaceDirective(BaseDirective):
@@ -96,11 +96,11 @@ class InterfaceDirective(BaseDirective):
             # pathlib.Path.relative_to() will not work here, the method won't traverse up then down again
             rel_path = os.path.relpath(screenshots_dir, env.srcdir).replace("\\", "/")
             # stick a "/" as the first character so Sphinx computes relative location from source directory
-            path = Path("/").joinpath(rel_path).joinpath(filename)
+            path = PurePosixPath("/").joinpath(rel_path).joinpath(filename)
             caption = ""
         else:
             # use stock not found image
-            path = Path("/images/ImageNotFound.png")
+            path = PurePosixPath("/images/ImageNotFound.png")
             width = 200
             caption = "Enable screenshots using DOCS_SCREENSHOTS in CMake"
 

--- a/docs/sphinxext/mantiddoc/directives/interface.py
+++ b/docs/sphinxext/mantiddoc/directives/interface.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantiddoc.directives.base import BaseDirective  # pylint: disable=unused-import
-import os
+from pathlib import Path
 
 
 class InterfaceDirective(BaseDirective):
@@ -83,22 +83,22 @@ class InterfaceDirective(BaseDirective):
         # conf.py file and a relative path is relative to the directory where the current rst file
         # is located.
         if picture:
-            screenshots_dir, filename = os.path.split(picture.imgpath)
+            picture_imgpath = Path(picture.imgpath)
+            screenshots_dir = picture_imgpath.parent
+            filename = picture_imgpath.name
 
             if width is None:
                 # No width provided, use screenshot width
                 width = picture.width
 
             # relative path to image
-            rel_path = os.path.relpath(screenshots_dir, env.srcdir)
-            # This is a href link so is expected to be in unix style
-            rel_path = rel_path.replace("\\", "/")
+            rel_path = screenshots_dir.relative_to(env.srcdir)
             # stick a "/" as the first character so Sphinx computes relative location from source directory
-            path = "/" + rel_path + "/" + filename
+            path = Path("/").joinpath(rel_path).joinpath(filename)
             caption = ""
         else:
             # use stock not found image
-            path = "/images/ImageNotFound.png"
+            path = Path("/images/ImageNotFound.png")
             width = 200
             caption = "Enable screenshots using DOCS_SCREENSHOTS in CMake"
 

--- a/docs/sphinxext/mantiddoc/directives/sourcelink.py
+++ b/docs/sphinxext/mantiddoc/directives/sourcelink.py
@@ -7,7 +7,7 @@
 import os
 import mantid
 from .base import AlgorithmBaseDirective
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 
 class SourceLinkError(Exception):
@@ -153,7 +153,7 @@ class SourceLinkDirective(AlgorithmBaseDirective):
             env = self.state.document.settings.env
             # assume root is two levels up
             direc = Path(env.srcdir, "..", "..").resolve()  # = C:\Mantid\Code\Mantid\docs\source
-            self.__source_root = direc  # pylint: disable=protected-access
+            self.__source_root = PurePosixPath(direc)  # pylint: disable=protected-access
 
         return self.__source_root
 
@@ -179,7 +179,7 @@ class SourceLinkDirective(AlgorithmBaseDirective):
                         self.file_lookup[base_name] = {}
                     if file_extensions not in self.file_lookup[base_name].keys():
                         self.file_lookup[base_name][file_extensions] = []
-                    self.file_lookup[base_name][file_extensions].append(Path(dir_name, fname))
+                    self.file_lookup[base_name][file_extensions].append(PurePosixPath(dir_name, fname))
 
     def output_to_page(self, file_paths, file_name, sanity_checks):
         """


### PR DESCRIPTION
At the time of writing we are using Sphinx 8, but generating the docs gives warnings about the use of strings to represent file paths not being allowed in Sphinx 9. 
- Replaced strings representing file paths with `pathlib.Path` objects
- Replaces `tags.tags` with `tags`

Fixes #37804. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

### To test:
- Build docs, no warnings
- Should be no warnings in the doc test build either (see #37804 for the message you get when the warnings are present)
- Check that the docs look correct and the links work
- Check release note generation (I changed `amalgamate.py`)

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **it has no effect on the user.**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
