### PR TITLE
Fix relative comparison in `CompareWorkspaces`

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CompareWorkspaces.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CompareWorkspaces.h
@@ -76,6 +76,9 @@ public:
            "testing process.";
   }
 
+  static bool withinAbsoluteTolerance(double x1, double x2, double atol);
+  static bool withinRelativeTolerance(double x1, double x2, double rtol);
+
 private:
   /// Initialise algorithm
   void init() override;
@@ -114,8 +117,6 @@ private:
 
   /// Records a mismatch in the Messages workspace and sets Result to false
   void recordMismatch(const std::string &msg, std::string ws1 = "", std::string ws2 = "");
-
-  bool relErr(double x1, double x2, double errorVal) const;
 
   /// Result of comparison (true if equal, false otherwise)
   bool m_result{false};

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -1369,9 +1369,6 @@ bool CompareWorkspaces::withinRelativeTolerance(double const x1, double const x2
   double const num = std::fabs(x1 - x2);
   // create a standardized size to compare against
   double const den = 0.5 * (std::fabs(x1) + std::fabs(x2));
-  // if (den < rtol)
-  //   return !(num > rtol);
-
-  return !(num / den > rtol);
+  return !(num > (rtol * den));
 }
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -1274,7 +1274,7 @@ void CompareWorkspaces::doTableComparison(const API::ITableWorkspace_const_sptr 
   const bool checkAllData = getProperty("CheckAllData");
   const bool isRelErr = getProperty("ToleranceRelErr");
   const double tolerance = getProperty("Tolerance");
-  bool mismatch;
+  bool mismatch = false;
   for (size_t i = 0; i < numCols; ++i) {
     const auto c1 = tws1->getColumn(i);
     const auto c2 = tws2->getColumn(i);
@@ -1366,9 +1366,14 @@ this error is within the limits requested.
 @returns true if error or false if the relative value is within the limits requested
 */
 bool CompareWorkspaces::withinRelativeTolerance(double const x1, double const x2, double const rtol) {
+  // calculate difference
   double const num = std::fabs(x1 - x2);
-  // create a standardized size to compare against
-  double const den = 0.5 * (std::fabs(x1) + std::fabs(x2));
+  // return early if the values are equal
+  if (num == 0.0)
+    return true;
+  // compare the difference to the midpoint value -- could lead to issues for negative values
+  double const den = 0.5 * std::fabs(x1 + x2);
+  // NOTE !(num > rtol*den) is not the same as (num <= rtol*den)
   return !(num > (rtol * den));
 }
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -265,7 +265,7 @@ void CompareWorkspaces::processGroups(const std::shared_ptr<const API::Workspace
     checker->setPropertyValue("Workspace1", namesOne[i]);
     checker->setPropertyValue("Workspace2", namesTwo[i]);
     for (size_t j = 0; j < numNonDefault; ++j) {
-      Property *p = nonDefaultProps[j];
+      Property const *p = nonDefaultProps[j];
       checker->setPropertyValue(p->name(), p->value());
     }
     checker->execute();
@@ -952,7 +952,7 @@ bool CompareWorkspaces::checkRunProperties(const API::Run &run1, const API::Run 
     return false;
   } else {
     // Sort logs by name before one-by-one comparison
-    auto compareNames = [](Kernel::Property *p1, Kernel::Property *p2) { return p1->name() < p2->name(); };
+    auto compareNames = [](Kernel::Property const *p1, Kernel::Property const *p2) { return p1->name() < p2->name(); };
     std::sort(ws1logs.begin(), ws1logs.end(), compareNames);
     std::sort(ws2logs.begin(), ws2logs.end(), compareNames);
     for (size_t i = 0; i < ws1logs.size(); ++i) {
@@ -1108,10 +1108,10 @@ void CompareWorkspaces::doPeaksComparison(PeaksWorkspace_sptr tws1, PeaksWorkspa
         mismatch = !withinRelativeTolerance(s1, s2, tolerance);
         // Q: whould we not also compare the vectors?
       } else {
-        mismatch = !withinAbsoluteTolerance(s1, s2, tolerance) || 
-                   !withinAbsoluteTolerance(v1[0], v2[0], tolerance) ||
-                   !withinAbsoluteTolerance(v1[1], v2[1], tolerance) ||
-                   !withinAbsoluteTolerance(v1[2], v2[2], tolerance);
+        mismatch = !withinAbsoluteTolerance(s1, s2, tolerance) ||       //
+                   !withinAbsoluteTolerance(v1[0], v2[0], tolerance) || //
+                   !withinAbsoluteTolerance(v1[1], v2[1], tolerance) || //
+                   !withinAbsoluteTolerance(v1[2], v2[2], tolerance);   //
       }
       if (mismatch) {
         g_log.notice(name);
@@ -1274,7 +1274,7 @@ void CompareWorkspaces::doTableComparison(const API::ITableWorkspace_const_sptr 
   const bool checkAllData = getProperty("CheckAllData");
   const bool isRelErr = getProperty("ToleranceRelErr");
   const double tolerance = getProperty("Tolerance");
-  bool mismatch = false;
+  bool mismatch;
   for (size_t i = 0; i < numCols; ++i) {
     const auto c1 = tws1->getColumn(i);
     const auto c2 = tws2->getColumn(i);
@@ -1287,7 +1287,6 @@ void CompareWorkspaces::doTableComparison(const API::ITableWorkspace_const_sptr 
     if (mismatch) {
       g_log.debug() << "Table data mismatch at column " << i << "\n";
       recordMismatch("Table data mismatch");
-      mismatch = false;
       if (!checkAllData) {
         return;
       }
@@ -1370,8 +1369,8 @@ bool CompareWorkspaces::withinRelativeTolerance(double const x1, double const x2
   double const num = std::fabs(x1 - x2);
   // create a standardized size to compare against
   double const den = 0.5 * (std::fabs(x1) + std::fabs(x2));
-  if (den < rtol)
-    return !(num > rtol);
+  // if (den < rtol)
+  //   return !(num > rtol);
 
   return !(num / den > rtol);
 }

--- a/Framework/Algorithms/test/CreateUserDefinedBackgroundTest.h
+++ b/Framework/Algorithms/test/CreateUserDefinedBackgroundTest.h
@@ -23,6 +23,9 @@ using Mantid::API::ITableWorkspace_sptr;
 using Mantid::API::MatrixWorkspace_sptr;
 
 namespace {
+// flag for absolute or relative comparison
+enum Comparison : bool { CMP_RELATIVE = true, CMP_ABSOLUTE = false };
+
 // Gaussian
 double gauss(double x, double height, double centre, double fwhm) {
   const double factor = 2.0 * sqrt(2.0 * log(2.0));
@@ -108,7 +111,7 @@ public:
 
     // The expected result
     const auto expected = createExpectedResults(true);
-    TS_ASSERT(workspacesEqual(expected, outputWS, 0.105, Comparison::RELATIVE));
+    TS_ASSERT(workspacesEqual(expected, outputWS, 0.105, Comparison::CMP_RELATIVE));
   }
 
   void test_exec_HistoWS_NormalisePlotsOn() {
@@ -134,7 +137,7 @@ public:
 
     // The expected result
     const auto expected = createExpectedResults(true, true);
-    TS_ASSERT(workspacesEqual(expected, outputWS, 5e-2, Comparison::ABSOLUTE));
+    TS_ASSERT(workspacesEqual(expected, outputWS, 5e-2, Comparison::CMP_ABSOLUTE));
   }
 
   void test_exec_PointsWS_extend() {
@@ -244,7 +247,7 @@ public:
     const auto expected = createExpectedResults(true, false);
     Mantid::API::WorkspaceHelpers::makeDistribution(expected);
 
-    TS_ASSERT(workspacesEqual(expected, outputWS, 0.105, Comparison::RELATIVE));
+    TS_ASSERT(workspacesEqual(expected, outputWS, 0.105, Comparison::CMP_RELATIVE));
   }
 
 private:
@@ -301,9 +304,8 @@ private:
   }
 
   /// Compare workspaces
-  enum Comparison : bool { RELATIVE = true, ABSOLUTE = false };
   bool workspacesEqual(const MatrixWorkspace_sptr &lhs, const MatrixWorkspace_sptr &rhs, double tolerance,
-                       bool relativeError = Comparison::ABSOLUTE) {
+                       bool const relativeError = Comparison::CMP_ABSOLUTE) {
     auto alg = Mantid::API::AlgorithmFactory::Instance().create("CompareWorkspaces", 1);
     alg->setChild(true);
     alg->initialize();
@@ -337,7 +339,7 @@ private:
 
     // The expected result
     const auto expected = createExpectedResults(false);
-    TS_ASSERT(workspacesEqual(expected, outputWS, 1e-4, Comparison::ABSOLUTE));
+    TS_ASSERT(workspacesEqual(expected, outputWS, 1e-4, Comparison::CMP_ABSOLUTE));
   }
 
   /// Cached string for option

--- a/Framework/Algorithms/test/CreateUserDefinedBackgroundTest.h
+++ b/Framework/Algorithms/test/CreateUserDefinedBackgroundTest.h
@@ -108,7 +108,7 @@ public:
 
     // The expected result
     const auto expected = createExpectedResults(true);
-    TS_ASSERT(workspacesEqual(expected, outputWS, 0.1, Comparison::RELATIVE));
+    TS_ASSERT(workspacesEqual(expected, outputWS, 0.105, Comparison::RELATIVE));
   }
 
   void test_exec_HistoWS_NormalisePlotsOn() {
@@ -244,7 +244,7 @@ public:
     const auto expected = createExpectedResults(true, false);
     Mantid::API::WorkspaceHelpers::makeDistribution(expected);
 
-    TS_ASSERT(workspacesEqual(expected, outputWS, 0.1, Comparison::RELATIVE));
+    TS_ASSERT(workspacesEqual(expected, outputWS, 0.105, Comparison::RELATIVE));
   }
 
 private:

--- a/Framework/Algorithms/test/CreateUserDefinedBackgroundTest.h
+++ b/Framework/Algorithms/test/CreateUserDefinedBackgroundTest.h
@@ -108,7 +108,7 @@ public:
 
     // The expected result
     const auto expected = createExpectedResults(true);
-    TS_ASSERT(workspacesEqual(expected, outputWS, 0.1, true));
+    TS_ASSERT(workspacesEqual(expected, outputWS, 0.1, Comparison::RELATIVE));
   }
 
   void test_exec_HistoWS_NormalisePlotsOn() {
@@ -134,7 +134,7 @@ public:
 
     // The expected result
     const auto expected = createExpectedResults(true, true);
-    TS_ASSERT(workspacesEqual(expected, outputWS, 5e-2));
+    TS_ASSERT(workspacesEqual(expected, outputWS, 5e-2, Comparison::ABSOLUTE));
   }
 
   void test_exec_PointsWS_extend() {
@@ -244,7 +244,7 @@ public:
     const auto expected = createExpectedResults(true, false);
     Mantid::API::WorkspaceHelpers::makeDistribution(expected);
 
-    TS_ASSERT(workspacesEqual(expected, outputWS, 0.1, true));
+    TS_ASSERT(workspacesEqual(expected, outputWS, 0.1, Comparison::RELATIVE));
   }
 
 private:
@@ -301,8 +301,9 @@ private:
   }
 
   /// Compare workspaces
+  enum Comparison : bool { RELATIVE = true, ABSOLUTE = false };
   bool workspacesEqual(const MatrixWorkspace_sptr &lhs, const MatrixWorkspace_sptr &rhs, double tolerance,
-                       bool relativeError = false) {
+                       bool relativeError = Comparison::ABSOLUTE) {
     auto alg = Mantid::API::AlgorithmFactory::Instance().create("CompareWorkspaces", 1);
     alg->setChild(true);
     alg->initialize();
@@ -336,7 +337,7 @@ private:
 
     // The expected result
     const auto expected = createExpectedResults(false);
-    TS_ASSERT(workspacesEqual(expected, outputWS, 1e-4));
+    TS_ASSERT(workspacesEqual(expected, outputWS, 1e-4, Comparison::ABSOLUTE));
   }
 
   /// Cached string for option

--- a/Testing/SystemTests/tests/framework/DirectILLAutoProcessTest.py
+++ b/Testing/SystemTests/tests/framework/DirectILLAutoProcessTest.py
@@ -29,7 +29,7 @@ class DirectILLAuto_PANTHER_Powder_Test(systemtesting.MantidSystemTest):
 
     def validate(self):
         self.tolerance = 1e-2
-        self.tolerance_is_rel_err = True
+        self.tolerance_is_rel_err = False
         self.disableChecking = ["Instrument", "SpectraMap"]
         return ["He3C60", "ILL_PANTHER_Powder_Auto.nxs"]
 

--- a/Testing/SystemTests/tests/framework/ILLDirectGeometryReductionTest.py
+++ b/Testing/SystemTests/tests/framework/ILLDirectGeometryReductionTest.py
@@ -164,7 +164,7 @@ class IN6(systemtesting.MantidSystemTest):
 
     def validate(self):
         self.tolerance = 1e-2
-        self.tolerance_is_rel_err = True
+        self.tolerance_is_rel_err = False
         self.disableChecking = ["Instrument", "Sample"]
         return ["cropped", "ILL_IN6_SofQW.nxs"]
 

--- a/Testing/SystemTests/tests/framework/PaalmanPingsMonteCarloAbsorptionTest.py
+++ b/Testing/SystemTests/tests/framework/PaalmanPingsMonteCarloAbsorptionTest.py
@@ -91,7 +91,7 @@ class AnnulusTest(systemtesting.MantidSystemTest):
 
     def validate(self):
         self.tolerance = 1e-3
-        self.tolerance_is_rel_err = True
+        self.tolerance_is_rel_err = False
         return ["annulus_corr", "irs_PP_MC_annulus.nxs"]
 
     def runTest(self):

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1664,3 +1664,4 @@ returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reductio
 returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferData.h:193
 returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferData.h:199
 returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferData.h:218
+unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CompareWorkspaces.cpp:1277

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -202,8 +202,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CreatePSDBle
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CreatePSDBleedMask.cpp:214
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CreateLogPropertyTable.cpp:126
 variableScope:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CreateGroupingWorkspace.cpp:684
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CompareWorkspaces.cpp:268
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CompareWorkspaces.cpp:947
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/EnabledWhenWorkspaceIsType.h:50
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DetectorEfficiencyCor.cpp:126
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DetectorEfficiencyCorUser.cpp:176

--- a/docs/source/release/v6.11.0/Indirect/Algorithms/Bugfixes/37889.rst
+++ b/docs/source/release/v6.11.0/Indirect/Algorithms/Bugfixes/37889.rst
@@ -1,0 +1,1 @@
+- fix :ref:`CompareWorkspaces <algm-CompareWorkspaces-v1>` for relative differences of small values.


### PR DESCRIPTION
### Description of work

#### Summary of work
`CompareWorkspaces` is supposed to be usable for both absolute and relative comparisons.

There are two situations where relative differences may be preferred over absolute differences.

1. One is the case of very large numbers.  Values may match to ten digits, but not match out to the thousandths place, which would make an absolute difference fail.
2. The other is the case of very small numbers, where the values themselves are below a tolerance.  Here, an absolute difference below the tolerance is meaningless, and the numbers should be checked for relative closeness.  

The comparison of relative difference was originally written as:
``` c++
bool CompareWorkspaces::relErr(double x1, double x2, double errorVal) const {
  double num = std::fabs(x1 - x2);
  // how to treat x1<0 and x2 > 0 ?  probably this way
  double den = 0.5 * (std::fabs(x1) + std::fabs(x2));
  if (den < errorVal)
    return (num > errorVal);

  return (num / den > errorVal);
}
``` 
This short-circuits any use of relative differences for case 2 above, instead performing an absolute difference in a situation where absolute difference is irrelevant.

This changes that calculation, to just do relative difference.

If the user asks for the relative difference, the user gets a relative difference.

Fixes #37877 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

This also caused one unit test and three system tests to fail.

The one unit test could be fixed by ever-so-slightly broadening the tolerance on the comparison.

The three system tests could be fixed by using absolute comparison instead (which is what they would have been doing anyway).

### To test:

Try running this script in workbench built from this branch.  If the issue has been fixed, then this should pass
``` python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

tol = 0.01
x1 = 0.00001
x2 = 0.00010
ws1 = CreateWorkspace(DataX=[x1], DataY=[1])
ws2 = CreateWorkspace(DataX=[x2], DataY=[1])
print( (x2-x1)/(0.5 * (x2+x1)) )
assert not (x2-x1)/(0.5 * (x2+x1)) <= tol
res, msg = CompareWorkspaces(ws1, ws2, Tolerance=tol, ToleranceRelErr=True)
print(res)
assert not res
```


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
