### PR TITLE
Fix Importing results on Muon ALC interface

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1562,7 +1562,6 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectome
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp:786
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp:545
 returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h:34
-constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.cpp:177
 returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h:54
 noCopyConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp:225
 noOperatorEq:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp:225

--- a/docs/source/release/v6.11.0/Muon/ALC/Bugfixes/37946.rst
+++ b/docs/source/release/v6.11.0/Muon/ALC/Bugfixes/37946.rst
@@ -1,0 +1,1 @@
+- Fixed the `Import results` option on the :ref:`Muon ALC <MuonALC-ref>` interface when the results being loaded are only partially complete.

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.cpp
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.cpp
@@ -154,16 +154,10 @@ void ALCBaselineModellingModel::enableDisabledPoints(const MatrixWorkspace_sptr 
 void ALCBaselineModellingModel::setErrorsAfterFit(const MatrixWorkspace_sptr &data) { data->mutableE(2) = data->e(0); }
 
 MatrixWorkspace_sptr ALCBaselineModellingModel::exportWorkspace() {
-  if (m_data && m_data->getNumberHistograms() == 3) {
-
-    // Export results only if data have been fit, that is,
-    // if m_data has three histograms
+  if (m_data) {
     return std::const_pointer_cast<MatrixWorkspace>(m_data);
-
-  } else {
-
-    return MatrixWorkspace_sptr();
   }
+  return nullptr;
 }
 
 ITableWorkspace_sptr ALCBaselineModellingModel::exportSections() {

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.cpp
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.cpp
@@ -168,7 +168,7 @@ ITableWorkspace_sptr ALCBaselineModellingModel::exportSections() {
     table->addColumn("double", "Start X");
     table->addColumn("double", "End X");
 
-    for (auto &section : m_sections) {
+    for (auto const &section : m_sections) {
       TableRow newRow = table->appendRow();
       newRow << section.first << section.second;
     }

--- a/qt/scientific_interfaces/Muon/ALCInterface.cpp
+++ b/qt/scientific_interfaces/Muon/ALCInterface.cpp
@@ -270,32 +270,20 @@ void ALCInterface::importResults() {
 
 void ALCInterface::importLoadedData(const std::string &workspaceName) {
   if (const auto dataWS = getWorkspace(workspaceName)) {
-    if (dataWS->getNumberHistograms() != 1) {
-      logger.warning("Workspace " + workspaceName + " must contain one spectrum only.");
-    } else {
-      m_dataLoading->setData(dataWS);
-    }
+    m_dataLoading->setData(dataWS);
   }
 }
 
 void ALCInterface::importBaselineData(const std::string &workspaceName) {
   if (const auto baselineWS = getWorkspace(workspaceName)) {
-    if (baselineWS->getNumberHistograms() != 3) {
-      logger.warning("Workspace " + workspaceName + " must contain three spectra.");
-    } else {
-      m_baselineModellingModel->setData(baselineWS);
-      m_baselineModellingModel->setCorrectedData(baselineWS);
-    }
+    m_baselineModellingModel->setData(baselineWS);
+    m_baselineModellingModel->setCorrectedData(baselineWS);
   }
 }
 
 void ALCInterface::importPeakData(const std::string &workspaceName) {
   if (const auto peaksWS = getWorkspace(workspaceName)) {
-    if (peaksWS->getNumberHistograms() < 3) {
-      logger.warning("Workspace " + workspaceName + " must contain at least three spectra.");
-    } else {
-      m_peakFittingModel->setData(peaksWS);
-    }
+    m_peakFittingModel->setData(peaksWS);
   }
 }
 

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
@@ -56,14 +56,10 @@ void ALCPeakFittingModel::setData(MatrixWorkspace_sptr newData) {
 }
 
 MatrixWorkspace_sptr ALCPeakFittingModel::exportWorkspace() {
-  if (m_data && m_data->getNumberHistograms() > 2) {
-
+  if (m_data) {
     return std::const_pointer_cast<MatrixWorkspace>(m_data);
-
-  } else {
-
-    return MatrixWorkspace_sptr();
   }
+  return nullptr;
 }
 
 ITableWorkspace_sptr ALCPeakFittingModel::exportFittedPeaks() {


### PR DESCRIPTION
### Description of work
This PR fixes an issue in the Muon ALC interface where it was not possible to import results into the interface which had not undergone the full analysis process (baseline modelling and peak fitting as well as data loading). When doing a subtraction on the data loading page, it also wasn't possible to load the dataset back in because there were 4 histograms rather than an expected 1 histogram.

The solution I went for was to make the Muon ALC interface less fussy about the number of histograms are contained within the results workspace. There are cases where the number of histograms will be different, such as when you do not fully complete your analysis and want to load partial results into the interface. There is also another case where doing a subtraction means a different number of histograms, but it is still safe to load this data in.

Fixes #37938

**Report to:** Adam Berlie

### To test:
1. Open the Muon->ALC interface
2. Load HIFI run 110542 from the ISIS archive
3. Click `Load` and wait
4. Click `Export results...` and choose anymore
5. Close the interface, then re-open
6. Go to the `Baseline modelling` page
7. Click `Import results...` and choose the workspace you exported
8. You should see a data point plotted on the Data Loading page, and also in the Baseline Modelling page

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
