### PR TITLE
Update AlignAndFocusPowder to use new rebin paramters from DiffractionFocussing

### DIFF
--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
@@ -60,6 +60,9 @@ private:
   /// Call diffraction focus to a matrix workspace.
   API::MatrixWorkspace_sptr diffractionFocus(API::MatrixWorkspace_sptr ws);
 
+  /// Call diffraction focus to a matrix workspace with ragged rebin parameters
+  API::MatrixWorkspace_sptr diffractionFocusRaggedRebinInDspace(API::MatrixWorkspace_sptr ws);
+
   /// Convert units
   API::MatrixWorkspace_sptr convertUnits(API::MatrixWorkspace_sptr matrixws, const std::string &target);
 

--- a/docs/source/release/v6.12.0/Diffraction/Powder/New_features/38188.rst
+++ b/docs/source/release/v6.12.0/Diffraction/Powder/New_features/38188.rst
@@ -1,0 +1,1 @@
+- :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder-v1>` has been modified to utilize the new binning parameters added to :ref:`DiffractionFocussing <algm-DiffractionFocussing-v2>`.


### PR DESCRIPTION
### Description of work

Use new options from DiffractionFocussing added in #38154 in AlignAndFocusPowder.

I added a unittest for ragged binning in AlignAndFocusPowder but it is also covered by existing system tests, _e.g._ `AlignAndFocusPowderFromFilesTest.VulcanRaggedInD`


#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [7072: AlignAndFocusPowder supplies DiffractionFocussing binning parameters](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/7072)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Modifying the [usage example](https://docs.mantidproject.org/nightly/algorithms/AlignAndFocusPowder-v1.html#usage) you can play with the parameters and see the the log information shows this is running correctly.

```python
PG3_9830_event = Load('PG3_9830_event.nxs')
out = AlignAndFocusPowder(PG3_9830_event, CalFileName='pg3_mantid_det.cal', DeltaRagged='0.1',DMin="0.5,0.35,0.3,0.28",DMax="3.5,1.3,1,0.85")
```

and the output log shows

```
AlignAndFocusPowder-[Information] running DiffractionFocussing(PreserveEvents=1 XMin=0.5,0.35,0.3,0.28 XMax=3.5,1.3,1,0.85 Delta=0.1) started at 2024-Oct-14 01:58:45.475956000
```

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
