### PR TITLE
Advanced Options for Single Crystal Elastic mode of DNS Reduction GUI

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_elastic/data_structures/dns_binning.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_elastic/data_structures/dns_binning.py
@@ -10,24 +10,94 @@ import numpy as np
 from mantidqtinterfaces.dns_powder_tof.data_structures.object_dict import ObjectDict
 
 
+DEFAULT_TWO_THETA_MIN = 5.0
+DEFAULT_TWO_THETA_RANGE = 115.0
+DEFAULT_TWO_THETA_STEP = 5.0
+DEFAULT_OMEGA_MIN = 5.0
+DEFAULT_OMEGA_MAX = 5.0
+DEFAULT_OMEGA_STEP = 0.0
+
+
+def get_automatic_omega_binning(sample_data):
+    """
+    Determines automatic sample rotation binning parameters from selected sample data.
+    """
+    selected_omega = [-x["det_rot"] + x["sample_rot"] for x in sample_data]
+
+    unique_omega = sorted(list(set(selected_omega)))
+    # default for the case when files with same values of omega are selected
+    omega_step = DEFAULT_OMEGA_STEP
+    number_omega_bins = 0
+
+    omega_min = min(unique_omega, default=DEFAULT_OMEGA_MIN)
+    omega_max = max(unique_omega, default=DEFAULT_OMEGA_MAX)
+    omega_steps = np.diff(unique_omega)
+    # use non-default step when several omega angles are selected
+    if omega_steps.size != 0:
+        omega_values, omega_counts = np.unique(omega_steps, return_counts=True)
+        omega_ind = np.argmax(omega_counts)
+        most_freq_omega_step = omega_values[omega_ind]
+        omega_step = most_freq_omega_step
+
+    if omega_step != 0:
+        omega_range = np.arange(omega_min, omega_max + omega_step, omega_step)
+        number_omega_bins = omega_range.size
+
+    omega_binning_dict = {"omega_min": omega_min, "omega_max": omega_max, "omega_bin_size": omega_step, "omega_nbins": number_omega_bins}
+
+    return omega_binning_dict
+
+
+def get_automatic_two_theta_binning(sample_data):
+    """
+    Determines automatic two theta binning parameters from selected sample data.
+    """
+    selected_det_rot = [-x["det_rot"] for x in sample_data]
+
+    unique_det_rot = sorted(list(set(selected_det_rot)))
+    # default for the case when files with same values of det_rot are selected
+    two_theta_step = DEFAULT_TWO_THETA_STEP
+
+    two_theta_min = min(unique_det_rot, default=DEFAULT_TWO_THETA_MIN)
+    two_theta_max = max(unique_det_rot, default=DEFAULT_TWO_THETA_MIN) + DEFAULT_TWO_THETA_RANGE
+    two_theta_steps = np.diff(unique_det_rot)
+    # use non-default step when several det_rot angles are selected
+    if two_theta_steps.size != 0:
+        two_theta_step_values, two_theta_step_counts = np.unique(two_theta_steps, return_counts=True)
+        two_theta_step_ind = np.argmax(two_theta_step_counts)
+        most_freq_two_theta_step = two_theta_step_values[two_theta_step_ind]
+        two_theta_step = most_freq_two_theta_step
+
+    two_theta_range = np.arange(two_theta_min, two_theta_max + two_theta_step, two_theta_step)
+    number_two_theta_bins = two_theta_range.size
+
+    two_theta_binning_dict = {
+        "two_theta_min": two_theta_min,
+        "two_theta_max": two_theta_max,
+        "two_theta_bin_size": two_theta_step,
+        "nbins": number_two_theta_bins,
+    }
+
+    return two_theta_binning_dict
+
+
 class DNSBinning(ObjectDict):
     """
     Stores DNS binning information. If the number of bins is not given,
     it is calculated from the step size, also defines bin_edges.
     """
 
-    def __init__(self, xmin, xmax, step, number_of_bins=None):
+    def __init__(self, xmin, xmax, step):
         super().__init__()
         self["min"] = xmin
         self["max"] = xmax
         self["step"] = step
-        if number_of_bins is None:
-            if step == 0:
-                number_of_bins = 1
-            else:
-                number_of_bins = int(round((xmax - xmin) / step) + 1)
-        self["nbins"] = number_of_bins
-        self["range"] = np.linspace(xmin, xmax, self.nbins)
         self["bin_edge_min"] = xmin - step / 2
         self["bin_edge_max"] = xmax + step / 2
-        self["bin_edge_range"] = np.linspace(self.bin_edge_min, self.bin_edge_max, self.nbins + 1)
+        if step == 0:
+            self["range"] = np.array([])
+            self["bin_edge_range"] = np.array([])
+        else:
+            self["range"] = np.arange(xmin, xmax + step, step)
+            self["bin_edge_range"] = np.arange(self["bin_edge_min"], self["bin_edge_max"] + self["step"], self["step"])
+        self["nbins"] = self["range"].size

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_elastic/helpers/converters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_elastic/helpers/converters.py
@@ -20,12 +20,5 @@ def elastic_two_theta_to_q(two_theta, wavelength):
     return pi * 4.0 * sin(deg2rad(two_theta / 2.0)) / wavelength
 
 
-def convert_hkl_string(hkl):
-    # catches if user uses brackets or spaces in hkl specification
-    hkl = hkl.strip("[]()")
-    hkl = hkl.replace(" ", ",")
-    return hkl
-
-
 def convert_hkl_string_to_float(hkl):
-    return [float(x) for x in convert_hkl_string(hkl).split(",")]
+    return [float(x) for x in hkl.split(",")]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_elastic/options/elastic_powder_options_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_elastic/options/elastic_powder_options_presenter.py
@@ -10,6 +10,7 @@ DNS powder elastic options tab presenter of DNS reduction GUI.
 """
 
 from mantidqtinterfaces.dns_powder_tof.options.common_options_presenter import DNSCommonOptionsPresenter
+from mantidqtinterfaces.dns_powder_elastic.data_structures.dns_binning import get_automatic_two_theta_binning
 
 
 class DNSElasticPowderOptionsPresenter(DNSCommonOptionsPresenter):
@@ -75,22 +76,3 @@ class DNSElasticPowderOptionsPresenter(DNSCommonOptionsPresenter):
             two_theta_max = own_options["two_theta_max"]
             two_theta_min = own_options["two_theta_min"]
             self.view._map["two_theta_bin_size"].setMaximum(two_theta_max - two_theta_min)
-
-
-def get_automatic_two_theta_binning(sample_data):
-    """
-    Determines automatic two theta binning parameters from selected sample data.
-    """
-    det_rot = [-x["det_rot"] for x in sample_data]
-    two_theta_last_det = 115.0
-    two_theta_max = max(det_rot) + two_theta_last_det
-    two_theta_min = min(det_rot)
-    two_theta_step = 0.5
-    number_two_theta_bins = int(round((two_theta_max - two_theta_min) / two_theta_step) + 1)
-    two_theta_binning_dict = {
-        "two_theta_min": two_theta_min,
-        "two_theta_max": two_theta_max,
-        "two_theta_bin_size": two_theta_step,
-        "nbins": number_two_theta_bins,
-    }
-    return two_theta_binning_dict

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/data_structures/dns_treemodel.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/data_structures/dns_treemodel.py
@@ -12,6 +12,10 @@ Custom tree model for DNS to store list of scans with files as children.
 import numpy as np
 from qtpy.QtCore import QAbstractItemModel, QModelIndex, Qt
 from mantidqtinterfaces.dns_powder_tof.data_structures.dns_treeitem import DNSTreeItem, TreeItemEnum
+import decimal
+
+
+decimal.getcontext().rounding = decimal.ROUND_HALF_UP
 
 
 class DNSTreeModel(QAbstractItemModel):
@@ -193,8 +197,8 @@ class DNSTreeModel(QAbstractItemModel):
                     n_checked.append(
                         {
                             "file_number": int(item.get_tree_item_data(TreeItemEnum.number.value)),
-                            "det_rot": float(item.get_tree_item_data(TreeItemEnum.det_rot.value)),
-                            "sample_rot": float(item.get_tree_item_data(TreeItemEnum.sample_rot.value)),
+                            "det_rot": float(round(decimal.Decimal(item.get_tree_item_data(TreeItemEnum.det_rot.value)), 1)),
+                            "sample_rot": float(round(decimal.Decimal(item.get_tree_item_data(TreeItemEnum.sample_rot.value)), 1)),
                             "field": item.get_tree_item_data(TreeItemEnum.field.value),
                             "temperature": float(item.get_tree_item_data(TreeItemEnum.temperature.value)),
                             "sample_name": item.get_tree_item_data(TreeItemEnum.sample.value),

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/file_selector/file_selector_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/file_selector/file_selector_view.py
@@ -10,7 +10,7 @@ DNS file selector tab view of DNS reduction GUI.
 """
 
 from mantidqt.utils.qt import load_ui
-from qtpy.QtCore import QModelIndex, Qt, Signal
+from qtpy.QtCore import QModelIndex, Qt, Signal, QSignalBlocker
 from qtpy.QtWidgets import QProgressDialog
 from mantidqtinterfaces.dns_powder_tof.data_structures.dns_view import DNSView
 from mantidqtinterfaces.dns_powder_tof.data_structures.dns_treeitem import TreeItemEnum
@@ -113,16 +113,14 @@ class DNSFileSelectorView(DNSView):
         self.sig_check_last.emit(sender_name)
 
     def _un_expand_all(self):
-        self._treeview.blockSignals(True)
-        self._treeview.collapseAll()
-        self._treeview.blockSignals(False)
+        with QSignalBlocker(self._treeview):
+            self._treeview.collapseAll()
         self.adjust_treeview_columns_width(TREEVIEW_MAX_NUMBER_COLUMNS)
 
     # public can be called from presenter
     def expand_all(self):
