### PR TITLE
37723 malformed xml crash

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/New_features/37723.rst
+++ b/docs/source/release/v6.11.0/Workbench/New_features/37723.rst
@@ -1,1 +1,1 @@
-- Handled error where malformed XML code caused mantid to crash.
+- Handled error where parsing malformed XML code in the code editor caused mantid to crash.

--- a/docs/source/release/v6.11.0/Workbench/New_features/37723.rst
+++ b/docs/source/release/v6.11.0/Workbench/New_features/37723.rst
@@ -1,0 +1,1 @@
+- Handled error where malformed XML code caused mantid to crash.

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/interpreter.py
@@ -14,7 +14,6 @@ from qtpy.QtCore import QObject, Qt, Signal
 from qtpy.QtGui import QColor, QFont, QFontMetrics
 from qtpy.QtWidgets import QFileDialog, QMessageBox, QStatusBar, QVBoxLayout, QWidget
 
-import mantid
 from mantidqt.io import open_a_file_dialog
 from mantid.kernel import config
 from mantidqt.widgets.codeeditor.codecommenter import CodeCommenter
@@ -397,10 +396,6 @@ class PythonFileInterpreterPresenter(QObject):
                         lineno = exc_stack[-1][1] + self._code_start_offset
                 except IndexError:
                     pass
-
-        # Log an error message if the XML is malformed or there's an issue with parsing
-        if exc_type is SyntaxError or "XML" in str(exc_value):
-            mantid.kernel.logger.error(f"Malformed XML detected. Error at line {lineno if lineno != -1 else 'unknown'}: {exc_value}")
 
         sys.stderr.write(self._error_formatter.format(exc_type, exc_value, exc_stack) + os.linesep)
         self.view.editor.updateProgressMarker(lineno, True)


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
--> Handled error where malformed XML code caused mantid to crash.

Fixes #37723. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
--> @thomashampson 

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
--> Handled the exception by checking if lineno is None, and if not it only tries one addition.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
--> 
1. Run the following in the script editor, (or any other malformed XML code)

```
from xml.etree import ElementTree as ET
ET.fromstring("**<data></dat>**")
```
An error message should pop up on the side and no window should pop up.

2.  Try it with good XML code as well


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
