### PR TITLE
RotateSampleShape algorithm created

### DIFF
--- a/Framework/Crystal/CMakeLists.txt
+++ b/Framework/Crystal/CMakeLists.txt
@@ -73,6 +73,7 @@ set(SRC_FILES
     src/SortPeaksWorkspace.cpp
     src/StatisticsOfPeaksWorkspace.cpp
     src/TransformHKL.cpp
+    src/RotateSampleShape.cpp
 )
 
 set(INC_FILES
@@ -153,6 +154,7 @@ set(INC_FILES
     inc/MantidCrystal/SortPeaksWorkspace.h
     inc/MantidCrystal/StatisticsOfPeaksWorkspace.h
     inc/MantidCrystal/TransformHKL.h
+    inc/MantidCrystal/RotateSampleShape.h
 )
 
 set(TEST_FILES
@@ -226,6 +228,7 @@ set(TEST_FILES
     SortPeaksWorkspaceTest.h
     StatisticsOfPeaksWorkspaceTest.h
     TransformHKLTest.h
+    RotateSampleShapeTest.h
 )
 
 if(COVERAGE)
@@ -261,7 +264,7 @@ include_directories(inc)
 target_link_libraries(
   Crystal
   PUBLIC Mantid::API Mantid::Geometry Mantid::Kernel
-  PRIVATE Mantid::DataObjects Mantid::Indexing
+  PRIVATE Mantid::DataObjects Mantid::Indexing Mantid::DataHandling
 )
 
 # Add the unit tests directory

--- a/Framework/Crystal/inc/MantidCrystal/RotateSampleShape.h
+++ b/Framework/Crystal/inc/MantidCrystal/RotateSampleShape.h
@@ -1,0 +1,53 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/MultipleExperimentInfos.h"
+#include "MantidCrystal/DllConfig.h"
+
+namespace Mantid {
+namespace Geometry {
+class Goniometer;
+}
+} // namespace Mantid
+
+namespace Mantid {
+namespace Crystal {
+
+using Mantid::Geometry::Goniometer;
+
+/** Define the initial orientation of the sample with respect to the beam and instrument by giving the axes and
+ *directions of rotations.
+ */
+class MANTID_CRYSTAL_DLL RotateSampleShape final : public API::Algorithm {
+public:
+  /// Algorithm's name for identification
+  const std::string name() const override { return "RotateSampleShape"; };
+  /// Summary of algorithms purpose
+  const std::string summary() const override {
+    return "Define the initial orientation of the sample with respect to the beam and instrument "
+           "by giving the axes, angle and directions of rotations.";
+  }
+
+  /// Algorithm's version for identification
+  int version() const override { return 1; };
+  const std::vector<std::string> seeAlso() const override { return {"SetGoniometer"}; }
+  /// Algorithm's category for identification
+  const std::string category() const override { return "Crystal\\Goniometer"; }
+
+private:
+  /// Initialise the properties
+  void init() override;
+  /// Run the algorithm
+  void exec() override;
+  void prepareGoniometerAxes(Goniometer &gon, const API::ExperimentInfo_sptr &ei);
+  bool checkIsValidShape(const API::ExperimentInfo_sptr &ei, std::string &shapeXML, bool &isMeshShape);
+};
+
+} // namespace Crystal
+} // namespace Mantid

--- a/Framework/Crystal/inc/MantidCrystal/RotateSampleShape.h
+++ b/Framework/Crystal/inc/MantidCrystal/RotateSampleShape.h
@@ -45,7 +45,7 @@ private:
   void init() override;
   /// Run the algorithm
   void exec() override;
-  void prepareGoniometerAxes(Goniometer &gon, const API::ExperimentInfo_sptr &ei);
+  void prepareGoniometerAxes(Goniometer &gon);
   bool checkIsValidShape(const API::ExperimentInfo_sptr &ei, std::string &shapeXML, bool &isMeshShape);
 };
 

--- a/Framework/Crystal/src/RotateSampleShape.cpp
+++ b/Framework/Crystal/src/RotateSampleShape.cpp
@@ -72,7 +72,7 @@ void RotateSampleShape::exec() {
 
   // Create a goniometer with provided rotations
   Goniometer gon;
-  prepareGoniometerAxes(gon, ei);
+  prepareGoniometerAxes(gon);
   if (gon.getNumberAxes() == 0)
     g_log.warning() << "Empty goniometer created; will always return an "
                        "identity rotation matrix.\n";
@@ -115,7 +115,7 @@ bool RotateSampleShape::checkIsValidShape(const API::ExperimentInfo_sptr &ei, st
   return false;
 }
 
-void RotateSampleShape::prepareGoniometerAxes(Goniometer &gon, const API::ExperimentInfo_sptr &ei) {
+void RotateSampleShape::prepareGoniometerAxes(Goniometer &gon) {
   for (size_t i = 0; i < NUM_AXES; i++) {
     std::ostringstream propName;
     propName << "Axis" << i;

--- a/Framework/Crystal/src/RotateSampleShape.cpp
+++ b/Framework/Crystal/src/RotateSampleShape.cpp
@@ -1,0 +1,179 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidCrystal/RotateSampleShape.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Run.h"
+#include "MantidAPI/Sample.h"
+#include "MantidDataHandling/CreateSampleShape.h"
+#include "MantidGeometry/Instrument/Goniometer.h"
+#include "MantidGeometry/Objects/MeshObject.h"
+#include "MantidGeometry/Objects/ShapeFactory.h"
+#include "MantidKernel/Strings.h"
+#include "MantidKernel/TimeSeriesProperty.h"
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+
+namespace Mantid::Crystal {
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(RotateSampleShape)
+
+using namespace Mantid::Geometry;
+using namespace Mantid::Kernel;
+using namespace Mantid::API;
+
+/// How many axes (max) to define
+const size_t NUM_AXES = 6;
+Mantid::Kernel::Logger g_log("RotateSampleShape");
+
+/** Initialize the algorithm's properties.
+ */
+void RotateSampleShape::init() {
+  declareProperty(std::make_unique<WorkspaceProperty<Workspace>>("Workspace", "", Direction::InOut),
+                  "The workspace containing the sample whose orientation is to be rotated");
+
+  std::string axisHelp = ": degrees,x,y,z,1/-1 (1 for ccw, -1 for cw rotation).";
+  for (size_t i = 0; i < NUM_AXES; i++) {
+    std::ostringstream propName;
+    propName << "Axis" << i;
+    declareProperty(std::make_unique<PropertyWithValue<std::string>>(propName.str(), "", Direction::Input),
+                    propName.str() + axisHelp);
+  }
+}
+
+/** Execute the algorithm.
+ */
+void RotateSampleShape::exec() {
+  Workspace_sptr ws = getProperty("Workspace");
+  auto ei = std::dynamic_pointer_cast<ExperimentInfo>(ws);
+
+  if (!ei) {
+    // We're dealing with an MD workspace which has multiple experiment infos
+    auto infos = std::dynamic_pointer_cast<MultipleExperimentInfos>(ws);
+    if (!infos) {
+      throw std::invalid_argument("Input workspace does not support RotateSampleShape");
+    }
+    if (infos->getNumExperimentInfo() < 1) {
+      ExperimentInfo_sptr info(new ExperimentInfo());
+      infos->addExperimentInfo(info);
+    }
+    ei = infos->getExperimentInfo(0);
+  }
+
+  std::string shapeXML;
+  bool isMeshShape = false;
+  if (!checkIsValidShape(ei, shapeXML, isMeshShape)) {
+    throw std::runtime_error("Input sample does not have a valid shape!");
+  }
+
+  // Create a goniometer with provided rotations
+  Goniometer gon;
+  prepareGoniometerAxes(gon, ei);
+  if (gon.getNumberAxes() == 0)
+    g_log.warning() << "Empty goniometer created; will always return an "
+                       "identity rotation matrix.\n";
+
+  const auto sampleShapeRotation = gon.getR();
+  if (sampleShapeRotation == Kernel::Matrix<double>(3, 3, true)) {
+    // If the resulting rotationMatrix is Identity, ignore the calculatrion
+    g_log.warning("Rotation matrix set via RotateSampleShape is an Identity matrix. Ignored rotating sample shape");
+    return;
+  }
+
+  const auto oldRotation = ei->run().getGoniometer().getR();
+  auto newSampleShapeRot = sampleShapeRotation * oldRotation;
+  if (isMeshShape) {
+    auto meshShape = std::dynamic_pointer_cast<MeshObject>(ei->sample().getShapePtr());
+    meshShape->rotate(newSampleShapeRot);
+  } else {
+    shapeXML = Geometry::ShapeFactory().addGoniometerTag(newSampleShapeRot, shapeXML);
+    Mantid::DataHandling::CreateSampleShape::setSampleShape(*ei, shapeXML, false);
+  }
+}
+
+bool RotateSampleShape::checkIsValidShape(const API::ExperimentInfo_sptr &ei, std::string &shapeXML,
+                                          bool &isMeshShape) {
+  if (ei->sample().hasShape()) {
+    const auto csgShape = std::dynamic_pointer_cast<CSGObject>(ei->sample().getShapePtr());
+    if (csgShape && csgShape->hasValidShape()) {
+      shapeXML = csgShape->getShapeXML();
+      if (!shapeXML.empty()) {
+        return true;
+      }
+    } else {
+      const auto meshShape = std::dynamic_pointer_cast<MeshObject>(ei->sample().getShapePtr());
+      if (meshShape && meshShape->hasValidShape()) {
+        isMeshShape = true;
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+void RotateSampleShape::prepareGoniometerAxes(Goniometer &gon, const API::ExperimentInfo_sptr &ei) {
+  for (size_t i = 0; i < NUM_AXES; i++) {
+    std::ostringstream propName;
+    propName << "Axis" << i;
+    std::string axisDesc = getPropertyValue(propName.str());
+    if (!axisDesc.empty()) {
+      std::vector<std::string> tokens;
+      boost::split(tokens, axisDesc, boost::algorithm::detail::is_any_ofF<char>(","));
+      if (tokens.size() != 5)
+        throw std::invalid_argument("Wrong number of arguments to parameter " + propName.str() +
+                                    ". Expected 5 comma-separated arguments.");
+
+      std::transform(tokens.begin(), tokens.end(), tokens.begin(), [](std::string str) { return Strings::strip(str); });
+      if (!std::all_of(tokens.begin(), tokens.end(), [](std::string tokenStr) { return !tokenStr.empty(); })) {
+        throw std::invalid_argument("Empty axis parameters found!");
+      }
+
+      double angle = 0;
+      if (!Strings::convert(tokens[0], angle)) {
+        throw std::invalid_argument("Error converting angle string '" + tokens[0] + "' to a number.");
+      }
+
+      std::string axisName = "RotateSampleShapeAxis" + Strings::toString(i) + "_FixedValue";
+      g_log.information() << "Axis " << i << " - create a new log value: " << axisName;
+      try {
+        Types::Core::DateAndTime now = Types::Core::DateAndTime::getCurrentTime();
+        auto tsp = new Kernel::TimeSeriesProperty<double>(axisName);
+        tsp->addValue(now, angle);
+        tsp->setUnits("degree");
+        if (ei->mutableRun().hasProperty(axisName)) {
+          ei->mutableRun().removeLogData(axisName);
+        }
+        ei->mutableRun().addLogData(tsp);
+      } catch (...) {
+        g_log.error("Could not add axis:" + axisName);
+      }
+
+      double x = 0, y = 0, z = 0;
+      if (!Strings::convert(tokens[1], x))
+        throw std::invalid_argument("Error converting x string '" + tokens[1] + "' to a number.");
+      if (!Strings::convert(tokens[2], y))
+        throw std::invalid_argument("Error converting y string '" + tokens[2] + "' to a number.");
+      if (!Strings::convert(tokens[3], z))
+        throw std::invalid_argument("Error converting z string '" + tokens[3] + "' to a number.");
+      V3D vec(x, y, z);
+      if (vec.norm() < 1e-4)
+        throw std::invalid_argument("Rotation axis vector should be non-zero!");
+
+      int ccw = 0;
+      if (!Strings::convert(tokens[4], ccw)) {
+        throw std::invalid_argument("Error converting sense of roation '" + tokens[4] + "' to a number.");
+      }
+      if (ccw != 1 && ccw != -1) {
+        throw std::invalid_argument("The sense of rotation parameter must only be 1 (ccw) or -1 (cw)");
+      }
+      // Default to degrees
+      gon.pushAxis(axisName, x, y, z, angle, ccw);
+    }
+  }
+}
+
+} // namespace Mantid::Crystal

--- a/Framework/Crystal/src/RotateSampleShape.cpp
+++ b/Framework/Crystal/src/RotateSampleShape.cpp
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +

--- a/Framework/Crystal/src/RotateSampleShape.cpp
+++ b/Framework/Crystal/src/RotateSampleShape.cpp
@@ -138,20 +138,6 @@ void RotateSampleShape::prepareGoniometerAxes(Goniometer &gon, const API::Experi
       }
 
       std::string axisName = "RotateSampleShapeAxis" + Strings::toString(i) + "_FixedValue";
-      g_log.information() << "Axis " << i << " - create a new log value: " << axisName;
-      try {
-        Types::Core::DateAndTime now = Types::Core::DateAndTime::getCurrentTime();
-        auto tsp = new Kernel::TimeSeriesProperty<double>(axisName);
-        tsp->addValue(now, angle);
-        tsp->setUnits("degree");
-        if (ei->mutableRun().hasProperty(axisName)) {
-          ei->mutableRun().removeLogData(axisName);
-        }
-        ei->mutableRun().addLogData(tsp);
-      } catch (...) {
-        g_log.error("Could not add axis:" + axisName);
-      }
-
       double x = 0, y = 0, z = 0;
       if (!Strings::convert(tokens[1], x))
         throw std::invalid_argument("Error converting x string '" + tokens[1] + "' to a number.");

--- a/Framework/Crystal/test/RotateSampleShapeTest.h
+++ b/Framework/Crystal/test/RotateSampleShapeTest.h
@@ -1,0 +1,205 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Sample.h"
+#include "MantidCrystal/RotateSampleShape.h"
+#include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidGeometry/Instrument/Goniometer.h"
+#include "MantidGeometry/Objects/MeshObject.h"
+#include "MantidGeometry/Objects/ShapeFactory.h"
+#include "MantidKernel/Matrix.h"
+#include "MantidKernel/V3D.h"
+#include <cxxtest/TestSuite.h>
+
+using namespace Mantid::Crystal;
+using namespace Mantid::API;
+using namespace Mantid::Geometry;
+using Mantid::DataObjects::Workspace2D_sptr;
+using Mantid::Kernel::V3D;
+
+class RotateSampleShapeTest : public CxxTest::TestSuite {
+public:
+  void test_Init() {
+    RotateSampleShape alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
+
+  Workspace2D_sptr getWsWithCSGSampleShape(std::string shapeXml, std::string wsName = "RotSampleShapeTest_ws") {
+    Workspace2D_sptr ws = WorkspaceCreationHelper::create2DWorkspace(10, 10);
+    AnalysisDataService::Instance().addOrReplace(wsName, ws);
+    ShapeFactory shapeMaker;
+    ws->mutableSample().setShape(shapeMaker.createShape(shapeXml));
+    return ws;
+  }
+
+  Workspace2D_sptr getWsWithMeshSampleShape(std::unique_ptr<MeshObject> &meshShape,
+                                            std::string wsName = "RotSampleShapeTest_ws") {
+    Workspace2D_sptr ws = WorkspaceCreationHelper::create2DWorkspace(10, 10);
+    AnalysisDataService::Instance().addOrReplace(wsName, ws);
+    ws->mutableSample().setShape(std::move(meshShape));
+    return ws;
+  }
+
+  void assert_fail_when_invalid_params(std::string axisName, std::string paramStr) {
+    RotateSampleShape alg;
+    alg.setRethrows(true);
+    auto shapeXML = ComponentCreationHelper::cappedCylinderXML(0.5, 1.5, V3D(0.0, 0.0, 0.0), V3D(0., 1.0, 0.), "tube");
+    Workspace2D_sptr ws = getWsWithCSGSampleShape(shapeXML);
+
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Workspace", "RotSampleShapeTest_ws"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(axisName, paramStr));
+    TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
+    TS_ASSERT(!alg.isExecuted());
+  }
+
+  void test_exec_failures_when_invalid_params() {
+    assert_fail_when_invalid_params("Axis1", ",,,,");
+    assert_fail_when_invalid_params("Axis2", ", 1.0,2.0,3.0, 1");
+    assert_fail_when_invalid_params("Axis3", "10, x,0,0, -1");
+    assert_fail_when_invalid_params("Axis4", "10, 1,y,0, -1");
+    assert_fail_when_invalid_params("Axis5", "10, 0,0,z, -1");
+    assert_fail_when_invalid_params("Axis0", "10, 1.0,2.0,3.0, sense");
+    assert_fail_when_invalid_params("Axis1", "30, 1.0,2.0,3.0, 10");
+    assert_fail_when_invalid_params("Axis2", "10, 0.00001,0.00001,0.00001, 1");
+  }
+
+  Workspace2D_sptr assert_rotatesample_runs_with_given_shape(std::string &shapeXML,
+                                                             std::map<std::string, std::string> &properties) {
+    Workspace2D_sptr ws = getWsWithCSGSampleShape(shapeXML, properties["Workspace"]);
+    RotateSampleShape alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+
+    for (const auto &pair : properties) {
+      TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(pair.first, pair.second));
+    }
+
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+    TS_ASSERT_EQUALS(ws->run().getNumGoniometers(), 1);
+    auto ei = std::dynamic_pointer_cast<ExperimentInfo>(ws);
+    const auto shape = std::dynamic_pointer_cast<CSGObject>(ei->sample().getShapePtr());
+    std::string shapeStr = shape->getShapeXML();
+    TS_ASSERT(shapeStr.find("<goniometer") != shapeStr.npos);
+    TS_ASSERT(ei->run().getGoniometer().getR() == Mantid::Kernel::Matrix<double>(3, 3, true));
+
+    return ws;
+  }
+
+  void test_rotate_cylindrical_sample_shape() {
+    auto shapeXML = ComponentCreationHelper::cappedCylinderXML(0.5, 1.5, V3D(0.0, 0.0, 0.0), V3D(0., 1.0, 0.), "tube");
+    std::map<std::string, std::string> algProperties = {
+        {"Workspace", "RotSampleShapeTest_ws"}, {"Axis0", "10,1.0,2.0,3.0,1"}, {"Axis3", "50,4.0,5.0,6.0,-1"}};
+    assert_rotatesample_runs_with_given_shape(shapeXML, algProperties);
+  }
+
+  void test_rotate_hollow_cylindrical_sample_shape() {
+    auto shapeXML = ComponentCreationHelper::hollowCylinderXML(0.3, 0.5, 0.5, V3D(0.0, 0.0, 0.0), V3D(0., 1.0, 0.),
+                                                               "hollow_cylinder");
+    std::map<std::string, std::string> algProperties = {{"Workspace", "RotSampleShapeTest_ws"},
+                                                        {"Axis2", " 45 , 1.0 ,   0.0 ,  1.0 , 1 "},
+                                                        {"Axis4", " 90 , 0.0 , 1.0 , 1.0 , -1 "}};
+    assert_rotatesample_runs_with_given_shape(shapeXML, algProperties);
+  }
+
+  void test_rotate_spherical_sample_shape() {
+    auto shapeXML = ComponentCreationHelper::sphereXML(0.02, V3D(0, 0, 0), "sphere");
+    std::map<std::string, std::string> algProperties = {{"Workspace", "RotSampleShapeTest_ws"},
+                                                        {"Axis0", "60, 1.0,2.0,3.0, 1"},
+                                                        {"Axis3", "30 , 4.0, 5.0,6.0, -1"},
+                                                        {"Axis2", "10 , 1.0, 0.0 , 0.0,  1 "}};
+    assert_rotatesample_runs_with_given_shape(shapeXML, algProperties);
+  }
+
+  void test_rotate_cuboid_sample_shape() {
+    auto shapeXML = ComponentCreationHelper::cuboidXML(0.005, 0.005, 0.0025, {0., 0., 0.}, "cuboid");
+    std::map<std::string, std::string> algProperties = {{"Workspace", "RotSampleShapeTest_ws"},
+                                                        {"Axis2", "60, 1.0,2.0,3.0, 1"},
+                                                        {"Axis3", "30 , 4.0, 5.0,6.0, -1"},
+                                                        {"Axis5", "10 , 1.0, 0.0 , 0.0,  1 "}};
+    assert_rotatesample_runs_with_given_shape(shapeXML, algProperties);
+  }
+
+  Workspace2D_sptr assert_rotatesample_runs_with_mesh_shape(std::unique_ptr<MeshObject> &meshShape,
+                                                            std::map<std::string, std::string> &properties) {
+    Workspace2D_sptr ws = getWsWithMeshSampleShape(meshShape, properties["Workspace"]);
+    RotateSampleShape alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+
+    for (const auto &pair : properties) {
+      TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(pair.first, pair.second));
+    }
+
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+    TS_ASSERT_EQUALS(ws->run().getNumGoniometers(), 1);
+    auto ei = std::dynamic_pointer_cast<ExperimentInfo>(ws);
+    const auto shape = std::dynamic_pointer_cast<MeshObject>(ei->sample().getShapePtr());
+    TS_ASSERT(shape != nullptr);
+    TS_ASSERT(ei->run().getGoniometer().getR() == Mantid::Kernel::Matrix<double>(3, 3, true));
+
+    return ws;
+  }
+
+  std::unique_ptr<MeshObject> createCube(const double size, const V3D &centre) {
+    /**
+     * Create cube of side length size with specified centre,
+     * parellel to axes and non-negative vertex coordinates.
+     */
+    double min = 0.0 - 0.5 * size;
+    double max = 0.5 * size;
+    std::vector<V3D> vertices;
+    vertices.emplace_back(centre + V3D(max, max, max));
+    vertices.emplace_back(centre + V3D(min, max, max));
+    vertices.emplace_back(centre + V3D(max, min, max));
+    vertices.emplace_back(centre + V3D(min, min, max));
+    vertices.emplace_back(centre + V3D(max, max, min));
+    vertices.emplace_back(centre + V3D(min, max, min));
+    vertices.emplace_back(centre + V3D(max, min, min));
+    vertices.emplace_back(centre + V3D(min, min, min));
+
+    std::vector<uint32_t> triangles;
+    // top face of cube - z max
+    triangles.insert(triangles.end(), {0, 1, 2});
+    triangles.insert(triangles.end(), {2, 1, 3});
+    // right face of cube - x max
+    triangles.insert(triangles.end(), {0, 2, 4});
+    triangles.insert(triangles.end(), {4, 2, 6});
+    // back face of cube - y max
+    triangles.insert(triangles.end(), {0, 4, 1});
+    triangles.insert(triangles.end(), {1, 4, 5});
+    // bottom face of cube - z min
+    triangles.insert(triangles.end(), {7, 5, 6});
+    triangles.insert(triangles.end(), {6, 5, 4});
+    // left face of cube - x min
+    triangles.insert(triangles.end(), {7, 3, 5});
+    triangles.insert(triangles.end(), {5, 3, 1});
+    // front fact of cube - y min
+    triangles.insert(triangles.end(), {7, 6, 3});
+    triangles.insert(triangles.end(), {3, 6, 2});
+
+    // Use efficient constructor
+    std::unique_ptr<MeshObject> retVal =
+        std::make_unique<MeshObject>(std::move(triangles), std::move(vertices), Mantid::Kernel::Material());
+    return retVal;
+  }
+
+  void test_rotate_mesh_cuboid_sample_shape() {
+    auto cuboidMeshShape = createCube(2, V3D(0, 0, 0));
+    std::map<std::string, std::string> algProperties = {{"Workspace", "RotSampleShapeTest_ws"},
+                                                        {"Axis2", "60, 1.0,2.0,3.0, 1"},
+                                                        {"Axis3", "30 , 4.0, 5.0,6.0, -1"},
+                                                        {"Axis5", "10 , 1.0, 0.0 , 0.0,  1 "}};
+    assert_rotatesample_runs_with_mesh_shape(cuboidMeshShape, algProperties);
+  }
+};

--- a/Framework/DataHandling/inc/MantidDataHandling/CreateSampleShape.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/CreateSampleShape.h
@@ -27,7 +27,7 @@ namespace DataHandling {
 */
 class MANTID_DATAHANDLING_DLL CreateSampleShape final : public API::Algorithm {
 public:
-  static void setSampleShape(API::ExperimentInfo &expt, const std::string &shapeXML);
+  static void setSampleShape(API::ExperimentInfo &expt, const std::string &shapeXML, bool addTypeTag = true);
 
 public:
   const std::string name() const override { return "CreateSampleShape"; }

--- a/Framework/DataHandling/src/CreateSampleShape.cpp
+++ b/Framework/DataHandling/src/CreateSampleShape.cpp
@@ -26,11 +26,12 @@ using namespace Mantid::API;
  * @brief Set the shape via an XML string on the given experiment
  * @param expt A reference to the experiment holding the sample object
  * @param shapeXML XML defining the object's shape
+ * @param addTypeTag true to wrap a \<type\> tag around the XML supplied(default)
  */
-void CreateSampleShape::setSampleShape(API::ExperimentInfo &expt, const std::string &shapeXML) {
+void CreateSampleShape::setSampleShape(API::ExperimentInfo &expt, const std::string &shapeXML, bool addTypeTag) {
   Geometry::ShapeFactory sFactory;
   // Create the object
-  auto shape = sFactory.createShape(shapeXML);
+  auto shape = sFactory.createShape(shapeXML, addTypeTag);
   // Check it's valid and attach it to the workspace sample but preserve any
   // material
   if (shape->hasValidShape()) {

--- a/docs/source/algorithms/RotateSampleShape-v1.rst
+++ b/docs/source/algorithms/RotateSampleShape-v1.rst
@@ -12,7 +12,8 @@ Description
 
 Use this algorithm to define the initial orientation of the sample with respect
 to the beam and instrument by giving the axes, angle and directions of rotations.
-Enter each axis in the order of rotation, starting with the one farthest from the sample.
+Enter each axis in the order of rotation, starting with the one farthest from the
+sample similar to :ref:`algm-SetGoniometer`
 
 You may enter up to 6 axes, for each of which you must define 5 values as below separated by
 commas:
@@ -25,7 +26,7 @@ commas:
    clockwise rotation.
 
 The sample shape would then be rotated by the goniometer before being used in the
-calculation of various attenuation corrections. This algorithm work for CSG shapes
+calculation of various attenuation corrections. This algorithm work for both CSG shapes
 (e.g. cylinders, flat plates etc.) and Mesh files.
 
 
@@ -35,14 +36,20 @@ Usage
 
 .. testcode:: RotateSampleShape
 
+    from mantid.simpleapi import *
+    import xml.dom.minidom as md
+
     ws = CreateSampleWorkspace()
     SetSample(ws,
-            Geometry={'Shape': 'Cylinder', 'Height': 4.0,
-                        'Radius': 1.0,
-                        'Center': [0.,0.,0.]},
-            Material={'ChemicalFormula': '(Li7)2-C-H4-N-Cl6',
-                        'NumberDensity': 0.1})
+    Geometry={'Shape': 'Cylinder', 'Height': 4.0,
+                'Radius': 1.0,
+                'Center': [0.,0.,0.]},
+    Material={'ChemicalFormula': '(Li7)2-C-H4-N-Cl6',
+                'NumberDensity': 0.1})
+
     RotateSampleShape(Workspace=ws, Axis0="45,1,1,0,1", Axis1="15,0,0,1,-1")
+
+    print(md.parseString(ws.sample().getShape().getShapeXML()).toprettyxml())
 
 .. testcleanup:: RotateSampleShape
 

--- a/docs/source/algorithms/RotateSampleShape-v1.rst
+++ b/docs/source/algorithms/RotateSampleShape-v1.rst
@@ -1,0 +1,54 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+Use this algorithm to define the initial orientation of the sample with respect
+to the beam and instrument by giving the axes, angle and directions of rotations.
+Enter each axis in the order of rotation, starting with the one farthest from the sample.
+
+You may enter up to 6 axes, for each of which you must define 5 values as below separated by
+commas:
+
+-  The angle of rotation in degrees.
+-  The X, Y, Z components of the vector of the axis of rotation.
+   Right-handed coordinates with +Z=beam direction; +Y=Vertically up
+   (against gravity); +X to the left.
+-  The sense of rotation as 1 or -1: 1 for counter-clockwise, -1 for
+   clockwise rotation.
+
+The sample shape would then be rotated by the goniometer before being used in the
+calculation of various attenuation corrections. This algorithm work for CSG shapes
+(e.g. cylinders, flat plates etc.) and Mesh files.
+
+
+Usage
+-----
+**Example - RotateSampleShape for sample with a CSG shape**
+
+.. testcode:: RotateSampleShape
+
+    ws = CreateSampleWorkspace()
+    SetSample(ws,
+            Geometry={'Shape': 'Cylinder', 'Height': 4.0,
+                        'Radius': 1.0,
+                        'Center': [0.,0.,0.]},
+            Material={'ChemicalFormula': '(Li7)2-C-H4-N-Cl6',
+                        'NumberDensity': 0.1})
+    RotateSampleShape(Workspace=ws, Axis0="45,1,1,0,1", Axis1="15,0,0,1,-1")
+
+.. testcleanup:: RotateSampleShapeEx1
+
+    DeleteWorkspace('ws')
+
+.. categories::
+
+.. sourcelink::
+

--- a/docs/source/algorithms/RotateSampleShape-v1.rst
+++ b/docs/source/algorithms/RotateSampleShape-v1.rst
@@ -44,9 +44,9 @@ Usage
                         'NumberDensity': 0.1})
     RotateSampleShape(Workspace=ws, Axis0="45,1,1,0,1", Axis1="15,0,0,1,-1")
 
-.. testcleanup:: RotateSampleShapeEx1
+.. testcleanup:: RotateSampleShape
 
-    DeleteWorkspace('ws')
+    DeleteWorkspace(ws)
 
 .. categories::
 

--- a/docs/source/release/v6.11.0/Diffraction/Single_Crystal/New_features/37908.rst
+++ b/docs/source/release/v6.11.0/Diffraction/Single_Crystal/New_features/37908.rst
@@ -1,0 +1,1 @@
+- New algorithm :ref:`RotateSampleShape <algm-rotatesampleshape>` that defines the initial orientation of a sample with respect to the beam and instrument.


### PR DESCRIPTION
### Description of work
Created a new algorithm named `RotateSampleShape` to define the initial orientation of a sample wrt the beam and instrument.

#### Summary of work
Using `RotateSampleShape` the sample shape can be rotated by the goniometer before being used in the calculation of various attenuation corrections. It would change the orientation of a sample on a workspace and work for CSG shapes (e.g. cylinders, flat plates etc.) and Mesh files.


Fixes #34565. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->



### To test:

#### Test 1: 
`RotateSampleShape` for a workspace containing a CSG sample shape: 
1. Run below code
```
ws = CreateSampleWorkspace()
shape_xml = " \
<hollow-cylinder id='A'>\
  <centre-of-bottom-base r='0.0' t='0.0' p='0.0' />  \
  <axis x='0.0' y='1.0' z='0' />\
  <inner-radius val='0.007' />\
  <outer-radius val='0.01' />\
  <height val='0.05' />\
</hollow-cylinder>\
"
SetSample(InputWorkspace=ws,
          Geometry={'Shape': 'CSG', 'Value': shape_xml},
          Material={'NumberDensity': 0.02, 'AttenuationXSection': 0.0,
                    'CoherentXSection': 0.0, 'IncoherentXSection': 0.0, 'ScatteringXSection': 80.0})
```
2. Observe the sample shape and orientation by right clicking on the `ws` ->`Show Sample Shape`
3. Now run the `RotateSampleShape` algorithm and observe the new orientation of the sample. 
```
RotateSampleShape(Workspace=ws, Axis0="45,1,0,0,1")
```
5. Repeat the test with different shape_xml as below
```
shape_xml = " \
<cuboid id='some-cuboid'>\
  <width val='2.0' />\
  <height val='4.0'  />\
  <depth  val='0.2' />\
  <centre x='10.0' y='10.0' z='10.0'  />\
</cuboid>\
<algebra val='some-cuboid' /> \
"
```

```
shape_xml = " \
<hexahedron id='Bertie'>\
  <left-back-bottom-point  x='0.0' y='0.0' z='0.0'  />\
  <left-front-bottom-point x='1.0' y='0.0' z='0.0'  />\
  <right-front-bottom-point x='1.0' y='1.0' z='0.0'  />\
  <right-back-bottom-point  x='0.0' y='1.0' z='0.0'  />\
  <left-back-top-point  x='0.0' y='0.0' z='2.0'  />\
  <left-front-top-point  x='0.5' y='0.0' z='2.0'  />\
  <right-front-top-point  x='0.5' y='0.5' z='2.0'  />\
  <right-back-top-point  x='0.0' y='0.5' z='2.0'  />\
</hexahedron>\
"
```


#### Test 2: 
`RotateSampleShape` for a workspace containing a Mesh shape:
1. Run below code
``` 
ws = CreateSampleWorkspace()
LoadSampleShape(InputWorkspace=ws, OutputWorkspace=ws.name(),  Filename=r"correct\filepath\here\Anvil.stl")
``` 
2. Observe the sample shape and orientation by right clicking on the `ws` ->`Show Sample Shape`
3. Run the `RotateSampleShape` algorithm and observe the new orientation of the sample.
```
RotateSampleShape(Workspace=ws, Axis0="45,0,1,0,1")
```

#### Test 3:
RotateSampleShape supports upto 6 axes of rotations. Play around with different combination of axes and configurations to observe the resulting orientation of the sample. Observe the resulting sample orientation when there is already a goniometer set with `SetGoniometer` as below.

```
ws = CreateSampleWorkspace()
SetGoniometer(Workspace=ws, Axis0="45,1,1,0,1")
SetSample(ws,
          Geometry={'Shape': 'Cylinder', 'Height': 4.0,
                    'Radius': 1.0,
                    'Center': [0.,0.,0.]},
          Material={'ChemicalFormula': '(Li7)2-C-H4-N-Cl6',
                    'NumberDensity': 0.1})
RotateSampleShape(Workspace=ws, Axis0="45,0,0,1,1")
```


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
