### PR TITLE
Implement CompressEvents method without sorting events - ornl-next

### DIFF
--- a/Framework/DataHandling/src/CompressEvents.cpp
+++ b/Framework/DataHandling/src/CompressEvents.cpp
@@ -118,11 +118,11 @@ void CompressEvents::exec() {
 
   // created required variables if using unsorted methdo
   auto histogram_bin_edges = std::make_shared<std::vector<double>>();
-  double tof_min_fixed;
-  double tof_max_fixed;
   size_t num_edges{0};
   if (!compressFat && !sortFirst && !(inputWS->getSortType() == TOF_SORT)) {
     // only initialize if needed
+    double tof_min_fixed;
+    double tof_max_fixed;
     inputWS->getEventXMinMax(tof_min_fixed, tof_max_fixed);
     Mantid::Kernel::VectorHelper::createAxisFromRebinParams(
         {tof_min_fixed, toleranceTof, (tof_max_fixed + std::abs(toleranceTof))}, *histogram_bin_edges, true, true);

--- a/Framework/DataHandling/test/CompressEventsTest.h
+++ b/Framework/DataHandling/test/CompressEventsTest.h
@@ -233,13 +233,13 @@ public:
     TS_ASSERT_EQUALS(output->getEventType(), WEIGHTED_NOTIME);
 
     EventList &output_el = output->getSpectrum(0);
-    TS_ASSERT_DELTA(output_el.getEvent(0).tof(), 1.5, 1e-9);
+    TS_ASSERT_DELTA(output_el.getEvent(0).tof(), 1, 1e-9);
     TS_ASSERT_DELTA(output_el.getEvent(0).weight(), 1.0, 1e-9);
     TS_ASSERT_DELTA(output_el.getEvent(0).errorSquared(), 1.0, 1e-9);
-    TS_ASSERT_DELTA(output_el.getEvent(1).tof(), 2.5, 1e-9);
+    TS_ASSERT_DELTA(output_el.getEvent(1).tof(), 2.85, 1e-9);
     TS_ASSERT_DELTA(output_el.getEvent(1).weight(), 2.0, 1e-9);
     TS_ASSERT_DELTA(output_el.getEvent(1).errorSquared(), 2.0, 1e-9);
-    TS_ASSERT_DELTA(output_el.getEvent(2).tof(), 3.5, 1e-9);
+    TS_ASSERT_DELTA(output_el.getEvent(2).tof(), 3.1, 1e-9);
     TS_ASSERT_DELTA(output_el.getEvent(2).weight(), 3.0, 1e-9);
     TS_ASSERT_DELTA(output_el.getEvent(2).errorSquared(), 3.0, 1e-9);
   }
@@ -272,13 +272,13 @@ public:
     TS_ASSERT_EQUALS(input->getNumberEvents(), 3);
     TS_ASSERT_EQUALS(input->getSortType(), TOF_SORT);
     TS_ASSERT_EQUALS(input->getEventType(), WEIGHTED_NOTIME);
-    TS_ASSERT_DELTA(el.getEvent(0).tof(), 1.5, 1e-9);
+    TS_ASSERT_DELTA(el.getEvent(0).tof(), 1, 1e-9);
     TS_ASSERT_DELTA(el.getEvent(0).weight(), 1.0, 1e-9);
     TS_ASSERT_DELTA(el.getEvent(0).errorSquared(), 1.0, 1e-9);
-    TS_ASSERT_DELTA(el.getEvent(1).tof(), 2.5, 1e-9);
+    TS_ASSERT_DELTA(el.getEvent(1).tof(), 2.85, 1e-9);
     TS_ASSERT_DELTA(el.getEvent(1).weight(), 2.0, 1e-9);
     TS_ASSERT_DELTA(el.getEvent(1).errorSquared(), 2.0, 1e-9);
-    TS_ASSERT_DELTA(el.getEvent(2).tof(), 3.5, 1e-9);
+    TS_ASSERT_DELTA(el.getEvent(2).tof(), 3.1, 1e-9);
     TS_ASSERT_DELTA(el.getEvent(2).weight(), 3.0, 1e-9);
     TS_ASSERT_DELTA(el.getEvent(2).errorSquared(), 3.0, 1e-9);
   }

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -386,13 +386,14 @@ private:
                                    double tolerance);
 
   template <class T>
