### PR TITLE
`EditInstrumentGeometry`: place detectors in single detector bank.

### DIFF
--- a/Framework/Algorithms/test/EditInstrumentGeometryTest.h
+++ b/Framework/Algorithms/test/EditInstrumentGeometryTest.h
@@ -9,11 +9,16 @@
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAlgorithms/EditInstrumentGeometry.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
 #include <cxxtest/TestSuite.h>
 
 using namespace Mantid;
 using namespace Mantid::Algorithms;
 using namespace Mantid::API;
+
+using ADS = AnalysisDataService;
 
 class EditInstrumentGeometryTest : public CxxTest::TestSuite {
 public:
@@ -26,7 +31,7 @@ public:
     TS_ASSERT(editdetector.isInitialized());
   }
 
-  /** Test for a workspace containing a single spectrum
+  /** Test `EditInstrumentGeometry` for a workspace containing a single spectrum
    */
   void test_SingleSpectrum() {
     // 1. Init
@@ -34,9 +39,8 @@ public:
     editdetector.initialize();
 
     // 2. Load Data
-    DataObjects::Workspace2D_sptr workspace2d =
-        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(1, 100, false);
-    API::AnalysisDataService::Instance().add("inputWS", workspace2d);
+    DataObjects::Workspace2D_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(1, 100, false);
+    ADS::Instance().add("inputWS", inputWS);
 
     // 3. Set Property
     TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Workspace", "inputWS"));
@@ -50,11 +54,11 @@ public:
     TS_ASSERT(editdetector.isExecuted());
 
     // 5. Check result
-    Mantid::API::MatrixWorkspace_sptr workspace;
-    TS_ASSERT_THROWS_NOTHING(workspace = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
-                                 Mantid::API::AnalysisDataService::Instance().retrieve("inputWS")));
+    Mantid::API::MatrixWorkspace_sptr outputWS;
+    TS_ASSERT_THROWS_NOTHING(
+        outputWS = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ADS::Instance().retrieve("inputWS")));
 
-    const auto &spectrumInfo = workspace->spectrumInfo();
+    const auto &spectrumInfo = outputWS->spectrumInfo();
     TS_ASSERT_EQUALS(spectrumInfo.hasUniqueDetector(0), true);
 
     double r, tth, phi;
@@ -62,84 +66,317 @@ public:
     TS_ASSERT_DELTA(r, 3.45, 0.000001);
     TS_ASSERT_DELTA(tth, 90.09, 0.000001);
     TS_ASSERT_DELTA(phi, 1.84, 0.000001);
+
+    // Clean up
+    AnalysisDataService::Instance().remove("inputWS");
   }
 
-  /** Unit test to edit instrument parameters of all spectrums (>1)
+  /** Test `EditInstrumentGeometry` using
+   *  default values for input spectrum numbers and for
+   *  output detector-ids.
    */
-  void test_MultipleWholeSpectrumEdit() {
+  void test_MultipleSpectraDefaultIndices() {
     // 1. Init
     EditInstrumentGeometry editdetector;
     editdetector.initialize();
 
     // 2. Load Data
-    DataObjects::Workspace2D_sptr workspace2d =
-        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(6, 100, false);
-    API::AnalysisDataService::Instance().add("inputWS2", workspace2d);
+    DataObjects::Workspace2D_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(6, 100, false);
+    ADS::Instance().add("inputWS2", inputWS);
 
     // 3. Set Property
     TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Workspace", "inputWS2"));
-    // TS_ASSERT_THROWS_NOTHING(
-    // editdetector.setPropertyValue("SpectrumIDs","3072,19456,40960,55296,74752,93184")
-    // );
-    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("L2", "1.1,2.2,3.3,4.4,5.5,6.6"));
-    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Polar", "90.1,90.2,90.3,90.4,90.5,90.6"));
-    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Azimuthal", "1,2,3,4,5,6"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("L2", "1.1, 2.2, 3.3, 4.4, 5.5, 6.6"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Polar", "90.1, 90.2, 90.3, 90.4, 90.5, 90.6"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Azimuthal", "1.0, 2.0, 3.0, 4.0, 5.0, 6.0"));
 
     // 4. Run
     TS_ASSERT_THROWS_NOTHING(editdetector.execute());
     TS_ASSERT(editdetector.isExecuted());
 
     // 5. Check result
-    Mantid::API::MatrixWorkspace_sptr workspace;
-    TS_ASSERT_THROWS_NOTHING(workspace = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
-                                 Mantid::API::AnalysisDataService::Instance().retrieve("inputWS2")));
+    Mantid::API::MatrixWorkspace_sptr outputWS;
+    TS_ASSERT_THROWS_NOTHING(
+        outputWS = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ADS::Instance().retrieve("inputWS2")));
 
