### PR TITLE
Check for legend existing before using in _correct_for_scroll_event_on_legend

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -171,7 +171,7 @@ class FigureInteraction(object):
     def _correct_for_scroll_event_on_legend(self, event):
         # Corrects default behaviour in Matplotlib where legend is picked up by scroll event
         legend = event.inaxes.axes.get_legend()
-        if legend.get_draggable() and legend.contains(event):
+        if legend is not None and legend.get_draggable() and legend.contains(event):
             legend_set_draggable(legend, False)
             legend_set_draggable(legend, True)
 


### PR DESCRIPTION
### Description of work

Found when doing engineering diffraction manual tests
https://github.com/mantidproject/mantid/issues/37992#issuecomment-2358011685

When scrolling on the plots created by the engineering diffraction interface (which have no legends), the following error occurred.
```
Traceback (most recent call last):
File "C:\MantidNightlyInstall\bin\lib\site-packages\matplotlib\cbook_init_.py", line 314, in process
func(*args, **kwargs)
File "C:\MantidNightlyInstall\bin\lib\site-packages\workbench\plotting\figureinteraction.py", line 141, in on_scroll
self._correct_for_scroll_event_on_legend(event)
File "C:\MantidNightlyInstall\bin\lib\site-packages\workbench\plotting\figureinteraction.py", line 174, in _correct_for_scroll_event_on_legend
if legend.get_draggable() and legend.contains(event):
AttributeError: 'NoneType' object has no attribute 'get_draggable'
```

*There is no associated issue.*

### To test:

- Turn on ISIS archive
- Open Diffraction -> Engineering Diffraction interface
- Select Create New Calibration and enter `305738`
- Click Calibrate and scroll on the plot which appears, no error should occur.

*This does not require release notes* because **changes added this release**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