-        self._treeview.blockSignals(True)
-        self._treeview.expandAll()
-        self._treeview.blockSignals(False)
+        with QSignalBlocker(self._treeview):
+            self._treeview.expandAll()
         self.adjust_treeview_columns_width(TREEVIEW_MAX_NUMBER_COLUMNS)
 
     def _filter_scans_checked(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/file_selector/file_selector_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/file_selector/file_selector_view.py
@@ -15,6 +15,8 @@ from qtpy.QtWidgets import QProgressDialog
 from mantidqtinterfaces.dns_powder_tof.data_structures.dns_view import DNSView
 from mantidqtinterfaces.dns_powder_tof.data_structures.dns_treeitem import TreeItemEnum
 
+TREEVIEW_MAX_NUMBER_COLUMNS = 10
+
 
 class DNSFileSelectorView(DNSView):
     """
@@ -111,11 +113,17 @@ class DNSFileSelectorView(DNSView):
         self.sig_check_last.emit(sender_name)
 
     def _un_expand_all(self):
+        self._treeview.blockSignals(True)
         self._treeview.collapseAll()
+        self._treeview.blockSignals(False)
+        self.adjust_treeview_columns_width(TREEVIEW_MAX_NUMBER_COLUMNS)
 
     # public can be called from presenter
     def expand_all(self):
+        self._treeview.blockSignals(True)
         self._treeview.expandAll()
+        self._treeview.blockSignals(False)
+        self.adjust_treeview_columns_width(TREEVIEW_MAX_NUMBER_COLUMNS)
 
     def _filter_scans_checked(self):
         self.sig_filters_clicked.emit()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/options/common_options_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/options/common_options_presenter.py
@@ -26,11 +26,11 @@ class DNSCommonOptionsPresenter(DNSObserver):
             self.raise_error("No data selected", critical=True)
             return None
         warnings = {
-            "wavelength_varies": "Warning, different wavelengths in" " datafiles. Set the wavelength manually.",
+            "wavelength_varies": "Warning, different wavelengths in datafiles. Set the wavelength manually.",
             "selector_wavelength_missmatch": "Warning, selector speeds"
             " in datafiles differ by more than 10 rpm. Set the"
             " wavelength manually.",
-            "selector_speed_varies": "Warning, selector speed differs from" " wavelength more than 10%. Set the wavelength manually.",
+            "selector_speed_varies": "Warning, selector speed differs from wavelength more than 10%. Set the wavelength manually.",
         }
         wavelength, errors = self.model.determine_wavelength(full_data)
         for key, value in errors.items():

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/script_generator/common_script_generator_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/script_generator/common_script_generator_presenter.py
@@ -10,6 +10,7 @@ Common presenter for DNS script generators.
 """
 
 from mantidqtinterfaces.dns_powder_tof.data_structures.dns_observer import DNSObserver
+from mantid.simpleapi import logger
 
 
 class DNSScriptGeneratorPresenter(DNSObserver):
@@ -46,6 +47,11 @@ class DNSScriptGeneratorPresenter(DNSObserver):
         script, error = self.model.script_maker(options, paths, file_selector)
         self.raise_error(error, critical=True, do_raise=error)
         if script != [""] and not error:
+            logger.warning(
+                "Warning: In order to consolidate the data reduction workflow, detector and sample "
+                "rotation angles of selected sample and standard data are rounded to the nearest tenth "
+                "of a degree, which corresponds to actual resolution of the detector."
+            )
             self._script_text = "\n".join(script)
             self.view.set_script_output(self._script_text)
             self.view.process_events()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/script_generator/script_generator.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_powder_tof/script_generator/script_generator.ui
@@ -25,7 +25,7 @@
      <item>
       <widget class="QPushButton" name="pB_generate_script">
        <property name="text">
-        <string>Generate Script</string>
+        <string>Generate and Run Script</string>
        </property>
       </widget>
      </item>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/data_structures/dns_single_crystal_map.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/data_structures/dns_single_crystal_map.py
@@ -25,6 +25,10 @@ def _get_mesh(omega, two_theta, z_mesh):
     return omega_mesh_no_nan, two_theta_mesh_no_nan, z_mesh_no_nan
 
 
+def _correct_omega_offset(omega, omega_offset):
+    return np.subtract(omega, omega_offset)
+
+
 def _get_unique(omega_mesh, two_theta_mesh):
     omega = np.unique(omega_mesh)
     two_theta = np.unique(two_theta_mesh)
@@ -50,7 +54,8 @@ class DNSScMap(ObjectDict):
     def __init__(self, parameter, two_theta=None, omega=None, z_mesh=None, error_mesh=None):
         super().__init__()
         # non interpolated data:
-        omega_mesh, two_theta_mesh, z_mesh = _get_mesh(omega, two_theta, z_mesh)
+        omega_corrected = _correct_omega_offset(omega, parameter["omega_offset"])
+        omega_mesh, two_theta_mesh, z_mesh = _get_mesh(omega_corrected, two_theta, z_mesh)
         omega_unique, two_theta_unique = _get_unique(omega_mesh, two_theta_mesh)
         qx_mesh, qy_mesh = _get_q_mesh(omega_mesh, two_theta_mesh, parameter["wavelength"])
         hklx_mesh, hkly_mesh = _get_hkl_mesh(qx_mesh, qy_mesh, parameter["dx"], parameter["dy"])

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/helpers/__init__.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/helpers/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/helpers/converters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/helpers/converters.py
@@ -1,0 +1,37 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+"""
+DNS unit converters.
+"""
+
+from numpy import cos, radians, sin, sqrt
+
+
+def d_spacing_from_lattice(a, b, c, alpha, beta, gamma, hkl):
+    # pylint: disable=too-many-arguments
+    # alpha beta gamma in deg
+    h, k, l = hkl
+    alpha = radians(alpha)
+    beta = radians(beta)
+    gamma = radians(gamma)
+    cos_alpha = cos(alpha)
+    cos_beta = cos(beta)
+    cos_gamma = cos(gamma)
+    sin_alpha = sin(alpha)
+    sin_beta = sin(beta)
+    sin_gamma = sin(gamma)
+    vol = a * b * c * sqrt(1.0 - cos_alpha**2 - cos_beta**2 - cos_gamma**2 + 2.0 * cos_alpha * cos_beta * cos_gamma)
+    s11 = b**2 * c**2 * sin_alpha**2
+    s22 = a**2 * c**2 * sin_beta**2
+    s33 = a**2 * b**2 * sin_gamma**2
+    s12 = a * b * c**2 * (cos_alpha * cos_beta - cos_gamma)
+    s23 = a**2 * b * c * (cos_beta * cos_gamma - cos_alpha)
+    s13 = a * b**2 * c * (cos_gamma * cos_alpha - cos_beta)
+    inverse_d_square = 1.0 / vol**2 * (s11 * h**2 + s22 * k**2 + s33 * l**2 + 2.0 * s12 * h * k + 2 * s23 * k * l + 2 * s13 * h * l)
+    d = sqrt(1 / inverse_d_square)
+    return d

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/helpers/converters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/helpers/converters.py
@@ -33,5 +33,5 @@ def d_spacing_from_lattice(a, b, c, alpha, beta, gamma, hkl):
     s23 = a**2 * b * c * (cos_beta * cos_gamma - cos_alpha)
     s13 = a * b**2 * c * (cos_gamma * cos_alpha - cos_beta)
     inverse_d_square = 1.0 / vol**2 * (s11 * h**2 + s22 * k**2 + s33 * l**2 + 2.0 * s12 * h * k + 2 * s23 * k * l + 2 * s13 * h * l)
-    d = sqrt(1 / inverse_d_square)
+    d = sqrt(1.0 / inverse_d_square)
     return d

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/helpers/converters.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/helpers/converters.py
@@ -9,29 +9,11 @@
 DNS unit converters.
 """
 
-from numpy import cos, radians, sin, sqrt
+from mantid.geometry import UnitCell
 
 
 def d_spacing_from_lattice(a, b, c, alpha, beta, gamma, hkl):
-    # pylint: disable=too-many-arguments
-    # alpha beta gamma in deg
+    unit_cell = UnitCell(a, b, c, alpha, beta, gamma)
     h, k, l = hkl
-    alpha = radians(alpha)
-    beta = radians(beta)
-    gamma = radians(gamma)
-    cos_alpha = cos(alpha)
-    cos_beta = cos(beta)
-    cos_gamma = cos(gamma)
-    sin_alpha = sin(alpha)
-    sin_beta = sin(beta)
-    sin_gamma = sin(gamma)
-    vol = a * b * c * sqrt(1.0 - cos_alpha**2 - cos_beta**2 - cos_gamma**2 + 2.0 * cos_alpha * cos_beta * cos_gamma)
-    s11 = b**2 * c**2 * sin_alpha**2
-    s22 = a**2 * c**2 * sin_beta**2
-    s33 = a**2 * b**2 * sin_gamma**2
-    s12 = a * b * c**2 * (cos_alpha * cos_beta - cos_gamma)
-    s23 = a**2 * b * c * (cos_beta * cos_gamma - cos_alpha)
-    s13 = a * b**2 * c * (cos_gamma * cos_alpha - cos_beta)
-    inverse_d_square = 1.0 / vol**2 * (s11 * h**2 + s22 * k**2 + s33 * l**2 + 2.0 * s12 * h * k + 2 * s23 * k * l + 2 * s13 * h * l)
-    d = sqrt(1.0 / inverse_d_square)
+    d = round(UnitCell.d(unit_cell, h, k, l), 5)
     return d

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options.ui
@@ -645,7 +645,7 @@
              <bool>false</bool>
             </property>
             <property name="maximum">
-             <double>150.000000000000000</double>
+             <double>0.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -669,7 +669,7 @@
              <bool>false</bool>
             </property>
             <property name="maximum">
-             <double>360.000000000000000</double>
+             <double>0.000000000000000</double>
             </property>
            </widget>
           </item>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options.ui
@@ -617,65 +617,67 @@
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="hBL_two_theta_and_omega_bin_size">
-        <property name="spacing">
-         <number>30</number>
-        </property>
-        <property name="leftMargin">
-         <number>15</number>
-        </property>
-        <item>
-         <layout class="QHBoxLayout" name="hBL_two_theta_bin_size" stretch="1,2">
-          <property name="spacing">
-           <number>15</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="l_two_theta_bin_size">
-            <property name="text">
-             <string>2θ bin size, deg</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QDoubleSpinBox" name="dSB_two_theta_bin_size">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="maximum">
-             <double>0.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="hBL_omega_bin_size" stretch="1,2">
-          <property name="spacing">
-           <number>15</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="l_omega_bin_size">
-            <property name="text">
-             <string>ω bin size, deg</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QDoubleSpinBox" name="dSB_omega_bin_size">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="maximum">
-             <double>0.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
+       <widget class="QWidget" name="widget" native="true">
+        <layout class="QHBoxLayout" name="hBL_two_theta_and_omega_bin_size">
+         <property name="spacing">
+          <number>30</number>
+         </property>
+         <property name="leftMargin">
+          <number>15</number>
+         </property>
+         <item>
+          <layout class="QHBoxLayout" name="hBL_two_theta_bin_size" stretch="1,2">
+           <property name="spacing">
+            <number>15</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="l_two_theta_bin_size">
+             <property name="text">
+              <string>2θ bin size, deg</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QDoubleSpinBox" name="dSB_two_theta_bin_size">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="maximum">
+              <double>0.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="hBL_omega_bin_size" stretch="1,2">
+           <property name="spacing">
+            <number>15</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="l_omega_bin_size">
+             <property name="text">
+              <string>ω bin size, deg</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QDoubleSpinBox" name="dSB_omega_bin_size">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="maximum">
+              <double>0.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -724,6 +726,9 @@
           <property name="text">
            <string>1,1,0</string>
           </property>
+          <property name="clearButtonEnabled">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
        </layout>
@@ -759,6 +764,9 @@
           </property>
           <property name="text">
            <string>1,-1,0</string>
+          </property>
+          <property name="clearButtonEnabled">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -921,6 +929,38 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>dSB_wavelength</tabstop>
+  <tabstop>cB_get_wavelength</tabstop>
+  <tabstop>rB_norm_time</tabstop>
+  <tabstop>rB_norm_monitor</tabstop>
+  <tabstop>gB_corrections</tabstop>
+  <tabstop>cB_det_efficiency</tabstop>
+  <tabstop>cB_sum_vana_sf_nsf</tabstop>
+  <tabstop>cB_ignore_vana_fields</tabstop>
+  <tabstop>cB_flipping_ratio</tabstop>
+  <tabstop>cB_subtract_background_from_sample</tabstop>
+  <tabstop>dSB_background_factor</tabstop>
+  <tabstop>dSB_a</tabstop>
+  <tabstop>dSB_b</tabstop>
+  <tabstop>dSB_c</tabstop>
+  <tabstop>dSB_alpha</tabstop>
+  <tabstop>dSB_beta</tabstop>
+  <tabstop>dSB_gamma</tabstop>
+  <tabstop>lE_hkl1</tabstop>
+  <tabstop>lE_hkl2</tabstop>
+  <tabstop>dSB_omega_offset</tabstop>
+  <tabstop>cB_use_dx_dy</tabstop>
+  <tabstop>dSB_dx</tabstop>
+  <tabstop>dSB_dy</tabstop>
+  <tabstop>cB_automatic_binning</tabstop>
+  <tabstop>dSB_two_theta_min</tabstop>
+  <tabstop>dSB_two_theta_max</tabstop>
+  <tabstop>dSB_two_theta_bin_size</tabstop>
+  <tabstop>dSB_omega_min</tabstop>
+  <tabstop>dSB_omega_max</tabstop>
+  <tabstop>dSB_omega_bin_size</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_model.py
@@ -1,0 +1,35 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+"""
+DNS single crystal elastic options tab model of DNS reduction GUI.
+"""
+
+from mantidqtinterfaces.dns_powder_elastic.helpers.converters import convert_hkl_string_to_float
+from mantidqtinterfaces.dns_single_crystal_elastic.helpers.converters import d_spacing_from_lattice
+from mantidqtinterfaces.dns_powder_tof.options.common_options_model import DNSCommonOptionsModel
+
+
+class DNSElasticSCOptionsModel(DNSCommonOptionsModel):
+    @staticmethod
+    def get_dx_dy(options):
+        hkl1 = convert_hkl_string_to_float(options["hkl1"])
+        hkl2 = convert_hkl_string_to_float(options["hkl2"])
+        dx = d_spacing_from_lattice(
+            a=options["a"], b=options["b"], c=options["c"], alpha=options["alpha"], beta=options["beta"], gamma=options["gamma"], hkl=hkl1
+        )
+        dy = d_spacing_from_lattice(
+            a=options["a"], b=options["b"], c=options["c"], alpha=options["alpha"], beta=options["beta"], gamma=options["gamma"], hkl=hkl2
+        )
+        return [dx, dy]
+
+    @staticmethod
+    def convert_hkl_string(hkl):
+        # catches if user uses brackets or spaces in hkl specification
+        hkl = hkl.strip("[]()")
+        hkl = hkl.replace(" ", ",")
+        return hkl

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_model.py
@@ -19,35 +19,6 @@ class DNSElasticSCOptionsModel(DNSCommonOptionsModel):
     def get_dx_dy(options):
         hkl1 = convert_hkl_string_to_float(options["hkl1"])
         hkl2 = convert_hkl_string_to_float(options["hkl2"])
-        dx = round(
-            d_spacing_from_lattice(
-                a=options["a"],
-                b=options["b"],
-                c=options["c"],
-                alpha=options["alpha"],
-                beta=options["beta"],
-                gamma=options["gamma"],
-                hkl=hkl1,
-            ),
-            5,
-        )
-        dy = round(
-            d_spacing_from_lattice(
-                a=options["a"],
-                b=options["b"],
-                c=options["c"],
-                alpha=options["alpha"],
-                beta=options["beta"],
-                gamma=options["gamma"],
-                hkl=hkl2,
-            ),
-            5,
-        )
+        dx = d_spacing_from_lattice(options["a"], options["b"], options["c"], options["alpha"], options["beta"], options["gamma"], hkl1)
+        dy = d_spacing_from_lattice(options["a"], options["b"], options["c"], options["alpha"], options["beta"], options["gamma"], hkl2)
         return [dx, dy]
-
-    @staticmethod
-    def convert_hkl_string(hkl):
-        # catches if user uses brackets or spaces in hkl specification
-        hkl = hkl.strip("[]()")
-        hkl = hkl.replace(" ", ",")
-        return hkl

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_model.py
@@ -19,11 +19,29 @@ class DNSElasticSCOptionsModel(DNSCommonOptionsModel):
     def get_dx_dy(options):
         hkl1 = convert_hkl_string_to_float(options["hkl1"])
         hkl2 = convert_hkl_string_to_float(options["hkl2"])
-        dx = d_spacing_from_lattice(
-            a=options["a"], b=options["b"], c=options["c"], alpha=options["alpha"], beta=options["beta"], gamma=options["gamma"], hkl=hkl1
+        dx = round(
+            d_spacing_from_lattice(
+                a=options["a"],
+                b=options["b"],
+                c=options["c"],
+                alpha=options["alpha"],
+                beta=options["beta"],
+                gamma=options["gamma"],
+                hkl=hkl1,
+            ),
+            5,
         )
-        dy = d_spacing_from_lattice(
-            a=options["a"], b=options["b"], c=options["c"], alpha=options["alpha"], beta=options["beta"], gamma=options["gamma"], hkl=hkl2
+        dy = round(
+            d_spacing_from_lattice(
+                a=options["a"],
+                b=options["b"],
+                c=options["c"],
+                alpha=options["alpha"],
+                beta=options["beta"],
+                gamma=options["gamma"],
+                hkl=hkl2,
+            ),
+            5,
         )
         return [dx, dy]
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_presenter.py
@@ -21,53 +21,50 @@ class DNSElasticSCOptionsPresenter(DNSCommonOptionsPresenter):
 
     def _set_binning(self):
         sample_data = self.param_dict["file_selector"]["full_data"]
-        auto_binning_is_on = self._get_automatic_binning_state()
         if sample_data:
-            self._set_min_max_binning_lims(sample_data)
-            if auto_binning_is_on:
+            self._set_binning_lims(sample_data)
+            if self._get_automatic_binning_is_checked():
                 self._set_auto_binning(sample_data)
             self.set_view_from_param()
         else:
-            if auto_binning_is_on:
+            if self._get_automatic_binning_is_checked():
                 self._set_default_auto_binning_no_data()
 
     def _set_auto_binning(self, sample_data):
         own_options = self.get_option_dict()
-        binning_param_dict = {}
-        binning_param_dict["two_theta"] = get_automatic_two_theta_binning(sample_data)
-        binning_param_dict["omega"] = get_automatic_omega_binning(sample_data)
+        binning_data_dict = {}
+        binning_data_dict["two_theta"] = get_automatic_two_theta_binning(sample_data)
+        binning_data_dict["omega"] = get_automatic_omega_binning(sample_data)
         for key in ["two_theta", "omega"]:
-            for parameter in binning_param_dict[key].keys():
-                own_options[parameter] = binning_param_dict[key][parameter]
+            for data in binning_data_dict[key].keys():
+                own_options[data] = binning_data_dict[key][data]
 
-    def _set_min_max_binning_lims(self, sample_data):
-        binning_param_dict = {}
-        binning_param_dict["two_theta"] = get_automatic_two_theta_binning(sample_data)
-        binning_param_dict["omega"] = get_automatic_omega_binning(sample_data)
+    def _set_binning_lims(self, sample_data):
+        binning_data_dict = {}
+        binning_data_dict["two_theta"] = get_automatic_two_theta_binning(sample_data)
+        binning_data_dict["omega"] = get_automatic_omega_binning(sample_data)
         for key in ["two_theta", "omega"]:
-            min_limit = binning_param_dict[key][f"{key}_min"]
-            max_limit = binning_param_dict[key][f"{key}_max"]
+            min_limit = binning_data_dict[key][f"{key}_min"]
+            max_limit = binning_data_dict[key][f"{key}_max"]
             self.view._map[f"{key}_min"].setMinimum(min_limit)
             self.view._map[f"{key}_max"].setMinimum(min_limit)
             self.view._map[f"{key}_min"].setMaximum(max_limit)
             self.view._map[f"{key}_max"].setMaximum(max_limit)
 
-    def _get_automatic_binning_state(self):
+    def _get_automatic_binning_is_checked(self):
         return self.view._map["automatic_binning"].isChecked()
 
-    def _get_wavelength_from_data_state(self):
+    def _get_wavelength_from_data_is_checked(self):
         return self.view._map["get_wavelength"].isChecked()
 
     def tab_got_focus(self):
         selected_data = self.param_dict["file_selector"]["full_data"]
         if selected_data:
-            get_wavelength_from_data_is_on = self._get_wavelength_from_data_state()
-            if get_wavelength_from_data_is_on:
+            if self._get_wavelength_from_data_is_checked():
                 self._determine_wavelength()
             self._set_binning()
         else:
-            auto_binning_is_on = self._get_automatic_binning_state()
-            if auto_binning_is_on:
+            if self._get_automatic_binning_is_checked():
                 self._set_default_auto_binning_no_data()
 
     def _set_default_auto_binning_no_data(self):
@@ -94,8 +91,6 @@ class DNSElasticSCOptionsPresenter(DNSCommonOptionsPresenter):
         if self.view is not None:
             self.own_dict.update(self.view.get_state())
             o_dic = self.own_dict
-            o_dic["hkl1"] = self.model.convert_hkl_string(o_dic["hkl1"])
-            o_dic["hkl2"] = self.model.convert_hkl_string(o_dic["hkl2"])
             if not self.own_dict.get("use_dx_dy", False):
                 o_dic["dx"], o_dic["dy"] = self.model.get_dx_dy(o_dic)
         return self.own_dict

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_presenter.py
@@ -19,6 +19,9 @@ class DNSElasticSCOptionsPresenter(DNSCommonOptionsPresenter):
         self._attach_signal_slots()
 
     def _set_auto_two_theta_binning(self):
+        """
+        Getting two theta binning parameters from selected sample data.
+        """
         if self.param_dict["file_selector"]["full_data"]:
             sample_data = self.param_dict["file_selector"]["full_data"]
             two_theta_params_dict = get_automatic_two_theta_binning(sample_data)
@@ -28,6 +31,9 @@ class DNSElasticSCOptionsPresenter(DNSCommonOptionsPresenter):
             self.set_view_from_param()
 
     def _set_auto_omega_binning(self):
+        """
+        Getting omega binning parameters from selected sample data.
+        """
         if self.param_dict["file_selector"]["full_data"]:
             sample_data = self.param_dict["file_selector"]["full_data"]
             omega_params_dict = get_automatic_omega_binning(sample_data)
@@ -35,6 +41,34 @@ class DNSElasticSCOptionsPresenter(DNSCommonOptionsPresenter):
             for parameter in omega_params_dict.keys():
                 own_options[parameter] = omega_params_dict[parameter]
             self.set_view_from_param()
+
+    def _set_manual_two_theta_binning_lims(self):
+        if self.param_dict["file_selector"]["full_data"]:
+            sample_data = self.param_dict["file_selector"]["full_data"]
+            auto_bin_params = get_automatic_two_theta_binning(sample_data)
+            min_lower_limit = auto_bin_params["two_theta_min"]
+            min_upper_limit = auto_bin_params["two_theta_max"] - auto_bin_params["two_theta_bin_size"]
+            max_lower_limit = auto_bin_params["two_theta_min"] + auto_bin_params["two_theta_bin_size"]
+            max_upper_limit = auto_bin_params["two_theta_max"]
+            self.view._map["two_theta_min"].setMinimum(min_lower_limit)
+            self.view._map["two_theta_min"].setMaximum(min_upper_limit)
+            self.view._map["two_theta_max"].setMinimum(max_lower_limit)
+            self.view._map["two_theta_max"].setMaximum(max_upper_limit)
+            self._evaluate_two_theta_max_bin_size()
+
+    def _set_manual_omega_binning_lims(self):
+        if self.param_dict["file_selector"]["full_data"]:
+            sample_data = self.param_dict["file_selector"]["full_data"]
+            auto_bin_params = get_automatic_omega_binning(sample_data)
+            min_lower_limit = auto_bin_params["omega_min"]
+            min_upper_limit = auto_bin_params["omega_max"] - auto_bin_params["omega_bin_size"]
+            max_lower_limit = auto_bin_params["omega_min"] + auto_bin_params["omega_bin_size"]
+            max_upper_limit = auto_bin_params["omega_max"]
+            self.view._map["omega_min"].setMinimum(min_lower_limit)
+            self.view._map["omega_min"].setMaximum(min_upper_limit)
+            self.view._map["omega_max"].setMinimum(max_lower_limit)
+            self.view._map["omega_max"].setMaximum(max_upper_limit)
+            self._evaluate_omega_max_bin_size()
 
     def _get_automatic_binning_state(self):
         return self.view._map["automatic_binning"].isChecked()
@@ -44,24 +78,64 @@ class DNSElasticSCOptionsPresenter(DNSCommonOptionsPresenter):
         if auto_binning_is_on:
             self._set_auto_two_theta_binning()
             self._set_auto_omega_binning()
+        else:
+            self._set_manual_two_theta_binning_lims()
+            self._set_manual_omega_binning_lims()
 
     def process_request(self):
         own_options = self.get_option_dict()
         if own_options["get_wavelength"]:
             self._determine_wavelength()
 
+    def process_commandline_request(self, command_line_options):
+        self.view.set_single_state_by_name("use_dx_dy", True)
+        for command in ["dx", "dy", "omega_offset", "hkl1", "hkl2", "det_efficiency", "flipping_ratio"]:
+            if command in command_line_options:
+                self.view.set_single_state_by_name(command, command_line_options[command])
+
     def get_option_dict(self):
+        """
+        Return own options from view.
+        """
         if self.view is not None:
             self.own_dict.update(self.view.get_state())
+            o_dic = self.own_dict
+            o_dic["hkl1"] = self.model.convert_hkl_string(o_dic["hkl1"])
+            o_dic["hkl2"] = self.model.convert_hkl_string(o_dic["hkl2"])
+            if not self.own_dict.get("use_dx_dy", False):
+                o_dic["dx"], o_dic["dy"] = self.model.get_dx_dy(o_dic)
         return self.own_dict
+
+    def _evaluate_two_theta_max_bin_size(self):
+        if self.param_dict["file_selector"]["full_data"] and not self._get_automatic_binning_state():
+            own_options = self.get_option_dict()
+            two_theta_max = own_options["two_theta_max"]
+            two_theta_min = own_options["two_theta_min"]
+            self.view._map["two_theta_bin_size"].setMaximum(two_theta_max - two_theta_min)
+
+    def _evaluate_omega_max_bin_size(self):
+        if self.param_dict["file_selector"]["full_data"] and not self._get_automatic_binning_state():
+            own_options = self.get_option_dict()
+            omega_max = own_options["omega_max"]
+            omega_min = own_options["omega_min"]
+            self.view._map["omega_bin_size"].setMaximum(omega_max - omega_min)
 
     def _attach_signal_slots(self):
         self.view.sig_get_wavelength.connect(self._determine_wavelength)
+        self.view.sig_two_theta_min_changed.connect(self._evaluate_two_theta_max_bin_size)
+        self.view.sig_two_theta_max_changed.connect(self._evaluate_two_theta_max_bin_size)
+        self.view.sig_omega_min_changed.connect(self._evaluate_omega_max_bin_size)
+        self.view.sig_omega_max_changed.connect(self._evaluate_omega_max_bin_size)
+        self.view.sig_auto_binning_clicked.connect(self._set_manual_two_theta_binning_lims)
         self.view.sig_auto_binning_clicked.connect(self._set_auto_two_theta_binning)
+        self.view.sig_auto_binning_clicked.connect(self._set_manual_omega_binning_lims)
         self.view.sig_auto_binning_clicked.connect(self._set_auto_omega_binning)
 
 
 def get_automatic_two_theta_binning(sample_data):
+    """
+    Determines automatic two theta binning parameters from selected sample data.
+    """
     det_rot = [-x["det_rot"] for x in sample_data]
     two_theta_last_det = 115.0
     two_theta_max = max(det_rot) + two_theta_last_det
@@ -78,6 +152,9 @@ def get_automatic_two_theta_binning(sample_data):
 
 
 def get_automatic_omega_binning(sample_data):
+    """
+    Determines automatic sample rotation binning parameters from selected sample data.
+    """
     omega = [x["sample_rot"] - x["det_rot"] for x in sample_data]
     omega_min = min(omega)
     omega_max = max(omega)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_presenter.py
@@ -10,6 +10,7 @@ DNS single crystal elastic options tab presenter of DNS reduction GUI.
 """
 
 from mantidqtinterfaces.dns_powder_tof.options.common_options_presenter import DNSCommonOptionsPresenter
+from mantidqtinterfaces.dns_powder_elastic.data_structures.dns_binning import get_automatic_omega_binning, get_automatic_two_theta_binning
 
 
 class DNSElasticSCOptionsPresenter(DNSCommonOptionsPresenter):
@@ -18,69 +19,62 @@ class DNSElasticSCOptionsPresenter(DNSCommonOptionsPresenter):
         # connect signals
         self._attach_signal_slots()
 
-    def _set_auto_two_theta_binning(self):
-        """
-        Getting two theta binning parameters from selected sample data.
-        """
-        if self.param_dict["file_selector"]["full_data"]:
-            sample_data = self.param_dict["file_selector"]["full_data"]
-            two_theta_params_dict = get_automatic_two_theta_binning(sample_data)
-            own_options = self.get_option_dict()
-            for parameter in two_theta_params_dict.keys():
-                own_options[parameter] = two_theta_params_dict[parameter]
+    def _set_binning(self):
+        sample_data = self.param_dict["file_selector"]["full_data"]
+        auto_binning_is_on = self._get_automatic_binning_state()
+        if sample_data:
+            self._set_min_max_binning_lims(sample_data)
+            if auto_binning_is_on:
+                self._set_auto_binning(sample_data)
             self.set_view_from_param()
+        else:
+            if auto_binning_is_on:
+                self._set_default_auto_binning_no_data()
 
-    def _set_auto_omega_binning(self):
-        """
-        Getting omega binning parameters from selected sample data.
-        """
-        if self.param_dict["file_selector"]["full_data"]:
-            sample_data = self.param_dict["file_selector"]["full_data"]
-            omega_params_dict = get_automatic_omega_binning(sample_data)
-            own_options = self.get_option_dict()
-            for parameter in omega_params_dict.keys():
-                own_options[parameter] = omega_params_dict[parameter]
-            self.set_view_from_param()
+    def _set_auto_binning(self, sample_data):
+        own_options = self.get_option_dict()
+        binning_param_dict = {}
+        binning_param_dict["two_theta"] = get_automatic_two_theta_binning(sample_data)
+        binning_param_dict["omega"] = get_automatic_omega_binning(sample_data)
+        for key in ["two_theta", "omega"]:
+            for parameter in binning_param_dict[key].keys():
+                own_options[parameter] = binning_param_dict[key][parameter]
 
-    def _set_manual_two_theta_binning_lims(self):
-        if self.param_dict["file_selector"]["full_data"]:
-            sample_data = self.param_dict["file_selector"]["full_data"]
-            auto_bin_params = get_automatic_two_theta_binning(sample_data)
-            min_lower_limit = auto_bin_params["two_theta_min"]
-            min_upper_limit = auto_bin_params["two_theta_max"] - auto_bin_params["two_theta_bin_size"]
-            max_lower_limit = auto_bin_params["two_theta_min"] + auto_bin_params["two_theta_bin_size"]
-            max_upper_limit = auto_bin_params["two_theta_max"]
-            self.view._map["two_theta_min"].setMinimum(min_lower_limit)
-            self.view._map["two_theta_min"].setMaximum(min_upper_limit)
-            self.view._map["two_theta_max"].setMinimum(max_lower_limit)
-            self.view._map["two_theta_max"].setMaximum(max_upper_limit)
-            self._evaluate_two_theta_max_bin_size()
-
-    def _set_manual_omega_binning_lims(self):
-        if self.param_dict["file_selector"]["full_data"]:
-            sample_data = self.param_dict["file_selector"]["full_data"]
-            auto_bin_params = get_automatic_omega_binning(sample_data)
-            min_lower_limit = auto_bin_params["omega_min"]
-            min_upper_limit = auto_bin_params["omega_max"] - auto_bin_params["omega_bin_size"]
-            max_lower_limit = auto_bin_params["omega_min"] + auto_bin_params["omega_bin_size"]
-            max_upper_limit = auto_bin_params["omega_max"]
-            self.view._map["omega_min"].setMinimum(min_lower_limit)
-            self.view._map["omega_min"].setMaximum(min_upper_limit)
-            self.view._map["omega_max"].setMinimum(max_lower_limit)
-            self.view._map["omega_max"].setMaximum(max_upper_limit)
-            self._evaluate_omega_max_bin_size()
+    def _set_min_max_binning_lims(self, sample_data):
+        binning_param_dict = {}
+        binning_param_dict["two_theta"] = get_automatic_two_theta_binning(sample_data)
+        binning_param_dict["omega"] = get_automatic_omega_binning(sample_data)
+        for key in ["two_theta", "omega"]:
+            min_limit = binning_param_dict[key][f"{key}_min"]
+            max_limit = binning_param_dict[key][f"{key}_max"]
+            self.view._map[f"{key}_min"].setMinimum(min_limit)
+            self.view._map[f"{key}_max"].setMinimum(min_limit)
+            self.view._map[f"{key}_min"].setMaximum(max_limit)
+            self.view._map[f"{key}_max"].setMaximum(max_limit)
 
     def _get_automatic_binning_state(self):
         return self.view._map["automatic_binning"].isChecked()
 
+    def _get_wavelength_from_data_state(self):
+        return self.view._map["get_wavelength"].isChecked()
+
     def tab_got_focus(self):
-        auto_binning_is_on = self._get_automatic_binning_state()
-        if auto_binning_is_on:
-            self._set_auto_two_theta_binning()
-            self._set_auto_omega_binning()
+        selected_data = self.param_dict["file_selector"]["full_data"]
+        if selected_data:
+            get_wavelength_from_data_is_on = self._get_wavelength_from_data_state()
+            if get_wavelength_from_data_is_on:
+                self._determine_wavelength()
+            self._set_binning()
         else:
-            self._set_manual_two_theta_binning_lims()
-            self._set_manual_omega_binning_lims()
+            auto_binning_is_on = self._get_automatic_binning_state()
+            if auto_binning_is_on:
+                self._set_default_auto_binning_no_data()
+
+    def _set_default_auto_binning_no_data(self):
+        keys_to_reset = ["two_theta_min", "two_theta_max", "two_theta_bin_size", "omega_min", "omega_max", "omega_bin_size"]
+        for key in keys_to_reset:
+            self.view._map[key].setMinimum(0)
+            self.view._map[key].setValue(0)
 
     def process_request(self):
         own_options = self.get_option_dict()
@@ -106,59 +100,16 @@ class DNSElasticSCOptionsPresenter(DNSCommonOptionsPresenter):
                 o_dic["dx"], o_dic["dy"] = self.model.get_dx_dy(o_dic)
         return self.own_dict
 
-    def _evaluate_two_theta_max_bin_size(self):
-        if self.param_dict["file_selector"]["full_data"] and not self._get_automatic_binning_state():
-            own_options = self.get_option_dict()
-            two_theta_max = own_options["two_theta_max"]
-            two_theta_min = own_options["two_theta_min"]
-            self.view._map["two_theta_bin_size"].setMaximum(two_theta_max - two_theta_min)
+    def _evaluate_two_theta_bin_size(self):
+        self.view._map["two_theta_bin_size"].setMaximum(self.view._map["two_theta_max"].value() - self.view._map["two_theta_min"].value())
+        self.view._map["two_theta_bin_size"].setMinimum(0)
 
-    def _evaluate_omega_max_bin_size(self):
-        if self.param_dict["file_selector"]["full_data"] and not self._get_automatic_binning_state():
-            own_options = self.get_option_dict()
-            omega_max = own_options["omega_max"]
-            omega_min = own_options["omega_min"]
-            self.view._map["omega_bin_size"].setMaximum(omega_max - omega_min)
+    def _evaluate_omega_bin_size(self):
+        self.view._map["omega_bin_size"].setMaximum(self.view._map["omega_max"].value() - self.view._map["omega_min"].value())
+        self.view._map["omega_bin_size"].setMinimum(0)
 
     def _attach_signal_slots(self):
         self.view.sig_get_wavelength.connect(self._determine_wavelength)
-        self.view.sig_two_theta_min_changed.connect(self._evaluate_two_theta_max_bin_size)
-        self.view.sig_two_theta_max_changed.connect(self._evaluate_two_theta_max_bin_size)
-        self.view.sig_omega_min_changed.connect(self._evaluate_omega_max_bin_size)
-        self.view.sig_omega_max_changed.connect(self._evaluate_omega_max_bin_size)
-        self.view.sig_auto_binning_clicked.connect(self._set_manual_two_theta_binning_lims)
-        self.view.sig_auto_binning_clicked.connect(self._set_auto_two_theta_binning)
-        self.view.sig_auto_binning_clicked.connect(self._set_manual_omega_binning_lims)
-        self.view.sig_auto_binning_clicked.connect(self._set_auto_omega_binning)
-
-
-def get_automatic_two_theta_binning(sample_data):
-    """
-    Determines automatic two theta binning parameters from selected sample data.
-    """
-    det_rot = [-x["det_rot"] for x in sample_data]
-    two_theta_last_det = 115.0
-    two_theta_max = max(det_rot) + two_theta_last_det
-    two_theta_min = min(det_rot)
-    two_theta_step = 0.5
-    number_two_theta_bins = int(round((two_theta_max - two_theta_min) / two_theta_step) + 1)
-    two_theta_binning_dict = {
-        "two_theta_min": two_theta_min,
-        "two_theta_max": two_theta_max,
-        "two_theta_bin_size": two_theta_step,
-        "nbins": number_two_theta_bins,
-    }
-    return two_theta_binning_dict
-
-
-def get_automatic_omega_binning(sample_data):
-    """
-    Determines automatic sample rotation binning parameters from selected sample data.
-    """
-    omega = [x["sample_rot"] - x["det_rot"] for x in sample_data]
-    omega_min = min(omega)
-    omega_max = max(omega)
-    omega_step = 1.0
-    number_omega_bins = int(round((omega_max - omega_min) / omega_step) + 1)
-    omega_binning_dict = {"omega_min": omega_min, "omega_max": omega_max, "omega_bin_size": omega_step, "omega_nbins": number_omega_bins}
-    return omega_binning_dict
+        self.view.sig_auto_binning_clicked.connect(self._set_binning)
+        self.view.sig_two_theta_changed.connect(self._evaluate_two_theta_bin_size)
+        self.view.sig_omega_changed.connect(self._evaluate_omega_bin_size)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_view.py
@@ -10,6 +10,8 @@ DNS single crystal elastic options tab view of DNS reduction GUI.
 """
 
 from qtpy.QtCore import Signal
+from qtpy.QtCore import QRegExp
+from qtpy.QtGui import QRegExpValidator
 
 from mantidqt.utils.qt import load_ui
 
@@ -62,6 +64,11 @@ class DNSElasticSCOptionsView(DNSView):
             "dx": self._content.dSB_dx,
             "dy": self._content.dSB_dy,
         }
+        # only one space after comma is allowed as optional
+        allowed_pattern = QRegExp(r"^-?\d+(\.\d+)?,( |-| -)?\d+(\.\d+)?,( |-| -)?\d+(\.\d+)?$")
+        validator = QRegExpValidator(allowed_pattern)
+        self._content.lE_hkl1.setValidator(validator)
+        self._content.lE_hkl2.setValidator(validator)
 
         # connect signals
         self._attach_signal_slots()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_view.py
@@ -63,11 +63,6 @@ class DNSElasticSCOptionsView(DNSView):
             "dy": self._content.dSB_dy,
         }
 
-        self._map["use_dx_dy"].setChecked(True)
-        self._map["dx"].setValue(3.672)
-        self._map["dy"].setValue(6.539)
-        self._map["corrections"].setChecked(False)
-        self._map["all_options"].setEnabled(False)
         # connect signals
         self._attach_signal_slots()
 
@@ -81,6 +76,55 @@ class DNSElasticSCOptionsView(DNSView):
 
     def deactivate_get_wavelength(self):
         self._map["get_wavelength"].setCheckState(0)
+
+    def _disable_det_efficiency(self, state):
+        if state == 0:
+            self._map["ignore_vana_fields"].setChecked(False)
+            self._map["ignore_vana_fields"].setEnabled(False)
+            self._map["sum_vana_sf_nsf"].setChecked(False)
+            self._map["sum_vana_sf_nsf"].setEnabled(False)
+        else:
+            self._map["ignore_vana_fields"].setEnabled(True)
+            self._map["sum_vana_sf_nsf"].setEnabled(True)
+
+    def _disable_sum_vanadium(self, state):
+        if state == 0:
+            self._map["ignore_vana_fields"].setEnabled(True)
+        else:
+            self._map["ignore_vana_fields"].setEnabled(False)
+            self._map["ignore_vana_fields"].setChecked(False)
+
+    def _disable_ignore_vana(self, state):
+        if state == 0:
+            self._map["sum_vana_sf_nsf"].setEnabled(True)
+        else:
+            self._map["sum_vana_sf_nsf"].setEnabled(False)
+            self._map["sum_vana_sf_nsf"].setChecked(False)
+
+    def _disable_lattice(self, state):
+        self._map["lattice_parameters"].setEnabled(not state)
+        self._map["dx"].setEnabled(state)
+        self._map["dy"].setEnabled(state)
+
+    def _disable_corrections(self, state):
+        if state == 0:
+            self._disable_det_efficiency(False)
+            self._map["det_efficiency"].setChecked(False)
+            self._map["flipping_ratio"].setChecked(False)
+            self._disable_subtract_sample_background(False)
+            self._map["subtract_background_from_sample"].setChecked(False)
+
+    def _disable_subtract_sample_background(self, state):
+        self._map["background_factor"].setEnabled(state)
+
+    def _automatic_binning_clicked(self, state):
+        self._map["two_theta_min"].setEnabled(not state)
+        self._map["two_theta_max"].setEnabled(not state)
+        self._map["two_theta_bin_size"].setEnabled(not state)
+        self._map["omega_min"].setEnabled(not state)
+        self._map["omega_max"].setEnabled(not state)
+        self._map["omega_bin_size"].setEnabled(not state)
+        self.sig_auto_binning_clicked.emit(state)
 
     def _get_wavelength(self, state):
         if state:
@@ -101,7 +145,14 @@ class DNSElasticSCOptionsView(DNSView):
     def _attach_signal_slots(self):
         self._map["wavelength"].valueChanged.connect(self.deactivate_get_wavelength)
         self._map["get_wavelength"].stateChanged.connect(self._get_wavelength)
+        self._map["det_efficiency"].stateChanged.connect(self._disable_det_efficiency)
+        self._map["subtract_background_from_sample"].stateChanged.connect(self._disable_subtract_sample_background)
+        self._map["corrections"].clicked.connect(self._disable_corrections)
+        self._map["sum_vana_sf_nsf"].stateChanged.connect(self._disable_sum_vanadium)
+        self._map["ignore_vana_fields"].stateChanged.connect(self._disable_ignore_vana)
+        self._map["use_dx_dy"].stateChanged.connect(self._disable_lattice)
         self._map["two_theta_min"].valueChanged.connect(self._two_theta_min_changed)
         self._map["two_theta_max"].valueChanged.connect(self._two_theta_max_changed)
         self._map["omega_min"].valueChanged.connect(self._omega_min_changed)
         self._map["omega_max"].valueChanged.connect(self._omega_max_changed)
+        self._map["automatic_binning"].stateChanged.connect(self._automatic_binning_clicked)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_view.py
@@ -68,11 +68,9 @@ class DNSElasticSCOptionsView(DNSView):
 
     # signals
     sig_get_wavelength = Signal()
-    sig_two_theta_max_changed = Signal()
-    sig_two_theta_min_changed = Signal()
-    sig_omega_max_changed = Signal()
-    sig_omega_min_changed = Signal()
-    sig_auto_binning_clicked = Signal(int)
+    sig_two_theta_changed = Signal()
+    sig_omega_changed = Signal()
+    sig_auto_binning_clicked = Signal()
 
     def deactivate_get_wavelength(self):
         self._map["get_wavelength"].setCheckState(0)
@@ -117,30 +115,28 @@ class DNSElasticSCOptionsView(DNSView):
     def _disable_subtract_sample_background(self, state):
         self._map["background_factor"].setEnabled(state)
 
-    def _automatic_binning_clicked(self, state):
-        self._map["two_theta_min"].setEnabled(not state)
-        self._map["two_theta_max"].setEnabled(not state)
-        self._map["two_theta_bin_size"].setEnabled(not state)
-        self._map["omega_min"].setEnabled(not state)
-        self._map["omega_max"].setEnabled(not state)
-        self._map["omega_bin_size"].setEnabled(not state)
-        self.sig_auto_binning_clicked.emit(state)
+    def _automatic_binning_clicked(self):
+        is_checked = self._map["automatic_binning"].isChecked()
+        keys_to_process = ["two_theta_min", "two_theta_max", "two_theta_bin_size", "omega_min", "omega_max", "omega_bin_size"]
+        for key in keys_to_process:
+            if is_checked:
+                self._map[key].setEnabled(False)
+            else:
+                self._map[key].setEnabled(True)
+        self.sig_auto_binning_clicked.emit()
+        self._map["automatic_binning"].setChecked(is_checked)
 
     def _get_wavelength(self, state):
         if state:
             self.sig_get_wavelength.emit()
+        else:
+            self.deactivate_get_wavelength()
 
-    def _two_theta_min_changed(self):
-        self.sig_two_theta_min_changed.emit()
+    def _two_theta_changed(self):
+        self.sig_two_theta_changed.emit()
 
-    def _two_theta_max_changed(self):
-        self.sig_two_theta_max_changed.emit()
-
-    def _omega_min_changed(self):
-        self.sig_omega_min_changed.emit()
-
-    def _omega_max_changed(self):
-        self.sig_omega_max_changed.emit()
+    def _omega_changed(self):
+        self.sig_omega_changed.emit()
 
     def _attach_signal_slots(self):
         self._map["wavelength"].valueChanged.connect(self.deactivate_get_wavelength)
@@ -151,8 +147,8 @@ class DNSElasticSCOptionsView(DNSView):
         self._map["sum_vana_sf_nsf"].stateChanged.connect(self._disable_sum_vanadium)
         self._map["ignore_vana_fields"].stateChanged.connect(self._disable_ignore_vana)
         self._map["use_dx_dy"].stateChanged.connect(self._disable_lattice)
-        self._map["two_theta_min"].valueChanged.connect(self._two_theta_min_changed)
-        self._map["two_theta_max"].valueChanged.connect(self._two_theta_max_changed)
-        self._map["omega_min"].valueChanged.connect(self._omega_min_changed)
-        self._map["omega_max"].valueChanged.connect(self._omega_max_changed)
-        self._map["automatic_binning"].stateChanged.connect(self._automatic_binning_clicked)
+        self._map["two_theta_min"].valueChanged.connect(self._two_theta_changed)
+        self._map["two_theta_max"].valueChanged.connect(self._two_theta_changed)
+        self._map["omega_min"].valueChanged.connect(self._omega_changed)
+        self._map["omega_max"].valueChanged.connect(self._omega_changed)
+        self._map["automatic_binning"].clicked.connect(self._automatic_binning_clicked)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_widget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/options/elastic_single_crystal_options_widget.py
@@ -10,7 +10,7 @@ DNS single crystal elastic options widget of DNS reduction GUI.
 """
 
 from mantidqtinterfaces.dns_powder_tof.data_structures.dns_widget import DNSWidget
-from mantidqtinterfaces.dns_powder_tof.options.common_options_model import DNSCommonOptionsModel
+from mantidqtinterfaces.dns_single_crystal_elastic.options.elastic_single_crystal_options_model import DNSElasticSCOptionsModel
 from mantidqtinterfaces.dns_single_crystal_elastic.options.elastic_single_crystal_options_presenter import DNSElasticSCOptionsPresenter
 from mantidqtinterfaces.dns_single_crystal_elastic.options.elastic_single_crystal_options_view import DNSElasticSCOptionsView
 
@@ -19,5 +19,5 @@ class DNSElasticSCOptionsWidget(DNSWidget):
     def __init__(self, name, parent):
         super().__init__(name, parent)
         self.view = DNSElasticSCOptionsView(parent=parent.view)
-        self.model = DNSCommonOptionsModel(parent=self)
+        self.model = DNSElasticSCOptionsModel(parent=self)
         self.presenter = DNSElasticSCOptionsPresenter(parent=self, view=self.view, model=self.model, name=name)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/script_generator/elastic_single_crystal_script_generator_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/script_generator/elastic_single_crystal_script_generator_model.py
@@ -19,6 +19,10 @@ INDENT_SPACE = 4 * " "
 
 
 class DNSElasticSCScriptGeneratorModel(DNSScriptGeneratorModel):
+    # pylint: disable=too-many-instance-attributes
+    # having the options as instance attributes, is much better readable
+    # none of them are public
+
     def __init__(self, parent):
         super().__init__(parent)
         self._data_arrays = {}
@@ -28,6 +32,15 @@ class DNSElasticSCScriptGeneratorModel(DNSScriptGeneratorModel):
         self._standard_data = None
         self._loop = None
         self._spacing = None
+        self._vana_correction = None
+        self._nicr_correction = None
+        self._sample_background_correction = None
+        self._background_factor = None
+        self._ignore_vana = None
+        self._sum_sf_nsf = None
+        self._non_magnetic = None
+        self._xyz = None
+        self._corrections = None
         self._export_path = None
         self._ascii = None
         self._nexus = None
@@ -47,7 +60,9 @@ class DNSElasticSCScriptGeneratorModel(DNSScriptGeneratorModel):
         self._ascii = paths["ascii"] and paths["export"] and bool(self._export_path)
         self._nexus = paths["nexus"] and paths["export"] and bool(self._export_path)
         self._norm = get_normalisation(options)
+
         self._setup_sample_data(paths, file_selector)
+        self._setup_standard_data(paths, file_selector)
         self._set_loop()
         # validate if input makes sense, otherwise return
         # an empty script and error message
@@ -60,9 +75,13 @@ class DNSElasticSCScriptGeneratorModel(DNSScriptGeneratorModel):
             # starting writing script
             self._add_lines_to_script(self._get_header_lines())
             self._add_lines_to_script(self._get_sample_data_lines())
+            self._add_lines_to_script(self._get_standard_data_lines())
             self._add_lines_to_script(self._get_param_lines(options))
             self._add_lines_to_script(self._get_binning_lines(options))
             self._add_lines_to_script(self._get_load_data_lines())
+            self._add_lines_to_script(self._get_subtract_bg_from_standard_lines())
+            self._add_lines_to_script(self._get_sample_corrections_lines())
+            self._add_lines_to_script(self._get_nicr_cor_lines())
             save_string = self._get_save_string()
             self._add_lines_to_script(self._get_convert_to_matrix_lines(save_string))
         return self._script, error_message
@@ -70,6 +89,17 @@ class DNSElasticSCScriptGeneratorModel(DNSScriptGeneratorModel):
     def _setup_sample_data(self, paths, file_selector):
         self._sample_data = DNSElasticDataset(data=file_selector["full_data"], path=paths["data_dir"], is_sample=True)
         self._plot_list = self._sample_data.create_subtract()
+
+    def _setup_standard_data(self, paths, file_selector):
+        if self._corrections:
+            self._standard_data = DNSElasticDataset(
+                data=file_selector["standard_data_tree_model"],
+                path=paths["standards_dir"],
+                is_sample=False,
+                banks=self._sample_data["banks"],
+                fields=self._sample_data["fields"],
+                ignore_van=self._ignore_vana,
+            )
 
     def _set_loop(self):
         if len(self._sample_data.keys()) == 1:
@@ -83,6 +113,9 @@ class DNSElasticSCScriptGeneratorModel(DNSScriptGeneratorModel):
     def _get_header_lines():
         lines = [
             "from mantidqtinterfaces.dns_single_crystal_elastic.scripts.md_single_crystal_elastic import load_all",
+            "from mantidqtinterfaces.dns_single_crystal_elastic.scripts.md_single_crystal_elastic import "
+            "vanadium_correction, flipping_ratio_correction",
+            "from mantidqtinterfaces.dns_single_crystal_elastic.scripts.md_single_crystal_elastic import background_subtraction",
             "from mantid.simpleapi import ConvertMDHistoToMatrixWorkspace, mtd, SaveAscii, SaveNexus",
             "",
         ]
@@ -90,6 +123,11 @@ class DNSElasticSCScriptGeneratorModel(DNSScriptGeneratorModel):
 
     def _get_sample_data_lines(self):
         return [f"sample_data = {self._sample_data.format_dataset()}"]
+
+    def _get_standard_data_lines(self):
+        if self._corrections:
+            return [f"standard_data = {self._standard_data.format_dataset()}"]
+        return [""]
 
     def _get_param_lines(self, options):
         return [
@@ -130,6 +168,41 @@ class DNSElasticSCScriptGeneratorModel(DNSScriptGeneratorModel):
         if self._corrections:
             lines += ["wss_standard = load_all(standard_data, binning, params, standard=True)"]
         lines += [""]
+        return lines
+
+    def _get_subtract_bg_from_standard_lines(self):
+        lines = []
+        if self._vana_correction or self._nicr_correction:
+            lines = [
+                "# subtract background from vanadium and nicr",
+                "for sample, workspacelist in wss_standard.items(): "
+                "\n    for workspace in workspacelist:"
+                "\n        background_subtraction(workspace)",
+                "",
+            ]
+        return lines
+
+    def _get_background_string(self):
+        return f"{self._spacing}background_subtraction(workspace, factor={self._background_factor})"
+
+    def _get_vana_correction_string(self):
+        return (
+            f"{self._spacing}vanadium_correction(workspace, vana_set=standard_data['vana'], "
+            f"ignore_vana_fields={self._ignore_vana}, sum_vana_sf_nsf={self._sum_sf_nsf})"
+        )
+
+    def _get_sample_corrections_lines(self):
+        background_string = self._get_background_string()
+        vana_correction_string = self._get_vana_correction_string()
+        lines = []
+        if self._sample_background_correction or self._vana_correction:
+            lines = ["# correct sample data", f"{self._loop}{background_string}{vana_correction_string}"]
+        return lines
+
+    def _get_nicr_cor_lines(self):
+        lines = []
+        if self._nicr_correction:
+            lines = [f"{self._loop}{self._spacing}flipping_ratio_correction(workspace)"]
         return lines
 
     def _get_ascii_save_string(self):
@@ -174,6 +247,57 @@ class DNSElasticSCScriptGeneratorModel(DNSScriptGeneratorModel):
             }
         return self._plot_list, self._data_arrays
 
+    def _vana_not_in_standard(self):
+        return "vana" not in self._standard_data.data_dic.keys()
+
+    def _nicr_not_in_standard(self):
+        return "nicr" not in self._standard_data.data_dic.keys()
+
+    def _empty_not_in_standard(self):
+        return "empty" not in self._standard_data.data_dic.keys()
+
+    def _flipping_ratio_not_possible(self):
+        selected_angle_fields_data = self._sample_data["angle_fields_data"]
+        flipping_ratio_possibility_list = []
+        incomplete_banks_list = []
+        for det_bank_angle in selected_angle_fields_data.keys():
+            sf_fields = sorted([field for field in selected_angle_fields_data[det_bank_angle] if field.endswith("_sf")])
+            sf_fields_components = [field.replace("_sf", "") for field in sf_fields]
+            nsf_fields = sorted([field for field in selected_angle_fields_data[det_bank_angle] if field.endswith("_nsf")])
+            nsf_fields_components = [field.replace("_nsf", "") for field in nsf_fields]
+            if nsf_fields_components == sf_fields_components:
+                flipping_ratio_possible = True
+            else:
+                flipping_ratio_possible = False
+                incomplete_banks_list.append(det_bank_angle)
+            flipping_ratio_possibility_list.append(flipping_ratio_possible)
+        is_possible = all(flipping_ratio_possibility_list)
+        angles = ", ".join(map(str, sorted(incomplete_banks_list)))
+        return not is_possible, angles
+
+    def _bank_positions_not_compatible(self, tol=0.05):
+        if self._corrections:
+            sorted_sample_banks = np.array(sorted(self._sample_data["banks"]))
+            sorted_standard_banks = np.array(sorted(self._standard_data["banks"]))
+            sample_banks_size = sorted_sample_banks.size
+            standard_banks_size = sorted_standard_banks.size
+            if sample_banks_size == standard_banks_size:
+                banks_match = np.allclose(sorted_sample_banks, sorted_standard_banks, atol=tol)
+            elif sample_banks_size < standard_banks_size:
+                count = 0
+                for sample_element in sorted_sample_banks:
+                    for standard_element in sorted_standard_banks:
+                        if np.allclose(sample_element, standard_element, atol=tol):
+                            print(sample_element)
+                            count += 1
+                if count == sample_banks_size:
+                    banks_match = True
+                else:
+                    banks_match = False
+            else:
+                banks_match = False
+            return not banks_match
+
     def _get_sample_data_omega_binning_array(self, options):
         min = round(options["omega_min"], 1)
         max = round(options["omega_max"], 1)
@@ -195,8 +319,47 @@ class DNSElasticSCScriptGeneratorModel(DNSScriptGeneratorModel):
         the corresponding error_message. If no inconsistencies are
         found then the empty string will be returned.
         """
+
         keys_to_check = ["wavelength", "dx", "dy", "hkl1", "hkl2", "omega_offset"]
         for key in keys_to_check:
             if options[key] == "" or options[key] == [] or options[key] is None:
                 return f"Missing input for {key}."
+
+        if self._corrections and not self._standard_data:
+            return "Standard data have to be selected to perform reduction of sample data."
+        if self._bank_positions_not_compatible():
+            return "Detector rotation angles of the selected standard data do not match the angles of the selected sample data."
+        if self._vana_correction and self._vana_not_in_standard():
+            return (
+                "Detector efficiency correction option is chosen, but detector bank rotation angles of the selected vanadium files "
+                "do not correspond to those of the selected sample files."
+            )
+        if self._vana_correction and self._empty_not_in_standard():
+            return (
+                "Detector efficiency correction option is chosen, "
+                'but detector bank rotation angles of the selected "empty" '
+                "files do not correspond to those of the selected sample files."
+            )
+        if self._nicr_correction and self._nicr_not_in_standard():
+            return (
+                "Flipping ratio correction option is chosen, but detector bank rotation angles of the selected NiCr "
+                "files do not correspond to those of the selected sample files."
+            )
+        if self._nicr_correction and self._empty_not_in_standard():
+            return (
+                "Flipping ratio correction option is chosen, but "
+                'detector bank rotation angles of the selected "empty" '
+                "files do not correspond to those of the selected sample files."
+            )
+        if self._sample_background_correction and self._empty_not_in_standard():
+            return (
+                "Background subtraction from sample is chosen, but "
+                'detector bank rotation angles of the selected "empty" '
+                "files do not correspond to those of the selected sample files."
+            )
+        if self._nicr_correction and self._flipping_ratio_not_possible()[0]:
+            return (
+                "Flipping ratio correction option is chosen, but an incomplete set of pairs of SF and NSF measurements "
+                f"is found for the following bank rotation angles: {self._flipping_ratio_not_possible()[1]}"
+            )
         return ""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/scripts/md_single_crystal_elastic.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/dns_single_crystal_elastic/scripts/md_single_crystal_elastic.py
@@ -9,7 +9,12 @@
 DNS script helpers for reduction of single crystal elastic data.
 """
 
-from mantid.simpleapi import BinMD, LoadDNSSCD, mtd
+from mantidqtinterfaces.dns_powder_elastic.scripts.md_powder_elastic import flipping_ratio_correction, raise_error, background_subtraction
+
+__all__ = ("background_subtraction", "flipping_ratio_correction")
+
+import numpy as np
+from mantid.simpleapi import BinMD, CreateSingleValuedWorkspace, DivideMD, LoadDNSSCD, MultiplyMD, mtd
 
 
 def load_all(data_dict, binning, params, standard=False):
@@ -41,23 +46,130 @@ def load_binned(workspace_name, binning, params, path, file_numbers, standard):
         field_name = workspace_name[-4:]
     else:
         field_name = workspace_name[-5:]
-    LoadDNSSCD(
-        FileNames=filepaths,
-        OutputWorkspace=workspace_name,
-        NormalizationWorkspace=norm_name,
-        Normalization=params["norm_to"],
-        a=params["a"],
-        b=params["b"],
-        c=params["c"],
-        alpha=params["alpha"],
-        beta=params["beta"],
-        gamma=params["gamma"],
-        OmegaOffset=params["omega_offset"],
-        HKL1=params["hkl1"],
-        HKL2=params["hkl2"],
-        LoadAs="raw",
-        SaveHuberTo=f"huber_{field_name}",
-    )
+    if not standard:
+        LoadDNSSCD(
+            FileNames=filepaths,
+            OutputWorkspace=workspace_name,
+            NormalizationWorkspace=norm_name,
+            Normalization=params["norm_to"],
+            a=params["a"],
+            b=params["b"],
+            c=params["c"],
+            alpha=params["alpha"],
+            beta=params["beta"],
+            gamma=params["gamma"],
+            OmegaOffset=params["omega_offset"],
+            HKL1=params["hkl1"],
+            HKL2=params["hkl2"],
+            LoadAs="raw",
+            SaveHuberTo=f"huber_{field_name}",
+        )
+    else:
+        LoadDNSSCD(
+            FileNames=filepaths,
+            OutputWorkspace=workspace_name,
+            NormalizationWorkspace=norm_name,
+            Normalization=params["norm_to"],
+            a=params["a"],
+            b=params["b"],
+            c=params["c"],
+            alpha=params["alpha"],
+            beta=params["beta"],
+            gamma=params["gamma"],
+            OmegaOffset=params["omega_offset"],
+            HKL1=params["hkl1"],
+            HKL2=params["hkl2"],
+            LoadAs="raw",
+            LoadHuberFrom=f"huber_{field_name}",
+        )
     BinMD(InputWorkspace=workspace_name, OutputWorkspace=workspace_name, AxisAligned=True, AlignedDim0=ad0, AlignedDim1=ad1)
     BinMD(InputWorkspace=norm_name, OutputWorkspace=norm_name, AxisAligned=True, AlignedDim0=ad0, AlignedDim1=ad1)
+    return mtd[workspace_name]
+
+
+def vanadium_correction(workspace_name, vana_set=None, ignore_vana_fields=False, sum_vana_sf_nsf=False):
+    """
+    Correction of workspace for detector efficiency, angular coverage, lorentz
+    factor based on vanadium data.
+
+    Key arguments:
+    vana_set = used Vanadium data, if not given fields matching sample are used
+    ignore_vana_fields = if True fields of vanadium files will be ignored
+    sum_vana_sf_nsf ) if True SF and NSF channels of vanadium are summed
+    """
+    vana_sum = None
+    vana_sum_norm = None
+    workspace_norm = "_".join((workspace_name, "norm"))
+    if workspace_name.endswith("_sf"):
+        field_name = workspace_name[-4:]
+    else:
+        field_name = workspace_name[-5:]
+    if ignore_vana_fields:
+        if vana_set:
+            vana_list = []
+            norm_list = []
+            for field in vana_set:
+                if field != "path":
+                    vana_name = "_".join(("vana", field))
+                    vana_norm = "_".join((vana_name, "norm"))
+                    try:
+                        vana = mtd[vana_name]
+                        vana_norm = mtd[vana_norm]
+                    except KeyError:
+                        raise_error(f"No vanadium file for field {field_name}.")
+                        return mtd[workspace_name]
+                    vana_list.append(vana)
+                    norm_list.append(vana_norm)
+            vana_sum = sum(vana_list)
+            vana_sum_norm = sum(norm_list)
+        else:
+            raise_error("Need to give vanadium dataset explicit if you want all vanadium files to be added.")
+    elif sum_vana_sf_nsf:
+        polarization = field_name.split("_")[0]
+        vana_nsf = "_".join(("vana", polarization, "nsf"))
+        vana_sf = "_".join(("vana", polarization, "sf"))
+        vana_nsf_norm = "_".join((vana_nsf, "norm"))
+        vana_sf_norm = "_".join((vana_sf, "norm"))
+        try:
+            vana_sf = mtd[vana_sf]
+            vana_sf_norm = mtd[vana_sf_norm]
+        except KeyError:
+            raise_error(f"No vanadium file for {polarization}_sf . You can choose to ignore vanadium fields in the options.")
+            return mtd[workspace_name]
+        try:
+            vana_nsf = mtd[vana_nsf]
+            vana_nsf_norm = mtd[vana_nsf_norm]
+        except KeyError:
+            raise_error(f"No vanadium file for {polarization}_nsf. You can choose to ignore vanadium fields in the options.")
+            return mtd[workspace_name]
+        vana_sum = vana_sf + vana_nsf
+        vana_sum_norm = vana_sf_norm + vana_nsf_norm
+    else:
+        vana_name = "_".join(("vana", field_name))
+        vana_norm = "_".join((vana_name, "norm"))
+        try:
+            vana_sum = mtd[vana_name]
+            vana_sum_norm = mtd[vana_norm]
+        except KeyError:
+            raise_error(f"No vanadium file for {field_name}. You can choose to ignore vanadium fields in the options.")
+            return mtd[workspace_name]
+    # common code, which will be run regardless of the case
+
+    sum_signal = np.nan_to_num(vana_sum.getSignalArray())
+    total_signal = np.sum(sum_signal)
+    sum_error = np.nan_to_num(vana_sum.getErrorSquaredArray())
+    total_error = np.sum(sum_error)
+    sum_signal_norm = np.nan_to_num(vana_sum_norm.getSignalArray())
+    total_signal_norm = np.sum(sum_signal_norm)
+    sum_error_norm = np.nan_to_num(vana_sum_norm.getErrorSquaredArray())
+    total_error_norm = np.sum(sum_error_norm)
+
+    vana_total = CreateSingleValuedWorkspace(DataValue=total_signal, ErrorValue=np.sqrt(total_error))
+    vana_total_norm = CreateSingleValuedWorkspace(DataValue=total_signal_norm, ErrorValue=np.sqrt(total_error_norm))
+
+    coef_u = vana_sum / vana_total
+    coef_norm = vana_sum_norm / vana_total_norm
+    coef = coef_u / coef_norm
+    MultiplyMD(coef, workspace_norm, OutputWorkspace=workspace_norm)
+    DivideMD(workspace_name, workspace_norm, OutputWorkspace=workspace_name)
     return mtd[workspace_name]

--- a/qt/python/mantidqtinterfaces/test/dns_powder_elastic/data_structures/dns_binning_test.py
+++ b/qt/python/mantidqtinterfaces/test/dns_powder_elastic/data_structures/dns_binning_test.py
@@ -28,9 +28,7 @@ class DNSBinningTest(unittest.TestCase):
         self.assertTrue(np.array_equal(self.binning.bin_edge_range, np.asarray([-0.5, 0.5, 1.5, 2.5, 3.5, 4.5, 5.5])))
 
         self.binning = DNSBinning(xmin=0, xmax=5, step=0)
-        self.assertEqual(self.binning.nbins, 1)
-        self.binning = DNSBinning(xmin=0, xmax=5, step=0, number_of_bins=3)
-        self.assertEqual(self.binning.nbins, 3)
+        self.assertEqual(self.binning.nbins, 0)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/test/dns_powder_elastic/data_structures/dns_elastic_powder_dataset_test.py
+++ b/qt/python/mantidqtinterfaces/test/dns_powder_elastic/data_structures/dns_elastic_powder_dataset_test.py
@@ -98,7 +98,7 @@ class DNSDatasetTest(unittest.TestCase):
     def test_automatic_omega_binning(self, mock_binning):
         test_v = automatic_omega_binning(self.full_data)
         self.assertEqual(test_v, mock_binning.return_value)
-        mock_binning.assert_called_once_with(304.0, 304.0, 1)
+        mock_binning.assert_called_once_with(304.0, 304.0, 0)
 
     def test_get_proposal_from_filename(self):
         test_v = get_proposal_from_filename("p678_000123.d_dat", 123)
@@ -139,7 +139,7 @@ class DNSDatasetTest(unittest.TestCase):
         test_v = get_bank_positions(self.full_data)
         self.assertEqual(test_v, [-9])
         test_v = get_bank_positions(self.standard_data)
-        self.assertEqual(test_v, [-9.04, -10])
+        self.assertEqual(test_v, [-10, -9.04, -9])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of work

This PR contains advanced data reduction options selection capabilities for the Single Cristal Elastic mode of DNS Reduction GUI. Complete integration of the Single Cristal Elastic mode into the DNS Reduction GUI will be implemented in several steps (in order to ensure reasonable PR sizes and reduce the workload for the reviewers), and this PR represents the 5th step of the integration process.

#### Summary of work
Fixes Part 5 of #36407, as well as a bug reported in #37712.


### To test:

- Download test data: [Single_Crystal_Elastic.zip](https://github.com/mantidproject/mantid/files/13751286/Single_Crystal_Elastic.zip)
- Open the reduction GUI [Interfaces->Direct->DNS Reduction]
- Make sure that the "Single Crystal Elastic" mode opens by default. Otherwise switch to this mode, by selecting Tools -> Change Mode -> Single Crystal Elastic
- Make sure that the corresponding documentation is up-to-date (run `cmake --build . --target docs-html` in build folder to create docs)
- Browse to the directory where the test data are located using the "Paths" tab of the GUI
- Load and select the sample data for reduction using the "Data" tab
- Click on the "Options" tab and and make sure that various option selection fields work as expected, and the selected options are then applied to the data once the data reduction script is generated using the "Script Generator" tab 
- Reduce the data and generate a data reduction script using the "Script Generator" tab
- Open the "Plotting" tab and make sure that the images are generated. Advanced plotting functionality is not implemented at this stage and will be activated in a follow-up PR. 

*This does not require release notes* because **this PR contains limited functionality.** Release notes for the Single Cristal Elastic mode will be included in a subsequent PR, once all components for implementing the data reduction workflow are uploaded. 

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
