### PR TITLE
Add CheckUncertainty property to `CompareWorkspaces` to turn off error-comparison - `ornl-next`

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CompareWorkspaces.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CompareWorkspaces.h
@@ -123,6 +123,9 @@ private:
   /// Result of comparison (true if equal, false otherwise)
   bool m_result{false};
 
+  /// The comparison method to use (true if equal, false otherwise)
+  std::function<bool(const double, const double)> m_compare;
+
   /// Mismatch messages that resulted from comparison
   API::ITableWorkspace_sptr m_messages;
 

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -78,13 +78,13 @@ int compareEventLists(Kernel::Logger &logger, const EventList &el1, const EventL
       diffpulse = true;
       ++numdiffpulse;
     }
-    if (std::fabs(e1.tof() - e2.tof()) > tolTof) {
+    if (std::abs(e1.tof() - e2.tof()) > tolTof) {
       difftof = true;
       ++numdifftof;
     }
     if (diffpulse && difftof)
       ++numdiffboth;
-    if (std::fabs(e1.weight() - e2.weight()) > tolWeight) {
+    if (std::abs(e1.weight() - e2.weight()) > tolWeight) {
       diffweight = true;
       ++numdiffweight;
     }
@@ -122,6 +122,9 @@ void CompareWorkspaces::init() {
 
   declareProperty("Tolerance", 1e-10, "The maximum amount by which values may differ between the workspaces.");
 
+  declareProperty("CheckUncertainty", true,
+                  "Whether to check that the y-value uncertainties (E) match "
+                  "(only for matrix workspaces). ");
   declareProperty("CheckType", true,
                   "Whether to check that the data types "
                   "(Workspace2D vs EventWorkspace) match.");
@@ -167,6 +170,17 @@ void CompareWorkspaces::exec() {
 
   if (g_log.is(Logger::Priority::PRIO_DEBUG))
     m_parallelComparison = false;
+
+  double const tolerance = getProperty("Tolerance");
+  if (getProperty("ToleranceRelErr")) {
+    this->m_compare = [tolerance](double const x1, double const x2) -> bool {
+      return CompareWorkspaces::withinRelativeTolerance(x1, x2, tolerance);
+    };
+  } else {
+    this->m_compare = [tolerance](double const x1, double const x2) -> bool {
+      return CompareWorkspaces::withinAbsoluteTolerance(x1, x2, tolerance);
+    };
+  }
 
   this->doComparison();
 
@@ -600,18 +614,7 @@ bool CompareWorkspaces::checkData(const API::MatrixWorkspace_const_sptr &ws1,
   }
   const bool histogram = ws1->isHistogramData();
   const bool checkAllData = getProperty("CheckAllData");
-  const bool isRelErr = getProperty("ToleranceRelErr");
-  const double tolerance = getProperty("Tolerance");
-  std::function<bool(double const, double const)> compare;
-  if (isRelErr) {
-    compare = [tolerance](double const x1, double const x2) -> bool {
-      return CompareWorkspaces::withinRelativeTolerance(x1, x2, tolerance);
-    };
-  } else {
-    compare = [tolerance](double const x1, double const x2) -> bool {
-      return CompareWorkspaces::withinAbsoluteTolerance(x1, x2, tolerance);
-    };
-  }
+  const bool checkError = getProperty("CheckUncertainty");
 
   // First check that the workspace are the same size
   if (numHists != ws2->getNumberHistograms() ||
@@ -653,14 +656,16 @@ bool CompareWorkspaces::checkData(const API::MatrixWorkspace_const_sptr &ws1,
       } else {
 
         for (int j = 0; j < static_cast<int>(Y1.size()); ++j) {
-          bool err = (!compare(X1[j], X2[j]) || !compare(Y1[j], Y2[j]) || !compare(E1[j], E2[j]));
+          bool err = (!m_compare(X1[j], X2[j]) || !m_compare(Y1[j], Y2[j]));
+          if (checkError)
+            err = err || !m_compare(E1[j], E2[j]);
           if (err) {
             if (logDebug) {
               g_log.debug() << "Data mismatch at cell (hist#,bin#): (" << i << "," << j << ")\n";
               g_log.debug() << " Dataset #1 (X,Y,E) = (" << X1[j] << "," << Y1[j] << "," << E1[j] << ")\n";
               g_log.debug() << " Dataset #2 (X,Y,E) = (" << X2[j] << "," << Y2[j] << "," << E2[j] << ")\n";
-              g_log.debug() << " Difference (X,Y,E) = (" << std::fabs(X1[j] - X2[j]) << "," << std::fabs(Y1[j] - Y2[j])
-                            << "," << std::fabs(E1[j] - E2[j]) << ")\n";
+              g_log.debug() << " Difference (X,Y,E) = (" << std::abs(X1[j] - X2[j]) << "," << std::abs(Y1[j] - Y2[j])
+                            << "," << std::abs(E1[j] - E2[j]) << ")\n";
             }
             PARALLEL_CRITICAL(resultBool)
             resultBool = false;
@@ -668,7 +673,7 @@ bool CompareWorkspaces::checkData(const API::MatrixWorkspace_const_sptr &ws1,
         }
 
         // Extra one for histogram data
-        if (histogram && !compare(X1.back(), X2.back())) {
+        if (histogram && !m_compare(X1.back(), X2.back())) {
           if (logDebug) {
             g_log.debug() << " Data ranges mismatch for spectra N: (" << i << ")\n";
             g_log.debug() << " Last bin ranges (X1_end vs X2_end) = (" << X1.back() << "," << X2.back() << ")\n";
@@ -1040,7 +1045,6 @@ void CompareWorkspaces::doPeaksComparison(PeaksWorkspace_sptr tws1, PeaksWorkspa
     tws2 = std::dynamic_pointer_cast<PeaksWorkspace>(tmp2);
   }
 
-  const double tolerance = getProperty("Tolerance");
   const bool isRelErr = getProperty("ToleranceRelErr");
   for (int i = 0; i < tws1->getNumberPeaks(); i++) {
     const Peak &peak1 = tws1->getPeak(i);
@@ -1105,13 +1109,13 @@ void CompareWorkspaces::doPeaksComparison(PeaksWorkspace_sptr tws1, PeaksWorkspa
       }
       bool mismatch = false;
       if (isRelErr) {
-        mismatch = !withinRelativeTolerance(s1, s2, tolerance);
-        // Q: whould we not also compare the vectors?
+        mismatch = !m_compare(s1, s2);
+        // Q: why should we not also compare the vectors?
       } else {
-        mismatch = !withinAbsoluteTolerance(s1, s2, tolerance) ||       //
-                   !withinAbsoluteTolerance(v1[0], v2[0], tolerance) || //
-                   !withinAbsoluteTolerance(v1[1], v2[1], tolerance) || //
-                   !withinAbsoluteTolerance(v1[2], v2[2], tolerance);   //
+        mismatch = !m_compare(s1, s2) ||       //
+                   !m_compare(v1[0], v2[0]) || //
+                   !m_compare(v1[1], v2[1]) || //
+                   !m_compare(v1[2], v2[2]);   //
       }
       if (mismatch) {
         g_log.notice(name);
@@ -1218,6 +1222,9 @@ void CompareWorkspaces::doLeanElasticPeaksComparison(const LeanElasticPeaksWorks
       }
       bool mismatch = false;
       // Q: why does it not perform the user-specified operation for QLab and QSample?
+      // if this is not necessary, then
+      //   bool mismatch = !m_compare(s1, s2)
+      // can replace this if/else, and isRelErr and tolerance can be deleted
       if (isRelErr && name != "QLab" && name != "QSample") {
         if (!withinRelativeTolerance(s1, s2, tolerance)) {
           mismatch = true;
@@ -1274,7 +1281,7 @@ void CompareWorkspaces::doTableComparison(const API::ITableWorkspace_const_sptr 
   const bool checkAllData = getProperty("CheckAllData");
   const bool isRelErr = getProperty("ToleranceRelErr");
   const double tolerance = getProperty("Tolerance");
-  bool mismatch = false;
+  bool mismatch;
   for (size_t i = 0; i < numCols; ++i) {
     const auto c1 = tws1->getColumn(i);
     const auto c2 = tws2->getColumn(i);
@@ -1351,7 +1358,7 @@ this error is within the limits requested.
 */
 bool CompareWorkspaces::withinAbsoluteTolerance(double const x1, double const x2, double const atol) {
   // NOTE !(|x1-x2| > atol) is not the same as |x1-x2| <= atol
-  return !(std::fabs(x1 - x2) > atol);
+  return !(std::abs(x1 - x2) > atol);
 }
 
 //------------------------------------------------------------------------------------------------
@@ -1367,12 +1374,14 @@ this error is within the limits requested.
 */
 bool CompareWorkspaces::withinRelativeTolerance(double const x1, double const x2, double const rtol) {
   // calculate difference
-  double const num = std::fabs(x1 - x2);
+  double const num = std::abs(x1 - x2);
   // return early if the values are equal
   if (num == 0.0)
     return true;
   // compare the difference to the midpoint value -- could lead to issues for negative values
-  double const den = 0.5 * std::fabs(x1 + x2);
+  double const den = 0.5 * (std::abs(x1) + std::abs(x2));
+  if (den <= 1.0 && num > rtol)
+    return false;
   // NOTE !(num > rtol*den) is not the same as (num <= rtol*den)
   return !(num > (rtol * den));
 }

--- a/Framework/Algorithms/test/CompareWorkspacesTest.h
+++ b/Framework/Algorithms/test/CompareWorkspacesTest.h
@@ -82,8 +82,6 @@ public:
 
     WorkspaceSingleValue_sptr ws1 = WorkspaceCreationHelper::createWorkspaceSingleValue(1.0);
     WorkspaceSingleValue_sptr ws2 = WorkspaceCreationHelper::createWorkspaceSingleValue(2.0);
-    // AnalysisDataService::Instance().add(AnalysisDataService::Instance().uniqueName(), ws1);
-    // AnalysisDataService::Instance().add(AnalysisDataService::Instance().uniqueName(), ws2);
     //
     TS_ASSERT_THROWS_NOTHING(checker.setProperty("Workspace1", ws1));
     TS_ASSERT_THROWS_NOTHING(checker.setProperty("Workspace2", ws2));
@@ -165,8 +163,6 @@ public:
 
     WorkspaceSingleValue_sptr ws1 = WorkspaceCreationHelper::createWorkspaceSingleValue(1.1);
     WorkspaceSingleValue_sptr ws2 = WorkspaceCreationHelper::createWorkspaceSingleValue(2.2);
-    // AnalysisDataService::Instance().add(AnalysisDataService::Instance().uniqueName(), ws1);
-    // AnalysisDataService::Instance().add(AnalysisDataService::Instance().uniqueName(), ws2);
     //
     TS_ASSERT_THROWS_NOTHING(checker.setProperty("Workspace1", ws1));
     TS_ASSERT_THROWS_NOTHING(checker.setProperty("Workspace2", ws2));
@@ -185,8 +181,6 @@ public:
 
     WorkspaceSingleValue_sptr ws1 = WorkspaceCreationHelper::createWorkspaceSingleValueWithError(1.1, 2.0);
     WorkspaceSingleValue_sptr ws2 = WorkspaceCreationHelper::createWorkspaceSingleValueWithError(1.1, 2.0);
-    // AnalysisDataService::Instance().add(AnalysisDataService::Instance().uniqueName(), ws1);
-    // AnalysisDataService::Instance().add(AnalysisDataService::Instance().uniqueName(), ws2);
     //
     TS_ASSERT_THROWS_NOTHING(checker.setProperty("CheckUncertainty", true));
     TS_ASSERT_THROWS_NOTHING(checker.setProperty("Workspace1", ws1));
@@ -206,8 +200,6 @@ public:
 
     WorkspaceSingleValue_sptr ws1 = WorkspaceCreationHelper::createWorkspaceSingleValueWithError(1.1, 2.0);
     WorkspaceSingleValue_sptr ws2 = WorkspaceCreationHelper::createWorkspaceSingleValueWithError(1.1, 4.0);
-    // AnalysisDataService::Instance().add(AnalysisDataService::Instance().uniqueName(), ws1);
-    // AnalysisDataService::Instance().add(AnalysisDataService::Instance().uniqueName(), ws2);
     // make sure ARE equal if errors NOT checked
     TS_ASSERT_THROWS_NOTHING(checker.setProperty("CheckUncertainty", false));
     TS_ASSERT_THROWS_NOTHING(checker.setProperty("Workspace1", ws1));

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1653,4 +1653,3 @@ returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reductio
 returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferData.h:193
 returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferData.h:199
 returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferData.h:218
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CompareWorkspaces.cpp:1277

--- a/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37933.rst
+++ b/docs/source/release/v6.11.0/Framework/Algorithms/New_features/37933.rst
@@ -1,0 +1,1 @@
+- add flag "CheckUncertainty" to :ref:`CompareWorkspaces <algm-CompareWorkspaces>` to turn off comparing the y-value uncertainties.


### PR DESCRIPTION
Sister PR to #37933  into `ornl-next`