### PR TITLE
Handle uncaught error in CompositeFunction::removeTie when tyring to unfix a tied parameter

### DIFF
--- a/Framework/API/src/CompositeFunction.cpp
+++ b/Framework/API/src/CompositeFunction.cpp
@@ -797,7 +797,13 @@ void CompositeFunction::clearTies() {
  * @return True if successful
  */
 bool CompositeFunction::removeTie(size_t i) {
-  bool foundAndRemovedTie = IFunction::removeTie(i);
+  bool foundAndRemovedTie = false;
+  // Handle the case when IFunction::removeTie throws a runtime error because it is trying to unfix a tied parameter
+  try {
+    foundAndRemovedTie = IFunction::removeTie(i);
+  } catch (std::runtime_error &) {
+    foundAndRemovedTie = false;
+  }
   if (!foundAndRemovedTie) {
     size_t iFun = functionIndex(i);
     bool res = m_functions[iFun]->removeTie(i - m_paramOffsets[iFun]);

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
@@ -411,7 +411,6 @@ class PeakFitter:
         fit_kwargs,
         error_strategy,
     ):
-
         self.ws = peak_data.ws
         self.pk: IPeak = pk
         self.peak_pos: tuple[int, int] = (peak_data.irow, peak_data.icol)

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -333,8 +333,8 @@ returnByReference:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/Expression.h:7
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/Expression.h:74
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/API/src/CatalogManager.cpp:54
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/CompositeFunction.cpp:560
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/CompositeFunction.cpp:879
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/CompositeFunction.cpp:906
+constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/CompositeFunction.cpp:885
+constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/CompositeFunction.cpp:912
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/BoostOptionalToAlgorithmProperty.cpp:11
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/src/BoostOptionalToAlgorithmProperty.cpp:14
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/API/src/BoostOptionalToAlgorithmProperty.cpp:30

--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/37940.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/37940.rst
@@ -1,0 +1,1 @@
+- Fix a crash in :ref:`Convolution <convfit>` :ref:`QENS Fitting interface <interface-inelastic-qens-fitting>` interface when attempting to Fix all IsoDiffRot parameters from the EditLocalParameter dialog.

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FunctionTemplatePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FunctionTemplatePresenter.cpp
@@ -109,6 +109,8 @@ void FunctionTemplatePresenter::handleEditLocalParameterFinished(std::string con
     if (!ties[i].isEmpty()) {
       setLocalParameterTie(parameterName, i, ties[i].toStdString());
     } else if (fixes[i]) {
+      // Removing the tie first because a tied parameter can't be fixed
+      setLocalParameterTie(parameterName, i, "");
       setLocalParameterFixed(parameterName, i, fixes[i]);
     } else {
       setLocalParameterTie(parameterName, i, "");


### PR DESCRIPTION
### Description of work
This PR fixes a runtime error that occurs when removing a tie in a composite function. Previously, `CompositeFunction::removeTie` would first try to remove the tie from `CompositeFunction`. If that failed, it would attempt to remove the tie from the associated function's parameter. However, `IFunction::removeTie` calls unfix before finishing, and if the parameter is tied, unfix triggers a runtime error. This caused `CompositeFunction::removeTie` to attempt removing a tied parameter that isn't present in `CompositeFunction`, leading to a crash. This PR resolves the issue by catching the exception on the first attempt.
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37940. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->


### To test:
Follow the steps in #37940 and it should work without a crash
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
