### PR TITLE
Set `performancelog.filename` default to `algotimeregister.out`

### DIFF
--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -327,7 +327,7 @@ plots.images.Colormap = viridis
 plots.images.ColorBarScale = Linear
 
 # Profiler Default Filename
-performancelog.filename = algorithmregister.out
+performancelog.filename = algotimeregister.out
 
 # Algorithm Profiler Default Status
 performancelog.write = Off

--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -401,9 +401,9 @@ See :doc:`algorithm profiling <mantid-dev:AlgorithmProfiler>` for more details o
 +---------------------------------+------------------------------------------------------------------+---------------------------+
 |Property                         |Description                                                       |Example value              |
 +=================================+==================================================================+===========================+
-|``performancelog.filename``      |The filename for saving the log file. This can be the absolute    | ``algorithmregister.out`` |
+|``performancelog.filename``      |The filename for saving the log file. This can be the absolute    | ``algotimeregister.out``  |
 |                                 |or relative path. This file is overwritten each session. Default  |                           |
-|                                 |is ``algorithmregister.out``                                      |                           |
+|                                 |is ``algotimeregister.out``                                       |                           |
 +---------------------------------+------------------------------------------------------------------+---------------------------+
 |``performancelog.write``         |Enable or disable writing the performance log. Write is disabled  | ``On``, ``True``, ``1``,  |
 |                                 |by default.                                                       | ``Off``, ``False``, ``0`` |


### PR DESCRIPTION
### Description of work
When I ran the mantid algorithm profiler for the first time in months, it wouldn't work because it couldn't find the output `algotimeregister.out` file. Through some digging I found out that the default had been (possibly accidentally) changed to `algorithmregister.out` so that it no longer matched with the default searched for by the mantid-profiler.

Additionally, everytime I rebuild mantid, this option will change, so I sometimes do my profiling (taking > 10 minutes), and then find out that the wrong output file was set in the `Mantid.properties`. This change makes sure that the default filename matches the performancelog filename expected by the algorithm profiler.

### To test:
1. Run the mantid-profiler on the following python script

```python
from mantid.simpleapi import Load

filepath = "//olympic/Babylon5/Public/RobApplin/loading"
filename = "irs26176_graphite002_red_Conv_seq_2L_0-50__Result.nxs"

Load(
    Filename=f"{filepath}/{filename}",
    LoadHistory=True,
    OutputWorkspace="output_workspace",
)

```

2. Make sure that the correct file (`algotimeregister.out`) is output in your working directory (or it might be in the build directory).

*This does not require release notes* because **this is not user-facing**

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
