### PR TITLE
Construct the model of OutputPlotOptions widget outside the Presenter class. 

### DIFF
--- a/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
@@ -52,9 +52,9 @@ void DiffractionReduction::initLayout() {
   m_uiForm.pbSettings->setIcon(Settings::icon());
 
   m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
-  auto OutputOptionsModel = std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>());
+  auto outputPlotOptionsModel = std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>());
   m_plotOptionsPresenter = std::make_unique<OutputPlotOptionsPresenter>(
-      m_uiForm.ipoPlotOptions, std::move(OutputOptionsModel), PlotWidget::SpectraUnit, "0");
+      m_uiForm.ipoPlotOptions, std::move(outputPlotOptionsModel), PlotWidget::SpectraUnit, "0");
 
   m_groupingWidget = new DetectorGroupingOptions(m_uiForm.fDetectorGrouping);
   m_uiForm.fDetectorGrouping->layout()->addWidget(m_groupingWidget);

--- a/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/Diffraction/DiffractionReduction.cpp
@@ -52,8 +52,9 @@ void DiffractionReduction::initLayout() {
   m_uiForm.pbSettings->setIcon(Settings::icon());
 
   m_runPresenter = std::make_unique<RunPresenter>(this, m_uiForm.runWidget);
-  m_plotOptionsPresenter =
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraUnit, "0");
+  auto OutputOptionsModel = std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>());
+  m_plotOptionsPresenter = std::make_unique<OutputPlotOptionsPresenter>(
+      m_uiForm.ipoPlotOptions, std::move(OutputOptionsModel), PlotWidget::SpectraUnit, "0");
 
   m_groupingWidget = new DetectorGroupingOptions(m_uiForm.fDetectorGrouping);
   m_uiForm.fDetectorGrouping->layout()->addWidget(m_groupingWidget);

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
@@ -36,15 +36,6 @@ DataReductionTab::DataReductionTab(IDataReduction *idrUI, std::unique_ptr<API::I
 
 DataReductionTab::~DataReductionTab() = default;
 
-void DataReductionTab::setOutputPlotOptionsPresenter(
-    IOutputPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
-    std::optional<std::map<std::string, std::string>> const &availableActions) {
-  auto OutputOptionsModel =
-      std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>(), availableActions);
-  m_plotOptionsPresenter =
-      std::make_unique<OutputPlotOptionsPresenter>(view, std::move(OutputOptionsModel), plotType, fixedIndices);
-}
-
 void DataReductionTab::setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces) {
   m_plotOptionsPresenter->setWorkspaces(outputWorkspaces);
 }

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.cpp
@@ -36,8 +36,13 @@ DataReductionTab::DataReductionTab(IDataReduction *idrUI, std::unique_ptr<API::I
 
 DataReductionTab::~DataReductionTab() = default;
 
-void DataReductionTab::setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter) {
-  m_plotOptionsPresenter = std::move(presenter);
+void DataReductionTab::setOutputPlotOptionsPresenter(
+    IOutputPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
+    std::optional<std::map<std::string, std::string>> const &availableActions) {
+  auto OutputOptionsModel =
+      std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>(), availableActions);
+  m_plotOptionsPresenter =
+      std::make_unique<OutputPlotOptionsPresenter>(view, std::move(OutputOptionsModel), plotType, fixedIndices);
 }
 
 void DataReductionTab::setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces) {

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
@@ -52,7 +52,10 @@ public:
   ~DataReductionTab() override;
 
   /// Set the presenter for the output plotting options
-  void setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter);
+  void setOutputPlotOptionsPresenter(
+      IOutputPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
+      std::string const &fixedIndices = "",
+      std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
   /// Set the active workspaces used in the plotting options
   void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces);
 

--- a/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/DataReductionTab.h
@@ -51,11 +51,6 @@ public:
   DataReductionTab(IDataReduction *idrUI, std::unique_ptr<API::IAlgorithmRunner> algorithmRunner);
   ~DataReductionTab() override;
 
-  /// Set the presenter for the output plotting options
-  void setOutputPlotOptionsPresenter(
-      IOutputPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
-      std::string const &fixedIndices = "",
-      std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
   /// Set the active workspaces used in the plotting options
   void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces);
 
