### PR TITLE
Switch to supported clang-format pre-commit hook - ornl-next

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,11 +23,15 @@ repos:
         args: [--allow-multiple-documents]
         exclude: conda/recipes/mantid/meta.yaml|conda/recipes/mantidqt/meta.yaml|conda/recipes/mantiddocs/meta.yaml|conda/recipes/mantidworkbench/meta.yaml
 
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v11.1.0 # updating to a new version should wait until maintenance
+    hooks:
+    - id: clang-format
+      exclude: Testing/Tools/cxxtest|tools
+
   - repo: https://github.com/mantidproject/pre-commit-hooks.git
     rev: 2f8a4f22629d0d23332f621df9de93751331161b
     hooks:
-      - id: clang-format
-        exclude: Testing/Tools/cxxtest|tools
       - id: cmake-missing-pytest-files
         # Exclude sphinx / template file
         exclude: test_doctest.py|python_export_maker.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,14 +55,14 @@ repos:
           )$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.5
+    rev: v0.6.4
     # ruff must appear before black in the list of hooks
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
         exclude: scripts/templates/reference/|Testing/Tools/cxxtest


### PR DESCRIPTION
This is a version of #37954 into `ornl-next`