### PR TITLE
Coverity issue fixes

### DIFF
--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -1384,7 +1384,7 @@ std::tuple<std::vector<double>, std::vector<double>> DiscusMultipleScatteringCor
         weightsM2[i] += deltas[i] * (weights[i] - weightsMeans[i]);
         // calculate sample SD (M2/n-1)
         // will give NaN for m_events=1, but that's correct
-        weightsErrors[i] = sqrt(weightsM2[i] / static_cast<double>(ie));
+        weightsErrors[i] = sqrt(weightsM2[i] / static_cast<double>(ie + 1));
       }
 
     } else
@@ -1441,7 +1441,7 @@ std::tuple<bool, std::vector<double>> DiscusMultipleScatteringCorrection::scatte
         for (auto &SQWSMapping : currentComponentWorkspaces)
           SQWSMapping.InvPOfQ = SQWSMapping.InvPOfQ->createCopy();
         prepareCumulativeProbForQ(k, newComponentWorkspaces);
-        currentComponentWorkspaces = newComponentWorkspaces;
+        currentComponentWorkspaces = std::move(newComponentWorkspaces);
       }
     }
     auto trackStillAlive =
@@ -1507,7 +1507,7 @@ std::tuple<bool, std::vector<double>> DiscusMultipleScatteringCorrection::scatte
       const double q = qVector.norm();
       const double finalW = fromWaveVector(k) - finalE;
       auto componentWSIt = findMatchingComponent(componentWorkspaces, shapeObjectWithScatter);
-      auto componentWSMapping = *componentWSIt; // to help debugging
+      auto &componentWSMapping = *componentWSIt; // to help debugging
       double SQ = Interpolate2D(componentWSMapping, q, finalW);
       scatteringXSection = m_NormalizeSQ ? scatteringXSection / interpolateFlat(*(componentWSMapping.QSQScaleFactor), k)
                                          : scatteringXSectionFull;

--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -1384,7 +1384,7 @@ std::tuple<std::vector<double>, std::vector<double>> DiscusMultipleScatteringCor
         weightsM2[i] += deltas[i] * (weights[i] - weightsMeans[i]);
         // calculate sample SD (M2/n-1)
         // will give NaN for m_events=1, but that's correct
-        weightsErrors[i] = sqrt(weightsM2[i] / static_cast<double>(ie + 1));
+        weightsErrors[i] = sqrt(weightsM2[i] / static_cast<double>(ie));
       }
 
     } else