@@ -89,7 +84,6 @@ protected:
 protected:
   IDataReduction *m_idrUI;
   std::unique_ptr<API::IAlgorithmRunner> m_algorithmRunner;
-  std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
 
 private slots:
   void handleNewInstrumentConfiguration();

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
@@ -45,8 +45,7 @@ ISISCalibration::ISISCalibration(IDataReduction *idrUI, QWidget *parent)
     : DataReductionTab(idrUI, parent), m_lastCalPlotFilename("") {
   m_uiForm.setupUi(parent);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraBin));
+  setOutputPlotOptionsPresenter(m_uiForm.ipoPlotOptions, PlotWidget::SpectraBin);
 
   m_uiForm.ppCalibration->setCanvasColour(QColor(240, 240, 240));
   m_uiForm.ppResolution->setCanvasColour(QColor(240, 240, 240));

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
@@ -32,8 +32,7 @@ namespace MantidQt::CustomInterfaces {
 ISISDiagnostics::ISISDiagnostics(IDataReduction *idrUI, QWidget *parent) : DataReductionTab(idrUI, parent) {
   m_uiForm.setupUi(parent);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::Spectra));
+  setOutputPlotOptionsPresenter(m_uiForm.ipoPlotOptions, PlotWidget::Spectra);
 
   m_uiForm.ppRawPlot->setCanvasColour(QColor(240, 240, 240));
   m_uiForm.ppSlicePreview->setCanvasColour(QColor(240, 240, 240));

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
@@ -55,8 +55,7 @@ IETPresenter::IETPresenter(IDataReduction *idrUI, IIETView *view, std::unique_pt
   m_view->subscribePresenter(this);
   m_algorithmRunner->subscribe(this);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_view->getRunView()));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptionsView(), PlotWidget::SpectraSliceSurface));
+  setOutputPlotOptionsPresenter(m_view->getPlotOptionsView(), PlotWidget::SpectraSliceSurface);
 }
 
 void IETPresenter::validateInstrumentDetails(IUserInputValidator *validator) const {

--- a/qt/scientific_interfaces/Indirect/Reduction/Transmission.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/Transmission.cpp
@@ -31,8 +31,7 @@ namespace MantidQt::CustomInterfaces {
 Transmission::Transmission(IDataReduction *idrUI, QWidget *parent) : DataReductionTab(idrUI, parent) {
   m_uiForm.setupUi(parent);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::Spectra, "0-2"));
+  setOutputPlotOptionsPresenter(m_uiForm.ipoPlotOptions, PlotWidget::Spectra, "0-2");
 
   // Update the preview plot when the algorithm is complete
   connect(m_batchAlgoRunner, &API::BatchAlgorithmRunner::batchComplete, this, &Transmission::transAlgDone);

--- a/qt/scientific_interfaces/Indirect/Simulation/DensityOfStates.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/DensityOfStates.cpp
@@ -27,8 +27,7 @@ enum class DensityOfStates::InputFormat : int { Unsupported = 0, Phonon, Castep,
 DensityOfStates::DensityOfStates(QWidget *parent) : SimulationTab(parent) {
   m_uiForm.setupUi(parent);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::Spectra));
+  setOutputPlotOptionsPresenter(m_uiForm.ipoPlotOptions, PlotWidget::Spectra);
 
   connect(m_uiForm.mwInputFile, &FileFinderWidget::filesFound, this, &DensityOfStates::handleFileChange);
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &DensityOfStates::saveClicked);

--- a/qt/scientific_interfaces/Indirect/Simulation/MolDyn.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/MolDyn.cpp
@@ -20,8 +20,7 @@ namespace MantidQt::CustomInterfaces {
 MolDyn::MolDyn(QWidget *parent) : SimulationTab(parent) {
   m_uiForm.setupUi(parent);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface, "0"));
+  setOutputPlotOptionsPresenter(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface, "0");
 
   connect(m_uiForm.ckCropEnergy, &QCheckBox::toggled, m_uiForm.dspMaxEnergy, &QDoubleSpinBox::setEnabled);
   connect(m_uiForm.ckResolution, &QCheckBox::toggled, m_uiForm.dsResolution, &DataSelector::setEnabled);

--- a/qt/scientific_interfaces/Indirect/Simulation/Sassena.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/Sassena.cpp
@@ -16,8 +16,7 @@ namespace MantidQt::CustomInterfaces {
 Sassena::Sassena(QWidget *parent) : SimulationTab(parent) {
   m_uiForm.setupUi(parent);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::Spectra));
