### PR TITLE
Migrate boost::filesystem to std::filesystem

### DIFF
--- a/Framework/API/inc/MantidAPI/ScopedWorkspace.h
+++ b/Framework/API/inc/MantidAPI/ScopedWorkspace.h
@@ -70,9 +70,6 @@ private:
   /// Generates a tricky name which is unique within ADS
   static std::string generateUniqueName();
 
-  /// Generates a random alpha-numeric string
-  static std::string randomString(size_t len);
-
   /// Length of workspace names generated
   static const size_t NAME_LENGTH;
 };

--- a/Framework/API/src/ScopedWorkspace.cpp
+++ b/Framework/API/src/ScopedWorkspace.cpp
@@ -9,6 +9,9 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/ScopedWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidKernel/Strings.h"
+
+using Mantid::Kernel::Strings::randomString;
 
 namespace Mantid::API {
 
@@ -97,24 +100,4 @@ std::string ScopedWorkspace::generateUniqueName() {
 
   return newName;
 }
-
-/**
- * Generates random alpha-numeric string.
- * @param len :: Length of the string
- * @return Random string of the given length
- */
-std::string ScopedWorkspace::randomString(size_t len) {
-  static const std::string alphabet = "0123456789abcdefghijklmnopqrstuvwxyz";
-
-  std::string result;
-  result.reserve(len);
-
-  while (result.size() != len) {
-    size_t randPos = ((rand() % (alphabet.size() - 1)));
-    result.push_back(alphabet[randPos]);
-  }
-
-  return result;
-}
-
 } // namespace Mantid::API

--- a/Framework/API/test/CMakeLists.txt
+++ b/Framework/API/test/CMakeLists.txt
@@ -19,7 +19,6 @@ if(CXXTEST_FOUND)
             Mantid::Nexus
             Mantid::NexusGeometry
             ${BCRYPT}
-            Boost::filesystem
             gmock
             Python::Python
   )

--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -1083,7 +1083,7 @@ set_property(TARGET Algorithms PROPERTY FOLDER "MantidFramework")
 target_link_libraries(
   Algorithms
   PUBLIC Mantid::API Mantid::HistogramData Mantid::Kernel Mantid::Geometry Mantid::Indexing
-  PRIVATE Mantid::DataObjects Mantid::Parallel Mantid::Types Boost::filesystem
+  PRIVATE Mantid::DataObjects Mantid::Parallel Mantid::Types
 )
 
 # Add the unit tests directory

--- a/Framework/Algorithms/src/CorelliCalibrationDatabase.cpp
+++ b/Framework/Algorithms/src/CorelliCalibrationDatabase.cpp
@@ -26,8 +26,7 @@
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/operations.hpp>
+#include <filesystem>
 #include <sstream>
 #include <string>
 
