### PR TITLE
Remove unnecessary startup test code

### DIFF
--- a/Testing/SystemTests/tests/qt/WorkbenchStartupTest.py
+++ b/Testing/SystemTests/tests/qt/WorkbenchStartupTest.py
@@ -5,7 +5,6 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
-import psutil
 import subprocess
 import sys
 import systemtesting
@@ -30,22 +29,8 @@ def get_mantid_executables_for_platform(platform):
 
 
 def start_and_wait_for_completion(args_list):
-    pids_before_open = set(psutil.pids())
     process = subprocess.Popen(args_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     exitcode = process.wait(timeout=SUBPROCESS_TIMEOUT_SECS)
-    if sys.platform == "win32":
-        # The setuptools generated .exe starts a new process using 'pythonw workbench-script.pyw'
-        # but this outer process does not wait for the child to finish so completes leaving workbench
-        # to continue. We attempt to find the python child process by looking at the created pids
-        # and we wait on that. A timeout is set just in case we pick the wrong process and we wait forever
-        pids_after_open = set(psutil.pids())
-        new_pids_created = pids_after_open - pids_before_open
-        for pid in new_pids_created:
-            proc = psutil.Process(pid)
-            if "python" in proc.exe():
-                print(f"Found Python subprocess {proc.exe()}. Pid={pid}. Waiting for completion...")
-                proc.wait(timeout=SUBPROCESS_TIMEOUT_SECS)
-
     return exitcode
 
 


### PR DESCRIPTION
Following the switch to `pip install --editable`, the code in this test for dealing with a Windows `.exe` and `workbench_script.pyw` is obsolete.

### To test:

`WorkbenchStartupTest` is a system test, so all system tests should pass on the below build, as well as all the unit tests.

https://builds.mantidproject.org/job/build_packages_from_branch/883/

Note that the Linux job failed on the above link because of unrelated failing test, but hopefully it's clear that the changes I've made are only going to affect Windows, and that should pass.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **it does not affect the user.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
