### PR TITLE
Fix for incorrect incident energies for Merlin in PyChop

### DIFF
--- a/docs/source/release/v6.11.0/Direct_Geometry/General/Bugfixes/38194.rst
+++ b/docs/source/release/v6.11.0/Direct_Geometry/General/Bugfixes/38194.rst
@@ -1,0 +1,1 @@
+- Fix for incorrect incident energies for MERLIN in PyChop when not in instrument scientist mode.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
@@ -198,10 +198,9 @@ class PyChopGui(QMainWindow):
         # Special case for MERLIN - only enable multirep for 'G' chopper
         self._merlin_chopper()
 
-    def _get_phase(self, key, widget):
-        idx = int(key[7])
+    def _get_phase(self, choppernumber, widget):
         phase = widget["Edit"].text()
-        if isinstance(self.engine.chopper_system.defaultPhase[idx], str):
+        if isinstance(self.engine.chopper_system.defaultPhase[choppernumber], str):
             phase = str(phase)
         else:
             try:
@@ -224,11 +223,11 @@ class PyChopGui(QMainWindow):
         # Special case for MERLIN
         # sets the default phase for Chopper0Phase if not in "Instrument Scientist Mode"
         if "MERLIN" in str(self.engine.instname) and not self.widgets["Chopper0Phase"]["Label"].isVisible():
-            phases.append(self._get_phase("Chopper0Phase", self.widgets["Chopper0Phase"]))
+            phases.append(self._get_phase(0, self.widgets["Chopper0Phase"]))
         else:
             for key, widget in self.widgets.items():
                 if key.endswith("Phase") and not widget["Label"].isHidden():
-                    phases.append(self._get_phase(key, widget))
+                    phases.append(self._get_phase(int(key[7]), widget))
         if phases:
             self.engine.setFrequency(freq_in, phase=phases)
         else:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
@@ -223,7 +223,7 @@ class PyChopGui(QMainWindow):
         phases = []
         # Special case for MERLIN
         # sets the default phase for Chopper0Phase if not in "Instrument Scientist Mode"
-        if "MERLIN" in str(self.engine.instname):
+        if "MERLIN" in str(self.engine.instname) and not self.widgets["Chopper0Phase"]["Label"].isVisible():
             phases.append(self._get_phase("Chopper0Phase", self.widgets["Chopper0Phase"]))
         else:
             for key, widget in self.widgets.items():

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
@@ -164,12 +164,7 @@ class PyChopGui(QMainWindow):
                     self.widgets[f"Chopper{idx}Phase"]["Label"].show()
                 self.widgets[f"Chopper{idx}Phase"]["Edit"].setText(str(self.engine.chopper_system.defaultPhase[idx]))
                 self.widgets[f"Chopper{idx}Phase"]["Label"].setText(self.engine.chopper_system.phaseNames[idx])
-            # Special case for MERLIN - hide phase control from normal users
-            if "MERLIN" in str(instname) and not self.instSciAct.isChecked():
-                self.widgets["Chopper0Phase"]["Edit"].hide()
-                self.widgets["Chopper0Phase"]["Label"].hide()
-        self.engine.setChopper(str(self.widgets["ChopperCombo"]["Combo"].currentText()))
-        self.engine.setFrequency(float(self.widgets["FrequencyCombo"]["Combo"].currentText()))
+        self.setChopper(str(self.widgets["ChopperCombo"]["Combo"].currentText()))
         val = self.flxslder.val * self.maxE[self.engine.instname] / 100
         self.flxedt.setText("%3.2f" % (val))
         nframe = self.engine.moderator.n_frame if hasattr(self.engine.moderator, "n_frame") else 1
@@ -192,6 +187,7 @@ class PyChopGui(QMainWindow):
         else:
             self.widgets["S2Edit"]["Edit"].hide()
             self.widgets["S2Edit"]["Label"].hide()
