### PR TITLE
Keep most recent successful nightly

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -441,9 +441,16 @@ pipeline {
         timestamps ()
       }
       steps {
-        // Keep this build. If it reaches this stage then it passed all other stages.
         script {
+          // Keep this build. If it reaches this stage then it passed all other stages.
           currentBuild.keepLog = true
+          // Remove the "keep" status for all previous successful runs.
+          build = currentBuild.getPreviousSuccessfulBuild()
+          while(build != null)
+          {
+            build.build().keepLog(false)
+            build = build.getPreviousSuccessfulBuild()
+          }
         }
       }
     }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -444,11 +444,21 @@ pipeline {
         script {
           // Keep this build. If it reaches this stage then it passed all other stages.
           currentBuild.keepLog = true
+
+          // Set the keep description to a known value so we know which previous builds to discard.
+          // This will allow builds to be manually kept and preserved by setting a custom description.
+          keepDescription = "Automatically preserving the most recent successful nightly"
+          currentBuild.setDescription(keepDescription)
+
           // Remove the "keep" status for all previous successful runs.
           build = currentBuild.getPreviousSuccessfulBuild()
           while(build != null)
           {
-            build.build().keepLog(false)
+            if(build.build().getDescription() == keepDescription)
+            {
+              build.build().setDescription("")
+              build.build().keepLog(false)
+            }
             build = build.getPreviousSuccessfulBuild()
           }
         }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -435,6 +435,18 @@ pipeline {
           "${WORKSPACE}/standalone-packages/* ${WORKSPACE}/conda-packages.tar"
       }
     }
+    stage ('Keep latest successful build') {
+      agent { label 'linux-64' } // Use linux for simplicity with shell scripts
+      options {
+        timestamps ()
+      }
+      steps {
+        // Keep this build. If it reaches this stage then it passed all other stages.
+        script {
+          currentBuild.keepLog = true
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Description of work
Added a stage to the end of the Jenkins build/test/deploy nightly pipeline. If all previous stages pass, the current build will be marked as "Keep this build forever", and previous builds that were automatically kept are "un-kept". If a developer manually keeps another previous build, it will be untouched by this new pipeline stage (as long as they don't set the description to "Automatically preserving the most recent successful nightly").

#### Purpose of work
It is useful to have a successful nightly to compare with failed nightlies so that we can diagnose the failure. In the past we have had so many consecutive failures that the most recent successful run has fallen off the end of the list. This will prevent that from happening.


Fixes #38147 

### To test:
Using the [Core_Team_test_pipeline](https://builds.mantidproject.org/job/Core_Team_test_pipeline/), run this branch (`38147_keep_most_recent_successful_nightly`) but with `BUILD_DEVEL` and `BUILD_PACKAGE` both set to **none**. It only takes about 10 seconds to complete the build. You can run it several times with different test criteria. Ensure that it:
- keeps the latest successful build and adds the build description "Automatically preserving the most recent successful nightly"
- un-keeps previous builds where the description is "Automatically preserving the most recent successful nightly" and resets the description to an empty string
- does not touch any other builds that have been "kept forever" if thier descriptions are empty or have antoher manually entered string value
Be creative with your testing and try to find edge cases where it doesn't work.

*This does not require release notes* because **it's a pipeline addition that doesn't affect the software**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
