### PR TITLE
Update Qt connection syntax in Inelastic Interfaces

### DIFF
--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFitting.cpp
@@ -33,14 +33,14 @@ void BayesFitting::initLayout() {
   // Connect each tab to the actions available in this GUI
   std::map<unsigned int, BayesFittingTab *>::iterator iter;
   for (iter = m_bayesTabs.begin(); iter != m_bayesTabs.end(); ++iter) {
-    connect(iter->second, SIGNAL(showMessageBox(const std::string &)), this, SLOT(showMessageBox(const std::string &)));
+    connect(iter->second, &BayesFittingTab::showMessageBox, this, &BayesFitting::showMessageBox);
   }
 
   loadSettings();
 
-  connect(m_uiForm.pbSettings, SIGNAL(clicked()), this, SLOT(settings()));
-  connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
-  connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this, SLOT(manageUserDirectories()));
+  connect(m_uiForm.pbSettings, &QPushButton::clicked, this, &BayesFitting::settings);
+  connect(m_uiForm.pbHelp, &QPushButton::clicked, this, &BayesFitting::help);
+  connect(m_uiForm.pbManageDirs, &QPushButton::clicked, this, &BayesFitting::manageUserDirectories);
 
   InelasticInterface::initLayout();
 }

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/BayesFittingTab.cpp
@@ -11,7 +11,7 @@ namespace MantidQt::CustomInterfaces {
 BayesFittingTab::BayesFittingTab(QWidget *parent) : InelasticTab(parent), m_propTree(new QtTreePropertyBrowser()) {
   m_propTree->setFactoryForManager(m_dblManager, m_dblEdFac);
 
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &BayesFittingTab::updateProperties);
 }
 
 BayesFittingTab::~BayesFittingTab() { m_propTree->unsetFactoryForManager(m_dblManager); }

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNorm.cpp
@@ -31,9 +31,8 @@ ResNorm::ResNorm(QWidget *parent) : BayesFittingTab(parent), m_previewSpec(0) {
 
   // Create range selector
   auto eRangeSelector = m_uiForm.ppPlot->addRangeSelector("ResNormERange");
-  connect(eRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(minValueChanged(double)));
-  connect(eRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(maxValueChanged(double)));
-
+  connect(eRangeSelector, &MantidWidgets::RangeSelector::minValueChanged, this, &ResNorm::minValueChanged);
+  connect(eRangeSelector, &MantidWidgets::RangeSelector::maxValueChanged, this, &ResNorm::maxValueChanged);
   // Add the properties browser to the ui form
   m_uiForm.treeSpace->addWidget(m_propTree);
 
@@ -49,20 +48,17 @@ ResNorm::ResNorm(QWidget *parent) : BayesFittingTab(parent), m_previewSpec(0) {
   formatTreeWidget(m_propTree, m_properties);
 
   // Connect data selector to handler method
-  connect(m_uiForm.dsVanadium, SIGNAL(dataReady(const QString &)), this,
-          SLOT(handleVanadiumInputReady(const QString &)));
-  connect(m_uiForm.dsResolution, SIGNAL(dataReady(const QString &)), this,
-          SLOT(handleResolutionInputReady(const QString &)));
+  connect(m_uiForm.dsVanadium, &DataSelector::dataReady, this, &ResNorm::handleVanadiumInputReady);
+  connect(m_uiForm.dsResolution, &DataSelector::dataReady, this, &ResNorm::handleResolutionInputReady);
 
   // Connect the preview spectrum selector
-  connect(m_uiForm.spPreviewSpectrum, SIGNAL(valueChanged(int)), this, SLOT(previewSpecChanged(int)));
-
-  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(handleAlgorithmComplete(bool)));
-
+  connect(m_uiForm.spPreviewSpectrum, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+          &ResNorm::previewSpecChanged);
+  connect(m_batchAlgoRunner, &API::BatchAlgorithmRunner::batchComplete, this, &ResNorm::handleAlgorithmComplete);
   // Post Plot and Save
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
-  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
-  connect(m_uiForm.pbPlotCurrent, SIGNAL(clicked()), this, SLOT(plotCurrentPreview()));
+  connect(m_uiForm.pbSave, &QPushButton::clicked, this, &ResNorm::saveClicked);
+  connect(m_uiForm.pbPlot, &QPushButton::clicked, this, &ResNorm::plotClicked);
+  connect(m_uiForm.pbPlotCurrent, &QPushButton::clicked, this, &ResNorm::plotCurrentPreview);
 
   // Allows empty workspace selector when initially selected
   m_uiForm.dsVanadium->isOptional(true);
@@ -308,10 +304,9 @@ void ResNorm::handleResolutionInputReady(const QString &filename) {
  * @param min :: The new value of the lower guide
  */
 void ResNorm::minValueChanged(double min) {
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updateProperties(QtProperty *, double)));
+  disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &ResNorm::updateProperties);
   m_dblManager->setValue(m_properties["EMin"], min);
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &ResNorm::updateProperties);
 }
 
 /**
@@ -320,10 +315,9 @@ void ResNorm::minValueChanged(double min) {
  * @param max :: The new value of the upper guide
  */
 void ResNorm::maxValueChanged(double max) {
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updateProperties(QtProperty *, double)));
+  disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &ResNorm::updateProperties);
   m_dblManager->setValue(m_properties["EMax"], max);
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &ResNorm::updateProperties);
 }
 
 /**
@@ -335,16 +329,14 @@ void ResNorm::maxValueChanged(double max) {
 void ResNorm::updateProperties(QtProperty *prop, double val) {
   auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("ResNormERange");
 
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updateProperties(QtProperty *, double)));
+  disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &ResNorm::updateProperties);
 
   if (prop == m_properties["EMin"]) {
     setRangeSelectorMin(m_properties["EMin"], m_properties["EMax"], eRangeSelector, val);
   } else if (prop == m_properties["EMax"]) {
     setRangeSelectorMax(m_properties["EMin"], m_properties["EMax"], eRangeSelector, val);
   }
-
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &ResNorm::updateProperties);
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/Stretch.cpp
@@ -35,25 +35,25 @@ Stretch::Stretch(QWidget *parent) : BayesFittingTab(parent), m_previewSpec(0), m
 
   // Create range selector
   auto eRangeSelector = m_uiForm.ppPlot->addRangeSelector("StretchERange");
-  connect(eRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(minValueChanged(double)));
-  connect(eRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(maxValueChanged(double)));
-
+  connect(eRangeSelector, &MantidWidgets::RangeSelector::minValueChanged, this, &Stretch::minValueChanged);
+  connect(eRangeSelector, &MantidWidgets::RangeSelector::maxValueChanged, this, &Stretch::maxValueChanged);
   setupFitOptions();
   setupPropertyBrowser();
   setupPlotOptions();
 
   // Connect the data selector for the sample to the mini plot
-  connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this, SLOT(handleSampleInputReady(const QString &)));
-  connect(m_uiForm.chkSequentialFit, SIGNAL(toggled(bool)), m_uiForm.cbPlot, SLOT(setEnabled(bool)));
+  connect(m_uiForm.dsSample, &DataSelector::dataReady, this, &Stretch::handleSampleInputReady);
+  connect(m_uiForm.chkSequentialFit, &QCheckBox::toggled, m_uiForm.cbPlot, &QComboBox::setEnabled);
   // Connect preview spectrum spinner to handler
-  connect(m_uiForm.spPreviewSpectrum, SIGNAL(valueChanged(int)), this, SLOT(previewSpecChanged(int)));
+  connect(m_uiForm.spPreviewSpectrum, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+          &Stretch::previewSpecChanged);
   m_uiForm.spPreviewSpectrum->setMaximum(0);
 
   // Connect the plot and save push buttons
-  connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotWorkspaces()));
-  connect(m_uiForm.pbPlotContour, SIGNAL(clicked()), this, SLOT(plotContourClicked()));
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveWorkspaces()));
-  connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this, SLOT(plotCurrentPreview()));
+  connect(m_uiForm.pbPlot, &QPushButton::clicked, this, &Stretch::plotWorkspaces);
+  connect(m_uiForm.pbPlotContour, &QPushButton::clicked, this, &Stretch::plotContourClicked);
+  connect(m_uiForm.pbSave, &QPushButton::clicked, this, &Stretch::saveWorkspaces);
+  connect(m_uiForm.pbPlotPreview, &QPushButton::clicked, this, &Stretch::plotCurrentPreview);
 
   // Allows empty workspace selector when initially selected
   m_uiForm.dsSample->isOptional(true);
@@ -138,7 +138,7 @@ void Stretch::handleRun() {
   }
 
   m_batchAlgoRunner->addAlgorithm(stretch);
-  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
+  connect(m_batchAlgoRunner, &API::BatchAlgorithmRunner::batchComplete, this, &Stretch::algorithmComplete);
   m_batchAlgoRunner->executeBatchAsync();
 }
 
@@ -146,7 +146,7 @@ void Stretch::handleRun() {
  * Handles the saving and plotting of workspaces after execution
  */
 void Stretch::algorithmComplete(const bool &error) {
-  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
+  disconnect(m_batchAlgoRunner, &API::BatchAlgorithmRunner::batchComplete, this, &Stretch::algorithmComplete);
 
   m_runPresenter->setRunEnabled(true);
   setPlotResultEnabled(!error);
@@ -413,10 +413,9 @@ void Stretch::plotCurrentPreview() {
  * @param min :: The new value of the lower guide
  */
 void Stretch::minValueChanged(double min) {
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updateProperties(QtProperty *, double)));
+  disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &Stretch::updateProperties);
   m_dblManager->setValue(m_properties["EMin"], min);
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &Stretch::updateProperties);
 }
 
 /**
@@ -425,10 +424,9 @@ void Stretch::minValueChanged(double min) {
  * @param max :: The new value of the upper guide
  */
 void Stretch::maxValueChanged(double max) {
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updateProperties(QtProperty *, double)));
+  disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &Stretch::updateProperties);
   m_dblManager->setValue(m_properties["EMax"], max);
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &Stretch::updateProperties);
 }
 
 /**
@@ -440,8 +438,7 @@ void Stretch::maxValueChanged(double max) {
 void Stretch::updateProperties(QtProperty *prop, double val) {
   auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("StretchERange");
 
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updateProperties(QtProperty *, double)));
+  disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &Stretch::updateProperties);
 
   if (prop == m_properties["EMin"]) {
     setRangeSelectorMin(m_properties["EMin"], m_properties["EMax"], eRangeSelector, val);
@@ -449,7 +446,7 @@ void Stretch::updateProperties(QtProperty *prop, double val) {
     setRangeSelectorMax(m_properties["EMin"], m_properties["EMax"], eRangeSelector, val);
   }
 
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &Stretch::updateProperties);
 }
 
 void Stretch::setPlotResultEnabled(bool enabled) {

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
@@ -133,14 +133,14 @@ AbsorptionCorrections::AbsorptionCorrections(QWidget *parent)
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &AbsorptionCorrections::saveClicked);
   // Handle density units
 
-  connect(m_uiForm.cbSampleDensity, static_cast<void (QComboBox::*)(QString const &)>(&QComboBox::currentIndexChanged),
-          this, &AbsorptionCorrections::setSampleDensityUnit);
-  connect(m_uiForm.cbCanDensity, static_cast<void (QComboBox::*)(QString const &)>(&QComboBox::currentIndexChanged),
-          this, &AbsorptionCorrections::setCanDensityUnit);
-  connect(m_uiForm.cbSampleDensity, static_cast<void (QComboBox::*)(QString const &)>(&QComboBox::currentIndexChanged),
-          this, &AbsorptionCorrections::setSampleDensityValue);
-  connect(m_uiForm.cbCanDensity, static_cast<void (QComboBox::*)(QString const &)>(&QComboBox::currentIndexChanged),
-          this, &AbsorptionCorrections::setCanDensityValue);
+  connect(m_uiForm.cbSampleDensity, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+          [=](int index) { this->setSampleDensityUnit(m_uiForm.cbSampleDensity->itemText(index)); });
+  connect(m_uiForm.cbCanDensity, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+          [=](int index) { this->setCanDensityUnit(m_uiForm.cbCanDensity->itemText(index)); });
+  connect(m_uiForm.cbSampleDensity, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+          [=](int index) { this->setSampleDensityValue(m_uiForm.cbSampleDensity->itemText(index)); });
+  connect(m_uiForm.cbCanDensity, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+          [=](int index) { this->setCanDensityValue(m_uiForm.cbCanDensity->itemText(index)); });
   connect(m_uiForm.cbSampleMaterialMethod, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
           &AbsorptionCorrections::changeSampleMaterialOptions);
   connect(m_uiForm.cbCanMaterialMethod, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
@@ -121,28 +121,34 @@ AbsorptionCorrections::AbsorptionCorrections(QWidget *parent)
   m_uiForm.leCanChemicalFormula->setValidator(formulaValidator);
 
   // Change of input
-  connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(const QString &)), this,
-          SLOT(getParameterDefaults(const QString &)));
-  connect(m_uiForm.cbShape, SIGNAL(currentIndexChanged(int)), this, SLOT(handlePresetShapeChanges(int)));
-  // Handle algorithm completion
-  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
-  // Handle running, plotting and saving
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
-  // Handle density units
-  connect(m_uiForm.cbSampleDensity, SIGNAL(currentIndexChanged(QString const &)), this,
-          SLOT(setSampleDensityUnit(QString const &)));
-  connect(m_uiForm.cbCanDensity, SIGNAL(currentIndexChanged(QString const &)), this,
-          SLOT(setCanDensityUnit(QString const &)));
-  connect(m_uiForm.cbSampleDensity, SIGNAL(currentIndexChanged(QString const &)), this,
-          SLOT(setSampleDensityValue(QString const &)));
-  connect(m_uiForm.cbCanDensity, SIGNAL(currentIndexChanged(QString const &)), this,
-          SLOT(setCanDensityValue(QString const &)));
 
-  connect(m_uiForm.cbSampleMaterialMethod, SIGNAL(currentIndexChanged(int)), this,
-          SLOT(changeSampleMaterialOptions(int)));
-  connect(m_uiForm.cbCanMaterialMethod, SIGNAL(currentIndexChanged(int)), this, SLOT(changeCanMaterialOptions(int)));
-  connect(m_uiForm.spSampleDensity, SIGNAL(valueChanged(double)), this, SLOT(setSampleDensity(double)));
-  connect(m_uiForm.spCanDensity, SIGNAL(valueChanged(double)), this, SLOT(setCanDensity(double)));
+  connect(m_uiForm.dsSampleInput, &DataSelector::dataReady, this,
+          static_cast<void (AbsorptionCorrections::*)(const QString &)>(&AbsorptionCorrections::getParameterDefaults));
+  connect(m_uiForm.cbShape, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+          &AbsorptionCorrections::handlePresetShapeChanges);
+  // Handle algorithm completion
+  connect(m_batchAlgoRunner, &API::BatchAlgorithmRunner::batchComplete, this,
+          &AbsorptionCorrections::algorithmComplete);
+  // Handle running, plotting and saving
+  connect(m_uiForm.pbSave, &QPushButton::clicked, this, &AbsorptionCorrections::saveClicked);
+  // Handle density units
+
+  connect(m_uiForm.cbSampleDensity, static_cast<void (QComboBox::*)(QString const &)>(&QComboBox::currentIndexChanged),
+          this, &AbsorptionCorrections::setSampleDensityUnit);
+  connect(m_uiForm.cbCanDensity, static_cast<void (QComboBox::*)(QString const &)>(&QComboBox::currentIndexChanged),
+          this, &AbsorptionCorrections::setCanDensityUnit);
+  connect(m_uiForm.cbSampleDensity, static_cast<void (QComboBox::*)(QString const &)>(&QComboBox::currentIndexChanged),
+          this, &AbsorptionCorrections::setSampleDensityValue);
+  connect(m_uiForm.cbCanDensity, static_cast<void (QComboBox::*)(QString const &)>(&QComboBox::currentIndexChanged),
+          this, &AbsorptionCorrections::setCanDensityValue);
+  connect(m_uiForm.cbSampleMaterialMethod, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+          &AbsorptionCorrections::changeSampleMaterialOptions);
+  connect(m_uiForm.cbCanMaterialMethod, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+          &AbsorptionCorrections::changeCanMaterialOptions);
+  connect(m_uiForm.spSampleDensity, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+          &AbsorptionCorrections::setSampleDensity);
+  connect(m_uiForm.spCanDensity, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+          &AbsorptionCorrections::setCanDensity);
 
   // Allows empty workspace selector when initially selected
   m_uiForm.dsSampleInput->isOptional(true);

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
@@ -19,6 +19,7 @@
 #include "MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h"
 
 #include <QStringList>
+#include <gmock/internal/gmock-internal-utils.h>
 #include <utility>
 
 using namespace DataValidationHelper;
@@ -39,17 +40,20 @@ ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent) : Correc
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface));
 
-  connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this, SLOT(newSample(const QString &)));
-  connect(m_uiForm.dsContainer, SIGNAL(dataReady(const QString &)), this, SLOT(newContainer(const QString &)));
-  connect(m_uiForm.spPreviewSpec, SIGNAL(valueChanged(int)), this, SLOT(plotPreview(int)));
-  connect(m_uiForm.spCanScale, SIGNAL(valueChanged(double)), this, SLOT(updateContainer()));
-  connect(m_uiForm.spCanShift, SIGNAL(valueChanged(double)), this, SLOT(updateContainer()));
-  connect(m_uiForm.ckShiftCan, SIGNAL(toggled(bool)), this, SLOT(updateContainer()));
-  connect(m_uiForm.ckScaleCan, SIGNAL(toggled(bool)), this, SLOT(updateContainer()));
-  connect(m_uiForm.ckRebinContainer, SIGNAL(toggled(bool)), this, SLOT(updateContainer()));
-  connect(m_uiForm.ckUseCan, SIGNAL(toggled(bool)), this, SLOT(updateContainer()));
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
-  connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this, SLOT(plotCurrentPreview()));
+  connect(m_uiForm.dsSample, &DataSelector::dataReady, this, &ApplyAbsorptionCorrections::newSample);
+  connect(m_uiForm.dsContainer, &DataSelector::dataReady, this, &ApplyAbsorptionCorrections::newContainer);
+  connect(m_uiForm.spPreviewSpec, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+          &ApplyAbsorptionCorrections::plotPreview);
+  connect(m_uiForm.spCanScale, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+          &ApplyAbsorptionCorrections::updateContainer);
+  connect(m_uiForm.spCanShift, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+          &ApplyAbsorptionCorrections::updateContainer);
+  connect(m_uiForm.ckShiftCan, &QCheckBox::toggled, this, &ApplyAbsorptionCorrections::updateContainer);
+  connect(m_uiForm.ckScaleCan, &QCheckBox::toggled, this, &ApplyAbsorptionCorrections::updateContainer);
+  connect(m_uiForm.ckRebinContainer, &QCheckBox::toggled, this, &ApplyAbsorptionCorrections::updateContainer);
+  connect(m_uiForm.ckUseCan, &QCheckBox::toggled, this, &ApplyAbsorptionCorrections::updateContainer);
+  connect(m_uiForm.pbSave, &QPushButton::clicked, this, &ApplyAbsorptionCorrections::saveClicked);
+  connect(m_uiForm.pbPlotPreview, &QPushButton::clicked, this, &ApplyAbsorptionCorrections::plotCurrentPreview);
 
   // Allows empty workspace selector when initially selected
   m_uiForm.dsSample->isOptional(true);
@@ -365,7 +369,8 @@ void ApplyAbsorptionCorrections::handleRun() {
   m_batchAlgoRunner->addAlgorithm(applyCorrAlg, std::move(absCorProps));
 
   // Run algorithm queue
-  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(absCorComplete(bool)));
+  connect(m_batchAlgoRunner, &API::BatchAlgorithmRunner::batchComplete, this,
+          &ApplyAbsorptionCorrections::absCorComplete);
   m_batchAlgoRunner->executeBatchAsync();
 
   // Set the result workspace for Python script export
@@ -401,7 +406,8 @@ void ApplyAbsorptionCorrections::addInterpolationStep(const MatrixWorkspace_sptr
  * @param error True if algorithm failed.
  */
 void ApplyAbsorptionCorrections::absCorComplete(bool error) {
-  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(absCorComplete(bool)));
+  disconnect(m_batchAlgoRunner, &API::BatchAlgorithmRunner::batchComplete, this,
+             &ApplyAbsorptionCorrections::absCorComplete);
   m_runPresenter->setRunEnabled(true);
   setSaveResultEnabled(!error);
 
