### PR TITLE
Fix to system test `ISISIndirectInelastic.OSIRISIqtAndIqtFitMulti`

### DIFF
--- a/Testing/SystemTests/tests/framework/ISISIndirectInelastic.py
+++ b/Testing/SystemTests/tests/framework/ISISIndirectInelastic.py
@@ -1003,18 +1003,15 @@ class OSIRISIqtAndIqtFitMulti(ISISIndirectInelasticIqtAndIqtFitMulti):
         self.spec_max = 41
 
     def skipTests(self):
-        # In its current state this test is not fit for purpose. There is a large amount of randomness present such
-        # that a very very wide relative tolerance is required to pass reliably (50+). This was discovered after
-        # a change to CompareWorkspaces that made the comparison actually relative. Prior, this test was actually
-        # using an absolute tolerance of 5.0. A redesign is needed to remove some of the randomness or determine
-        # the actual required tolerance.
-        return True
+        # This test was once giving issues.  It seems the failures were caused by the large fluctuations in the
+        # uncertainties (i.e. delta delta y) due to the Monte Carlo calculation.  Turning off the check of uncertainity
+        # should fix this test, combined with a reasonable absolute tolerance of 0.05.
+        return False
 
     def get_reference_files(self):
-        # Relative tolerance is used because the calculation of Monte Carlo errors means the Iqt errors are randomized
-        # within a set amount
-        self.tolerance = 5.0
-        self.tolerance_is_rel_err = True
+        self.tolerance = 0.05
+        self.tolerance_is_rel_err = False
+        self.disableChecking = ["Uncertainty"]
         return ["II.OSIRISIqt.nxs", "II.OSIRISIqtFitMulti.nxs"]
 
 

--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37920.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37920.rst
@@ -1,0 +1,1 @@
+- fix comparison operation in ``ISISIndirectInelastic.OSIRISIqtAndIqtFitMulti`` system test by turning off uncertainty check, using absolute comparison, and adjusting the tolerance.


### PR DESCRIPTION
### Description of work

#### Summary of work
There are two workspaces checked in this test.

Firstly, a workspace with numerous spectra are compared to a standard.  This comparison on the $x$- and $y$-values is correct out to order 1.e-15, which is astounding, and yet the comparison was failing anyway, due to differences in the $y$-value uncertainties (called `e` inside mantid).  To handle this, the test used relative tolerance of an astounding 5, with this comment:
> Relative tolerance is used because the calculation of Monte Carlo errors means the Iqt errors are randomized within a set amount

which suggests the only reason for the relative difference and large tolerance was to handle the errors, which are not expected to compare all that well anyway.

Second, a workspace with a few named physical values is compared to a standard.  These $y$-values seem to be normalized to a max value of 1, which is the primary situation where a relative difference is _not_ desired.  Low magnitude values led to very large relative differences.  Because there is uncertainty on this, the relative difference would sometimes be larger than the tolerance of 5, and other times not, making this test unstable.

Both of these comparisons worked because of an errant relative difference calculation inside `CompareWorkspaces` (see Issue #37877 ), which was fixed in PR #37889.  But this fix exposed that this test never actually compared the relative difference, but was checking all values against an absolute difference of 5, meaning everything always passed.  With the fix, this test began to sporadically fail.

Based on investigation of the problem, `CompareWorkspaces` received the extra flag "CheckUncertainty" in PR #37933, so that checking the uncertainty (not expected to be close in this test) can be turned off.  Also, the comparison was changed to an absolute comparison of 0.05, which is reasonably small, yet still large enough for the test to consistently pass.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37920. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

Makes use of the `self.disableChecking` list [used by mantid system tests](https://github.com/mantidproject/mantid/blob/ea76699259c572d162ec4c352c9bfd3d8095760d/Testing/SystemTests/lib/systemtests/systemtesting.py#L356).

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

The original failures were random, reported at about 70% of the time.  Please [run this system test](https://developer.mantidproject.org/SystemTests.html) many, many times.

This can be done by
1. pulling and building this branch
2. within `mantid/build/` run `./systemtest -R OSIRISIqtAndIqtFitMulti`
3. rinse and repeat

Run at least ten times, if not hundreds.  The randomness is inherent to the test, due to the Monte Carlo nature of the algorithm it tests.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
