### PR TITLE
Turn off automerge of release-next into ornl-next

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -35,17 +35,3 @@ jobs:
           target_branch: main
           message: Merge ornl-next into main
           github_token: ${{ secrets.MANTID_BUILDER_TOKEN }}
-
-  merge-release-into-ornl:
-    runs-on: ubuntu-latest
-    if: ${{ github.ref_name == 'release-next' }}
-    steps:
-      - uses: actions/checkout@master
-
-      - name: Merge release-next into ornl-next
-        uses: devmasx/merge-branch@master
-        with:
-          type: now
-          target_branch: ornl-next
-          message: Merge release-next into ornl-next
-          github_token: ${{ secrets.MANTID_BUILDER_TOKEN }}


### PR DESCRIPTION
It was decided that ORNL wants more control of when `release-next` is merged into `ornl-next`. ORNL is still committed to merging every release, but we want to control when that merge happens.

*There is no associated issue,* but it is associated with [EWM7874](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7874)

### To test:

This removes a build step so no testing is necessary.

*This does not require release notes* because it removes automerging one branch into another.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
