### PR TITLE
Deprecated SofQWCentre and SofQWPolygon

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SofQWCentre.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SofQWCentre.h
@@ -10,6 +10,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAlgorithms/DllConfig.h"
 #include "MantidAlgorithms/SofQCommon.h"
 
@@ -33,8 +34,10 @@ common bins. </LI>
 @author Russell Taylor, Tessella plc
 @date 24/02/2010
 */
-class MANTID_ALGORITHMS_DLL SofQWCentre final : public API::Algorithm {
+class MANTID_ALGORITHMS_DLL SofQWCentre final : public API::Algorithm, public API::DeprecatedAlgorithm {
 public:
+  /// Default constructor
+  SofQWCentre();
   /// Algorithm's name
   const std::string name() const override { return "SofQWCentre"; }
   /// Summary of algorithms purpose

--- a/Framework/Algorithms/inc/MantidAlgorithms/SofQWPolygon.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SofQWPolygon.h
@@ -8,6 +8,7 @@
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
+#include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAlgorithms/Rebin2D.h"
 #include "MantidAlgorithms/SofQCommon.h"
 #include <list>
@@ -38,7 +39,7 @@ common bins. </LI>
 @author Martyn Giggg
 @date 2011-07-15
  */
-class MANTID_ALGORITHMS_DLL SofQWPolygon : public Rebin2D {
+class MANTID_ALGORITHMS_DLL SofQWPolygon : public Rebin2D, public API::DeprecatedAlgorithm {
 public:
   /// Default constructor
   SofQWPolygon();

--- a/Framework/Algorithms/src/SofQWCentre.cpp
+++ b/Framework/Algorithms/src/SofQWCentre.cpp
@@ -22,6 +22,12 @@ DECLARE_ALGORITHM(SofQWCentre)
 using namespace Kernel;
 using namespace API;
 
+/// Default constructor
+SofQWCentre::SofQWCentre() {
+  useAlgorithm("SofQWNormalisedPolygon");
+  deprecatedDate("2024-11-07");
+}
+
 /**
  * Create the input properties
  */

--- a/Framework/Algorithms/src/SofQWPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWPolygon.cpp
@@ -28,7 +28,10 @@ using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;
 
 /// Default constructor
-SofQWPolygon::SofQWPolygon() : Rebin2D(), m_Qout(), m_thetaPts(), m_thetaWidth(0.0) {}
+SofQWPolygon::SofQWPolygon() : Rebin2D(), m_Qout(), m_thetaPts(), m_thetaWidth(0.0) {
+  useAlgorithm("SofQWNormalisedPolygon");
+  deprecatedDate("2024-11-07");
+}
 
 /**
  * Initialize the algorithm

--- a/docs/source/release/v6.12.0/Direct_Geometry/General/New_features/38367.rst
+++ b/docs/source/release/v6.12.0/Direct_Geometry/General/New_features/38367.rst
@@ -1,0 +1,1 @@
+- Deprecated :ref:`SofQWCentre <algm-SofQWCentre>` and :ref:`SofQWPolygon <algm-SofQWPolygon>`.


### PR DESCRIPTION
### Description of work

#### Summary of work
Both `SofQWCentre` and `SofQWPolygon` are replaced by `SofQWNormalisedPolygon` and should get removed, eventually. According to the usage database, they are not in use anymore, but there might be uses that are not registered in the database. This PR adds a deprecation warning for both to give potential users a warning that these algorithms will get removed in a few releases.

*There is no associated issue.*

### To test:

Call `SofQWCentre` and `SofQWPolygon` and check that the deprecation warning is displayed.


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
