### PR TITLE
Refactor cutviewer to init view and model outside presenter

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/presenter.py
@@ -6,20 +6,25 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 #
-from mantidqt.widgets.sliceviewer.cutviewer.view import CutViewerView
-from mantidqt.widgets.sliceviewer.cutviewer.model import CutViewerModel
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mantidqt.widgets.sliceviewer.cutviewer.view import CutViewerView
+    from mantidqt.widgets.sliceviewer.cutviewer.model import CutViewerModel
+    from mantidqt.widgets.sliceviewer.presenters.presenter import SliceViewer
 
 
 class CutViewerPresenter:
-    def __init__(self, sliceviewer_presenter, canvas):
+    def __init__(self, sliceviewer_presenter: "SliceViewer", model: "CutViewerModel", view: "CutViewerView"):
         """
         :param painter: An object responsible for drawing the representation of the cut
         :param sliceinfo_provider: An object responsible for providing access to current slice information
         :param parent: An optional parent widget
         """
-        self.view = CutViewerView(self, canvas, sliceviewer_presenter.get_frame())
-        self.model = CutViewerModel(sliceviewer_presenter.get_proj_matrix())
+        self.view = view
+        self.model = model
         self._sliceview_presenter = sliceviewer_presenter
+        self.view.subscribe_presenter(self)
 
     def show_view(self):
         self.view.show()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/test/test_cutviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/test/test_cutviewer_presenter.py
@@ -11,16 +11,18 @@ from unittest import mock
 from numpy import eye, c_, array, tile, array_equal
 
 from mantidqt.widgets.sliceviewer.cutviewer.presenter import CutViewerPresenter
+from mantidqt.widgets.sliceviewer.cutviewer.view import CutViewerView
+from mantidqt.widgets.sliceviewer.cutviewer.model import CutViewerModel
 from mantidqt.widgets.sliceviewer.presenters.presenter import SliceViewer
 
 
 class TestCutViewerModel(unittest.TestCase):
-    @mock.patch("mantidqt.widgets.sliceviewer.cutviewer.presenter.CutViewerModel", autospec=True)
-    @mock.patch("mantidqt.widgets.sliceviewer.cutviewer.presenter.CutViewerView", autospec=True)
-    def setUp(self, mock_view, mock_model):
+    def setUp(self):
         # load empty instrument so can create a peak table
+        mock_view = mock.create_autospec(CutViewerView)
+        mock_model = mock.create_autospec(CutViewerModel)
         self.mock_sv_presenter = mock.create_autospec(SliceViewer)
-        self.presenter = CutViewerPresenter(self.mock_sv_presenter, canvas=mock.MagicMock())
+        self.presenter = CutViewerPresenter(self.mock_sv_presenter, mock_model, mock_view)
 
     def test_on_cut_done(self):
         self.presenter.on_cut_done("wsname")

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
@@ -16,6 +16,10 @@ import matplotlib.text as text
 from mantid.simpleapi import AnalysisDataService as ADS
 from mantid.kernel import SpecialCoordinateSystem
 from numpy import zeros
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mantidqt.widgets.sliceviewer.cutviewer.presenter import CutViewerPresenter  # noqa: F401
 
 # local imports
 from .representation.cut_representation import CutRepresentation
@@ -26,14 +30,14 @@ class CutViewerView(QWidget):
     to interact with the peaks.
     """
 
-    def __init__(self, presenter, canvas, frame, parent=None):
+    def __init__(self, canvas, frame, parent=None):
         """
         :param painter: An object responsible for drawing the representation of the cut
         :param sliceinfo_provider: An object responsible for providing access to current slice information
         :param parent: An optional parent widget
         """
         super().__init__(parent)
-        self.presenter = presenter
+        self.presenter = None
         self.layout = None
         self.figure_layout = None
         self.table = None
@@ -44,6 +48,9 @@ class CutViewerView(QWidget):
         self._setup_ui()
         self._init_slice_table()
         self.table.cellChanged.connect(self.on_cell_changed)
+
+    def subscribe_presenter(self, presenter: "CutViewPresenter"):
+        self.presenter = presenter
 
     def hide(self):
         super().hide()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from mantidqt.widgets.sliceviewer.cutviewer.presenter import CutViewerPresenter  # noqa: F401
+    from workbench.plotting.mantidfigurecanvas import MantidFigureCanvas  # noqa: F401
 
 # local imports
 from .representation.cut_representation import CutRepresentation
@@ -30,13 +31,13 @@ class CutViewerView(QWidget):
     to interact with the peaks.
     """
 
