### PR TITLE
Switch to supported clang-format pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,11 +23,15 @@ repos:
         args: [--allow-multiple-documents]
         exclude: conda/recipes/mantid/meta.yaml|conda/recipes/mantidqt/meta.yaml|conda/recipes/mantiddocs/meta.yaml|conda/recipes/mantidworkbench/meta.yaml
 
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v11.1.0 # updating to a new version should wait until maintenance
+    hooks:
+    - id: clang-format
+      exclude: Testing/Tools/cxxtest|tools
+
   - repo: https://github.com/mantidproject/pre-commit-hooks.git
     rev: 2f8a4f22629d0d23332f621df9de93751331161b
     hooks:
-      - id: clang-format
-        exclude: Testing/Tools/cxxtest|tools
       - id: cmake-missing-pytest-files
         # Exclude sphinx / template file
         exclude: test_doctest.py|python_export_maker.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,14 +55,14 @@ repos:
           )$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.5
+    rev: v0.6.4
     # ruff must appear before black in the list of hooks
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
         exclude: scripts/templates/reference/|Testing/Tools/cxxtest


### PR DESCRIPTION
### Description of work
This changes from [our custom pre-commit hook](https://github.com/mantidproject/pre-commit-hooks/tree/2f8a4f22629d0d23332f621df9de93751331161b/clang-format/bin) to [pre-commit/mirrors-clang-format](https://github.com/pre-commit/mirrors-clang-format). This reduces the maintenance burden in mantid.

For some reason this is showing more of the diff than there should be. It is actually
```diff
diff --git a/.pre-commit-config.yaml b/.pre-commit-config.yaml
index 043969f7875..045498c9f4e 100644
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,11 +23,15 @@ repos:
         args: [--allow-multiple-documents]
         exclude: conda/recipes/mantid/meta.yaml|conda/recipes/mantidqt/meta.yaml|conda/recipes/mantiddocs/meta.yaml|conda/recipes/mantidworkbench/meta.yaml
 
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v11.1.0 # updating to a new version should wait until maintenance
+    hooks:
+    - id: clang-format
+      exclude: Testing/Tools/cxxtest|tools
+
   - repo: https://github.com/mantidproject/pre-commit-hooks.git
     rev: 2f8a4f22629d0d23332f621df9de93751331161b
     hooks:
-      - id: clang-format
-        exclude: Testing/Tools/cxxtest|tools
       - id: cmake-missing-pytest-files
         # Exclude sphinx / template file
         exclude: test_doctest.py|python_export_maker.py
```
Related: https://github.com/mantidproject/pre-commit-hooks/pull/12 removes the mantid hook from our repository.

*There is no associated issue.*

### To test:

You will see that only the `.pre-commit-config.yaml` file is changed and all the builds still pass. 

*This does not require release notes* because it is a refactor.
---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
