### PR TITLE
Fix restricted suffix not working on Elwin interface.

### DIFF
--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/38041.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/38041.rst
@@ -1,0 +1,1 @@
+- Data unrestricted by suffix can be loaded on   :ref:`Elwin Tab <elwin>` of the :ref:`Data Processor Interface <interface-inelastic-data-processor>` if the option is selected from Settings.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
@@ -54,7 +54,7 @@ public:
 
   StringPairVec retrieveSelectedNameIndexPairs();
 
-  QStringList getWSSuffixes() const;
+  QStringList getWSSuffixes();
   void setWSSuffixes(const QStringList &suffix);
 
   bool isValid() const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
@@ -54,7 +54,7 @@ public:
 
   StringPairVec retrieveSelectedNameIndexPairs();
 
-  QStringList getWSSuffixes();
+  const QStringList &getWSSuffixes() const;
   void setWSSuffixes(const QStringList &suffix);
 
   bool isValid() const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceMultiSelector.h
@@ -34,16 +34,14 @@ double underscore at the start of the
           workspace name
  * By providing a suffix that the workspace name must have
 */
-class EXPORT_OPT_MANTIDQT_COMMON WorkspaceMultiSelector : public QTableWidget {
+class EXPORT_OPT_MANTIDQT_COMMON WorkspaceMultiSelector final : public QTableWidget {
   Q_OBJECT
 
-  Q_PROPERTY(QStringList WorkspaceTypes READ getWorkspaceTypes WRITE setWorkspaceTypes)
-  Q_PROPERTY(bool ShowGroups READ showWorkspaceGroups WRITE showWorkspaceGroups)
   Q_PROPERTY(QStringList Suffix READ getWSSuffixes WRITE setWSSuffixes)
 
 public:
   /// Default Constructor
-  explicit WorkspaceMultiSelector(QWidget *parent = 0, bool init = true);
+  explicit WorkspaceMultiSelector(QWidget *parent = nullptr);
 
   /// Destructor
   ~WorkspaceMultiSelector() override;
@@ -54,19 +52,15 @@ public:
   void resetIndexRangeToDefault();
   void unifyRange();
 
-  bool showWorkspaceGroups() const;
-  void showWorkspaceGroups(bool show);
   StringPairVec retrieveSelectedNameIndexPairs();
 
-  QStringList getWorkspaceTypes() const;
   QStringList getWSSuffixes() const;
-  void setWorkspaceTypes(const QStringList &types);
   void setWSSuffixes(const QStringList &suffix);
 
   bool isValid() const;
 
-  void connectObservers();
-  void disconnectObservers();
+  void connectObservers() const;
+  void disconnectObservers() const;
 
 signals:
   void emptied();
@@ -98,14 +92,7 @@ private:
   Poco::NObserver<WorkspaceMultiSelector, Mantid::API::WorkspaceRenameNotification> m_renameObserver;
   Poco::NObserver<WorkspaceMultiSelector, Mantid::API::WorkspaceAfterReplaceNotification> m_replaceObserver;
 
-  bool m_init;
-
-  /// A list of workspace types that should be shown in the QtableWidget
-  QStringList m_workspaceTypes;
-  // show/hide workspace groups
-  bool m_showGroups;
   QStringList m_suffix;
-
   // Mutex for synchronized event handling
   std::mutex m_adsMutex;
 };

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -102,7 +102,7 @@ bool WorkspaceMultiSelector::isValid() const {
   return (item != nullptr);
 }
 
-QStringList WorkspaceMultiSelector::getWSSuffixes() { return m_suffix; }
+const QStringList &WorkspaceMultiSelector::getWSSuffixes() const { return m_suffix; }
 
 void WorkspaceMultiSelector::setWSSuffixes(const QStringList &suffix) {
   if (suffix != m_suffix)

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -102,7 +102,7 @@ bool WorkspaceMultiSelector::isValid() const {
   return (item != nullptr);
 }
 
-QStringList WorkspaceMultiSelector::getWSSuffixes() const { return m_suffix; }
+QStringList WorkspaceMultiSelector::getWSSuffixes() { return m_suffix; }
 
 void WorkspaceMultiSelector::setWSSuffixes(const QStringList &suffix) {
   if (suffix != m_suffix)

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -44,17 +44,14 @@ QStringList headerLabels = {"Workspace Name", "Ws Index"};
 namespace MantidQt {
 namespace MantidWidgets {
 
-WorkspaceMultiSelector::WorkspaceMultiSelector(QWidget *parent, bool init)
+WorkspaceMultiSelector::WorkspaceMultiSelector(QWidget *parent)
     : QTableWidget(parent), m_addObserver(*this, &WorkspaceMultiSelector::handleAddEvent),
       m_remObserver(*this, &WorkspaceMultiSelector::handleRemEvent),
       m_clearObserver(*this, &WorkspaceMultiSelector::handleClearEvent),
       m_renameObserver(*this, &WorkspaceMultiSelector::handleRenameEvent),
-      m_replaceObserver(*this, &WorkspaceMultiSelector::handleReplaceEvent), m_init(init), m_workspaceTypes(),
-      m_showGroups(false), m_suffix() {
-
-  if (init) {
-    connectObservers();
-  }
+      m_replaceObserver(*this, &WorkspaceMultiSelector::handleReplaceEvent), m_suffix(QStringList()) {
+  connectObservers();
+  refresh();
 }
 
 /**
@@ -80,51 +77,24 @@ void WorkspaceMultiSelector::setupTable() {
 /**
  * De-subscribes this object from the Poco NotificationCentre
  */
-void WorkspaceMultiSelector::disconnectObservers() {
-  if (m_init) {
-    Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_addObserver);
-    Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_remObserver);
-    Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_clearObserver);
-    Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_renameObserver);
-    Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_replaceObserver);
-    m_init = false;
-  }
+void WorkspaceMultiSelector::disconnectObservers() const {
+  Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_addObserver);
+  Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_remObserver);
+  Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_clearObserver);
+  Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_renameObserver);
+  Mantid::API::AnalysisDataService::Instance().notificationCenter.removeObserver(m_replaceObserver);
 }
 
 /**
  * Subscribes this object to the Poco NotificationCentre
  */
