### PR TITLE
Add optional direction to `PropertyWithValue` binding

### DIFF
--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PropertyWithValueExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PropertyWithValueExporter.h
@@ -43,7 +43,8 @@ struct PropertyWithValueExporter {
     using namespace Mantid::Kernel;
 
     class_<PropertyWithValue<HeldType>, bases<Property>, boost::noncopyable>(
-        pythonClassName, init<std::string, HeldType>((arg("self"), arg("name"), arg("value"))))
+        pythonClassName, init<std::string, HeldType, unsigned int>(
+                             (arg("self"), arg("name"), arg("value"), arg("direction") = Direction::Input)))
         .add_property("value",
                       make_function(&PropertyWithValue<HeldType>::operator(), return_value_policy<ValueReturnPolicy>()))
         .def("dtype", &dtype<HeldType>, arg("self"));

--- a/Framework/PythonInterface/test/python/mantid/kernel/PropertyWithValueTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PropertyWithValueTest.py
@@ -222,11 +222,17 @@ class PropertyWithValueTest(unittest.TestCase):
         AlgorithmFactory.subscribe(MyAlgorithm)
         algo = MyAlgorithm()
         algo.initialize()
-        _create_algorithm_function("MyAlgorithm", 1, algo)
+        myAlgorithmName = "MyAlgorithm"
+        _create_algorithm_function(myAlgorithmName, 1, algo)
         from mantid.simpleapi import MyAlgorithm as MyAlgorithmInMantid
         # call the algorithm, ensure the output is the large integer expected
         ret = MyAlgorithmInMantid(1)
         assert ret == BIGINT
+        # clean up the the algorithm manager and verify
+        AlgorithmFactory.unsubscribe(myAlgorithmName, 1)
+        with self.assertRaises(RuntimeError) as cm:
+            MyAlgorithmInMantid(2)
+        assert f"not registered {myAlgorithmName}" in str(cm.exception)
 
 
 if __name__ == "__main__":

--- a/docs/source/release/v6.12.0/Framework/Python/New_features/38144.rst
+++ b/docs/source/release/v6.12.0/Framework/Python/New_features/38144.rst
@@ -1,1 +1,1 @@
-- allows for declaring the many `PropertyWithValue` types as output properties from the python API.
+- allows for declaring the many :class:`PropertyWithValue <mantid.kernel.FloatPropertyWithValue>` types as output properties from the python API.

--- a/docs/source/release/v6.12.0/Framework/Python/New_features/38144.rst
+++ b/docs/source/release/v6.12.0/Framework/Python/New_features/38144.rst
@@ -1,0 +1,1 @@
+- allows for declaring the many `PropertyWithValue` types as output properties from the python API.


### PR DESCRIPTION
### Description of work

#### Summary of work
It is not currently possible for algorithms inheriting from `PythonAlgorithm` to have simple primitive/vector return types, when created from the python API.

Adds an extra optional argument for creating `PropertyWithValue` types so that they can be declared as outputs through the Python API.

#### Purpose of work
SNAPRed creates mantid algorithms for processing, and often wants to return values from the algorithm.  This is not currently possible from within the python API.

#### Further detail of work
The change is minimal.  The direction of a `PropertyWithValue` will default to input (as before), but can be setup as an output using the class' constructor.

The unit test proves 


### To test:

The unit test is the test I would run to prove this worked.  It creates a mantid `PythonAlgorithm` class with an output `PropertyWithValue`, registers it, then calls it as a function and verifies the output.  This proves that `PropertyWithValue` can be set as an output through the python API.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
