### PR TITLE
34758 fixed issue on ranges in SliceViewer's non orthogonal view

### DIFF
--- a/dev-docs/source/Testing/SliceViewer/SliceViewer.rst
+++ b/dev-docs/source/Testing/SliceViewer/SliceViewer.rst
@@ -157,11 +157,19 @@ Test the :ref:`Nonorthogonal view<mantid:sliceviewer_nonortho>`
 
     - Confirm the autoscaling of the colorbar works in non-orthogonal view
 
-3. Change one of the viewing axes to be `L` (e.g. click `X` button next to L in top left of window)
+3. Note the range of data in `X` and `Y` axes to be `0 to 2` for `H` and `-1 to +1` for `K` respectively. Swap the viewing axes by clicking `Y` button next to `H` in the top left of the window
+
+    - `X` and `Y` axes should now display data for `K` and `H` respectively preserving their original ranges.
+
+4. Click on `X` button next to the `H` button to swap the axes again
+
+    - Now `X` and `Y` axes should display data for `H` and `K` respectively preserving their original ranges.
+
+5. Change one of the viewing axes to be `L` (e.g. click `X` button next to L in top left of window)
 
     - Gridlines should now appear to be orthogonal
 
-4. For ``md_4D`` only change one of the viewing axes to be `E` (e.g. click `Y` button next to `E` in top left of window)
+6. For ``md_4D`` only change one of the viewing axes to be `E` (e.g. click `Y` button next to `E` in top left of window)
 
     - Nonorthogonal view should be disabled (only enabled for momentum axes)
     - Line plots and ROI should be enabled

--- a/docs/source/release/v6.12.0/Workbench/SliceViewer/Bugfixes/34758.rst
+++ b/docs/source/release/v6.12.0/Workbench/SliceViewer/Bugfixes/34758.rst
@@ -1,0 +1,1 @@
+- Fixed a bug in the :ref:sliceviewer which was not showing data with correct ranges when doing a Transpose in non-orthogonal view.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -231,6 +231,8 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
         self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.SlicePointChanged)
         self._call_cutviewer_presenter_if_created("on_slicepoint_changed")
         self.update_plot_data()
+        if self.view.data_view.nonorthogonal_mode:
+            self.show_all_data_clicked()
 
     def export_roi(self, limits):
         """Notify that an roi has been selected for export to a workspace

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -225,14 +225,14 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
         else:
             self.new_plot()
         self._call_cutviewer_presenter_if_created("on_dimension_changed")
+        if self.view.data_view.nonorthogonal_mode:
+            self.show_all_data_clicked()
 
     def slicepoint_changed(self):
         """Indicates the slicepoint has been updated"""
         self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.SlicePointChanged)
         self._call_cutviewer_presenter_if_created("on_slicepoint_changed")
         self.update_plot_data()
-        if self.view.data_view.nonorthogonal_mode:
-            self.show_all_data_clicked()
 
     def export_roi(self, limits):
         """Notify that an roi has been selected for export to a workspace

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -787,6 +787,24 @@ class SliceViewerTest(unittest.TestCase):
 
         presenter.dimensions_changed.assert_called_once()
 
+    def test_slicepoint_changed_on_non_orthogonal_mode(self):
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+        presenter.show_all_data_clicked = mock.MagicMock()
+        presenter.view.data_view.nonorthogonal_mode = True
+
+        presenter.slicepoint_changed()
+
+        presenter.show_all_data_clicked.assert_called_once()
+
+    def test_slicepoint_changed_on_orthogonal_mode(self):
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+        presenter.show_all_data_clicked = mock.MagicMock()
+        presenter.view.data_view.nonorthogonal_mode = False
+
+        presenter.slicepoint_changed()
+
+        presenter.show_all_data_clicked.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -370,10 +370,12 @@ class SliceViewerTest(unittest.TestCase):
         self.model.get_number_dimensions.return_value = 2
         mock_sliceinfo_cls.slicepoint = [None, None]  # no slicepoint as 2D ws
         data_view_mock.dimensions.get_previous_states.return_value = [0, 1]  # no None that indicates integrated dim
+        presenter.show_all_data_clicked = mock.MagicMock()
 
         presenter.dimensions_changed()
 
         mock_new_plot.assert_called_with(dimensions_transposing=True)
+        presenter.show_all_data_clicked.assert_not_called()
 
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceInfo")
     def test_changing_dimensions_in_nonortho_mode_switches_to_ortho_when_dim_not_Q(self, mock_sliceinfo_cls):
@@ -381,12 +383,14 @@ class SliceViewerTest(unittest.TestCase):
             self.model, self.view, mock_sliceinfo_cls, enable_nonortho_axes=True, supports_nonortho=False
         )
         self.model.get_number_dimensions.return_value = 2
+        presenter.show_all_data_clicked = mock.MagicMock()
 
         presenter.dimensions_changed()
 
         data_view_mock.disable_tool_button.assert_called_once_with(ToolItemText.NONORTHOGONAL_AXES)
         data_view_mock.create_axes_orthogonal.assert_called_once()
         data_view_mock.create_axes_nonorthogonal.assert_not_called()
+        presenter.show_all_data_clicked.assert_called_once()
 
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceInfo")
     def test_changing_dimensions_in_nonortho_mode_keeps_nonortho_when_dim_is_Q(self, mock_sliceinfo_cls):
@@ -786,24 +790,6 @@ class SliceViewerTest(unittest.TestCase):
         yaxes_edit.on_ok()
 
         presenter.dimensions_changed.assert_called_once()
-
-    def test_slicepoint_changed_on_non_orthogonal_mode(self):
-        presenter = SliceViewer(None, model=self.model, view=self.view)
-        presenter.show_all_data_clicked = mock.MagicMock()
-        presenter.view.data_view.nonorthogonal_mode = True
-
-        presenter.slicepoint_changed()
-
-        presenter.show_all_data_clicked.assert_called_once()
-
-    def test_slicepoint_changed_on_orthogonal_mode(self):
-        presenter = SliceViewer(None, model=self.model, view=self.view)
-        presenter.show_all_data_clicked = mock.MagicMock()
-        presenter.view.data_view.nonorthogonal_mode = False
-
-        presenter.slicepoint_changed()
-
-        presenter.show_all_data_clicked.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of work
This PR fixes an issue on data ranges shown in SliceViewer's non orthogonal view.

Fixes #34758. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1. Build `dev-docs-html` and open developer Testing Instructions for `SliceViewer Testing` and follow the test instructions for `Test the Nonorthogonal view`
2. Notice the ranges of each axis to be preserved when doing a transpose of axes in Non Orthogonal view/Orthogonal view

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
