### PR TITLE
Avoid problem with mamba 2.0 when building standalone packages

### DIFF
--- a/installers/conda/linux/create_tarball.sh
+++ b/installers/conda/linux/create_tarball.sh
@@ -131,6 +131,8 @@ mkdir -p "$bundle_contents"
 
 # Create conda environment internally. --always-copy ensures no symlinks are used
 bundle_conda_prefix="$bundle_contents"
+# Make sure the directory doesn't exist before we create the conda environment otherwise it will fail
+rm -rf "$bundle_conda_prefix"
 
 echo "Creating Conda environment in '$bundle_conda_prefix'"
 "$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --always-copy \

--- a/installers/conda/linux/create_tarball.sh
+++ b/installers/conda/linux/create_tarball.sh
@@ -129,11 +129,11 @@ fi
 # Create base directory.
 mkdir -p "$bundle_contents"
 
-# Create conda environment internally. --copy ensures no symlinks are used
+# Create conda environment internally. --always-copy ensures no symlinks are used
 bundle_conda_prefix="$bundle_contents"
 
 echo "Creating Conda environment in '$bundle_conda_prefix'"
-"$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --copy \
+"$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --always-copy \
   --channel "$conda_channel" --channel conda-forge --yes \
   mantidworkbench \
   jq  # used for processing the version string

--- a/installers/conda/osx/create_bundle.sh
+++ b/installers/conda/osx/create_bundle.sh
@@ -197,12 +197,12 @@ fi
 mkdir -p "$bundle_contents"/{Resources,MacOS}
 
 # Create conda environment internally.
-# --copy ensures no symlinks are used
+# --always-copy ensures no symlinks are used
 # --platform osx-64 is required to allow ARM-based systems to install the osx-64 mantid packages.
 bundle_conda_prefix="$bundle_contents"/Resources
 
 echo "Creating Conda environment in '$bundle_conda_prefix'"
-"$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --copy --platform osx-64 \
+"$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --always-copy --platform osx-64 \
   --channel "$conda_channel" --channel conda-forge --yes \
   mantidworkbench \
   jq  # used for processing the version string

--- a/installers/conda/osx/create_bundle.sh
+++ b/installers/conda/osx/create_bundle.sh
@@ -194,12 +194,15 @@ elif [ -e "$BUILD_DIR" ]; then
 fi
 
 # Create basic directory structure.
-mkdir -p "$bundle_contents"/{Resources,MacOS}
+mkdir -p "$bundle_contents"/MacOS
 
 # Create conda environment internally.
 # --always-copy ensures no symlinks are used
 # --platform osx-64 is required to allow ARM-based systems to install the osx-64 mantid packages.
 bundle_conda_prefix="$bundle_contents"/Resources
+
+# Make sure the directory doesn't exist before we create the conda environment otherwise it will fail
+rm -rf "$bundle_conda_prefix"
 
 echo "Creating Conda environment in '$bundle_conda_prefix'"
 "$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --always-copy --platform osx-64 \

--- a/installers/conda/win/create_package.sh
+++ b/installers/conda/win/create_package.sh
@@ -74,7 +74,7 @@ mkdir $COPY_DIR
 
 echo "Creating conda env from mantidworkbench and jq"
 "$CONDA_EXE" create --prefix $CONDA_ENV_PATH \
-  --copy --channel $CONDA_CHANNEL --channel conda-forge -y \
+  --always-copy --channel $CONDA_CHANNEL --channel conda-forge -y \
   mantidworkbench \
   m2w64-jq
 echo "Conda env created"


### PR DESCRIPTION
### Description of work
It looks like the `--copy` option isn't recognised in the new release of mamba (v2.0), which breaks our standalone packaging script. Following advice given [here](https://github.com/mamba-org/mamba/issues/3470), `--copy` has been replaced with `--always-copy`

#### Purpose of work
Standalone packaging fails with this error:
`The following argument was not expected: --copy`

*There is no associated issue.*

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
Ensure that this build passes and creates the standalone installers for all OS:
https://builds.mantidproject.org/job/build_packages_from_branch/905/


*This does not require release notes* because **it's a fix to a build script**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
