### PR TITLE
Pull in parameter renaming changes from main into ornl-next

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed2.h
@@ -36,7 +36,10 @@ enum class InstrumentLayout { Mantid, NexusFormat, NotRecognised };
  */
 class MANTID_DATAHANDLING_DLL LoadNexusProcessed2 : public LoadNexusProcessed {
 public:
-  const std::string name() const override;
+  // algorithm "name" is still "LoadNexusProcessed" (not "LoadNexusProcessed2"):
+  //   `cppcheck` has an issue with any "useless" override.
+  // const std::string name() const override;
+
   int version() const override;
   int confidence(Kernel::NexusHDF5Descriptor &descriptor) const override;
 

--- a/Framework/DataHandling/src/H5Util.cpp
+++ b/Framework/DataHandling/src/H5Util.cpp
@@ -403,8 +403,8 @@ bool groupExists(H5::H5Object &h5, const std::string &groupPath) {
   // Unfortunately, this is actually the approach recommended by the HDF Group.
   try {
     h5.openGroup(groupPath);
-  } catch (const H5::Exception &x) {
-    UNUSED_ARG(x);
+  } catch (const H5::Exception &e) {
+    UNUSED_ARG(e);
     status = false;
   }
   return status;
@@ -419,8 +419,8 @@ bool keyHasValue(H5::H5Object &h5, const std::string &key, const std::string &va
     attr.read(attr.getDataType(), value_);
     if (value_ != value)
       status = false;
-  } catch (const H5::Exception &x) {
-    UNUSED_ARG(x);
+  } catch (const H5::Exception &e) {
+    UNUSED_ARG(e);
     status = false;
   }
   return status;

--- a/Framework/DataHandling/src/LoadNexusProcessed2.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed2.cpp
@@ -69,9 +69,6 @@ InstrumentLayout instrumentFormat(Mantid::NeXus::NXEntry &entry) {
 
 } // namespace
 
-/// Algorithms name for identification. @see Algorithm::name
-const std::string LoadNexusProcessed2::name() const { return "LoadNexusProcessed"; }
-
 /// Algorithm's version for identification. @see Algorithm::version
 int LoadNexusProcessed2::version() const { return 2; }
 

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometrySave.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometrySave.h
@@ -46,8 +46,8 @@ namespace NexusGeometrySave {
 
 MANTID_NEXUSGEOMETRY_DLL void saveInstrument(const Geometry::ComponentInfo &compInfo,
                                              const Geometry::DetectorInfo &detInfo, const std::string &fullPath,
-                                             const std::string &rootName, AbstractLogger &logger, bool append = false,
-                                             Kernel::ProgressBase *reporter = nullptr);
+                                             const std::string &parentGroupName, AbstractLogger &logger,
+                                             bool append = false, Kernel::ProgressBase *reporter = nullptr);
 
 MANTID_NEXUSGEOMETRY_DLL void saveInstrument(const Mantid::API::MatrixWorkspace &ws, const std::string &filePath,
                                              const std::string &entryNamePrefix, std::optional<size_t> entryNumber,
@@ -55,12 +55,12 @@ MANTID_NEXUSGEOMETRY_DLL void saveInstrument(const Mantid::API::MatrixWorkspace 
                                              Kernel::ProgressBase *reporter = nullptr);
 
 MANTID_NEXUSGEOMETRY_DLL void saveInstrument(const Mantid::API::MatrixWorkspace &ws, const std::string &fullPath,
-                                             const std::string &rootName, AbstractLogger &logger, bool append = false,
-                                             Kernel::ProgressBase *reporter = nullptr);
+                                             const std::string &parentGroupName, AbstractLogger &logger,
+                                             bool append = false, Kernel::ProgressBase *reporter = nullptr);
 
 MANTID_NEXUSGEOMETRY_DLL void saveInstrument(
     const std::pair<std::unique_ptr<Geometry::ComponentInfo>, std::unique_ptr<Geometry::DetectorInfo>> &instrPair,
-    const std::string &fullPath, const std::string &rootName, AbstractLogger &logger, bool append = false,
+    const std::string &fullPath, const std::string &parentGroupName, AbstractLogger &logger, bool append = false,
     Kernel::ProgressBase *reporter = nullptr);
 
 } // namespace NexusGeometrySave

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -432,7 +432,7 @@ Workspace2D_sptr create2DWorkspaceWithGeographicalDetectors(const int nlat, cons
  * @param numBanks :: number of rectangular banks
  * @param numPixels :: each bank will be numPixels*numPixels
  * @param numBins :: each spectrum will have this # of bins
- * @param instrumentName :: the name of the workspace's instrument
+ * @param instrumentName :: the name of the new instrument
  * @return The Workspace2D
  */
 Mantid::DataObjects::Workspace2D_sptr create2DWorkspaceWithRectangularInstrument(int numBanks, int numPixels,

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -684,7 +684,7 @@ cstyleCast:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/NexusFileIO.h:208
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/NexusFileIO.h:211
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/NexusFileIO.h:273
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/NexusFileIO.h:276
-uselessOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed2.h:39
+uselessOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed2.h:38
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus1.h:60
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus1.h:62
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus1.h:70


### PR DESCRIPTION
There are some variable/parameter renaming that managed to not get pulled into `ornl-next` which are creating merge conflicts. This should get them in.