@@ -419,7 +425,9 @@ void ApplyAbsorptionCorrections::absCorComplete(bool error) {
       }
     }
     // Run algorithm queue
-    connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(postProcessComplete(bool)));
+    connect(m_batchAlgoRunner, &API::BatchAlgorithmRunner::batchComplete, this,
+            &ApplyAbsorptionCorrections::postProcessComplete);
+
     m_batchAlgoRunner->executeBatchAsync();
 
     setOutputPlotOptionsWorkspaces({m_pythonExportWsName});
@@ -434,7 +442,8 @@ void ApplyAbsorptionCorrections::absCorComplete(bool error) {
  * @param error True if algorithm failed.
  */
 void ApplyAbsorptionCorrections::postProcessComplete(bool error) {
-  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(postProcessComplete(bool)));
+  disconnect(m_batchAlgoRunner, &API::BatchAlgorithmRunner::batchComplete, this,
+             &ApplyAbsorptionCorrections::postProcessComplete);
   m_runPresenter->setRunEnabled(true);
   setSaveResultEnabled(!error);
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
@@ -19,7 +19,6 @@
 #include "MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h"
 
 #include <QStringList>
-#include <gmock/internal/gmock-internal-utils.h>
 #include <utility>
 
 using namespace DataValidationHelper;

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
@@ -32,13 +32,16 @@ ContainerSubtraction::ContainerSubtraction(QWidget *parent) : CorrectionsTab(par
   setOutputPlotOptionsPresenter(
       std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface));
 
-  connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this, SLOT(newSample(const QString &)));
-  connect(m_uiForm.dsContainer, SIGNAL(dataReady(const QString &)), this, SLOT(newContainer(const QString &)));
-  connect(m_uiForm.spPreviewSpec, SIGNAL(valueChanged(int)), this, SLOT(plotPreview(int)));
-  connect(m_uiForm.spCanScale, SIGNAL(valueChanged(double)), this, SLOT(updateCan()));
-  connect(m_uiForm.spShift, SIGNAL(valueChanged(double)), this, SLOT(updateCan()));
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
-  connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this, SLOT(plotCurrentPreview()));
+  connect(m_uiForm.dsSample, &DataSelector::dataReady, this, &ContainerSubtraction::newSample);
+  connect(m_uiForm.dsContainer, &DataSelector::dataReady, this, &ContainerSubtraction::newContainer);
+  connect(m_uiForm.spPreviewSpec, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+          &ContainerSubtraction::plotPreview);
+  connect(m_uiForm.spCanScale, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+          &ContainerSubtraction::updateCan);
+  connect(m_uiForm.spShift, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+          &ContainerSubtraction::updateCan);
+  connect(m_uiForm.pbSave, &QPushButton::clicked, this, &ContainerSubtraction::saveClicked);
+  connect(m_uiForm.pbPlotPreview, &QPushButton::clicked, this, &ContainerSubtraction::plotCurrentPreview);
 
   // Allows empty workspace selector when initially selected
   m_uiForm.dsSample->isOptional(true);