-    checkDetectorParameters(workspace, 0, 1.1, 90.1, 1.0);
-    checkDetectorParameters(workspace, 1, 2.2, 90.2, 2.0);
-    checkDetectorParameters(workspace, 3, 4.4, 90.4, 4.0);
-    checkDetectorParameters(workspace, 5, 6.6, 90.6, 6.0);
+    checkDetectorParameters(outputWS, 0, 1.1, 90.1, 1.0);
+    checkDetectorParameters(outputWS, 1, 2.2, 90.2, 2.0);
+    checkDetectorParameters(outputWS, 2, 3.3, 90.3, 3.0);
+    checkDetectorParameters(outputWS, 3, 4.4, 90.4, 4.0);
+    checkDetectorParameters(outputWS, 4, 5.5, 90.5, 5.0);
+    checkDetectorParameters(outputWS, 5, 6.6, 90.6, 6.0);
+
+    // For `EditInstrumentGeometry`: the default detector ID values start with 100.
+    checkDetectorID(outputWS, 0, 100);
+    checkDetectorID(outputWS, 1, 101);
+    checkDetectorID(outputWS, 2, 102);
+    checkDetectorID(outputWS, 3, 103);
+    checkDetectorID(outputWS, 4, 104);
+    checkDetectorID(outputWS, 5, 105);
+
+    checkSpectrumNumber(outputWS, 0, 1);
+    checkSpectrumNumber(outputWS, 1, 2);
+    checkSpectrumNumber(outputWS, 2, 3);
+    checkSpectrumNumber(outputWS, 3, 4);
+    checkSpectrumNumber(outputWS, 4, 5);
+    checkSpectrumNumber(outputWS, 5, 6);
+
+    // Clean up
+    AnalysisDataService::Instance().remove("inputWS2");
   }
 
   //----------------------------------------------------------------------------------------------
-  /** Unit test to edit instrument parameters of all spectrums (>1) and using
-   * new detector IDs
+  /** Test `EditInstrumentGeometry` using
+   *  specified output detector IDs.
    */
-  void test_MultiplePartialSpectrumEdit() {
-    // Init
+  void test_MultipleSpectraNewDetectorIds() {
+    // 1. Init
     EditInstrumentGeometry editdetector;
     editdetector.initialize();
 
-    // Load Data
-    DataObjects::Workspace2D_sptr workspace2d =
-        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(6, 100, false);
-    API::AnalysisDataService::Instance().addOrReplace("inputWS3", workspace2d);
+    // 2. Load Data
+    DataObjects::Workspace2D_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(6, 100, false);
+    ADS::Instance().add("inputWS3", inputWS);
 
-    // Set Property
+    // 3. Set Properties
     TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Workspace", "inputWS3"));
-    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("SpectrumIDs", "1,2,3,4,5,6"));
-    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("L2", "1.1,2.2,3.3, 4.4, 5.5, 6.6"));
-    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Polar", "90.1,90.2,90.3, 90.4, 90.5, 90.6"));
-    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Azimuthal", "1,2,3,4,5,6"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("L2", "1.1, 2.2, 3.3, 4.4, 5.5, 6.6"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Polar", "90.1, 90.2, 90.3, 90.4, 90.5, 90.6"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Azimuthal", "1.0, 2.0, 3.0, 4.0, 5.0, 6.0"));
     TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("DetectorIDs", "200, 201, 300, 301, 400, 401"));
 
-    // Run
-    editdetector.execute();
+    // 4. Run
+    TS_ASSERT_THROWS_NOTHING(editdetector.execute());
     TS_ASSERT(editdetector.isExecuted());
 
-    // Check
-    checkDetectorID(workspace2d, 0, 200);
-    checkDetectorID(workspace2d, 1, 201);
-    checkDetectorID(workspace2d, 2, 300);
-    checkDetectorID(workspace2d, 3, 301);
-    checkDetectorID(workspace2d, 4, 400);
-    checkDetectorID(workspace2d, 5, 401);
+    // 5. Check result
+    Mantid::API::MatrixWorkspace_sptr outputWS;
+    TS_ASSERT_THROWS_NOTHING(
+        outputWS = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ADS::Instance().retrieve("inputWS3")));
 
