### PR TITLE
Remove direct calls to presenter from cut viewer view

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/presenter.py
@@ -88,3 +88,7 @@ class CutViewerPresenter:
 
     def on_cut_done(self, wsname):
         self.view.plot_cut_ws(wsname)
+
+    def handle_cell_changed(self, irow: int, icol: int):
+        self.view.set_bin_params(*self.validate_bin_params(irow, icol))
+        self.update_cut()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/presenter.py
@@ -82,7 +82,7 @@ class CutViewerPresenter:
         axes_transform = self._sliceview_presenter.get_sliceinfo().get_northogonal_transform()
         return xmin, xmax, ymin, ymax, thickness, axes_transform
 
-    def update_bin_params_from_cut_representation(self, xmin, xmax, ymin, ymax, thickness):
+    def handle_cut_representation_changed(self, xmin, xmax, ymin, ymax, thickness):
         out_plane_vector = self.view.get_vector(2)  # integrated dimension (last row in table)
         vectors_in_plane, extents_in_plane, nbins_in_plane = self.model.calc_bin_params_from_cut_representation(
             xmin, xmax, ymin, ymax, thickness, out_plane_vector

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/presenter.py
@@ -39,14 +39,13 @@ class CutViewerPresenter:
         return self.view
 
     def reset_view_table(self):
-        self.view.set_bin_params(
-            *self.model.get_default_bin_params(
-                self._sliceview_presenter.get_dimensions(),
-                self._sliceview_presenter.get_data_limits_to_fill_current_axes(),
-                self._sliceview_presenter.get_sliceinfo().z_value,
-            )
+        vectors, extents, nbins = self.model.get_default_bin_params(
+            self._sliceview_presenter.get_dimensions(),
+            self._sliceview_presenter.get_data_limits_to_fill_current_axes(),
+            self._sliceview_presenter.get_sliceinfo().z_value,
         )
-        self.view.plot_cut_representation(*self.get_cut_representation_parameters())
+        self.view.set_bin_params(vectors, extents, nbins)
+        self.view.plot_cut_representation(*self.get_cut_representation_parameters(vectors[:-1, :], extents[:, :-1], nbins[:-1]))
 
     def validate_bin_params(self, irow, icol):
         iunchanged = int(not bool(irow))  # index of u1 or u2 - which ever not changed (3rd row not editable)
@@ -76,17 +75,20 @@ class CutViewerPresenter:
         if self.model.valid_bin_params(vectors, extents, nbins):
             self._sliceview_presenter.perform_non_axis_aligned_cut(vectors, extents.flatten(order="F"), nbins)
 
-    def get_cut_representation_parameters(self):
+    def get_cut_representation_parameters(self, vectors_in_plane, extents_in_plane, nbins_in_plane):
         xmin, xmax, ymin, ymax, thickness = self.model.calc_cut_representation_parameters(
-            *self.get_bin_params_from_view(), self._sliceview_presenter.get_dimensions().get_states()
+            vectors_in_plane, extents_in_plane, nbins_in_plane, self._sliceview_presenter.get_dimensions().get_states()
         )
         axes_transform = self._sliceview_presenter.get_sliceinfo().get_northogonal_transform()
         return xmin, xmax, ymin, ymax, thickness, axes_transform
 
     def update_bin_params_from_cut_representation(self, xmin, xmax, ymin, ymax, thickness):
         out_plane_vector = self.view.get_vector(2)  # integrated dimension (last row in table)
-        self.view.set_bin_params(*self.model.calc_bin_params_from_cut_representation(xmin, xmax, ymin, ymax, thickness, out_plane_vector))
-        self.view.plot_cut_representation(*self.get_cut_representation_parameters())
+        vectors_in_plane, extents_in_plane, nbins_in_plane = self.model.calc_bin_params_from_cut_representation(
+            xmin, xmax, ymin, ymax, thickness, out_plane_vector
+        )
+        self.view.set_bin_params(vectors_in_plane, extents_in_plane, nbins_in_plane)
+        self.view.plot_cut_representation(*self.get_cut_representation_parameters(vectors_in_plane, extents_in_plane, nbins_in_plane))
         self.update_cut()
 
     # signals
@@ -104,6 +106,7 @@ class CutViewerPresenter:
         self.view.plot_cut_ws(wsname)
 
     def handle_cell_changed(self, irow: int, icol: int):
-        self.view.set_bin_params(*self.validate_bin_params(irow, icol))
+        vectors, extents, nbins = self.validate_bin_params(irow, icol)
+        self.view.set_bin_params(vectors, extents, nbins)
         self.update_cut()
-        self.view.plot_cut_representation(*self.get_cut_representation_parameters())
+        self.view.plot_cut_representation(*self.get_cut_representation_parameters(vectors[:-1, :], extents[:, :-1], nbins[:-1]))

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/test/test_cutviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/test/test_cutviewer_model.py
@@ -77,7 +77,7 @@ class TestCutViewerModel(unittest.TestCase):
 
     def test_calc_cut_representation_parameters(self):
         xmin, xmax, ymin, ymax, thick = self.model.calc_cut_representation_parameters(
-            eye(3), tile(c_[[0.0, 1.0]], (1, 3)), array([10, 1, 1]), [0, 1, None]
+            eye(3)[:-1, :], tile(c_[[0.0, 1.0]], (1, 2)), array([10, 1]), [0, 1, None]
         )
 
         self.assertTrue(array_equal(self.model.xvec, array([1, 0, 0])))

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/test/test_cutviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/test/test_cutviewer_presenter.py
@@ -74,7 +74,7 @@ class TestCutViewerModel(unittest.TestCase):
         self.mock_sv_presenter.perform_non_axis_aligned_cut.assert_not_called()
 
     @mock.patch("mantidqt.widgets.sliceviewer.cutviewer.presenter.CutViewerPresenter.update_cut")
-    def test_update_bin_params_from_cut_representation(self, mock_update_cut):
+    def test_handle_cut_representation_changed(self, mock_update_cut):
         xmin, xmax, ymin, ymax, thickness = 0, 1, 0, 1, 0.1
         self.presenter.model.calc_bin_params_from_cut_representation.return_value = 3 * [None]  # vecs, extents, nbins
         self.presenter.model.calc_cut_representation_parameters.return_value = xmin, xmax, ymin, ymax, thickness
@@ -83,7 +83,7 @@ class TestCutViewerModel(unittest.TestCase):
         self.presenter.view.get_extents.return_value = [-1, 1]  # ignored
         self.presenter.view.get_nbin.return_value = 2  # ignored
 
-        self.presenter.update_bin_params_from_cut_representation(xmin, xmax, ymin, ymax, thickness)
+        self.presenter.handle_cut_representation_changed(xmin, xmax, ymin, ymax, thickness)
 
         mock_update_cut.assert_called_once()
         # check last vector passed as out of plane vector

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
@@ -72,6 +72,15 @@ class CutViewerView(QWidget):
     def get_step(self, irow):
         return float(self.table.item(irow, 6).text())
 
+    def get_nbin(self, irow):
+        return int(self.table.item(irow, 5).text())
+
+    def get_extents(self, irow):
+        return [float(self.table.item(irow, icol).text()) for icol in (3, 4)]  # start, stop
+
+    def get_vector(self, irow):
+        return [float(self.table.item(irow, icol).text()) for icol in range(3)]
+
     # setters
 
     def set_vector(self, irow, vector):
@@ -90,15 +99,6 @@ class CutViewerView(QWidget):
     def update_step(self, irow, nbin):
         extents = self.get_extents(irow)
         self.set_step(irow, (extents[1] - extents[0]) / nbin)
-
-    def get_nbin(self, irow):
-        return int(self.table.item(irow, 5).text())
-
-    def get_extents(self, irow):
-        return [float(self.table.item(irow, icol).text()) for icol in (3, 4)]  # start, stop
-
-    def get_vector(self, irow):
-        return [float(self.table.item(irow, icol).text()) for icol in range(3)]
 
     def set_nbin(self, irow, nbin):
         self.table.item(irow, 5).setData(Qt.EditRole, int(nbin))
@@ -132,7 +132,7 @@ class CutViewerView(QWidget):
         self.cut_rep = CutRepresentation(self.canvas, self.on_representation_changed, xmin, xmax, ymin, ymax, thickness, axes_transform)
 
     def on_representation_changed(self, xmin, xmax, ymin, ymax, thickness):
-        self.presenter.update_bin_params_from_cut_representation(xmin, xmax, ymin, ymax, thickness)
+        self.presenter.handle_cut_representation_changed(xmin, xmax, ymin, ymax, thickness)
 
     # private api
     def _setup_ui(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
@@ -37,7 +37,7 @@ class CutViewerView(QWidget):
         :param parent: An optional parent widget
         """
         super().__init__()
-        self.presenter = None
+        self._presenter = None
         self.layout = None
         self.figure_layout = None
         self.table = None
@@ -50,7 +50,7 @@ class CutViewerView(QWidget):
         self.table.cellChanged.connect(self.on_cell_changed)
 
     def subscribe_presenter(self, presenter: CutViewPresenter):
-        self.presenter = presenter
+        self._presenter = presenter
 
     def hide(self):
         super().hide()
@@ -61,7 +61,7 @@ class CutViewerView(QWidget):
     # signals
 
     def on_cell_changed(self, irow, icol):
-        self.presenter.handle_cell_changed(irow, icol)
+        self._presenter.handle_cell_changed(irow, icol)
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
@@ -132,7 +132,7 @@ class CutViewerView(QWidget):
         self.cut_rep = CutRepresentation(self.canvas, self.on_representation_changed, xmin, xmax, ymin, ymax, thickness, axes_transform)
 
     def on_representation_changed(self, xmin, xmax, ymin, ymax, thickness):
-        self.presenter.handle_cut_representation_changed(xmin, xmax, ymin, ymax, thickness)
+        self._presenter.handle_cut_representation_changed(xmin, xmax, ymin, ymax, thickness)
 
     # private api
     def _setup_ui(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
@@ -62,8 +62,7 @@ class CutViewerView(QWidget):
     # signals
 
     def on_cell_changed(self, irow, icol):
-        self.set_bin_params(*self.presenter.validate_bin_params(irow, icol))
-        self.presenter.update_cut()
+        self.presenter.handle_cell_changed(irow, icol)
 
     def resizeEvent(self, event):
         super().resizeEvent(event)


### PR DESCRIPTION
### Description of work

Remove direct calls to presenter from cut viewer view for MVP training.
This is blocked by #38101(which must be merged first)

Fixes #38102

### To test:

(1) Follow manual testing instructions 
https://developer.mantidproject.org/Testing/SliceViewer/SliceViewer.html#cutviewer-tool

*This does not require release notes* because **internal change, users shouldn't notice difference**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