+  setOutputPlotOptionsPresenter(m_uiForm.ipoPlotOptions, PlotWidget::Spectra);
 
   connect(m_batchAlgoRunner, &API::BatchAlgorithmRunner::batchComplete, this, &Sassena::handleAlgorithmFinish);
   connect(m_uiForm.pbSave, &QPushButton::clicked, this, &Sassena::saveClicked);

--- a/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.cpp
@@ -14,15 +14,6 @@ SimulationTab::SimulationTab(QWidget *parent) : InelasticTab(parent) {}
 
 SimulationTab::~SimulationTab() = default;
 
-void SimulationTab::setOutputPlotOptionsPresenter(
-    IOutputPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
-    std::optional<std::map<std::string, std::string>> const &availableActions) {
-  auto OutputOptionsModel =
-      std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>(), availableActions);
-  m_plotOptionsPresenter =
-      std::make_unique<OutputPlotOptionsPresenter>(view, std::move(OutputOptionsModel), plotType, fixedIndices);
-}
-
 void SimulationTab::setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces) {
   m_plotOptionsPresenter->setWorkspaces(outputWorkspaces);
 }

--- a/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.cpp
+++ b/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.cpp
@@ -14,8 +14,13 @@ SimulationTab::SimulationTab(QWidget *parent) : InelasticTab(parent) {}
 
 SimulationTab::~SimulationTab() = default;
 
-void SimulationTab::setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter) {
-  m_plotOptionsPresenter = std::move(presenter);
+void SimulationTab::setOutputPlotOptionsPresenter(
+    IOutputPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
+    std::optional<std::map<std::string, std::string>> const &availableActions) {
+  auto OutputOptionsModel =
+      std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>(), availableActions);
+  m_plotOptionsPresenter =
+      std::make_unique<OutputPlotOptionsPresenter>(view, std::move(OutputOptionsModel), plotType, fixedIndices);
 }
 
 void SimulationTab::setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces) {

--- a/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.h
+++ b/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.h
@@ -35,10 +35,6 @@ public:
   SimulationTab(QWidget *parent = nullptr);
   ~SimulationTab() override;
 
-  void setOutputPlotOptionsPresenter(
-      IOutputPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
-      std::string const &fixedIndices = "",
-      std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
   void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces);
   void clearOutputPlotOptionsWorkspaces();
 
@@ -47,7 +43,6 @@ public:
 
 private:
   virtual void setLoadHistory(bool doLoadHistory) { UNUSED_ARG(doLoadHistory); }
-  std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.h
+++ b/qt/scientific_interfaces/Indirect/Simulation/SimulationTab.h
@@ -35,7 +35,10 @@ public:
   SimulationTab(QWidget *parent = nullptr);
   ~SimulationTab() override;
 
-  void setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter);
+  void setOutputPlotOptionsPresenter(
+      IOutputPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
+      std::string const &fixedIndices = "",
+      std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
   void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces);
   void clearOutputPlotOptionsWorkspaces();
 

--- a/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/AbsorptionCorrections.cpp
@@ -112,8 +112,7 @@ AbsorptionCorrections::AbsorptionCorrections(QWidget *parent)
   actions["Plot Spectra"] = "Plot Wavelength";
   actions["Plot Bins"] = "Plot Angle";
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraBin, "", actions));
+  setOutputPlotOptionsPresenter(m_uiForm.ipoPlotOptions, PlotWidget::SpectraBin, "", actions);
 
   QRegExp regex(R"([A-Za-z0-9\-\(\)]*)");
   QValidator *formulaValidator = new QRegExpValidator(regex, this);

--- a/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ApplyAbsorptionCorrections.cpp
@@ -36,8 +36,7 @@ namespace MantidQt::CustomInterfaces {
 ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent) : CorrectionsTab(parent), m_spectra(0u) {
   m_uiForm.setupUi(parent);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface));
+  setOutputPlotOptionsPresenter(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface);
 
   connect(m_uiForm.dsSample, &DataSelector::dataReady, this, &ApplyAbsorptionCorrections::newSample);
   connect(m_uiForm.dsContainer, &DataSelector::dataReady, this, &ApplyAbsorptionCorrections::newContainer);