-    // Clean
+    // Check output detector IDs
+    checkDetectorID(outputWS, 0, 200);
+    checkDetectorID(outputWS, 1, 201);
+    checkDetectorID(outputWS, 2, 300);
+    checkDetectorID(outputWS, 3, 301);
+    checkDetectorID(outputWS, 4, 400);
+    checkDetectorID(outputWS, 5, 401);
+
+    // Clean up
     AnalysisDataService::Instance().remove("inputWS3");
   }
 
   //----------------------------------------------------------------------------------------------
-  /** Check detector parameter
+  /** Test `EditInstrumentGeometry` using
+   *  a specified order of the input spectrum numbers.
+   */
+  void test_MultipleSpectraWithInputSpectrumIds() {
+    // 1. Init
+    EditInstrumentGeometry editdetector;
+    editdetector.initialize();
+
+    // 2. Load Data
+    DataObjects::Workspace2D_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(6, 100, false);
+
+    // Assign these deliberately out-of-order
+    inputWS->getSpectrum(0).setSpectrumNo(specnum_t(93184));
+    inputWS->getSpectrum(1).setSpectrumNo(specnum_t(55296));
+    inputWS->getSpectrum(2).setSpectrumNo(specnum_t(19456));
+    inputWS->getSpectrum(3).setSpectrumNo(specnum_t(74752));
+    inputWS->getSpectrum(4).setSpectrumNo(specnum_t(40960));
+    inputWS->getSpectrum(5).setSpectrumNo(specnum_t(3072));
+    ADS::Instance().add("inputWS4", inputWS);
+
+    // 3. Set Properties
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Workspace", "inputWS4"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("SpectrumIDs", "3072,19456,40960,55296,74752,93184"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("L2", "1.1, 2.2, 3.3, 4.4, 5.5, 6.6"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Polar", "90.1, 90.2, 90.3, 90.4, 90.5, 90.6"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Azimuthal", "1.0, 2.0, 3.0, 4.0, 5.0, 6.0"));
+
+    // 4. Run
+    TS_ASSERT_THROWS_NOTHING(editdetector.execute());
+    TS_ASSERT(editdetector.isExecuted());
+
+    // 5. Check result
+    Mantid::API::MatrixWorkspace_sptr outputWS;
+    TS_ASSERT_THROWS_NOTHING(
+        outputWS = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ADS::Instance().retrieve("inputWS4")));
+
+    checkDetectorParameters(outputWS, 5, 1.1, 90.1, 1.0);
+    checkDetectorParameters(outputWS, 2, 2.2, 90.2, 2.0);
+    checkDetectorParameters(outputWS, 4, 3.3, 90.3, 3.0);
+    checkDetectorParameters(outputWS, 1, 4.4, 90.4, 4.0);
+    checkDetectorParameters(outputWS, 3, 5.5, 90.5, 5.0);
+    checkDetectorParameters(outputWS, 0, 6.6, 90.6, 6.0);
+
+    // For `EditInstrumentGeometry`: the default detector ID values start with 100.
+    // In this *default* case, regardless of the order of the input spectra,
+    //   these are assigned in order of the workspace indices.
+    // (TODO: this behavior is almost certainly a _defect_.)
+    checkDetectorID(outputWS, 0, 100);
+    checkDetectorID(outputWS, 1, 101);
+    checkDetectorID(outputWS, 2, 102);
+    checkDetectorID(outputWS, 3, 103);
+    checkDetectorID(outputWS, 4, 104);
+    checkDetectorID(outputWS, 5, 105);
+
+    // Check spectrum numbers:
+    //   these should not have changed from the input workspace.
+    checkSpectrumNumber(outputWS, 0, specnum_t(93184));
+    checkSpectrumNumber(outputWS, 1, specnum_t(55296));
+    checkSpectrumNumber(outputWS, 2, specnum_t(19456));
+    checkSpectrumNumber(outputWS, 3, specnum_t(74752));
+    checkSpectrumNumber(outputWS, 4, specnum_t(40960));
+    checkSpectrumNumber(outputWS, 5, specnum_t(3072));
+
+    // Clean up
+    AnalysisDataService::Instance().remove("inputWS4");
+  }
+
+  //----------------------------------------------------------------------------------------------
+  /** Test `EditInstrumentGeometry` using specified output
+   *  detector Ids and also a specified order of the input spectrum numbers.
+   */
+  void test_MultipleSpectraWithInputSpectrumIdsAndNewDetectorIds() {
+    // 1. Init
+    EditInstrumentGeometry editdetector;
+    editdetector.initialize();
+
+    // 2. Load Data
+    DataObjects::Workspace2D_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(6, 100, false);
+
+    // Assign these deliberately out-of-order
+    inputWS->getSpectrum(0).setSpectrumNo(specnum_t(93184));
+    inputWS->getSpectrum(1).setSpectrumNo(specnum_t(55296));
+    inputWS->getSpectrum(2).setSpectrumNo(specnum_t(19456));
+    inputWS->getSpectrum(3).setSpectrumNo(specnum_t(74752));
+    inputWS->getSpectrum(4).setSpectrumNo(specnum_t(40960));
+    inputWS->getSpectrum(5).setSpectrumNo(specnum_t(3072));
+    ADS::Instance().add("inputWS5", inputWS);
+
+    // 3. Set Properties
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Workspace", "inputWS5"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("SpectrumIDs", "3072,19456,40960,55296,74752,93184"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("DetectorIDs", "1001,1002,1003,1004,1005,1006"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("L2", "1.1, 2.2, 3.3, 4.4, 5.5, 6.6"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Polar", "90.1, 90.2, 90.3, 90.4, 90.5, 90.6"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Azimuthal", "1.0, 2.0, 3.0, 4.0, 5.0, 6.0"));
+
+    // 4. Run
+    TS_ASSERT_THROWS_NOTHING(editdetector.execute());
+    TS_ASSERT(editdetector.isExecuted());
+
+    // 5. Check result
+    Mantid::API::MatrixWorkspace_sptr outputWS;
+    TS_ASSERT_THROWS_NOTHING(
+        outputWS = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ADS::Instance().retrieve("inputWS5")));
+
+    checkDetectorParameters(outputWS, 5, 1.1, 90.1, 1.0);
+    checkDetectorParameters(outputWS, 2, 2.2, 90.2, 2.0);
+    checkDetectorParameters(outputWS, 4, 3.3, 90.3, 3.0);
+    checkDetectorParameters(outputWS, 1, 4.4, 90.4, 4.0);
+    checkDetectorParameters(outputWS, 3, 5.5, 90.5, 5.0);
+    checkDetectorParameters(outputWS, 0, 6.6, 90.6, 6.0);
+
+    // For `EditInstrumentGeometry`:
+    //   the workspace index to spectrum number mapping is not changed.
+    // For this non-default case,
+    //   each detector ID is assigned to the spectrum at the corresponding
+    //   position in the input spectrum-number list.
+    checkDetectorID(outputWS, 0, 1006);
+    checkDetectorID(outputWS, 1, 1004);
+    checkDetectorID(outputWS, 2, 1002);
+    checkDetectorID(outputWS, 3, 1005);
+    checkDetectorID(outputWS, 4, 1003);
+    checkDetectorID(outputWS, 5, 1001);
+
+    // Spectrum numbers should not have changed from those of the input workspace.
+    checkSpectrumNumber(outputWS, 0, specnum_t(93184));
+    checkSpectrumNumber(outputWS, 1, specnum_t(55296));
+    checkSpectrumNumber(outputWS, 2, specnum_t(19456));
+    checkSpectrumNumber(outputWS, 3, specnum_t(74752));
+    checkSpectrumNumber(outputWS, 4, specnum_t(40960));
+    checkSpectrumNumber(outputWS, 5, specnum_t(3072));
+
+    // Clean up
+    AnalysisDataService::Instance().remove("inputWS5");
+  }
+
+  //----------------------------------------------------------------------------------------------
+  /** Test `EditInstrumentGeometry`:
+   *    verify the layout of the resulting instrument.
+   */
+  void test_InstrumentLayout() {
+    // 1. Init
+    EditInstrumentGeometry editdetector;
+    editdetector.initialize();
+
+    // 2. Load Data
+    DataObjects::Workspace2D_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(6, 100, false);
+    ADS::Instance().add("inputWS6", inputWS);
+
+    // 3. Set Properties
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Workspace", "inputWS6"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("L2", "1.1, 2.2, 3.3, 4.4, 5.5, 6.6"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Polar", "90.1, 90.2, 90.3, 90.4, 90.5, 90.6"));
+    TS_ASSERT_THROWS_NOTHING(editdetector.setPropertyValue("Azimuthal", "1.0, 2.0, 3.0, 4.0, 5.0, 6.0"));
+
+    // 4. Run
+    TS_ASSERT_THROWS_NOTHING(editdetector.execute());
+    TS_ASSERT(editdetector.isExecuted());
+
+    // 5. Check result
+    Mantid::API::MatrixWorkspace_sptr outputWS;
+    TS_ASSERT_THROWS_NOTHING(
+        outputWS = std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ADS::Instance().retrieve("inputWS6")));
+
+    const auto instrument = outputWS->getInstrument();
+    const auto &detectorInfo = outputWS->detectorInfo();
+    const auto &componentInfo = outputWS->componentInfo();
+
+    // The instrument includes no monitors
+    TS_ASSERT_EQUALS(instrument->getNumberDetectors(true), instrument->getNumberDetectors(false));
+
+    // The instrument has one detector per spectrum
+    TS_ASSERT_EQUALS(detectorInfo.size(), outputWS->getNumberHistograms());
+
+    // The instrument includes a source.
+    TS_ASSERT(componentInfo.hasSource());
+
+    // The workspace includes a sample.
+    TS_ASSERT(componentInfo.hasSample());
+
+    // The component info consists of only these components:
+    //   <detectors> + <detector bank> + <source> + <sample> + <root>
+    TS_ASSERT_EQUALS(componentInfo.size(), detectorInfo.size() + 4);
+
+    std::optional<size_t> bank = std::nullopt;
+    for (size_t index = 0; index < componentInfo.size(); ++index) {
+      // Detectors span a contiguous low-index section of the component info.
+      if (!componentInfo.isDetector(index))
+        break;
+
+      // No detector has the root as its immediate parent.
+      // (Changed from previous: this allows `SaveNexusESS` to actually save the instrument.)
+      TS_ASSERT(componentInfo.parent(index) != componentInfo.root());
+
+      // There is only one detector bank.
+      if (!bank) {
+        bank = componentInfo.parent(index);
+        // The detector bank's immediate parent is the root.
+        TS_ASSERT_EQUALS(componentInfo.parent(*bank), componentInfo.root());
+      } else
+        // Each detector belongs to the same detector bank.
+        TS_ASSERT_EQUALS(componentInfo.parent(index), *bank);
+    }
+
+    // Clean up
+    AnalysisDataService::Instance().remove("inputWS6");
+  }
+
+  //----------------------------------------------------------------------------------------------
+  /** Check detector parameters
    */
   void checkDetectorParameters(const API::MatrixWorkspace_sptr &workspace, size_t wsindex, double realr, double realtth,
                                double realphi) {
@@ -155,12 +392,18 @@ public:
   }
 
   //----------------------------------------------------------------------------------------------