-void WorkspaceMultiSelector::connectObservers() {
+void WorkspaceMultiSelector::connectObservers() const {
   Mantid::API::AnalysisDataServiceImpl &ads = Mantid::API::AnalysisDataService::Instance();
   ads.notificationCenter.addObserver(m_addObserver);
   ads.notificationCenter.addObserver(m_remObserver);
   ads.notificationCenter.addObserver(m_renameObserver);
   ads.notificationCenter.addObserver(m_clearObserver);
   ads.notificationCenter.addObserver(m_replaceObserver);
-  refresh();
-  m_init = true;
-}
-
-QStringList WorkspaceMultiSelector::getWorkspaceTypes() const { return m_workspaceTypes; }
-
-void WorkspaceMultiSelector::setWorkspaceTypes(const QStringList &types) {
-  if (types != m_workspaceTypes) {
-    m_workspaceTypes = types;
-    if (m_init) {
-      refresh();
-    }
-  }
-}
-
-bool WorkspaceMultiSelector::showWorkspaceGroups() const { return m_showGroups; }
-
-void WorkspaceMultiSelector::showWorkspaceGroups(bool show) {
-  if (show != m_showGroups) {
-    m_showGroups = show;
-    if (m_init) {
-      refresh();
-    }
-  }
 }
 
 bool WorkspaceMultiSelector::isValid() const {
@@ -135,12 +105,9 @@ bool WorkspaceMultiSelector::isValid() const {
 QStringList WorkspaceMultiSelector::getWSSuffixes() const { return m_suffix; }
 
 void WorkspaceMultiSelector::setWSSuffixes(const QStringList &suffix) {
-  if (suffix != m_suffix) {
+  if (suffix != m_suffix)
     m_suffix = suffix;
-    if (m_init) {
-      refresh();
-    }
-  }
+  refresh();
 }
 
 void WorkspaceMultiSelector::addItem(const std::string &name) {
@@ -274,14 +241,9 @@ void WorkspaceMultiSelector::handleReplaceEvent(Mantid::API::WorkspaceAfterRepla
 }
 
 bool WorkspaceMultiSelector::checkEligibility(const std::string &name) const {
-  auto &ads = Mantid::API::AnalysisDataService::Instance();
-  auto workspace = ads.retrieve(name);
-  if ((!m_workspaceTypes.empty()) && m_workspaceTypes.indexOf(QString::fromStdString(workspace->id())) == -1)
+  auto const workspace = Mantid::API::AnalysisDataService::Instance().retrieve(name);
+  if (workspace->isGroup() || !hasValidSuffix(name))
     return false;
-  else if (!hasValidSuffix(name))
-    return false;
-  else if (!m_showGroups)
-    return std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(workspace) == nullptr;
   return true;
 }
 
@@ -296,8 +258,7 @@ bool WorkspaceMultiSelector::hasValidSuffix(const std::string &name) const {
 void WorkspaceMultiSelector::refresh() {
   const std::lock_guard<std::mutex> lock(m_adsMutex);
   this->clearContents();
-  auto &ads = Mantid::API::AnalysisDataService::Instance();
-  auto items = ads.getObjectNames();
+  auto const items = Mantid::API::AnalysisDataService::Instance().getObjectNames();
   addItems(items);
 }
 

--- a/qt/widgets/common/src/WorkspaceMultiSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceMultiSelector.cpp
@@ -105,8 +105,7 @@ bool WorkspaceMultiSelector::isValid() const {
 const QStringList &WorkspaceMultiSelector::getWSSuffixes() const { return m_suffix; }
 
 void WorkspaceMultiSelector::setWSSuffixes(const QStringList &suffix) {
-  if (suffix != m_suffix)
-    m_suffix = suffix;
+  m_suffix = suffix;
   refresh();
 }
 


### PR DESCRIPTION
### Description of work
Fixes #38041 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
The WorkspaceMultiSelector widget was created from the DataSelector widget, but there are many functions of the DataSelector which don't need to be used (and probably we won't need to use them in the future) and clutter the class. I have remove the workspacetype and show group properties of the table and simplify the code where possible. Additionally, the suffix was not being properly updated when initiating the class, which may be why the unrestricted setting was being ignored. 

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38041. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
Note: this test modifies the Procesor interface settings, which is done from a Settings dialog, everytime you change a Settings, make sure to click the button `Apply` and then `Ok` for the setting to change. 
- Load any data. 
- Open Data Processor interface. 
- Click on Settings icon (cog), make sure to untick the `Restrict allowed input files.. .` checkbox.
- Go to the Elwin tab, and click on `Add Workspaces`. The resulting dialog should contain a table with 1 entry with the same data as that you added on step 1. 
- Close the Dialog. 
- Go to Settings again, and this time tick the `Restrict allowed input files..` checkbox. 
- Go to the elwin tab, click on `Add Workspaces`, the resulting dialog should contain no data (unless the data you loaded had suffix _red or _sqw) 
- Close the dialog and the Data Processor interface. 
- Clear the ADS. 
- Load any _red data (for example irs26176_graphite002_red from SampleData-ISIS). 
- Open the Data Processor interface, check that the Settings `Restrict allowed input..` is ticked. Then on Elwin tab click on `Add Workspaces` and in the resulting dialog you should see an entry with the data that you added to the ADS(irs26176..) . 
- Close the dialog, and in the Settings dialog, untick again the `Restrict allowed input..` checkbox. 
- Wehn opening again the `Add Workspaces` dialog from the Elwin tab, you should still see the data that you added (irs26176...)

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