--- a/qt/scientific_interfaces/Inelastic/Corrections/Corrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/Corrections.cpp
@@ -57,7 +57,7 @@ void Corrections::initLayout() {
 
   // Set up all tabs
   for (auto &tab : m_tabs) {
-    connect(tab.second, SIGNAL(showMessageBox(const std::string &)), this, SLOT(showMessageBox(const std::string &)));
+    connect(tab.second, &CorrectionsTab::showMessageBox, this, &Corrections::showMessageBox);
   }
 
   m_uiForm.pbSettings->setIcon(Settings::icon());

--- a/qt/scientific_interfaces/Inelastic/Corrections/Corrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/Corrections.cpp
@@ -61,10 +61,10 @@ void Corrections::initLayout() {
   }
 
   m_uiForm.pbSettings->setIcon(Settings::icon());
-  connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this, SLOT(exportTabPython()));
-  connect(m_uiForm.pbSettings, SIGNAL(clicked()), this, SLOT(settings()));
-  connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
-  connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this, SLOT(manageUserDirectories()));
+  connect(m_uiForm.pbPythonExport, &QPushButton::clicked, this, &Corrections::exportTabPython);
+  connect(m_uiForm.pbSettings, &QPushButton::clicked, this, &Corrections::settings);
+  connect(m_uiForm.pbHelp, &QPushButton::clicked, this, &Corrections::help);
+  connect(m_uiForm.pbManageDirs, &QPushButton::clicked, this, &Corrections::manageUserDirectories);
 
   InelasticInterface::initLayout();
 }

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessorInterface.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessorInterface.cpp
@@ -68,13 +68,13 @@ void DataProcessorInterface::initLayout() {
   addMVPTab<ElwinPresenter, ElwinView, ElwinModel>("Elwin");
   addMVPTab<IqtPresenter, IqtView, IqtModel>("Iqt");
 
-  connect(m_uiForm.pbSettings, SIGNAL(clicked()), this, SLOT(settings()));
+  connect(m_uiForm.pbSettings, &QPushButton::clicked, this, &DataProcessorInterface::settings);
   // Connect "?" (Help) Button
-  connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
+  connect(m_uiForm.pbHelp, &QPushButton::clicked, this, &DataProcessorInterface::help);
   // Connect the Python export button
-  connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this, SLOT(exportTabPython()));
+  connect(m_uiForm.pbPythonExport, &QPushButton::clicked, this, &DataProcessorInterface::exportTabPython);
   // Connect the "Manage User Directories" Button
-  connect(m_uiForm.pbManageDirectories, SIGNAL(clicked()), this, SLOT(manageUserDirectories()));
+  connect(m_uiForm.pbManageDirectories, &QPushButton::clicked, this, &DataProcessorInterface::manageUserDirectories);
 
   InelasticInterface::initLayout();
 }

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
@@ -87,36 +87,37 @@ void ElwinView::setup() {
 
   auto integrationRangeSelector = m_uiForm.ppPlot->addRangeSelector("ElwinIntegrationRange");
   integrationRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
-  connect(integrationRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(notifyMinChanged(double)));
-  connect(integrationRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(notifyMaxChanged(double)));
+  connect(integrationRangeSelector, &RangeSelector::minValueChanged, this, &ElwinView::notifyMinChanged);
+  connect(integrationRangeSelector, &RangeSelector::maxValueChanged, this, &ElwinView::notifyMaxChanged);
   // create the second range
   auto backgroundRangeSelector = m_uiForm.ppPlot->addRangeSelector("ElwinBackgroundRange");
   backgroundRangeSelector->setColour(Qt::darkGreen); // dark green for background
   backgroundRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
 
-  connect(integrationRangeSelector, SIGNAL(selectionChanged(double, double)), backgroundRangeSelector,
-          SLOT(setRange(double, double)));
-  connect(backgroundRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(notifyMinChanged(double)));
-  connect(backgroundRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(notifyMaxChanged(double)));
-
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(notifyDoubleValueChanged(QtProperty *, double)));
-  connect(m_blnManager, SIGNAL(valueChanged(QtProperty *, bool)), this,
-          SLOT(notifyCheckboxValueChanged(QtProperty *, bool)));
+  connect(integrationRangeSelector, &RangeSelector::selectionChanged, backgroundRangeSelector,
+          static_cast<void (RangeSelector::*)(double, double)>(&RangeSelector::setRange));
+  connect(backgroundRangeSelector, &RangeSelector::minValueChanged, this, &ElwinView::notifyMinChanged);
+  connect(backgroundRangeSelector, &RangeSelector::maxValueChanged, this, &ElwinView::notifyMaxChanged);
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &ElwinView::notifyDoubleValueChanged);
+  connect(m_blnManager, &QtBoolPropertyManager::valueChanged, this, &ElwinView::notifyCheckboxValueChanged);
   notifyCheckboxValueChanged(m_properties["BackgroundSubtraction"], false);
 
-  connect(m_uiForm.wkspAdd, SIGNAL(clicked()), this, SLOT(notifyAddWorkspaceDialog()));
-  connect(m_uiForm.wkspRemove, SIGNAL(clicked()), this, SLOT(notifyRemoveDataClicked()));
-  connect(m_uiForm.pbSelAll, SIGNAL(clicked()), this, SLOT(notifySelectAllClicked()));
+  connect(m_uiForm.wkspAdd, &QPushButton::clicked, this, &ElwinView::notifyAddWorkspaceDialog);
+  connect(m_uiForm.wkspRemove, &QPushButton::clicked, this, &ElwinView::notifyRemoveDataClicked);
+  connect(m_uiForm.pbSelAll, &QPushButton::clicked, this, &ElwinView::notifySelectAllClicked);
 
