### PR TITLE
Revert "Skip PowderReduceP2DTest on macOS and re-enable on Windows"

### DIFF
--- a/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
+++ b/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
@@ -16,10 +16,6 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
         self.tolerance = 1e-6
         self.setUp()
 
-    def skipTests(self):
-        # Windows produces different outputs. Disable there for further investigation
-        return sys.platform.startswith("win")
-
     def setUp(self):
         self.sample = self._sampleEventData()
         self.vana = self._vanadiumEventData()

--- a/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
+++ b/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
@@ -16,6 +16,11 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
         self.tolerance = 1e-6
         self.setUp()
 
+    def skipTests(self):
+        # Now working on macOS but producing different outputs on windows.
+        # Skipped while investigation continues.
+        return sys.platform.startswith("win")
+
     def setUp(self):
         self.sample = self._sampleEventData()
         self.vana = self._vanadiumEventData()

--- a/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
+++ b/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
@@ -17,9 +17,8 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
         self.setUp()
 
     def skipTests(self):
-        # MacOS produces different results since moving from clang version 15 to 16.
-        # We skip it for now while investigation continues.
-        return sys.platform.startswith("darwin")
+        # Windows produces different outputs. Disable there for further investigation
+        return sys.platform.startswith("win")
 
     def setUp(self):
         self.sample = self._sampleEventData()


### PR DESCRIPTION
Reverts mantidproject/mantid#37727

It's back to failing on windows again. It also seems like the python version downgraded recently, which may be related. 

Commits should probably be squashed. They all just revert back to the first one. 