### PR TITLE
Minor usability fixes to ISIS sx diffraction class post beta testing

### DIFF
--- a/docs/source/release/v6.12.0/Diffraction/Single_Crystal/New_features/38337.rst
+++ b/docs/source/release/v6.12.0/Diffraction/Single_Crystal/New_features/38337.rst
@@ -1,0 +1,6 @@
+- Small usability improvements to :ref:`ISIS Single Crystal Diffraction Reduction Classes <isis-single-crystal-diffraction-ref>`:
+
+  - Allow users to pass key-word arguments to methods ``save_peak_table`` and ``save_all_peaks`` (passed to :ref:`SaveReflections<algm-SaveReflections-v1>`)
+  - Make saving of .nxs file of peak tables in above methods optional using argument ``save_nxs`` (default is True)
+  - Check UB filepath exists in method ``load_isaw_ub``
+  - Added option to set min I/Sigma ``min_intens_over_Sigma`` in method ``remove_non_integrated_peaks`` (default is 0)

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -406,15 +406,15 @@ class BaseSX(ABC):
         # store result
         self.set_peaks(run, peak_int_name, peak_type, integration_type)
 
-    def save_peak_table(self, run, peak_type, integration_type, save_dir, save_format, run_ref=None):
+    def save_peak_table(self, run, peak_type, integration_type, save_dir, save_format, run_ref=None, **kwargs):
         peaks = self.get_peaks_name(run, peak_type, integration_type)
         if run_ref is not None and run_ref != run:
             self.make_UB_consistent(self.get_peaks_name(run_ref, peak_type, integration_type), peaks)
         filepath = path.join(save_dir, "_".join([peaks, save_format])) + ".int"
-        mantid.SaveReflections(InputWorkspace=peaks, Filename=filepath, Format=save_format, SplitFiles=False)
+        mantid.SaveReflections(InputWorkspace=peaks, Filename=filepath, Format=save_format, **kwargs)
         mantid.SaveNexus(InputWorkspace=peaks, Filename=filepath[:-3] + "nxs")
 
-    def save_all_peaks(self, peak_type, integration_type, save_dir, save_format, run_ref=None):
+    def save_all_peaks(self, peak_type, integration_type, save_dir, save_format, run_ref=None, **kwargs):
         runs = list(self.runs.keys())
         if len(runs) > 1:
             # get name for peak table from range of runs integrated
@@ -431,7 +431,7 @@ class BaseSX(ABC):
                     self.make_UB_consistent(self.get_peaks(run_ref, peak_type, integration_type), peaks)
                 mantid.CombinePeaksWorkspaces(LHSWorkspace=all_peaks, RHSWorkspace=peaks, OutputWorkspace=all_peaks)
             filepath = path.join(save_dir, "_".join([all_peaks, save_format])) + ".int"
-            mantid.SaveReflections(InputWorkspace=all_peaks, Filename=filepath, Format=save_format, SplitFiles=False)
+            mantid.SaveReflections(InputWorkspace=all_peaks, Filename=filepath, Format=save_format, **kwargs)
             mantid.SaveNexus(InputWorkspace=all_peaks, Filename=filepath[:-3] + "nxs")
 
     def _is_vanadium_processed(self):

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -648,12 +648,12 @@ class BaseSX(ABC):
         )
 
     @staticmethod
-    def remove_non_integrated_peaks(peaks):
+    def remove_non_integrated_peaks(peaks, min_intens_over_sigma=0):
         return mantid.FilterPeaks(
             InputWorkspace=peaks,
             OutputWorkspace=BaseSX.retrieve(peaks).name(),
             FilterVariable="Signal/Noise",
-            FilterValue=0,
+            FilterValue=min_intens_over_sigma,
             Operator=">",
             EnableLogging=False,
         )

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -211,6 +211,9 @@ class BaseSX(ABC):
 
     @default_apply_to_all_runs
     def load_isaw_ub(self, isaw_file: str, run=None, tol=0.15):
+        if not path.exists(isaw_file):
+            logger.error(f"Invalid path {isaw_file} to ISAW UB file")
+            return
         ws = self.get_ws_name(run)
         try:
             mantid.LoadIsawUB(InputWorkspace=ws, Filename=isaw_file)
