### PR TITLE
Update to cmakeLists.txt to remove Mantid::DataHandling

### DIFF
--- a/Framework/Crystal/CMakeLists.txt
+++ b/Framework/Crystal/CMakeLists.txt
@@ -261,7 +261,7 @@ include_directories(inc)
 target_link_libraries(
   Crystal
   PUBLIC Mantid::API Mantid::Geometry Mantid::Kernel
-  PRIVATE Mantid::DataObjects Mantid::Indexing Mantid::DataHandling
+  PRIVATE Mantid::DataObjects Mantid::Indexing
 )
 
 # Add the unit tests directory

--- a/Framework/Crystal/inc/MantidCrystal/RotateSampleShape.h
+++ b/Framework/Crystal/inc/MantidCrystal/RotateSampleShape.h
@@ -47,6 +47,7 @@ private:
   void exec() override;
   void prepareGoniometerAxes(Goniometer &gon);
   bool checkIsValidShape(const API::ExperimentInfo_sptr &ei, std::string &shapeXML, bool &isMeshShape);
+  void setSampleShape(API::ExperimentInfo &expt, const std::string &shapeXML, bool addTypeTag);
 };
 
 } // namespace Crystal

--- a/Framework/Crystal/src/RotateSampleShape.cpp
+++ b/Framework/Crystal/src/RotateSampleShape.cpp
@@ -8,7 +8,6 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
-#include "MantidDataHandling/CreateSampleShape.h"
 #include "MantidGeometry/Instrument/Goniometer.h"
 #include "MantidGeometry/Objects/MeshObject.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
@@ -91,7 +90,34 @@ void RotateSampleShape::exec() {
     meshShape->rotate(newSampleShapeRot);
   } else {
     shapeXML = Geometry::ShapeFactory().addGoniometerTag(newSampleShapeRot, shapeXML);
-    Mantid::DataHandling::CreateSampleShape::setSampleShape(*ei, shapeXML, false);
+    setSampleShape(*ei, shapeXML, false);
+  }
+}
+
+/**
+ * @brief Set the shape via an XML string on the given experiment
+ * @param expt A reference to the experiment holding the sample object
+ * @param shapeXML XML defining the object's shape
+ * @param addTypeTag true to wrap a \<type\> tag around the XML supplied(default)
+ */
+void RotateSampleShape::setSampleShape(API::ExperimentInfo &expt, const std::string &shapeXML, bool addTypeTag) {
+  Geometry::ShapeFactory sFactory;
+  // Create the object
+  auto shape = sFactory.createShape(shapeXML, addTypeTag);
+  // Check it's valid and attach it to the workspace sample but preserve any
+  // material
+  if (shape->hasValidShape()) {
+    const auto mat = expt.sample().getMaterial();
+    shape->setMaterial(mat);
+    expt.mutableSample().setShape(shape);
+  } else {
+    std::ostringstream msg;
+    msg << "Object has invalid shape.";
+    if (auto csgShape = dynamic_cast<Geometry::CSGObject *>(shape.get())) {
+      msg << " TopRule = " << csgShape->topRule() << ", number of surfaces = " << csgShape->getSurfacePtr().size()
+          << "\n";
+    }
+    throw std::runtime_error(msg.str());
   }
 }
 

--- a/Framework/DataHandling/inc/MantidDataHandling/CreateSampleShape.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/CreateSampleShape.h
@@ -27,7 +27,7 @@ namespace DataHandling {
 */
 class MANTID_DATAHANDLING_DLL CreateSampleShape final : public API::Algorithm {
 public:
-  static void setSampleShape(API::ExperimentInfo &expt, const std::string &shapeXML, bool addTypeTag = true);
+  static void setSampleShape(API::ExperimentInfo &expt, const std::string &shapeXML);
 
 public:
   const std::string name() const override { return "CreateSampleShape"; }

--- a/Framework/DataHandling/src/CreateSampleShape.cpp
+++ b/Framework/DataHandling/src/CreateSampleShape.cpp
@@ -26,12 +26,11 @@ using namespace Mantid::API;
  * @brief Set the shape via an XML string on the given experiment
  * @param expt A reference to the experiment holding the sample object
  * @param shapeXML XML defining the object's shape
- * @param addTypeTag true to wrap a \<type\> tag around the XML supplied(default)
  */
-void CreateSampleShape::setSampleShape(API::ExperimentInfo &expt, const std::string &shapeXML, bool addTypeTag) {
+void CreateSampleShape::setSampleShape(API::ExperimentInfo &expt, const std::string &shapeXML) {
   Geometry::ShapeFactory sFactory;
   // Create the object
-  auto shape = sFactory.createShape(shapeXML, addTypeTag);
+  auto shape = sFactory.createShape(shapeXML);
   // Check it's valid and attach it to the workspace sample but preserve any
   // material
   if (shape->hasValidShape()) {


### PR DESCRIPTION
### Description of work
This fix was added to not to import and reuse a method from Mantid::DataHandling library by linking with target_link_libraries in cmake which had caused some weird import errors on some Operating systems and to caused to miss some Crystal algorithms.

In this PR, the method that was required to be imported which was a only a small number of lines, was copied into RotateSampleShape class rather than reusing.

<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
The problem only appears when using a standalone installer, not a conda install (don't know why). [This](https://builds.mantidproject.org/job/Core_Team_test_pipeline/118/artifact/) will give you a Windows installer until the full build_packages_from_branch can run for the other operating systems.
https://builds.mantidproject.org/job/build_packages_from_branch/908/

1- Follow the testing instructions as mentioned in https://github.com/mantidproject/mantid/pull/37908 
2- Check for any startup errors or any missing Crystal libraries in different OSs specially on Linux

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Release notes were not added since this is just an internal fix.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---



### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.

