### PR TITLE
Fix for Enumerated String Properties docs bug

### DIFF
--- a/Framework/Kernel/src/Property.cpp
+++ b/Framework/Kernel/src/Property.cpp
@@ -325,7 +325,13 @@ std::string getUnmangledTypeName(const std::type_info &type) {
   if (mitr != typestrings.end()) {
     return mitr->second;
   }
-
+  /* if a type name looks like
+  N6Mantid6Kernel16EnumeratedStringINS_12_GLOBAL__N_111BinningModeEXadL_ZNS2_L16binningModeNamesEEEXadL_ZNS0_12_GLOBAL__N_114compareStringsEEEEE
+  we assume it is a EnumeratedStringProperty and return a "string" for it */
+  string type_name = type.name();
+  if (type_name.find("Mantid") != std::string::npos && type_name.find("EnumeratedString") != std::string::npos) {
+    return "string";
+  }
   return type.name();
 }
 

--- a/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
+++ b/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
@@ -88,11 +88,7 @@ class SimpleAPITest(unittest.TestCase):
         )
         doc = simpleapi.rebin.__doc__
         self.assertGreater(len(doc), 0)
-        # The missing part of the expected_doc string contains "BinningMode(Input) *string* " ...
-        # Due to introduction of EnumeratedStringProperty the "*string*" is replaced by some
-        # generated during build characters in the "doc" string here.
-        # Cutting them out to compare two strings
-        self.assertEqual(doc[0:1897], expected_doc[0:1897])
+        self.assertEqual(doc, expected_doc)
 
     def test_function_call_executes_correct_algorithm_when_passed_correct_args(self):
         wsname = "test_function_call_executes_correct_algorithm_when_passed_correct_args"

--- a/docs/sphinxext/mantiddoc/directives/properties.py
+++ b/docs/sphinxext/mantiddoc/directives/properties.py
@@ -75,11 +75,12 @@ class PropertiesDirective(AlgorithmBaseDirective):
 
             for prop in alg_properties:
                 # Append a tuple of properties to the list.
+                str_prop_type = str(prop.type)
                 properties.append(
                     (
                         str(prop.name),
                         str(direction_string[prop.direction]),
-                        property_type_dict.get(str(prop.type), str(prop.type)),
+                        property_type_dict.get(str_prop_type, str_prop_type),
                         str(self._get_default_prop(prop)),
                         self._create_property_description_string(prop),
                     )


### PR DESCRIPTION
### Description of work
[7925: EnumeratedStringProperty, type should be the literal "string", not a mangled name](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/7925)
By implementation of Enumerated String Property, the C++ mangled name was placed inside the documentation, and this is fixed as the type of the enumerated string is set to "string". The changed unit test is reverted.


#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes mangled C++ names in docs for ```EnumeratedStringProperties```. They are mapped to ```"string"``` now in the function  ```getUnmangledTypeName``` in ```Framework/Kernel/src/Property.cpp```
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

```ctest -R SimpleAPITest```
Check for C++ mangled names in html docs.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
No release note needed because it fixes an issue introduced during the development cycle
<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
