### PR TITLE
Fix BayesQuasi when sample workspace has numeric axis

### DIFF
--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37898.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37898.rst
@@ -1,0 +1,1 @@
+- Fixed an 'index out of range' error in the :ref:`BayesQuasi <algm-BayesQuasi>` algorithm when using a sample with a Numeric Axis.

--- a/scripts/Inelastic/IndirectCommon.py
+++ b/scripts/Inelastic/IndirectCommon.py
@@ -169,13 +169,8 @@ def get_two_theta_and_q(workspace: Union[str, MatrixWorkspace]) -> Tuple[np.ndar
 
     # If axis is in Q need to calculate back to angles and just return axis values
     elif axis.isNumeric() and axis.getUnit().unitID() == "MomentumTransfer":
-        q_bin_edge = axis.extractValues()
-        q = list()
-        for i in range(1, len(q_bin_edge)):
-            q_centre = ((q_bin_edge[i] - q_bin_edge[i - 1]) / 2) + q_bin_edge[i - 1]
-            q.append(q_centre)
-        np_q = np.array(q)
-        two_theta = 2.0 * np.degrees(np.arcsin(np_q / k0))
+        q = axis.extractValues()
+        two_theta = 2.0 * np.degrees(np.arcsin(np.array(q) / k0))
 
     # Out of options here
     else:


### PR DESCRIPTION
**Report to:** Mona Sarter

### Description of work
This PR fixes a bug in the BayesQuasi algorithm where an "index out of range" error would show when using a sample or vanadium with a NumericAxis rather than a SpectraAxis. ILL data has a NumericAxis, so this should make it  possible to use this interface with this ILL data.

The problem was with the incorrect extraction of the Q values from the NumericAxis. It was previously calculating the centre value, but this was not necessary.


*There is no associated issue.*

### To test:
1. Open Inelastic Bayes Fitting interface
2. Go to the Quasi tab
3. Load the following data as Sample and resolution. (You might need to unrestrict data by name in the Settings dialog)
[BCA299_Subtract.zip](https://github.com/user-attachments/files/16815965/BCA299_Subtract.zip)
[vanadium.zip](https://github.com/user-attachments/files/16815966/vanadium.zip)

5. Click `Run`. If you get a pop-up, click Yes
6. The algorithm should run to completion. Previously a red error message would appear in the log saying "index out of range"

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