-  connect(m_uiForm.cbPreviewFile, SIGNAL(currentIndexChanged(int)), this, SLOT(notifyPreviewIndexChanged(int)));
-  connect(m_uiForm.spPlotSpectrum, SIGNAL(valueChanged(int)), this, SLOT(notifySelectedSpectrumChanged()));
-  connect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this, SLOT(notifySelectedSpectrumChanged()));
-  connect(m_uiForm.ckCollapse, SIGNAL(stateChanged(int)), this, SLOT(notifyRowModeChanged()));
+  connect(m_uiForm.cbPreviewFile, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+          &ElwinView::notifyPreviewIndexChanged);
+  connect(m_uiForm.spPlotSpectrum, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+          &ElwinView::notifySelectedSpectrumChanged);
+  connect(m_uiForm.cbPlotSpectrum, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+          &ElwinView::notifySelectedSpectrumChanged);
+
+  connect(m_uiForm.ckCollapse, &QCheckBox::stateChanged, this, &ElwinView::notifyRowModeChanged);
 
   // Handle plot and save
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
-  connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this, SLOT(notifyPlotPreviewClicked()));
+  connect(m_uiForm.pbSave, &QPushButton::clicked, this, &ElwinView::notifySaveClicked);
+  connect(m_uiForm.pbPlotPreview, &QPushButton::clicked, this, &ElwinView::notifyPlotPreviewClicked);
 
   // Set any default values
   m_dblManager->setValue(m_properties["IntegrationStart"], -0.02);
@@ -148,8 +149,7 @@ void ElwinView::notifyAddWorkspaceDialog() { showAddWorkspaceDialog(); }
 
 void ElwinView::showAddWorkspaceDialog() {
   auto dialog = new MantidWidgets::AddWorkspaceMultiDialog(parentWidget());
-  connect(dialog, SIGNAL(addData(MantidWidgets::IAddWorkspaceDialog *)), this,
-          SLOT(notifyAddData(MantidWidgets::IAddWorkspaceDialog *)));
+  connect(dialog, &AddWorkspaceMultiDialog::addData, this, &ElwinView::notifyAddData);
   auto const tabName("Elwin");
   dialog->setup();
   dialog->setAttribute(Qt::WA_DeleteOnClose);
@@ -278,12 +278,12 @@ void ElwinView::notifyCheckboxValueChanged(QtProperty *prop, bool enabled) {
     m_properties["BackgroundStart"]->setEnabled(enabled);
     m_properties["BackgroundEnd"]->setEnabled(enabled);
 
-    disconnect(integrationRangeSelector, SIGNAL(selectionChanged(double, double)), backgroundRangeSelector,
-               SLOT(setRange(double, double)));
+    disconnect(integrationRangeSelector, &RangeSelector::selectionChanged, backgroundRangeSelector,
+               static_cast<void (RangeSelector::*)(double, double)>(&RangeSelector::setRange));
     if (!enabled) {
       backgroundRangeSelector->setRange(integrationRangeSelector->getRange());
-      connect(integrationRangeSelector, SIGNAL(selectionChanged(double, double)), backgroundRangeSelector,
-              SLOT(setRange(double, double)));
+      connect(integrationRangeSelector, &RangeSelector::selectionChanged, backgroundRangeSelector,
+              static_cast<void (RangeSelector::*)(double, double)>(&RangeSelector::setRange));
     }
   }
 }
@@ -323,29 +323,27 @@ void ElwinView::notifyDoubleValueChanged(QtProperty *prop, double val) {
 }
 
 void ElwinView::disconnectSignals() const {
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(notifyDoubleValueChanged(QtProperty *, double)));
-  disconnect(m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange"), SIGNAL(maxValueChanged(double)), this,
-             SLOT(notifyMaxChanged(double)));
-  disconnect(m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange"), SIGNAL(minValueChanged(double)), this,
-             SLOT(notifyMinChanged(double)));
-  disconnect(m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange"), SIGNAL(maxValueChanged(double)), this,
-             SLOT(notifyMaxChanged(double)));
-  disconnect(m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange"), SIGNAL(minValueChanged(double)), this,
-             SLOT(notifyMinChanged(double)));
+  disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &ElwinView::notifyDoubleValueChanged);
+  disconnect(m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange"), &RangeSelector::maxValueChanged, this,
+             &ElwinView::notifyMaxChanged);
+  disconnect(m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange"), &RangeSelector::minValueChanged, this,
+             &ElwinView::notifyMinChanged);
+  disconnect(m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange"), &RangeSelector::maxValueChanged, this,
+             &ElwinView::notifyMaxChanged);
+  disconnect(m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange"), &RangeSelector::minValueChanged, this,
+             &ElwinView::notifyMinChanged);
 }
 
 void ElwinView::connectSignals() const {
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(notifyDoubleValueChanged(QtProperty *, double)));
-  connect(m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange"), SIGNAL(maxValueChanged(double)), this,
-          SLOT(notifyMaxChanged(double)));
-  connect(m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange"), SIGNAL(minValueChanged(double)), this,
-          SLOT(notifyMinChanged(double)));
-  connect(m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange"), SIGNAL(maxValueChanged(double)), this,
-          SLOT(notifyMaxChanged(double)));
-  connect(m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange"), SIGNAL(minValueChanged(double)), this,
-          SLOT(notifyMinChanged(double)));
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &ElwinView::notifyDoubleValueChanged);
+  connect(m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange"), &RangeSelector::maxValueChanged, this,
+          &ElwinView::notifyMaxChanged);
+  connect(m_uiForm.ppPlot->getRangeSelector("ElwinIntegrationRange"), &RangeSelector::minValueChanged, this,
+          &ElwinView::notifyMinChanged);
+  connect(m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange"), &RangeSelector::maxValueChanged, this,
+          &ElwinView::notifyMaxChanged);
+  connect(m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange"), &RangeSelector::minValueChanged, this,
+          &ElwinView::notifyMinChanged);
 }
 
 void ElwinView::setIntegrationStart(double value) { m_dblManager->setValue(m_properties["IntegrationStart"], value); }
@@ -436,7 +434,8 @@ void ElwinView::setAvailableSpectra(WorkspaceIndex minimum, WorkspaceIndex maxim
 
 void ElwinView::setAvailableSpectra(const std::vector<WorkspaceIndex>::const_iterator &from,
                                     const std::vector<WorkspaceIndex>::const_iterator &to) {
-  disconnect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this, SLOT(notifySelectedSpectrumChanged()));
+  disconnect(m_uiForm.cbPlotSpectrum, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+             &ElwinView::notifySelectedSpectrumChanged);
   m_uiForm.elwinPreviewSpec->setCurrentIndex(1);
   m_uiForm.cbPlotSpectrum->clear();
 
@@ -445,7 +444,8 @@ void ElwinView::setAvailableSpectra(const std::vector<WorkspaceIndex>::const_ite
 
   m_uiForm.cbPlotSpectrum->setCurrentIndex(0);
 
-  connect(m_uiForm.cbPlotSpectrum, SIGNAL(currentIndexChanged(int)), this, SLOT(notifySelectedSpectrumChanged()));
+  connect(m_uiForm.cbPlotSpectrum, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+          &ElwinView::notifySelectedSpectrumChanged);
 }
 
 std::string ElwinView::getPreviewWorkspaceName(int index) const {

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
@@ -142,21 +142,20 @@ void IqtView::setup() {
   xRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
 
   // signals / slots & validators
-  connect(m_uiForm.dsInput, SIGNAL(dataReady(const QString &)), this, SLOT(notifySampDataReady(const QString &)));
-  connect(m_uiForm.dsResolution, SIGNAL(dataReady(const QString &)), this, SLOT(notifyResDataReady(const QString &)));
-  connect(m_uiForm.spIterations, SIGNAL(valueChanged(int)), this, SLOT(notifyIterationsChanged(int)));
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
-  connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this, SLOT(notifyPlotCurrentPreview()));
-  connect(m_uiForm.cbCalculateErrors, SIGNAL(stateChanged(int)), this, SLOT(notifyErrorsClicked(int)));
-  connect(m_uiForm.enEnforceNormalization, SIGNAL(stateChanged(int)), this,
-          SLOT(notifyEnableNormalizationClicked(int)));
-  connect(m_uiForm.spPreviewSpec, SIGNAL(valueChanged(int)), this, SLOT(notifyPreviewSpectrumChanged(int)));
-  connect(m_uiForm.ckSymmetricEnergy, SIGNAL(stateChanged(int)), this, SLOT(notifyUpdateEnergyRange(int)));
-  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyRangeChanged(double, double)));
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(notifyValueChanged(QtProperty *, double)));
+  connect(m_uiForm.dsInput, &DataSelector::dataReady, this, &IqtView::notifySampDataReady);
+  connect(m_uiForm.dsResolution, &DataSelector::dataReady, this, &IqtView::notifyResDataReady);
+  connect(m_uiForm.spIterations, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+          &IqtView::notifyIterationsChanged);
+  connect(m_uiForm.pbSave, &QPushButton::clicked, this, &IqtView::notifySaveClicked);
+  connect(m_uiForm.pbPlotPreview, &QPushButton::clicked, this, &IqtView::notifyPlotCurrentPreview);
+  connect(m_uiForm.cbCalculateErrors, &QCheckBox::stateChanged, this, &IqtView::notifyErrorsClicked);
+  connect(m_uiForm.enEnforceNormalization, &QCheckBox::stateChanged, this, &IqtView::notifyEnableNormalizationClicked);
+  connect(m_uiForm.spPreviewSpec, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+          &IqtView::notifyPreviewSpectrumChanged);
+  connect(m_uiForm.ckSymmetricEnergy, &QCheckBox::stateChanged, this, &IqtView::notifyUpdateEnergyRange);
+  connect(xRangeSelector, &RangeSelector::selectionChanged, this, &IqtView::notifyRangeChanged);
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &IqtView::notifyUpdateRangeSelector);
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &IqtView::notifyValueChanged);
 
   m_uiForm.dsInput->isOptional(true);
   m_uiForm.dsResolution->isOptional(true);
@@ -212,9 +211,8 @@ void IqtView::notifyRangeChanged(double min, double max) {
 
   auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
 
-  disconnect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyRangeChanged(double, double)));
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
+  disconnect(xRangeSelector, &RangeSelector::selectionChanged, this, &IqtView::notifyRangeChanged);
+  disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &IqtView::notifyUpdateRangeSelector);
 
   if (fabs(oldMin - min) > 0.0000001) {
     m_dblManager->setValue(m_properties["ELow"], min);
@@ -234,9 +232,8 @@ void IqtView::notifyRangeChanged(double min, double max) {
     }
   }
 