@@ -280,7 +279,7 @@ TableWorkspace_sptr CalibrationTableHandler::saveCompomentDatabase(const std::st
   // Load the database file for the specific component to a table workspace
   // if extant, otherwise instantiate an empty table
   TableWorkspace_sptr compcaltable = nullptr;
-  if (boost::filesystem::exists(filename)) {
+  if (std::filesystem::exists(filename)) {
     compcaltable = loadComponentCalibrationTable(filename, tablewsname);
   } else {
     compcaltable = createCalibrationTableWorkspace(tablewsname, true);
@@ -646,7 +645,7 @@ bool CorelliCalibrationDatabase::isFileExist(const std::string &filepath) {
 
   // TODO - replace by std::filesystem::exists(filename) until C++17 is properly
   // supported
-  return boost::filesystem::exists(filepath);
+  return std::filesystem::exists(filepath);
 }
 
 //-----------------------------------------------------------------------------
@@ -657,9 +656,9 @@ bool CorelliCalibrationDatabase::isFileExist(const std::string &filepath) {
  * @return
  */
 std::string CorelliCalibrationDatabase::joinPath(const std::string &directory, const std::string &basename) {
-  boost::filesystem::path dir(directory);
-  boost::filesystem::path file(basename);
-  boost::filesystem::path fullpath = dir / file;
+  std::filesystem::path dir(directory);
+  std::filesystem::path file(basename);
+  std::filesystem::path fullpath = dir / file;
 
   return fullpath.string();
 }

--- a/Framework/Algorithms/test/CMakeLists.txt
+++ b/Framework/Algorithms/test/CMakeLists.txt
@@ -42,7 +42,6 @@ if(CXXTEST_FOUND)
             Mantid::DataObjects
             Mantid::Kernel
             Boost::boost
-            Boost::filesystem
             ${BCRYPT}
             gmock
   )

--- a/Framework/Algorithms/test/CorelliCalibrationDatabaseTest.h
+++ b/Framework/Algorithms/test/CorelliCalibrationDatabaseTest.h
@@ -18,7 +18,7 @@
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/TimeSeriesProperty.h"
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <fstream>
 
 using Mantid::Algorithms::CorelliCalibrationDatabase;
@@ -50,11 +50,11 @@ public:
   void test_file_io() {
     // create directory
     std::string test_dir{"TestCorelliCalibrationX"};
-    boost::filesystem::create_directory(test_dir);
-    TS_ASSERT(boost::filesystem::is_directory(test_dir));
+    std::filesystem::create_directory(test_dir);
+    TS_ASSERT(std::filesystem::is_directory(test_dir));
 
     // clean
-    boost::filesystem::remove_all(test_dir);
+    std::filesystem::remove_all(test_dir);
   }
 
   //-----------------------------------------------------------------------------
@@ -125,9 +125,9 @@ public:
     // component file: name, remove file if it does exist, save and check file
     // existence
     const std::string testcalibtablefilename{"/tmp/testsourcedb2.csv"};
-    boost::filesystem::remove(testcalibtablefilename);
+    std::filesystem::remove(testcalibtablefilename);
     calib_handler.saveCalibrationTable(testcalibtablefilename);
-    TS_ASSERT(boost::filesystem::exists(testcalibtablefilename));
+    TS_ASSERT(std::filesystem::exists(testcalibtablefilename));
     // load file and check
     TableWorkspace_sptr duptable = loadCSVtoTable(testcalibtablefilename, "DuplicatedSource");
     TS_ASSERT_EQUALS(duptable->rowCount(), 3);
@@ -135,10 +135,10 @@ public:
 
     // Test: save single component file
     const std::string testsamplecalfilename{"/tmp/testsampledb2.csv"};
-    boost::filesystem::remove(testsamplecalfilename);
+    std::filesystem::remove(testsamplecalfilename);
     // save
     calib_handler.saveCompomentDatabase("20201117", "sample-position", testsamplecalfilename);
-    TS_ASSERT(boost::filesystem::exists(testsamplecalfilename));
+    TS_ASSERT(std::filesystem::exists(testsamplecalfilename));
 
     // load
     TableWorkspace_sptr dupsampletable =
@@ -162,9 +162,9 @@ public:
     // create directory database
     std::string calibdir{"/tmp/TestCorelliCalibration1117"};
     // clean previous
-    boost::filesystem::remove_all(calibdir);
+    std::filesystem::remove_all(calibdir);
     // create data base
-    boost::filesystem::create_directory(calibdir);
+    std::filesystem::create_directory(calibdir);
     // create a previously generated database file
     // will create the following files:
     // moderator.csv, sample-position.csv, bank2.csv, bank42.csv
@@ -206,11 +206,11 @@ public:
     TS_ASSERT_EQUALS(combinedcalibws->cell<std::string>(4, 0), "bank42/sixteenpack");
 
     // Output 2: search the saved output calibration file
-    boost::filesystem::path pdir(calibdir);
-    boost::filesystem::path pbase("corelli_instrument_20201117.csv");
-    boost::filesystem::path ptodaycalfile = pdir / pbase;
+    std::filesystem::path pdir(calibdir);
+    std::filesystem::path pbase("corelli_instrument_20201117.csv");
+    std::filesystem::path ptodaycalfile = pdir / pbase;
     std::string todaycalfile = ptodaycalfile.string();
-    TS_ASSERT(boost::filesystem::exists(todaycalfile));
+    TS_ASSERT(std::filesystem::exists(todaycalfile));
     // load and compare
     // ... ...
 
@@ -341,13 +341,13 @@ private:
    */
   void create_existing_database_files(const std::string &calibdir, std::vector<std::string> &banks) {
 
-    boost::filesystem::path dir(calibdir);
+    std::filesystem::path dir(calibdir);
 
     for (auto bankname : banks) {
       // create full path database name
       std::string basename = bankname + ".csv";
-      boost::filesystem::path basepath(basename);
-      boost::filesystem::path fullpath = dir / basename;
+      std::filesystem::path basepath(basename);
+      std::filesystem::path fullpath = dir / basename;
       std::string filename = fullpath.string();
       // write file
       std::ofstream bankofs(filename, std::ofstream::out);
@@ -369,13 +369,13 @@ private:
   void verify_component_files(const std::string &calfiledir, const std::string &component,
                               size_t expectedrecordsnumber) {
     // Create full file path
-    boost::filesystem::path pdir(calfiledir);
-    boost::filesystem::path pbase(component + ".csv");
-    boost::filesystem::path pcompcalfile = pdir / pbase;
+    std::filesystem::path pdir(calfiledir);
+    std::filesystem::path pbase(component + ".csv");
+    std::filesystem::path pcompcalfile = pdir / pbase;
     std::string compcalfile = pcompcalfile.string();
 
     // Assert file existence
-    TS_ASSERT(boost::filesystem::exists(compcalfile));
+    TS_ASSERT(std::filesystem::exists(compcalfile));
 
     // Load table
     TableWorkspace_sptr tablews = loadCSVtoTable(compcalfile, "CorelliVerify_" + component);

--- a/Framework/Crystal/CMakeLists.txt
+++ b/Framework/Crystal/CMakeLists.txt
@@ -261,7 +261,7 @@ include_directories(inc)
 target_link_libraries(
   Crystal
   PUBLIC Mantid::API Mantid::Geometry Mantid::Kernel
-  PRIVATE Mantid::DataObjects Mantid::Indexing Boost::filesystem
+  PRIVATE Mantid::DataObjects Mantid::Indexing
 )
 
 # Add the unit tests directory

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -28,9 +28,9 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <cmath>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -1435,7 +1435,7 @@ void SCDCalibratePanels2::profileL1(Mantid::API::IPeaksWorkspace_sptr &pws,
     }
   }
 
-  double xValues[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}; // xValues is not used
+  const double xValues[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}; // xValues is not used
 
   // scan from -4cm to 4cm along dL1 where the minimum is supposed to be at 0 for null
   // case with instrument at the engineering position
@@ -1464,8 +1464,7 @@ void SCDCalibratePanels2::profileL1(Mantid::API::IPeaksWorkspace_sptr &pws,
   }
 
   // output to file
-  auto filenamebase = boost::filesystem::temp_directory_path();
-  filenamebase /= boost::filesystem::unique_path("profileSCDCalibratePanels2_L1.csv");
+  auto filenamebase = std::filesystem::temp_directory_path() / "profileSCDCalibratePanels2_L1.csv";
   std::ofstream profL1File;
   profL1File.open(filenamebase.string());
   profL1File << msgrst.str();
@@ -1538,8 +1537,8 @@ void SCDCalibratePanels2::profileBanks(Mantid::API::IPeaksWorkspace_sptr &pws,
         target[i * 3 + j] = qv[j];
       }
     }
-    //
-    double xValues[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}; // xValues is not used
+
+    const double xValues[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}; // xValues is not used
 
     // NOTE: very expensive scan of the parameter space
     for (double dx = -1e-2; dx < 1e-2; dx += 2e-2 / 20.0) {
@@ -1585,9 +1584,8 @@ void SCDCalibratePanels2::profileBanks(Mantid::API::IPeaksWorkspace_sptr &pws,
     }
 
     // output to file
-    auto filenamebase = boost::filesystem::temp_directory_path();
-    std::string fnbase = "profileSCDCalibratePanels2_" + bankname + ".csv";
-    filenamebase /= boost::filesystem::unique_path(fnbase);
+    const std::string csvname = "profileSCDCalibratePanels2_" + bankname + ".csv";
+    auto filenamebase = std::filesystem::temp_directory_path() / csvname;
     std::ofstream profBankFile;
     profBankFile.open(filenamebase.string());
     profBankFile << msgrst.str();
@@ -1644,7 +1642,7 @@ void SCDCalibratePanels2::profileT0(Mantid::API::IPeaksWorkspace_sptr &pws,
     }
   }
 
-  double xValues[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}; // xValues is not used
+  const double xValues[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}; // xValues is not used
 
   // scan from -10 ~ 10 ms along dT0
   double deltaT0 = -10;
@@ -1671,8 +1669,7 @@ void SCDCalibratePanels2::profileT0(Mantid::API::IPeaksWorkspace_sptr &pws,
   }
 
   // output to file
-  auto filenamebase = boost::filesystem::temp_directory_path();
-  filenamebase /= boost::filesystem::unique_path("profileSCDCalibratePanels2_T0.csv");
+  auto filenamebase = std::filesystem::temp_directory_path() / "profileSCDCalibratePanels2_T0.csv";
   std::ofstream profL1File;
   profL1File.open(filenamebase.string());
   profL1File << msgrst.str();
@@ -1722,7 +1719,7 @@ void SCDCalibratePanels2::profileL1T0(Mantid::API::IPeaksWorkspace_sptr &pws,
     }
   }
 
-  double xValues[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}; // xValues is not used
+  const double xValues[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}; // xValues is not used
 
   // profile begin
   for (double deltaL1 = -4e-2; deltaL1 < 4e-2; deltaL1 += 1e-4) {
@@ -1748,8 +1745,7 @@ void SCDCalibratePanels2::profileL1T0(Mantid::API::IPeaksWorkspace_sptr &pws,
   }
 
   // output to file
-  auto filenamebase = boost::filesystem::temp_directory_path();
-  filenamebase /= boost::filesystem::unique_path("profileSCDCalibratePanels2_L1T0.csv");
+  auto filenamebase = std::filesystem::temp_directory_path() / "profileSCDCalibratePanels2_L1T0.csv";
   std::ofstream profL1File;
   profL1File.open(filenamebase.string());
   profL1File << msgrst.str();

--- a/Framework/Crystal/test/CMakeLists.txt
+++ b/Framework/Crystal/test/CMakeLists.txt
@@ -9,7 +9,7 @@ if(CXXTEST_FOUND)
 
   cxxtest_add_test(CrystalTest ${TEST_FILES})
   target_link_libraries(
-    CrystalTest PRIVATE Mantid::Crystal Mantid::DataHandling Mantid::MDAlgorithms Mantid::Nexus Boost::filesystem gmock
+    CrystalTest PRIVATE Mantid::Crystal Mantid::DataHandling Mantid::MDAlgorithms Mantid::Nexus gmock
   )
   add_framework_test_helpers(CrystalTest)
   add_dependencies(CrystalTest Algorithms CurveFitting)

--- a/Framework/Crystal/test/SCDCalibratePanels2ObjFuncTest.h
+++ b/Framework/Crystal/test/SCDCalibratePanels2ObjFuncTest.h
@@ -29,7 +29,6 @@
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/Unit.h"
 
-#include <boost/filesystem.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <cxxtest/TestSuite.h>
@@ -83,9 +82,6 @@ public:
   void test_rot_shift() {
     g_log.notice() << "test_rot_shift() starts.\n";
 
-    // Generate unique temp files
-    auto filenamebase = boost::filesystem::temp_directory_path();
-    filenamebase /= boost::filesystem::unique_path("testBank_%%%%%%%%");
     // Make a clone of the standard peak workspace
     PeaksWorkspace_sptr pws = m_pws->clone();
     Mantid::API::IPeaksWorkspace_sptr ipws = std::dynamic_pointer_cast<Mantid::API::IPeaksWorkspace>(pws);
@@ -143,9 +139,6 @@ public:
   void test_detector_resize() {
     g_log.notice() << "test_Bank() starts.\n";
 
-    // Generate unique temp files
-    auto filenamebase = boost::filesystem::temp_directory_path();
-    filenamebase /= boost::filesystem::unique_path("testBank_%%%%%%%%");
     // Make a clone of the standard peak workspace
     PeaksWorkspace_sptr pws = m_pws->clone();
     Mantid::API::IPeaksWorkspace_sptr ipws = std::dynamic_pointer_cast<Mantid::API::IPeaksWorkspace>(pws);

--- a/Framework/Crystal/test/SCDCalibratePanelsTest.h
+++ b/Framework/Crystal/test/SCDCalibratePanelsTest.h
@@ -15,8 +15,8 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidCrystal/SCDCalibratePanels.h"
-#include <boost/filesystem.hpp>
 #include <cxxtest/TestSuite.h>
+#include <filesystem>
 
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
@@ -54,7 +54,7 @@ public:
     alg->setProperty("alpha", 90.0);
     alg->setProperty("beta", 90.0);
     alg->setProperty("gamma", 120.0);
-    auto detCalTempPath = boost::filesystem::temp_directory_path();
+    auto detCalTempPath = std::filesystem::temp_directory_path();
     detCalTempPath /= "topaz.detcal";
     alg->setPropertyValue("DetCalFilename", detCalTempPath.string());
     TS_ASSERT(alg->execute());

--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -698,7 +698,7 @@ target_link_libraries(
          Mantid::Kernel
          Mantid::Indexing
          Mantid::Parallel
-  PRIVATE Mantid::Json Boost::filesystem Mantid::NexusGeometry
+  PRIVATE Mantid::Json Mantid::NexusGeometry
 )
 
 # Lib3mf is technically a public dependency as it is in our public headers. We are assuming here that it won't be used.

--- a/Framework/DataHandling/src/LoadEMU.cpp
+++ b/Framework/DataHandling/src/LoadEMU.cpp
@@ -23,7 +23,6 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidNexus/NexusClasses.h"
 
-#include <boost/filesystem.hpp>
 #include <boost/math/special_functions/round.hpp>
 #include <boost/math/tools/minima.hpp>
 
@@ -34,6 +33,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <utility>
 
@@ -676,7 +676,7 @@ template <typename FD> void LoadEMU<FD>::createWorkspace(const std::string &titl
 ///   Setting up the masks
 template <typename FD> void LoadEMU<FD>::exec(const std::string &hdfFile, const std::string &eventFile) {
 
-  namespace fs = boost::filesystem;
+  namespace fs = std::filesystem;
 
   // Create workspace
   // ----------------
@@ -1217,7 +1217,7 @@ void LoadEMUHdf::init() { LoadEMU<Kernel::NexusDescriptor>::init(true); }
 // exec() function that works with the two files.
 void LoadEMUHdf::exec() {
 
-  namespace fs = boost::filesystem;
+  namespace fs = std::filesystem;
 
   // Open the hdf file and find the dirname and dataset number
   std::string hdfFile = Base::getPropertyValue(FilenameStr);
@@ -1227,8 +1227,8 @@ void LoadEMUHdf::exec() {
 
   // if relative ./ or ../ then append to the directory for the hdf file
   if (evtPath.rfind("./") == 0 || evtPath.rfind("../") == 0) {
-    fs::path hp = hdfFile;
-    evtPath = fs::canonical(evtPath, hp.parent_path()).generic_string();
+    fs::path hp(hdfFile);
+    evtPath = fs::canonical(hp.parent_path() / evtPath).string();
   }
 
   // dataset index to be loaded

--- a/Framework/DataHandling/src/LoadPLN.cpp
+++ b/Framework/DataHandling/src/LoadPLN.cpp
@@ -21,10 +21,9 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidNexus/NexusClasses.h"
 
-#include <boost/filesystem.hpp>
-
 #include <algorithm>
 #include <cmath>
+#include <filesystem>
 #include <fstream>
 #include <utility>
 
@@ -524,7 +523,7 @@ void LoadPLN::createWorkspace(const std::string &title) {
 
 void LoadPLN::exec(const std::string &hdfFile, const std::string &eventFile) {
 
-  namespace fs = boost::filesystem;
+  namespace fs = std::filesystem;
 
   // Create workspace
   // ----------------
@@ -852,7 +851,7 @@ int LoadPLN::confidence(Kernel::NexusDescriptor &descriptor) const {
 // exec() function that works with the two files.
 void LoadPLN::exec() {
 
-  namespace fs = boost::filesystem;
+  namespace fs = std::filesystem;
 
   // Open the hdf file and find the dirname and dataset number
   std::string hdfFile = getPropertyValue(FilenameStr);
@@ -862,8 +861,8 @@ void LoadPLN::exec() {
 
   // if relative ./ or ../ then append to the directory for the hdf file
   if (evtPath.rfind("./") == 0 || evtPath.rfind("../") == 0) {
-    fs::path hp = hdfFile;
-    evtPath = fs::canonical(evtPath, hp.parent_path()).generic_string();
+    fs::path hp(hdfFile);
+    evtPath = fs::canonical(hp.parent_path() / evtPath).string();
   }
 
   // dataset index to be loaded

--- a/Framework/DataHandling/src/LoadPSIMuonBin.cpp
+++ b/Framework/DataHandling/src/LoadPSIMuonBin.cpp
@@ -27,9 +27,9 @@
 #include "MantidKernel/UnitLabelTypes.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 
 #include <algorithm>
+#include <filesystem>
 #include <fstream>
 #include <map>
 #include <memory>
@@ -800,7 +800,7 @@ std::string LoadPSIMuonBin::detectTempFile() {
   // directory containing the main file. The search has
   // a fixed limited depth to ensure we don't accidentally
   // crawl the while filesystem.
-  namespace fs = boost::filesystem;
+  namespace fs = std::filesystem;
   const fs::path searchDir{fs::path{getPropertyValue("Filename")}.parent_path()};
 
   std::deque<fs::path> queue{fs::path{searchDir}};

--- a/Framework/DataHandling/test/CMakeLists.txt
+++ b/Framework/DataHandling/test/CMakeLists.txt
@@ -19,7 +19,6 @@ if(CXXTEST_FOUND)
             Mantid::Nexus
             Mantid::NexusGeometry
             Mantid::HistogramData
-            Boost::filesystem
             gmock
   )
 

--- a/Framework/DataHandling/test/SaveNexusESSTest.h
+++ b/Framework/DataHandling/test/SaveNexusESSTest.h
@@ -26,7 +26,6 @@
 #include "MantidKernel/Logger.h"
 #include "MantidNexusGeometry/NexusGeometryParser.h"
 #include "MantidNexusGeometry/NexusGeometrySave.h"
-#include <boost/filesystem.hpp>
 #include <memory>
 
 using namespace Mantid::DataHandling;

--- a/Framework/Kernel/inc/MantidKernel/Strings.h
+++ b/Framework/Kernel/inc/MantidKernel/Strings.h
@@ -426,6 +426,13 @@ template <typename Integer> std::vector<std::vector<Integer>> parseGroups(const 
   return groups;
 }
 
+/**
+ * Generates random alpha-numeric string.
+ * @param len :: Length of the string
+ * @return Random string of the given length
+ */
+MANTID_KERNEL_DLL std::string randomString(const size_t len);
+
 /// Extract a line from input stream, discarding any EOL characters encountered
 MANTID_KERNEL_DLL std::istream &extractToEOL(std::istream &is, std::string &str);
 

--- a/Framework/Kernel/src/Strings.cpp
+++ b/Framework/Kernel/src/Strings.cpp
@@ -1156,6 +1156,21 @@ std::istream &extractToEOL(std::istream &is, std::string &str) {
   return is;
 }
 
+//------------------------------------------------------------------------------------------------
+std::string randomString(size_t len) {
+  static const std::string alphabet = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+  std::string result;
+  result.reserve(len);
+
+  while (result.size() != len) {
+    size_t randPos = ((rand() % (alphabet.size() - 1)));
+    result.push_back(alphabet[randPos]);
+  }
+
+  return result;
+}
+
 /// \cond TEMPLATE
 template MANTID_KERNEL_DLL int section(std::string &, double &);
 template MANTID_KERNEL_DLL int section(std::string &, float &);

--- a/Framework/Kernel/test/CMakeLists.txt
+++ b/Framework/Kernel/test/CMakeLists.txt
@@ -5,7 +5,7 @@ if(CXXTEST_FOUND)
 
   cxxtest_add_test(KernelTest ${TEST_FILES})
   target_include_directories(KernelTest SYSTEM PRIVATE ${CXXTEST_INCLUDE_DIR})
-  target_link_libraries(KernelTest PRIVATE Mantid::Types Mantid::Kernel Mantid::Json gmock Boost::filesystem)
+  target_link_libraries(KernelTest PRIVATE Mantid::Types Mantid::Kernel Mantid::Json gmock)
   add_framework_test_helpers(KernelTest)
   add_dependencies(FrameworkTests KernelTest)
   # Test data

--- a/Framework/Kernel/test/StringsTest.h
+++ b/Framework/Kernel/test/StringsTest.h
@@ -592,6 +592,13 @@ public:
     getLine(text, line);
     TSM_ASSERT_EQUALS("Strings::getLine didn't return empty string after eof.", line, "");
   }
+
+  void test_randomString() {
+    for (size_t length = 0; length < 5; ++length) {
+      const auto text = randomString(length);
+      TS_ASSERT_EQUALS(text.length(), length);
+    }
+  }
 };
 
 class StringsTestPerformance : public CxxTest::TestSuite {

--- a/Framework/NexusGeometry/CMakeLists.txt
+++ b/Framework/NexusGeometry/CMakeLists.txt
@@ -67,7 +67,7 @@ set_property(TARGET NexusGeometry PROPERTY FOLDER "MantidFramework")
 target_link_libraries(
   NexusGeometry
   PUBLIC Mantid::Geometry Mantid::API
-  PRIVATE Mantid::Kernel Mantid::Json Mantid::Indexing Boost::filesystem
+  PRIVATE Mantid::Kernel Mantid::Json Mantid::Indexing
 )
 
 # Add the unit tests directory

--- a/Framework/NexusGeometry/src/NexusGeometrySave.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometrySave.cpp
@@ -27,8 +27,8 @@
 #include "MantidNexusGeometry/NexusGeometryUtilities.h"
 #include <H5Cpp.h>
 #include <algorithm>
-#include <boost/filesystem/operations.hpp>
 #include <cmath>
+#include <filesystem>
 #include <list>
 #include <memory>
 #include <string>
@@ -541,14 +541,14 @@ SpectraMappings makeMappings(const Geometry::ComponentInfo &compInfo, const deti
 }
 
 void validateInputs(AbstractLogger &logger, const std::string &fullPath, const Geometry::ComponentInfo &compInfo) {
-  boost::filesystem::path tmp(fullPath);
-  if (!boost::filesystem::is_directory(tmp.root_directory())) {
+  std::filesystem::path tmp(fullPath);
+  if (!std::filesystem::is_directory(tmp.root_directory())) {
     throw std::invalid_argument("The path provided for saving the file is invalid: " + fullPath + "\n");
   }
 
   // check the file extension matches any of the valid extensions defined in
   // nexus_geometry_extensions
-  const auto ext = boost::filesystem::path(tmp).extension();
+  const auto ext = std::filesystem::path(tmp).extension();
   bool isValidExt = std::any_of(nexus_geometry_extensions.begin(), nexus_geometry_extensions.end(),
                                 [&ext](const std::string &str) { return ext.generic_string() == str; });
 

--- a/Framework/NexusGeometry/test/CMakeLists.txt
+++ b/Framework/NexusGeometry/test/CMakeLists.txt
@@ -7,9 +7,7 @@ if(CXXTEST_FOUND)
 
   cxxtest_add_test(NexusGeometryTest ${TEST_FILES})
 
-  target_link_libraries(
-    NexusGeometryTest PRIVATE Mantid::NexusGeometry Mantid::Types Mantid::Kernel Boost::filesystem gmock
-  )
+  target_link_libraries(NexusGeometryTest PRIVATE Mantid::NexusGeometry Mantid::Types Mantid::Kernel gmock)
 
   add_framework_test_helpers(NexusGeometryTest)
   add_dependencies(NexusGeometryTest Geometry)

--- a/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
+++ b/Framework/PythonInterface/test/cpp/PythonStdoutChannelTest.h
@@ -13,8 +13,8 @@
 #include "MantidKernel/Logger.h"
 #include <Poco/AutoPtr.h>
 #include <Poco/Logger.h>
-#include <boost/filesystem.hpp>
 #include <cxxtest/TestSuite.h>
+#include <filesystem>
 
 // standard
 #include <fstream>
@@ -41,7 +41,7 @@ public:
     std::string script = "import sys\n"
                          "stdout_old = sys.stdout\n"                           // backup the standard file descriptor
                          "sys.stdout = open(r'TEMPFILE', 'w', buffering=1)\n"; // redirection, small buffer needed
-    auto tmpFilePath = boost::filesystem::temp_directory_path() / "testPySysWriteStdout.txt";
+    auto tmpFilePath = std::filesystem::temp_directory_path() / "testPySysWriteStdout.txt";
     replaceSubstring(script, "TEMPFILE", tmpFilePath.string());
     PyRun_SimpleString(script.c_str()); // execute the python script
 
@@ -61,7 +61,7 @@ public:
     std::getline(logFile, message);
     TS_ASSERT_EQUALS(message, loggedMessage)
     logFile.close();
-    boost::filesystem::remove(tmpFilePath);
+    std::filesystem::remove(tmpFilePath);
 
     Poco::Logger::root().setChannel(channelOld); // restore the channel
   }

--- a/Framework/TestHelpers/CMakeLists.txt
+++ b/Framework/TestHelpers/CMakeLists.txt
@@ -81,7 +81,6 @@ target_link_libraries(
   FrameworkTestHelpers
   PRIVATE Mantid::API
           Boost::boost
-          Boost::filesystem
           Mantid::DataObjects
           Mantid::Catalog
           Mantid::DataHandling

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FileResource.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FileResource.h
@@ -13,7 +13,7 @@
 
 #pragma once
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <iostream>
 #include <string>
 
@@ -27,7 +27,7 @@ public:
 
 private:
   bool m_debugMode;
-  boost::filesystem::path m_full_path; // full path to file
+  std::filesystem::path m_full_path; // full path to file
   // prevent heap allocation for ScopedFileHandle
 protected:
   static void *operator new(std::size_t);   // prevent heap allocation of scalar.

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/NexusFileReader.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/NexusFileReader.h
@@ -11,7 +11,7 @@
 
 #include <Eigen/Dense>
 #include <H5Cpp.h>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -73,9 +73,9 @@ class NexusFileReader {
 
 public:
   NexusFileReader(const std::string &fullPath) {
-    boost::filesystem::path tmp = fullPath;
+    std::filesystem::path tmp = fullPath;
 
-    if (!boost::filesystem::exists(tmp)) {
+    if (!std::filesystem::exists(tmp)) {
       throw std::invalid_argument("no such file.\n");
     } else {
       m_file.openFile(fullPath, H5F_ACC_RDONLY);

--- a/Framework/TestHelpers/src/FileResource.cpp
+++ b/Framework/TestHelpers/src/FileResource.cpp
@@ -5,12 +5,12 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidFrameworkTestHelpers/FileResource.h"
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <string>
 
 FileResource::FileResource(const std::string &fileName, bool debugMode) : m_debugMode(debugMode) {
 
-  const auto temp_dir = boost::filesystem::temp_directory_path();
+  const auto temp_dir = std::filesystem::temp_directory_path();
   auto temp_full_path = temp_dir;
   // append full path to temp directory to user input file name
   temp_full_path /= fileName;
@@ -18,7 +18,7 @@ FileResource::FileResource(const std::string &fileName, bool debugMode) : m_debu
   // Check proposed location and throw std::invalid argument if file does
   // not exist. otherwise set m_full_path to location.
 
-  if (boost::filesystem::is_directory(temp_dir)) {
+  if (std::filesystem::is_directory(temp_dir)) {
     m_full_path = temp_full_path;
 
   } else {
@@ -32,9 +32,9 @@ std::string FileResource::fullPath() const { return m_full_path.generic_string()
 FileResource::~FileResource() {
 
   // file is removed at end of file handle's lifetime
-  if (boost::filesystem::is_regular_file(m_full_path)) {
+  if (std::filesystem::is_regular_file(m_full_path)) {
     if (!m_debugMode)
-      boost::filesystem::remove(m_full_path);
+      std::filesystem::remove(m_full_path);
     else
       std::cout << "Debug file at: " << m_full_path << " not removed. " << std::endl;
   }

--- a/Framework/WorkflowAlgorithms/CMakeLists.txt
+++ b/Framework/WorkflowAlgorithms/CMakeLists.txt
@@ -125,7 +125,7 @@ set_property(TARGET WorkflowAlgorithms PROPERTY FOLDER "MantidFramework")
 target_link_libraries(
   WorkflowAlgorithms
   PUBLIC Mantid::Nexus Mantid::API Mantid::DataObjects
-  PRIVATE Mantid::Kernel Boost::filesystem
+  PRIVATE Mantid::Kernel
 )
 
 # Add the unit tests directory

--- a/Framework/WorkflowAlgorithms/src/SofTwoThetaTOF.cpp
+++ b/Framework/WorkflowAlgorithms/src/SofTwoThetaTOF.cpp
@@ -14,8 +14,11 @@
 #include "MantidGeometry/Instrument/ParameterMap.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/CompositeValidator.h"
+#include "MantidKernel/Strings.h"
 
-#include "boost/filesystem.hpp"
+#include <filesystem>
+
+using Mantid::Kernel::Strings::randomString;
 
 namespace {
 /// Constants for the algorithm's property names.
@@ -31,9 +34,9 @@ struct RemoveFileAtScopeExit {
   std::string name;
   ~RemoveFileAtScopeExit() {
     if (!name.empty()) {
-      auto const path = boost::filesystem::path(name);
-      if (boost::filesystem::exists(path)) {
-        boost::filesystem::remove(path);
+      auto const path = std::filesystem::path(name);
+      if (std::filesystem::exists(path)) {
+        std::filesystem::remove(path);
       }
     }
   }
@@ -78,7 +81,7 @@ double binWidth(Mantid::API::MatrixWorkspace const &ws) {
  */
 std::string ensureXMLExtension(std::string const &filename) {
   std::string name = filename;
-  auto const path = boost::filesystem::path(filename);
+  auto const path = std::filesystem::path(filename);
   if (path.extension() != ".xml") {
     name += ".xml";
   }
@@ -184,8 +187,9 @@ API::MatrixWorkspace_sptr SofTwoThetaTOF::groupByTwoTheta(API::MatrixWorkspace_s
   std::string filename;
   RemoveFileAtScopeExit deleteThisLater;
   if (isDefault(Prop::FILENAME)) {
-    auto tempPath = boost::filesystem::temp_directory_path();
-    tempPath /= boost::filesystem::unique_path("detector-grouping-%%%%-%%%%-%%%%-%%%%.xml");
+    const std::string shortname = "detector-grouping-" + randomString(4) + "-" + randomString(4) + "-" +
+                                  randomString(4) + "-" + randomString(4) + ".xml";
+    const auto tempPath = std::filesystem::temp_directory_path() / shortname;
     filename = tempPath.string();
     generateGrouping->setProperty("GenerateParFile", false);
     // Make sure the file gets deleted at scope exit.

--- a/Framework/WorkflowAlgorithms/test/CMakeLists.txt
+++ b/Framework/WorkflowAlgorithms/test/CMakeLists.txt
@@ -19,8 +19,7 @@ if(CXXTEST_FOUND)
   # into the test executable. It will go out of scope at the end of this file so doesn't need un-setting
   cxxtest_add_test(WorkflowAlgorithmsTest ${TEST_FILES})
   target_link_libraries(
-    WorkflowAlgorithmsTest PRIVATE Mantid::WorkflowAlgorithms Mantid::Algorithms Mantid::DataHandling Boost::filesystem
-                                   gmock
+    WorkflowAlgorithmsTest PRIVATE Mantid::WorkflowAlgorithms Mantid::Algorithms Mantid::DataHandling gmock
   )
   add_dependencies(WorkflowAlgorithmsTest CurveFitting)
   add_dependencies(FrameworkTests WorkflowAlgorithmsTest)

--- a/Framework/WorkflowAlgorithms/test/SofTwoThetaTOFTest.h
+++ b/Framework/WorkflowAlgorithms/test/SofTwoThetaTOFTest.h
@@ -15,12 +15,13 @@
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidGeometry/Crystal/AngleUnits.h"
 #include "MantidGeometry/Instrument.h"
-
-#include <boost/filesystem.hpp>
+#include "MantidKernel/Strings.h"
+#include <filesystem>
 
 using namespace Mantid;
 using Mantid::Geometry::deg2rad;
 using Mantid::Geometry::rad2deg;
+using Mantid::Kernel::Strings::randomString;
 
 class SofTwoThetaTOFTest : public CxxTest::TestSuite {
 public:
@@ -90,23 +91,22 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "_unused_for_child"));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("AngleStep", angleStep))
-    auto tempXml = boost::filesystem::temp_directory_path();
-    tempXml /= boost::filesystem::unique_path("SofTwoThetaTest-%%%%%%%%.xml");
+    auto tempXml = std::filesystem::temp_directory_path() / ("SofTwoThetaTest-" + randomString(8) + ".xml");
     std::string const filename{tempXml.string()};
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("GroupingFilename", filename))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     TS_ASSERT(alg.isExecuted())
-    auto const xmlExists = boost::filesystem::exists(tempXml);
+    auto const xmlExists = std::filesystem::exists(tempXml);
     TS_ASSERT(xmlExists)
     if (xmlExists) {
-      boost::filesystem::remove(tempXml);
+      std::filesystem::remove(tempXml);
     }
     auto tempPar = tempXml;
     tempPar.replace_extension(".par");
-    auto const parExists = boost::filesystem::exists(tempPar);
+    auto const parExists = std::filesystem::exists(tempPar);
     TS_ASSERT(parExists)
     if (parExists) {
-      boost::filesystem::remove(tempPar);
+      std::filesystem::remove(tempPar);
     }
   }
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -521,11 +521,7 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithm
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/EigenVector.h:91
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/Fit1D.h:61
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:1385
-constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:1484
-constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:1438
-constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:1542
-constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:1647
-constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:1725
+constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:1483
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/Fit1D.cpp:379
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BSpline.h:34
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Chebyshev.h:37
@@ -1193,7 +1189,7 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/WorkflowAlgorithms/src/HFIRLo
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/WorkflowAlgorithms/src/HFIRLoad.cpp:215
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/WorkflowAlgorithms/src/HFIRLoad.cpp:223
 internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/AndMD.cpp:0
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/WorkflowAlgorithms/src/SofTwoThetaTOF.cpp:192
+unreadVariable:${CMAKE_SOURCE_DIR}/Framework/WorkflowAlgorithms/src/SofTwoThetaTOF.cpp:196
 internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/BooleanBinaryOperationMD.cpp:0
 internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/BinaryOperationMD.cpp:0
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/CompactMD.cpp:30

--- a/buildconfig/CMake/TestTargetFunctions.cmake
+++ b/buildconfig/CMake/TestTargetFunctions.cmake
@@ -13,7 +13,6 @@ macro(add_framework_test_helpers target_name)
     ${target_name}
     PRIVATE Mantid::API
             Boost::boost
-            Boost::filesystem
             Mantid::DataObjects
             Mantid::Catalog
             Mantid::DataHandling

--- a/qt/applications/workbench/mantidworkbench.cpp
+++ b/qt/applications/workbench/mantidworkbench.cpp
@@ -4,8 +4,7 @@
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 
 // clang-format off
 // boost 1.77 has a missing header on Windows. Include algorithm manually
@@ -40,7 +39,7 @@ static constexpr auto ERRORREPORTS_APP_NAME = "workbench";
 
 // aliases
 namespace bp = boost::process;
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 using ExeArgs = std::vector<std::string>;
 
 // helper functions


### PR DESCRIPTION
This is a second round of many to move everything to using `std::filesystem` which is part of c++17. With this change, nothing links to the boost filesystem library anymore. As a bonus item, generating a fixed then string with random contents was moved into Kernel so it can be used more broadly.

Refs #37868. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. 

### To test:

This is a refactor so looking at the code is enough.

*This does not require release notes* because it is a refactor which reduces what libraries are loaded/linked.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
