### PR TITLE
Fix Inelastic Symmetrise Preview crash

### DIFF
--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
@@ -44,7 +44,7 @@ SymmetrisePresenter::SymmetrisePresenter(QWidget *parent,
 SymmetrisePresenter::~SymmetrisePresenter() { m_propTrees["SymmPropTree"]->unsetFactoryForManager(m_dblManager); }
 
 void SymmetrisePresenter::handleValidation(IUserInputValidator *validator) const {
-  validateDataIsOfType(validator, m_view->getDataSelector(), "Sample", DataType::Red);
+  validateDataIsOfType(validator, m_view->getDataSelector(), "Sample", DataType::Red, false, false);
 }
 
 void SymmetrisePresenter::handleRun() {

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
@@ -18,6 +18,8 @@ using namespace MantidQt::CustomInterfaces::InterfaceUtils;
 
 namespace {
 Mantid::Kernel::Logger g_log("SymmetrisePresenter");
+
+auto &ads = Mantid::API::AnalysisDataService::Instance();
 } // namespace
 
 namespace MantidQt {
@@ -29,8 +31,7 @@ namespace CustomInterfaces {
 SymmetrisePresenter::SymmetrisePresenter(QWidget *parent,
                                          std::unique_ptr<MantidQt::API::IAlgorithmRunner> algorithmRunner,
                                          ISymmetriseView *view, std::unique_ptr<ISymmetriseModel> model)
-    : DataProcessor(parent, std::move(algorithmRunner)), m_adsInstance(Mantid::API::AnalysisDataService::Instance()),
-      m_view(view), m_model(std::move(model)), m_isPreview(false) {
+    : DataProcessor(parent, std::move(algorithmRunner)), m_view(view), m_model(std::move(model)), m_isPreview(false) {
   m_view->subscribePresenter(this);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_view->getRunView()));
   setOutputPlotOptionsPresenter(
@@ -57,7 +58,7 @@ void SymmetrisePresenter::handleRun() {
 
   // Return if no data has been loaded
   auto const dataWorkspaceName = m_view->getDataName();
-  if (dataWorkspaceName.empty())
+  if (!ads.doesExist(dataWorkspaceName))
     return;
   // Return if E range is incorrect
   if (!m_view->verifyERange(dataWorkspaceName))

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.h
@@ -78,7 +78,6 @@ private:
   void setFileExtensionsByName(bool filter) override;
   void setLoadHistory(bool doLoadHistory) override;
 
-  Mantid::API::AnalysisDataServiceImpl &m_adsInstance;
   ISymmetriseView *m_view;
   std::unique_ptr<ISymmetriseModel> m_model;
   // wether batch algorunner is running preview or run buttons

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
@@ -61,7 +61,6 @@ class EXPORT_OPT_MANTIDQT_COMMON DataSelector : public API::MantidWidget {
 
   // These are global properties of data selector
   Q_PROPERTY(bool optional READ isOptional WRITE isOptional)
-  Q_PROPERTY(bool autoLoad READ willAutoLoad WRITE setAutoLoad)
   Q_PROPERTY(QString loadLabelText READ getLoadBtnText WRITE setLoadBtnText)
 
 public:
@@ -73,7 +72,7 @@ public:
   /// Get the workspace name from the list of files
   QString getWsNameFromFiles() const;
   /// Get the currently available file or workspace name
-  virtual QString getCurrentDataName() const;
+  virtual QString getCurrentDataName(bool const autoLoad = true) const;
   /// Sets which selector (file or workspace) is visible
   void setSelectorIndex(int index);
   /// Sets if the option to choose selector is visible
@@ -85,7 +84,7 @@ public:
   /// Get whether the workspace selector is currently being shown
   bool isWorkspaceSelectorVisible() const;
   /// Checks if widget is in a valid state
-  virtual bool isValid();
+  virtual bool isValid(bool const autoLoad = true);
   /// Get file problem, empty string means no error.
   QString getProblem() const;
   /// Read settings from the given group
@@ -96,10 +95,6 @@ public:
   bool isOptional() const;
   /// Sets if optional
   void isOptional(bool /*optional*/);
-  /// Gets will auto load
-  bool willAutoLoad() const;
-  /// Sets will auto load
-  void setAutoLoad(bool /*load*/);
   /// Check if the widget will show the load button
   bool willShowLoad();
   /// Set if the load button should be shown
@@ -376,8 +371,6 @@ private:
   Mantid::API::AlgorithmRuntimeProps m_loadProperties;
   /// Algorithm Runner used to run the load algorithm
   MantidQt::API::QtAlgorithmRunner m_algRunner;
-  /// Flag to enable auto loading. By default this is set to true.
-  bool m_autoLoad;
   /// Flag to show or hide the load button. By default this is set to true.
   bool m_showLoad;
   /// Flag if optional

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MockUserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MockUserInputValidator.h
@@ -23,7 +23,8 @@ public:
   MOCK_METHOD3(checkFieldIsValid, bool(const QString &errorMessage, QLineEdit *field, QLabel *errorLabel));
   MOCK_METHOD2(checkWorkspaceSelectorIsNotEmpty, bool(const QString &name, WorkspaceSelector *workspaceSelector));
   MOCK_METHOD2(checkFileFinderWidgetIsValid, bool(const QString &name, const FileFinderWidget *widget));
-  MOCK_METHOD3(checkDataSelectorIsValid, bool(const QString &name, DataSelector *widget, bool silent));
+  MOCK_METHOD4(checkDataSelectorIsValid,
+               bool(const QString &name, DataSelector *widget, bool const silent, bool const autoLoad));
   MOCK_METHOD3(checkWorkspaceGroupIsValid, bool(QString const &groupName, QString const &inputType, bool silent));
   MOCK_METHOD2(checkWorkspaceExists, bool(QString const &workspaceName, bool silent));
   MOCK_METHOD2(checkValidRange, bool(QString const &name, std::pair<double, double> range));

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -32,7 +32,8 @@ public:
   virtual bool checkFieldIsValid(const QString &errorMessage, QLineEdit *field, QLabel *errorLabel = nullptr) = 0;
   virtual bool checkWorkspaceSelectorIsNotEmpty(const QString &name, WorkspaceSelector *workspaceSelector) = 0;
   virtual bool checkFileFinderWidgetIsValid(const QString &name, const FileFinderWidget *widget) = 0;
-  virtual bool checkDataSelectorIsValid(const QString &name, DataSelector *widget, bool silent = false) = 0;
+  virtual bool checkDataSelectorIsValid(const QString &name, DataSelector *widget, bool const silent = false,
+                                        bool const autoLoad = true) = 0;
   virtual bool checkWorkspaceGroupIsValid(QString const &groupName, QString const &inputType, bool silent = false) = 0;
   virtual bool checkWorkspaceExists(QString const &workspaceName, bool silent = false) = 0;
   virtual bool checkValidRange(const QString &name, std::pair<double, double> range) = 0;
@@ -76,7 +77,8 @@ public:
   /// Check that the given FileFinderWidget widget has valid files.
   bool checkFileFinderWidgetIsValid(const QString &name, const FileFinderWidget *widget) override;
   /// Check that the given DataSelector widget has valid input.
-  bool checkDataSelectorIsValid(const QString &name, DataSelector *widget, bool silent = false) override;
+  bool checkDataSelectorIsValid(const QString &name, DataSelector *widget, bool const silent = false,
+                                bool const autoLoad = true) override;
   /// Check that the given start and end range is valid.
   bool checkValidRange(const QString &name, std::pair<double, double> range) override;
   /// Check that the given ranges dont overlap.

--- a/qt/widgets/common/src/DataSelector.cpp
+++ b/qt/widgets/common/src/DataSelector.cpp
@@ -61,8 +61,7 @@ void makeGroup(std::string const &workspaceName) {
 namespace MantidQt::MantidWidgets {
 
 DataSelector::DataSelector(QWidget *parent)
-    : API::MantidWidget(parent), m_loadProperties(), m_algRunner(), m_autoLoad(true), m_showLoad(true),
-      m_alwaysLoadAsGroup(false) {
+    : API::MantidWidget(parent), m_loadProperties(), m_algRunner(), m_showLoad(true), m_alwaysLoadAsGroup(false) {
   m_uiForm.setupUi(this);
   connect(m_uiForm.cbInputType, SIGNAL(currentIndexChanged(int)), this, SLOT(handleViewChanged(int)));
   connect(m_uiForm.pbLoadFile, SIGNAL(clicked()), this, SIGNAL(loadClicked()));
@@ -106,14 +105,8 @@ void DataSelector::handleFileInput() {
     return;
   }
 
-  // attempt to load the file
-  if (m_autoLoad) {
-    emit filesAutoLoaded();
-    autoLoadFile(filename);
-  } else {
-    // files were found
-    emit filesFound();
-  }
+  emit filesAutoLoaded();
+  autoLoadFile(filename);
 }
 
 /**
@@ -148,10 +141,10 @@ bool DataSelector::isWorkspaceSelectorVisible() const { return !isFileSelectorVi
  *
  * Checks using the relvant widgets isValid method depending
  * on what view is currently being shown
- *
+ * @param autoLoad :: Whether to automatically load the data if it is not found in the ADS.
  * @return :: If the data selector is valid
  */
-bool DataSelector::isValid() {
+bool DataSelector::isValid(bool const autoLoad) {
   bool isValid = false;
 
   if (isFileSelectorVisible()) {
@@ -159,7 +152,7 @@ bool DataSelector::isValid() {
 
     // check to make sure the user hasn't deleted the auto-loaded file
     // since choosing it.
-    if (isValid && m_autoLoad) {
+    if (isValid && autoLoad) {
       auto const wsName = getCurrentDataName().toStdString();
 
       isValid = !wsName.empty();
@@ -344,10 +337,10 @@ QString DataSelector::getWsNameFromFiles() const {
  * If multiple files are allowed, and auto-loading is off, it will return the
  * full user input.
  * If there is no valid input the method returns an empty string.
- *
+ * @param autoLoad :: Whether or not autoload is turned on.
  * @return The name of the current data item
  */
-QString DataSelector::getCurrentDataName() const {
+QString DataSelector::getCurrentDataName(bool const autoLoad) const {
   QString filename("");
 
   int index = m_uiForm.stackedDataSelect->currentIndex();
@@ -356,7 +349,7 @@ QString DataSelector::getCurrentDataName() const {
   case 0:
     // the file selector is visible
     if (m_uiForm.rfFileInput->isValid()) {
-      if (m_uiForm.rfFileInput->allowMultipleFiles() && !m_autoLoad) {
+      if (m_uiForm.rfFileInput->allowMultipleFiles() && !autoLoad) {
         // if multiple files are allowed, auto-loading is not on, return the
         // full user input
         filename = getFullFilePath();
@@ -373,20 +366,6 @@ QString DataSelector::getCurrentDataName() const {
 
   return filename;
 }
-
-/**
- * Gets whether the widget will attempt to auto load files
- *
- * @return Whether the widget will auto load
- */
-bool DataSelector::willAutoLoad() const { return m_autoLoad; }
-
-/**
- * Sets whether the widget will attempt to auto load files.
- *
- * @param load :: Whether the widget will auto load
- */
-void DataSelector::setAutoLoad(bool load) { m_autoLoad = load; }
 
 /**
  * Gets the text displayed on the load button

--- a/qt/widgets/common/src/DataSelector.cpp
+++ b/qt/widgets/common/src/DataSelector.cpp
@@ -263,16 +263,15 @@ void DataSelector::setLoadProperty(std::string const &propertyName, bool const v
  * @param error :: Whether loading completed without error
  */
 void DataSelector::handleAutoLoadComplete(bool error) {
-  if (!error) {
-    if (m_alwaysLoadAsGroup) {
-      makeGroup(getWsNameFromFiles().toStdString());
-    }
+  m_uiForm.rfFileInput->setFileProblem(error ? "Could not load file. See log for details." : "");
 
-    // emit that we got a valid workspace/file to work with
-    emit dataReady(getWsNameFromFiles());
-  } else {
-    m_uiForm.rfFileInput->setFileProblem("Could not load file. See log for details.");
+  if (error) {
+    return;
   }
+  if (m_alwaysLoadAsGroup) {
+    makeGroup(getWsNameFromFiles().toStdString());
+  }
+  emit dataReady(getWsNameFromFiles());
 }
 
 /**

--- a/qt/widgets/common/src/UserInputValidator.cpp
+++ b/qt/widgets/common/src/UserInputValidator.cpp
@@ -139,6 +139,7 @@ bool UserInputValidator::checkFileFinderWidgetIsValid(const QString &name, const
  * @param name   :: the "name" of the widget so as to be recognised by the user.
  * @param widget :: the widget to check
  * @param silent True if an error should not be added to the validator.
+ * @param autoLoad True if the data should be reloaded if it is not in the ADS.
  * @returns True if the input was valid
  */
 bool UserInputValidator::checkDataSelectorIsValid(const QString &name, DataSelector *widget, bool const silent,

--- a/qt/widgets/common/src/UserInputValidator.cpp
+++ b/qt/widgets/common/src/UserInputValidator.cpp
@@ -141,8 +141,9 @@ bool UserInputValidator::checkFileFinderWidgetIsValid(const QString &name, const
  * @param silent True if an error should not be added to the validator.
  * @returns True if the input was valid
  */
-bool UserInputValidator::checkDataSelectorIsValid(const QString &name, DataSelector *widget, bool silent) {
-  if (!widget->isValid()) {
+bool UserInputValidator::checkDataSelectorIsValid(const QString &name, DataSelector *widget, bool const silent,
+                                                  bool const autoLoad) {
+  if (!widget->isValid(autoLoad)) {
     addErrorMessage(name.toStdString() + " error: " + widget->getProblem().toStdString(), silent);
     return false;
   }

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/DataValidationHelper.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/DataValidationHelper.h
@@ -16,27 +16,32 @@ enum DataType { Red, Sqw, Calib, Corrections };
 MANTID_SPECTROSCOPY_DLL bool validateDataIsOneOf(MantidQt::CustomInterfaces::IUserInputValidator *uiv,
                                                  MantidQt::MantidWidgets::DataSelector *dataSelector,
                                                  std::string const &inputType, DataType const &primaryType,
-                                                 std::vector<DataType> const &otherTypes, bool silent = false);
+                                                 std::vector<DataType> const &otherTypes, bool const silent = false,
+                                                 bool const autoLoad = true);
 
 MANTID_SPECTROSCOPY_DLL bool validateDataIsOfType(MantidQt::CustomInterfaces::IUserInputValidator *uiv,
                                                   MantidQt::MantidWidgets::DataSelector *dataSelector,
                                                   std::string const &inputType, DataType const &type,
-                                                  bool silent = false);
+                                                  bool const silent = false, bool const autoLoad = true);
 
 MANTID_SPECTROSCOPY_DLL bool validateDataIsAReducedFile(MantidQt::CustomInterfaces::IUserInputValidator *uiv,
                                                         MantidQt::MantidWidgets::DataSelector *dataSelector,
-                                                        std::string const &inputType, bool silent = false);
+                                                        std::string const &inputType, bool const silent = false,
+                                                        bool const autoLoad = true);
 
 MANTID_SPECTROSCOPY_DLL bool validateDataIsASqwFile(MantidQt::CustomInterfaces::IUserInputValidator *uiv,
                                                     MantidQt::MantidWidgets::DataSelector *dataSelector,
-                                                    std::string const &inputType, bool silent = false);
+                                                    std::string const &inputType, bool const silent = false,
+                                                    bool const autoLoad = true);
 
 MANTID_SPECTROSCOPY_DLL bool validateDataIsACalibrationFile(MantidQt::CustomInterfaces::IUserInputValidator *uiv,
                                                             MantidQt::MantidWidgets::DataSelector *dataSelector,
-                                                            std::string const &inputType, bool silent = false);
+                                                            std::string const &inputType, bool const silent = false,
+                                                            bool const autoLoad = true);
 
 MANTID_SPECTROSCOPY_DLL bool validateDataIsACorrectionsFile(MantidQt::CustomInterfaces::IUserInputValidator *uiv,
                                                             MantidQt::MantidWidgets::DataSelector *dataSelector,
-                                                            std::string const &inputType, bool silent = false);
+                                                            std::string const &inputType, bool const silent = false,
+                                                            bool const autoLoad = true);
 
 } // namespace DataValidationHelper

--- a/qt/widgets/spectroscopy/src/DataValidationHelper.cpp
+++ b/qt/widgets/spectroscopy/src/DataValidationHelper.cpp
@@ -28,9 +28,11 @@ namespace DataValidationHelper {
  * @return True if the data is valid.
  */
 bool validateDataIsOneOf(IUserInputValidator *uiv, DataSelector *dataSelector, std::string const &inputType,
-                         DataType const &primaryType, std::vector<DataType> const &otherTypes, bool silent) {
-  if (std::any_of(otherTypes.cbegin(), otherTypes.cend(),
-                  [&](auto const &type) { return validateDataIsOfType(uiv, dataSelector, inputType, type, true); })) {
+                         DataType const &primaryType, std::vector<DataType> const &otherTypes, bool const silent,
+                         bool const autoLoad) {
+  if (std::any_of(otherTypes.cbegin(), otherTypes.cend(), [&](auto const &type) {
+        return validateDataIsOfType(uiv, dataSelector, inputType, type, true, autoLoad);
+      })) {
     return true;
   }
 
@@ -47,16 +49,16 @@ bool validateDataIsOneOf(IUserInputValidator *uiv, DataSelector *dataSelector, s
  * @return True if the data is valid.
  */
 bool validateDataIsOfType(IUserInputValidator *uiv, DataSelector *dataSelector, std::string const &inputType,
-                          DataType const &type, bool silent) {
+                          DataType const &type, bool const silent, bool const autoLoad) {
   switch (type) {
   case DataType::Red:
-    return validateDataIsAReducedFile(uiv, dataSelector, inputType, silent);
+    return validateDataIsAReducedFile(uiv, dataSelector, inputType, silent, autoLoad);
   case DataType::Sqw:
-    return validateDataIsASqwFile(uiv, dataSelector, inputType, silent);
+    return validateDataIsASqwFile(uiv, dataSelector, inputType, silent, autoLoad);
   case DataType::Calib:
-    return validateDataIsACalibrationFile(uiv, dataSelector, inputType, silent);
+    return validateDataIsACalibrationFile(uiv, dataSelector, inputType, silent, autoLoad);
   case DataType::Corrections:
-    return validateDataIsACorrectionsFile(uiv, dataSelector, inputType, silent);
+    return validateDataIsACorrectionsFile(uiv, dataSelector, inputType, silent, autoLoad);
   default:
     return false;
   }
@@ -73,9 +75,9 @@ bool validateDataIsOfType(IUserInputValidator *uiv, DataSelector *dataSelector, 
  * @return True if the data is valid.
  */
 bool validateDataIsAReducedFile(IUserInputValidator *uiv, DataSelector *dataSelector, std::string const &inputType,
-                                bool silent) {
+                                bool const silent, bool const autoLoad) {
   auto const dataName = dataSelector->getCurrentDataName();
-  uiv->checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector, silent);
+  uiv->checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector, silent, autoLoad);
   uiv->checkWorkspaceType<MatrixWorkspace>(dataName, QString::fromStdString(inputType), "MatrixWorkspace", silent);
   // TODO :: check the axis labels for the data units
   return uiv->isAllInputValid();
@@ -90,9 +92,9 @@ bool validateDataIsAReducedFile(IUserInputValidator *uiv, DataSelector *dataSele
  * @return True if the data is valid.
  */
 bool validateDataIsASqwFile(IUserInputValidator *uiv, DataSelector *dataSelector, std::string const &inputType,
-                            bool silent) {
+                            bool const silent, bool const autoLoad) {
   auto const dataName = dataSelector->getCurrentDataName();
-  uiv->checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector, silent);
+  uiv->checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector, silent, autoLoad);
   uiv->checkWorkspaceType<MatrixWorkspace>(dataName, QString::fromStdString(inputType), "MatrixWorkspace", silent);
   // TODO :: check the axis labels for the data units
   return uiv->isAllInputValid();
@@ -107,9 +109,9 @@ bool validateDataIsASqwFile(IUserInputValidator *uiv, DataSelector *dataSelector
  * @return True if the data is valid.
  */
 bool validateDataIsACalibrationFile(IUserInputValidator *uiv, DataSelector *dataSelector, std::string const &inputType,
-                                    bool silent) {
+                                    bool const silent, bool const autoLoad) {
   auto const dataName = dataSelector->getCurrentDataName();
-  uiv->checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector, silent);
+  uiv->checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector, silent, autoLoad);
   uiv->checkWorkspaceType<MatrixWorkspace>(dataName, QString::fromStdString(inputType), "MatrixWorkspace", silent);
   // TODO :: check the axis labels for the data units
   return uiv->isAllInputValid();
@@ -124,9 +126,9 @@ bool validateDataIsACalibrationFile(IUserInputValidator *uiv, DataSelector *data
  * @return True if the data is valid.
  */
 bool validateDataIsACorrectionsFile(IUserInputValidator *uiv, DataSelector *dataSelector, std::string const &inputType,
-                                    bool silent) {
+                                    bool const silent, bool const autoLoad) {
   auto const dataName = dataSelector->getCurrentDataName();
-  uiv->checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector, silent);
+  uiv->checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector, silent, autoLoad);
   uiv->checkWorkspaceType<WorkspaceGroup>(dataName, QString::fromStdString(inputType), "WorkspaceGroup", silent);
   uiv->checkWorkspaceGroupIsValid(dataName, QString::fromStdString(inputType), silent);
   // TODO :: check the axis labels for the data units

--- a/qt/widgets/spectroscopy/test/DataValidationHelperTest.h
+++ b/qt/widgets/spectroscopy/test/DataValidationHelperTest.h
@@ -61,8 +61,8 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 class MockDataSelector : public DataSelector {
 public:
   /// Public Methods
-  MOCK_CONST_METHOD0(getCurrentDataName, QString());
-  MOCK_METHOD0(isValid, bool());
+  MOCK_CONST_METHOD1(getCurrentDataName, QString(bool const));
+  MOCK_METHOD1(isValid, bool(bool const));
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
@@ -193,54 +193,54 @@ public:
 
 private:
   template <typename Functor> void assertTheDataIsCheckedOneTime(Functor const &functor, DataType const &primaryType) {
-    ON_CALL(*m_dataSelector, getCurrentDataName()).WillByDefault(Return(QString::fromStdString(WORKSPACE_NAME)));
-    ON_CALL(*m_dataSelector, isValid()).WillByDefault(Return(true));
+    ON_CALL(*m_dataSelector, getCurrentDataName(true)).WillByDefault(Return(QString::fromStdString(WORKSPACE_NAME)));
+    ON_CALL(*m_dataSelector, isValid(true)).WillByDefault(Return(true));
 
-    EXPECT_CALL(*m_dataSelector, getCurrentDataName()).Times(1);
-    EXPECT_CALL(*m_dataSelector, isValid()).Times(1);
+    EXPECT_CALL(*m_dataSelector, getCurrentDataName(true)).Times(1);
+    EXPECT_CALL(*m_dataSelector, isValid(true)).Times(1);
 
-    (void)functor(m_uiv.get(), m_dataSelector.get(), ERROR_LABEL, primaryType, false);
+    (void)functor(m_uiv.get(), m_dataSelector.get(), ERROR_LABEL, primaryType, false, true);
   }
 
   template <typename Functor>
   void assertTheDataIsCheckedNTimes(Functor const &functor, int nTimes, DataType const &primaryType,
                                     std::vector<DataType> const &otherTypes) {
-    ON_CALL(*m_dataSelector, getCurrentDataName()).WillByDefault(Return(QString::fromStdString(WORKSPACE_NAME)));
-    ON_CALL(*m_dataSelector, isValid()).WillByDefault(Return(true));
+    ON_CALL(*m_dataSelector, getCurrentDataName(true)).WillByDefault(Return(QString::fromStdString(WORKSPACE_NAME)));
+    ON_CALL(*m_dataSelector, isValid(true)).WillByDefault(Return(true));
 
-    EXPECT_CALL(*m_dataSelector, getCurrentDataName()).Times(nTimes);
-    EXPECT_CALL(*m_dataSelector, isValid()).Times(nTimes);
+    EXPECT_CALL(*m_dataSelector, getCurrentDataName(true)).Times(nTimes);
+    EXPECT_CALL(*m_dataSelector, isValid(true)).Times(nTimes);
 
-    (void)functor(m_uiv.get(), m_dataSelector.get(), ERROR_LABEL, primaryType, otherTypes, false);
+    (void)functor(m_uiv.get(), m_dataSelector.get(), ERROR_LABEL, primaryType, otherTypes, false, true);
   }
 
   template <typename Functor>
   void assertThatTheDataIsValid(std::string const &workspaceName, std::string const &errorLabel,
                                 Functor const &functor) {
-    ON_CALL(*m_dataSelector, getCurrentDataName()).WillByDefault(Return(QString::fromStdString(workspaceName)));
-    ON_CALL(*m_dataSelector, isValid()).WillByDefault(Return(true));
+    ON_CALL(*m_dataSelector, getCurrentDataName(true)).WillByDefault(Return(QString::fromStdString(workspaceName)));
+    ON_CALL(*m_dataSelector, isValid(true)).WillByDefault(Return(true));
 
-    TS_ASSERT(functor(m_uiv.get(), m_dataSelector.get(), errorLabel, false));
+    TS_ASSERT(functor(m_uiv.get(), m_dataSelector.get(), errorLabel, false, true));
     TS_ASSERT(m_uiv->generateErrorMessage().empty());
   }
 
   template <typename Functor>
   void assertThatTheDataIsInvalid(std::string const &workspaceName, std::string const &errorLabel,
                                   Functor const &functor) {
-    ON_CALL(*m_dataSelector, getCurrentDataName()).WillByDefault(Return(QString::fromStdString(workspaceName)));
-    ON_CALL(*m_dataSelector, isValid()).WillByDefault(Return(true));
+    ON_CALL(*m_dataSelector, getCurrentDataName(true)).WillByDefault(Return(QString::fromStdString(workspaceName)));
+    ON_CALL(*m_dataSelector, isValid(true)).WillByDefault(Return(true));
 
-    TS_ASSERT(!functor(m_uiv.get(), m_dataSelector.get(), errorLabel, false));
+    TS_ASSERT(!functor(m_uiv.get(), m_dataSelector.get(), errorLabel, false, true));
     TS_ASSERT(!m_uiv->generateErrorMessage().empty());
   }
 
   template <typename Functor>
   void assertErrorMessage(std::string const &workspaceName, std::string const &errorLabel, Functor const &functor,
                           std::string const &errorMessage) {
-    ON_CALL(*m_dataSelector, getCurrentDataName()).WillByDefault(Return(QString::fromStdString(workspaceName)));
-    ON_CALL(*m_dataSelector, isValid()).WillByDefault(Return(true));
+    ON_CALL(*m_dataSelector, getCurrentDataName(true)).WillByDefault(Return(QString::fromStdString(workspaceName)));
+    ON_CALL(*m_dataSelector, isValid(true)).WillByDefault(Return(true));
 
-    (void)functor(m_uiv.get(), m_dataSelector.get(), errorLabel, false);
+    (void)functor(m_uiv.get(), m_dataSelector.get(), errorLabel, false, true);
 
     TS_ASSERT_EQUALS(m_uiv->generateErrorMessage(), errorMessage);
   }


### PR DESCRIPTION
### Description of work
This PR fixes a crash on the Symmetrise tab of the Inelastic Data Processor interface after clearing the ADS and clicking the Preview button. The tab will now not proceed with processing if it can't find the loaded workspace in the ADS. The auto loading feature has also been disabled when validating the DataSelector on the Symmetrise tab because it was causing multiple confusing messages.

Fixes #38042

### To test:
Follow the instructions on the attached issue

*This does not require release notes* because **it is a regression since the last release**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
