### PR TITLE
Wait for result before removing observers in BatchAlgorithmRunner destructor

### DIFF
--- a/docs/source/release/v6.11.0/Direct_Geometry/General/Bugfixes/38136.rst
+++ b/docs/source/release/v6.11.0/Direct_Geometry/General/Bugfixes/38136.rst
@@ -1,0 +1,1 @@
+- Fixed a crash on the :ref:`ALF View <ALFView-ref>` when closing the interface while it is loading data.

--- a/qt/widgets/common/src/BatchAlgorithmRunner.cpp
+++ b/qt/widgets/common/src/BatchAlgorithmRunner.cpp
@@ -55,7 +55,9 @@ BatchAlgorithmRunner::BatchAlgorithmRunner(QObject *parent)
       m_executeAsync(this, &BatchAlgorithmRunner::executeBatchAsyncImpl) {}
 
 BatchAlgorithmRunner::~BatchAlgorithmRunner() {
-  cancelBatch();
+  Poco::ActiveResult<bool> result = m_executeAsync(Poco::Void());
+  result.wait();
+
   removeAllObservers();
 }
 

--- a/qt/widgets/common/src/BatchAlgorithmRunner.cpp
+++ b/qt/widgets/common/src/BatchAlgorithmRunner.cpp
@@ -54,7 +54,10 @@ BatchAlgorithmRunner::BatchAlgorithmRunner(QObject *parent)
       m_algorithmErrorObserver(*this, &BatchAlgorithmRunner::handleAlgorithmError),
       m_executeAsync(this, &BatchAlgorithmRunner::executeBatchAsyncImpl) {}
 
-BatchAlgorithmRunner::~BatchAlgorithmRunner() { removeAllObservers(); }
+BatchAlgorithmRunner::~BatchAlgorithmRunner() {
+  cancelBatch();
+  removeAllObservers();
+}
 
 void BatchAlgorithmRunner::addAllObservers() {
   std::lock_guard<std::recursive_mutex> lock(m_notificationMutex);


### PR DESCRIPTION
### Description of work

This PR fixes a crash when closing the AlfView interface at the same time as the interface is still loading data.

Closing the AlfView interface results in a call to the destructor of the BatchAlgorithmRunner. If this happens while the interface is still loading data, the notification that data loading is complete causes an exception. A brief wait for the result in the destructor prevents this. 

Fixes #38136.

### To test:

Follow the instructions on the original issue. 

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
