### PR TITLE
Add `value` attribute to python binding of `Property` base class

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
@@ -147,6 +147,9 @@ void export_Property() {
                     "The units attached to this property as a encoded bytes object. It "
                     "is assumed the caller knows the correct endcoding used.")
 
+      .add_property("value", &Property::value, &Property::setValue,
+                    "The value of the property. For a generic property, equivalent to valueAsStr.")
+
       .add_property("valueAsStr", &Property::value, &Property::setValue,
                     "The value of the property as a string. "
                     "For some property types, e.g. Workspaces, it is useful to "


### PR DESCRIPTION
### Description of work

#### Summary of work

Within the python binding, added a `value` attribute to the generic `Property` type.  This will have the same behavior as `valueAsStr`.

#### Purpose of work

Most `Property`s in mantid inherit from `PropertyWithValue` and have a `.value` attribute.

However, some inherit from `Property` directly and don't have this attribute.  Since users might look for it, this was programmed to just return the same as `.valueAsStr` for the generic base `Property` type.

This came up within the context of PR #38177, which adds an `EnumeratedStringProperty` without a python binding.  When the property is retrieved from an algorithm, it has type `Property`, and hence has no `.value` attribute.  This PR will make sure that `.value` still works.

#### Further detail of work

Change was two lines:
``` c++
.add_property("value", &Property::value, &Property::setValue,
                    "The value of the property. For a generic property, equivalent to valueAsStr.")
```

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

This should be basically inaccessible from the python API.  There is no way to create a generic `Property` object from within python.  

This would only even come up in the situation of a class inheriting directly from `Property`, without its own python binding,  The only property that meets this description is `MatrixProperty`, but that is not used inside any algorithm.  I tried testing in a few ways, but couldn't get anything to come up.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
