### PR TITLE
Disable uncertainty checking for IRISIqtAndIqtFit test

### DIFF
--- a/Testing/SystemTests/tests/framework/ISISIndirectInelastic.py
+++ b/Testing/SystemTests/tests/framework/ISISIndirectInelastic.py
@@ -923,10 +923,11 @@ class IRISIqtAndIqtFit(ISISIndirectInelasticIqtAndIqtFit):
         self.endx = 0.169171
 
     def get_reference_files(self):
-        # Relative tolerance is used because the calculation of Monte Carlo errors means the Iqt errors are randomized
-        # within a set amount. Also, gsl v2 gives a slightly different result than v1 for II.IRISFuryFitSeq.
+        # The calculation of Monte Carlo errors means the Iqt errors are randomized within a set amount. We therefore
+        # turn off checking the uncertainties in the resulting workspace.
         self.tolerance = 5.0
         self.tolerance_is_rel_err = True
+        self.disableChecking = ["Uncertainty"]
         return ["II.IRISFury.nxs", "II.IRISFuryFitSeq.nxs"]
 
 


### PR DESCRIPTION
### Description of work
The uncertainty for Iqt are calculated using a Monte Carlo method and so they are randomized within a set amount. This means we can get slightly different answers across operating systems, and even different answers on the same operating system at different times. We want to disable this check to prevent an unreliable test failure.

Fixes #38165 

### To test:
Check that the following build packages from branch passes:
https://builds.mantidproject.org/job/build_packages_from_branch/937/

*This does not require release notes* because **it is a change to a system test**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