+        self.setFreq()
 
     def setChopper(self, choppername):
         """
@@ -201,6 +197,18 @@ class PyChopGui(QMainWindow):
         self.engine.setFrequency(float(self.widgets["FrequencyCombo"]["Combo"].currentText()))
         # Special case for MERLIN - only enable multirep for 'G' chopper
         self._merlin_chopper()
+
+    def _get_phase(self, key, widget):
+        idx = int(key[7])
+        phase = widget["Edit"].text()
+        if isinstance(self.engine.chopper_system.defaultPhase[idx], str):
+            phase = str(phase)
+        else:
+            try:
+                phase = float(phase) % (1e6 / self.engine.moderator.source_rep)
+            except ValueError:
+                raise ValueError(f'Incorrect phase value "{phase}" for {widget["Label"].text()}')
+        return phase
 
     def setFreq(self, freqtext=None, **kwargs):
         """
@@ -213,21 +221,14 @@ class PyChopGui(QMainWindow):
             freq_in = [freq_in, freqpr]
         # Checks for independent phases
         phases = []
-        for key, widget in self.widgets.items():
-            if key.endswith("Phase"):
-                # Special case for MERLIN
-                # sets the default phase for Chopper0Phase if not in "Instrument Scientist Mode"
-                if not widget["Label"].isHidden() or "MERLIN" in str(self.engine.instname) and key[7] == 0:
-                    idx = int(key[7])
-                    phase = widget["Edit"].text()
-                    if isinstance(self.engine.chopper_system.defaultPhase[idx], str):
-                        phase = str(phase)
-                    else:
-                        try:
-                            phase = float(phase) % (1e6 / self.engine.moderator.source_rep)
-                        except ValueError:
-                            raise ValueError(f'Incorrect phase value "{phase}" for {widget["Label"].text()}')
-                    phases.append(phase)
+        # Special case for MERLIN
+        # sets the default phase for Chopper0Phase if not in "Instrument Scientist Mode"
+        if "MERLIN" in str(self.engine.instname):
+            phases.append(self._get_phase("Chopper0Phase", self.widgets["Chopper0Phase"]))
+        else:
+            for key, widget in self.widgets.items():
+                if key.endswith("Phase") and not widget["Label"].isHidden():
+                    phases.append(self._get_phase(key, widget))
         if phases:
             self.engine.setFrequency(freq_in, phase=phases)
         else:
@@ -240,14 +241,22 @@ class PyChopGui(QMainWindow):
 
     def _merlin_chopper(self):
         if "MERLIN" in self.engine.instname:
+            try:
+                if self.engine.getChopper() is None:
+                    self.setChopper(self.widgets["ChopperCombo"]["Combo"].currentText())
+            except ValueError as err:
+                self.errormessage(err)
             if "G" in self.engine.getChopper():
                 self.widgets["MultiRepCheck"].setEnabled(True)
                 self.tabs.setTabEnabled(self.tdtabID, True)
+                self.widgets["Chopper0Phase"]["Edit"].setText("12400")
+                self.widgets["Chopper0Phase"]["Label"].setText("Disk chopper phase delay time")
                 if self.instSciAct.isChecked():
-                    self.widgets["Chopper0Phase"]["Edit"].setText("12400")
-                    self.widgets["Chopper0Phase"]["Label"].setText("Disk chopper phase delay time")
                     self.widgets["Chopper0Phase"]["Edit"].show()
                     self.widgets["Chopper0Phase"]["Label"].show()
+                else:
+                    self.widgets["Chopper0Phase"]["Edit"].hide()
+                    self.widgets["Chopper0Phase"]["Label"].hide()
             else:
                 self.widgets["MultiRepCheck"].setEnabled(False)
                 self.widgets["MultiRepCheck"].setChecked(False)


### PR DESCRIPTION
### Description of work

#### Summary of work
When PyChop is used in normal user mode instead of instrument scientist mode, the default value for the chopper phase has to be used. The default value is now ensured, even without a widget for the chopper phase.

Fixes #38182.

### To test:

Follow the instructions in the original issue first in normal user mode, then in instrument scientist mode. The `Resolution` plots should be the same for both modes. Instrument scientist mode can be enabled in the `Options` menu.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
