### PR TITLE
Fix index error in OS name string extraction method

### DIFF
--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1068,7 +1068,7 @@ std::string getValueFromStdOut(const std::string &orig, const std::string &key) 
     return std::string();
   }
 
-  return Mantid::Kernel::Strings::strip(orig.substr(start, stop - start - 1));
+  return Mantid::Kernel::Strings::strip(orig.substr(start, stop - start));
 }
 
 /**

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -17,6 +17,7 @@
 #include <Poco/Path.h>
 #include <fstream>
 #include <memory>
+#include <regex>
 #include <string>
 
 #include <Poco/NObserver.h>
@@ -643,6 +644,19 @@ public:
     ConfigService::Instance().remove(rootName);
     mantidLegs = ConfigService::Instance().hasProperty(rootName);
     TS_ASSERT_EQUALS(mantidLegs, false);
+  }
+
+  void testMacOsVersionReadable() {
+    const std::string osName = ConfigService::Instance().getOSName();
+    const std::string osVersionReadable = ConfigService::Instance().getOSVersionReadable();
+    if (osName == "Darwin") {
+      const std::string macOsRegexPattern = "[mM]ac[ ]?OS.*";
+      const bool match = std::regex_match(osVersionReadable, std::regex(macOsRegexPattern));
+      if (!match) {
+        // This will print the incorrect string, unlike TS_ASSERT(match)
+        TS_ASSERT_EQUALS(osVersionReadable, macOsRegexPattern);
+      }
+    }
   }
 
 protected:

--- a/docs/source/release/v6.12.0/Workbench/Bugfixes/38054.rst
+++ b/docs/source/release/v6.12.0/Workbench/Bugfixes/38054.rst
@@ -1,0 +1,1 @@
+- Fixed the reported name of the operating system for macOS users when an error report is generated.


### PR DESCRIPTION
Fixes reported name of macOS in error reports.

Fixes #38054. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->

### To test:

On Windows and macOS (the function I changed is not used on Linux), turn on usage reporting and then run the `Segfault` algorithm. Check that the information in the generated error report contains the correct name of the operating system.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