--- a/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CalculatePaalmanPings.cpp
@@ -48,8 +48,7 @@ CalculatePaalmanPings::CalculatePaalmanPings(QWidget *parent)
   std::map<std::string, std::string> actions;
   actions["Plot Spectra"] = "Plot Wavelength";
   actions["Plot Bins"] = "Plot Angle";
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraBin, "", actions));
+  setOutputPlotOptionsPresenter(m_uiForm.ipoPlotOptions, PlotWidget::SpectraBin, "", actions);
 
   connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this,
           SLOT(getBeamWidthFromWorkspace(const QString &)));

--- a/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/ContainerSubtraction.cpp
@@ -29,8 +29,7 @@ namespace MantidQt::CustomInterfaces {
 ContainerSubtraction::ContainerSubtraction(QWidget *parent) : CorrectionsTab(parent), m_spectra(0) {
   m_uiForm.setupUi(parent);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_uiForm.runWidget));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface));
+  setOutputPlotOptionsPresenter(m_uiForm.ipoPlotOptions, PlotWidget::SpectraSliceSurface);
 
   connect(m_uiForm.dsSample, &DataSelector::dataReady, this, &ContainerSubtraction::newSample);
   connect(m_uiForm.dsContainer, &DataSelector::dataReady, this, &ContainerSubtraction::newContainer);

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
@@ -26,15 +26,6 @@ CorrectionsTab::CorrectionsTab(QWidget *parent) : InelasticTab(parent), m_dblEdF
   m_blnEdFac = new QtCheckBoxFactory(this);
 }
 
-void CorrectionsTab::setOutputPlotOptionsPresenter(
-    IOutputPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
-    std::optional<std::map<std::string, std::string>> const &availableActions) {
-  auto OutputOptionsModel =
-      std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>(), availableActions);
-  m_plotOptionsPresenter =
-      std::make_unique<OutputPlotOptionsPresenter>(view, std::move(OutputOptionsModel), plotType, fixedIndices);
-}
-
 void CorrectionsTab::setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces) {
   m_plotOptionsPresenter->setWorkspaces(outputWorkspaces);
 }

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.cpp
@@ -26,8 +26,13 @@ CorrectionsTab::CorrectionsTab(QWidget *parent) : InelasticTab(parent), m_dblEdF
   m_blnEdFac = new QtCheckBoxFactory(this);
 }
 
-void CorrectionsTab::setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter) {
-  m_plotOptionsPresenter = std::move(presenter);
+void CorrectionsTab::setOutputPlotOptionsPresenter(
+    IOutputPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
+    std::optional<std::map<std::string, std::string>> const &availableActions) {
+  auto OutputOptionsModel =
+      std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>(), availableActions);
+  m_plotOptionsPresenter =
+      std::make_unique<OutputPlotOptionsPresenter>(view, std::move(OutputOptionsModel), plotType, fixedIndices);
 }
 
 void CorrectionsTab::setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces) {

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.h
@@ -69,7 +69,10 @@ public:
   CorrectionsTab(QWidget *parent = nullptr);
 
   /// Set the presenter for the output plotting options
-  void setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter);
+  void setOutputPlotOptionsPresenter(
+      IOutputPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
+      std::string const &fixedIndices = "",
+      std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
   /// Set the active workspaces used in the plotting options
   void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces);
   /// Used to clear the workspaces held by the output plotting widget

