### PR TITLE
Updated MSlice SHA and added release notes

### DIFF
--- a/docs/source/release/v6.11.0/Direct_Geometry/MSlice/Bugfixes/38199.rst
+++ b/docs/source/release/v6.11.0/Direct_Geometry/MSlice/Bugfixes/38199.rst
@@ -1,0 +1,2 @@
+- The ‘Intensity’ menu on slice plots is now disabled in interactive mode to prevent crashes.
+- Bug fix implemented to save cut data in a 3-column file instead of a single line.

--- a/docs/source/release/v6.11.0/Direct_Geometry/MSlice/New_features/38199.rst
+++ b/docs/source/release/v6.11.0/Direct_Geometry/MSlice/New_features/38199.rst
@@ -1,0 +1,2 @@
+- ‘None’ is now a new line style option. With this feature, it is possible to plot error bars without including a line.
+- The spectrum ID is no longer printed when saving a 2D workspace as an ASCII file.

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -8,7 +8,7 @@ externalproject_add(
   PREFIX ${_mslice_external_root}
   UPDATE_DISCONNECTED "false"
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
-  GIT_TAG cf985c648530d78d4d841896a6d2ead92a7a6b86
+  GIT_TAG 94705e4fd83f15548d230fee6f2df76b350fc815
   EXCLUDE_FROM_ALL 1
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""


### PR DESCRIPTION
### Description of work

#### Summary of work
Replaced MSlice SHA for Mantid with SHA of current MSlice main branch.

Added release notes for all changes since the last SHA update.

*There is no associated issue.*

### To test:

Double-check SHA with SHA of current MSlice main branch.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