--- a/Framework/Crystal/src/RotateSampleShape.cpp
+++ b/Framework/Crystal/src/RotateSampleShape.cpp
@@ -77,14 +77,14 @@ void RotateSampleShape::exec() {
     g_log.warning() << "Empty goniometer created; will always return an "
                        "identity rotation matrix.\n";
 
-  const auto sampleShapeRotation = gon.getR();
+  const auto &sampleShapeRotation = gon.getR();
   if (sampleShapeRotation == Kernel::Matrix<double>(3, 3, true)) {
     // If the resulting rotationMatrix is Identity, ignore the calculatrion
     g_log.warning("Rotation matrix set via RotateSampleShape is an Identity matrix. Ignored rotating sample shape");
     return;
   }
 
-  const auto oldRotation = ei->run().getGoniometer().getR();
+  const auto &oldRotation = ei->run().getGoniometer().getR();
   auto newSampleShapeRot = sampleShapeRotation * oldRotation;
   if (isMeshShape) {
     auto meshShape = std::dynamic_pointer_cast<MeshObject>(ei->sample().getShapePtr());


### PR DESCRIPTION
### Description of work
Fixes below coverity issues related to diffraction.

1.
```
*** CID 1561115:  Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
/jenkins_workdir/workspace/coverity_build_and_submit/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp: 1444 in Mantid::Algorithms::DiscusMultipleScatteringCorrection::scatter(int, Mantid::Kernel::PseudoRandomNumberGenerator &, const boost::container::small_vector<Mantid::Algorithms::ComponentWorkspaceMapping, (unsigned long)5, void, void> &, double, const std::vector<double, std::allocator<double>> &, bool, const Mantid::Geometry::DetectorInfo &, const unsigned long &)()
1438         if ((k != kinc)) {
1439           if (m_importanceSampling) {
1440             auto newComponentWorkspaces = componentWorkspaces;
1441             for (auto &SQWSMapping : currentComponentWorkspaces)
1442               SQWSMapping.InvPOfQ = SQWSMapping.InvPOfQ->createCopy();
1443             prepareCumulativeProbForQ(k, newComponentWorkspaces);
>>>     CID 1561115:  Performance inefficiencies  (COPY_INSTEAD_OF_MOVE)
>>>     "newComponentWorkspaces" is copied in a call to copy assignment "operator =", when it could be moved instead.
1444             currentComponentWorkspaces = newComponentWorkspaces;
1445           }
1446         }
1447         auto trackStillAlive =
1448             q_dir(track, shapeObjectWithScatter, currentComponentWorkspaces, k, scatteringXSection, rng, weight);
1449         if (!trackStillAlive)
```

2.
```
*** CID 1561112:  Performance inefficiencies  (AUTO_CAUSES_COPY)
/jenkins_workdir/workspace/coverity_build_and_submit/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp: 1510 in Mantid::Algorithms::DiscusMultipleScatteringCorrection::scatter(int, Mantid::Kernel::PseudoRandomNumberGenerator &, const boost::container::small_vector<Mantid::Algorithms::ComponentWorkspaceMapping, (unsigned long)5, void, void> &, double, const std::vector<double, std::allocator<double>> &, bool, const Mantid::Geometry::DetectorInfo &, const unsigned long &)()
1504         if (finalE > 0) {
1505           const double kout = toWaveVector(finalE);
1506           const auto qVector = directionToDetector * kout - prevDirection * k;
1507           const double q = qVector.norm();
1508           const double finalW = fromWaveVector(k) - finalE;
1509           auto componentWSIt = findMatchingComponent(componentWorkspaces, shapeObjectWithScatter);
>>>     CID 1561112:  Performance inefficiencies  (AUTO_CAUSES_COPY)
>>>     Using the "auto" keyword without an "&" causes the copy of an object of type "Mantid::Algorithms::ComponentWorkspaceMapping".
1510           auto componentWSMapping = *componentWSIt; // to help debugging
1511           double SQ = Interpolate2D(componentWSMapping, q, finalW);
1512           scatteringXSection = m_NormalizeSQ ? scatteringXSection / interpolateFlat(*(componentWSMapping.QSQScaleFactor), k)
1513                                              : scatteringXSectionFull;
1514     
1515           double AT2 = 1;
```

3.
```
*** CID 1561111:  Performance inefficiencies  (AUTO_CAUSES_COPY)
/jenkins_workdir/workspace/coverity_build_and_submit/Framework/Crystal/src/RotateSampleShape.cpp: 87 in Mantid::Crystal::RotateSampleShape::exec()()
81       if (sampleShapeRotation == Kernel::Matrix<double>(3, 3, true)) {
82         // If the resulting rotationMatrix is Identity, ignore the calculatrion
83         g_log.warning("Rotation matrix set via RotateSampleShape is an Identity matrix. Ignored rotating sample shape");
84         return;
85       }
86     
>>>     CID 1561111:  Performance inefficiencies  (AUTO_CAUSES_COPY)
>>>     Using the "auto" keyword without an "&" causes the copy of an object of type "Mantid::Kernel::DblMatrix".
87       const auto oldRotation = ei->run().getGoniometer().getR();
88       auto newSampleShapeRot = sampleShapeRotation * oldRotation;
89       if (isMeshShape) {
90         auto meshShape = std::dynamic_pointer_cast<MeshObject>(ei->sample().getShapePtr());
91         meshShape->rotate(newSampleShapeRot);
92       } else {
```


<!--
4. 
```
*** CID 1561110:  Incorrect expression  (DIVIDE_BY_ZERO)
/jenkins_workdir/workspace/coverity_build_and_submit/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp: 1387 in Mantid::Algorithms::DiscusMultipleScatteringCorrection::simulatePaths(int, int, Mantid::Kernel::PseudoRandomNumberGenerator &, const boost::container::small_vector<Mantid::Algorithms::ComponentWorkspaceMapping, (unsigned long)5, void, void> &, double, const std::vector<double, std::allocator<double>> &, bool, const Mantid::Geometry::DetectorInfo &, const unsigned long &)()
1381           for (size_t i = 0; i < wValues.size(); i++) {
1382             deltas[i] = weights[i] - weightsMeans[i];
1383             weightsMeans[i] += deltas[i] / static_cast<double>(ie + 1);
1384             weightsM2[i] += deltas[i] * (weights[i] - weightsMeans[i]);
1385             // calculate sample SD (M2/n-1)
1386             // will give NaN for m_events=1, but that's correct
>>>     CID 1561110:  Incorrect expression  (DIVIDE_BY_ZERO)
>>>     In expression "weightsM2[i] / static_cast<double>(ie)", division by expression "ie" which may be zero has undefined behavior.
1387             weightsErrors[i] = sqrt(weightsM2[i] / static_cast<double>(ie));
1388           }
1389     
1390         } else
1391           ie--;
1392       }
```
-->


4.
```
*** CID 1561108:  Performance inefficiencies  (AUTO_CAUSES_COPY)
/jenkins_workdir/workspace/coverity_build_and_submit/Framework/Crystal/src/RotateSampleShape.cpp: 80 in Mantid::Crystal::RotateSampleShape::exec()()
74       Goniometer gon;
75       prepareGoniometerAxes(gon);
76       if (gon.getNumberAxes() == 0)
77         g_log.warning() << "Empty goniometer created; will always return an "
78                            "identity rotation matrix.\n";
79     
>>>     CID 1561108:  Performance inefficiencies  (AUTO_CAUSES_COPY)
>>>     Using the "auto" keyword without an "&" causes the copy of an object of type "Mantid::Kernel::DblMatrix".
80       const auto sampleShapeRotation = gon.getR();
81       if (sampleShapeRotation == Kernel::Matrix<double>(3, 3, true)) {
82         // If the resulting rotationMatrix is Identity, ignore the calculatrion
83         g_log.warning("Rotation matrix set via RotateSampleShape is an Identity matrix. Ignored rotating sample shape");
84         return;
85       }

```

<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
CI should be green and functionality of the code should not break.

References to test:
1. `RotateSampleShape`: https://docs.mantidproject.org/nightly/algorithms/RotateSampleShape-v1.html
2. `DiscusMultipleScatteringCorrection`: https://docs.mantidproject.org/nightly/algorithms/DiscusMultipleScatteringCorrection-v1.html


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
