### PR TITLE
Fix sphinx warning

### DIFF
--- a/docs/source/concepts/ElementalAnalysisUsingNegativeMuons.rst
+++ b/docs/source/concepts/ElementalAnalysisUsingNegativeMuons.rst
@@ -29,7 +29,7 @@ where :math:`\nu_mu` is muon neutrino.
 Controlling implantation depth of muons
 ---------------------------------------
 The implantation depth depends on the density of the target material and is proportional to the momentum of the incident muons.
-At ISIS, the momentum of the muons can be tuned from :math:`17 \textit{MeV/c}` to :math:`120 \textit{MeV/c}` [#MAT]_.
+At ISIS [#HIL3]_, the momentum of the muons can be tuned from :math:`17 \textit{MeV/c}` to :math:`120 \textit{MeV/c}` [#MAT]_.
 The maximum penetration depth is a few metres for most gases depending on the pressure.
 For most metals the maximum penetration depth is a few centimetres, with a resolution of few :math:`10's` to :math:`100's` of microns.
 
@@ -48,7 +48,7 @@ References
 .. [#HIL1] Hillier, A.D. et al (in press). Depth Dependent Bulk Elemental Analysis using Negative Muons, D’Amico ,S. , Venuti ,V.,
 			Handbook of cultural heritage , Springer.
 .. [#MEA] Measday, D. F. (2001). The nuclear physics of muon capture. Physics Reports, 354(4-5), 243-409.
+.. [#HIL3] Hillier , A.D. et al (2019).Muons at ISIS., Philos. Trans. R. Soc A Math. Phys. Eng. Sci., Vol. 377, pp. 1-7.
 .. [#MAT] Matsuzaki, T. et al (2001). The RIKEN-RAL pulsed muon facility. Nuclear Instruments and Methods in Physics Research
 			Section A: Accelerators, Spectrometers, Detectors and Associated Equipment, 465(2-3), 365-383.
-.. [#HIL3] Hillier , A.D. et al (2019).Muons at ISIS., Philos. Trans. R. Soc A Math. Phys. Eng. Sci., Vol. 377, pp. 1-7.
 


### PR DESCRIPTION
### Description of work
Sphinx 8.0.2 -> 8.1.0 upgrade found an unused reference, which causes a warning. Then the nighlty builds failed. Here we make use of the reference to fix the warning.

*There is no associated issue.*

### To test:
Ensure the docs build and linux package build pass and that the reference is in a sensible place.

*This does not require release notes* because **it is a minor update to docs**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
