### PR TITLE
Replace Poco with std::filesystem in dynamic library loading code

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/LibraryManager.h
+++ b/Framework/Kernel/inc/MantidKernel/LibraryManager.h
@@ -9,6 +9,7 @@
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
+#include <filesystem>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -16,11 +17,6 @@
 #include "MantidKernel/DllConfig.h"
 #include "MantidKernel/LibraryWrapper.h"
 #include "MantidKernel/SingletonHolder.h"
-
-namespace Poco {
-class File;
-class Path;
-} // namespace Poco
 
 namespace Mantid {
 namespace Kernel {
@@ -48,7 +44,7 @@ private:
 
   /// Load libraries from the given Poco::File path
   /// Private so Poco::File doesn't leak to the public interface
-  int openLibraries(const Poco::File &libpath, LoadLibraries loadingBehaviour,
+  int openLibraries(const std::filesystem::path &libpath, LoadLibraries loadingBehaviour,
                     const std::vector<std::string> &excludes);
   /// Check if the library should be loaded
   bool shouldBeLoaded(const std::string &filename, const std::vector<std::string> &excludes) const;
@@ -57,7 +53,7 @@ private:
   /// Returns true if the library has been requested to be excluded
   bool isExcluded(const std::string &filename, const std::vector<std::string> &excludes) const;
   /// Load a given library
-  int openLibrary(const Poco::File &filepath, const std::string &cacheKey);
+  int openLibrary(const std::filesystem::path &filepath, const std::string &cacheKey);
 
   /// Storage for the LibraryWrappers.
   std::unordered_map<std::string, LibraryWrapper> m_openedLibs;

--- a/Framework/Kernel/src/DllOpen.cpp
+++ b/Framework/Kernel/src/DllOpen.cpp
@@ -13,8 +13,6 @@
 #include <dlfcn.h>
 #endif
 
-#include <boost/algorithm/string/predicate.hpp>
-
 #include <string>
 
 namespace Mantid::Kernel {
@@ -36,7 +34,7 @@ const std::string LIB_SUFFIX = ".dll";
  * @param filename The file name of the library
  * @return True if it matches the expected format, false otherwise
  */
-bool DllOpen::isValidFilename(const std::string &filename) { return boost::ends_with(filename, LIB_SUFFIX); }
+bool DllOpen::isValidFilename(const std::string &filename) { return filename.ends_with(LIB_SUFFIX); }
 
 /* Opens the Windows .dll file.
  * @param filePath :: Filepath of the library.
@@ -86,7 +84,7 @@ const std::string LIB_SUFFIX = ".dylib";
  * @return True if it matches the expected format, false otherwise
  */
 bool DllOpen::isValidFilename(const std::string &filename) {
-  return boost::starts_with(filename, LIB_PREFIX) && boost::ends_with(filename, LIB_SUFFIX);
+  return filename.starts_with(LIB_PREFIX) && filename.ends_with(LIB_SUFFIX);
 }
 
 /* Opens the Linux .so file


### PR DESCRIPTION
Use `std::filesystem` methods and classes instead of `Poco` in the code loading dynamic libraries. Also threw in replacing `boost` string methods with std equivalents in `DllOpen.cpp`.

Related to #37868 

### To test:

Check libraries are loaded correctly by setting logging to `Debug` and checking that e.g. `MantidCrystal.dll` is loaded, along with all other `.dll` files in the bin folder. In a package some of those files will appear in the plugins folder.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **it has no effect on the user.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
