### PR TITLE
Fixed FindPeaksConvolve's racing condition to fix the test failure

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FindPeaksConvolve.h
@@ -66,7 +66,7 @@ private:
   bool m_centreBins;
   Eigen::VectorXd m_pdf;
   std::vector<std::string> m_intermediateWsNames;
-  std::mutex mtx;
+  std::mutex m_mtx;
 
   void init() override;
   void exec() override;

--- a/Framework/Algorithms/test/FindPeaksConvolveTest.h
+++ b/Framework/Algorithms/test/FindPeaksConvolveTest.h
@@ -10,6 +10,7 @@
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAlgorithms/FindPeaksConvolve.h"
@@ -69,11 +70,13 @@ public:
   static FindPeaksConvolveTest *createSuite() { return new FindPeaksConvolveTest(); }
   static void destroySuite(FindPeaksConvolveTest *suite) { delete suite; }
 
+  FindPeaksConvolveTest() { Mantid::API::FrameworkManager::Instance(); }
+
   void setUp() override {
     // Load data file into ADS once
-    loadNexusProcessed("ENGINX_277208_focused_bank_2.nxs", INPUT_TEST_WS_NAME);
-    loadNexusProcessed("VesuvioCalibSpec177.nxs", INPUT_TEST_WS_NAME + "_noisy");
-    loadNexusProcessed("focussed.nxs", INPUT_TEST_WS_NAME + "_focussed");
+    TS_ASSERT_THROWS_NOTHING(loadNexusProcessed("ENGINX_277208_focused_bank_2.nxs", INPUT_TEST_WS_NAME));
+    TS_ASSERT_THROWS_NOTHING(loadNexusProcessed("VesuvioCalibSpec177.nxs", INPUT_TEST_WS_NAME + "_noisy"));
+    TS_ASSERT_THROWS_NOTHING(loadNexusProcessed("focussed.nxs", INPUT_TEST_WS_NAME + "_focussed"));
   }
 
   void test_exec() {

--- a/docs/source/release/v6.12.0/Framework/Algorithms/Bugfixes/37752.rst
+++ b/docs/source/release/v6.12.0/Framework/Algorithms/Bugfixes/37752.rst
@@ -1,0 +1,1 @@
+- Fixed a segmentation fault in :ref:`FindPeaksConvolve <algm-FindPeaksConvolve>` algorithm due to a racing condition in the parallel loop. The issue was first observed as a flaky unit test failure in the CI.


### PR DESCRIPTION
### Description of work
The purpose of this PR is to fix the flakiness of the FindPeaksConvolveTest as seen here
Mantid Failing Unit Test Dashboards
Linux - https://mantidproject.github.io/unittest-monitor/Linux_table.html
Windows (see https://mantidproject.github.io/unittest-monitor/Windows_table.html

In addition, below coverity issue was also addressed here.
1542210 | Use of auto that causes a copy | Low | 03/26/24 | Framework | Performance inefficiencies | /jenkins_workdir/workspace/coverity_build_and_submit/Framework/Algorithms/src/FindPeaksConvolve.cpp | populateOutputWorkspaces | 458

#### Summary of work
There has been a racing condition in the parallel for loop and some non atomic member variables were accessed for writing without locking with a mutex. Lock guards were applied for those variables accessing as the fix.

<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37752 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
FindPeaksConvolveTest should pass without flakiness locally and in the CI.

Release notes are not added as its just an update to unit tests.
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
