### PR TITLE
Fix typo in mantid profiling link

### DIFF
--- a/dev-docs/source/AlgorithmProfiler.rst
+++ b/dev-docs/source/AlgorithmProfiler.rst
@@ -23,7 +23,7 @@ It consists two to parts: special mantid build and analytical tool.
 Mantid build
 ^^^^^^^^^^^^
 
-On linux the profiler is built by default but to enable profiling, the :ref:`properties <mantd:Algorithm_Profiling>` must be set.
+On linux the profiler is built by default but to enable profiling, the :ref:`properties <mantid:Algorithm_Profiling>` must be set.
 Enabling the profiler will create a file that contains the time stamps for start and finish of executed algorithms with ~nanosecond precision in a very simple text format.
 
 Adding more detailed information


### PR DESCRIPTION
### Description of work
The following pipeline is currently failing because of a typo in a documentation link:
https://builds.mantidproject.org/job/build_and_publish_developer_site/

This PR fixes the typo.

### To test:
Code review and check the builds pass.

*This does not require release notes* because **it is a change to developer docs**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
