### PR TITLE
Fixed a typo

### DIFF
--- a/docs/source/release/v6.12.0/Framework/Data_Objects/New_features/38177.rst
+++ b/docs/source/release/v6.12.0/Framework/Data_Objects/New_features/38177.rst
@@ -1,1 +1,1 @@
-- ``EnumeratedStringProperty`` which uses ``EnumeratedString`` can be used in C++ bases algorithms
+- ``EnumeratedStringProperty`` which uses ``EnumeratedString`` can be used in C++ based algorithms


### PR DESCRIPTION
### Description of work

Fixed a typo in ornl-next which causes automatic merge failure from ornl-next to main. 