-  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyRangeChanged(double, double)));
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
+  connect(xRangeSelector, &RangeSelector::selectionChanged, this, &IqtView::notifyRangeChanged);
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &IqtView::notifyUpdateRangeSelector);
 
   updateDisplayedBinParameters();
 }
@@ -251,9 +248,8 @@ void IqtView::notifyRangeChanged(double min, double max) {
 void IqtView::notifyUpdateRangeSelector(QtProperty *prop, double val) {
   auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
 
-  disconnect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyRangeChanged(double, double)));
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
+  disconnect(xRangeSelector, &RangeSelector::selectionChanged, this, &IqtView::notifyRangeChanged);
+  disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &IqtView::notifyUpdateRangeSelector);
 
   if (prop == m_properties["ELow"]) {
     setRangeSelectorMin(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, val);
@@ -270,9 +266,8 @@ void IqtView::notifyUpdateRangeSelector(QtProperty *prop, double val) {
     }
   }
 
-  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyRangeChanged(double, double)));
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
+  connect(xRangeSelector, &RangeSelector::selectionChanged, this, &IqtView::notifyRangeChanged);
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &IqtView::notifyUpdateRangeSelector);
 
   updateDisplayedBinParameters();
 }
@@ -410,16 +405,14 @@ void IqtView::updateDisplayedBinParameters() {
   std::tie(success, energyWidth, sampleBins, resolutionBins) =
       calculateBinParameters(sampleName, resolutionName, energyMin, energyMax, numBins);
   if (success) {
-    disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-               SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
+    disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &IqtView::notifyUpdateRangeSelector);
 
     // Update data in property editor
     m_dblManager->setValue(m_properties["EWidth"], energyWidth);
     m_dblManager->setValue(m_properties["ResolutionBins"], resolutionBins);
     m_dblManager->setValue(m_properties["SampleBins"], sampleBins);
 
-    connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-            SLOT(notifyUpdateRangeSelector(QtProperty *, double)));
+    connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &IqtView::notifyUpdateRangeSelector);
 
     // Warn for low number of resolution bins
     if (resolutionBins < 5)

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
@@ -34,16 +34,14 @@ MomentsView::MomentsView(QWidget *parent) : QWidget(parent), m_presenter() {
 
   MantidWidgets::RangeSelector *xRangeSelector = m_uiForm.ppRawPlot->addRangeSelector("XRange");
 
-  connect(m_uiForm.dsInput, SIGNAL(dataReady(QString const &)), this, SLOT(notifyDataReady(const QString &)));
-  connect(m_uiForm.ckScale, SIGNAL(stateChanged(int)), this, SLOT(notifyScaleChanged(int)));
-  connect(m_uiForm.spScale, SIGNAL(valueChanged(double)), this, SLOT(notifyScaleValueChanged(double)));
+  connect(m_uiForm.dsInput, &DataSelector::dataReady, this, &MomentsView::notifyDataReady);
+  connect(m_uiForm.ckScale, &QCheckBox::stateChanged, this, &MomentsView::notifyScaleChanged);
+  connect(m_uiForm.spScale, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+          &MomentsView::notifyScaleValueChanged);
+  connect(m_uiForm.pbSave, &QPushButton::clicked, this, &MomentsView::notifySaveClicked);
 
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
-
-  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyRangeChanged(double, double)));
-
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(notifyValueChanged(QtProperty *, double)));
+  connect(xRangeSelector, &MantidWidgets::RangeSelector::selectionChanged, this, &MomentsView::notifyRangeChanged);
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &MomentsView::notifyValueChanged);
 
   // Allows empty workspace selector when initially selected
   m_uiForm.dsInput->isOptional(true);
@@ -141,16 +139,14 @@ void MomentsView::plotNewData(std::string const &filename) {
  * @param bounds :: The upper and lower bounds to be set in the property browser
  */
 void MomentsView::setPlotPropertyRange(const QPair<double, double> &bounds) {
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(notifyValueChanged(QtProperty *, double)));
+  disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &MomentsView::notifyValueChanged);
   m_dblManager->setMinimum(m_properties["EMin"], bounds.first);
   m_dblManager->setMaximum(m_properties["EMin"], bounds.second);
   m_dblManager->setMinimum(m_properties["EMax"], bounds.first);
   m_dblManager->setMaximum(m_properties["EMax"], bounds.second);
   auto xRangeSelector = getRangeSelector();
   xRangeSelector->setBounds(bounds.first, bounds.second);
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(notifyValueChanged(QtProperty *, double)));
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &MomentsView::notifyValueChanged);
 }
 
 /**
@@ -159,8 +155,7 @@ void MomentsView::setPlotPropertyRange(const QPair<double, double> &bounds) {
  * @param bounds :: The upper and lower bounds to be set
  */
 void MomentsView::setRangeSelector(const QPair<double, double> &bounds) {
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(notifyValueChanged(QtProperty *, double)));
+  disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &MomentsView::notifyValueChanged);
 
   double deltaX = abs(bounds.second - bounds.first);
   double lowX = bounds.first + (0.1) * deltaX;
@@ -170,8 +165,7 @@ void MomentsView::setRangeSelector(const QPair<double, double> &bounds) {
   m_dblManager->setValue(m_properties["EMax"], highX);
 
   // connecting back so that the model is updated.
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(notifyValueChanged(QtProperty *, double)));
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &MomentsView::notifyValueChanged);
 
   auto xRangeSelector = getRangeSelector();
   xRangeSelector->setRange(bounds.first, bounds.second);

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwView.cpp
@@ -38,15 +38,21 @@ SqwView::SqwView(QWidget *parent) : QWidget(parent), m_presenter() {
 
   m_uiForm.rqwPlot2D->setCanvasColour(QColor(240, 240, 240));
 
-  connect(m_uiForm.dsInput, SIGNAL(dataReady(QString const &)), this, SLOT(notifyDataReady(QString const &)));
-  connect(m_uiForm.spQLow, SIGNAL(valueChanged(double)), this, SLOT(notifyQLowChanged(double)));
-  connect(m_uiForm.spQWidth, SIGNAL(valueChanged(double)), this, SLOT(notifyQWidthChanged(double)));
-  connect(m_uiForm.spQHigh, SIGNAL(valueChanged(double)), this, SLOT(notifyQHighChanged(double)));
-  connect(m_uiForm.spELow, SIGNAL(valueChanged(double)), this, SLOT(notifyELowChanged(double)));
-  connect(m_uiForm.spEWidth, SIGNAL(valueChanged(double)), this, SLOT(notifyEWidthChanged(double)));
-  connect(m_uiForm.spEHigh, SIGNAL(valueChanged(double)), this, SLOT(notifyEHighChanged(double)));
-  connect(m_uiForm.ckRebinInEnergy, SIGNAL(stateChanged(int)), this, SLOT(notifyRebinEChanged(int)));
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
+  connect(m_uiForm.dsInput, &DataSelector::dataReady, this, &SqwView::notifyDataReady);
+  connect(m_uiForm.spQLow, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+          &SqwView::notifyQLowChanged);
+  connect(m_uiForm.spQWidth, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+          &SqwView::notifyQWidthChanged);
+  connect(m_uiForm.spQHigh, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+          &SqwView::notifyQHighChanged);
+  connect(m_uiForm.spELow, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+          &SqwView::notifyELowChanged);
+  connect(m_uiForm.spEWidth, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+          &SqwView::notifyEWidthChanged);
+  connect(m_uiForm.spEHigh, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged), this,
+          &SqwView::notifyEHighChanged);
+  connect(m_uiForm.ckRebinInEnergy, &QCheckBox::stateChanged, this, &SqwView::notifyRebinEChanged);
+  connect(m_uiForm.pbSave, &QPushButton::clicked, this, &SqwView::notifySaveClicked);
   // Allows empty workspace selector when initially selected
   m_uiForm.dsInput->isOptional(true);
 

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
@@ -119,19 +119,19 @@ SymmetriseView::SymmetriseView(QWidget *parent) : QWidget(parent), m_presenter()
 
   // SIGNAL/SLOT CONNECTIONS
   // Validate the E range when it is changed
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(notifyDoubleValueChanged(QtProperty *, double)));
-  connect(m_enumManager, SIGNAL(valueChanged(QtProperty *, int)), this,
-          SLOT(notifyReflectTypeChanged(QtProperty *, int)));
+  connect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &SymmetriseView::notifyDoubleValueChanged);
+  connect(m_enumManager, &QtEnumPropertyManager::valueChanged, this, &SymmetriseView::notifyReflectTypeChanged);
   // Plot miniplot when file has finished loading
-  connect(m_uiForm.dsInput, SIGNAL(dataReady(QString const &)), this, SLOT(notifyDataReady(QString const &)));
+  connect(m_uiForm.dsInput, &DataSelector::dataReady, this, &SymmetriseView::notifyDataReady);
   // Preview symmetrise
-  connect(m_uiForm.pbPreview, SIGNAL(clicked()), this, SLOT(notifyPreviewClicked()));
+  connect(m_uiForm.pbPreview, &QPushButton::clicked, this, &SymmetriseView::notifyPreviewClicked);
   // X range selectors
-  connect(rangeESelector, SIGNAL(minValueChanged(double)), this, SLOT(notifyXrangeLowChanged(double)));
-  connect(rangeESelector, SIGNAL(maxValueChanged(double)), this, SLOT(notifyXrangeHighChanged(double)));
+  connect(rangeESelector, &MantidWidgets::RangeSelector::minValueChanged, this,
+          &SymmetriseView::notifyXrangeLowChanged);
+  connect(rangeESelector, &MantidWidgets::RangeSelector::maxValueChanged, this,
+          &SymmetriseView::notifyXrangeHighChanged);
   // Handle running, plotting and saving
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
+  connect(m_uiForm.pbSave, &QPushButton::clicked, this, &SymmetriseView::notifySaveClicked);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionAddWorkspaceDialog.cpp
@@ -6,11 +6,13 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "ConvolutionAddWorkspaceDialog.h"
 
