### PR TITLE
Enable F405 ruff check

### DIFF
--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-# ruff: noqa: F403   # Allow wild imports
+# ruff: noqa: F403,F405   # Wild imports and Undefined locals
 """
 This module defines a function-style API for running Mantid
 algorithms. Each algorithm within Mantid is mapped to a Python

--- a/Testing/Tools/cxxtest/build_tools/SCons/cxxtest.py
+++ b/Testing/Tools/cxxtest/build_tools/SCons/cxxtest.py
@@ -61,18 +61,19 @@
 # the 1st argument to the function. This will result in the end executable
 # called that. Normal Program builder rules apply.
 #
-# ruff: noqa: F403   # Allow wild imports
-from SCons.Script import *
+from SCons.Script import Dir, File, Flatten, Split
 from SCons.Builder import Builder
+from SCons.Warnings import enableWarningClass, warn, Warning
 import os
+import sys
 
 
 # A warning class to notify users of problems
-class ToolCxxTestWarning(SCons.Warnings.Warning):
+class ToolCxxTestWarning(Warning):
     pass
 
 
-SCons.Warnings.enableWarningClass(ToolCxxTestWarning)
+enableWarningClass(ToolCxxTestWarning)
 
 
 def accumulateEnvVar(dicts, name, default = []):
@@ -138,8 +139,7 @@ def isValidScriptPath(cxxtestgen):
     if cxxtestgen and os.path.exists(cxxtestgen):
         return True
     else:
-        SCons.Warnings.warn(ToolCxxTestWarning,
-                            "Invalid CXXTEST environment variable specified!")
+        warn(ToolCxxTestWarning, "Invalid CXXTEST environment variable specified!")
         return False
 
 
@@ -159,7 +159,7 @@ def findCxxTestGen(env):
 
     # check for common passing errors and provide diagnostics.
     if isinstance(cxxtest, (list, tuple, dict)):
-        SCons.Warnings.warn(
+        warn(
                 ToolCxxTestWarning,
                 "The CXXTEST variable was specified as a list."
                 " This is not supported. Please pass a string."
@@ -193,7 +193,7 @@ def findCxxTestGen(env):
         return cxxtest
     else:
         # If we weren't able to locate the cxxtestgen script, complain...
-        SCons.Warnings.warn(
+        warn(
                 ToolCxxTestWarning,
                 "Unable to locate cxxtestgen in environment, path or"
                 " project!\n"
@@ -271,7 +271,7 @@ def generate(env, **kwargs):
     env.SetDefault( CXXTEST_CXXTESTGEN_SCRIPT_NAME = 'cxxtestgen' )
 
     #Here's where keyword arguments are applied
-    apply(env.Replace, (), kwargs)
+    env.Replace(**kwargs)
 
     #If the user specified the path to CXXTEST, make sure it is correct
     #otherwise, search for and set the default toolpath.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ lint.select = ["C90", "E", "F", "RUF100", "W"]
 lint.ignore = ["E402", # module level import not at top of file
                "E722", # bare except
                "E741", "E743", # ambiguous function name, generally 'l'
-               "F405", "F821", # unknown names from probably from wild imports
+               "F821", # unknown names from probably from wild imports
 ]
 exclude = [
    "Framework/PythonInterface/test",

--- a/scripts/Reflectometry/isis_reflectometry/procedures.py
+++ b/scripts/Reflectometry/isis_reflectometry/procedures.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=too-many-lines, invalid-name, too-many-arguments, too-many-branches, too-many-locals
-# ruff: noqa: F403   # Allow wild imports
+# ruff: noqa: F403,F405   # Wild imports and Undefined locals
 from math import *
 
 try:

--- a/scripts/reduction_workflow/instruments/sans/sns_command_interface.py
+++ b/scripts/reduction_workflow/instruments/sans/sns_command_interface.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=invalid-name,unused-import
-# ruff: noqa: F403   # Allow wild imports
+# ruff: noqa: F403,F405   # Wild imports and Undefined locals
 """
 Command set for EQSANS reduction
 """


### PR DESCRIPTION
### Description of work
This PR fixes any remaining ruff F405 warnings, documented here:
https://docs.astral.sh/ruff/rules/undefined-local-with-import-star-usage/

It also enables this check to run on all pull requests.

### To test:
Code review - check that all imports look correct.

Run ruff locally on all files using the following terminal command
```
pre-commit run ruff --all-files
```

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
