### PR TITLE
Fix startup tests

### DIFF
--- a/Testing/SystemTests/tests/qt/WorkbenchStartupTest.py
+++ b/Testing/SystemTests/tests/qt/WorkbenchStartupTest.py
@@ -15,7 +15,7 @@ from tempfile import NamedTemporaryFile
 
 TEST_MESSAGE = "Hello Mantid!"
 EXECUTABLE_SWITCHER = {
-    "linux": ["launch_mantidworkbench.sh", "mantidworkbench", "workbench"],
+    "linux": ["launch_mantidworkbench.sh", "workbench"],
     "darwin": ["workbench"],
     "win32": ["workbench"],
 }

--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -8,7 +8,7 @@ if(APPLE OR WIN32)
   endif()
   add_python_package(workbench EXECUTABLE EGGLINKNAME MantidWorkbench EXCLUDE_FROM_INSTALL ${_exclude_on_install})
   # Allow VS to start workbench for debugging
-  set(_vs_debugger_args "${MSVC_BIN_DIR}/workbench-script.pyw --single-process")
+  set(_vs_debugger_args "-m workbench --single-process")
   # cmake-format: off
   set_target_properties(
     workbench


### PR DESCRIPTION
Since we switched to `pip install --editable` instead of calling `setup.py` directly (#37775), we no longer get an executable file in the build output, so this test needed adjusting. It was also attempting to do a for loop and returning at the first entry so we fixed that.

On Linux it was trying to test `mantidworkbench` as an entry point but:
- Because it was previously returning at the first item in the loop, this was never actually tested.
- The `mantidworkbench` entry point is created by `conda-build`, not when you do a dev build, so this wouldn't have worked previously anyway.

### To test:

https://builds.mantidproject.org/job/build_packages_from_branch/876/

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
