### PR TITLE
fix for sliceviewer

### DIFF
--- a/docs/source/release/v6.11.0/mantidworkbench.rst
+++ b/docs/source/release/v6.11.0/mantidworkbench.rst
@@ -60,6 +60,7 @@ Bugfixes
 - Changing normalisation with the ``gist_rainbow`` colourmap no longer causes an error.
 - A warning will now be displayed if a workspace with unordered spectrum numbers is opened in the :ref:`Slice Viewer <sliceviewer>`.
   These workspaces can fail to display correctly and may result in errors.
+- Fixed a bug where the workspace normalization is not preserved when one has more than two dimensions and one uses the slider to change the slice point.
 
 
 :ref:`Release 6.11.0 <v6.11.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -10,7 +10,7 @@ from typing import List, Sequence, Tuple, Optional
 
 from mantid.api import MatrixWorkspace, MultipleExperimentInfos
 from mantid.kernel import SpecialCoordinateSystem
-from mantid.plots.datafunctions import get_indices
+from mantid.plots.datafunctions import get_indices, get_normalization, get_md_data2d_bin_bounds
 from mantid.simpleapi import BinMD, IntegrateMDHistoWorkspace, TransposeMD
 
 from .base_model import SliceViewerBaseModel
@@ -181,10 +181,9 @@ class SliceViewerModel(SliceViewerBaseModel):
 
     def get_data_MDH(self, slicepoint, transpose=False):
         indices, _ = get_indices(self.get_ws(), slicepoint=slicepoint)
-        if transpose:
-            return np.ma.masked_invalid(self.get_ws().getSignalArray()[indices]).T
-        else:
-            return np.ma.masked_invalid(self.get_ws().getSignalArray()[indices])
+        mdh_normalization, _ = get_normalization(self.get_ws())
+        _, _, z = get_md_data2d_bin_bounds(self.get_ws(), mdh_normalization, indices, not (transpose))
+        return z
 
     def get_data_MDE(self, slicepoint, bin_params, dimension_indices, limits=None, transpose=False):
         """
@@ -196,10 +195,10 @@ class SliceViewerModel(SliceViewerBaseModel):
                        should be provided in the order of the workspace not the display
         :param transpose: If true then transpose the data before returning
         """
-        if transpose:
-            return np.ma.masked_invalid(self.get_ws_MDE(slicepoint, bin_params, limits, dimension_indices).getSignalArray().squeeze()).T
-        else:
-            return np.ma.masked_invalid(self.get_ws_MDE(slicepoint, bin_params, limits, dimension_indices).getSignalArray().squeeze())
+        mdh = self.get_ws_MDE(slicepoint, bin_params, limits, dimension_indices)
+        mdh_normalization, _ = get_normalization(mdh)
+        _, _, z = get_md_data2d_bin_bounds(mdh, mdh_normalization, transpose=not (transpose))
+        return z
 
     def get_properties(self):
         """


### PR DESCRIPTION
### Description of work
Fixes sliceviewer using the wrong normalization for MD workspaces
#### Summary of work
In the following script, the MD workspaces should show something like this
![image](https://github.com/user-attachments/assets/f6774da7-6df5-4709-9359-4df71dd59a25)

```
from mantid.simpleapi import Load, ConvertToMD, BinMD, ConvertUnits, Rebin, AddSampleLog, MergeMD

data = Load('CNCS_7860')
data = ConvertUnits(InputWorkspace=data,Target='DeltaE', EMode='Direct', EFixed=3)
data = Rebin(InputWorkspace=data, Params='-3,0.025,3', PreserveEvents=False)
for i in range(5):
    AddSampleLog(Workspace=data, LogName='value', LogText=f'{i}.0', LogType='Number Series')
    ConvertToMD(InputWorkspace=data,
                QDimensions='|Q|',
                dEAnalysisMode='Direct',
                OtherDimensions='value',
                MinValues='0,-3,-1',
                MaxValues='3,3,5',
                OutputWorkspace=f'md{i}')
md = MergeMD(InputWorkspaces=[f'md{i}' for i in range(5)])
from mantid.simpleapi import *

mdh = BinMD(InputWorkspace=md, 
                          AlignedDim0='|Q|,0,3,100', 
                          AlignedDim1='DeltaE,-3,3,100', 
                          AlignedDim2='value,0,5,5')

```
If one creates an MD workspace with more dimensions (see the mdh in the above script) and opens the slice viewer, it shows fine first, but it does no normalization as soon as one moves the slider. The issue is that it updates from `getSignalArray` instead of getting the normalized data.
![image](https://github.com/user-attachments/assets/a26ff9b3-c8c4-47f9-bf33-14848ded2523)


*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
