### PR TITLE
Stop observing ADS while the algorithms are running

### DIFF
--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
@@ -86,6 +86,7 @@ protected:
 protected:
   IDataReduction *m_idrUI;
   std::unique_ptr<API::IAlgorithmRunner> m_algorithmRunner;
+  std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
 
 private slots:
   void handleNewInstrumentConfiguration();
@@ -94,8 +95,6 @@ private:
   virtual void setFileExtensionsByName(bool filter) { UNUSED_ARG(filter); };
   virtual void setLoadHistory(bool doLoadHistory) { (void)doLoadHistory; }
   virtual void updateInstrumentConfiguration() = 0;
-
-  std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
@@ -287,6 +287,7 @@ void ISISCalibration::setResolutionSpectraRange(const double &minimum, const dou
  * @param error If the algorithms failed.
  */
 void ISISCalibration::algorithmComplete(bool error) {
+  m_plotOptionsPresenter->watchADS(true);
   m_runPresenter->setRunEnabled(true);
   if (!error) {
     std::vector<std::string> outputWorkspaces{m_outputCalibrationName.toStdString()};
@@ -328,6 +329,7 @@ void ISISCalibration::handleRun() {
     m_pythonExportWsName = m_outputResolutionName.toStdString();
   }
 
+  m_plotOptionsPresenter->watchADS(false);
   m_batchAlgoRunner->executeBatchAsync();
 }
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
@@ -166,6 +166,7 @@ void ISISDiagnostics::handleRun() {
   }
 
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
+  m_plotOptionsPresenter->watchADS(false);
   runAlgorithm(sliceAlg);
 }
 
@@ -202,6 +203,7 @@ void ISISDiagnostics::handleValidation(IUserInputValidator *validator) const {
  * @param error If the algorithm failed
  */
 void ISISDiagnostics::algorithmComplete(bool error) {
+  m_plotOptionsPresenter->watchADS(true);
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
   m_runPresenter->setRunEnabled(true);
   m_uiForm.pbSave->setEnabled(!error);

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsPresenter.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsPresenter.h
@@ -56,9 +56,10 @@ public:
   void setWorkspaces(std::vector<std::string> const &workspaces);
   void clearWorkspaces();
 
+  void watchADS(bool on);
+
 private:
   void setupPresenter(PlotWidget const &plotType, std::string const &fixedIndices);
-  void watchADS(bool on);
 
   void setPlotting(bool plotting);
   void setOptionsEnabled(bool enable);


### PR DESCRIPTION
### Description of work
This PR fixes a crash in the ISIS Calibration and ISIS Diagnostics tabs. The crash is caused by multiple calls to the setIndices slot, which updates the text of the plot indices line edit. This PR provides a quick solution for the release by disabling the ADS observer while running the algorithms to avoid multiple simultaneous updates.


<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38078. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->
### To test:
Follow #38078

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **regression bug introduced in this release**
<!-- delete this if you added release notes

If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