-    def __init__(self, canvas, frame, parent=None):
+    def __init__(self, canvas: "SliceViewerCanvas", frame: SpecialCoordinateSystem):
         """
         :param painter: An object responsible for drawing the representation of the cut
         :param sliceinfo_provider: An object responsible for providing access to current slice information
         :param parent: An optional parent widget
         """
-        super().__init__(parent)
+        super().__init__()
         self.presenter = None
         self.layout = None
         self.figure_layout = None

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -20,6 +20,8 @@ from mantidqt.widgets.sliceviewer.models.model import SliceViewerModel, WS_TYPE
 from mantidqt.widgets.sliceviewer.models.sliceinfo import SliceInfo
 from mantidqt.widgets.sliceviewer.models.workspaceinfo import WorkspaceInfo
 from mantidqt.widgets.sliceviewer.cutviewer.presenter import CutViewerPresenter
+from mantidqt.widgets.sliceviewer.cutviewer.view import CutViewerView
+from mantidqt.widgets.sliceviewer.cutviewer.model import CutViewerModel
 from mantidqt.widgets.sliceviewer.peaksviewer import PeaksViewerPresenter, PeaksViewerCollectionPresenter
 from mantidqt.widgets.sliceviewer.presenters.base_presenter import SliceViewerBasePresenter
 from mantidqt.widgets.sliceviewer.views.toolbar import ToolItemText
@@ -360,7 +362,9 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
         data_view = self._data_view
         if state:
             if self._cutviewer_presenter is None:
-                self._cutviewer_presenter = CutViewerPresenter(self, data_view.canvas)
+                cutviewer_view = CutViewerView(data_view.canvas, self.get_frame())
+                cutviewer_model = CutViewerModel(self.get_proj_matrix())
+                self._cutviewer_presenter = CutViewerPresenter(self, cutviewer_model, cutviewer_view)
                 self.view.add_widget_to_splitter(self._cutviewer_presenter.get_view())
             self._cutviewer_presenter.show_view()
             data_view.deactivate_tool(ToolItemText.ZOOM)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -328,14 +328,16 @@ class SliceViewerTest(unittest.TestCase):
 
         self.view.data_view.disable_tool_button.assert_has_calls([mock.call(ToolItemText.NONAXISALIGNEDCUTS)])
 
-    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.CutViewerPresenter")
-    def test_cut_view_toggled_on(self, mock_cv_pres):
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.CutViewerPresenter", autospec=True)
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.CutViewerView", autospec=True)
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.CutViewerModel", autospec=True)
+    def test_cut_view_toggled_on(self, mock_cv_model, mock_cv_view, mock_cv_pres):
         presenter = SliceViewer(None, model=self.model, view=self.view)
         self.view.data_view.track_cursor = mock.MagicMock()
 
         presenter.non_axis_aligned_cut(True)
 
-        mock_cv_pres.assert_called_once_with(presenter, self.view.data_view.canvas)
+        self.assertTrue(presenter._cutviewer_presenter is not None)
         # test correct buttons disabled
         self.view.data_view.deactivate_and_disable_tool.assert_has_calls(
             [mock.call(tool) for tool in (ToolItemText.REGIONSELECTION, ToolItemText.LINEPLOTS)]


### PR DESCRIPTION
### Description of work

Refactor cutviewer to init view and model outside presenter and update tests accordingly.

Fixes #38101 

### To test:

(1) Follow manual testing instructions 
https://developer.mantidproject.org/Testing/SliceViewer/SliceViewer.html#cutviewer-tool

*This does not require release notes* because **internal change, no change for user**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
