### PR TITLE
Add missing testoutput for RotateSampleShape doctest

### DIFF
--- a/docs/source/algorithms/RotateSampleShape-v1.rst
+++ b/docs/source/algorithms/RotateSampleShape-v1.rst
@@ -51,6 +51,26 @@ Usage
 
     print(md.parseString(ws.sample().getShape().getShapeXML()).toprettyxml())
 
+Output:
+
+.. testoutput:: RotateSampleShape
+
+    <?xml version="1.0" ?>
+    <type name="userShape">
+
+        <cylinder id="sample-shape">
+
+            <centre-of-bottom-base x="0" y="-0.02" z="0"/>
+
+            <axis x="0" y="1" z="0"/>
+            <height val="0.04"/>
+
+            <radius val="0.01"/>
+        </cylinder>
+
+        <goniometer a11="0.786566" a12="0.362372" a13="0.500000" a21="-0.079459" a22="0.862372" a23="-0.500000" a31="-0.612372" a32="0.353553" a33="0.707107"/>
+    </type>
+
 .. testcleanup:: RotateSampleShape
 
     DeleteWorkspace(ws)


### PR DESCRIPTION
### Description of work
Add expected output to RotateSampleShape doctest. Somehow it didn't fail the PR check when it went in.

*There is no associated issue.*

### To test:
ensure the doctest runs and passes.

*This does not require release notes* because **it's a fix to a doctest**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
