### PR TITLE
Fix ENGINX data cache search on IDAaaS

### DIFF
--- a/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
+++ b/Framework/API/inc/MantidAPI/ISISInstrumentDataCache.h
@@ -30,7 +30,7 @@ private:
   std::pair<Mantid::Kernel::InstrumentInfo, std::string> validateInstrumentAndNumber(const std::string &filename) const;
   std::filesystem::path makeIndexFilePath(const std::string &instrumentName) const;
   std::pair<std::string, std::string> splitIntoInstrumentAndNumber(const std::string &filename) const;
-  [[nodiscard]] std::pair<std::string, Json::Value>
+  [[nodiscard]] std::pair<std::filesystem::path, Json::Value>
   openCacheJsonFile(const Mantid::Kernel::InstrumentInfo &instrument) const;
   [[nodiscard]] Mantid::Kernel::InstrumentInfo getInstrumentFromName(const std::string &instName) const;
   std::string m_dataCachePath;

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -826,7 +826,8 @@ const API::Result<std::string> FileFinderImpl::getPath(const std::vector<IArchiv
     errors += cacheFilePath.errors();
 
   } else {
-    errors += "Could not find data cache directory: " + cachePathToSearch.string();
+    g_log.debug() << "Data cache directory not found, proceeding with the search." << std::endl;
+    errors += "Could not find data cache directory: " + cachePathToSearch.string() + '\n';
   }
 
   // Search the archive

--- a/Framework/API/src/ISISInstrumentDataCache.cpp
+++ b/Framework/API/src/ISISInstrumentDataCache.cpp
@@ -34,10 +34,11 @@ std::string ISISInstrumentDataCache::getFileParentDirectoryPath(const std::strin
                                 ".");
   }
 
-  std::string dirPath = jsonPath.parent_path().string() + "/" + relativePath;
+  std::filesystem::path dirPath = jsonPath.parent_path() / relativePath;
+  std::string dirPathString = dirPath.make_preferred().string();
 