--- a/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.h
+++ b/qt/scientific_interfaces/Inelastic/Corrections/CorrectionsTab.h
@@ -67,12 +67,6 @@ class MANTIDQT_INELASTIC_DLL CorrectionsTab : public InelasticTab {
 public:
   /// Constructor
   CorrectionsTab(QWidget *parent = nullptr);
-
-  /// Set the presenter for the output plotting options
-  void setOutputPlotOptionsPresenter(
-      IOutputPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
-      std::string const &fixedIndices = "",
-      std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
   /// Set the active workspaces used in the plotting options
   void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces);
   /// Used to clear the workspaces held by the output plotting widget
@@ -105,8 +99,6 @@ private:
   virtual void loadSettings(const QSettings &settings) = 0;
   virtual void setFileExtensionsByName(bool filter) = 0;
   virtual void setLoadHistory(bool doLoadHistory) { (void)doLoadHistory; };
-
-  std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
@@ -28,8 +28,13 @@ DataProcessor::DataProcessor(QObject *parent, std::unique_ptr<MantidQt::API::IAl
   m_algorithmRunner->subscribe(this);
 }
 
-void DataProcessor::setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter) {
-  m_plotOptionsPresenter = std::move(presenter);
+void DataProcessor::setOutputPlotOptionsPresenter(
+    IOutputPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
+    std::optional<std::map<std::string, std::string>> const &availableActions) {
+  auto OutputOptionsModel =
+      std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>(), availableActions);
+  m_plotOptionsPresenter =
+      std::make_unique<OutputPlotOptionsPresenter>(view, std::move(OutputOptionsModel), plotType, fixedIndices);
 }
 
 void DataProcessor::notifyBatchComplete(API::IConfiguredAlgorithm_sptr &algorithm, bool error) {

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.cpp
@@ -28,15 +28,6 @@ DataProcessor::DataProcessor(QObject *parent, std::unique_ptr<MantidQt::API::IAl
   m_algorithmRunner->subscribe(this);
 }
 
-void DataProcessor::setOutputPlotOptionsPresenter(
-    IOutputPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
-    std::optional<std::map<std::string, std::string>> const &availableActions) {
-  auto OutputOptionsModel =
-      std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>(), availableActions);
-  m_plotOptionsPresenter =
-      std::make_unique<OutputPlotOptionsPresenter>(view, std::move(OutputOptionsModel), plotType, fixedIndices);
-}
-
 void DataProcessor::notifyBatchComplete(API::IConfiguredAlgorithm_sptr &algorithm, bool error) {
   if (algorithm->algorithm()->name() != "SaveNexusProcessed") {
     m_runPresenter->setRunEnabled(true);

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
@@ -39,7 +39,10 @@ class DataReduction;
 class MANTIDQT_INELASTIC_DLL IDataProcessor {
 public:
   virtual ~IDataProcessor() = default;
-  virtual void setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter>) = 0;
+  virtual void setOutputPlotOptionsPresenter(
+      IOutputPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
+      std::string const &fixedIndices = "",
+      std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt) = 0;
   virtual void clearOutputPlotOptionsWorkspaces() = 0;
   virtual void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces) = 0;
   virtual void filterInputData(bool filter) = 0;
@@ -61,7 +64,10 @@ public:
   DataProcessor(QObject *parent = nullptr, std::unique_ptr<MantidQt::API::IAlgorithmRunner> algorithmRunner = nullptr);
   ~DataProcessor() override = default;
   /// Set the presenter for the output plotting options
-  void setOutputPlotOptionsPresenter(std::unique_ptr<OutputPlotOptionsPresenter> presenter) override;
+  void setOutputPlotOptionsPresenter(
+      IOutputPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
+      std::string const &fixedIndices = "",
+      std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt) override;
   /// Overridden from IAlgorithmRunnerSubscriber: Notifies when a batch of algorithms is completed
   void notifyBatchComplete(API::IConfiguredAlgorithm_sptr &algorithm, bool error) override;
 

--- a/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/DataProcessor.h
@@ -39,10 +39,6 @@ class DataReduction;
 class MANTIDQT_INELASTIC_DLL IDataProcessor {
 public:
   virtual ~IDataProcessor() = default;
-  virtual void setOutputPlotOptionsPresenter(
-      IOutputPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
-      std::string const &fixedIndices = "",
-      std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt) = 0;
   virtual void clearOutputPlotOptionsWorkspaces() = 0;
   virtual void setOutputPlotOptionsWorkspaces(std::vector<std::string> const &outputWorkspaces) = 0;
   virtual void filterInputData(bool filter) = 0;
@@ -63,11 +59,6 @@ class MANTIDQT_INELASTIC_DLL DataProcessor : public IDataProcessor,
 public:
   DataProcessor(QObject *parent = nullptr, std::unique_ptr<MantidQt::API::IAlgorithmRunner> algorithmRunner = nullptr);
   ~DataProcessor() override = default;
-  /// Set the presenter for the output plotting options
-  void setOutputPlotOptionsPresenter(
-      IOutputPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
-      std::string const &fixedIndices = "",
-      std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt) override;
   /// Overridden from IAlgorithmRunnerSubscriber: Notifies when a batch of algorithms is completed
   void notifyBatchComplete(API::IConfiguredAlgorithm_sptr &algorithm, bool error) override;
 
@@ -94,7 +85,6 @@ protected:
 private:
   virtual void setFileExtensionsByName(bool filter) { (void)filter; };
   virtual void setLoadHistory(bool doLoadHistory) { (void)doLoadHistory; }
-  std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinPresenter.cpp
@@ -44,8 +44,7 @@ ElwinPresenter::ElwinPresenter(QWidget *parent, std::unique_ptr<API::IAlgorithmR
       m_dataModel(std::make_unique<DataModel>()), m_selectedSpectrum(0) {
   m_view->subscribePresenter(this);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_view->getRunView()));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraSliceSurface));
