### PR TITLE
Setting invalid value is not an exception

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
+++ b/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
@@ -81,7 +81,10 @@ public:
       name = s;
     } else {
       std::stringstream msg;
-      msg << "Invalid string " << s << " for enumerated string " << typeid(E).name();
+      msg << "Invalid string \"" << s << "\" for EnumeratedString";
+#ifdef _DEBUG
+      msg << typeid(E).name();
+#endif
       throw std::runtime_error(msg.str());
     }
     return *this;

--- a/Framework/Kernel/inc/MantidKernel/EnumeratedStringProperty.hxx
+++ b/Framework/Kernel/inc/MantidKernel/EnumeratedStringProperty.hxx
@@ -218,8 +218,16 @@ std::string EnumeratedStringProperty<E, names>::setValue(E const value) {
  */
 template <class E, std::vector<std::string> const *const names>
 std::string EnumeratedStringProperty<E, names>::setValue(std::string const &value) {
-  this->m_value = static_cast<EnumeratedString<E, names>>(value);
-  return "";
+  try {
+    this->m_value = static_cast<EnumeratedString<E, names>>(value);
+  } catch (std::runtime_error &exc) {
+    const std::string msg = exc.what();
+    if (msg.empty())
+      return "value \"" + value + "\" not in allowed list";
+    else
+      return msg;
+  }
+  return ""; // everything was fine
 }
 
 /** Set the value of the property from a string representation.

--- a/Framework/Kernel/test/EnumeratedStringPropertyTest.h
+++ b/Framework/Kernel/test/EnumeratedStringPropertyTest.h
@@ -48,15 +48,40 @@ public:
   static EnumeratedStringPropertyTest *createSuite() { return new EnumeratedStringPropertyTest(); }
   static void destroySuite(EnumeratedStringPropertyTest *suite) { delete suite; }
 
-  void testConstructor() {
-    g_log.notice("\ntestConstructor...");
+  void testAlgorithm() {
+    g_log.notice("\ntestAlgorithm...");
+
     testalg alg;
     alg.initialize();
     alg.execute();
     TS_ASSERT_EQUALS(alg.existsProperty("testname"), true)
     TS_ASSERT_EQUALS(alg.getPropertyValue("testname"), "Frederic");
+
     TS_ASSERT_EQUALS(alg.getPropertyValue("testname"), coolGuyNames[0]);
     alg.setPropertyValue("testname", "Joseph");
     TS_ASSERT_EQUALS(alg.getPropertyValue("testname"), "Joseph");
+  }
+
+  void testAssign() {
+    g_log.notice("\ntestAssign...");
+    auto prop = EnumeratedStringProperty<CoolGuys, &coolGuyNames>("testname");
+    // by default it is fine
+    TS_ASSERT(prop.isValid().empty());
+    TS_ASSERT_EQUALS(prop.value(), "Frederic");
+    TS_ASSERT_EQUALS(prop(), CoolGuys::Fred);
+
+    // set to a good value
+    TS_ASSERT_THROWS_NOTHING(prop.setValue("Joseph"));
+    TS_ASSERT(prop.isValid().empty());
+    TS_ASSERT_EQUALS(prop.value(), "Joseph");
+    TS_ASSERT_EQUALS(prop(), CoolGuys::Joe);
+
+    // set to a bad value
+    TS_ASSERT_THROWS_NOTHING(prop.setValue("Gauss"));
+    TS_ASSERT(!prop.setValue("Gauss").empty());
+
+    // set to an empty string
+    TS_ASSERT_THROWS_NOTHING(prop.setValue(""));
+    TS_ASSERT(!prop.setValue("").empty());
   }
 };


### PR DESCRIPTION
`EnuperatedStringProperty` threw an exception when given bad input rather than return an error message. This fixes that problem and adds tests to exercise the behavior.

The original issue is that bringing up the algorithm dialog for Rebin crashed the dialog so users couldn't run it. This fixes the crash, but the widget for the property is wrong and will be fixed soon.

*There is no associated issue,* but it is associated with [EWM7925](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=7925)

### To test:

1. Start mantidworkbench
2. Open the dialog for `Rebin`
3. See that it doesn't crash

*This does not require release notes* because it fixes an issue introduced during the development cycle.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
