### PR TITLE
Add optional direction to `PropertyWithValue` binding - `ornl-next`

### DIFF
--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PropertyWithValueExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PropertyWithValueExporter.h
@@ -43,7 +43,8 @@ struct PropertyWithValueExporter {
     using namespace Mantid::Kernel;
 
     class_<PropertyWithValue<HeldType>, bases<Property>, boost::noncopyable>(
-        pythonClassName, init<std::string, HeldType>((arg("self"), arg("name"), arg("value"))))
+        pythonClassName, init<std::string, HeldType, unsigned int>(
+                             (arg("self"), arg("name"), arg("value"), arg("direction") = Direction::Input)))
         .add_property("value",
                       make_function(&PropertyWithValue<HeldType>::operator(), return_value_policy<ValueReturnPolicy>()))
         .def("dtype", &dtype<HeldType>, arg("self"));

--- a/docs/source/release/v6.12.0/Framework/Python/New_features/38144.rst
+++ b/docs/source/release/v6.12.0/Framework/Python/New_features/38144.rst
@@ -1,0 +1,1 @@
+- allows for declaring the many :class:`PropertyWithValue <mantid.kernel.FloatPropertyWithValue>` types as output properties from the python API.


### PR DESCRIPTION
Sister to PR #38144  into `ornl-next`