-  static void createWeightedEvents(std::vector<WeightedEventNoTime> &out, std::vector<T> &weight, std::vector<T> &error,
-                                   std::shared_ptr<std::vector<double>> histogram_bin_edges);
+  static void createWeightedEvents(std::vector<WeightedEventNoTime> &out, const std::vector<T> &weight,
+                                   const std::vector<T> &error,
+                                   const std::shared_ptr<std::vector<double>> histogram_bin_edges);
 
   template <class T>
-  static void processWeightedEvents(std::vector<T> events, std::vector<WeightedEventNoTime> &out,
-                                    std::shared_ptr<std::vector<double>> histogram_bin_edges, double divisor,
-                                    double offset,
+  static void processWeightedEvents(const std::vector<T> &events, std::vector<WeightedEventNoTime> &out,
+                                    const std::shared_ptr<std::vector<double>> histogram_bin_edges,
+                                    const double divisor, const double offset,
                                     boost::optional<size_t> (*findBin)(const MantidVec &, const double, const double,
                                                                        const double, const bool));
 

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -386,9 +386,8 @@ private:
                                    double tolerance);
 
   template <class T>
-  static void createWeightedEvents(std::vector<WeightedEventNoTime> &out, const std::vector<T> &weight,
-                                   const std::vector<T> &error,
-                                   const std::shared_ptr<std::vector<double>> histogram_bin_edges);
+  static void createWeightedEvents(std::vector<WeightedEventNoTime> &out, const std::vector<double> &tof,
+                                   const std::vector<T> &weight, const std::vector<T> &error);
 
   template <class T>
   static void processWeightedEvents(const std::vector<T> &events, std::vector<WeightedEventNoTime> &out,

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -393,9 +393,7 @@ private:
   template <class T>
   static void processWeightedEvents(const std::vector<T> &events, std::vector<WeightedEventNoTime> &out,
                                     const std::shared_ptr<std::vector<double>> histogram_bin_edges,
-                                    const double divisor, const double offset,
-                                    boost::optional<size_t> (*findBin)(const MantidVec &, const double, const double,
-                                                                       const double, const bool));
+                                    struct FindBin findBin);
 
   template <class T>
   static void compressFatEventsHelper(const std::vector<T> &events, std::vector<WeightedEvent> &out,

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -201,6 +201,8 @@ public:
   virtual size_t histogram_size() const;
 
   void compressEvents(double tolerance, EventList *destination);
+  void compressEvents(double tolerance, EventList *destination,
+                      std::shared_ptr<std::vector<double>> histogram_bin_edges);
   void compressFatEvents(const double tolerance, const Types::Core::DateAndTime &timeStart, const double seconds,
                          EventList *destination);
   // get EventType declaration
@@ -382,6 +384,17 @@ private:
   template <class T>
   static void compressEventsHelper(const std::vector<T> &events, std::vector<WeightedEventNoTime> &out,
                                    double tolerance);
+
+  template <class T>
+  static void createWeightedEvents(std::vector<WeightedEventNoTime> &out, std::vector<T> &weight, std::vector<T> &error,
+                                   std::shared_ptr<std::vector<double>> histogram_bin_edges);
+
+  template <class T>
+  static void processWeightedEvents(std::vector<T> events, std::vector<WeightedEventNoTime> &out,
+                                    std::shared_ptr<std::vector<double>> histogram_bin_edges, double divisor,
+                                    double offset,
+                                    boost::optional<size_t> (*findBin)(const MantidVec &, const double, const double,
+                                                                       const double, const bool));
 
   template <class T>
   static void compressFatEventsHelper(const std::vector<T> &events, std::vector<WeightedEvent> &out,

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -1754,9 +1754,9 @@ void EventList::compressEvents(double tolerance, EventList *destination) {
 }
 
 template <class T>
-inline void EventList::createWeightedEvents(std::vector<WeightedEventNoTime> &out, std::vector<T> &weight,
-                                            std::vector<T> &error,
-                                            std::shared_ptr<std::vector<double>> histogram_bin_edges) {
+inline void EventList::createWeightedEvents(std::vector<WeightedEventNoTime> &out, const std::vector<T> &weight,
+                                            const std::vector<T> &error,
+                                            const std::shared_ptr<std::vector<double>> histogram_bin_edges) {
   out.clear();
   auto binIter = histogram_bin_edges->begin();
   for (size_t i = 0; i < weight.size(); ++i) {
@@ -1769,8 +1769,8 @@ inline void EventList::createWeightedEvents(std::vector<WeightedEventNoTime> &ou
 
 template <class T>
 inline void EventList::processWeightedEvents(
-    std::vector<T> events, std::vector<WeightedEventNoTime> &out,
-    std::shared_ptr<std::vector<double>> histogram_bin_edges, double divisor, double offset,
+    const std::vector<T> &events, std::vector<WeightedEventNoTime> &out,
+    const std::shared_ptr<std::vector<double>> histogram_bin_edges, const double divisor, const double offset,
     boost::optional<size_t> (*findBin)(const MantidVec &, const double, const double, const double, const bool)) {
   const auto NUM_BINS = histogram_bin_edges->size() - 1;
   std::vector<float> weight(NUM_BINS, 0.);

--- a/Framework/DataObjects/src/WorkspaceCreation.cpp
+++ b/Framework/DataObjects/src/WorkspaceCreation.cpp
@@ -69,7 +69,8 @@ void doInitializeFromParent<std::true_type>(const API::MatrixWorkspace &parent, 
  * @param ws
  */
 template <class UseIndexInfo> void initializeFromParent(const API::MatrixWorkspace &parent, API::MatrixWorkspace &ws) {
-  bool differentSize = (parent.x(0).size() != ws.x(0).size()) || (parent.y(0).size() != ws.y(0).size());
+  bool differentSize = (parent.x(0).size() != ws.x(0).size()) ||
+                       (parent.id() != "EventWorkspace" && (parent.y(0).size() != ws.y(0).size()));
   doInitializeFromParent<UseIndexInfo>(parent, ws, differentSize);
   // For EventWorkspace, `ws.y(0)` put entry 0 in the MRU. However, clients
   // would typically expect an empty MRU and fail to clear it. This dummy call

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -2414,6 +2414,77 @@ public:
     TS_ASSERT_THROWS(el.compressFatEvents(-1, DateAndTime{0}, 10, &el_output), const std::runtime_error &)
   }
 
+  void test_compressEvents_unsorted() {
+    el = EventList();
+    el += TofEvent(2.8, 0);
+    el += TofEvent(2.9, 0);
+    el += TofEvent(3.0, 0);
+    el += TofEvent(3.1, 0);
+    el += TofEvent(3.2, 0);
+    el += TofEvent(1, 0);
+    compressEvents_unsorted(el, 1.0, false);
+    compressEvents_unsorted(el, 1.0, true);
+  }
+
+  void test_compressEvents_unsorted_weighted() {
+    el = EventList();
+    el.switchTo(WEIGHTED);
+    el += WeightedEvent(2.8, 0, 2.0, 2.0);
+    el += WeightedEvent(2.9, 0, 2.0, 2.0);
+    el += WeightedEvent(3.0, 0, 2.0, 2.0);
+    el += WeightedEvent(3.1, 0, 2.0, 2.0);
+    el += WeightedEvent(3.2, 0, 2.0, 2.0);
+    el += WeightedEvent(1, 0, 2.0, 2.0);
+    compressEvents_unsorted(el, 2.0, false);
+    compressEvents_unsorted(el, 2.0, true);
+  }
+
+  void test_compressEvents_unsorted_weighted_notime() {
+    el = EventList();
+    el.switchTo(WEIGHTED);
+    el += WeightedEvent(2.8, 0, 2.0, 2.0);
+    el += WeightedEvent(2.9, 0, 2.0, 2.0);
+    el += WeightedEvent(3.0, 0, 2.0, 2.0);
+    el += WeightedEvent(3.1, 0, 2.0, 2.0);
+    el += WeightedEvent(3.2, 0, 2.0, 2.0);
+    el += WeightedEvent(1, 0, 2.0, 2.0);
+    el.switchTo(WEIGHTED_NOTIME);
+    compressEvents_unsorted(el, 2.0, false);
+    compressEvents_unsorted(el, 2.0, true);
+  }
+
+  void compressEvents_unsorted(EventList el, double event_weight, bool inplace) {
+    auto histogram = std::make_shared<std::vector<double>>();
+    VectorHelper::createAxisFromRebinParams({1., 1., 4.0}, *histogram);
+    EventList *el_output;
+    if (inplace)
+      el_output = &el;
+    TS_ASSERT_THROWS_NOTHING(el.compressEvents(1., el_output, histogram));
+
+    // verify that the input remained unsorted if not inplace
+    if (!inplace)
+      TS_ASSERT_EQUALS(el.getSortType(), UNSORTED)
+    else
+      TS_ASSERT_EQUALS(el.getSortType(), TOF_SORT)
+
+    // now check events
+    TS_ASSERT_EQUALS(el_output->getEventType(), WEIGHTED_NOTIME);
+    TS_ASSERT_EQUALS(el_output->getSortType(), TOF_SORT);
+    TS_ASSERT_EQUALS(el_output->getNumberEvents(), 3);
+
+    TS_ASSERT_DELTA(el_output->getEvent(0).tof(), 1.5, 1e-5)
+    TS_ASSERT_EQUALS(el_output->getEvent(0).weight(), event_weight)
+    TS_ASSERT_EQUALS(el_output->getEvent(0).errorSquared(), event_weight)
+
+    TS_ASSERT_DELTA(el_output->getEvent(1).tof(), 2.5, 1e-5)
+    TS_ASSERT_EQUALS(el_output->getEvent(1).weight(), event_weight * 2)
+    TS_ASSERT_EQUALS(el_output->getEvent(1).errorSquared(), event_weight * 2)
+
+    TS_ASSERT_DELTA(el_output->getEvent(2).tof(), 3.5, 1e-5)
+    TS_ASSERT_EQUALS(el_output->getEvent(2).weight(), event_weight * 3)
+    TS_ASSERT_EQUALS(el_output->getEvent(2).errorSquared(), event_weight * 3)
+  }
+
   //==================================================================================
   // Mocking functions
   //==================================================================================

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -2459,6 +2459,9 @@ public:
     EventList *el_output;
     if (inplace)
       el_output = &el;
+    else
+      el_output = new EventList();
+
     TS_ASSERT_THROWS_NOTHING(el.compressEvents(1., el_output, histogram));
 
     // verify that the input remained unsorted if not inplace

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -2475,15 +2475,15 @@ public:
     TS_ASSERT_EQUALS(el_output->getSortType(), TOF_SORT);
     TS_ASSERT_EQUALS(el_output->getNumberEvents(), 3);
 
-    TS_ASSERT_DELTA(el_output->getEvent(0).tof(), 1.5, 1e-5)
+    TS_ASSERT_DELTA(el_output->getEvent(0).tof(), 1, 1e-5)
     TS_ASSERT_EQUALS(el_output->getEvent(0).weight(), event_weight)
     TS_ASSERT_EQUALS(el_output->getEvent(0).errorSquared(), event_weight)
 
-    TS_ASSERT_DELTA(el_output->getEvent(1).tof(), 2.5, 1e-5)
+    TS_ASSERT_DELTA(el_output->getEvent(1).tof(), 2.85, 1e-5) // (2.8+2.9)/2 = 2.85
     TS_ASSERT_EQUALS(el_output->getEvent(1).weight(), event_weight * 2)
     TS_ASSERT_EQUALS(el_output->getEvent(1).errorSquared(), event_weight * 2)
 
-    TS_ASSERT_DELTA(el_output->getEvent(2).tof(), 3.5, 1e-5)
+    TS_ASSERT_DELTA(el_output->getEvent(2).tof(), 3.1, 1e-5) // (3.0+3.1+3.2)/3 = 3.1
     TS_ASSERT_EQUALS(el_output->getEvent(2).weight(), event_weight * 3)
     TS_ASSERT_EQUALS(el_output->getEvent(2).errorSquared(), event_weight * 3)
   }

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -830,14 +830,14 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TableWorksp
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/TableWorkspace.cpp:318
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDataObjects/EventList.h:144
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/OffsetsWorkspace.cpp:49
-identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:999
-identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1095
+identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1020
+identicalConditionAfterEarlyExit:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1116
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNexusProcessed.cpp:380
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNexusProcessed.cpp:381
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/CenteringGroup.h:46
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/CompositeBraggScatterer.h:64
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/CompositeBraggScatterer.cpp:189
-derefInvalidIterator:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1590
+derefInvalidIterator:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventList.cpp:1611
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/Group.h:148
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/MaskWorkspace.cpp:411
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/BraggScattererInCrystalStructure.h:35

--- a/docs/source/algorithms/CompressEvents-v1.rst
+++ b/docs/source/algorithms/CompressEvents-v1.rst
@@ -50,9 +50,8 @@ method to compress events will be used where the events do not need to
 be sorted first. This will be faster when the number of events going
 into a single compressed events is large, so when you have lots of
 events per spectra. This method works by histogramming the events into
-a regular grid that is then converted into events using the bin center
-as the x value, so this assumes a uniform distribution of events
-within the bin.
+a regular grid that is then converted back into events using the
+weighted average x value.
 
 This method will not be used if the events are already sorted as that
 will be faster. This option will be ignored when used with

--- a/docs/source/algorithms/CompressEvents-v1.rst
+++ b/docs/source/algorithms/CompressEvents-v1.rst
@@ -42,6 +42,21 @@ with/without compression are identical. If your workspace has undergone
 changes to its X values (unit conversion for example), you have to use
 your best judgement for the Tolerance value.
 
+Compressing events without sorting
+**********************************
+
+If you set the option ``SortFirst`` to ``False`` then a different
+method to compress events will be used where the events do not need to
+be sorted first. This will be faster when the number of events going
+into a single compressed events is large, so when you have lots of
+events per spectra. This method works by histogramming the events into
+a regular grid that is then converted into events using the bin center
+as the x value.
+
+This method will not be used if the events are already sorted as that
+will be faster. This option will be ignored when used with
+``WallClockTolerance``.
+
 With pulsetime resolution
 #########################
 

--- a/docs/source/algorithms/CompressEvents-v1.rst
+++ b/docs/source/algorithms/CompressEvents-v1.rst
@@ -51,7 +51,8 @@ be sorted first. This will be faster when the number of events going
 into a single compressed events is large, so when you have lots of
 events per spectra. This method works by histogramming the events into
 a regular grid that is then converted into events using the bin center
-as the x value.
+as the x value, so this assumes a uniform distribution of events
+within the bin.
 
 This method will not be used if the events are already sorted as that
 will be faster. This option will be ignored when used with

--- a/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37900.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37900.rst
@@ -1,0 +1,1 @@
+- Add a new method to :ref:`CompressEvents <algm-CompressEvents>` that will compress events without sorting first. This will be faster when there is a large density of events.


### PR DESCRIPTION
This is a version of #37900 into `ornl-next`