-  /** Check detector parameter
+  /** Check detector-id
    */
   void checkDetectorID(const API::MatrixWorkspace_sptr &workspace, size_t wsindex, detid_t detid) {
 
     const auto &spectrumInfo = workspace->spectrumInfo();
     TS_ASSERT_EQUALS(spectrumInfo.hasUniqueDetector(wsindex), true);
     TS_ASSERT_EQUALS(spectrumInfo.detector(wsindex).getID(), detid);
+  }
+
+  /** Check spectrum number
+   */
+  void checkSpectrumNumber(const API::MatrixWorkspace_sptr &workspace, size_t wsindex, specnum_t spectrumNumber) {
+    TS_ASSERT_EQUALS(workspace->getSpectrum(wsindex).getSpectrumNo(), spectrumNumber);
   }
 };

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -200,7 +200,6 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/EnabledWhen
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DetectorEfficiencyCorUser.cpp:176
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DirectILLTubeBackground.cpp:348
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DirectILLTubeBackground.cpp:364
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/EditInstrumentGeometry.cpp:273
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:97
 containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiffractionFocussing2.cpp:826
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ExportTimeSeriesLog.cpp:134

--- a/docs/source/algorithms/EditInstrumentGeometry-v1.rst
+++ b/docs/source/algorithms/EditInstrumentGeometry-v1.rst
@@ -11,9 +11,9 @@ Description
 
 This algorithm can:
 