+#include "FitTabConstants.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidQtWidgets/Common/TableWidgetValidators.h"
 #include "MantidQtWidgets/Common/WorkspaceUtils.h"
 #include "MantidQtWidgets/Spectroscopy/InterfaceUtils.h"
+#include <qcheckbox.h>
 #include <utility>
 
 using namespace MantidQt::MantidWidgets::WorkspaceUtils;
@@ -24,10 +26,10 @@ ConvolutionAddWorkspaceDialog::ConvolutionAddWorkspaceDialog(QWidget *parent) : 
   m_uiForm.leWorkspaceIndices->setValidator(new QRegExpValidator(QRegExp(validatorString), this));
   setAllSpectraSelectionEnabled(false);
 
-  connect(m_uiForm.dsWorkspace, SIGNAL(dataReady(const QString &)), this, SLOT(workspaceChanged(const QString &)));
-  connect(m_uiForm.ckAllSpectra, SIGNAL(stateChanged(int)), this, SLOT(selectAllSpectra(int)));
-  connect(m_uiForm.pbAdd, SIGNAL(clicked()), this, SLOT(emitAddData()));
-  connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SLOT(close()));
+  connect(m_uiForm.dsWorkspace, &DataSelector::dataReady, this, &ConvolutionAddWorkspaceDialog::workspaceChanged);
+  connect(m_uiForm.ckAllSpectra, &QCheckBox::stateChanged, this, &ConvolutionAddWorkspaceDialog::selectAllSpectra);
+  connect(m_uiForm.pbAdd, &QPushButton::clicked, this, &ConvolutionAddWorkspaceDialog::emitAddData);
+  connect(m_uiForm.pbClose, &QPushButton::clicked, this, &ConvolutionAddWorkspaceDialog::close);
 }
 
 std::string ConvolutionAddWorkspaceDialog::workspaceName() const {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/ConvolutionDataView.cpp
@@ -38,8 +38,7 @@ ConvolutionDataView::ConvolutionDataView(const QStringList &headers, QWidget *pa
 
 void ConvolutionDataView::showAddWorkspaceDialog() {
   auto dialog = new ConvolutionAddWorkspaceDialog(parentWidget());
-  connect(dialog, SIGNAL(addData(MantidWidgets::IAddWorkspaceDialog *)), this,
-          SLOT(notifyAddData(MantidWidgets::IAddWorkspaceDialog *)));
+  connect(dialog, &ConvolutionAddWorkspaceDialog::addData, this, &ConvolutionDataView::notifyAddData);
 
   auto tabName = m_presenter->tabName();
   dialog->setAttribute(Qt::WA_DeleteOnClose);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/EditResultsDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/EditResultsDialog.cpp
@@ -13,9 +13,9 @@ EditResultsDialog::EditResultsDialog(QWidget *parent) : QDialog(parent) {
   m_uiForm.wsInputWorkspace->setLowerBinLimit(2);
   m_uiForm.wsSingleFitWorkspace->setUpperBinLimit(1);
 
-  connect(m_uiForm.pbPasteInputName, SIGNAL(clicked()), this, SLOT(setOutputWorkspaceName()));
-  connect(m_uiForm.pbReplaceFitResult, SIGNAL(clicked()), this, SIGNAL(replaceSingleFitResult()));
-  connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SLOT(close()));
+  connect(m_uiForm.pbPasteInputName, &QPushButton::clicked, this, &EditResultsDialog::setOutputWorkspaceName);
+  connect(m_uiForm.pbReplaceFitResult, &QPushButton::clicked, this, &EditResultsDialog::replaceSingleFitResult);
+  connect(m_uiForm.pbClose, &QPushButton::clicked, this, &EditResultsDialog::close);
 }
 
 void EditResultsDialog::setWorkspaceSelectorSuffices(QStringList const &suffices) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitDataView.cpp
@@ -41,10 +41,10 @@ FitDataView::FitDataView(const QStringList &headers, QWidget *parent)
 
   setHorizontalHeaders(headers);
 
-  connect(m_uiForm->pbAdd, SIGNAL(clicked()), this, SLOT(showAddWorkspaceDialog()));
-  connect(m_uiForm->pbRemove, SIGNAL(clicked()), this, SLOT(notifyRemoveClicked()));
-  connect(m_uiForm->pbUnify, SIGNAL(clicked()), this, SLOT(notifyUnifyClicked()));
-  connect(m_uiForm->tbFitData, SIGNAL(cellChanged(int, int)), this, SLOT(notifyCellChanged(int, int)));
+  connect(m_uiForm->pbAdd, &QPushButton::clicked, this, &FitDataView::showAddWorkspaceDialog);
+  connect(m_uiForm->pbRemove, &QPushButton::clicked, this, &FitDataView::notifyRemoveClicked);
+  connect(m_uiForm->pbUnify, &QPushButton::clicked, this, &FitDataView::notifyUnifyClicked);
+  connect(m_uiForm->tbFitData, &QTableWidget::cellChanged, this, &FitDataView::notifyCellChanged);
 }
 
 void FitDataView::subscribePresenter(IFitDataPresenter *presenter) { m_presenter = presenter; }
@@ -140,8 +140,7 @@ QModelIndexList FitDataView::getSelectedIndexes() const {
 
 void FitDataView::showAddWorkspaceDialog() {
   auto dialog = new MantidWidgets::AddWorkspaceDialog(parentWidget());
-  connect(dialog, SIGNAL(addData(MantidWidgets::IAddWorkspaceDialog *)), this,
-          SLOT(notifyAddData(MantidWidgets::IAddWorkspaceDialog *)));
+  connect(dialog, &AddWorkspaceDialog::addData, this, &FitDataView::notifyAddData);
 
   auto tabName = m_presenter->tabName();
   dialog->setAttribute(Qt::WA_DeleteOnClose);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsView.cpp
@@ -17,9 +17,8 @@ FitOutputOptionsView::FitOutputOptionsView(QWidget *parent)
       m_presenter() {
   m_outputOptions->setupUi(this);
 
-  connect(m_outputOptions->cbGroupWorkspace,
-          static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::currentIndexChanged), this,
-          &FitOutputOptionsView::notifyGroupWorkspaceChanged);
+  connect(m_outputOptions->cbGroupWorkspace, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+          [=](int index) { this->notifyGroupWorkspaceChanged(m_outputOptions->cbGroupWorkspace->itemText(index)); });
   connect(m_outputOptions->pbPlot, &QPushButton::clicked, this, &FitOutputOptionsView::notifyPlotClicked);
   connect(m_outputOptions->pbPlot, &QPushButton::clicked, this, &FitOutputOptionsView::notifyPlotClicked);
   connect(m_outputOptions->pbSave, &QPushButton::clicked, this, &FitOutputOptionsView::notifySaveClicked);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsView.cpp
@@ -17,12 +17,13 @@ FitOutputOptionsView::FitOutputOptionsView(QWidget *parent)
       m_presenter() {
   m_outputOptions->setupUi(this);
 
-  connect(m_outputOptions->cbGroupWorkspace, SIGNAL(currentIndexChanged(QString const &)), this,
-          SLOT(notifyGroupWorkspaceChanged(QString const &)));
-
-  connect(m_outputOptions->pbPlot, SIGNAL(clicked()), this, SLOT(notifyPlotClicked()));
-  connect(m_outputOptions->pbSave, SIGNAL(clicked()), this, SLOT(notifySaveClicked()));
-  connect(m_outputOptions->pbEditResult, SIGNAL(clicked()), this, SLOT(handleEditResultClicked()));
+  connect(m_outputOptions->cbGroupWorkspace,
+          static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::currentIndexChanged), this,
+          &FitOutputOptionsView::notifyGroupWorkspaceChanged);
+  connect(m_outputOptions->pbPlot, &QPushButton::clicked, this, &FitOutputOptionsView::notifyPlotClicked);
+  connect(m_outputOptions->pbPlot, &QPushButton::clicked, this, &FitOutputOptionsView::notifyPlotClicked);
+  connect(m_outputOptions->pbSave, &QPushButton::clicked, this, &FitOutputOptionsView::notifySaveClicked);
+  connect(m_outputOptions->pbEditResult, &QPushButton::clicked, this, &FitOutputOptionsView::handleEditResultClicked);
 }
 
 void FitOutputOptionsView::subscribePresenter(IFitOutputOptionsPresenter *presenter) { m_presenter = presenter; }
@@ -113,7 +114,8 @@ void FitOutputOptionsView::handleEditResultClicked() {
   m_editResultsDialog->setAttribute(Qt::WA_DeleteOnClose);
   m_editResultsDialog->setWorkspaceSelectorSuffices({"_Result"});
   m_editResultsDialog->show();
-  connect(m_editResultsDialog, SIGNAL(replaceSingleFitResult()), this, SLOT(notifyReplaceSingleFitResult()));
+  connect(m_editResultsDialog, &EditResultsDialog::replaceSingleFitResult, this,
+          &FitOutputOptionsView::notifyReplaceSingleFitResult);
 }
 
 void FitOutputOptionsView::displayWarning(std::string const &message) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotView.cpp
@@ -40,9 +40,8 @@ FitPlotView::FitPlotView(QWidget *parent)
           &FitPlotView::notifySelectedFitDataChanged);
   connect(m_plotForm->spPlotSpectrum, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
           &FitPlotView::notifyDelayedPlotSpectrumChanged);
-  connect(m_plotForm->cbPlotSpectrum,
-          static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::currentIndexChanged), this,
-          static_cast<void (FitPlotView::*)(const QString &)>(&FitPlotView::notifyPlotSpectrumChanged));
+  connect(m_plotForm->cbPlotSpectrum, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+          [=](int index) { this->notifyPlotSpectrumChanged(m_plotForm->cbPlotSpectrum->itemText(index)); });
   connect(m_plotForm->ckPlotGuess, &QCheckBox::stateChanged, this, &FitPlotView::notifyPlotGuessChanged);
   connect(m_plotForm->pbPlotPreview, &QPushButton::clicked, this, &FitPlotView::notifyPlotCurrentPreview);
   connect(m_plotForm->pbFitSingle, &QPushButton::clicked, this, &FitPlotView::notifyFitSelectedSpectrum);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotView.cpp
