### PR TITLE
added crosshair option in mantid

### DIFF
--- a/docs/source/release/v6.12.0/Workbench/New_features/38186.rst
+++ b/docs/source/release/v6.12.0/Workbench/New_features/38186.rst
@@ -1,0 +1,1 @@
+- A crosshair toggle option has been added in mantidplots

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -237,8 +237,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             tbs_height = self.toolbar.sizeHint().height()
         else:
             tbs_height = 0
-        # canvas.mpl_connect("motion_notify_event", self.crosshair)
-        # self.crosshair_toggle(False)
 
         # resize the main window so it will display the canvas with the
         # requested size:

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -611,8 +611,8 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         axes = self.canvas.figure.gca()
 
         # create a crosshair made from horizontal and verticle lines.
-        self.horizontal_line = axes.axhline(color="r", lw=1.0, ls="--")
-        self.vertical_line = axes.axvline(color="r", lw=1.0, ls="--")
+        self.horizontal_line = axes.axhline(color="r", lw=1.0, ls="-")
+        self.vertical_line = axes.axvline(color="r", lw=1.0, ls="-")
 
         def set_cross_hair_visible(visible):
             need_redraw = self.horizontal_line.get_visible() != visible

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -118,6 +118,15 @@ class ToolBarTest(unittest.TestCase):
         self.assertTrue(self._is_grid_button_checked(fig))
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_button_checked_for_plot_with_no_crosshair(self, mock_qappthread):
+        mock_qappthread.return_value = mock_qappthread
+
+        fig, axes = plt.subplots(subplot_kw={"projection": "mantid"})
+        axes.plot([-10, 10], [1, 2])
+        # Grid button should be OFF because we have not enabled the crosshair.
+        self.assertFalse(self._is_crosshair_button_checked(fig))
+
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
     def test_button_checked_for_plot_with_grid_using_kwargs(self, mock_qappthread):
         mock_qappthread.return_value = mock_qappthread
 
@@ -265,6 +274,19 @@ class ToolBarTest(unittest.TestCase):
         # This is only called when show() is called on the figure manager, so we have to manually call it here.
         fig_manager.toolbar.set_buttons_visibility(fig)
         return fig_manager.toolbar._actions[button].isEnabled()
+
+    @classmethod
+    def _is_crosshair_button_checked(cls, fig):
+        """
+        Create the figure manager and check whether its toolbar is toggled on or off for the given figure.
+        We have to explicitly call set_button_visibility() here, which would otherwise be called within the show()
+        function.
+        """
+        canvas = MantidFigureCanvas(fig)
+        fig_manager = FigureManagerWorkbench(canvas, 1)
+        # This is only called when show() is called on the figure manager, so we have to manually call it here.
+        fig_manager.toolbar.set_buttons_visibility(fig)
+        return fig_manager.toolbar._actions["toggle_crosshair"].isChecked()
 
 
 if __name__ == "__main__":

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -34,6 +34,7 @@ def _create_script_action(self, text, tooltip_text, mdi_icon, *args):
 class WorkbenchNavigationToolbar(MantidNavigationToolbar):
     sig_home_clicked = QtCore.Signal()
     sig_grid_toggle_triggered = QtCore.Signal(bool)
+    sig_crosshair_toggle_triggered = QtCore.Signal(bool)
     sig_active_triggered = QtCore.Signal()
     sig_hold_triggered = QtCore.Signal()
     sig_toggle_fit_triggered = QtCore.Signal()
@@ -83,6 +84,7 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         MantidNavigationTool("Fill Area", "Fill area under curves", "mdi.format-color-fill", "waterfall_fill_area", None),
         MantidStandardNavigationTools.SEPARATOR,
         MantidNavigationTool("Help", "Open plotting help documentation", "mdi.help", "launch_plot_help", None),
+        MantidNavigationTool("Crosshair", "Toggle crosshair", "mdi.plus", "toggle_crosshair", False),
         MantidNavigationTool("Hide", "Hide the plot", "mdi.eye", "hide_plot", None),
     )
 
@@ -92,6 +94,13 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         # Adjust icon size or they are too small in PyQt5 by default
         dpi_ratio = QtWidgets.QApplication.instance().desktop().physicalDpiX() / 100
         self.setIconSize(QtCore.QSize(int(24 * dpi_ratio), int(24 * dpi_ratio)))
+
+    def toggle_crosshair(self, enable=None):
+        if enable is None:
+            enable = self._actions["toggle_crosshair"].isChecked()
+        else:
+            self._actions["toggle_crosshair"].setChecked(enable)
+        self.sig_crosshair_toggle_triggered.emit(enable)
 
     def hide_plot(self):
         self.sig_hide_plot_triggered.emit()


### PR DESCRIPTION
### Description of work
This PR adds a crosshair toggle functionality in mantidplot.
[EWM 5302](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5302)
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

After loading a workspace in mantid. Right click on the workspace -> plot data. At the upper right corner there is a '+' option which enables a crosshair being drawn on the plot. Current color option of the crosshair is set to red to distinguish black background if one choose to do color contour plot.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Load data into mantid workspace. Right click on the workspace -> plot. Toggle on the crosshair option in the upper right panel with an icon of '+'.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
