### PR TITLE
Fix ISIS SANS beam centre finder exception when no direction is selected

### DIFF
--- a/docs/source/release/v6.11.0/SANS/Bugfixes/38079.rst
+++ b/docs/source/release/v6.11.0/SANS/Bugfixes/38079.rst
@@ -1,0 +1,1 @@
+- Fixed a crash and improved the error message when no direction checkbox is selected on the ISIS SANS :ref:`ISIS_SANS_Beam_Centre_Tab-ref`.

--- a/scripts/Interface/ui/sans_isis/beam_centre.ui
+++ b/scripts/Interface/ui/sans_isis/beam_centre.ui
@@ -220,7 +220,7 @@
             <item>
              <widget class="QCheckBox" name="left_right_check_box">
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string/>
               </property>
               <property name="text">
                <string>Left/Right</string>
@@ -230,7 +230,7 @@
             <item>
              <widget class="QCheckBox" name="up_down_check_box">
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string/>
               </property>
               <property name="text">
                <string>Up/Down</string>

--- a/scripts/Interface/ui/sans_isis/beam_centre.ui
+++ b/scripts/Interface/ui/sans_isis/beam_centre.ui
@@ -211,7 +211,7 @@
          <item row="13" column="0" colspan="5">
           <widget class="QGroupBox" name="groupBox">
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls in which directions the algorithm will search for the beam centre.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Controls in which directions the algorithm will search for the beam centre. One or more options must be selected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="title">
             <string>Direction</string>

--- a/scripts/SANS/sans/gui_logic/models/async_workers/beam_centre_async.py
+++ b/scripts/SANS/sans/gui_logic/models/async_workers/beam_centre_async.py
@@ -64,7 +64,7 @@ class BeamCentreAsync(IQtAsync):
         centre_finder = SANSCentreFinder()
         if not settings.find_direction:
             self._logger.error("Have chosen no find direction exiting early")
-            return
+            raise ValueError("Unable to run beam centre finder as no direction settings have been provided.")
 
         pos_1 = settings.lab_pos_1 if settings.component is DetectorType.LAB else settings.hab_pos_1
         pos_2 = settings.lab_pos_2 if settings.component is DetectorType.LAB else settings.hab_pos_2

--- a/scripts/SANS/sans/gui_logic/models/async_workers/beam_centre_async.py
+++ b/scripts/SANS/sans/gui_logic/models/async_workers/beam_centre_async.py
@@ -63,7 +63,7 @@ class BeamCentreAsync(IQtAsync):
         """
         centre_finder = SANSCentreFinder()
         if not settings.find_direction:
-            self._logger.error("Have chosen no find direction exiting early")
+            self._logger.error("No direction has been selected - please select either one or both of the Direction checkboxes.")
             raise ValueError("Unable to run beam centre finder as no direction settings have been provided.")
 
         pos_1 = settings.lab_pos_1 if settings.component is DetectorType.LAB else settings.hab_pos_1

--- a/scripts/test/SANS/gui_logic/models/async_workers/test_beam_centre_async.py
+++ b/scripts/test/SANS/gui_logic/models/async_workers/test_beam_centre_async.py
@@ -108,3 +108,4 @@ class BeamCentreAsyncTest(unittest.TestCase):
         self.worker.find_beam_centre(state, fields)
         self.assertEqual(0, mocked_alg.return_value.call_count)
         self.worker._logger.error.assert_called_once()
+        self.mocked_presenter.on_processing_error_centre_finder.assert_called_once()


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Prevents an unexpected exception when the beam centre finder is run with none of the Direction checkboxes selected. This fix changes the code to raise an error when validating the direction settings rather than simply returning nothing. This signals a failure to the asynchronous process, which prevents us incorrectly continuing down the success pathway of the code. Also ensures that the error message that's printed gives clearer instructions so that the user knows how to resolve the problem.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38079. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Follow instructions on linked issue. There should now be a clear error message and no crash. The tooltip for the Direction controls should also contain additional information to help users make the correction selection.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
