### PR TITLE
Refactor `eagroup_context_test` for readability and speed

### DIFF
--- a/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/elemental_analysis_eagroup_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/elemental_analysis_eagroup_context_test.py
@@ -5,15 +5,17 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-from unittest import mock
+from unittest import mock, TestCase
+
 from mantid.api import AnalysisDataService, WorkspaceGroup
 from mantid.simpleapi import CreateSampleWorkspace
+
 from mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.context.ea_group_context import EAGroupContext
 from mantidqtinterfaces.Muon.GUI.Common.muon_load_data import MuonLoadData
 from mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group import EAGroup
 
 
-class EAGroupContextTest(unittest.TestCase):
+class EAGroupContextTest(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls._detector_ws_name_1 = "9999; Detector 1"
@@ -41,37 +43,39 @@ class EAGroupContextTest(unittest.TestCase):
         self._loaded_data.clear()
         self.assertEqual(0, self._loaded_data.num_items())
 
-    # ------------------------------------------------------------------------------------------------------------------
-    # TESTS
-    # ------------------------------------------------------------------------------------------------------------------
-
     def test_add_new_group(self):
         self._loaded_data.add_data(run=[self._run], workspace=self._group)
         empty_group = []
+
         new_group = self._context.add_new_group(empty_group, self._loaded_data)
-        self.assertEqual(len(new_group), 2)
+
+        self.assertEqual(2, len(new_group))
+
+    def test_reset_group_to_default(self):
+        self._loaded_data.add_data(run=[self._run], workspace=self._group)
+
+        self._context.reset_group_to_default(self._loaded_data)
+
+        self.assertEqual(2, len(self._context.groups))
+        self.assertTrue(self._detector_ws_name_1 in self._context.group_names)
+        self.assertTrue(self._detector_ws_name_2 in self._context.group_names)
 
     def test_remove_group(self):
         self._loaded_data.add_data(run=[self._run], workspace=self._group)
         self._context.reset_group_to_default(self._loaded_data)
-        self.assertEqual(len(self._context.groups), 2)
-        self.assertTrue(self._detector_ws_name_1 in self._context.group_names)
 
         self._context.remove_group(self._detector_ws_name_1)
-        self.assertFalse(self._detector_ws_name_1 in self._context.group_names)
 
-    def test_reset_group_to_default(self):
-        self._loaded_data.add_data(run=[self._run], workspace=self._group)
-        self._context.reset_group_to_default(self._loaded_data)
-        self.assertEqual(len(self._context.groups), 2)
+        self.assertEqual(1, len(self._context.groups))
+        self.assertFalse(self._detector_ws_name_1 in self._context.group_names)
 
     def test_clear(self):
         self._loaded_data.add_data(run=[self._run], workspace=self._group)
         self._context.reset_group_to_default(self._loaded_data)
-        self.assertEqual(len(self._context.groups), 2)
 
         self._context.clear()
-        self.assertEqual(len(self._context.groups), 0)
+
+        self.assertEqual(0, len(self._context.groups))
 
     @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_rebinned_workspace")
     @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_peak_table")
@@ -79,7 +83,9 @@ class EAGroupContextTest(unittest.TestCase):
     def test_remove_rebinned_workspace_from_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
         mock_group = EAGroup(self._detector_ws_name_1, "detector 1", "9999")
         self._context.add_group(mock_group)
+
         self._context.remove_workspace_from_group("9999; Detector 1_EA_Rebinned_Fixed")
+
         mock_remove_rebinned.assert_called_once()
         mock_remove_peak.assert_not_called()
         mock_remove_matches.assert_not_called()
@@ -90,7 +96,9 @@ class EAGroupContextTest(unittest.TestCase):
     def test_remove_peak_table_from_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
         mock_group = EAGroup(self._detector_ws_name_1, "detector 1", "9999")
         self._context.add_group(mock_group)
+
         self._context.remove_workspace_from_group("9999; Detector 1_EA_peak_table")
+
         mock_remove_rebinned.assert_not_called()
         mock_remove_peak.aassert_called_once()
         mock_remove_matches.assert_not_called()
@@ -101,7 +109,9 @@ class EAGroupContextTest(unittest.TestCase):
     def test_remove_matches_table_from_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
         mock_group = EAGroup(self._detector_ws_name_1, "detector 1", "9999")
         self._context.add_group(mock_group)
+
         self._context.remove_workspace_from_group("9999; Detector 1_EA_matches")
+
         mock_remove_rebinned.assert_not_called()
         mock_remove_peak.aassert_not_called()
         mock_remove_matches.assert_called_once()
@@ -112,7 +122,9 @@ class EAGroupContextTest(unittest.TestCase):
     def test_remove_workspace_from_group_when_not_in_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
         mock_group = EAGroup(self._detector_ws_name_1, "detector 1", "9999")
         self._context.add_group(mock_group)
+
         self._context.remove_workspace_from_group("mock_workspace")
+
         mock_remove_rebinned.assert_not_called()
         mock_remove_peak.aassert_not_called()
         mock_remove_matches.assert_not_called()
@@ -121,13 +133,12 @@ class EAGroupContextTest(unittest.TestCase):
     def test_error_raised_when_deleting_EAGroup(self, mock_remove_ws):
         self._loaded_data.add_data(run=[self._run], workspace=self._group)
         self._context.reset_group_to_default(self._loaded_data)
-        self.assertEqual(len(self._context.groups), 2)
-        self.assertTrue(self._detector_ws_name_1 in self._context.group_names)
         mock_remove_ws.side_effect = ValueError("mock error")
         error_notifier_mock = mock.Mock()
         self._context[self._detector_ws_name_1].error_notifier = error_notifier_mock
 
         self._context.remove_group(self._detector_ws_name_1)
+
         self.assertFalse(self._detector_ws_name_1 in self._context.group_names)
         mock_remove_ws.assert_called_once_with(self._detector_ws_name_1)
         error_notifier_mock.notify_subscribers.assert_called_once_with(

--- a/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/elemental_analysis_eagroup_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/elemental_analysis_eagroup_context_test.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from unittest import mock
-from mantid.api import WorkspaceGroup
+from mantid.api import AnalysisDataService, WorkspaceGroup
 from mantid.simpleapi import CreateSampleWorkspace
 from mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.context.ea_group_context import EAGroupContext
 from mantidqtinterfaces.Muon.GUI.Common.muon_load_data import MuonLoadData
@@ -14,64 +14,72 @@ from mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group import EAGroup
 
 
 class EAGroupContextTest(unittest.TestCase):
-    def setUp(self):
-        self.context = EAGroupContext()
-        self.loadedData = MuonLoadData()
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._detector_ws_name_1 = "9999; Detector 1"
+        cls._detector_ws_name_2 = "9999; Detector 2"
+        cls._detector_ws_1 = CreateSampleWorkspace(StoreInADS=False)
+        cls._detector_ws_2 = CreateSampleWorkspace(StoreInADS=False)
 
-    def create_group_workspace_and_load(self):
-        grpws = WorkspaceGroup()
-        ws_detector1 = "9999; Detector 1"
-        grpws.addWorkspace(CreateSampleWorkspace(OutputWorkspace=ws_detector1))
-        ws_detector2 = "9999; Detector 2"
-        grpws.addWorkspace(CreateSampleWorkspace(OutputWorkspace=ws_detector2))
-        run = 9999
-        self.loadedData.add_data(run=[run], workspace=grpws)
+        cls._group = WorkspaceGroup()
+        cls._group.addWorkspace(cls._detector_ws_1)
+        cls._group.addWorkspace(cls._detector_ws_2)
+
+        cls._run = 9999
+
+        cls._context = EAGroupContext()
+        cls._loaded_data = MuonLoadData()
+
+    def setUp(self) -> None:
+        AnalysisDataService.addOrReplace(self._detector_ws_name_1, self._detector_ws_1)
+        AnalysisDataService.addOrReplace(self._detector_ws_name_2, self._detector_ws_2)
+
+    def tearDown(self) -> None:
+        self._context.clear()
+        self.assertEqual(0, len(self._context.groups))
+
+        self._loaded_data.clear()
+        self.assertEqual(0, self._loaded_data.num_items())
 
     # ------------------------------------------------------------------------------------------------------------------
     # TESTS
     # ------------------------------------------------------------------------------------------------------------------
 
     def test_add_new_group(self):
-        self.loadedData.clear()
-        self.create_group_workspace_and_load()
+        self._loaded_data.add_data(run=[self._run], workspace=self._group)
         empty_group = []
-        new_group = self.context.add_new_group(empty_group, self.loadedData)
+        new_group = self._context.add_new_group(empty_group, self._loaded_data)
         self.assertEqual(len(new_group), 2)
 
     def test_remove_group(self):
-        self.loadedData.clear()
-        self.create_group_workspace_and_load()
-        self.context.reset_group_to_default(self.loadedData)
-        self.assertEqual(len(self.context.groups), 2)
-        group_name1 = "9999; Detector 1"
-        self.assertTrue(group_name1 in self.context.group_names)
+        self._loaded_data.add_data(run=[self._run], workspace=self._group)
+        self._context.reset_group_to_default(self._loaded_data)
+        self.assertEqual(len(self._context.groups), 2)
+        self.assertTrue(self._detector_ws_name_1 in self._context.group_names)
 
-        self.context.remove_group(group_name1)
-        self.assertFalse(group_name1 in self.context.group_names)
+        self._context.remove_group(self._detector_ws_name_1)
+        self.assertFalse(self._detector_ws_name_1 in self._context.group_names)
 
     def test_reset_group_to_default(self):
-        self.loadedData.clear()
-        self.assertEqual(self.loadedData.num_items(), 0)
-        self.create_group_workspace_and_load()
-        self.context.reset_group_to_default(self.loadedData)
-        self.assertEqual(len(self.context.groups), 2)
+        self._loaded_data.add_data(run=[self._run], workspace=self._group)
+        self._context.reset_group_to_default(self._loaded_data)
+        self.assertEqual(len(self._context.groups), 2)
 
     def test_clear(self):
-        self.loadedData.clear()
-        self.create_group_workspace_and_load()
-        self.context.reset_group_to_default(self.loadedData)
-        self.assertEqual(len(self.context.groups), 2)
+        self._loaded_data.add_data(run=[self._run], workspace=self._group)
+        self._context.reset_group_to_default(self._loaded_data)
+        self.assertEqual(len(self._context.groups), 2)
 
-        self.context.clear()
-        self.assertEqual(len(self.context.groups), 0)
+        self._context.clear()
+        self.assertEqual(len(self._context.groups), 0)
 
     @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_rebinned_workspace")
     @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_peak_table")
     @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_matches_group")
     def test_remove_rebinned_workspace_from_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
-        mock_group = EAGroup("9999; Detector 1", "detector 1", "9999")
-        self.context.add_group(mock_group)
-        self.context.remove_workspace_from_group("9999; Detector 1_EA_Rebinned_Fixed")
+        mock_group = EAGroup(self._detector_ws_name_1, "detector 1", "9999")
+        self._context.add_group(mock_group)
+        self._context.remove_workspace_from_group("9999; Detector 1_EA_Rebinned_Fixed")
         mock_remove_rebinned.assert_called_once()
         mock_remove_peak.assert_not_called()
         mock_remove_matches.assert_not_called()
@@ -80,9 +88,9 @@ class EAGroupContextTest(unittest.TestCase):
     @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_peak_table")
     @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_matches_group")
     def test_remove_peak_table_from_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
-        mock_group = EAGroup("9999; Detector 1", "detector 1", "9999")
-        self.context.add_group(mock_group)
-        self.context.remove_workspace_from_group("9999; Detector 1_EA_peak_table")
+        mock_group = EAGroup(self._detector_ws_name_1, "detector 1", "9999")
+        self._context.add_group(mock_group)
+        self._context.remove_workspace_from_group("9999; Detector 1_EA_peak_table")
         mock_remove_rebinned.assert_not_called()
         mock_remove_peak.aassert_called_once()
         mock_remove_matches.assert_not_called()
@@ -91,9 +99,9 @@ class EAGroupContextTest(unittest.TestCase):
     @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_peak_table")
     @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_matches_group")
     def test_remove_matches_table_from_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
-        mock_group = EAGroup("9999; Detector 1", "detector 1", "9999")
-        self.context.add_group(mock_group)
-        self.context.remove_workspace_from_group("9999; Detector 1_EA_matches")
+        mock_group = EAGroup(self._detector_ws_name_1, "detector 1", "9999")
+        self._context.add_group(mock_group)
+        self._context.remove_workspace_from_group("9999; Detector 1_EA_matches")
         mock_remove_rebinned.assert_not_called()
         mock_remove_peak.aassert_not_called()
         mock_remove_matches.assert_called_once()
@@ -102,30 +110,28 @@ class EAGroupContextTest(unittest.TestCase):
     @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_peak_table")
     @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_matches_group")
     def test_remove_workspace_from_group_when_not_in_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
-        mock_group = EAGroup("9999; Detector 1", "detector 1", "9999")
-        self.context.add_group(mock_group)
-        self.context.remove_workspace_from_group("mock_workspace")
+        mock_group = EAGroup(self._detector_ws_name_1, "detector 1", "9999")
+        self._context.add_group(mock_group)
+        self._context.remove_workspace_from_group("mock_workspace")
         mock_remove_rebinned.assert_not_called()
         mock_remove_peak.aassert_not_called()
         mock_remove_matches.assert_not_called()
 
     @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.remove_ws_if_present")
     def test_error_raised_when_deleting_EAGroup(self, mock_remove_ws):
-        self.loadedData.clear()
-        self.create_group_workspace_and_load()
-        self.context.reset_group_to_default(self.loadedData)
-        self.assertEqual(len(self.context.groups), 2)
-        group_name1 = "9999; Detector 1"
-        self.assertTrue(group_name1 in self.context.group_names)
+        self._loaded_data.add_data(run=[self._run], workspace=self._group)
+        self._context.reset_group_to_default(self._loaded_data)
+        self.assertEqual(len(self._context.groups), 2)
+        self.assertTrue(self._detector_ws_name_1 in self._context.group_names)
         mock_remove_ws.side_effect = ValueError("mock error")
         error_notifier_mock = mock.Mock()
-        self.context[group_name1].error_notifier = error_notifier_mock
+        self._context[self._detector_ws_name_1].error_notifier = error_notifier_mock
 
-        self.context.remove_group(group_name1)
-        self.assertFalse(group_name1 in self.context.group_names)
-        mock_remove_ws.assert_called_once_with(group_name1)
+        self._context.remove_group(self._detector_ws_name_1)
+        self.assertFalse(self._detector_ws_name_1 in self._context.group_names)
+        mock_remove_ws.assert_called_once_with(self._detector_ws_name_1)
         error_notifier_mock.notify_subscribers.assert_called_once_with(
-            f"Unexpected error occurred when" f" deleting group {group_name1}: mock error"
+            f"Unexpected error occurred when" f" deleting group {self._detector_ws_name_1}: mock error"
         )
 
 


### PR DESCRIPTION
### Description of work
This PR does a refactor of the `elemental_analysis_eagroup_context_test` to improve its readability and its speed. There are several changes made to this test:

- The detector workspaces are only created once inside the `setUpClass` method (previously they were created 4 times).
- The `Context` and `MuonLoadData` objects are cleared in the `tearDown` method to avoid code duplication
- The Given-When-Then structure is used to improve the readability of the test https://pythontest.com/strategy/given-when-then-2/
- I avoid storing the workspaces in the ADS immediately until they are required. This makes it more explicitely obvious that the workspaces are required in the ADS (because the context is unfortunately currently dependent on the ADS)

### To test:
Code review and check the test is passing on all PR operating systems jobs

*This does not require release notes* because **it is a refactor of a unit test**


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