-#. Add an Instrument to a Workspace without any real instrument associated with, or
-#. Replace a Workspace's Instrument with a new Instrument, or
-#. Edit all detectors' parameters of the instrument associated with a Workspace (partial instrument editing is not supported).
+#. Add an Instrument to a Workspace without any real instrument associated with it, or
+#. Replace a Workspace's Instrument with a new Instrument, or
+#. Edit all detector parameters of the instrument associated with a Workspace.  (Partial instrument editing is not supported.)
 
 Requirements on input properties
 --------------------------------

--- a/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38308.rst
+++ b/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38308.rst
@@ -1,0 +1,1 @@
+- The algorithm EditInstrumentGeometry now adds detectors to a single detector bank, rather than directly to the ComponentInfo root.


### PR DESCRIPTION
### Description of work

At the end of its reduction process, SNAPRed saves multiple workspaces to a single NeXus HDF5 file.  Each of these workspaces has a programmatically-generated instrument.  In general, the current state of Mantid's instrument I/O does not support a straightforward way to save such an instrument.  The `SaveNexusESS` algorithm does allow this, but only for instruments of a limited geometry.  By adding detectors to a single detector bank, rather than directly to the `ComponentInfo` root, the instrument generated by `EditInstrumentGeometry` can now be saved by `SaveNexusESS`.  The NeXus-format HDF5 file generated can also be successfully reloaded by `LoadNexus`.