@@ -219,7 +222,9 @@ class BaseSX(ABC):
                 mantid.LoadIsawUB(InputWorkspace=peaks, Filename=isaw_file)
                 mantid.IndexPeaks(PeaksWorkspace=peaks, Tolerance=tol, RoundHKLs=True)
         except:
-            print(f"LoadIsawUB failed for run {run}")
+            logger.error(
+                f"LoadIsawUB failed for run {run} - check file contains valid ISAW format UB and the U matrix is a proper rotation matrix."
+            )
 
     def find_ub_using_lattice_params(self, global_B, tol=0.15, **kwargs):
         if global_B:

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -217,7 +217,7 @@ class BaseSX(ABC):
         ws = self.get_ws_name(run)
         try:
             mantid.LoadIsawUB(InputWorkspace=ws, Filename=isaw_file)
-            peaks = self.get_peaks(run, PEAK_TYPE.FOUND)
+            peaks = self.get_peaks_name(run, PEAK_TYPE.FOUND)
             if peaks is not None:
                 mantid.LoadIsawUB(InputWorkspace=peaks, Filename=isaw_file)
                 mantid.IndexPeaks(PeaksWorkspace=peaks, Tolerance=tol, RoundHKLs=True)

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -406,15 +406,16 @@ class BaseSX(ABC):
         # store result
         self.set_peaks(run, peak_int_name, peak_type, integration_type)
 
-    def save_peak_table(self, run, peak_type, integration_type, save_dir, save_format, run_ref=None, **kwargs):
+    def save_peak_table(self, run, peak_type, integration_type, save_dir, save_format, run_ref=None, save_nxs=True, **kwargs):
         peaks = self.get_peaks_name(run, peak_type, integration_type)
         if run_ref is not None and run_ref != run:
             self.make_UB_consistent(self.get_peaks_name(run_ref, peak_type, integration_type), peaks)
         filepath = path.join(save_dir, "_".join([peaks, save_format])) + ".int"
         mantid.SaveReflections(InputWorkspace=peaks, Filename=filepath, Format=save_format, **kwargs)
-        mantid.SaveNexus(InputWorkspace=peaks, Filename=filepath[:-3] + "nxs")
+        if save_nxs:
+            mantid.SaveNexus(InputWorkspace=peaks, Filename=filepath[:-3] + "nxs")
 
-    def save_all_peaks(self, peak_type, integration_type, save_dir, save_format, run_ref=None, **kwargs):
+    def save_all_peaks(self, peak_type, integration_type, save_dir, save_format, run_ref=None, save_nxs=True, **kwargs):
         runs = list(self.runs.keys())
         if len(runs) > 1:
             # get name for peak table from range of runs integrated
@@ -432,7 +433,8 @@ class BaseSX(ABC):
                 mantid.CombinePeaksWorkspaces(LHSWorkspace=all_peaks, RHSWorkspace=peaks, OutputWorkspace=all_peaks)
             filepath = path.join(save_dir, "_".join([all_peaks, save_format])) + ".int"
             mantid.SaveReflections(InputWorkspace=all_peaks, Filename=filepath, Format=save_format, **kwargs)
-            mantid.SaveNexus(InputWorkspace=all_peaks, Filename=filepath[:-3] + "nxs")
+            if save_nxs:
+                mantid.SaveNexus(InputWorkspace=all_peaks, Filename=filepath[:-3] + "nxs")
 
     def _is_vanadium_processed(self):
         return self.van_ws is not None and ADS.doesExist(self.van_ws)

--- a/scripts/Diffraction/single_crystal/test/test_base_sx.py
+++ b/scripts/Diffraction/single_crystal/test/test_base_sx.py
@@ -90,6 +90,15 @@ class BaseSXTest(unittest.TestCase):
         self.assertEqual(1, peaks.getNumberPeaks())
         self.assertEqual(0.0, peaks.getPeak(0).getQLabFrame()[0])
 
