### PR TITLE
Add -u argument to mambaforge

### DIFF
--- a/buildconfig/Jenkins/Conda/download-and-install-mambaforge
+++ b/buildconfig/Jenkins/Conda/download-and-install-mambaforge
@@ -81,7 +81,7 @@ if [ ! -f $EXPECTED_MAMBA_EXE ]; then
           sed -e '/^export\ CONDA_/s/\\/\//g' | \
           sed -e '/^export\ CONDA_/s/\(\w\)\:/\/\1/g' > $EXPECTED_MAMBAFORGE_PATH/etc/profile.d/conda.sh
     else
-        bash $MAMBAFORGE_SCRIPT_NAME -b -p $EXPECTED_MAMBAFORGE_PATH
+        bash $MAMBAFORGE_SCRIPT_NAME -b -p $EXPECTED_MAMBAFORGE_PATH -u
     fi
     rm $MAMBAFORGE_SCRIPT_NAME
 fi


### PR DESCRIPTION
This tells `mambaforge` to update an existing installation.

Fixes this error:
```
16:25:23 + bash Mambaforge-23.1.0-4-MacOSX-x86_64.sh -b -p /Users/builder/Jenkins/workspace/pull_requests-conda-osx/mambaforge
16:25:23 ERROR: File or directory already exists: '/Users/builder/Jenkins/workspace/pull_requests-conda-osx/mambaforge'
16:25:23 If you want to update an existing installation, use the -u option.
```

### To test:

CI runs

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **the user is not affected by these changes.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
