### PR TITLE
Fix windows post linking

### DIFF
--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -83,7 +83,6 @@ done
 
 # Mamba
 setup_mamba $WORKSPACE/mambaforge "package-conda" true
-# boa 0.15.1 causes an issue with zstd import on Windows
 mamba install --yes boa conda-verify versioningit
 
 # Clean up any legacy conda-recipes git clones

--- a/buildconfig/Jenkins/Conda/package-standalone
+++ b/buildconfig/Jenkins/Conda/package-standalone
@@ -60,7 +60,8 @@ done
 
 # Mamba
 setup_mamba $WORKSPACE/mambaforge "package-standalone"
-mamba install --yes mamba=1.5 conda-build
+# Pin conda to known working version. In 24.9 the post-link.bat script doesn't work.
+mamba install --yes mamba=1.5 conda-build conda=24.7
 
 # Build packages
 # Setup a local conda channel to find our locally built packages package. It is


### PR DESCRIPTION
### Description of work
Something has changed between `conda` 24.7 and 24.9 to cause a failure when installing the `mantidworkbench` package on our Windows CI machines. It fails at the `post-link.bat` stage, which is required to set a Qt plugin path environment variable:

```
ERROR conda.core.link:_execute(951): An error occurred while installing package 'file:///C:/jenkins_workdir/workspace/release-next_nightly_deployment/conda-bld::mantidworkbench-6.10.20241002.1135-py310h424512f_0'.
Rolling back transaction: ...working... done
post-link script failed for package file:///C:/jenkins_workdir/workspace/release-next_nightly_deployment/conda-bld::mantidworkbench-6.10.20241002.1135-py310h424512f_0
location of failed script: C:\jenkins_workdir\workspace\release-next_nightly_deployment\source\installers\conda\win\_conda_env\Scripts\.mantidworkbench-post-link.bat
==> script messages <==
<None>
==> script output <==
stdout:
stderr: The system cannot find the path specified.

return code: 1
```

Pinning `conda` in the `package-conda` environment appears circumvent the problem. We do this for now to get the nightly running and investigate further later. For some reason I wasn't able to reproduce the problem locally but since there were no code changes that could cause this it is almost certainly the conda version change that has broken it.

*There is no associated issue.*

### To test:
Verify the packages are build in this job:
https://builds.mantidproject.org/job/build_packages_from_branch/916/
Install the Windows conda package with:
```
mamba create -n workbench_windows_test
mamba activate workbench_windows_test
mamba install -c thomashampson/label/postlinkfix mantidworkbench
```
and verify that it launches with the `workbench` command.


*This does not require release notes* because **it's a build script change**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