-  g_log.debug() << "Found path to search: " << dirPath << std::endl;
-  return dirPath;
+  g_log.debug() << "Found path to search: " << dirPathString << std::endl;
+  return dirPathString;
 }
 
 /**

--- a/Framework/API/test/ISISInstrumentDataCacheTest.h
+++ b/Framework/API/test/ISISInstrumentDataCacheTest.h
@@ -56,33 +56,38 @@ public:
   void testInstrNameExpanded() {
     ISISInstrumentDataCache dc(m_dataCacheDir);
     std::string actualPath = dc.getFileParentDirectoryPath("MAR25054");
-    TS_ASSERT_EQUALS(actualPath, m_dataCacheDir + "/MARI/2019/RB1868000-1");
+    std::filesystem::path expectedPath = m_dataCacheDir + "/MARI/2019/RB1868000-1";
+    TS_ASSERT_EQUALS(actualPath, expectedPath.make_preferred().string());
   }
 
   void testLowerCaseInstrName() {
     ISISInstrumentDataCache dc(m_dataCacheDir);
     std::string actualPath = dc.getFileParentDirectoryPath("mar25054");
-    TS_ASSERT_EQUALS(actualPath, m_dataCacheDir + "/MARI/2019/RB1868000-1");
+    std::filesystem::path expectedPath = m_dataCacheDir + "/MARI/2019/RB1868000-1";
+    TS_ASSERT_EQUALS(actualPath, expectedPath.make_preferred().string());
   }
 
   void testCorrectInstrRunSplit() {
     ISISInstrumentDataCache dc(m_dataCacheDir);
     std::string actualPath = dc.getFileParentDirectoryPath("SANS2D101115");
-    TS_ASSERT_EQUALS(actualPath, m_dataCacheDir + "/SANS2D/2018/RB1800009-2");
+    std::filesystem::path expectedPath = m_dataCacheDir + "/SANS2D/2018/RB1800009-2";
+    TS_ASSERT_EQUALS(actualPath, expectedPath.make_preferred().string());
   }
 
   void testInstrWithDelimiter() {
     // Checks short name + delimiter gets correctly identified
     ISISInstrumentDataCache dc(m_dataCacheDir);
     std::string actualPath = dc.getFileParentDirectoryPath("PG3_11111");
-    TS_ASSERT_EQUALS(actualPath, m_dataCacheDir + "/POWGEN/mock/path");
+    std::filesystem::path expectedPath = m_dataCacheDir + "/POWGEN/mock/path";
+    TS_ASSERT_EQUALS(actualPath, expectedPath.make_preferred().string());
   }
 
   void testShortNameIsTried() {
     // Name ENGIN-X is tried first and if it fails it tries ENGINX
     ISISInstrumentDataCache dc(m_dataCacheDir);
     std::string actualPath = dc.getFileParentDirectoryPath("ENGINX55555");
-    TS_ASSERT_EQUALS(actualPath, m_dataCacheDir + "/ENGINX/subdir1/subdir2");
+    std::filesystem::path expectedPath = m_dataCacheDir + "/ENGINX/subdir1/subdir2";
+    TS_ASSERT_EQUALS(actualPath, expectedPath.make_preferred().string());
   }
 
   void testInstrWithSuffix() {

--- a/Framework/API/test/ISISInstrumentDataCacheTest.h
+++ b/Framework/API/test/ISISInstrumentDataCacheTest.h
@@ -31,12 +31,12 @@ public:
     std::string sansJson = R"({"101115": "2018/RB1800009-2"})";
     std::string pg3Json = R"({"11111": "mock/path"})";
     std::string wishJson = R"({"12345": "subdir1/subdir2"})";
+    std::string enginxJson = R"({"55555": "subdir1/subdir2"})";
 
-    // Create test JSON file
     std::filesystem::create_directory(m_dataCacheDir);
 
     std::unordered_map<std::string, std::string> instrFiles = {
-        {"MARI", marJson}, {"SANS2D", sansJson}, {"POWGEN", pg3Json}, {"WISH", wishJson}};
+        {"MARI", marJson}, {"SANS2D", sansJson}, {"POWGEN", pg3Json}, {"WISH", wishJson}, {"ENGINX", enginxJson}};
     for (const auto &[instrName, instrIndex] : instrFiles) {
 
       std::filesystem::create_directory(m_dataCacheDir + "/" + instrName);
@@ -78,6 +78,13 @@ public:
     TS_ASSERT_EQUALS(actualPath, m_dataCacheDir + "/POWGEN/mock/path");
   }
 
+  void testShortNameIsTried() {
+    // Name ENGIN-X is tried first and if it fails it tries ENGINX
+    ISISInstrumentDataCache dc(m_dataCacheDir);
+    std::string actualPath = dc.getFileParentDirectoryPath("ENGINX55555");
+    TS_ASSERT_EQUALS(actualPath, m_dataCacheDir + "/ENGINX/subdir1/subdir2");
+  }
+
   void testInstrWithSuffix() {
     ISISInstrumentDataCache dc(m_dataCacheDir);
     TS_ASSERT_THROWS_EQUALS(dc.getFileParentDirectoryPath("LOQ11111-add"), const std::invalid_argument &e,
@@ -106,7 +113,7 @@ public:
   void testRunNumberNotFound() {
     ISISInstrumentDataCache dc(m_dataCacheDir);
     TS_ASSERT_THROWS_EQUALS(dc.getFileParentDirectoryPath("SANS2D1234"), const std::invalid_argument &e,
-                            std::string(e.what()), "Run number 1234 not found for instrument SANS2D.");
+                            std::string(e.what()), "Run number 1234 not found in index file SANS2D_index.json.");
   }
 
   void testIndexFileExistsWhenExists() {

--- a/docs/source/release/v6.11.0/Framework/Data_Objects/Bugfixes/38027.rst
+++ b/docs/source/release/v6.11.0/Framework/Data_Objects/Bugfixes/38027.rst
@@ -1,1 +1,1 @@
-- Loading `ENGIN-X` data on IDAaaS from the insttrument data cache no longer throws a path not found error.
+- Loading ``ENGIN-X`` data on IDAaaS from the instrument data cache no longer throws a "path not found" error.

--- a/docs/source/release/v6.11.0/Framework/Data_Objects/Bugfixes/38027.rst
+++ b/docs/source/release/v6.11.0/Framework/Data_Objects/Bugfixes/38027.rst
@@ -1,0 +1,1 @@
+- Loading `ENGIN-X` data on IDAaaS from the insttrument data cache no longer throws a path not found error.


### PR DESCRIPTION
### Description of work
From the issue described in https://github.com/mantidproject/mantid/issues/37398, the ENGINX files were still not being found in the data cache because part of the path was still using `ENGIN-X` instead of `ENGINX`.

#### Summary of work
I changed a few lines of code that ensure that when the shortname of the instrument is used (`ENGINX`) to find the index file, the path is also constructed consistently with this, and uses the shortname version.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->
Access ENGINX files easily on IDAaaS from the data cache.
Fixes #37398 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
Test with build number 892.
1. Install `mantid` python package (workbench not needed) with `conda install -c guimacielpereira/label/fix-enginx mantid`
2. Open python interpreter on terminal by typing `python`
3. Run:
```
from mantid.simpleapi import Load
Load("ENGINX283000")
```
4. Should get an error with permissions denied, but the path it tried to access should be printed 
5. The important bit is that the path shows the file was trying to be accessed inside the folder `ENGINX` instead of `ENGIN-X`


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
