### PR TITLE
Fix crash on Inelastic Data Processor interface

### DIFF
--- a/qt/scientific_interfaces/Indirect/Reduction/DataReduction.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReduction.h
@@ -170,7 +170,7 @@ private:
     tabScrollArea->setWidget(tabContent);
     tabScrollArea->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-    auto jobRunner = std::make_unique<MantidQt::API::QtJobRunner>();
+    auto jobRunner = std::make_unique<MantidQt::API::QtJobRunner>(true);
     auto algorithmRunner = std::make_unique<MantidQt::API::AlgorithmRunner>(std::move(jobRunner));
     auto presenter = std::make_unique<TabPresenter>(this, new TabView(tabContent), std::make_unique<TabModel>(),
                                                     std::move(algorithmRunner));

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessorInterface.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessorInterface.h
@@ -90,7 +90,7 @@ private:
     tabScrollArea->setWidget(tabContent);
     tabScrollArea->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-    auto jobRunner = std::make_unique<MantidQt::API::QtJobRunner>();
+    auto jobRunner = std::make_unique<MantidQt::API::QtJobRunner>(true);
     auto algorithmRunner = std::make_unique<MantidQt::API::AlgorithmRunner>(std::move(jobRunner));
 
     std::unique_ptr<TabModel> tabModel = std::make_unique<TabModel>();


### PR DESCRIPTION
### Description of work
This PR fixes multiple crashes on the Inelastic Data Processor interface when trying to load and process invalid data. The crash was caused by not using the "Stop on failure" option in the BatchAlgorithmRunner. When an algorithm failed, it would continue with the processing without recording an error, and hence the crash would occur. We have spotted two crashes, one on the Elwin tab and another on the Moments tab. However, this crash will be present on all the tabs.

Fixes #38255 

### To test:
1. Open `Interfaces`->`Inelastic`->`Data Processor`
2. Go to the Moments tab
3. Load the following data (this data was created in a weird way, and is not the usual kind of file we use for Indirect/Inelastic)
[irs26176_graphite002_red.zip](https://github.com/user-attachments/files/17463216/irs26176_graphite002_red.zip)

5. Click `Run`

6. It should not crash. There should be a red error in the log messages

Also try the instructions in the attached issue:
1. *.dat files are currently not supported, so the `Save Result` button should be disabled after clicking `Run` 

*This does not require release notes* because **it is a regression since the last release**


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