@@ -15,6 +15,7 @@
 #include <QSignalBlocker>
 #include <QTimer>
 
+#include <gtest/gtest-param-test.h>
 #include <limits>
 
 namespace {
@@ -35,14 +36,16 @@ FitPlotView::FitPlotView(QWidget *parent)
     : API::MantidWidget(parent), m_plotForm(new Ui::FitPreviewPlot), m_presenter() {
   m_plotForm->setupUi(this);
 
-  connect(m_plotForm->cbDataSelection, SIGNAL(currentIndexChanged(int)), this, SLOT(notifySelectedFitDataChanged(int)));
-  connect(m_plotForm->spPlotSpectrum, SIGNAL(valueChanged(int)), this, SLOT(notifyDelayedPlotSpectrumChanged()));
-
-  connect(m_plotForm->cbPlotSpectrum, SIGNAL(currentIndexChanged(const QString &)), this,
-          SLOT(notifyPlotSpectrumChanged(const QString &)));
-  connect(m_plotForm->ckPlotGuess, SIGNAL(stateChanged(int)), this, SLOT(notifyPlotGuessChanged(int)));
-  connect(m_plotForm->pbPlotPreview, SIGNAL(clicked()), this, SLOT(notifyPlotCurrentPreview()));
-  connect(m_plotForm->pbFitSingle, SIGNAL(clicked()), this, SLOT(notifyFitSelectedSpectrum()));
+  connect(m_plotForm->cbDataSelection, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+          &FitPlotView::notifySelectedFitDataChanged);
+  connect(m_plotForm->spPlotSpectrum, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+          &FitPlotView::notifyDelayedPlotSpectrumChanged);
+  connect(m_plotForm->cbPlotSpectrum,
+          static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::currentIndexChanged), this,
+          static_cast<void (FitPlotView::*)(const QString &)>(&FitPlotView::notifyPlotSpectrumChanged));
+  connect(m_plotForm->ckPlotGuess, &QCheckBox::stateChanged, this, &FitPlotView::notifyPlotGuessChanged);
+  connect(m_plotForm->pbPlotPreview, &QPushButton::clicked, this, &FitPlotView::notifyPlotCurrentPreview);
+  connect(m_plotForm->pbFitSingle, &QPushButton::clicked, this, &FitPlotView::notifyFitSelectedSpectrum);
 
   // Create a Splitter and place two plots within the splitter layout
   createSplitterWithPlots();
@@ -266,8 +269,8 @@ void FitPlotView::addFitRangeSelector() {
   auto fitRangeSelector = m_topPlot->addRangeSelector("FitRange");
   fitRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
 
-  connect(fitRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(notifyStartXChanged(double)));
-  connect(fitRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(notifyEndXChanged(double)));
+  connect(fitRangeSelector, &RangeSelector::minValueChanged, this, &FitPlotView::notifyStartXChanged);
+  connect(fitRangeSelector, &RangeSelector::maxValueChanged, this, &FitPlotView::notifyEndXChanged);
 }
 
 void FitPlotView::addBackgroundRangeSelector() {
@@ -277,8 +280,8 @@ void FitPlotView::addBackgroundRangeSelector() {
   backRangeSelector->setLowerBound(0.0);
   backRangeSelector->setUpperBound(10.0);
 
-  connect(backRangeSelector, SIGNAL(valueChanged(double)), this, SLOT(notifyBackgroundChanged(double)));
-  connect(backRangeSelector, SIGNAL(resetScientificBounds()), this, SLOT(setBackgroundBounds()));
+  connect(backRangeSelector, &SingleSelector::valueChanged, this, &FitPlotView::notifyBackgroundChanged);
+  connect(backRangeSelector, &SingleSelector::resetScientificBounds, this, &FitPlotView::setBackgroundBounds);
 }
 
 void FitPlotView::setBackgroundBounds() {
@@ -294,9 +297,9 @@ void FitPlotView::addHWHMRangeSelector() {
   hwhmRangeSelector->setRange(0.0, 0.0);
   hwhmRangeSelector->setVisible(false);
 
-  connect(hwhmRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(notifyHWHMMinimumChanged(double)));
-  connect(hwhmRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(notifyHWHMMaximumChanged(double)));
-  connect(hwhmRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(notifyFWHMChanged(double, double)));
+  connect(hwhmRangeSelector, &RangeSelector::minValueChanged, this, &FitPlotView::notifyHWHMMinimumChanged);
+  connect(hwhmRangeSelector, &RangeSelector::maxValueChanged, this, &FitPlotView::notifyHWHMMaximumChanged);
+  connect(hwhmRangeSelector, &RangeSelector::selectionChanged, this, &FitPlotView::notifyFWHMChanged);
 }
 
 void FitPlotView::setBackgroundRangeVisible(bool visible) {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitPlotView.cpp
@@ -15,7 +15,6 @@
 #include <QSignalBlocker>
 #include <QTimer>
 
-#include <gtest/gtest-param-test.h>
 #include <limits>
 
 namespace {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FunctionTemplateView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionBrowser/FunctionTemplateView.cpp
@@ -25,6 +25,7 @@
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h"
 
+#include <MantidKernel/UsageService.h>
 #include <QMessageBox>
 #include <QSettings>
 #include <QVBoxLayout>
@@ -73,19 +74,18 @@ void FunctionTemplateView::createBrowser() {
   m_browser->setFactoryForManager(m_enumManager, comboBoxFactory);
   m_browser->setFactoryForManager(m_parameterManager, doubleDialogFactory);
 
-  connect(m_intManager, SIGNAL(propertyChanged(QtProperty *)), this, SLOT(intChanged(QtProperty *)));
-  connect(m_boolManager, SIGNAL(propertyChanged(QtProperty *)), this, SLOT(boolChanged(QtProperty *)));
-  connect(m_enumManager, SIGNAL(propertyChanged(QtProperty *)), this, SLOT(enumChanged(QtProperty *)));
-  connect(m_parameterManager, SIGNAL(propertyChanged(QtProperty *)), this, SLOT(parameterChanged(QtProperty *)));
-
-  connect(doubleDialogFactory, SIGNAL(buttonClicked(QtProperty *)), this, SLOT(parameterButtonClicked(QtProperty *)));
-  connect(doubleDialogFactory, SIGNAL(closeEditor()), m_browser, SLOT(closeEditor()));
+  connect(m_intManager, &QtIntPropertyManager::propertyChanged, this, &FunctionTemplateView::intChanged);
+  connect(m_boolManager, &QtBoolPropertyManager::propertyChanged, this, &FunctionTemplateView::boolChanged);
+  connect(m_enumManager, &QtEnumPropertyManager::propertyChanged, this, &FunctionTemplateView::enumChanged);
+  connect(m_parameterManager, &ParameterPropertyManager::propertyChanged, this,
+          &FunctionTemplateView::parameterChanged);
+  connect(doubleDialogFactory, &DoubleDialogEditorFactory::buttonClicked, this,
+          &FunctionTemplateView::parameterButtonClicked);
+  connect(doubleDialogFactory, &DoubleDialogEditorFactory::closeEditor, m_browser, &QtTreePropertyBrowser::closeEditor);
 
   m_browser->setContextMenuPolicy(Qt::CustomContextMenu);
-  connect(m_browser, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(popupMenu(const QPoint &)));
-
-  connect(m_browser, SIGNAL(optionChanged(QtProperty *, const QString &, bool)), this,
-          SLOT(globalChanged(QtProperty *, const QString &, bool)));
+  connect(m_browser, &QtTreePropertyBrowser::customContextMenuRequested, this, &FunctionTemplateView::popupMenu);
+  connect(m_browser, &QtTreePropertyBrowser::optionChanged, this, &FunctionTemplateView::globalChanged);
 }
 
 void FunctionTemplateView::init() {
@@ -171,8 +171,7 @@ void FunctionTemplateView::openEditLocalParameterDialog(std::string const &param
                                                         QStringList const &ties, QStringList const &constraints) {
   auto dialog =
       new EditLocalParameterDialog(this, parameterName, datasetNames, domainNames, values, fixes, ties, constraints);
-  connect(dialog, SIGNAL(dialogFinished(int, EditLocalParameterDialog *)), this,
-          SLOT(editLocalParameterFinished(int, EditLocalParameterDialog *)));
+  connect(dialog, &EditLocalParameterDialog::dialogFinished, this, &FunctionTemplateView::editLocalParameterFinished);
   dialog->open();
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.cpp
@@ -6,6 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "FunctionQAddWorkspaceDialog.h"
 
+#include "FitTabConstants.h"
+
 #include <optional>
 
 #include <QSignalBlocker>
@@ -15,12 +17,14 @@ namespace MantidQt::CustomInterfaces::Inelastic {
 FunctionQAddWorkspaceDialog::FunctionQAddWorkspaceDialog(QWidget *parent) : QDialog(parent) {
   m_uiForm.setupUi(this);
 
-  connect(m_uiForm.dsWorkspace, SIGNAL(dataReady(const QString &)), this, SLOT(emitWorkspaceChanged(const QString &)));
-  connect(m_uiForm.dsWorkspace, SIGNAL(filesAutoLoaded()), this, SLOT(handleAutoLoaded()));
-  connect(m_uiForm.cbParameterType, SIGNAL(currentIndexChanged(const QString &)), this,
-          SLOT(emitParameterTypeChanged(const QString &)));
-  connect(m_uiForm.pbAdd, SIGNAL(clicked()), this, SLOT(emitAddData()));
-  connect(m_uiForm.pbClose, SIGNAL(clicked()), this, SLOT(close()));
+  connect(m_uiForm.dsWorkspace, &MantidWidgets::DataSelector::dataReady, this,
+          &FunctionQAddWorkspaceDialog::emitWorkspaceChanged);
+  connect(m_uiForm.dsWorkspace, &MantidWidgets::DataSelector::filesAutoLoaded, this,
+          &FunctionQAddWorkspaceDialog::handleAutoLoaded);
+  connect(m_uiForm.cbParameterType, static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::currentIndexChanged),
+          this, &FunctionQAddWorkspaceDialog::emitParameterTypeChanged);
+  connect(m_uiForm.pbAdd, &QPushButton::clicked, this, &FunctionQAddWorkspaceDialog::emitAddData);
+  connect(m_uiForm.pbClose, &QPushButton::clicked, this, &FunctionQAddWorkspaceDialog::close);
 }
 
 std::string FunctionQAddWorkspaceDialog::workspaceName() const {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQAddWorkspaceDialog.cpp
@@ -21,8 +21,8 @@ FunctionQAddWorkspaceDialog::FunctionQAddWorkspaceDialog(QWidget *parent) : QDia
           &FunctionQAddWorkspaceDialog::emitWorkspaceChanged);
   connect(m_uiForm.dsWorkspace, &MantidWidgets::DataSelector::filesAutoLoaded, this,
           &FunctionQAddWorkspaceDialog::handleAutoLoaded);
-  connect(m_uiForm.cbParameterType, static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::currentIndexChanged),
-          this, &FunctionQAddWorkspaceDialog::emitParameterTypeChanged);
+  connect(m_uiForm.cbParameterType, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+          [=](int index) { this->emitParameterTypeChanged(m_uiForm.cbParameterType->itemText(index)); });
   connect(m_uiForm.pbAdd, &QPushButton::clicked, this, &FunctionQAddWorkspaceDialog::emitAddData);
   connect(m_uiForm.pbClose, &QPushButton::clicked, this, &FunctionQAddWorkspaceDialog::close);
 }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FunctionQDataView.cpp
@@ -30,7 +30,7 @@ QStringList functionQHeaders() {
 namespace MantidQt::CustomInterfaces::Inelastic {
 
 FunctionQDataView::FunctionQDataView(QWidget *parent) : FunctionQDataView(functionQHeaders(), parent) {
-  connect(m_uiForm->pbAdd, SIGNAL(clicked()), this, SLOT(notifyAddClicked()));
+  connect(m_uiForm->pbAdd, &QPushButton::clicked, this, &FunctionQDataView::notifyAddClicked);
 }
 
 FunctionQDataView::FunctionQDataView(const QStringList &headers, QWidget *parent) : FitDataView(headers, parent) {
@@ -40,12 +40,11 @@ FunctionQDataView::FunctionQDataView(const QStringList &headers, QWidget *parent
 
 void FunctionQDataView::showAddWorkspaceDialog() {
   auto dialog = new FunctionQAddWorkspaceDialog(parentWidget());
-  connect(dialog, SIGNAL(addData(MantidWidgets::IAddWorkspaceDialog *)), this,
-          SLOT(notifyAddData(MantidWidgets::IAddWorkspaceDialog *)));
-  connect(dialog, SIGNAL(workspaceChanged(FunctionQAddWorkspaceDialog *, const std::string &)), this,
-          SLOT(notifyWorkspaceChanged(FunctionQAddWorkspaceDialog *, const std::string &)));
-  connect(dialog, SIGNAL(parameterTypeChanged(FunctionQAddWorkspaceDialog *, const std::string &)), this,
-          SLOT(notifyParameterTypeChanged(FunctionQAddWorkspaceDialog *, const std::string &)));
+
+  connect(dialog, &FunctionQAddWorkspaceDialog::addData, this, &FunctionQDataView::notifyAddData);
+  connect(dialog, &FunctionQAddWorkspaceDialog::workspaceChanged, this, &FunctionQDataView::notifyWorkspaceChanged);
+  connect(dialog, &FunctionQAddWorkspaceDialog::parameterTypeChanged, this,
+          &FunctionQDataView::notifyParameterTypeChanged);
 
   auto tabName = m_presenter->tabName();
   dialog->setAttribute(Qt::WA_DeleteOnClose);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/InelasticFitPropertyBrowser.cpp
@@ -70,14 +70,16 @@ void InelasticFitPropertyBrowser::initFunctionBrowser() {
   m_functionBrowser = new FunctionBrowser(nullptr, true);
   m_functionBrowser->setObjectName("functionBrowser");
   // Process internally
-  connect(m_functionBrowser, SIGNAL(globalsChanged()), this, SLOT(updateFitType()));
+  connect(m_functionBrowser, &FunctionBrowser::globalsChanged, this, &InelasticFitPropertyBrowser::updateFitType);
   // Re-emit
-  connect(m_functionBrowser, SIGNAL(functionStructureChanged()), this, SLOT(notifyFunctionChanged()));
-  connect(m_functionBrowser, SIGNAL(parameterChanged(std::string const &, std::string const &)), this,
-          SLOT(notifyFunctionChanged()));
-  connect(m_functionBrowser, SIGNAL(globalsChanged()), this, SLOT(notifyFunctionChanged()));
-  connect(m_functionBrowser, SIGNAL(localParameterButtonClicked(std::string const &)), this,
-          SIGNAL(localParameterEditRequested(std::string const &)));
+  connect(m_functionBrowser, &FunctionBrowser::functionStructureChanged, this,
+          &InelasticFitPropertyBrowser::notifyFunctionChanged);
+  connect(m_functionBrowser, &FunctionBrowser::parameterChanged, this,
+          &InelasticFitPropertyBrowser::notifyFunctionChanged);
+  connect(m_functionBrowser, &FunctionBrowser::globalsChanged, this,
+          &InelasticFitPropertyBrowser::notifyFunctionChanged);
+  connect(m_functionBrowser, &FunctionBrowser::localParameterButtonClicked, this,
+          &InelasticFitPropertyBrowser::localParameterEditRequested);
 }
 
 void InelasticFitPropertyBrowser::initFitOptionsBrowser() {
@@ -166,7 +168,7 @@ void InelasticFitPropertyBrowser::init() {
     m_functionWidget->insertWidget(0, m_templatePresenter->browser());
     m_browserSwitcher = new QCheckBox("See full function");
     m_browserSwitcher->setObjectName("browserSwitcher");
-    connect(m_browserSwitcher, SIGNAL(clicked(bool)), this, SLOT(showFullFunctionBrowser(bool)));
+    connect(m_browserSwitcher, &QCheckBox::clicked, this, &InelasticFitPropertyBrowser::showFullFunctionBrowser);
     m_fitStatusWidget = new FitStatusWidget(w);
     m_fitStatusWidget->setObjectName("browserFitStatus");
     m_fitStatusWidget->hide();
@@ -188,7 +190,8 @@ void InelasticFitPropertyBrowser::setFunctionTemplatePresenter(std::unique_ptr<I
   }
   m_templatePresenter = std::move(templatePresenter);
   m_templatePresenter->init();
-  connect(m_templatePresenter->browser(), SIGNAL(functionStructureChanged()), this, SLOT(notifyFunctionChanged()));
+  connect(m_templatePresenter->browser(), &FunctionTemplateView::functionStructureChanged, this,
+          &InelasticFitPropertyBrowser::notifyFunctionChanged);
 }
 
 void InelasticFitPropertyBrowser::notifyFunctionChanged() {

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/QENSFitting.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/QENSFitting.cpp
@@ -31,13 +31,13 @@ QENSFitting::QENSFitting(QWidget *parent)
 void QENSFitting::initLayout() {
   // Set up all tabs
   for (auto &tab : m_tabs) {
-    connect(tab.second, SIGNAL(showMessageBox(const std::string &)), this, SLOT(showMessageBox(const std::string &)));
+    connect(tab.second, &FitTab::showMessageBox, this, &QENSFitting::showMessageBox);
   }
 
-  connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this, SLOT(exportTabPython()));
-  connect(m_uiForm.pbSettings, SIGNAL(clicked()), this, SLOT(settings()));
-  connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
-  connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this, SLOT(manageUserDirectories()));
+  connect(m_uiForm.pbPythonExport, &QPushButton::clicked, this, &QENSFitting::exportTabPython);
+  connect(m_uiForm.pbSettings, &QPushButton::clicked, this, &QENSFitting::settings);
+  connect(m_uiForm.pbHelp, &QPushButton::clicked, this, &QENSFitting::help);
+  connect(m_uiForm.pbManageDirs, &QPushButton::clicked, this, &QENSFitting::manageUserDirectories);
 
   InelasticInterface::initLayout();
 }


### PR DESCRIPTION
### Description of work
Changes the signals and slots of the Inelastic interfaces from string-based to functor-based connections (getting rid of SIGNAL/SLOT macros). 
One of the main advantages is that the connections are checked at compile-time, so we avoid the problem of missing connections in qt interfaces at runtime.
Additionally, syntax is probably more straightforward, as it explicitly states the object that sends/receives the signal. 
On the flip side, the syntax for overloaded signals/slots (which there are a few) is a little bit more involved, as the function has to be cast with a pointer to member function.  (qoverloaded classes could have been used here, but it is not available for qt 5.15)
Details here: https://wiki.qt.io/New_Signal_Slot_Syntax
Also, if the slots are expected to be called with a default argument, a lambda function shall be used. 

This is first part of #37904 , indirect interface and spectroscopy widget libraries are also going to be updated soon. 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37904 (partially). <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
Testing is straightforward, although probably tedious. I have tested it on MacOS and every GUI seems to be responding as expected.  
- Code check. 
- Manual test inelastic interfaces, particularly making sure the GUIs are responsive and working as expected: 
https://developer.mantidproject.org/Testing/Inelastic/BayesFittingTests.html
https://developer.mantidproject.org/Testing/Inelastic/CorrectionsTests.html
https://developer.mantidproject.org/Testing/Inelastic/DataProcessorTests.html
https://developer.mantidproject.org/Testing/Inelastic/QENSFittingTests.html

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->
_Does not required release notes as it is an internal change_
<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
