### PR TITLE
Untie legend from layout in external plot of Muon interfaces

### DIFF
--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon Analysis Unscripted Testing Guide.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon Analysis Unscripted Testing Guide.rst
@@ -14,8 +14,10 @@ The tests follow real use cases provided by scientists and are intended to exerc
 As changes are made to the interface and features added, anything for which it is not possible to write an automated
 test should have a manual test added to this list. You may need to use the muon feature flags to turn on some additional features (like model analysis, raw plots and fit wizard features). Check the :ref:`Muon_Feature_Flags-ref` documentation for more information.
 
-.. note:: The tests here are grouped into sections. The test groups can be done in any order.
+.. note::
+        The tests here are grouped into sections. The test groups can be done in any order.
 
+        In Muon Interfaces, the embedded plot axis are reversed on the plot if ``Xmax < Xmin`` (idem with ``Y`` axis)
 
 Common setup
 ^^^^^^^^^^^^

--- a/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_FDA.rst
+++ b/dev-docs/source/Testing/MuonAnalysis_test_guides/Muon_FDA.rst
@@ -94,5 +94,5 @@ Maxent calculates the frequency spectra and then converts using an FFT to compar
 - It will contain several workspaces
 - The workspace that ends with ``phase_convergence`` will show a plot that tends to a single y value as x gets larger (just check a spectrum or two)
 - The table that ends with ``dead_times`` will have two columns: spectrum number and dead time
-- The table taht ends with ``phase_table`` will have three columns: spectrum number, asymmetry, and phase
+- The table that ends with ``phase_table`` will have three columns: spectrum number, asymmetry, and phase
 - The workspace that ends with ``reconstructed_spectra`` will look like the original data

--- a/docs/source/release/v6.12.0/Muon/Muon_Analysis/Bugfixes/38028.rst
+++ b/docs/source/release/v6.12.0/Muon/Muon_Analysis/Bugfixes/38028.rst
@@ -1,0 +1,1 @@
+- On Muon Interfaces, a legend containing a large string of text does not shrink the plot axes for tight layouts.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/external_plotting/external_plotting_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/external_plotting/external_plotting_view.py
@@ -7,7 +7,6 @@
 from typing import List
 
 from mantidqtinterfaces.Muon.GUI.Common.plot_widget.external_plotting.external_plotting_model import PlotInformation
-from mantid.plots.utility import legend_set_draggable
 
 
 class ExternalPlottingView(object):
@@ -55,7 +54,7 @@ class ExternalPlottingView(object):
             external_axis.plot(
                 plot_info.workspace, specNum=plot_info.specNum, autoscale_on_update=True, distribution=not plot_info.normalised
             )
-            legend_set_draggable(external_axis.legend(), True)
+            external_axis.make_legend()
         fig_window.show()
 
     def _create_external_workbench_fig_window(self):


### PR DESCRIPTION
### Description of work
This PR fixes #38028, it was found during manual testing for Muon Interfaces, that a figure containing a long string in the legend caption can shrink the main axes figure as it is produce tied to the layout of the figure. In mantid, legends are plot untie to the layout, so I have used the make_legend method of the mantid axes class to produce the legend instead of using matplotlib. 

Additionally, I've added a warning in the manual testing instructions regarding #38029 to make testers know that reversing axis inverting x or y limits is expected behaviour in the plot. 


Fixes #38028, also closes #38029. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Open `Muon Analysis` interface. 
- Select `EMU` instrument. 
- Type run number: 54123 for example
- When run is loaded, a plot should render on the figure widget at the right of the interface. 
- On the top right corner of the plot, there is a `External Plot` button, click on it. 
- A new plot window should prompt with the same plot. 
- The legend of the external plot should be draggable, also when you drag the legend out of the axes, the axes dimensions shouldn't change. 

__Added release notes__
<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