+  setOutputPlotOptionsPresenter(m_view->getPlotOptions(), PlotWidget::SpectraSliceSurface);
   m_view->setup();
   observeRename(true);
   observeDelete(true);
@@ -60,8 +59,7 @@ ElwinPresenter::ElwinPresenter(QWidget *parent, std::unique_ptr<MantidQt::API::I
       m_dataModel(std::move(dataModel)), m_selectedSpectrum(0) {
   m_view->subscribePresenter(this);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_view->getRunView()));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraSliceSurface));
+  setOutputPlotOptionsPresenter(m_view->getPlotOptions(), PlotWidget::SpectraSliceSurface);
   m_view->setup();
   updateAvailableSpectra();
 }

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtPresenter.cpp
@@ -34,8 +34,7 @@ IqtPresenter::IqtPresenter(QWidget *parent, std::unique_ptr<MantidQt::API::IAlgo
       m_selectedSpectrum(0) {
   m_view->subscribePresenter(this);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_view->getRunView()));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraTiled));
+  setOutputPlotOptionsPresenter(m_view->getPlotOptions(), PlotWidget::SpectraTiled);
   m_view->setup();
 }
 

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsPresenter.cpp
@@ -35,8 +35,7 @@ MomentsPresenter::MomentsPresenter(QWidget *parent, std::unique_ptr<MantidQt::AP
     : DataProcessor(parent, std::move(algorithmRunner)), m_view(view), m_model(std::move(model)) {
   m_view->subscribePresenter(this);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_view->getRunView()));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::Spectra, "0,2,4"));
+  setOutputPlotOptionsPresenter(m_view->getPlotOptions(), PlotWidget::Spectra, "0,2,4");
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.cpp
@@ -39,8 +39,7 @@ SqwPresenter::SqwPresenter(QWidget *parent, std::unique_ptr<MantidQt::API::IAlgo
     : DataProcessor(parent, std::move(algorithmRunner)), m_view(view), m_model(std::move(model)) {
   m_view->subscribePresenter(this);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_view->getRunView()));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraSliceSurface));
+  setOutputPlotOptionsPresenter(m_view->getPlotOptions(), PlotWidget::SpectraSliceSurface);
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetrisePresenter.cpp
@@ -34,8 +34,7 @@ SymmetrisePresenter::SymmetrisePresenter(QWidget *parent,
     : DataProcessor(parent, std::move(algorithmRunner)), m_view(view), m_model(std::move(model)), m_isPreview(false) {
   m_view->subscribePresenter(this);
   setRunWidgetPresenter(std::make_unique<RunPresenter>(this, m_view->getRunView()));
-  setOutputPlotOptionsPresenter(
-      std::make_unique<OutputPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::Spectra));
+  setOutputPlotOptionsPresenter(m_view->getPlotOptions(), PlotWidget::Spectra);
 
   m_model->setIsPositiveReflect(true);
   m_view->setDefaults();

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/InelasticTab.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/InelasticTab.h
@@ -18,6 +18,7 @@
 #include "MantidQtWidgets/Plotting/ExternalPlotter.h"
 #include "MantidQtWidgets/Plotting/PreviewPlot.h"
 #include "MantidQtWidgets/Plotting/RangeSelector.h"
+#include "MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsPresenter.h"
 #include "MantidQtWidgets/Spectroscopy/RunWidget/RunPresenter.h"
 
 #include <boost/none_t.hpp>
@@ -72,6 +73,12 @@ protected:
   /// Set the presenter for the run widget
   void setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter);
 
