### PR TITLE
Revert "Turn ISIS SANS compatibility mode off by default"

### DIFF
--- a/docs/source/interfaces/isis_sans/Settings Tab.rst
+++ b/docs/source/interfaces/isis_sans/Settings Tab.rst
@@ -104,9 +104,6 @@ use 8, 9, 10, 12, 14, 16, 20, 21, 22.
 Compatibility Mode
 """"""""""""""""""
 
-*As of version 6.11 of Mantid, this feature is no longer enabled by default.
-It should be considered deprecated and will be removed in a future release.*
-
 The previous SANS GUI converted event-mode data to histogram-mode early into
 processing. This used the time-of-flight binning parameters specified by the
 user or copied the monitor binning.

--- a/docs/source/release/v6.11.0/SANS/New_features/38053.rst
+++ b/docs/source/release/v6.11.0/SANS/New_features/38053.rst
@@ -1,1 +1,0 @@
-- The :ref:`compatibility_mode` feature in the ISIS SANS GUI is no longer selected by default. This feature should be considered deprecated and will be removed completely in a future release.

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -95,7 +95,7 @@ QGroupBox::title {
       <item>
        <widget class="QStackedWidget" name="main_stacked_widget">
         <property name="currentIndex">
-         <number>1</number>
+         <number>0</number>
         </property>
         <widget class="QWidget" name="run_page">
          <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -988,7 +988,7 @@ QGroupBox::title {
                      <bool>true</bool>
                     </property>
                     <property name="checked">
-                     <bool>false</bool>
+                     <bool>true</bool>
                     </property>
                     <layout class="QGridLayout" name="gridLayout_16">
                      <item row="0" column="0">

--- a/scripts/SANS/sans/state/StateObjects/StateCompatibility.py
+++ b/scripts/SANS/sans/state/StateObjects/StateCompatibility.py
@@ -28,7 +28,7 @@ from sans.state.automatic_setters import automatic_setters
 class StateCompatibility(metaclass=JsonSerializable):
     def __init__(self):
         super(StateCompatibility, self).__init__()
-        self.use_compatibility_mode = False  # : Bool
+        self.use_compatibility_mode = True  # : Bool
         self.use_event_slice_optimisation = False  # : Bool
         self.time_rebin_string = ""  # Str
 

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -35,9 +35,9 @@ class StateGuiModelTest(unittest.TestCase):
     # ------------------------------------------------------------------------------------------------------------------
     # Compatibility Mode
     # ------------------------------------------------------------------------------------------------------------------
-    def test_that_default_compatibility_mode_is_false(self):
+    def test_that_default_compatibility_mode_is_true(self):
         state_gui_model = StateGuiModel(AllStates())
-        self.assertFalse(state_gui_model.compatibility_mode)
+        self.assertTrue(state_gui_model.compatibility_mode)
 
     def test_that_can_set_compatibility_mode(self):
         state_gui_model = StateGuiModel(AllStates())


### PR DESCRIPTION
### Description of work

#### Summary of work

Reverts mantidproject/mantid#38057

The SANS Group have been doing some performance testing since their original decision to have the default state of this checkbox changed. They have found that having compatibility mode off has a large impact on the performance of all of their reductions, apart from on IDAaaS. As a result they have asked that this change be removed from the release. Further discussions will be required to decide the long term solution that's required for the linked issue.

Refs #25899.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
1) Go to `Interfaces->SANS->ISIS SANS`.
1) Use the `Load User File` button to load `MaskFile.toml` from `TrainingCourseData->loqdemo`.
1) Go to the Settings tab (from the left side of the window).
1) The `Use compatibility mode` checkbox should be selected.

*This does not require release notes* because **it is reverting a change since the last release.**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