+    def test_remove_non_integrated_peaks_min_intens_over_sigma(self):
+        peaks = self._make_peaks_qsample(wsname="peaks5")
+        peaks.getPeak(0).setIntensity(1.0)
+        peaks.getPeak(0).setSigmaIntensity(1.0)
+
+        peaks = BaseSX.remove_non_integrated_peaks(peaks, min_intens_over_sigma=3)
+
+        self.assertEqual(0, peaks.getNumberPeaks())
+
     def test_remove_non_indexed_peaks(self):
         peaks = self._make_peaks_HKL(hs=[1.15, 2], wsname="peaks6")
         IndexPeaks(peaks, Tolerance=0.1)  # will not index first peak

--- a/scripts/Diffraction/single_crystal/test/test_sxd.py
+++ b/scripts/Diffraction/single_crystal/test/test_sxd.py
@@ -248,6 +248,36 @@ class SXDTest(unittest.TestCase):
 
         self.assertAlmostEqual(peaks_to_correct.getPeak(0).getIntensity(), 8.7690, delta=1e-4)
 
+    @patch(sxd_path + ".path.exists")
+    @patch(sxd_path + ".mantid.LoadIsawUB")
+    @patch(sxd_path + ".mantid.IndexPeaks")
+    def test_load_isaw_ub(self, mock_index, mock_load_ub, mock_path_exists):
+        runno = 1234
+        self.sxd.set_ws(runno, self.ws)
+        self.sxd.set_peaks(runno, self.peaks, PEAK_TYPE.FOUND)
+        mock_path_exists.return_value = True
+        fname = "UB.mat"
+
+        self.sxd.load_isaw_ub(fname)
+
+        self.assertEqual(mock_load_ub.call_count, 2)
+        mock_load_ub.assert_any_call(InputWorkspace=self.ws, Filename=fname)
+        mock_load_ub.assert_any_call(InputWorkspace=self.peaks, Filename=fname)
+        mock_index.assert_called_once()
+
+    @patch(sxd_path + ".path.exists")
+    @patch(sxd_path + ".mantid.LoadIsawUB")
+    @patch(sxd_path + ".mantid.IndexPeaks")
+    def test_load_isaw_ub_invalid_path(self, mock_index, mock_load_ub, mock_path_exists):
+        runno = 1234
+        self.sxd.set_ws(runno, self.ws)
+        mock_path_exists.return_value = False
+
+        self.sxd.load_isaw_ub("UB.mat")
+
+        mock_load_ub.assert_not_called()
+        mock_index.assert_not_called()
+
     #  --- methods specific to SXD class ---
 
     @patch("Diffraction.single_crystal.base_sx.mantid.SetGoniometer")

