### PR TITLE
LoadNexusProcessed: root-level NXentry groups

### DIFF
--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -40,6 +40,7 @@
 #include <boost/regex.hpp>
 #include <nexus/NeXusException.hpp>
 
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <string>
@@ -373,28 +374,28 @@ Workspace_sptr LoadNexusProcessed::doAccelleratedMultiPeriodLoading(NXRoot &root
 void LoadNexusProcessed::execLoader() {
 
   API::Workspace_sptr tempWS;
-  int nWorkspaceEntries = 0;
+  size_t nWorkspaceEntries = 0;
   // Start scoped block
   {
     progress(0, "Opening file...");
 
-    // Throws an approriate exception if there is a problem with file access
+    // Throws an appropriate exception if there is a problem with file access
     const std::string filename = getPropertyValue("Filename");
     NXRoot root(filename);
 
     // "Open" the same file but with the C++ interface
     m_nexusFile = std::make_unique<::NeXus::File>(root.m_fileID);
 
-    // Find out how many first level entries there are
-    // Cast down to int as another property later on is an int
-    nWorkspaceEntries = static_cast<int>((root.groups().size()));
+    // Find out how many NXentry groups there are in the file.
+    nWorkspaceEntries = std::count_if(root.groups().cbegin(), root.groups().cend(),
+                                      [](const auto &g) { return g.nxclass == "NXentry"; });
 
     // Check for an entry number property
     int entrynumber = getProperty("EntryNumber");
     Property const *const entryNumberProperty = this->getProperty("EntryNumber");
     bool bDefaultEntryNumber = entryNumberProperty->isDefault();
 
-    if (!bDefaultEntryNumber && entrynumber > nWorkspaceEntries) {
+    if (!bDefaultEntryNumber && entrynumber > static_cast<int>(nWorkspaceEntries)) {
       g_log.error() << "Invalid entry number specified. File only contains " << nWorkspaceEntries << " entries.\n";
       throw std::invalid_argument("Invalid entry number specified.");
     }
@@ -421,7 +422,7 @@ void LoadNexusProcessed::execLoader() {
       // We already know that this is a group workspace. Is it a true
       // multiperiod workspace.
       const bool bFastMultiPeriod = this->getProperty("FastMultiPeriod");
-      const bool bIsMultiPeriod = isMultiPeriodFile(nWorkspaceEntries, tempWS, g_log);
+      const bool bIsMultiPeriod = isMultiPeriodFile(static_cast<int>(nWorkspaceEntries), tempWS, g_log);
       const Property *specListProp = this->getProperty("SpectrumList");
       m_list = !specListProp->isDefault();
 
@@ -433,7 +434,7 @@ void LoadNexusProcessed::execLoader() {
 
       // load names of each of the workspaces. Note that if we have duplicate
       // names then we don't select them
-      auto names = extractWorkspaceNames(root, static_cast<size_t>(nWorkspaceEntries));
+      auto names = extractWorkspaceNames(root, nWorkspaceEntries);
 
       // remove existing workspace and replace with the one being loaded
       bool wsExists = AnalysisDataService::Instance().doesExist(base_name);
@@ -465,7 +466,7 @@ void LoadNexusProcessed::execLoader() {
         g_log.information("Individual group loading");
       }
 
-      for (int p = 1; p <= nWorkspaceEntries; ++p) {
+      for (size_t p = 1; p <= nWorkspaceEntries; ++p) {
         const auto indexStr = std::to_string(p);
 
         // decide what the workspace should be called
@@ -503,7 +504,7 @@ void LoadNexusProcessed::execLoader() {
     root.close();
   } // All file resources should be scoped to here. All previous file handles
   // must be cleared to release locks
-  loadNexusGeometry(*tempWS, nWorkspaceEntries, g_log, std::string(getProperty("Filename")));
+  loadNexusGeometry(*tempWS, static_cast<int>(nWorkspaceEntries), g_log, std::string(getProperty("Filename")));
 
   m_axis1vals.clear();
 } // namespace DataHandling
@@ -913,13 +914,13 @@ void LoadNexusProcessed::loadV3DColumn(Mantid::NeXus::NXDouble &data, const API:
 
     const int rowCount = data.dim0();
 
-    // This might've been done already, but doing it twice should't do any harm
+    // This might've been done already, but doing it twice shouldn't do any harm
     tableWs->setRowCount(rowCount);
 
     data.load();
 
     for (int i = 0; i < rowCount; ++i) {
-      auto &cell = col[i];
+      auto &cell = col[i]; // cppcheck-suppress constVariableReference
       cell(data(i, 0), data(i, 1), data(i, 2));
     }
   }

--- a/Framework/DataHandling/test/LoadNexusProcessedTest.h
+++ b/Framework/DataHandling/test/LoadNexusProcessedTest.h
@@ -539,6 +539,34 @@ public:
     }
   }
 
+  void test_load_workspace_group_other_root_groups() {
+
+    // Test that a group workspace can be loaded in the presence of other
+    //   non-NXentry NeXus and non-NeXus root groups.
+
+    LoadNexusProcessed alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    alg.setPropertyValue("Filename", "WorkspaceGroup_other_groups.nxs");
+    alg.setPropertyValue("OutputWorkspace", "group");
+
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    Workspace_sptr workspace;
+    TS_ASSERT_THROWS_NOTHING(workspace = AnalysisDataService::Instance().retrieve("group"));
+    WorkspaceGroup_sptr group = std::dynamic_pointer_cast<WorkspaceGroup>(workspace);
+    TS_ASSERT(group);
+    int groupSize = group->getNumberOfEntries();
+    TS_ASSERT_EQUALS(groupSize, 12);
+    for (int i = 0; i < groupSize; ++i) {
+      MatrixWorkspace_sptr ws = std::dynamic_pointer_cast<MatrixWorkspace>(group->getItem(i));
+      TS_ASSERT(ws);
+      TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
+      TS_ASSERT_EQUALS(ws->blocksize(), 10);
+      TS_ASSERT_EQUALS(ws->getName(), "group_" + std::to_string(i + 1));
+    }
+  }
+
   void test_load_fit_parameters() {
     LoadNexusProcessed alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());

--- a/Testing/Data/UnitTest/WorkspaceGroup_other_groups.nxs.md5
+++ b/Testing/Data/UnitTest/WorkspaceGroup_other_groups.nxs.md5
@@ -1,0 +1,1 @@
+cc76a6f1e3a36626a1d38cda0f88e5ac

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -733,7 +733,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveFullpr
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveHKL.cpp:579
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveHKL.cpp:580
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveHKL.cpp:158
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNexusProcessed.cpp:922
 containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveHKL.cpp:607
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveLauenorm.cpp:164
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveLauenorm.cpp:234

--- a/docs/source/release/v6.12.0/Framework/Algorithms/Bugfixes/38324.rst
+++ b/docs/source/release/v6.12.0/Framework/Algorithms/Bugfixes/38324.rst
@@ -1,0 +1,1 @@
+- fixes a bug in :ref:`LoadNexusProcessed <algm-LoadNexusProcessed>` when determining the number of workspaces in a NeXus HDF5 file.  It now counts the number of root-level "NX_class: NXentry" groups. Previously, it simply counted the number of root-level groups, assuming all were of "NX_class: NXentry".


### PR DESCRIPTION
### Description of work

Mantid's interpretation of the NeXus format uses multiple root-level "NX_class: NXentry" groups to store multiple workspaces in a single NeXus HDF5 file.  By using additional root-level groups, such as "NX_class: NXcollection", metadata about a group of workspaces may be stored.  In addition, the NeXus format itself allows other, non-NeXus information to be stored in an HDF5 file, provided it avoids collisions with the NeXus naming system.  In combination, all of this led to the requirement solved by the current PR, which allows `LoadNexusProcessed` to function correctly in the presence of other root-level non-NXentry and non-NeXus groups.

#### Summary of work

This commit includes the following changes:

  * When `LoadNexusProcessed` is determining the number of workspaces in a NeXus HDF5 file, it now counts the number of root-level "NX_class: NXentry" groups.  Previously, it counted the number of root-level groups, assuming all were of "NX_class: NXentry".

#### EWM ref:
[EWM#7148](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=7148)

### To test:

A new unit test has been added to test these changes: `LoadNexusProcessedTest::test_load_workspace_group_other_root_groups`.

In order to verify these changes "by hand" it's recommended to take a look at the _contents_ of the test-input file: `build/ExternalData/Testing/Data/UnitTest/WorkspaceGroup_other_groups.nxs` using the `h5dump` tool.  In addition to including twelve workspaces (, as `NX_class: NXentry` "mantid_workspace_nn" groups), this file adds a root-level `NX_class: NXcollection` "metadata" group, and another root-level non-NeXus group.  Following the form of the new unit test, verify that `LoadNexusProcessed` loads this file as a group workspace, and successfully _ignores_ the other root-level groups in the file.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
