### PR TITLE
DiffractionFocussing binning parameters

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/DiffractionFocussing2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DiffractionFocussing2.h
@@ -97,6 +97,7 @@ private:
   /// (Xmin,Xmax,step) for each group.
   /// The result is stored in group2params
   void determineRebinParameters(const std::vector<int> &udet2group);
+  void determineRebinParametersFromParameters(const std::vector<int> &udet2group);
   int validateSpectrumInGroup(const std::vector<int> &udet2group, size_t wi);
 
   /// Shared pointer to the input workspace

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -62,9 +62,13 @@ void DiffractionFocussing2::init() {
                   "input has events (default).\n"
                   "If false, then the workspace gets converted to a "
                   "Workspace2D histogram.");
-  declareProperty(std::make_unique<ArrayProperty<double>>("DMin"), "minimum x values");
-  declareProperty(std::make_unique<ArrayProperty<double>>("DMax"), "maximum x values");
-  declareProperty(std::make_unique<ArrayProperty<double>>("Delta"), "step parameters for rebin");
+  declareProperty(std::make_unique<ArrayProperty<double>>("DMin"),
+                  "Minimum x values, one value for each output specta or single value which is common to all");
+  declareProperty(std::make_unique<ArrayProperty<double>>("DMax"),
+                  "Maximum x values, one value for each output specta or single value which is common to all");
+  declareProperty(std::make_unique<ArrayProperty<double>>("Delta"),
+                  "Step parameters for rebin, positive values are constant step-size, negative are logorithmic. One "
+                  "value for each output specta or single value which is common to all");
 }
 
 std::map<std::string, std::string> DiffractionFocussing2::validateInputs() {

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -128,7 +128,7 @@ std::map<std::string, std::string> DiffractionFocussing2::validateInputs() {
       min_less_than_max = false;
     }
   } else if (xmaxs.size() == 1) {
-    if (xmaxs[0] < *std::max_element(xmins.cbegin(), xmins.cend())) {
+    if (xmaxs[0] <= *std::max_element(xmins.cbegin(), xmins.cend())) {
       min_less_than_max = false;
     }
   } else if (xmins.size() != xmaxs.size()) {
@@ -258,7 +258,7 @@ void DiffractionFocussing2::exec() {
     // first time)
     int nPoints_local(nPoints);
     if (!autoBinning) {
-      nPoints_local = Xout.size() - 1;
+      nPoints_local = static_cast<int>(Xout.size() - 1);
       out->resizeHistogram(outWorkspaceIndex, nPoints_local);
     }
 
@@ -738,9 +738,9 @@ void DiffractionFocussing2::determineRebinParametersFromParameters(const std::ve
   std::vector<double> xmaxs = getProperty("DMax");
   std::vector<double> deltas = getProperty("Delta");
 
-  const auto numMin = xmins.size();
-  const auto numMax = xmaxs.size();
-  const auto numDelta = deltas.size();
+  const int64_t numMin = xmins.size();
+  const int64_t numMax = xmaxs.size();
+  const int64_t numDelta = deltas.size();
   if (numMin > 1 && numMin != nGroups)
     throw std::runtime_error("DMin must have length 1 or equal to number of output groups which is " + nGroups);
   if (numMax > 1 && numMax != nGroups)

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -746,11 +746,14 @@ void DiffractionFocussing2::determineRebinParametersFromParameters(const std::ve
   const int64_t numMax = xmaxs.size();
   const int64_t numDelta = deltas.size();
   if (numMin > 1 && numMin != nGroups)
-    throw std::runtime_error("DMin must have length 1 or equal to number of output groups which is " + nGroups);
+    throw std::runtime_error("DMin must have length 1 or equal to number of output groups which is " +
+                             std::to_string(nGroups));
   if (numMax > 1 && numMax != nGroups)
-    throw std::runtime_error("DMax must have length 1 or equal to number of output groups which is " + nGroups);
+    throw std::runtime_error("DMax must have length 1 or equal to number of output groups which is " +
+                             std::to_string(nGroups));
   if (numDelta > 1 && numDelta != nGroups)
-    throw std::runtime_error("Delta must have length 1 or equal to number of output groups which is " + nGroups);
+    throw std::runtime_error("Delta must have length 1 or equal to number of output groups which is " +
+                             std::to_string(nGroups));
 
   // resize vectors with only one value
   if (numMin == 1)

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -202,8 +202,8 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DetectorEffici
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DirectILLTubeBackground.cpp:348
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DirectILLTubeBackground.cpp:364
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/EditInstrumentGeometry.cpp:273
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:89
-containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:685
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:97
+containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:823
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ExportTimeSeriesLog.cpp:134
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ExportTimeSeriesLog.cpp:330
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp:54

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -203,7 +203,7 @@ constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DirectILLTu
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DirectILLTubeBackground.cpp:364
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/EditInstrumentGeometry.cpp:273
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:97
-containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:823
+containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:826
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ExportTimeSeriesLog.cpp:134
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ExportTimeSeriesLog.cpp:330
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionEventCalibrateDetectors.cpp:54

--- a/docs/source/algorithms/DiffractionFocussing-v2.rst
+++ b/docs/source/algorithms/DiffractionFocussing-v2.rst
@@ -50,6 +50,20 @@ means that you can rebin the resulting spectra to finer bins with no
 loss of data. In fact, it is unnecessary to bin your incoming data at
 all; binning can be performed as the very last step.
 
+Rebin parameters
+################
+
+By default ``DiffractionFocussing`` will use the min and max of each
+spectra and the number of bins in the input workspace to automatically
+determine the output binning. An alternative is to provide the min,
+max and delta for each output spectra similar to
+:ref:`algm-RebinRagged`. The minimum and maximum values that are
+specified are interpreted as one value per spectrum. If there is only
+one value overall, it is used for all of the spectra. The ``Delta``
+parameter is required and can either be a single number which is
+common to all, or one number per spectra. Positive values are
+interpreted as constant step-size. Negative are logarithmic.
+
 Usage
 -----
 
@@ -98,6 +112,29 @@ Output:
 
    Number of focussed spectra: 2
    What type is the workspace after focussing: Workspace2D
+
+**Example - Defining binning parameters:**
+
+.. testcode:: ExHRPDFocussing2
+
+   # Load HRP dataset
+   ws = Load("HRP39180.RAW")
+
+   # specify groupping file, here using CalFile format
+   cal_file = "hrpd_new_072_01_corr.cal"
+
+   # For HRPD data, perform a unit conversion TOF->d-spacing, taking into account detector position offsets
+   ws = AlignDetectors(InputWorkspace='ws',CalibrationFile=cal_file)
+   # Focus the data with defined binning parameters
+   ws = DiffractionFocussing(InputWorkspace='ws',GroupingFileName=cal_file, DMin=[0.6,1.0,2.2], DMax=[1.0,1.5,4.0], Delta=0.1)
+
+   print(f"Output has {ws.getNumberHistograms()} spectra with number of bins {len(ws.readY(0))}, {len(ws.readY(1))} and {len(ws.readY(2))}")
+
+Output:
+
+.. testoutput:: ExHRPDFocussing2
+
+   Output has 3 spectra with number of bins 4, 5 and 18
 
 Previous Versions
 -----------------

--- a/docs/source/release/v6.12.0/Diffraction/Powder/New_features/38154.rst
+++ b/docs/source/release/v6.12.0/Diffraction/Powder/New_features/38154.rst
@@ -1,0 +1,1 @@
+- The ability to define the output binning of each spectra has been added to :ref:`DiffractionFocussing <algm-DiffractionFocussing-v2>`.


### PR DESCRIPTION
### Description of work

Ref: [7068: DiffractionFocussing binning parameters as optional input](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/7068)

Very frequently, the only reason why DiffractionFocussing is used with `PreserveEvents=True` so RebinRagged  can be run afterward. This adds the ability to define the binning parameters for each output spectra.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->



<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

You should test having Histogram and Event input along with PreserveEvents=True/False. And test different DMin, DMax and Delta.


#### Event workspace input

```python
ws = CreateSampleWorkspace(WorkspaceType="Event", XUnit="dSpacing", Function="Flat background", BankPixelWidth=2)

CreateGroupingWorkspace(InputWorkspace='ws', GroupDetectorsBy="bank", OutputWorkspace='groups')

# PreserveEvents
out = DiffractionFocussing(ws, GroupingWorkspace="groups", PreserveEvents=True, DMin=200, DMax=400, Delta=[100,200])
# don't PreserveEvents
out2 = DiffractionFocussing(ws, GroupingWorkspace="groups", PreserveEvents=False, DMin=200, DMax=400, Delta=[100,200])
```

#### Histogram input
```python
ws = CreateSampleWorkspace(XUnit="dSpacing", NumBanks=2, BankPixelWidth=2)
CreateGroupingWorkspace(InputWorkspace='ws', GroupDetectorsBy="bank", OutputWorkspace='groups')
out = DiffractionFocussing(ws, GroupingWorkspace="groups", DMin=[100,200], DMax=[300,500], Delta=100)
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