--- a/scripts/Diffraction/single_crystal/test/test_sxd.py
+++ b/scripts/Diffraction/single_crystal/test/test_sxd.py
@@ -20,9 +20,9 @@ from mantid.simpleapi import (
 from Diffraction.single_crystal.sxd import SXD
 from Diffraction.single_crystal.base_sx import PEAK_TYPE, INTEGRATION_TYPE
 
-diffraction_path = "Diffraction.single_crystal"
-sxd_path = diffraction_path + ".sxd"
-base_sx_path = diffraction_path + ".base_sx"
+DIFFRACTION_PATH = "Diffraction.single_crystal"
+SXD_PATH = DIFFRACTION_PATH + ".sxd"
+BASE_SX_PATH = DIFFRACTION_PATH + ".base_sx"
 
 
 class SXDTest(unittest.TestCase):
@@ -48,7 +48,7 @@ class SXDTest(unittest.TestCase):
 
     # --- test BaseSX methods (parent class with abstract methods) that require class instantiation ---
 
-    @patch(sxd_path + ".BaseSX.retrieve")
+    @patch(SXD_PATH + ".BaseSX.retrieve")
     def test_get_ws(self, mock_retrieve):
         runno = 1234
         wsname = "wsname"
@@ -58,7 +58,7 @@ class SXDTest(unittest.TestCase):
         self.assertEqual(wsname, self.sxd.get_ws_name(runno))
         self.assertIsNone(self.sxd.get_ws_name(101))
 
-    @patch(sxd_path + ".BaseSX.retrieve")
+    @patch(SXD_PATH + ".BaseSX.retrieve")
     def test_get_md(self, mock_retrieve):
         runno = 1234
         mdname = "mdname"
@@ -128,7 +128,7 @@ class SXDTest(unittest.TestCase):
         self.sxd.set_goniometer_axes([0, 1, 0, 1], [1, 1, 0, -1])
         self.assertListEqual(["0,1,0,1", "1,1,0,-1"], self.sxd.gonio_axes)
 
-    @patch(sxd_path + ".mantid.IntegratePeaksMD")
+    @patch(SXD_PATH + ".mantid.IntegratePeaksMD")
     def test_integrate_peaks_MD_optimal_radius(self, mock_int_md):
         ws_md = "ws_md"
         peaks = self._make_peaks_detids(detids=[2016, 2016, 10209, 10209], tofs=2 * [5000, 10000], wsname="peaks3")
@@ -146,9 +146,9 @@ class SXDTest(unittest.TestCase):
             for kwarg in int_md_kwargs:
                 self.assertTrue(mock_int_md.call_args_list[icall].kwargs[kwarg])
 
-    @patch(sxd_path + ".BaseSX.retrieve")
-    @patch(sxd_path + ".mantid.SaveReflections")
-    @patch(sxd_path + ".mantid.SaveNexus")
+    @patch(SXD_PATH + ".BaseSX.retrieve")
+    @patch(SXD_PATH + ".mantid.SaveReflections")
+    @patch(SXD_PATH + ".mantid.SaveNexus")
     def test_save_peak_table(self, mock_save_nxs, mock_save_ref, mock_retrieve):
         fmt = "SHELX"
         self._call_save_peak_table(mock_retrieve, save_format=fmt, SplitFiles=False)
@@ -157,9 +157,9 @@ class SXDTest(unittest.TestCase):
         mock_save_nxs.assert_called_once_with(InputWorkspace=self.peaks.name(), Filename=fpath + ".nxs")
         mock_save_ref.assert_called_once_with(InputWorkspace=self.peaks.name(), Filename=fpath + ".int", Format=fmt, SplitFiles=False)
 
-    @patch(sxd_path + ".BaseSX.retrieve")
-    @patch(sxd_path + ".mantid.SaveReflections")
-    @patch(sxd_path + ".mantid.SaveNexus")
+    @patch(SXD_PATH + ".BaseSX.retrieve")
+    @patch(SXD_PATH + ".mantid.SaveReflections")
+    @patch(SXD_PATH + ".mantid.SaveNexus")
     def test_save_peak_table_save_nxs_False(self, mock_save_nxs, mock_save_ref, mock_retrieve):
         fmt = "SHELX"
         self._call_save_peak_table(mock_retrieve, save_format=fmt, save_nxs=False, SplitFiles=False)
@@ -168,8 +168,8 @@ class SXDTest(unittest.TestCase):
         mock_save_nxs.assert_not_called()
         mock_save_ref.assert_called_once_with(InputWorkspace=self.peaks.name(), Filename=fpath + ".int", Format=fmt, SplitFiles=False)
 
-    @patch(sxd_path + ".mantid.SaveReflections")
-    @patch(sxd_path + ".mantid.SaveNexus")
+    @patch(SXD_PATH + ".mantid.SaveReflections")
+    @patch(SXD_PATH + ".mantid.SaveNexus")
     def test_save_all_peaks(self, mock_save_nxs, mock_save_ref):
         self.sxd.runs = dict()
         for runno in range(1234, 1236):
@@ -199,8 +199,8 @@ class SXDTest(unittest.TestCase):
             pred_peaks = self.sxd.get_peaks(runno, pk_type)
             self.assertEqual(pred_peaks.name(), peaks.name() + "_" + pk_type.value)
 
-    @patch(sxd_path + ".SXD.set_md")
-    @patch(sxd_path + ".BaseSX.convert_ws_to_MD")
+    @patch(SXD_PATH + ".SXD.set_md")
+    @patch(SXD_PATH + ".BaseSX.convert_ws_to_MD")
     def test_convert_to_md_sets_ub_if_HKL(self, mock_conv_md, mock_set_md):
         self.peaks = self._make_peaks_detids(wsname="peaks_for_md")
         SetUB(self.peaks, UB="0.25,0,0,0,0.25,0,0,0,0.1")
@@ -250,9 +250,9 @@ class SXDTest(unittest.TestCase):
 
         self.assertAlmostEqual(peaks_to_correct.getPeak(0).getIntensity(), 8.7690, delta=1e-4)
 
-    @patch(base_sx_path + ".path.exists")
-    @patch(base_sx_path + ".mantid.LoadIsawUB")
-    @patch(base_sx_path + ".mantid.IndexPeaks")
+    @patch(BASE_SX_PATH + ".path.exists")
+    @patch(BASE_SX_PATH + ".mantid.LoadIsawUB")
+    @patch(BASE_SX_PATH + ".mantid.IndexPeaks")
     def test_load_isaw_ub(self, mock_index, mock_load_ub, mock_path_exists):
         runno = 1234
         self.sxd.set_ws(runno, self.ws)
@@ -267,9 +267,9 @@ class SXDTest(unittest.TestCase):
         mock_load_ub.assert_any_call(InputWorkspace=self.peaks.name(), Filename=fname)
         mock_index.assert_called_once()
 
-    @patch(base_sx_path + ".path.exists")
-    @patch(base_sx_path + ".mantid.LoadIsawUB")
-    @patch(base_sx_path + ".mantid.IndexPeaks")
+    @patch(BASE_SX_PATH + ".path.exists")
+    @patch(BASE_SX_PATH + ".mantid.LoadIsawUB")
+    @patch(BASE_SX_PATH + ".mantid.IndexPeaks")
     def test_load_isaw_ub_invalid_path(self, mock_index, mock_load_ub, mock_path_exists):
         runno = 1234
         self.sxd.set_ws(runno, self.ws)
@@ -282,12 +282,12 @@ class SXDTest(unittest.TestCase):
 
     #  --- methods specific to SXD class ---
 
-    @patch(base_sx_path + ".mantid.SetGoniometer")
-    @patch(sxd_path + ".SXD.set_ws")
-    @patch(sxd_path + ".SXD.load_run")
-    @patch(sxd_path + ".SXD._divide_workspaces")
-    @patch(sxd_path + ".mantid.DeleteWorkspace")
-    @patch(sxd_path + ".mantid.ConvertUnits")
+    @patch(BASE_SX_PATH + ".mantid.SetGoniometer")
+    @patch(SXD_PATH + ".SXD.set_ws")
+    @patch(SXD_PATH + ".SXD.load_run")
+    @patch(SXD_PATH + ".SXD._divide_workspaces")
+    @patch(SXD_PATH + ".mantid.DeleteWorkspace")
+    @patch(SXD_PATH + ".mantid.ConvertUnits")
     def test_process_data_with_gonio_angle_strings(self, mock_conv, mock_del, mock_divide, mock_load, mock_set_ws, mock_set_gonio):
         sxd = SXD(vanadium_runno=1, empty_runno=2)
         sxd.set_goniometer_axes([0, 1, 0, 1], [1, 0, 0, 0])
@@ -301,12 +301,12 @@ class SXDTest(unittest.TestCase):
         expected_calls = len(runnos) * [call(Workspace="wsname", EnableLogging=False, Axis0="log1,0,1,0,1", Axis1="log2,1,0,0,0")]
         mock_set_gonio.assert_has_calls(expected_calls)
 
-    @patch(base_sx_path + ".mantid.SetGoniometer")
-    @patch(sxd_path + ".SXD.set_ws")
-    @patch(sxd_path + ".SXD.load_run")
-    @patch(sxd_path + ".SXD._divide_workspaces")
-    @patch(sxd_path + ".mantid.DeleteWorkspace")
-    @patch(sxd_path + ".mantid.ConvertUnits")
+    @patch(BASE_SX_PATH + ".mantid.SetGoniometer")
+    @patch(SXD_PATH + ".SXD.set_ws")
+    @patch(SXD_PATH + ".SXD.load_run")
+    @patch(SXD_PATH + ".SXD._divide_workspaces")
+    @patch(SXD_PATH + ".mantid.DeleteWorkspace")
+    @patch(SXD_PATH + ".mantid.ConvertUnits")
     def test_process_data_with_gonio_angle_sequences(self, mock_conv, mock_del, mock_divide, mock_load, mock_set_ws, mock_set_gonio):
         sxd = SXD(vanadium_runno=1, empty_runno=2)
         sxd.set_goniometer_axes([0, 1, 0, 1], [1, 0, 0, 0])

--- a/scripts/Diffraction/single_crystal/test/test_sxd.py
+++ b/scripts/Diffraction/single_crystal/test/test_sxd.py
@@ -154,7 +154,7 @@ class SXDTest(unittest.TestCase):
         fmt = "SHELX"
         mock_retrieve.side_effect = lambda name: make_mock_ws_with_name(name)
 
-        self.sxd.save_peak_table(runno, pk_type, int_type, self._test_dir, fmt)
+        self.sxd.save_peak_table(runno, pk_type, int_type, self._test_dir, fmt, SplitFiles=False)
 
         fpath = path.join(self._test_dir, "peaks_" + fmt)
         mock_save_nxs.assert_called_once_with(InputWorkspace=self.peaks.name(), Filename=fpath + ".nxs")
@@ -171,12 +171,12 @@ class SXDTest(unittest.TestCase):
         pk_type, int_type = PEAK_TYPE.FOUND, INTEGRATION_TYPE.MD_OPTIMAL_RADIUS
         fmt = "SHELX"
 
-        self.sxd.save_all_peaks(pk_type, int_type, self._test_dir, fmt)
+        self.sxd.save_all_peaks(pk_type, int_type, self._test_dir, fmt, MinIntensOverSigma=3)
 
         all_peaks_name = "1234-1235_found_int_MD_opt"
         fpath = path.join(self._test_dir, f"{all_peaks_name}_{fmt}")
         mock_save_nxs.assert_called_once_with(InputWorkspace=all_peaks_name, Filename=fpath + ".nxs")
-        mock_save_ref.assert_called_once_with(InputWorkspace=all_peaks_name, Filename=fpath + ".int", Format=fmt, SplitFiles=False)
+        mock_save_ref.assert_called_once_with(InputWorkspace=all_peaks_name, Filename=fpath + ".int", Format=fmt, MinIntensOverSigma=3)
         self.assertTrue(HasUB(Workspace=all_peaks_name))
         ClearUB(Workspace=self.peaks)
 

--- a/scripts/Diffraction/single_crystal/test/test_sxd.py
+++ b/scripts/Diffraction/single_crystal/test/test_sxd.py
@@ -20,7 +20,9 @@ from mantid.simpleapi import (
 from Diffraction.single_crystal.sxd import SXD
 from Diffraction.single_crystal.base_sx import PEAK_TYPE, INTEGRATION_TYPE
 
-sxd_path = "Diffraction.single_crystal.sxd"
+diffraction_path = "Diffraction.single_crystal"
+sxd_path = diffraction_path + ".sxd"
+base_sx_path = diffraction_path + ".base_sx"
 
 
 class SXDTest(unittest.TestCase):
@@ -248,9 +250,9 @@ class SXDTest(unittest.TestCase):
 
         self.assertAlmostEqual(peaks_to_correct.getPeak(0).getIntensity(), 8.7690, delta=1e-4)
 
-    @patch(sxd_path + ".path.exists")
-    @patch(sxd_path + ".mantid.LoadIsawUB")
-    @patch(sxd_path + ".mantid.IndexPeaks")
+    @patch(base_sx_path + ".path.exists")
+    @patch(base_sx_path + ".mantid.LoadIsawUB")
+    @patch(base_sx_path + ".mantid.IndexPeaks")
     def test_load_isaw_ub(self, mock_index, mock_load_ub, mock_path_exists):
         runno = 1234
         self.sxd.set_ws(runno, self.ws)
@@ -261,13 +263,13 @@ class SXDTest(unittest.TestCase):
         self.sxd.load_isaw_ub(fname)
 
         self.assertEqual(mock_load_ub.call_count, 2)
-        mock_load_ub.assert_any_call(InputWorkspace=self.ws, Filename=fname)
-        mock_load_ub.assert_any_call(InputWorkspace=self.peaks, Filename=fname)
+        mock_load_ub.assert_any_call(InputWorkspace=self.ws.name(), Filename=fname)
+        mock_load_ub.assert_any_call(InputWorkspace=self.peaks.name(), Filename=fname)
         mock_index.assert_called_once()
 
-    @patch(sxd_path + ".path.exists")
-    @patch(sxd_path + ".mantid.LoadIsawUB")
-    @patch(sxd_path + ".mantid.IndexPeaks")
+    @patch(base_sx_path + ".path.exists")
+    @patch(base_sx_path + ".mantid.LoadIsawUB")
+    @patch(base_sx_path + ".mantid.IndexPeaks")
     def test_load_isaw_ub_invalid_path(self, mock_index, mock_load_ub, mock_path_exists):
         runno = 1234
         self.sxd.set_ws(runno, self.ws)
@@ -280,7 +282,7 @@ class SXDTest(unittest.TestCase):
 
     #  --- methods specific to SXD class ---
 
-    @patch("Diffraction.single_crystal.base_sx.mantid.SetGoniometer")
+    @patch(base_sx_path + ".mantid.SetGoniometer")
     @patch(sxd_path + ".SXD.set_ws")
     @patch(sxd_path + ".SXD.load_run")
     @patch(sxd_path + ".SXD._divide_workspaces")
@@ -299,7 +301,7 @@ class SXDTest(unittest.TestCase):
         expected_calls = len(runnos) * [call(Workspace="wsname", EnableLogging=False, Axis0="log1,0,1,0,1", Axis1="log2,1,0,0,0")]
         mock_set_gonio.assert_has_calls(expected_calls)
 
-    @patch("Diffraction.single_crystal.base_sx.mantid.SetGoniometer")
+    @patch(base_sx_path + ".mantid.SetGoniometer")
     @patch(sxd_path + ".SXD.set_ws")
     @patch(sxd_path + ".SXD.load_run")
     @patch(sxd_path + ".SXD._divide_workspaces")


### PR DESCRIPTION
### Description of work
Changes requested during beta-testing and in preparing for PCG conference last week.

- Allow user to specify kwargs passed to `SaveReflections`
- Make saving .nxs for peak tables optional
- Check UB file exists before calling `LoadIsawUB` - because the user doesn't know if it failed because there was no file or because the U matrix was invalid.

In addressing the above tests have been updated - there were no tests for the UB loading so have added some.

*There is no associated issue.*

### To test:
(1) Setup
```
from mantid.simpleapi import *
from Diffraction.single_crystal.sxd import SXD
from Diffraction.single_crystal.base_sx import PEAK_TYPE, INTEGRATION_TYPE

runno = 23767
ws = Load(Filename=f'SXD{runno}.raw', OutputWorkspace=f'SXD{runno}')
# make peaks workspace and set intensity to 1
peaks = FindSXPeaksConvolve(InputWorkspace=ws, PeaksWorkspace=ws.name() + '_peaks', 
                            ThresholdIoverSigma=50, NRows=3, NCols=3, GetNBinsFromBackToBackParams=True, 
                            NFWHM=3, PeakFindingStrategy="IOverSigma")

sxd = SXD()
sxd.set_ws(runno, ws)
sxd.set_peaks(runno, peaks, PEAK_TYPE.FOUND, INTEGRATION_TYPE.MD)
```
(2) Try loading UB with invalid path (should now print an error)
```
sxd.load_isaw_ub("not a valid path",  run=runno)
```
(3) Pass kwargs to `SaveReflections`
```
sxd.save_peak_table(runno, PEAK_TYPE.FOUND, INTEGRATION_TYPE.MD, save_nxs=False, save_dir="", 
                    MinIntensOverSigma=200, SplitFiles=True)
```
Check the .int file produced (there shouldn't be a .nxs) - it should have ~6 peaks in it with I/sigma > 200

(4) Run (3) again with `save_nxs=True` - there should now be a .nxs file produced as well.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
