### PR TITLE
Remove workspace history workaround from binaryOpertaions

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
@@ -130,34 +130,13 @@ ResultType performBinaryOp(const LHSType lhs, const RHSType rhs, const std::stri
 template <typename LHSType, typename ResultType>
 ResultType performBinaryOpWithDouble(const LHSType inputWS, const double value, const std::string &op,
                                      const std::string &name, bool inplace, bool reverse) {
-  // RAII struct to add/remove workspace from ADS
-  struct ScopedADSEntry {
-    ScopedADSEntry(const std::string &entryName, const MatrixWorkspace_sptr &value) : name(entryName) {
-      ads.addOrReplace(entryName, value);
-    }
-    ~ScopedADSEntry() { ads.remove(name); }
 
-    const std::string &name;
-    API::AnalysisDataServiceImpl &ads = API::AnalysisDataService::Instance();
-  };
-
-  // In order to recreate a history record of the final binary operation
-  // there must be a record of the creation of the single value workspace used
-  // on the RHS here. This is achieved by running CreateSingleValuedWorkspace
-  // algorithm and adding the output workspace to the ADS. Adding the output
-  // to the ADS is critical so that workspace.name() is updated, by the ADS, to
-  // return the same string. WorkspaceProperty<TYPE>::createHistory() then
-  // records the correct workspace name for input into the final binary
-  // operation rather than creating a temporary name.
   auto alg = API::AlgorithmManager::Instance().createUnmanaged("CreateSingleValuedWorkspace");
   alg->setChild(false);
-  // we manually store the workspace as it's easier to retrieve the correct
-  // type from alg->getProperty rather than calling the ADS again and casting
   alg->setAlwaysStoreInADS(false);
   alg->initialize();
   alg->setProperty<double>("DataValue", value);
-  const std::string tmpName("__python_binary_op_single_value");
-  alg->setPropertyValue("OutputWorkspace", tmpName);
+  alg->setPropertyValue("OutputWorkspace", "python_binary_op_single_value");
   { // instantiate releaseGIL in limited scope to allow for repeat in 'performBinaryOp'
     ReleaseGlobalInterpreterLock releaseGIL;
     alg->execute();
@@ -170,7 +149,6 @@ ResultType performBinaryOpWithDouble(const LHSType inputWS, const double value, 
     throw std::runtime_error("performBinaryOp: Error in execution of "
                              "CreateSingleValuedWorkspace");
   }
-  ScopedADSEntry removeOnExit(tmpName, singleValue);
   ResultType result =
       performBinaryOp<LHSType, MatrixWorkspace_sptr, ResultType>(inputWS, singleValue, op, name, inplace, reverse);
   return result;


### PR DESCRIPTION
### Description of work

Previously, there was a workaround in `BinaryOperations::performBinaryOpWithDouble` to ensure that workspace history was preserved. This involved adding a workspace briefly to the ads in order to give it a `name` property.

Since the pr https://github.com/mantidproject/mantid/pull/37839, algorithms run with `storeInADS=False` should have their histories reconstructed correctly, and not need such workarounds.

I think what's now happening in the function is covered by tests added in the previous pr.

Fixes #38018

### To test:

Follow instructions from issue, running test 3 from project recovery test.

This issue in particular is with workspace binary ops so you could run something like
```
ws = CreateSampleWorkspace()
ws *= 2
```
Then generate the workspace history and check it is correct. (right-click, Show History, Script to Cliboard).

*This does not require release notes* because **added this release**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
