### PR TITLE
37594 sliceviewer sample data order

### DIFF
--- a/docs/source/release/v6.11.0/Workbench/SliceViewer/Bugfixes/37594.rst
+++ b/docs/source/release/v6.11.0/Workbench/SliceViewer/Bugfixes/37594.rst
@@ -1,0 +1,1 @@
+- A warning will now be displayed if a workspace with unordered spectrum numbers is opened in the :ref:sliceviewer. These workspaces can fail to display correctly and may result in errors. This is a temporary fix.

--- a/docs/source/release/v6.11.0/Workbench/SliceViewer/Bugfixes/37594.rst
+++ b/docs/source/release/v6.11.0/Workbench/SliceViewer/Bugfixes/37594.rst
@@ -1,1 +1,1 @@
-- A warning will now be displayed if a workspace with unordered spectrum numbers is opened in the :ref:sliceviewer. These workspaces can fail to display correctly and may result in errors. This is a temporary fix.
+- A warning will now be displayed if a workspace with unordered spectrum numbers is opened in the :ref:sliceviewer. These workspaces can fail to display correctly and may result in errors.

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -260,14 +260,12 @@ class WorkspaceWidget(PluginWidget):
         parent, flags = get_window_config()
         for ws in self._ads.retrieveWorkspaces(names, unrollGroups=True):
             try:
-                specs = ws.getSpectrumNumbers()
                 y = ws.getYDimension()
                 if y.getName() == "sample":
                     spec_xvals = [ws.getYDimension().getX(ispec) for ispec in range(ws.getNumberHistograms())]
-
-                    # Check if the q values are sorted, if not sort them
-                    if sorted(spec_to_y_dim.values()) != spec_to_y_dim.values():
-                        logger.warning("Warning: Invalid Data Format. " "Consider sorting by sample number and try again")
+                    # Check if the q values are sorted, if not display error
+                    if sorted(spec_xvals) != spec_xvals:
+                        logger.warning("Warning: Invalid Data Format. Consider sorting by sample number and try again")
 
                 presenter = SliceViewer(ws=ws, conf=CONF, parent=parent, window_flags=flags)
                 presenter.view.show()

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -263,7 +263,7 @@ class WorkspaceWidget(PluginWidget):
                 specs = ws.getSpectrumNumbers()
                 y = ws.getYDimension()
                 if y.getName() == "sample":
-                    spec_to_y_dim = {s: y.getX(s) for s in specs}
+                    spec_xvals = [ws.getYDimension().getX(ispec) for ispec in range(ws.getNumberHistograms())]
 
                     # Check if the q values are sorted, if not sort them
                     if sorted(spec_to_y_dim.values()) != spec_to_y_dim.values():

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -23,7 +23,7 @@ from mantidqt.plotting.functions import (
 )
 from mantidqt.plotting import sample_shape
 from mantid.plots.utility import MantidAxType
-from mantid.simpleapi import CreateDetectorTable, ExtractSpectra
+from mantid.simpleapi import CreateDetectorTable
 from mantidqt.utils.asynchronous import BlockingAsyncTaskWithCallback
 from mantidqt.widgets.instrumentview.presenter import InstrumentViewPresenter
 from mantidqt.widgets.samplelogs.presenter import SampleLogs
@@ -267,14 +267,9 @@ class WorkspaceWidget(PluginWidget):
 
                     # Check if the q values are sorted, if not sort them
                     if sorted(spec_to_y_dim.values()) != spec_to_y_dim.values():
-                        sorted_dict = dict(sorted(spec_to_y_dim.items(), key=lambda item: item[1]))
-                        ws_sorted = ExtractSpectra(ws, OutputWorkspace=f"{ws.name()}_sorted", WorkspaceIndexList=list(sorted_dict.keys()))
-                        presenter = SliceViewer(ws=ws_sorted, conf=CONF, parent=parent, window_flags=flags)
-                        logger.warning("Warning: Data was sorted to display. Other view modes will not be affected")
-                    else:
-                        presenter = SliceViewer(ws=ws, conf=CONF, parent=parent, window_flags=flags)
-                else:
-                    presenter = SliceViewer(ws=ws, conf=CONF, parent=parent, window_flags=flags)
+                        logger.warning("Warning: Invalid Data Format. " "Consider sorting by sample number and try again")
+
+                presenter = SliceViewer(ws=ws, conf=CONF, parent=parent, window_flags=flags)
                 presenter.view.show()
             except Exception as exception:
                 logger.warning("Could not open slice viewer for workspace '{}'." "".format(ws.name()))


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
--> Slice viewed displays error when sample data (Y axis) is unordered. Concluded to just displaying a warning when the unusual data is imported telling the user to order the relevant data themselves in necessary. 

Fixes #37594. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
--> @robertapplin 

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
--> 

### To test:

1. **Import the attached data:**
File: [osiris100318-100329_graphite002_red_elwin_eq.zip](https://github.com/user-attachments/files/16931474/osiris100318-100329_graphite002_red_elwin_eq.zip)

2. **Open the Slice Viewer:**
Right click the data and click "Slice Viewer"

3. **Check for a Warning:**
The window should display the data, but also show a warning message on the side. 
Expected behavior: The data should appear "broken" (Thin line strip), and the warning should provide further details.

4. **Test with Other Data:**
Try importing and viewing other data files

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
