### PR TITLE
Fix plot crash on negative errors

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -288,12 +288,12 @@ def errorbar(axes, workspace, *args, **kwargs):
     kwargs.pop("normalize_by_bin_width", None)
 
     if dy is not None and min(dy) < 0:
-        dy = abs(dy)
-        logger.warning("Negative values found in y error when plotting error bars. Converting to positive and continuing.")
+        dy = None
+        logger.warning("Negative values found in y error when plotting error bars. Continuing without y error bars.")
 
     if dx is not None and min(dx) < 0:
-        dx = abs(dx)
-        logger.warning("Negative values found in x error when plotting error bars. Converting to positive and continuing.")
+        dx = None
+        logger.warning("Negative values found in x error when plotting error bars. Continuing without x error bars.")
 
     return axes.errorbar(x, y, dy, dx, *args, **kwargs)
 

--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -41,6 +41,7 @@ from mantid.plots.datafunctions import (
 )
 from mantid.plots.utility import MantidAxType
 from mantid.plots.quad_mesh_wrapper import QuadMeshWrapper
+from mantid import logger
 
 # Used for initializing searches of max, min values
 _LARGEST, _SMALLEST = float(sys.maxsize), -sys.maxsize
@@ -285,6 +286,14 @@ def errorbar(axes, workspace, *args, **kwargs):
     if kwargs.pop("update_axes_labels", True):
         _setLabels1D(axes, workspace, indices, normalize_by_bin_width=normalize_by_bin_width, axis=axis)
     kwargs.pop("normalize_by_bin_width", None)
+
+    if dy is not None and min(dy) < 0:
+        dy = abs(dy)
+        logger.warning("Negative values found in y error when plotting error bars. Converting to positive and continuing.")
+
+    if dx is not None and min(dx) < 0:
+        dx = abs(dx)
+        logger.warning("Negative values found in x error when plotting error bars. Converting to positive and continuing.")
 
     return axes.errorbar(x, y, dy, dx, *args, **kwargs)
 

--- a/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
@@ -45,6 +45,12 @@ class PlotFunctionsTest(unittest.TestCase):
             VerticalAxisValues=[4, 6, 8],
             OutputWorkspace="ws2d_histo",
         )
+        cls.ws2d_histo_negative_errors = CreateWorkspace(
+            DataX=[1, 2, 3, 4],
+            DataY=[10, 20, 30, 40],
+            DataE=[1, -2, 3, -4],
+            OutputWorkspace="ws2d_histo_negative_errors"
+        )
         cls.ws2d_histo_non_dist = CreateWorkspace(
             DataX=[10, 20, 30, 10, 20, 30],
             DataY=[2, 3, 4, 5],
@@ -150,6 +156,10 @@ class PlotFunctionsTest(unittest.TestCase):
         funcs.errorbar(ax, self.ws2d_histo, "rs", specNum=1)
         funcs.errorbar(ax, self.ws2d_histo, specNum=2, linewidth=6)
         funcs.errorbar(ax, self.ws_MD_1d, "bo")
+
+    def test_1d_errorbars_with_negative_errors(self):
+        _, ax = plt.subplots()
+        funcs.errorbar(ax, self.ws2d_histo_negative_errors, specNum=1)
 
     def test_1d_scatter(self):
         fig, ax = plt.subplots()

--- a/docs/source/release/v6.11.0/Workbench/Bugfixes/37973.rst
+++ b/docs/source/release/v6.11.0/Workbench/Bugfixes/37973.rst
@@ -1,0 +1,1 @@
+- Fixed crash when attempting to plot data with negative error values.


### PR DESCRIPTION
### Description of work

Fix crash in the case of plotting data with negative errors.

Instead, print a warning and plot without errors.

Fixes #37973

### To test:

- Load this data with negative errors
[BCA299_Subt_QLd_Result.zip](https://github.com/user-attachments/files/17027794/BCA299_Subt_QLd_Result.zip)

- Plot Spectra with errors 6-8
- Should see a warning printed but plot opens normally.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