#### Summary of work

This commit includes the following changes:

  * The instrument created by `EditInstrumentGeometry` now adds its detectors to a single detector bank, rather than directly to the instrument root as previously.  This change facilitates saving the instrument using `SaveNexusESS` (via `NexusGeometrySave`) and reloading it using `LoadNexusProcessed2` (via `NexusGeometryParser`).

#### EWM link:
[EWM#6549](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=6549)

### To test:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

def showDetectorPositions(ws):
    info = ws.detectorInfo()
    show: str = f"{info.size()} detectors:\n"
    for n in range(info.size()):
        show += f"  {n}: (l2: {info.l2(n): 4.2f}, "\
                + f"2-theta: {np.rad2deg(info.twoTheta(n)): 4.2f}, "\
                + f"azimuth:  {np.rad2deg(info.azimuthal(n)): 4.2f})\n"
    print(show)

def showSpectraMappings(ws):
    print(f"{ws.getNumberHistograms()} spectra:")
    for n in range(ws.getNumberHistograms()):
        spectrum = ws.getSpectrum(n)
        print(f"spectrum # {spectrum.getSpectrumNo()}: {[id for id in spectrum.getDetectorIDs()]}")

def showComponentInfo(ws):
    info = ws.componentInfo()
    dids = ws.detectorInfo().detectorIDs()
    for n in range(info.size()):
        detIDs = [dids[index] for index in info.detectorsInSubtree(n)]
        print(f"{info.name(n)}: detIDs: {detIDs}")
        
ws = CreateSampleWorkspace(InstrumentName="test_instrument", NumBanks=2, BankPixelWidth=2)
# Number of spectra: 8
# Default instrument: 2 banks, 8 pixels, 

grouping = CreateGroupingWorkspace(ws, GroupDetectorsBy="bank")
ws = GroupDetectors(ws, CopyGroupingFromWorkspace="grouping")
# Now there are 2 spectra, with 4 detectors per spectrum:
#   spectrum 1: 4..8,
#   spectrum 2: 8..12
showComponentInfo(ws)

EditInstrumentGeometry(ws, L2=[1.0, 2.0], Polar=[80.0, 60.0], Azimuthal=[15.0, 45.0], InstrumentName="test_instrument1")
# WARNING: a syntax such as `ws2 = EditInstrumentGeometry(ws1, ...) ` doesn't work -- this is a known defect!
# Now there are (still) two spectra, but with 1 detector per spectrum.
print("DETECTORs:")
showDetectorPositions(ws)
print("\nSPECTRA:")
showSpectraMappings(ws)
print("\nCOMPONENTs")
showComponentInfo(ws)

# Save and reload using `SaveNexus`: this is expected to FAIL and spam the logs.
filePath = "/tmp/EditInstrumentGeometry_test.nxs"
SaveNexus(InputWorkspace=ws, Filename=filePath)
ws2 = LoadNexus(OutputWorkspace="ws2", Filename=filePath)
# ws2 reloads with no meaningful instrument...
print(f"Instrument after `LoadNexus` legacy-instrument reload:")
showComponentInfo(ws2)

# Now try with `SaveNexusESS`:
SaveNexusESS(InputWorkspace=ws, Filename=filePath)
ws3 = LoadNexus(OutputWorkspace="ws3", Filename=filePath)
# Note that the error message: "NXopengroup(instrument, NXinstrument) failed" is normal -- there is no legacy instrument.

# This should have reloaded correctly:
print("DETECTORs:")
showDetectorPositions(ws3)
print("\nSPECTRA:")
showSpectraMappings(ws3)
print("\nCOMPONENTs")
showComponentInfo(ws3)

```


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
