### PR TITLE
Cancel algorithm before destructing QtAlgorithmRunner

### DIFF
--- a/docs/source/release/v6.11.0/Inelastic/Bugfixes/38116.rst
+++ b/docs/source/release/v6.11.0/Inelastic/Bugfixes/38116.rst
@@ -1,0 +1,1 @@
+- Fixed a crash on the :ref:`Inelastic Bayes Fitting <interface-inelastic-bayes-fitting>` when closing the interface while it is loading data.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MockQtAlgorithmRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MockQtAlgorithmRunner.h
@@ -19,7 +19,6 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 class MockQtAlgorithmRunner : public QtAlgorithmRunner {
 public:
   MockQtAlgorithmRunner() = default;
-  MOCK_METHOD0(cancelRunningAlgorithm, void());
   MOCK_METHOD1(startAlgorithmImpl, void(Mantid::API::IAlgorithm_sptr));
   MOCK_CONST_METHOD0(getAlgorithm, Mantid::API::IAlgorithm_sptr());
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtAlgorithmRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtAlgorithmRunner.h
@@ -36,7 +36,7 @@ public:
   explicit QtAlgorithmRunner(QObject *parent = nullptr);
   ~QtAlgorithmRunner() override;
 
-  virtual void cancelRunningAlgorithm();
+  void cancelRunningAlgorithm();
 
   virtual void startAlgorithm(Mantid::API::IAlgorithm_sptr alg);
   virtual Mantid::API::IAlgorithm_sptr getAlgorithm() const;

--- a/qt/widgets/common/src/QtAlgorithmRunner.cpp
+++ b/qt/widgets/common/src/QtAlgorithmRunner.cpp
@@ -13,25 +13,12 @@ using namespace Mantid::API;
 
 namespace MantidQt::API {
 
-//----------------------------------------------------------------------------------------------
-/** Constructor
- */
 QtAlgorithmRunner::QtAlgorithmRunner(QObject *parent)
     : QObject(parent), m_finishedObserver(*this, &QtAlgorithmRunner::handleAlgorithmFinishedNotification),
       m_progressObserver(*this, &QtAlgorithmRunner::handleAlgorithmProgressNotification),
       m_errorObserver(*this, &QtAlgorithmRunner::handleAlgorithmErrorNotification), m_asyncResult(nullptr) {}
 
-//----------------------------------------------------------------------------------------------
-/** Destructor
- */
-QtAlgorithmRunner::~QtAlgorithmRunner() {
-  if (m_asyncAlg) {
-    m_asyncAlg->removeObserver(m_finishedObserver);
-    m_asyncAlg->removeObserver(m_errorObserver);
-    m_asyncAlg->removeObserver(m_progressObserver);
-  }
-  delete m_asyncResult;
-}
+QtAlgorithmRunner::~QtAlgorithmRunner() { cancelRunningAlgorithm(); }
 
 //--------------------------------------------------------------------------------------
 /** If an algorithm is already running, cancel it.


### PR DESCRIPTION
### Description of work
This PR fixes a crash when closing the Inelastic Bayes Fitting interface at the same time as the interface is still loading data.

Fixes #38116 

### To test:
Following the instructions in the attached issue. The interface should close OK and there should be no crash.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
