### PR TITLE
fix coverity issues in FindReflectometryLines Algorithm

### DIFF
--- a/Framework/Reflectometry/src/FindReflectometryLines2.cpp
+++ b/Framework/Reflectometry/src/FindReflectometryLines2.cpp
@@ -134,7 +134,7 @@ void FindReflectometryLines2::exec() {
   setProperty(Prop::LINE_CENTRE, peakWSIndex);
   if (!isDefault(Prop::OUTPUT_WS)) {
     auto outputWS = makeOutput(peakWSIndex);
-    setProperty(Prop::OUTPUT_WS, outputWS);
+    setProperty(Prop::OUTPUT_WS, std::move(outputWS));
   }
 }
 
@@ -189,7 +189,7 @@ double FindReflectometryLines2::findPeak(const API::MatrixWorkspace_sptr &ws) {
   func = API::FunctionFactory::Instance().createFunction("LinearBackground");
   func->setParameter("A0", medianY);
   func->setParameter("A1", 0.);
-  sum->addFunction(func);
+  sum->addFunction(std::move(func));
   // call Fit child algorithm
   auto fit = createChildAlgorithm("Fit");
   fit->initialize();


### PR DESCRIPTION
### Description of work
- Fix coverity Issue in FindReflectometryLines
- used std::move to address unnecessary copies

Fixes #38263 

### To test:
- run the instructions on https://docs.mantidproject.org/nightly/algorithms/FindReflectometryLines-v2.html, algorithm should run successfully
- unit tests should pass

This change does not require release notes because it is a code refactoring focused on performance improvements.