### PR TITLE
Consistently position const in FileSaver class using east const approach

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/FileSaver.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/FileSaver.cpp
@@ -16,16 +16,16 @@
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 namespace {
-static constexpr auto MULTI_DATASET_FILE_SUFFIX = "_multi";
+static auto constexpr MULTI_DATASET_FILE_SUFFIX = "_multi";
 } // unnamed namespace
 
 namespace FileExtensions {
-static constexpr auto CUSTOM = "custom";
-static constexpr auto DAT = ".dat";
-static constexpr auto TXT = ".txt";
-static constexpr auto MFT = ".mft";
-static constexpr auto ORT = ".ort";
-static constexpr auto ORB = ".orb";
+static auto constexpr CUSTOM = "custom";
+static auto constexpr DAT = ".dat";
+static auto constexpr TXT = ".txt";
+static auto constexpr MFT = ".mft";
+static auto constexpr ORT = ".ort";
+static auto constexpr ORB = ".orb";
 } // namespace FileExtensions
 
 FileSaver::FileSaver(std::unique_ptr<ISaveAlgorithmRunner> saveAlgRunner, IFileHandler *fileHandler)
@@ -69,7 +69,7 @@ std::string FileSaver::assembleSavePath(std::string const &saveDirectory, std::s
 }
 
 Mantid::API::Workspace_sptr FileSaver::workspace(std::string const &workspaceName) const {
-  const auto &ads = Mantid::API::AnalysisDataService::Instance();
+  auto const &ads = Mantid::API::AnalysisDataService::Instance();
 
   if (!ads.doesExist(workspaceName)) {
     throw std::runtime_error("Cannot find workspace " + workspaceName + " in the ADS.");
@@ -79,7 +79,7 @@ Mantid::API::Workspace_sptr FileSaver::workspace(std::string const &workspaceNam
 }
 
 void FileSaver::runSaveAsciiAlgorithm(std::string const &savePath, std::string const &extension,
-                                      const Mantid::API::Workspace_sptr &workspace,
+                                      Mantid::API::Workspace_sptr const &workspace,
                                       std::vector<std::string> const &logParameters,
                                       FileFormatOptions const &fileFormat) const {
   m_saveAlgRunner->runSaveAsciiAlgorithm(workspace, savePath, extension, logParameters,
@@ -93,13 +93,13 @@ void FileSaver::runSaveORSOAlgorithm(std::string const &savePath, std::vector<st
                                         fileFormat.shouldIncludeAdditionalColumns());
 }
 
-void FileSaver::save(const Mantid::API::Workspace_sptr &workspace, std::string const &saveDirectory,
+void FileSaver::save(Mantid::API::Workspace_sptr const &workspace, std::string const &saveDirectory,
                      std::vector<std::string> const &logParameters, FileFormatOptions const &fileFormat) const {
-  const auto extension = extensionForFormat(fileFormat.format());
-  const auto savePath = assembleSavePath(saveDirectory, fileFormat.prefix(), workspace->getName(), extension);
+  auto const extension = extensionForFormat(fileFormat.format());
+  auto const savePath = assembleSavePath(saveDirectory, fileFormat.prefix(), workspace->getName(), extension);
 
   if (fileFormat.isORSOFormat()) {
-    const std::vector<std::string> workspaceNames{workspace->getName()};
+    std::vector<std::string> const workspaceNames{workspace->getName()};
     runSaveORSOAlgorithm(savePath, workspaceNames, fileFormat);
   } else {
     runSaveAsciiAlgorithm(savePath, extension, workspace, logParameters, fileFormat);
@@ -108,9 +108,9 @@ void FileSaver::save(const Mantid::API::Workspace_sptr &workspace, std::string c
 
 void FileSaver::saveToSingleFile(std::vector<std::string> const &workspaceNames, std::string const &saveDirectory,
                                  FileFormatOptions const &fileFormat) const {
-  const auto extension = extensionForFormat(fileFormat.format());
-  const auto filename = workspaceNames.front() + MULTI_DATASET_FILE_SUFFIX;
-  const auto savePath = assembleSavePath(saveDirectory, fileFormat.prefix(), filename, extension);
+  auto const extension = extensionForFormat(fileFormat.format());
+  auto const filename = workspaceNames.front() + MULTI_DATASET_FILE_SUFFIX;
+  auto const savePath = assembleSavePath(saveDirectory, fileFormat.prefix(), filename, extension);
 
   if (fileFormat.isORSOFormat()) {
     runSaveORSOAlgorithm(savePath, workspaceNames, fileFormat);
@@ -130,8 +130,8 @@ void FileSaver::save(std::string const &saveDirectory, std::vector<std::string> 
   if (shouldSaveToSingleFile(workspaceNames, fileFormat)) {
     saveToSingleFile(workspaceNames, saveDirectory, fileFormat);
   } else {
-    for (const auto &name : workspaceNames) {
-      const auto ws = workspace(name);
+    for (auto const &name : workspaceNames) {
+      auto const ws = workspace(name);
       if (ws->isGroup()) {
         // Save child workspaces into separate files
         Mantid::API::WorkspaceGroup_sptr group = std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(ws);
@@ -156,7 +156,7 @@ bool FileSaver::shouldSaveToSingleFile(std::vector<std::string> const &workspace
   }
 
   // If there is only one workspace name in the list then we may still have multiple datasets if it is a workspace group
-  const auto ws = workspace(workspaceNames.front());
+  auto const ws = workspace(workspaceNames.front());
   if (!ws->isGroup()) {
     return false;
   }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/FileSaver.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/FileSaver.cpp
@@ -69,7 +69,7 @@ std::string FileSaver::assembleSavePath(std::string const &saveDirectory, std::s
 }
 
 Mantid::API::Workspace_sptr FileSaver::workspace(std::string const &workspaceName) const {
-  auto const &ads = Mantid::API::AnalysisDataService::Instance();
+  const auto &ads = Mantid::API::AnalysisDataService::Instance();
 
   if (!ads.doesExist(workspaceName)) {
     throw std::runtime_error("Cannot find workspace " + workspaceName + " in the ADS.");
@@ -95,8 +95,8 @@ void FileSaver::runSaveORSOAlgorithm(std::string const &savePath, std::vector<st
 
 void FileSaver::save(const Mantid::API::Workspace_sptr &workspace, std::string const &saveDirectory,
                      std::vector<std::string> const &logParameters, FileFormatOptions const &fileFormat) const {
-  auto const extension = extensionForFormat(fileFormat.format());
-  auto const savePath = assembleSavePath(saveDirectory, fileFormat.prefix(), workspace->getName(), extension);
+  const auto extension = extensionForFormat(fileFormat.format());
+  const auto savePath = assembleSavePath(saveDirectory, fileFormat.prefix(), workspace->getName(), extension);
 
   if (fileFormat.isORSOFormat()) {
     const std::vector<std::string> workspaceNames{workspace->getName()};
@@ -108,9 +108,9 @@ void FileSaver::save(const Mantid::API::Workspace_sptr &workspace, std::string c
 
 void FileSaver::saveToSingleFile(std::vector<std::string> const &workspaceNames, std::string const &saveDirectory,
                                  FileFormatOptions const &fileFormat) const {
-  auto const extension = extensionForFormat(fileFormat.format());
-  auto filename = workspaceNames.front() + MULTI_DATASET_FILE_SUFFIX;
-  auto const savePath = assembleSavePath(saveDirectory, fileFormat.prefix(), filename, extension);
+  const auto extension = extensionForFormat(fileFormat.format());
+  const auto filename = workspaceNames.front() + MULTI_DATASET_FILE_SUFFIX;
+  const auto savePath = assembleSavePath(saveDirectory, fileFormat.prefix(), filename, extension);
 
   if (fileFormat.isORSOFormat()) {
     runSaveORSOAlgorithm(savePath, workspaceNames, fileFormat);
@@ -130,8 +130,8 @@ void FileSaver::save(std::string const &saveDirectory, std::vector<std::string> 
   if (shouldSaveToSingleFile(workspaceNames, fileFormat)) {
     saveToSingleFile(workspaceNames, saveDirectory, fileFormat);
   } else {
-    for (auto const &name : workspaceNames) {
-      auto ws = workspace(name);
+    for (const auto &name : workspaceNames) {
+      const auto ws = workspace(name);
       if (ws->isGroup()) {
         // Save child workspaces into separate files
         Mantid::API::WorkspaceGroup_sptr group = std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(ws);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/FileSaver.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/FileSaver.h
@@ -41,7 +41,7 @@ private:
                                std::string const &extension) const;
 
   Mantid::API::Workspace_sptr workspace(std::string const &workspaceName) const;
-  void save(const Mantid::API::Workspace_sptr &workspace, std::string const &saveDirectory,
+  void save(Mantid::API::Workspace_sptr const &workspace, std::string const &saveDirectory,
             std::vector<std::string> const &logParameters, FileFormatOptions const &fileFormat) const;
 
   void saveToSingleFile(std::vector<std::string> const &workspaceNames, std::string const &saveDirectory,

--- a/qt/scientific_interfaces/ISISReflectometry/test/Save/FileSaverTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Save/FileSaverTest.h
@@ -83,17 +83,17 @@ public:
   }
 
   void test_save_to_ORSOAscii_single_file_one_ws_group_with_multiple_child_workspaces_includes_filename_suffix() {
-    const auto workspaceGrpToSave = "ws_grp_1";
+    auto const workspaceGrpToSave = "ws_grp_1";
     std::vector<std::string> const childWorkspaces = {"ws_1", "ws_2"};
-    const auto expectedFileName = "ws_grp_1" + m_multiFileSuffix;
+    auto const expectedFileName = "ws_grp_1" + m_multiFileSuffix;
     runTestSaveToSingleORSOFileForWorkspaceGroup(NamedFormat::ORSOAscii, workspaceGrpToSave, childWorkspaces,
                                                  expectedFileName);
   }
 
   void test_save_to_ORSOAscii_single_file_one_ws_group_with_one_child_workspace_excludes_filename_suffix() {
-    const auto workspaceGrpToSave = "ws_grp_1";
+    auto const workspaceGrpToSave = "ws_grp_1";
     std::vector<std::string> const childWorkspaces = {"ws_1"};
-    const auto expectedFileName = "ws_1";
+    auto const expectedFileName = "ws_1";
     runTestSaveToSingleORSOFileForWorkspaceGroup(NamedFormat::ORSOAscii, workspaceGrpToSave, childWorkspaces,
                                                  expectedFileName);
   }
@@ -114,17 +114,17 @@ public:
   }
 
   void test_save_to_ORSONexus_single_file_one_ws_group_with_multiple_child_workspaces_includes_filename_suffix() {
-    const auto workspaceGrpToSave = "ws_grp_1";
+    auto const workspaceGrpToSave = "ws_grp_1";
     std::vector<std::string> const childWorkspaces = {"ws_1", "ws_2"};
-    const auto expectedFileName = "ws_grp_1" + m_multiFileSuffix;
+    auto const expectedFileName = "ws_grp_1" + m_multiFileSuffix;
     runTestSaveToSingleORSOFileForWorkspaceGroup(NamedFormat::ORSONexus, workspaceGrpToSave, childWorkspaces,
                                                  expectedFileName);
   }
 
   void test_save_to_ORSONexus_single_file_one_ws_group_with_one_child_workspace_excludes_filename_suffix() {
-    const auto workspaceGrpToSave = "ws_grp_1";
+    auto const workspaceGrpToSave = "ws_grp_1";
     std::vector<std::string> const childWorkspaces = {"ws_1"};
-    const auto expectedFileName = "ws_1";
+    auto const expectedFileName = "ws_1";
     runTestSaveToSingleORSOFileForWorkspaceGroup(NamedFormat::ORSONexus, workspaceGrpToSave, childWorkspaces,
                                                  expectedFileName);
   }
@@ -269,7 +269,7 @@ private:
     expectIsValidSaveDirectory(mockFileHandler);
 
     if (saveAsSingleFile) {
-      const auto filename =
+      auto const filename =
           expectMultiDatasetSuffix ? workspacesToSave.front() + m_multiFileSuffix : workspacesToSave.front();
       expectSaveOrsoAlgorithmCalled(*mockSaveAlgorithmRunner, filename, formatOptions.format());
     } else {
@@ -295,7 +295,7 @@ private:
     expectSaveOrsoAlgorithmCalled(*mockSaveAlgorithmRunner, expectedFileName, formatOptions.format());
 
     auto saver = createSaver(std::move(mockSaveAlgorithmRunner), mockFileHandler);
-    const auto saveList = {workspaceGrpToSave};
+    auto const saveList = {workspaceGrpToSave};
     saver.save(m_saveDirectory, saveList, logParams, formatOptions);
   }
 };


### PR DESCRIPTION
### Description of work
Consistently position const in FileSaver.cpp  and FileSaverTest.h classes following the east const approach

Fixes #37283 

### To test:
Review the FileSaver.cpp class to ensure const position follows the east const approach.
Review the FileSaverTest.h class to ensure const position follows the east const approach.


This does not require release notes because the changes involved refactoring some few lines of code without introducing any functional changes