### PR TITLE
Stop ReflectometryReductionOneLiveData from re-writing the spectra map on instrument load

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -154,7 +154,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
 
     def _setup_instrument(self):
         """Sets the instrument name and loads the instrument on the workspace"""
-        LoadInstrument(Workspace=self._temp_ws_name, RewriteSpectraMap=True, InstrumentName=self._instrument)
+        LoadInstrument(Workspace=self._temp_ws_name, RewriteSpectraMap=False, InstrumentName=self._instrument)
 
     def _setup_sample_logs(self, liveValues):
         """Set up the sample logs based on live values from the instrument"""

--- a/docs/source/release/v6.12.0/Reflectometry/Bugfixes/38202.rst
+++ b/docs/source/release/v6.12.0/Reflectometry/Bugfixes/38202.rst
@@ -1,0 +1,1 @@
+- Fix a bug where :ref:`algm-ReflectometryReductionOneLiveData` was re-writing the spectra map when loading the instrument into the input live data workspace.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Changes the step in `ReflectometryReductionOneLiveData` that loads the instrument so that it doesn't re-write the spectra map, as this can result in spectra being associated with the wrong detectors.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38202. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

The live data workspace already has the instrument loaded, but we need to re-load it because many of the Reflectometry IDFs position their pixels based on the theta value in the log. We add this theta value as part of setting up the workspace in `ReflectometryReductionOneLiveData`, so we then re-load the instrument to apply the changes. Re-writing the spectra map under these circumstances can lead to spectra being associated with the wrong detector pixels. This PR fixes that issue.

There were a few updates/additions required for the unit tests, and I've also refactored the tests in a couple of places to avoid code duplication.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

1) To prevent the algorithm attempting to look up information from the instrument, edit the code in method `_live_value_list`, to provide values for `_theta_name`, `_s1vg_name` and `_s2vg_name`:

```
self._theta_name(): LiveValue(2.3, "deg", self._alternative_theta_name(), LiveValue.LOG_TYPE_NUM_SERIES),
self._s1vg_name(): LiveValue(1.0, "m", self._alternative_s1vg_name(), LiveValue.LOG_TYPE_NUM_SERIES),
self._s2vg_name(): LiveValue(3.0, "m", self._alternative_s2vg_name(), LiveValue.LOG_TYPE_NUM_SERIES),
```

2) Run the following script:

```
in_ws = LoadNexus("SURF138942")
out_ws = ReflectometryReductionOneLiveData(InputWorkspace=in_ws, Instrument="SURF")
```

It should complete successfully. If you check the detector table on `in_ws` (i.e. using Show Detector from the right click menu) then you should see detectors 20001, 20002, 30001 listed.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