+  /// Set the presenter for the output plotting options
+  void setOutputPlotOptionsPresenter(
+      IOutputPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
+      std::string const &fixedIndices = "",
+      std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
+
   /// Run the load algorithms
   bool loadFile(const std::string &filename, const std::string &outputName, const int specMin = -1,
                 const int specMax = -1, bool loadHistory = true);
@@ -102,6 +109,8 @@ protected:
   bool checkADSForPlotSaveWorkspace(const std::string &workspaceName, const bool plotting, const bool warn = true);
 
   std::unique_ptr<RunPresenter> m_runPresenter;
+
+  std::unique_ptr<OutputPlotOptionsPresenter> m_plotOptionsPresenter;
 
   /// Parent QWidget (if applicable)
   QWidget *m_parentWidget;

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsPresenter.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsPresenter.h
@@ -18,6 +18,7 @@ namespace CustomInterfaces {
 
 class MANTID_SPECTROSCOPY_DLL IOutputPlotOptionsPresenter {
 public:
+  virtual ~IOutputPlotOptionsPresenter() = default;
   virtual void handleWorkspaceChanged(std::string const &workspaceName) = 0;
   virtual void handleSelectedUnitChanged(std::string const &unit) = 0;
   virtual void handleSelectedIndicesChanged(std::string const &indices) = 0;
@@ -35,7 +36,7 @@ public:
   explicit OutputPlotOptionsPresenter(IOutputPlotOptionsView *view, std::unique_ptr<IOutputPlotOptionsModel> model,
                                       PlotWidget const &plotType = PlotWidget::Spectra,
                                       std::string const &fixedIndices = "");
-  ~OutputPlotOptionsPresenter() = default;
+  ~OutputPlotOptionsPresenter() override = default;
 
   void handleWorkspaceChanged(std::string const &workspaceName) override;
   void handleSelectedUnitChanged(std::string const &unit) override;

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsPresenter.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsPresenter.h
@@ -34,12 +34,9 @@ class MANTID_SPECTROSCOPY_DLL OutputPlotOptionsPresenter final : public IOutputP
                                                                  public AnalysisDataServiceObserver {
 
 public:
-  OutputPlotOptionsPresenter(IOutputPlotOptionsView *view, PlotWidget const &plotType = PlotWidget::Spectra,
-                             std::string const &fixedIndices = "",
-                             std::optional<std::map<std::string, std::string>> const &availableActions = std::nullopt);
-  /// Used by the unit tests so that the view and model can be mocked
-  OutputPlotOptionsPresenter(IOutputPlotOptionsView *view, std::unique_ptr<IOutputPlotOptionsModel> model,
-                             PlotWidget const &plotType = PlotWidget::Spectra, std::string const &fixedIndices = "");
+  explicit OutputPlotOptionsPresenter(IOutputPlotOptionsView *view, std::unique_ptr<IOutputPlotOptionsModel> model,
+                                      PlotWidget const &plotType = PlotWidget::Spectra,
+                                      std::string const &fixedIndices = "");
   ~OutputPlotOptionsPresenter() = default;
 
   void handleWorkspaceChanged(std::string const &workspaceName) override;

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsPresenter.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsPresenter.h
@@ -6,8 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "MantidQtWidgets/Spectroscopy/InelasticInterface.h"
-#include "MantidQtWidgets/Spectroscopy/InelasticTab.h"
 #include "MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsModel.h"
 #include "MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsView.h"
 

--- a/qt/widgets/spectroscopy/src/InelasticTab.cpp
+++ b/qt/widgets/spectroscopy/src/InelasticTab.cpp
@@ -18,6 +18,7 @@
 #include "MantidQtWidgets/Common/AlgorithmDialog.h"
 #include "MantidQtWidgets/Common/InterfaceManager.h"
 #include "MantidQtWidgets/Plotting/RangeSelector.h"
+#include "MantidQtWidgets/Spectroscopy/OutputWidget/OutputPlotOptionsView.h"
 
 #include <MantidQtWidgets/Spectroscopy/SettingsWidget/SettingsHelper.h>
 #include <QDomDocument>
@@ -52,10 +53,11 @@ void setPropertyIf(const Algorithm_sptr &algorithm, std::string const &propName,
 namespace MantidQt::CustomInterfaces {
 
 InelasticTab::InelasticTab(QObject *parent)
-    : QObject(parent), m_runPresenter(), m_properties(), m_dblManager(new QtDoublePropertyManager()),
-      m_blnManager(new QtBoolPropertyManager()), m_grpManager(new QtGroupPropertyManager()),
-      m_dblEdFac(new DoubleEditorFactory()), m_tabStartTime(DateAndTime::getCurrentTime()),
-      m_tabEndTime(DateAndTime::maximum()), m_plotter(std::make_unique<Widgets::MplCpp::ExternalPlotter>()),
+    : QObject(parent), m_runPresenter(), m_plotOptionsPresenter(), m_properties(),
+      m_dblManager(new QtDoublePropertyManager()), m_blnManager(new QtBoolPropertyManager()),
+      m_grpManager(new QtGroupPropertyManager()), m_dblEdFac(new DoubleEditorFactory()),
+      m_tabStartTime(DateAndTime::getCurrentTime()), m_tabEndTime(DateAndTime::maximum()),
+      m_plotter(std::make_unique<Widgets::MplCpp::ExternalPlotter>()),
       m_adsInstance(Mantid::API::AnalysisDataService::Instance()) {
   m_parentWidget = dynamic_cast<QWidget *>(parent);
 
@@ -72,6 +74,15 @@ InelasticTab::InelasticTab(QObject *parent)
 
 void InelasticTab::setRunWidgetPresenter(std::unique_ptr<RunPresenter> presenter) {
   m_runPresenter = std::move(presenter);
+}
+
+void InelasticTab::setOutputPlotOptionsPresenter(
+    IOutputPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
+    std::optional<std::map<std::string, std::string>> const &availableActions) {
+  auto outputPlotOptionsModel =
+      std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>(), availableActions);
+  m_plotOptionsPresenter =
+      std::make_unique<OutputPlotOptionsPresenter>(view, std::move(outputPlotOptionsModel), plotType, fixedIndices);
 }
 
 /**

--- a/qt/widgets/spectroscopy/src/OutputWidget/OutputPlotOptionsPresenter.cpp
+++ b/qt/widgets/spectroscopy/src/OutputWidget/OutputPlotOptionsPresenter.cpp
@@ -33,15 +33,6 @@ std::string const WORKSPACE_INDICES = "(" + NATURAL_OR_RANGE + "(" + COMMA + NAT
 } // namespace
 
 namespace MantidQt::CustomInterfaces {
-
-OutputPlotOptionsPresenter::OutputPlotOptionsPresenter(
-    IOutputPlotOptionsView *view, PlotWidget const &plotType, std::string const &fixedIndices,
-    std::optional<std::map<std::string, std::string>> const &availableActions)
-    : m_view(view),
-      m_model(std::make_unique<OutputPlotOptionsModel>(std::make_unique<ExternalPlotter>(), availableActions)) {
-  setupPresenter(plotType, fixedIndices);
-}
-
 /// Used by the unit tests so that m_plotter can be mocked
 OutputPlotOptionsPresenter::OutputPlotOptionsPresenter(IOutputPlotOptionsView *view,
                                                        std::unique_ptr<IOutputPlotOptionsModel> model,

--- a/qt/widgets/spectroscopy/src/OutputWidget/OutputPlotOptionsPresenter.cpp
+++ b/qt/widgets/spectroscopy/src/OutputWidget/OutputPlotOptionsPresenter.cpp
@@ -33,7 +33,6 @@ std::string const WORKSPACE_INDICES = "(" + NATURAL_OR_RANGE + "(" + COMMA + NAT
 } // namespace
 
 namespace MantidQt::CustomInterfaces {
-/// Used by the unit tests so that m_plotter can be mocked
 OutputPlotOptionsPresenter::OutputPlotOptionsPresenter(IOutputPlotOptionsView *view,
                                                        std::unique_ptr<IOutputPlotOptionsModel> model,
                                                        PlotWidget const &plotType, std::string const &fixedIndices)


### PR DESCRIPTION
### Description of work
Part of #36324. 
This PR is part of MVP updating of Spectroscopy related interfaces. In this case the OutputPlotOptions widget was not passing a model to initialize the widget but creating it within the presenter. This PR refactors the functions creating the presenter to pass the model in the creation. 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Part of #36324 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Test that the Output Plot Options widget  work correctly in the following interfaces: Data Reduction, Diffraction, Corrections, Data Processor and Simulation. 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

__No need for release notes as it is an internal change__

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
