### PR TITLE
SetBeam to prevent invalid bounding box error when running AddAbsorptionWeightedPathLengths in ISIS SX reduction classes

### DIFF
--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -284,6 +284,7 @@ class BaseSX(ABC):
         default_kwargs = {"ApplyCorrection": self.scale_integrated, "EventsPerPoint": 1500, "MaxScatterPtAttempts": 7500}
         kwargs = {**default_kwargs, **kwargs}
         ws = self.get_ws(run)
+        mantid.SetBeam(ws, Geometry={"Shape": "Slit", "Width": self.beam_width, "Height": self.beam_height})
         peaks = self.get_peaks(run, peak_type, int_type)
         mantid.CopySample(InputWorkspace=ws, OutputWorkspace=peaks, CopyEnvironment=False)
         mantid.AddAbsorptionWeightedPathLengths(InputWorkspace=peaks, **kwargs)

--- a/scripts/Diffraction/single_crystal/sxd.py
+++ b/scripts/Diffraction/single_crystal/sxd.py
@@ -26,6 +26,8 @@ class SXD(BaseSX):
                                <centre x="0.0"  y="0.0" z="0.0" />
                                <radius val="0.003"/>
                                </sphere>"""  # sphere radius 3mm  - used for vanadium and NaCl
+        self.beam_width = 0.6  # cm
+        self.beam_height = 0.6  # cm
 
     def process_data(self, runs: Sequence[str], *args):
         """

--- a/scripts/Diffraction/wish/wishSX.py
+++ b/scripts/Diffraction/wish/wishSX.py
@@ -23,6 +23,8 @@ class WishSX(BaseSX):
                                <centre x="0.0"  y="0.0" z="0.0" />
                                <radius val="0.0025"/>
                                </sphere>"""  # sphere radius 2.5mm  - used for vanadium and NaCl
+        self.beam_width = 0.2  # cm
+        self.beam_height = 0.4  # cm
 
     def process_data(self, runs: Sequence[str], *args):
         """


### PR DESCRIPTION
### Description of work

Bounding box error comes from AddAbsorptionWeightedPathLengths algorithm - this sets the beam size to something sensible for each instrument such that the bounding box calculation is correct.

The error is thrown here
https://github.com/mantidproject/mantid/blob/005e651f12b64e9dc38d472d5d74627d51a99af7/Framework/Geometry/inc/MantidGeometry/Objects/BoundingBox.h#L67

I think the max > min comparison is invalid (sometimes - not all the time!) due to to floating point precision? But this doesn't happen when a sensible beam size is used.

*There is no associated issue.*

**Report to:** SXD (found during beta testing with SXD scientists)

### To test:

(1) Run this script

```
from mantid.simpleapi import *
from Diffraction.single_crystal.sxd import SXD
from Diffraction.single_crystal.base_sx import PEAK_TYPE

runno = 34768
ws = Load(Filename=f'SXD{runno}.raw', OutputWorkspace=f'SXD{runno}')

SetSample(
    ws,
    Geometry={'Shape': 'Cylinder', 'Height': 0.4, 'Radius': 0.065, 'Center': [0.,0.,0.]},
    Material={"ChemicalFormula": "C2 H4", "SampleNumberDensity": 0.02, "NumberDensityUnit": "Formula Units"},
)
# make peaks workspace and set intensity to 1
peaks = FindSXPeaksConvolve(InputWorkspace=ws, PeaksWorkspace=ws.name() + '_peaks', 
                            ThresholdIoverSigma=50, NRows=3, NCols=3, GetNBinsFromBackToBackParams=True, 
                            NFWHM=3, PeakFindingStrategy="IOverSigma")

sxd = SXD()
sxd.set_ws(runno, ws)
sxd.set_peaks(runno, peaks, PEAK_TYPE.FOUND)
sxd.calc_absorption_weighted_path_lengths(PEAK_TYPE.FOUND)
```
(2) Check that tbar column is populated in peak table

*This does not require release notes* because **bug in feature added in this release**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
