### PR TITLE
Remove QObjects from ALCFitting Presenter and Model

### DIFF
--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.cpp
@@ -23,6 +23,10 @@ void ALCBaselineModellingPresenter::initialize() {
   m_view->subscribePresenter(this);
 }
 
+void ALCBaselineModellingPresenter::subscribe(IALCBaselineModellingPresenterSubscriber *subscriber) {
+  m_subscriber = subscriber;
+}
+
 /**
  * Perform a fit and updates the view accordingly
  */
@@ -156,6 +160,7 @@ void ALCBaselineModellingPresenter::updateCorrectedCurve() {
     m_view->setCorrectedCurve(correctedDataWs);
   else
     m_view->removePlot("Corrected");
+  m_subscriber->correctedDataChanged();
 }
 
 void ALCBaselineModellingPresenter::updateBaselineCurve() {

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.h
@@ -8,6 +8,7 @@
 
 #include "IALCBaselineModellingModel.h"
 #include "IALCBaselineModellingPresenter.h"
+#include "IALCBaselineModellingPresenterSubscriber.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidKernel/System.h"
 
@@ -42,6 +43,9 @@ public:
   /// Called when on of section selectors is modified
   void onSectionSelectorModified(int index) override;
 
+  /// Subscribe to updates on changes to the corrected data.
+  void subscribe(IALCBaselineModellingPresenterSubscriber *subscriber);
+
   /// Updates data curve from the model
   void updateDataCurve();
 
@@ -72,6 +76,9 @@ public:
 
 private:
   void updateAfterFit();
+
+  /// Subscriber to notify of corrected curve changes.
+  IALCBaselineModellingPresenterSubscriber *m_subscriber;
 
   /// Associated view
   IALCBaselineModellingView *const m_view;

--- a/qt/scientific_interfaces/Muon/ALCInterface.cpp
+++ b/qt/scientific_interfaces/Muon/ALCInterface.cpp
@@ -25,6 +25,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/Logger.h"
+#include "MantidQtWidgets/Common/QtJobRunner.h"
 
 #include <algorithm>
 
@@ -88,8 +89,7 @@ void ALCInterface::closeEvent(QCloseEvent *event) {
 // namespace CustomInterfaces
 ALCInterface::ALCInterface(QWidget *parent)
     : UserSubWindow(parent), m_ui(), m_peakFittingView(nullptr), m_dataLoading(nullptr), m_baselineModelling(nullptr),
-      m_peakFitting(nullptr), m_peakFittingModel(new ALCPeakFittingModel()),
-      m_externalPlotter(std::make_unique<Widgets::MplCpp::ExternalPlotter>()) {}
+      m_peakFitting(nullptr), m_externalPlotter(std::make_unique<Widgets::MplCpp::ExternalPlotter>()) {}
 
 void ALCInterface::initLayout() {
   m_ui.setupUi(this);
@@ -115,7 +115,10 @@ void ALCInterface::initLayout() {
   m_baselineModelling->initialize();
 
   m_peakFittingView = new ALCPeakFittingView(m_ui.peakFittingView);
-  m_peakFitting = new ALCPeakFittingPresenter(m_peakFittingView, m_peakFittingModel);
+  auto jobRunner = std::make_unique<MantidQt::API::QtJobRunner>(true);
+  auto algorithmRunner = std::make_unique<MantidQt::API::AlgorithmRunner>(std::move(jobRunner));
+  m_peakFittingModel = std::make_shared<ALCPeakFittingModel>(std::move(algorithmRunner));
+  m_peakFitting = new ALCPeakFittingPresenter(m_peakFittingView, m_peakFittingModel.get());
   m_peakFitting->initialize();
 
   assert(m_ui.stepView->count() == STEP_NAMES.count()); // Should have names for all steps

--- a/qt/scientific_interfaces/Muon/ALCInterface.cpp
+++ b/qt/scientific_interfaces/Muon/ALCInterface.cpp
@@ -153,7 +153,7 @@ void ALCInterface::updatePeakData() {
     if (m_peakFittingView->function("")) {
 
       // Fit the data
-      m_peakFittingView->emitFitRequested();
+      m_peakFittingView->fitRequested();
     }
   }
 }

--- a/qt/scientific_interfaces/Muon/ALCInterface.cpp
+++ b/qt/scientific_interfaces/Muon/ALCInterface.cpp
@@ -94,15 +94,15 @@ ALCInterface::ALCInterface(QWidget *parent)
 void ALCInterface::initLayout() {
   m_ui.setupUi(this);
 
-  connect(m_ui.nextStep, SIGNAL(clicked()), SLOT(nextStep()));
-  connect(m_ui.previousStep, SIGNAL(clicked()), SLOT(previousStep()));
-  connect(m_ui.exportResults, SIGNAL(clicked()), SLOT(exportResults()));
-  connect(m_ui.importResults, SIGNAL(clicked()), SLOT(importResults()));
-  connect(m_ui.externalPlotButton, SIGNAL(clicked()), SLOT(externalPlotRequested()));
+  connect(m_ui.nextStep, &QPushButton::clicked, this, &ALCInterface::nextStep);
+  connect(m_ui.previousStep, &QPushButton::clicked, this, &ALCInterface::previousStep);
+  connect(m_ui.exportResults, &QPushButton::clicked, this, &ALCInterface::exportResults);
+  connect(m_ui.importResults, &QPushButton::clicked, this, &ALCInterface::importResults);
+  connect(m_ui.externalPlotButton, &QPushButton::clicked, this, &ALCInterface::externalPlotRequested);
 
   auto dataLoadingModel = std::make_unique<ALCDataLoadingModel>();
   auto dataLoadingView = new ALCDataLoadingView(m_ui.dataLoadingView);
-  connect(dataLoadingView, SIGNAL(dataChanged()), SLOT(updateBaselineData()));
+  connect(dataLoadingView, &ALCDataLoadingView::dataChanged, this, &ALCInterface::updateBaselineData);
 
   m_dataLoading = std::make_unique<ALCDataLoadingPresenter>(dataLoadingView, std::move(dataLoadingModel));
   m_dataLoading->initialize();
@@ -118,10 +118,9 @@ void ALCInterface::initLayout() {
   auto jobRunner = std::make_unique<MantidQt::API::QtJobRunner>(true);
   auto algorithmRunner = std::make_unique<MantidQt::API::AlgorithmRunner>(std::move(jobRunner));
   m_peakFittingModel = std::make_shared<ALCPeakFittingModel>(std::move(algorithmRunner));
-  m_peakFitting = new ALCPeakFittingPresenter(m_peakFittingView, m_peakFittingModel.get());
+  m_peakFitting = std::make_unique<ALCPeakFittingPresenter>(m_peakFittingView, m_peakFittingModel.get());
   m_peakFitting->initialize();
 
-  connect(m_dataLoading, SIGNAL(dataChanged()), SLOT(updateBaselineData()));
   m_baselineModelling->subscribe(this);
 
   assert(m_ui.stepView->count() == STEP_NAMES.count()); // Should have names for all steps

--- a/qt/scientific_interfaces/Muon/ALCInterface.cpp
+++ b/qt/scientific_interfaces/Muon/ALCInterface.cpp
@@ -121,6 +121,9 @@ void ALCInterface::initLayout() {
   m_peakFitting = new ALCPeakFittingPresenter(m_peakFittingView, m_peakFittingModel.get());
   m_peakFitting->initialize();
 
+  connect(m_dataLoading, SIGNAL(dataChanged()), SLOT(updateBaselineData()));
+  m_baselineModelling->subscribe(this);
+
   assert(m_ui.stepView->count() == STEP_NAMES.count()); // Should have names for all steps
 
   switchStep(0); // We always start from the first step
@@ -143,6 +146,8 @@ void ALCInterface::updateBaselineData() {
     }
   }
 }
+
+void ALCInterface::correctedDataChanged() { updatePeakData(); }
 
 void ALCInterface::updatePeakData() {
 

--- a/qt/scientific_interfaces/Muon/ALCInterface.h
+++ b/qt/scientific_interfaces/Muon/ALCInterface.h
@@ -84,7 +84,7 @@ private:
   ALCPeakFittingPresenter *m_peakFitting;
 
   // Models
-  ALCPeakFittingModel *m_peakFittingModel;
+  std::shared_ptr<ALCPeakFittingModel> m_peakFittingModel;
 
   /// Name for every step for labels
   static const QStringList STEP_NAMES;

--- a/qt/scientific_interfaces/Muon/ALCInterface.h
+++ b/qt/scientific_interfaces/Muon/ALCInterface.h
@@ -14,6 +14,7 @@
 #include "MantidQtWidgets/Plotting/ExternalPlotter.h"
 
 #include "ALCBaselineModellingPresenter.h"
+#include "IALCBaselineModellingPresenterSubscriber.h"
 #include "ALCDataLoadingPresenter.h"
 
 #include "ui_ALCInterface.h"
@@ -32,12 +33,14 @@ class ALCPeakFittingModel;
 
 /** ALCInterface : Custom interface for Avoided Level Crossing analysis
  */
-class MANTIDQT_MUONINTERFACE_DLL ALCInterface : public API::UserSubWindow {
+class MANTIDQT_MUONINTERFACE_DLL ALCInterface : public API::UserSubWindow,
+                                                public IALCBaselineModellingPresenterSubscriber {
   Q_OBJECT
 
 public:
   ALCInterface(QWidget *parent = nullptr);
 
+  void correctedDataChanged() override;
   void closeEvent(QCloseEvent *event) override;
   static std::string name() { return "ALC"; }
   static QString categoryInfo() { return "Muon"; }

--- a/qt/scientific_interfaces/Muon/ALCInterface.h
+++ b/qt/scientific_interfaces/Muon/ALCInterface.h
@@ -14,6 +14,7 @@
 #include "MantidQtWidgets/Plotting/ExternalPlotter.h"
 
 #include "ALCBaselineModellingPresenter.h"
+#include "ALCPeakFittingPresenter.h"
 #include "IALCBaselineModellingPresenterSubscriber.h"
 #include "ALCDataLoadingPresenter.h"
 
@@ -28,7 +29,6 @@ class ALCBaselineModellingView;
 class ALCBaselineModellingModel;
 
 class ALCPeakFittingView;
-class ALCPeakFittingPresenter;
 class ALCPeakFittingModel;
 
 /** ALCInterface : Custom interface for Avoided Level Crossing analysis
@@ -84,7 +84,7 @@ private:
   // Step presenters
   std::unique_ptr<ALCDataLoadingPresenter> m_dataLoading;
   std::unique_ptr<ALCBaselineModellingPresenter> m_baselineModelling;
-  ALCPeakFittingPresenter *m_peakFitting;
+  std::unique_ptr<ALCPeakFittingPresenter> m_peakFitting;
 
   // Models
   std::shared_ptr<ALCPeakFittingModel> m_peakFittingModel;

--- a/qt/scientific_interfaces/Muon/ALCInterface.h
+++ b/qt/scientific_interfaces/Muon/ALCInterface.h
@@ -14,9 +14,9 @@
 #include "MantidQtWidgets/Plotting/ExternalPlotter.h"
 
 #include "ALCBaselineModellingPresenter.h"
+#include "ALCDataLoadingPresenter.h"
 #include "ALCPeakFittingPresenter.h"
 #include "IALCBaselineModellingPresenterSubscriber.h"
-#include "ALCDataLoadingPresenter.h"
 
 #include "ui_ALCInterface.h"
 

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
@@ -14,7 +14,6 @@
 #include "MantidAPI/TableRow.h"
 #include "MantidAPI/TextAxis.h"
 #include "MantidAPI/WorkspaceFactory.h"
-#include <Poco/ActiveResult.h>
 #include <utility>
 
 using namespace Mantid::API;

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
@@ -7,6 +7,7 @@
 #include "ALCPeakFittingModel.h"
 
 #include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AlgorithmRuntimeProps.h"
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -15,7 +16,6 @@
 #include "MantidAPI/WorkspaceFactory.h"
 
 #include <Poco/ActiveResult.h>
-#include <QApplication>
 #include <utility>
 
 using namespace Mantid::API;
@@ -50,9 +50,20 @@ MatrixWorkspace_sptr evaluateFunction(const IFunction_const_sptr &function,
 
 namespace MantidQt::CustomInterfaces {
 
+ALCPeakFittingModel::ALCPeakFittingModel(std::unique_ptr<MantidQt::API::IAlgorithmRunner> algorithmRunner)
+    : m_algorithmRunner(std::move(algorithmRunner)) {
+  m_algorithmRunner->subscribe(this);
+}
+
+void ALCPeakFittingModel::subscribe(std::weak_ptr<IALCPeakFittingModelSubscriber> subscriber) {
+  m_subscriber = subscriber;
+}
+
 void ALCPeakFittingModel::setData(MatrixWorkspace_sptr newData) {
   m_data = std::move(newData);
-  emit dataChanged();
+  if (auto subscriber = m_subscriber.lock()) {
+    subscriber->dataChanged();
+  }
 }
 
 MatrixWorkspace_sptr ALCPeakFittingModel::exportWorkspace() {
@@ -75,30 +86,39 @@ ITableWorkspace_sptr ALCPeakFittingModel::exportFittedPeaks() {
 
 void ALCPeakFittingModel::setFittedPeaks(IFunction_const_sptr fittedPeaks) {
   m_fittedPeaks = std::move(fittedPeaks);
-  emit fittedPeaksChanged();
+  if (auto subscriber = m_subscriber.lock()) {
+    subscriber->fittedPeaksChanged();
+  }
 }
 
 void ALCPeakFittingModel::fitPeaks(IFunction_const_sptr peaks) {
   IAlgorithm_sptr fit = AlgorithmManager::Instance().create("Fit");
   fit->setAlwaysStoreInADS(false);
-  fit->setProperty("Function", peaks->asString());
-  fit->setProperty("InputWorkspace", std::const_pointer_cast<MatrixWorkspace>(m_data));
-  fit->setProperty("CreateOutput", true);
-  fit->setProperty("OutputCompositeMembers", true);
+  auto runtimeProps = std::make_unique<Mantid::API::AlgorithmRuntimeProps>();
+  runtimeProps->setProperty("Function", peaks->asString());
+  runtimeProps->setProperty("InputWorkspace", std::const_pointer_cast<MatrixWorkspace>(m_data));
+  runtimeProps->setProperty("CreateOutput", true);
+  runtimeProps->setProperty("OutputCompositeMembers", true);
 
-  // Execute async so we can show progress bar
-  Poco::ActiveResult<bool> result(fit->executeAsync());
-  while (!result.available()) {
-    QCoreApplication::processEvents();
-  }
-  if (!result.error().empty()) {
-    QString msg = "Fit algorithm failed.\n\n" + QString(result.error().c_str()) + "\n";
-    emit errorInModel(msg);
-  }
+  MantidQt::API::IConfiguredAlgorithm_sptr fitAlg =
+      std::make_shared<MantidQt::API::ConfiguredAlgorithm>(fit, std::move(runtimeProps));
 
-  m_data = fit->getProperty("OutputWorkspace");
-  m_parameterTable = fit->getProperty("OutputParameters");
-  setFittedPeaks(static_cast<IFunction_sptr>(fit->getProperty("Function")));
+  m_algorithmRunner->execute(fitAlg);
+}
+
+void ALCPeakFittingModel::notifyAlgorithmComplete(MantidQt::API::IConfiguredAlgorithm_sptr &confAlgorithm) {
+  auto const &alg = confAlgorithm->algorithm();
+  m_data = alg->getProperty("OutputWorkspace");
+  m_parameterTable = alg->getProperty("OutputParameters");
+  setFittedPeaks(static_cast<IFunction_sptr>(alg->getProperty("Function")));
+}
+
+void ALCPeakFittingModel::notifyAlgorithmError(MantidQt::API::IConfiguredAlgorithm_sptr &algorithm,
+                                               const std::string &message) {
+  std::string msg = algorithm->algorithm()->name() + " Algorithm failed.\n\n" + std::string(message) + "\n";
+  if (auto subscriber = m_subscriber.lock()) {
+    subscriber->errorInModel(msg);
+  }
 }
 
 MatrixWorkspace_sptr ALCPeakFittingModel::guessData(IFunction_const_sptr function, const std::vector<double> &xValues) {

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
@@ -14,8 +14,6 @@
 #include "MantidAPI/TableRow.h"
 #include "MantidAPI/TextAxis.h"
 #include "MantidAPI/WorkspaceFactory.h"
-#include "MantidQtWidgets/Common/QtJobRunner.h"
-
 #include <Poco/ActiveResult.h>
 #include <utility>
 
@@ -53,12 +51,6 @@ namespace MantidQt::CustomInterfaces {
 
 ALCPeakFittingModel::ALCPeakFittingModel(std::unique_ptr<MantidQt::API::IAlgorithmRunner> algorithmRunner)
     : m_algorithmRunner(std::move(algorithmRunner)) {
-  m_algorithmRunner->subscribe(this);
-}
-
-ALCPeakFittingModel::ALCPeakFittingModel() {
-  auto jobRunner = std::make_unique<MantidQt::API::QtJobRunner>(true);
-  m_algorithmRunner = std::make_unique<MantidQt::API::AlgorithmRunner>(std::move(jobRunner));
   m_algorithmRunner->subscribe(this);
 }
 

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingModel.cpp
@@ -107,7 +107,8 @@ void ALCPeakFittingModel::fitPeaks(IFunction_const_sptr peaks) {
   m_algorithmRunner->execute(std::move(fitAlg));
 }
 
-void ALCPeakFittingModel::notifyBatchComplete(MantidQt::API::IConfiguredAlgorithm_sptr &confAlgorithm, bool _) {
+void ALCPeakFittingModel::notifyBatchComplete(MantidQt::API::IConfiguredAlgorithm_sptr &confAlgorithm,
+                                              bool /*unused*/) {
   auto const &alg = confAlgorithm->algorithm();
   m_data = alg->getProperty("OutputWorkspace");
   m_parameterTable = alg->getProperty("OutputParameters");

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingModel.h
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingModel.h
@@ -47,8 +47,6 @@ public:
 
   ALCPeakFittingModel(std::unique_ptr<MantidQt::API::IAlgorithmRunner> algorithmRunner);
 
-  ALCPeakFittingModel();
-
   /// Update the data
   void setData(Mantid::API::MatrixWorkspace_sptr newData);
 

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingModel.h
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingModel.h
@@ -10,14 +10,19 @@
 
 #include "DllConfig.h"
 #include "IALCPeakFittingModel.h"
+#include "IALCPeakFittingModelSubscriber.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
+#include "MantidQtWidgets/Common/AlgorithmRunner.h"
+#include "MantidQtWidgets/Common/IAlgorithmRunnerSubscriber.h"
+#include "MantidQtWidgets/Common/IConfiguredAlgorithm.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
 
 /** ALCPeakFittingModel : Concrete model for ALC peak fitting
  */
-class MANTIDQT_MUONINTERFACE_DLL ALCPeakFittingModel : public IALCPeakFittingModel {
+class MANTIDQT_MUONINTERFACE_DLL ALCPeakFittingModel : public IALCPeakFittingModel,
+                                                       public API::IAlgorithmRunnerSubscriber {
 public:
   // -- IALCPeakFittingModel interface
   // -----------------------------------------------------------
@@ -32,6 +37,16 @@ public:
   // -- End of IALCPeakFittingModel interface
   // ----------------------------------------------------
 
+  // -- IAlgorithmRunnerSubscriber interface
+  // -----------------------------------------------------------
+  void notifyAlgorithmComplete(API::IConfiguredAlgorithm_sptr &algorithm) override;
+  void notifyAlgorithmError(MantidQt::API::IConfiguredAlgorithm_sptr &algorithm, const std::string &message) override;
+
+  // -- End of IAlgorithmRunnerSubscriber interface
+  // ----------------------------------------------------
+
+  ALCPeakFittingModel(std::unique_ptr<MantidQt::API::IAlgorithmRunner> algorithmRunner);
+
   /// Update the data
   void setData(Mantid::API::MatrixWorkspace_sptr newData);
 
@@ -41,7 +56,15 @@ public:
   /// Export fitted peaks as a table workspace
   Mantid::API::ITableWorkspace_sptr exportFittedPeaks();
 
+  void subscribe(std::weak_ptr<IALCPeakFittingModelSubscriber> subscriber) override;
+
 private:
+  /// The subscriber to the model.
+  std::weak_ptr<IALCPeakFittingModelSubscriber> m_subscriber;
+
+  /// The Algorithm runner for async processing.
+  std::unique_ptr<MantidQt::API::IAlgorithmRunner> m_algorithmRunner;
+
   /// The data we are fitting peaks to
   Mantid::API::MatrixWorkspace_sptr m_data;
 

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingModel.h
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingModel.h
@@ -39,13 +39,15 @@ public:
 
   // -- IAlgorithmRunnerSubscriber interface
   // -----------------------------------------------------------
-  void notifyAlgorithmComplete(API::IConfiguredAlgorithm_sptr &algorithm) override;
+  void notifyBatchComplete(API::IConfiguredAlgorithm_sptr &algorithm, bool error) override;
   void notifyAlgorithmError(MantidQt::API::IConfiguredAlgorithm_sptr &algorithm, const std::string &message) override;
 
   // -- End of IAlgorithmRunnerSubscriber interface
   // ----------------------------------------------------
 
   ALCPeakFittingModel(std::unique_ptr<MantidQt::API::IAlgorithmRunner> algorithmRunner);
+
+  ALCPeakFittingModel();
 
   /// Update the data
   void setData(Mantid::API::MatrixWorkspace_sptr newData);
@@ -56,11 +58,11 @@ public:
   /// Export fitted peaks as a table workspace
   Mantid::API::ITableWorkspace_sptr exportFittedPeaks();
 
-  void subscribe(std::weak_ptr<IALCPeakFittingModelSubscriber> subscriber) override;
+  void subscribe(IALCPeakFittingModelSubscriber *subscriber) override;
 
 private:
   /// The subscriber to the model.
-  std::weak_ptr<IALCPeakFittingModelSubscriber> m_subscriber;
+  IALCPeakFittingModelSubscriber *m_subscriber;
 
   /// The Algorithm runner for async processing.
   std::unique_ptr<MantidQt::API::IAlgorithmRunner> m_algorithmRunner;

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.cpp
@@ -20,21 +20,11 @@ ALCPeakFittingPresenter::ALCPeakFittingPresenter(IALCPeakFittingView *view, IALC
 void ALCPeakFittingPresenter::initialize() {
   m_view->initialize();
 
-  connect(m_view, SIGNAL(fitRequested()), SLOT(fit()));
-  connect(m_view, SIGNAL(currentFunctionChanged()), SLOT(onCurrentFunctionChanged()));
-  connect(m_view, SIGNAL(peakPickerChanged()), SLOT(onPeakPickerChanged()));
-
-  // We are updating the whole function anyway, so paramName if left out
-  connect(m_view, SIGNAL(parameterChanged(std::string const &, std::string const &)),
-          SLOT(onParameterChanged(std::string const &)));
-
-  connect(m_model, SIGNAL(fittedPeaksChanged()), SLOT(onFittedPeaksChanged()));
-  connect(m_model, SIGNAL(dataChanged()), SLOT(onDataChanged()));
-  connect(m_view, SIGNAL(plotGuessClicked()), SLOT(onPlotGuessClicked()));
-  connect(m_model, SIGNAL(errorInModel(const QString &)), m_view, SLOT(displayError(const QString &)));
+  m_model->subscribe(this);
+  m_view->subscribe(this);
 }
 
-void ALCPeakFittingPresenter::fit() {
+void ALCPeakFittingPresenter::onFitRequested() {
   IFunction_const_sptr func = m_view->function("");
   auto dataWS = m_model->data();
   if (func && dataWS) {
@@ -80,7 +70,7 @@ void ALCPeakFittingPresenter::onPeakPickerChanged() {
   }
 }
 
-void ALCPeakFittingPresenter::onParameterChanged(std::string const &funcIndex) {
+void ALCPeakFittingPresenter::onParameterChanged(std::string const &funcIndex, std::string const &_) {
   auto currentIndex = m_view->currentFunctionIndex();
 
   // We are interested in parameter changed of the currently selected function
@@ -93,7 +83,13 @@ void ALCPeakFittingPresenter::onParameterChanged(std::string const &funcIndex) {
   }
 }
 
-void ALCPeakFittingPresenter::onFittedPeaksChanged() {
+void ALCPeakFittingPresenter::dataChanged() const {
+  auto dataWS = m_model->data();
+  if (dataWS)
+    m_view->setDataCurve(dataWS);
+}
+
+void ALCPeakFittingPresenter::fittedPeaksChanged() const {
   IFunction_const_sptr fitted = m_model->fittedPeaks();
   auto dataWS = m_model->data();
   if (fitted && dataWS) {
@@ -105,11 +101,7 @@ void ALCPeakFittingPresenter::onFittedPeaksChanged() {
   }
 }
 
-void ALCPeakFittingPresenter::onDataChanged() {
-  auto dataWS = m_model->data();
-  if (dataWS)
-    m_view->setDataCurve(dataWS);
-}
+void ALCPeakFittingPresenter::errorInModel(const std::string &message) const { m_view->displayError(message); }
 
 /**
  * Called when user clicks "Plot/Remove guess" on the view.
@@ -149,7 +141,7 @@ bool ALCPeakFittingPresenter::plotGuessOnGraph() {
  * Removes any fit function from the graph.
  */
 void ALCPeakFittingPresenter::removePlot(std::string const &plotName) {
-  m_view->removePlot(QString::fromStdString(plotName));
+  m_view->removePlot(plotName);
   m_view->changePlotGuessState(false);
   m_guessPlotted = false;
 }

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.cpp
@@ -70,7 +70,7 @@ void ALCPeakFittingPresenter::onPeakPickerChanged() {
   }
 }
 
-void ALCPeakFittingPresenter::onParameterChanged(std::string const &funcIndex, std::string const &_) {
+void ALCPeakFittingPresenter::onParameterChanged(std::string const &funcIndex, std::string const & /*unused*/) {
   auto currentIndex = m_view->currentFunctionIndex();
 
   // We are interested in parameter changed of the currently selected function

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.h
@@ -11,41 +11,54 @@
 #include "DllConfig.h"
 
 #include "IALCPeakFittingModel.h"
+#include "IALCPeakFittingModelSubscriber.h"
 #include "IALCPeakFittingView.h"
+#include "IALCPeakFittingViewSubscriber.h"
 
-namespace MantidQt {
-namespace CustomInterfaces {
+namespace MantidQt::CustomInterfaces {
 
 /** ALCPeakFittingPresenter : Presenter for Peak Fitting step of ALC interface.
  */
-class MANTIDQT_MUONINTERFACE_DLL ALCPeakFittingPresenter : public QObject {
-  Q_OBJECT
+class MANTIDQT_MUONINTERFACE_DLL ALCPeakFittingPresenter : public IALCPeakFittingModelSubscriber,
+                                                           public IALCPeakFittingViewSubscriber {
+  //  Q_OBJECT
 
 public:
   ALCPeakFittingPresenter(IALCPeakFittingView *view, IALCPeakFittingModel *model);
 
   void initialize();
 
-private slots:
-  /// Fit the data using the peaks from the view, and update them
-  void fit();
+  // IALCPeakFittingModelSubscriber Overrides
+  void dataChanged() const override;
+  void fittedPeaksChanged() const override;
+  void errorInModel(std::string const &message) const override;
 
-  /// Executed when user selects a function in a Function Browser
-  void onCurrentFunctionChanged();
-
-  /// Executed when Peak Picker if moved/resized
-  void onPeakPickerChanged();
-
-  /// Executed when user changes parameter in Function Browser
-  void onParameterChanged(std::string const &funcIndex);
-
-  void onFittedPeaksChanged();
-  void onDataChanged();
-
-  /// Executed when user clicks "Plot guess"
-  void onPlotGuessClicked();
+  // IALCPeakFittingViewSubscriber Overrides
+  void onFitRequested() override;
+  void onCurrentFunctionChanged() override;
+  void onPeakPickerChanged() override;
+  void onParameterChanged(std::string const &functionIndex, std::string const &parameter) override;
+  void onPlotGuessClicked() override;
 
 private:
+  //  /// Fit the data using the peaks from the view, and update them
+  //  void fit();
+  //
+  //  /// Executed when user selects a function in a Function Browser
+  //  void onCurrentFunctionChanged();
+  //
+  //  /// Executed when Peak Picker if moved/resized
+  //  void onPeakPickerChanged();
+  //
+  //  /// Executed when user changes parameter in Function Browser
+  //  void onParameterChanged(std::string const &funcIndex);
+
+  //  void onFittedPeaksChanged();
+  //  void onDataChanged();
+
+  //  /// Executed when user clicks "Plot guess"
+  //  void onPlotGuessClicked();
+
   /// Plot guess on graph
   bool plotGuessOnGraph();
 
@@ -62,5 +75,4 @@ private:
   bool m_guessPlotted;
 };
 
-} // namespace CustomInterfaces
-} // namespace MantidQt
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.h
@@ -21,7 +21,6 @@ namespace MantidQt::CustomInterfaces {
  */
 class MANTIDQT_MUONINTERFACE_DLL ALCPeakFittingPresenter : public IALCPeakFittingModelSubscriber,
                                                            public IALCPeakFittingViewSubscriber {
-  //  Q_OBJECT
 
 public:
   ALCPeakFittingPresenter(IALCPeakFittingView *view, IALCPeakFittingModel *model);

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.h
@@ -41,24 +41,6 @@ public:
   void onPlotGuessClicked() override;
 
 private:
-  //  /// Fit the data using the peaks from the view, and update them
-  //  void fit();
-  //
-  //  /// Executed when user selects a function in a Function Browser
-  //  void onCurrentFunctionChanged();
-  //
-  //  /// Executed when Peak Picker if moved/resized
-  //  void onPeakPickerChanged();
-  //
-  //  /// Executed when user changes parameter in Function Browser
-  //  void onParameterChanged(std::string const &funcIndex);
-
-  //  void onFittedPeaksChanged();
-  //  void onDataChanged();
-
-  //  /// Executed when user clicks "Plot guess"
-  //  void onPlotGuessClicked();
-
   /// Plot guess on graph
   bool plotGuessOnGraph();
 

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingView.cpp
@@ -33,7 +33,7 @@ IPeakFunction_const_sptr ALCPeakFittingView::peakPicker() const { return m_peakP
 void ALCPeakFittingView::initialize() {
   m_ui.setupUi(m_widget);
 
-  connect(m_ui.fit, SIGNAL(clicked()), this, SLOT(fitRequested()));
+  connect(m_ui.fit, &QPushButton::clicked, this, &ALCPeakFittingView::fitRequested);
 
   m_ui.plot->setCanvasColour(Qt::white);
 
@@ -50,8 +50,8 @@ void ALCPeakFittingView::initialize() {
   // connect(m_ui.peaks, SIGNAL(functionStructureChanged()), SIGNAL(currentFunctionChanged()));
   // connect(m_ui.peaks, SIGNAL(parameterChanged(QString, QString)), SIGNAL(parameterChanged(QString, QString)));
 
-  connect(m_ui.help, SIGNAL(clicked()), this, SLOT(help()));
-  connect(m_ui.plotGuess, SIGNAL(clicked()), this, SLOT(plotGuess()));
+  connect(m_ui.help, &QPushButton::clicked, this, &ALCPeakFittingView::help);
+  connect(m_ui.plotGuess, &QPushButton::clicked, this, &ALCPeakFittingView::plotGuess);
 }
 
 void ALCPeakFittingView::setDataCurve(MatrixWorkspace_sptr workspace, std::size_t const &workspaceIndex) {

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingView.h
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingView.h
@@ -10,6 +10,7 @@
 
 #include "DllConfig.h"
 #include "IALCPeakFittingView.h"
+#include "IALCPeakFittingViewSubscriber.h"
 #include "MantidQtWidgets/Plotting/PeakPicker.h"
 
 #include "ui_ALCPeakFittingView.h"
@@ -30,7 +31,10 @@ public:
   Mantid::API::IFunction_const_sptr function(std::string const &index) const override;
   std::optional<std::string> currentFunctionIndex() const override;
   Mantid::API::IPeakFunction_const_sptr peakPicker() const override;
-  void emitFitRequested();
+
+  void displayError(const std::string &message) override;
+
+  void subscribe(IALCPeakFittingViewSubscriber *subscriber) override;
 
 public slots:
 
@@ -38,15 +42,18 @@ public slots:
   void setDataCurve(Mantid::API::MatrixWorkspace_sptr workspace, std::size_t const &workspaceIndex = 0) override;
   void setFittedCurve(Mantid::API::MatrixWorkspace_sptr workspace, std::size_t const &workspaceIndex = 0) override;
   void setGuessCurve(Mantid::API::MatrixWorkspace_sptr workspace, std::size_t const &workspaceIndex = 0) override;
-  void removePlot(QString const &plotName) override;
+  void removePlot(std::string const &plotName) override;
   void setFunction(const Mantid::API::IFunction_const_sptr &newFunction) override;
   void setParameter(std::string const &funcIndex, std::string const &paramName, double value) override;
   void setPeakPickerEnabled(bool enabled) override;
   void setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) override;
-  void displayError(const QString &message) override;
   void help() override;
   void plotGuess() override;
   void changePlotGuessState(bool plotted) override;
+
+  // Subscriber notifiers.
+  void fitRequested() override;
+  void onParameterChanged(std::string const &function, std::string const &parameter) override;
 
 private:
   /// The widget used
@@ -54,6 +61,9 @@ private:
 
   /// UI form
   Ui::ALCPeakFittingView m_ui;
+
+  /// Subscriber (the presenter, usually) to be notified of inputs.
+  IALCPeakFittingViewSubscriber *m_subscriber;
 
   /// Peak picker tool - only one on the plot at any given moment
   MantidWidgets::PeakPicker *m_peakPicker;

--- a/qt/scientific_interfaces/Muon/CMakeLists.txt
+++ b/qt/scientific_interfaces/Muon/CMakeLists.txt
@@ -41,6 +41,7 @@ set(INC_FILES
     IALCBaselineModellingModel.h
     IALCBaselineModellingView.h
     IALCBaselineModellingPresenter.h
+    IALCBaselineModellingPresenterSubscriber.h
     IALCDataLoadingView.h
     IALCDataLoadingModel.h
     IALCDataLoadingPresenter.h

--- a/qt/scientific_interfaces/Muon/CMakeLists.txt
+++ b/qt/scientific_interfaces/Muon/CMakeLists.txt
@@ -18,12 +18,10 @@ set(MOC_FILES
     ALCBaselineModellingPresenter.h
     ALCBaselineModellingView.h
     ALCInterface.h
-    ALCPeakFittingPresenter.h
     ALCDataLoadingView.h
     IALCBaselineModellingView.h
     IALCBaselineModellingModel.h
     IALCPeakFittingView.h
-    IALCPeakFittingModel.h
     MuonAnalysisHelper.h
 )
 
@@ -49,6 +47,7 @@ set(INC_FILES
     IALCPeakFittingModel.h
     IALCPeakFittingView.h
     IALCPeakFittingModelSubscriber.h
+    IALCPeakFittingViewSubscriber.h
 )
 
 set(UI_FILES ALCBaselineModellingView.ui ALCDataLoadingView.ui ALCInterface.ui ALCPeakFittingView.ui)

--- a/qt/scientific_interfaces/Muon/CMakeLists.txt
+++ b/qt/scientific_interfaces/Muon/CMakeLists.txt
@@ -48,6 +48,7 @@ set(INC_FILES
     IALCDataLoadingPresenter.h
     IALCPeakFittingModel.h
     IALCPeakFittingView.h
+    IALCPeakFittingModelSubscriber.h
 )
 
 set(UI_FILES ALCBaselineModellingView.ui ALCDataLoadingView.ui ALCInterface.ui ALCPeakFittingView.ui)

--- a/qt/scientific_interfaces/Muon/IALCBaselineModellingPresenterSubscriber.h
+++ b/qt/scientific_interfaces/Muon/IALCBaselineModellingPresenterSubscriber.h
@@ -1,0 +1,27 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllConfig.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+/** IALCBaselineModellingPresenterSubscriber : Subscriber's interface for getting updates from
+ * ALCBaselineModellingPresenter
+ */
+class MANTIDQT_MUONINTERFACE_DLL IALCBaselineModellingPresenterSubscriber {
+
+public:
+  virtual ~IALCBaselineModellingPresenterSubscriber() = default;
+
+  /// Notify the subscriber that the corrected baseline has changed.
+  virtual void correctedDataChanged() = 0;
+};
+
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Muon/IALCPeakFittingModel.h
+++ b/qt/scientific_interfaces/Muon/IALCPeakFittingModel.h
@@ -12,15 +12,14 @@
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 
-#include <QObject>
-
 namespace MantidQt {
 namespace CustomInterfaces {
 
+class IALCPeakFittingModelSubscriber;
+
 /** IALCPeakFittingModel : ALC peak fitting step model interface.
  */
-class MANTIDQT_MUONINTERFACE_DLL IALCPeakFittingModel : public QObject {
-  Q_OBJECT
+class MANTIDQT_MUONINTERFACE_DLL IALCPeakFittingModel {
 
 public:
   /**
@@ -47,6 +46,8 @@ public:
   virtual Mantid::API::MatrixWorkspace_sptr guessData(Mantid::API::IFunction_const_sptr function,
                                                       const std::vector<double> &xValues) = 0;
 
+  virtual void subscribe(std::weak_ptr<IALCPeakFittingModelSubscriber> subscriber) = 0;
+
 signals:
 
   /// Signal to inform that the fitting was done and fitted peaks were updated
@@ -56,7 +57,7 @@ signals:
   void dataChanged();
 
   /// Signal to inform presenter of an error with fitting
-  void errorInModel(const QString &message);
+  void errorInModel(const std::string &message);
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Muon/IALCPeakFittingModel.h
+++ b/qt/scientific_interfaces/Muon/IALCPeakFittingModel.h
@@ -46,18 +46,7 @@ public:
   virtual Mantid::API::MatrixWorkspace_sptr guessData(Mantid::API::IFunction_const_sptr function,
                                                       const std::vector<double> &xValues) = 0;
 
-  virtual void subscribe(std::weak_ptr<IALCPeakFittingModelSubscriber> subscriber) = 0;
-
-signals:
-
-  /// Signal to inform that the fitting was done and fitted peaks were updated
-  void fittedPeaksChanged();
-
-  /// Signal to inform that data was set
-  void dataChanged();
-
-  /// Signal to inform presenter of an error with fitting
-  void errorInModel(const std::string &message);
+  virtual void subscribe(IALCPeakFittingModelSubscriber *subscriber) = 0;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Muon/IALCPeakFittingModelSubscriber.h
+++ b/qt/scientific_interfaces/Muon/IALCPeakFittingModelSubscriber.h
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2014 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
@@ -18,7 +18,7 @@ public:
 
   virtual void fittedPeaksChanged() const = 0;
 
-  virtual void errorInModel(const std::string &) const = 0;
+  virtual void errorInModel(std::string const &) const = 0;
 };
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Muon/IALCPeakFittingModelSubscriber.h
+++ b/qt/scientific_interfaces/Muon/IALCPeakFittingModelSubscriber.h
@@ -1,0 +1,24 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2014 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#pragma once
+
+namespace MantidQt::CustomInterfaces {
+
+class MANTIDQT_MUONINTERFACE_DLL IALCPeakFittingModelSubscriber {
+
+public:
+  virtual ~IALCPeakFittingModelSubscriber() = default;
+
+  virtual void dataChanged() const = 0;
+
+  virtual void fittedPeaksChanged() const = 0;
+
+  virtual void errorInModel(const std::string &) const = 0;
+};
+
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Muon/IALCPeakFittingView.h
+++ b/qt/scientific_interfaces/Muon/IALCPeakFittingView.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "IALCPeakFittingViewSubscriber.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidKernel/System.h"
@@ -15,8 +16,7 @@
 #include <QObject>
 #include <optional>
 
-namespace MantidQt {
-namespace CustomInterfaces {
+namespace MantidQt::CustomInterfaces {
 
 /** IALCPeakFittingView : Interface for ALC Peak Fitting step view.
  */
@@ -33,7 +33,15 @@ public:
   /// @return A peak currently represented by the peak picker
   virtual Mantid::API::IPeakFunction_const_sptr peakPicker() const = 0;
 
-  virtual void removePlot(QString const &plotName) = 0;
+  virtual void removePlot(std::string const &plotName) = 0;
+
+  /**
+   * Pops-up an error box
+   * @param message :: Error message to display
+   */
+  virtual void displayError(const std::string &message) = 0;
+
+  virtual void subscribe(IALCPeakFittingViewSubscriber *subscriber) = 0;
 
 public slots:
   /// Performs any necessary initialization
@@ -72,25 +80,29 @@ public slots:
   /// @param peak :: A new peak to represent
   virtual void setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) = 0;
 
-  /**
-   * Pops-up an error box
-   * @param message :: Error message to display
-   */
-  virtual void displayError(const QString &message) = 0;
+  //  /**
+  //   * Pops-up an error box
+  //   * @param message :: Error message to display
+  //   */
+  //  virtual void displayError(const QString &message) = 0;
 
   /// Opens the Mantid Wiki web page
   virtual void help() = 0;
 
-  /// Emits signal
+  /// Calls out to the subscriber
   virtual void plotGuess() = 0;
 
   /// Changes button state
   virtual void changePlotGuessState(bool plotted) = 0;
 
-signals:
   /// Request to perform peak fitting
-  void fitRequested();
+  virtual void fitRequested() = 0;
 
+  /// Parameter value is changed in the Function Browser _either by user or
+  /// programmatically_
+  virtual void onParameterChanged(std::string const &, std::string const &) = 0;
+
+signals:
   /// Currently selected function in Function Browser has changed
   void currentFunctionChanged();
 
@@ -106,5 +118,4 @@ signals:
   void plotGuessClicked();
 };
 
-} // namespace CustomInterfaces
-} // namespace MantidQt
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Muon/IALCPeakFittingView.h
+++ b/qt/scientific_interfaces/Muon/IALCPeakFittingView.h
@@ -80,12 +80,6 @@ public slots:
   /// @param peak :: A new peak to represent
   virtual void setPeakPicker(const Mantid::API::IPeakFunction_const_sptr &peak) = 0;
 
-  //  /**
-  //   * Pops-up an error box
-  //   * @param message :: Error message to display
-  //   */
-  //  virtual void displayError(const QString &message) = 0;
-
   /// Opens the Mantid Wiki web page
   virtual void help() = 0;
 

--- a/qt/scientific_interfaces/Muon/IALCPeakFittingViewSubscriber.h
+++ b/qt/scientific_interfaces/Muon/IALCPeakFittingViewSubscriber.h
@@ -1,0 +1,29 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#pragma once
+#include "DllConfig.h"
+
+namespace MantidQt::CustomInterfaces {
+
+class MANTIDQT_MUONINTERFACE_DLL IALCPeakFittingViewSubscriber {
+
+public:
+  virtual ~IALCPeakFittingViewSubscriber() = default;
+
+  virtual void onFitRequested() = 0;
+
+  virtual void onCurrentFunctionChanged() = 0;
+
+  virtual void onPeakPickerChanged() = 0;
+
+  virtual void onParameterChanged(std::string const &, std::string const &) = 0;
+
+  virtual void onPlotGuessClicked() = 0;
+};
+
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Muon/IALCPeakFittingViewSubscriber.h
+++ b/qt/scientific_interfaces/Muon/IALCPeakFittingViewSubscriber.h
@@ -7,6 +7,7 @@
 
 #pragma once
 #include "DllConfig.h"
+#include <string>
 
 namespace MantidQt::CustomInterfaces {
 

--- a/qt/scientific_interfaces/Muon/test/ALCPeakFittingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCPeakFittingPresenterTest.h
@@ -38,36 +38,37 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockALCPeakFittingView : public IALCPeakFittingView {
 public:
-  MOCK_CONST_METHOD1(function, IFunction_const_sptr(std::string const &));
-  MOCK_CONST_METHOD0(currentFunctionIndex, std::optional<std::string>());
-  MOCK_CONST_METHOD0(peakPicker, IPeakFunction_const_sptr());
+  MOCK_METHOD(IFunction_const_sptr, function, (std::string const &), (const, override));
+  MOCK_METHOD(std::optional<std::string>, currentFunctionIndex, (), (const, override));
+  MOCK_METHOD(IPeakFunction_const_sptr, peakPicker, (), (const, override));
 
-  MOCK_METHOD0(initialize, void());
-  MOCK_METHOD2(setDataCurve, void(MatrixWorkspace_sptr workspace, const std::size_t &workspaceIndex));
-  MOCK_METHOD2(setFittedCurve, void(MatrixWorkspace_sptr workspace, const std::size_t &workspaceIndex));
-  MOCK_METHOD2(setGuessCurve, void(MatrixWorkspace_sptr workspace, const std::size_t &workspaceIndex));
-  MOCK_METHOD1(setPeakPickerEnabled, void(bool));
-  MOCK_METHOD1(setPeakPicker, void(const IPeakFunction_const_sptr &));
-  MOCK_METHOD1(setFunction, void(const IFunction_const_sptr &));
-  MOCK_METHOD3(setParameter, void(std::string const &, std::string const &, double));
-  MOCK_METHOD0(help, void());
-  MOCK_METHOD1(changePlotGuessState, void(bool));
+  MOCK_METHOD(void, initialize, (), (override));
+  MOCK_METHOD(void, setDataCurve, (MatrixWorkspace_sptr workspace, const std::size_t &workspaceIndex), (override));
+  MOCK_METHOD(void, setFittedCurve, (MatrixWorkspace_sptr workspace, const std::size_t &workspaceIndex), (override));
+  MOCK_METHOD(void, setGuessCurve, (MatrixWorkspace_sptr workspace, const std::size_t &workspaceIndex), (override));
+  MOCK_METHOD(void, setPeakPickerEnabled, (bool), (override));
+  MOCK_METHOD(void, setPeakPicker, (const IPeakFunction_const_sptr &), (override));
+  MOCK_METHOD(void, setFunction, (const IFunction_const_sptr &), (override));
+  MOCK_METHOD(void, setParameter, (std::string const &, std::string const &, double), (override));
+  MOCK_METHOD(void, help, (), (override));
+  MOCK_METHOD(void, changePlotGuessState, (bool), (override));
 
-  MOCK_METHOD1(removePlot, void(const std::string &plotName));
-  MOCK_METHOD(void, displayError, (std::string const &));
-  MOCK_METHOD(void, plotGuess, ());
-  MOCK_METHOD(void, subscribe, (IALCPeakFittingViewSubscriber *));
-  MOCK_METHOD(void, onParameterChanged, (std::string const &, std::string const &));
-  MOCK_METHOD(void, fitRequested, ());
+  MOCK_METHOD(void, removePlot, (const std::string &plotName), (override));
+  MOCK_METHOD(void, displayError, (std::string const &), (override));
+  MOCK_METHOD(void, plotGuess, (), (override));
+  MOCK_METHOD(void, subscribe, (IALCPeakFittingViewSubscriber *), (override));
+  MOCK_METHOD(void, onParameterChanged, (std::string const &, std::string const &), (override));
+  MOCK_METHOD(void, fitRequested, (), (override));
 };
 
 class MockALCPeakFittingModel : public IALCPeakFittingModel {
 public:
-  MOCK_CONST_METHOD0(fittedPeaks, IFunction_const_sptr());
-  MOCK_CONST_METHOD0(data, MatrixWorkspace_sptr());
-  MOCK_METHOD1(fitPeaks, void(IFunction_const_sptr));
-  MOCK_METHOD2(guessData, MatrixWorkspace_sptr(IFunction_const_sptr function, const std::vector<double> &xValues));
-  MOCK_METHOD(void, subscribe, (IALCPeakFittingModelSubscriber *));
+  MOCK_METHOD(IFunction_const_sptr, fittedPeaks, (), (const, override));
+  MOCK_METHOD(MatrixWorkspace_sptr, data, (), (const, override));
+  MOCK_METHOD(void, fitPeaks, (IFunction_const_sptr), (override));
+  MOCK_METHOD(MatrixWorkspace_sptr, guessData, (IFunction_const_sptr function, const std::vector<double> &xValues),
+              (override));
+  MOCK_METHOD(void, subscribe, (IALCPeakFittingModelSubscriber *), (override));
 };
 
 // DoubleNear matcher was introduced in gmock 1.7 only

--- a/qt/scientific_interfaces/Muon/test/ALCPeakFittingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCPeakFittingPresenterTest.h
@@ -63,6 +63,7 @@ public:
 
 class MockALCPeakFittingModel : public IALCPeakFittingModel {
 public:
+  virtual ~MockALCPeakFittingModel() = default;
   MOCK_METHOD(IFunction_const_sptr, fittedPeaks, (), (const, override));
   MOCK_METHOD(MatrixWorkspace_sptr, data, (), (const, override));
   MOCK_METHOD(void, fitPeaks, (IFunction_const_sptr), (override));

--- a/qt/scientific_interfaces/Muon/test/ALCPeakFittingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCPeakFittingPresenterTest.h
@@ -38,14 +38,6 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockALCPeakFittingView : public IALCPeakFittingView {
 public:
-  void requestFit() { emit fitRequested(); }
-  void changeCurrentFunction() { emit currentFunctionChanged(); }
-  void changePeakPicker() { emit peakPickerChanged(); }
-  void changeParameter(std::string const &funcIndex, std::string const &paramName) {
-    emit parameterChanged(funcIndex, paramName);
-  }
-  void plotGuess() override { emit plotGuessClicked(); }
-
   MOCK_CONST_METHOD1(function, IFunction_const_sptr(std::string const &));
   MOCK_CONST_METHOD0(currentFunctionIndex, std::optional<std::string>());
   MOCK_CONST_METHOD0(peakPicker, IPeakFunction_const_sptr());
@@ -58,23 +50,24 @@ public:
   MOCK_METHOD1(setPeakPicker, void(const IPeakFunction_const_sptr &));
   MOCK_METHOD1(setFunction, void(const IFunction_const_sptr &));
   MOCK_METHOD3(setParameter, void(std::string const &, std::string const &, double));
-  MOCK_METHOD1(displayError, void(const QString &));
   MOCK_METHOD0(help, void());
   MOCK_METHOD1(changePlotGuessState, void(bool));
 
-  MOCK_METHOD1(removePlot, void(const QString &plotName));
+  MOCK_METHOD1(removePlot, void(const std::string &plotName));
+  MOCK_METHOD(void, displayError, (std::string const &));
+  MOCK_METHOD(void, plotGuess, ());
+  MOCK_METHOD(void, subscribe, (IALCPeakFittingViewSubscriber *));
+  MOCK_METHOD(void, onParameterChanged, (std::string const &, std::string const &));
+  MOCK_METHOD(void, fitRequested, ());
 };
 
 class MockALCPeakFittingModel : public IALCPeakFittingModel {
 public:
-  void changeFittedPeaks() { emit fittedPeaksChanged(); }
-  void changeData() { emit dataChanged(); }
-  void setError(const QString &message) { emit errorInModel(message); }
-
   MOCK_CONST_METHOD0(fittedPeaks, IFunction_const_sptr());
   MOCK_CONST_METHOD0(data, MatrixWorkspace_sptr());
   MOCK_METHOD1(fitPeaks, void(IFunction_const_sptr));
   MOCK_METHOD2(guessData, MatrixWorkspace_sptr(IFunction_const_sptr function, const std::vector<double> &xValues));
+  MOCK_METHOD(void, subscribe, (IALCPeakFittingModelSubscriber *));
 };
 
 // DoubleNear matcher was introduced in gmock 1.7 only
@@ -134,9 +127,9 @@ public:
     auto ws = WorkspaceCreationHelper::create2DWorkspace123(1, 3);
     ON_CALL(*m_model, data()).WillByDefault(Return(ws));
     ON_CALL(*m_view, function(std::string(""))).WillByDefault(Return(IFunction_const_sptr()));
-    EXPECT_CALL(*m_view, displayError(QString("Couldn't fit with empty function/data"))).Times(1);
+    EXPECT_CALL(*m_view, displayError(std::string("Couldn't fit with empty function/data"))).Times(1);
 
-    m_view->requestFit();
+    m_presenter->onFitRequested();
   }
 
   void test_fit() {
@@ -150,7 +143,7 @@ public:
     EXPECT_CALL(*m_model,
                 fitPeaks(Property(&IFunction_const_sptr::get, Property(&IFunction::asString, peaks->asString()))));
 
-    m_view->requestFit();
+    m_presenter->onFitRequested();
   }
 
   void test_onDataChanged() {
@@ -160,10 +153,10 @@ public:
     ON_CALL(*m_model, data()).WillByDefault(Return(dataWorkspace));
 
     EXPECT_CALL(*m_view, setDataCurve(dataWorkspace, 0));
-    m_model->changeData();
+    m_presenter->dataChanged();
   }
 
-  void test_onFittedPeaksChanged() {
+  void test_fittedPeaksChanged() {
     IFunction_const_sptr fitFunction = createGaussian(1, 2, 3);
     auto dataWorkspace =
         std::dynamic_pointer_cast<MatrixWorkspace>(WorkspaceCreationHelper::create2DWorkspace123(1, 3));
@@ -175,19 +168,19 @@ public:
     EXPECT_CALL(*m_view, setFittedCurve(dataWorkspace, 1));
     EXPECT_CALL(*m_view, setFunction(fitFunction));
 
-    m_model->changeFittedPeaks();
+    m_presenter->fittedPeaksChanged();
   }
 
-  void test_onFittedPeaksChanged_toEmpty() {
+  void test_fittedPeaksChanged_toEmpty() {
     const auto dataWorkspace = WorkspaceCreationHelper::create2DWorkspace123(1, 3);
 
     ON_CALL(*m_model, fittedPeaks()).WillByDefault(Return(IFunction_const_sptr()));
     ON_CALL(*m_model, data()).WillByDefault(Return(dataWorkspace));
 
-    EXPECT_CALL(*m_view, removePlot(QString("Fit")));
+    EXPECT_CALL(*m_view, removePlot(std::string("Fit")));
     EXPECT_CALL(*m_view, setFunction(IFunction_const_sptr()));
 
-    m_model->changeFittedPeaks();
+    m_presenter->fittedPeaksChanged();
   }
 
   void test_onCurrentFunctionChanged_nothing() {
@@ -195,7 +188,7 @@ public:
 
     EXPECT_CALL(*m_view, setPeakPickerEnabled(false));
 
-    m_view->changeCurrentFunction();
+    m_presenter->onCurrentFunctionChanged();
   }
 
   void test_onCurrentFunctionChanged_peak() {
@@ -208,7 +201,7 @@ public:
                                        AllOf(Property(&IPeakFunction::centre, 1), Property(&IPeakFunction::fwhm, 2),
                                              Property(&IPeakFunction::height, 3)))));
 
-    m_view->changeCurrentFunction();
+    m_presenter->onCurrentFunctionChanged();
   }
 
   void test_onCurrentFunctionChanged_nonPeak() {
@@ -218,7 +211,7 @@ public:
 
     EXPECT_CALL(*m_view, setPeakPickerEnabled(false));
 
-    m_view->changeCurrentFunction();
+    m_presenter->onCurrentFunctionChanged();
   }
 
   void test_onPeakPickerChanged() {
@@ -229,7 +222,7 @@ public:
     EXPECT_CALL(*m_view, setParameter(std::string("f1"), std::string("Sigma"), DoubleDelta(2.123, 1E-3)));
     EXPECT_CALL(*m_view, setParameter(std::string("f1"), std::string("Height"), 6));
 
-    m_view->changePeakPicker();
+    m_presenter->onPeakPickerChanged();
   }
 
   void test_onParameterChanged_peak() {
@@ -242,7 +235,7 @@ public:
                                        AllOf(Property(&IPeakFunction::centre, 4), Property(&IPeakFunction::fwhm, 2),
                                              Property(&IPeakFunction::height, 6)))));
 
-    m_view->changeParameter("f1", "Sigma");
+    m_presenter->onParameterChanged("f1", "Sigma");
   }
 
   // parameterChanged signal is thrown in many scenarios - we want to update the
@@ -254,7 +247,7 @@ public:
 
     EXPECT_CALL(*m_view, setPeakPicker(_)).Times(0);
 
-    m_view->changeParameter("f1", "Sigma");
+    m_presenter->onParameterChanged("f1", "Sigma");
   }
 
   void test_onParameterChanged_nonPeak() {
@@ -264,7 +257,7 @@ public:
 
     EXPECT_CALL(*m_view, setPeakPicker(_)).Times(0);
 
-    m_view->changeParameter("f1", "A0");
+    m_presenter->onParameterChanged("f1", "A0");
   }
 
   void test_helpPage() {
@@ -281,8 +274,8 @@ public:
     ON_CALL(*m_model, data()).WillByDefault(Return(dataWorkspace));
     ON_CALL(*m_view, function(std::string(""))).WillByDefault(Return(IFunction_const_sptr()));
 
-    EXPECT_CALL(*m_view, removePlot(QString("Guess")));
-    m_view->plotGuess();
+    EXPECT_CALL(*m_view, removePlot(std::string("Guess")));
+    m_presenter->onPlotGuessClicked();
   }
 
   /**
@@ -295,9 +288,9 @@ public:
     ON_CALL(*m_model, data()).WillByDefault(Return(nullptr));
     ON_CALL(*m_view, function(std::string(""))).WillByDefault(Return(peaks));
 
-    EXPECT_CALL(*m_view, removePlot(QString("Guess")));
+    EXPECT_CALL(*m_view, removePlot(std::string("Guess")));
 
-    TS_ASSERT_THROWS_NOTHING(m_view->plotGuess());
+    TS_ASSERT_THROWS_NOTHING(m_presenter->onPlotGuessClicked());
   }
 
   /**
@@ -317,7 +310,7 @@ public:
 
     EXPECT_CALL(*m_view, setGuessCurve(guessWorkspace, 0));
 
-    m_view->plotGuess();
+    m_presenter->onPlotGuessClicked();
   }
 
   /**
@@ -325,16 +318,16 @@ public:
    */
   void test_plotGuessAndThenClear() {
     test_plotGuess();
-    EXPECT_CALL(*m_view, removePlot(QString("Guess")));
-    m_view->plotGuess(); // click again i.e. "Remove guess"
+    EXPECT_CALL(*m_view, removePlot(std::string("Guess")));
+    m_presenter->onPlotGuessClicked(); // click again i.e. "Remove guess"
   }
 
   /**
    * Test that errors coming from the model are displayed in the view
    */
   void test_displayError() {
-    EXPECT_CALL(*m_view, displayError(QString("Test error")));
-    m_model->setError("Test error");
+    EXPECT_CALL(*m_view, displayError(std::string("Test error")));
+    m_presenter->errorInModel("Test error");
   }
 };
 GNU_DIAG_ON_SUGGEST_OVERRIDE


### PR DESCRIPTION
### Description of work

#### Summary of work

Stops the presenter and the model from being QObjects, replacing their signals and slots with functionality based on the observer pattern where the presenter (as an observer) subscribes to the view and the model and is updated on their progress. 

As part of this, the view and model no longer directly communicate, making this compliant with MVP principles. 

Fixes #38007 



#### Further detail of work
Tests have been updated with new mocks to test the implemented functionality independently of any changes to the other parts of the MVP structure. 

### To test:
1. Run through the tests here: https://developer.mantidproject.org/Testing/MuonAnalysis_test_guides/Muon_ALC.html#alc-peak-fitting


*This does not require release notes* because **no user-facing functionality should have changed.**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
