### PR TITLE
Use std::pair instead of QPair in utility files

### DIFF
--- a/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISCalibration.cpp
@@ -248,20 +248,20 @@ QString ISISCalibration::backgroundString() const {
 void ISISCalibration::setPeakRange(const double &minimumTof, const double &maximumTof) {
   auto calibrationPeak = m_uiForm.ppCalibration->getRangeSelector("CalPeak");
   setRangeSelector(calibrationPeak, m_properties["CalPeakMin"], m_properties["CalPeakMax"],
-                   qMakePair(minimumTof, maximumTof));
+                   std::pair(minimumTof, maximumTof));
 }
 
 void ISISCalibration::setBackgroundRange(const double &minimumTof, const double &maximumTof) {
   auto background = m_uiForm.ppCalibration->getRangeSelector("CalBackground");
   setRangeSelector(background, m_properties["CalBackMin"], m_properties["CalBackMax"],
-                   qMakePair(minimumTof, maximumTof));
+                   std::pair(minimumTof, maximumTof));
 }
 
 void ISISCalibration::setRangeLimits(MantidWidgets::RangeSelector *rangeSelector, const double &minimum,
                                      const double &maximum, const QString &minPropertyName,
                                      const QString &maxPropertyName) {
   setPlotPropertyRange(rangeSelector, m_properties[minPropertyName], m_properties[maxPropertyName],
-                       qMakePair(minimum, maximum));
+                       std::pair(minimum, maximum));
 }
 
 void ISISCalibration::setPeakRangeLimits(const double &peakMin, const double &peakMax) {
@@ -483,7 +483,7 @@ void ISISCalibration::calPlotEnergy() {
   }
 
   const auto &dataX = energyWs->x(0);
-  QPair<double, double> range(dataX.front(), dataX.back());
+  std::pair<double, double> range(dataX.front(), dataX.back());
 
   auto resBackground = m_uiForm.ppResolution->getRangeSelector("ResBackground");
   setPlotPropertyRange(resBackground, m_properties["ResStart"], m_properties["ResEnd"], range);
@@ -528,7 +528,7 @@ void ISISCalibration::calSetDefaultResolution(const MatrixWorkspace_const_sptr &
       if (-res * minScaleFactor > energyRange.first && res * maxScaleFactor < energyRange.second) {
         offset = 0.0;
       }
-      QPair<double, double> peakERange(-res * minScaleFactor + offset, res * maxScaleFactor + offset);
+      std::pair<double, double> peakERange(-res * minScaleFactor + offset, res * maxScaleFactor + offset);
       auto resPeak = m_uiForm.ppResolution->getRangeSelector("ResPeak");
       setPlotPropertyRange(resPeak, m_properties["ResELow"], m_properties["ResEHigh"], energyRange);
       setRangeSelector(resPeak, m_properties["ResELow"], m_properties["ResEHigh"], peakERange);
@@ -543,7 +543,7 @@ void ISISCalibration::calSetDefaultResolution(const MatrixWorkspace_const_sptr &
         maxScaleFactor = 15.;
         offset = (energyRange.second + energyRange.first) / 2.0;
       }
-      QPair<double, double> backgroundERange(-res * minScaleFactor + offset, -res * maxScaleFactor + offset);
+      std::pair<double, double> backgroundERange(-res * minScaleFactor + offset, -res * maxScaleFactor + offset);
       auto resBackground = m_uiForm.ppResolution->getRangeSelector("ResBackground");
       setRangeSelector(resBackground, m_properties["ResStart"], m_properties["ResEnd"], backgroundERange);
     }

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISDiagnostics.cpp
@@ -300,18 +300,18 @@ void ISISDiagnostics::setBackgroundRangeLimits(double backgroundMin, double back
 void ISISDiagnostics::setRangeLimits(MantidWidgets::RangeSelector *rangeSelector, double minimum, double maximum,
                                      QString const &minPropertyName, QString const &maxPropertyName) {
   setPlotPropertyRange(rangeSelector, m_properties[minPropertyName], m_properties[maxPropertyName],
-                       qMakePair(minimum, maximum));
+                       std::pair(minimum, maximum));
 }
 
 void ISISDiagnostics::setPeakRange(double minimum, double maximum) {
   auto slicePeak = m_uiForm.ppRawPlot->getRangeSelector("SlicePeak");
-  setRangeSelector(slicePeak, m_properties["PeakStart"], m_properties["PeakEnd"], qMakePair(minimum, maximum));
+  setRangeSelector(slicePeak, m_properties["PeakStart"], m_properties["PeakEnd"], std::pair(minimum, maximum));
 }
 
 void ISISDiagnostics::setBackgroundRange(double minimum, double maximum) {
   auto sliceBackground = m_uiForm.ppRawPlot->getRangeSelector("SliceBackground");
   setRangeSelector(sliceBackground, m_properties["BackgroundStart"], m_properties["BackgroundEnd"],
-                   qMakePair(minimum, maximum));
+                   std::pair(minimum, maximum));
 }
 
 /**

--- a/qt/scientific_interfaces/Inelastic/BayesFitting/ResNormView.cpp
+++ b/qt/scientific_interfaces/Inelastic/BayesFitting/ResNormView.cpp
@@ -115,7 +115,7 @@ void ResNormView::setMaximumSpectrum(int maximum) const { m_uiForm.spPreviewSpec
 
 void ResNormView::updateSelectorRange(std::string const &filename) const {
   auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("ResNormViewERange");
-  QPair<double, double> res;
+  std::pair<double, double> res;
 
   auto const range = getXRangeFromWorkspace(filename);
 

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinView.cpp
@@ -374,8 +374,8 @@ double ElwinView::getBackgroundEnd() { return m_dblManager->value(m_properties["
  * @param range :: The range to set the range selector to.
  */
 void ElwinView::setRangeSelector(RangeSelector *rs, QtProperty *lower, QtProperty *upper,
-                                 const QPair<double, double> &range,
-                                 const std::optional<QPair<double, double>> &bounds) {
+                                 const std::pair<double, double> &range,
+                                 const std::optional<std::pair<double, double>> &bounds) {
   m_dblManager->setValue(lower, range.first);
   m_dblManager->setValue(upper, range.second);
   rs->setRange(range.first, range.second);

--- a/qt/scientific_interfaces/Inelastic/Processor/ElwinView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ElwinView.h
@@ -102,8 +102,8 @@ private:
 
   /// Function to set the range selector on the mini plot
   void setRangeSelector(MantidWidgets::RangeSelector *rs, QtProperty *lower, QtProperty *upper,
-                        const QPair<double, double> &range,
-                        const std::optional<QPair<double, double>> &bounds = std::nullopt);
+                        const std::pair<double, double> &range,
+                        const std::optional<std::pair<double, double>> &bounds = std::nullopt);
   /// Sets the min of the range selector if it is less than the max
   void setRangeSelectorMin(QtProperty *minProperty, QtProperty *maxProperty,
                            MantidWidgets::RangeSelector *rangeSelector, double newValue);

--- a/qt/scientific_interfaces/Inelastic/Processor/IIqtView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IIqtView.h
@@ -39,7 +39,7 @@ public:
   virtual void setPreviewSpectrumMaximum(int value) = 0;
   virtual void updateDisplayedBinParameters() = 0;
   virtual void setRangeSelectorDefault(const Mantid::API::MatrixWorkspace_sptr inputWorkspace,
-                                       const QPair<double, double> &range) = 0;
+                                       const std::pair<double, double> &range) = 0;
   virtual void setSampleFBSuffixes(const QStringList &suffix) = 0;
   virtual void setSampleWSSuffixes(const QStringList &suffix) = 0;
   virtual void setResolutionFBSuffixes(const QStringList &suffix) = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/IMomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IMomentsView.h
@@ -43,9 +43,9 @@ public:
   virtual void setLoadHistory(bool doLoadHistory) = 0;
 
   /// Function to set the range limits of the plot
-  virtual void setPlotPropertyRange(const QPair<double, double> &bounds) = 0;
+  virtual void setPlotPropertyRange(const std::pair<double, double> &bounds) = 0;
   /// Function to set the range selector on the mini plot
-  virtual void setRangeSelector(const QPair<double, double> &bounds) = 0;
+  virtual void setRangeSelector(const std::pair<double, double> &bounds) = 0;
   /// Sets the min of the range selector if it is less than the max
   virtual void setRangeSelectorMin(double newValue) = 0;
   /// Sets the max of the range selector if it is more than the min

--- a/qt/scientific_interfaces/Inelastic/Processor/ISymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/ISymmetriseView.h
@@ -54,7 +54,7 @@ public:
   virtual void setRawPlotWatchADS(bool watchADS) = 0;
 
   virtual void resetEDefaults(bool isPositive) = 0;
-  virtual void resetEDefaults(bool isPositive, QPair<double, double> range) = 0;
+  virtual void resetEDefaults(bool isPositive, std::pair<double, double> range) = 0;
 
   virtual void previewAlgDone() = 0;
   virtual void enableSave(bool save) = 0;

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtView.cpp
@@ -302,7 +302,7 @@ void IqtView::plotInput(MatrixWorkspace_sptr inputWS, int spectrum) {
   }
 }
 
-void IqtView::setRangeSelectorDefault(const MatrixWorkspace_sptr workspace, const QPair<double, double> &range) {
+void IqtView::setRangeSelectorDefault(const MatrixWorkspace_sptr workspace, const std::pair<double, double> &range) {
   auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
   try {
     double rounded_min(range.first);

--- a/qt/scientific_interfaces/Inelastic/Processor/IqtView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/IqtView.h
@@ -39,7 +39,8 @@ public:
   void plotInput(MatrixWorkspace_sptr inputWS, int spectrum) override;
   void setPreviewSpectrumMaximum(int value) override;
   void updateDisplayedBinParameters() override;
-  void setRangeSelectorDefault(const MatrixWorkspace_sptr inputWorkspace, const QPair<double, double> &range) override;
+  void setRangeSelectorDefault(const MatrixWorkspace_sptr inputWorkspace,
+                               const std::pair<double, double> &range) override;
   void setSampleFBSuffixes(const QStringList &suffix) override;
   void setSampleWSSuffixes(const QStringList &suffix) override;
   void setResolutionFBSuffixes(const QStringList &suffix) override;

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.cpp
@@ -138,7 +138,7 @@ void MomentsView::plotNewData(std::string const &filename) {
  *
  * @param bounds :: The upper and lower bounds to be set in the property browser
  */
-void MomentsView::setPlotPropertyRange(const QPair<double, double> &bounds) {
+void MomentsView::setPlotPropertyRange(const std::pair<double, double> &bounds) {
   disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &MomentsView::notifyValueChanged);
   m_dblManager->setMinimum(m_properties["EMin"], bounds.first);
   m_dblManager->setMaximum(m_properties["EMin"], bounds.second);
@@ -154,7 +154,7 @@ void MomentsView::setPlotPropertyRange(const QPair<double, double> &bounds) {
  *
  * @param bounds :: The upper and lower bounds to be set
  */
-void MomentsView::setRangeSelector(const QPair<double, double> &bounds) {
+void MomentsView::setRangeSelector(const std::pair<double, double> &bounds) {
   disconnect(m_dblManager, &QtDoublePropertyManager::valueChanged, this, &MomentsView::notifyValueChanged);
 
   double deltaX = abs(bounds.second - bounds.first);

--- a/qt/scientific_interfaces/Inelastic/Processor/MomentsView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/MomentsView.h
@@ -40,9 +40,9 @@ public:
   void setLoadHistory(bool doLoadHistory) override;
 
   /// Function to set the range limits of the plot
-  void setPlotPropertyRange(const QPair<double, double> &bounds) override;
+  void setPlotPropertyRange(const std::pair<double, double> &bounds) override;
   /// Function to set the range selector on the mini plot
-  void setRangeSelector(const QPair<double, double> &bounds) override;
+  void setRangeSelector(const std::pair<double, double> &bounds) override;
   /// Sets the min of the range selector if it is less than the max
   void setRangeSelectorMin(double newValue) override;
   /// Sets the max of the range selector if it is more than the min

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.cpp
@@ -152,7 +152,7 @@ void SymmetriseView::setDefaults() {
   m_enumManager->setValue(m_properties["ReflectType"], 0);
 
   // Set default x axis range
-  QPair<double, double> defaultRange(-1.0, 1.0);
+  std::pair<double, double> defaultRange(-1.0, 1.0);
   m_uiForm.ppRawPlot->setAxisRange(defaultRange, AxisID::XBottom);
   m_uiForm.ppPreviewPlot->setAxisRange(defaultRange, AxisID::XBottom);
 
@@ -220,7 +220,7 @@ void SymmetriseView::resetEDefaults(bool isPositive) {
  * @param range Active spectra range
  *
  */
-void SymmetriseView::resetEDefaults(bool isPositive, QPair<double, double> range) {
+void SymmetriseView::resetEDefaults(bool isPositive, std::pair<double, double> range) {
   auto rangeESelector = m_uiForm.ppRawPlot->getRangeSelector("rangeE");
 
   // Set Selector range boundaries
@@ -332,8 +332,8 @@ void SymmetriseView::updateMiniPlots() {
   m_uiForm.ppPreviewPlot->replot();
 
   // Update bounds for horizontal markers
-  auto verticalRange = m_uiForm.ppRawPlot->getAxisRange(AxisID::YLeft);
-  updateHorizontalMarkers(convertTupleToQPair(verticalRange));
+  auto const verticalRange = m_uiForm.ppRawPlot->getAxisRange(AxisID::YLeft);
+  updateHorizontalMarkers(convertTupleToPair(verticalRange));
 }
 
 /**
@@ -342,7 +342,7 @@ void SymmetriseView::updateMiniPlots() {
  * @param Y range for current workspace
  *
  */
-void SymmetriseView::updateHorizontalMarkers(QPair<double, double> yrange) {
+void SymmetriseView::updateHorizontalMarkers(std::pair<double, double> yrange) {
   auto horzMarkFirst = m_uiForm.ppRawPlot->getSingleSelector("horzMarkFirst");
   auto horzMarkSecond = m_uiForm.ppRawPlot->getSingleSelector("horzMarkSecond");
 

--- a/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SymmetriseView.h
@@ -53,7 +53,7 @@ public:
   void enableSave(bool save) override;
   void showMessageBox(std::string const &message) const override;
   void resetEDefaults(bool isPositive) override;
-  void resetEDefaults(bool isPositive, QPair<double, double> range) override;
+  void resetEDefaults(bool isPositive, std::pair<double, double> range) override;
 
 private slots:
   void notifyDoubleValueChanged(QtProperty *, double);
@@ -65,7 +65,7 @@ private slots:
   void notifyXrangeHighChanged(double value);
 
 private:
-  void updateHorizontalMarkers(QPair<double, double> yrange);
+  void updateHorizontalMarkers(std::pair<double, double> yrange);
 
   Ui::SymmetriseTab m_uiForm;
 

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/MockObjects.h
@@ -526,8 +526,8 @@ public:
   MOCK_METHOD1(setWSSuffixes, void(QStringList const &suffix));
   MOCK_METHOD1(setLoadHistory, void(bool doLoadHistory));
 
-  MOCK_METHOD1(setPlotPropertyRange, void(const QPair<double, double> &bounds));
-  MOCK_METHOD1(setRangeSelector, void(const QPair<double, double> &bounds));
+  MOCK_METHOD1(setPlotPropertyRange, void(const std::pair<double, double> &bounds));
+  MOCK_METHOD1(setRangeSelector, void(const std::pair<double, double> &bounds));
   MOCK_METHOD1(setRangeSelectorMin, void(double newValue));
   MOCK_METHOD1(setRangeSelectorMax, void(double newValue));
   MOCK_METHOD1(setSaveResultEnabled, void(bool enable));
@@ -563,7 +563,7 @@ public:
   MOCK_METHOD1(setPreviewSpectrumMaximum, void(int value));
   MOCK_METHOD0(updateDisplayedBinParameters, void());
   MOCK_METHOD2(setRangeSelectorDefault,
-               void(const Mantid::API::MatrixWorkspace_sptr inputWorkspace, const QPair<double, double> &range));
+               void(const Mantid::API::MatrixWorkspace_sptr inputWorkspace, const std::pair<double, double> &range));
 
   MOCK_METHOD1(setSampleWSSuffixes, void(const QStringList &suffix));
   MOCK_METHOD1(setSampleFBSuffixes, void(const QStringList &suffix));

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceUtils.h
@@ -26,14 +26,14 @@ extractAxisLabels(const Mantid::API::MatrixWorkspace_const_sptr &workspace, cons
 EXPORT_OPT_MANTIDQT_COMMON std::string getEMode(const Mantid::API::MatrixWorkspace_sptr &ws);
 EXPORT_OPT_MANTIDQT_COMMON std::optional<double> getEFixed(const Mantid::API::MatrixWorkspace_sptr &ws);
 
-EXPORT_OPT_MANTIDQT_COMMON bool getResolutionRangeFromWs(const std::string &workspace, QPair<double, double> &res);
+EXPORT_OPT_MANTIDQT_COMMON bool getResolutionRangeFromWs(const std::string &workspace, std::pair<double, double> &res);
 EXPORT_OPT_MANTIDQT_COMMON bool getResolutionRangeFromWs(const Mantid::API::MatrixWorkspace_const_sptr &workspace,
-                                                         QPair<double, double> &res);
+                                                         std::pair<double, double> &res);
 
-EXPORT_OPT_MANTIDQT_COMMON QPair<double, double>
+EXPORT_OPT_MANTIDQT_COMMON std::pair<double, double>
 getXRangeFromWorkspace(const Mantid::API::MatrixWorkspace_const_sptr &workspace, double precision = 0.00001);
-EXPORT_OPT_MANTIDQT_COMMON QPair<double, double> getXRangeFromWorkspace(std::string const &workspaceName,
-                                                                        double precision = 0.000001);
+EXPORT_OPT_MANTIDQT_COMMON std::pair<double, double> getXRangeFromWorkspace(std::string const &workspaceName,
+                                                                            double precision = 0.000001);
 
 EXPORT_OPT_MANTIDQT_COMMON std::optional<std::size_t> maximumIndex(const Mantid::API::MatrixWorkspace_sptr &workspace);
 EXPORT_OPT_MANTIDQT_COMMON std::string getIndexString(const std::string &workspaceName);

--- a/qt/widgets/common/src/WorkspaceUtils.cpp
+++ b/qt/widgets/common/src/WorkspaceUtils.cpp
@@ -22,9 +22,9 @@ Mantid::Kernel::Logger g_log("WorkspaceUtils");
 
 double roundToPrecision(double value, double precision) { return value - std::remainder(value, precision); }
 
-QPair<double, double> roundRangeToPrecision(double rangeStart, double rangeEnd, double precision) {
-  return QPair<double, double>(roundToPrecision(rangeStart, precision) + precision,
-                               roundToPrecision(rangeEnd, precision) - precision);
+std::pair<double, double> roundRangeToPrecision(double rangeStart, double rangeEnd, double precision) {
+  return std::pair<double, double>(roundToPrecision(rangeStart, precision) + precision,
+                                   roundToPrecision(rangeEnd, precision) - precision);
 }
 
 auto const regDigits = std::regex("\\d+");
@@ -163,7 +163,7 @@ std::optional<double> getEFixed(const Mantid::API::MatrixWorkspace_sptr &ws) {
  * @param res :: The retrieved values for the resolution parameter (if one was
  *found)
  */
-bool getResolutionRangeFromWs(const std::string &workspace, QPair<double, double> &res) {
+bool getResolutionRangeFromWs(const std::string &workspace, std::pair<double, double> &res) {
   auto const ws =
       Mantid::API::AnalysisDataService::Instance().retrieveWS<const Mantid::API::MatrixWorkspace>(workspace);
   return getResolutionRangeFromWs(ws, res);
@@ -176,7 +176,8 @@ bool getResolutionRangeFromWs(const std::string &workspace, QPair<double, double
  * @param res :: The retrieved values for the resolution parameter (if one was
  *found)
  */
-bool getResolutionRangeFromWs(const Mantid::API::MatrixWorkspace_const_sptr &workspace, QPair<double, double> &res) {
+bool getResolutionRangeFromWs(const Mantid::API::MatrixWorkspace_const_sptr &workspace,
+                              std::pair<double, double> &res) {
   if (workspace) {
     auto const instrument = workspace->getInstrument();
     if (instrument && instrument->hasParameter("analyser")) {
@@ -188,7 +189,7 @@ bool getResolutionRangeFromWs(const Mantid::API::MatrixWorkspace_const_sptr &wor
 
           // set the default instrument resolution
           if (params.size() > 0) {
-            res = qMakePair(-params[0], params[0]);
+            res = std::pair(-params[0], params[0]);
             return true;
           }
         }
@@ -198,15 +199,16 @@ bool getResolutionRangeFromWs(const Mantid::API::MatrixWorkspace_const_sptr &wor
   return false;
 }
 
-QPair<double, double> getXRangeFromWorkspace(std::string const &workspaceName, double precision) {
+std::pair<double, double> getXRangeFromWorkspace(std::string const &workspaceName, double precision) {
   auto const &ads = AnalysisDataService::Instance();
   if (ads.doesExist(workspaceName))
     return getXRangeFromWorkspace(ads.retrieveWS<MatrixWorkspace>(workspaceName), precision);
-  return QPair<double, double>(0.0, 0.0);
+  return std::pair<double, double>(0.0, 0.0);
 }
 
-QPair<double, double> getXRangeFromWorkspace(const Mantid::API::MatrixWorkspace_const_sptr &workspace,
-                                             double precision) {
+std::pair<double, double> getXRangeFromWorkspace(const Mantid::API::MatrixWorkspace_const_sptr &workspace,
+                                                 double precision) {
+  assert(workspace != nullptr);
   auto const &xValues = workspace->x(0);
   return roundRangeToPrecision(xValues.front(), xValues.back(), precision);
 }

--- a/qt/widgets/common/test/WorkspaceUtilsTest.h
+++ b/qt/widgets/common/test/WorkspaceUtilsTest.h
@@ -9,8 +9,8 @@
 #include "MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h"
 #include "MantidQtWidgets/Common/WorkspaceUtils.h"
 
-#include <QPair>
 #include <cxxtest/TestSuite.h>
+#include <utility>
 
 using namespace Mantid::API;
 using namespace MantidQt::MantidWidgets::WorkspaceUtils;
@@ -49,13 +49,13 @@ public:
   }
 
   void test_getResolutionFromWs_returns_false_for_no_instrument_workspace() {
-    auto res = QPair<double, double>(0, 0);
+    auto res = std::pair<double, double>(0, 0);
     auto const testWorkspace = createWorkspace(1, 5);
 
     TS_ASSERT(!getResolutionRangeFromWs(testWorkspace, res));
   }
   void test_getResolutionFromWs_returns_res_for_instrument_workspace() {
-    auto res = QPair<double, double>(0, 0);
+    auto res = std::pair<double, double>(0, 0);
     auto const testWorkspace = createWorkspaceWithIndirectInstrumentAndParameters();
     getResolutionRangeFromWs(testWorkspace, res);
 

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
@@ -76,7 +76,7 @@ public:
 
   void setOverrideAxisLabel(AxisID const &axisID, char const *const label);
   void tickLabelFormat(const std::string &axis, const std::string &style, bool useOffset);
-  void setAxisRange(const QPair<double, double> &range, AxisID axisID = AxisID::XBottom);
+  void setAxisRange(const std::pair<double, double> &range, AxisID axisID = AxisID::XBottom);
   std::tuple<double, double> getAxisRange(AxisID axisID = AxisID::XBottom);
 
   void allowRedraws(bool state);

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -270,7 +270,7 @@ void PreviewPlot::setAxisLabel(AxisID const &axisID, char const *const label) {
  * @param range The new range
  * @param axisID An enumeration defining the axis
  */
-void PreviewPlot::setAxisRange(const QPair<double, double> &range, AxisID axisID) {
+void PreviewPlot::setAxisRange(const std::pair<double, double> &range, AxisID axisID) {
   switch (axisID) {
   case AxisID::XBottom:
     m_canvas->gca().setXLim(range.first, range.second);

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/InelasticTab.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/InelasticTab.h
@@ -93,11 +93,11 @@ protected:
 
   /// Function to set the range limits of the plot
   void setPlotPropertyRange(MantidWidgets::RangeSelector *rs, QtProperty *min, QtProperty *max,
-                            const QPair<double, double> &bounds);
+                            const std::pair<double, double> &bounds);
   /// Function to set the range selector on the mini plot
   void setRangeSelector(MantidWidgets::RangeSelector *rs, QtProperty *lower, QtProperty *upper,
-                        const QPair<double, double> &range,
-                        const std::optional<QPair<double, double>> &bounds = std::nullopt);
+                        const std::pair<double, double> &range,
+                        const std::optional<std::pair<double, double>> &bounds = std::nullopt);
   /// Sets the min of the range selector if it is less than the max
   void setRangeSelectorMin(QtProperty *minProperty, QtProperty *maxProperty,
                            MantidWidgets::RangeSelector *rangeSelector, double newValue);

--- a/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/InterfaceUtils.h
+++ b/qt/widgets/spectroscopy/inc/MantidQtWidgets/Spectroscopy/InterfaceUtils.h
@@ -46,19 +46,18 @@ MANTID_SPECTROSCOPY_DLL QStringList getContainerWSSuffixes(std::string const &in
 MANTID_SPECTROSCOPY_DLL QStringList getCorrectionsFBSuffixes(std::string const &interfaceName);
 MANTID_SPECTROSCOPY_DLL QStringList getCorrectionsWSSuffixes(std::string const &interfaceName);
 
-MANTID_SPECTROSCOPY_DLL QPair<double, double> convertTupleToQPair(std::tuple<double, double> const &doubleTuple);
 MANTID_SPECTROSCOPY_DLL std::pair<double, double> convertTupleToPair(std::tuple<double, double> const &doubleTuple);
 MANTID_SPECTROSCOPY_DLL QString makeQStringNumber(double value, int precision);
 
 /// Function to set the range limits of the plot
 MANTID_SPECTROSCOPY_DLL void setPlotPropertyRange(QtDoublePropertyManager *dblPropertyManager,
                                                   MantidWidgets::RangeSelector *rs, QtProperty *min, QtProperty *max,
-                                                  const QPair<double, double> &bounds);
+                                                  const std::pair<double, double> &bounds);
 /// Function to set the range selector on the mini plot
 MANTID_SPECTROSCOPY_DLL void setRangeSelector(QtDoublePropertyManager *dblPropertyManager,
                                               MantidWidgets::RangeSelector *rs, QtProperty *lower, QtProperty *upper,
-                                              const QPair<double, double> &range,
-                                              const std::optional<QPair<double, double>> &bounds = std::nullopt);
+                                              const std::pair<double, double> &range,
+                                              const std::optional<std::pair<double, double>> &bounds = std::nullopt);
 /// Sets the min of the range selector if it is less than the max
 MANTID_SPECTROSCOPY_DLL void setRangeSelectorMin(QtDoublePropertyManager *dblPropertyManager, QtProperty *minProperty,
                                                  QtProperty *maxProperty, MantidWidgets::RangeSelector *rangeSelector,

--- a/qt/widgets/spectroscopy/src/InelasticTab.cpp
+++ b/qt/widgets/spectroscopy/src/InelasticTab.cpp
@@ -196,7 +196,7 @@ void InelasticTab::addSaveWorkspaceToQueue(const std::string &wsName, const std:
  * @param bounds :: The upper and lower bounds to be set
  */
 void InelasticTab::setPlotPropertyRange(RangeSelector *rs, QtProperty *min, QtProperty *max,
-                                        const QPair<double, double> &bounds) {
+                                        const std::pair<double, double> &bounds) {
   m_dblManager->setRange(min, bounds.first, bounds.second);
   m_dblManager->setRange(max, bounds.first, bounds.second);
   rs->setBounds(bounds.first, bounds.second);
@@ -212,8 +212,8 @@ void InelasticTab::setPlotPropertyRange(RangeSelector *rs, QtProperty *min, QtPr
  * @param range :: The range to set the range selector to.
  */
 void InelasticTab::setRangeSelector(RangeSelector *rs, QtProperty *lower, QtProperty *upper,
-                                    const QPair<double, double> &range,
-                                    const std::optional<QPair<double, double>> &bounds) {
+                                    const std::pair<double, double> &range,
+                                    const std::optional<std::pair<double, double>> &bounds) {
   m_dblManager->setValue(lower, range.first);
   m_dblManager->setValue(upper, range.second);
   rs->setRange(range.first, range.second);

--- a/qt/widgets/spectroscopy/src/InterfaceUtils.cpp
+++ b/qt/widgets/spectroscopy/src/InterfaceUtils.cpp
@@ -147,10 +147,6 @@ QStringList getCorrectionsWSSuffixes(std::string const &interfaceName) {
   return getWSSuffixes(interfaceName, "corrections");
 }
 
-QPair<double, double> convertTupleToQPair(std::tuple<double, double> const &doubleTuple) {
-  return QPair<double, double>(std::get<0>(doubleTuple), std::get<1>(doubleTuple));
-}
-
 std::pair<double, double> convertTupleToPair(std::tuple<double, double> const &doubleTuple) {
   return std::make_pair(std::get<0>(doubleTuple), std::get<1>(doubleTuple));
 }
@@ -168,7 +164,7 @@ QString makeQStringNumber(double value, int precision) { return QString::number(
  * @param bounds :: The upper and lower bounds to be set
  */
 void setPlotPropertyRange(QtDoublePropertyManager *dblPropertyManager, MantidWidgets::RangeSelector *rs,
-                          QtProperty *min, QtProperty *max, const QPair<double, double> &bounds) {
+                          QtProperty *min, QtProperty *max, const std::pair<double, double> &bounds) {
   dblPropertyManager->setRange(min, bounds.first, bounds.second);
   dblPropertyManager->setRange(max, bounds.first, bounds.second);
   rs->setBounds(bounds.first, bounds.second);
@@ -185,8 +181,8 @@ void setPlotPropertyRange(QtDoublePropertyManager *dblPropertyManager, MantidWid
  * @param range :: The range to set the range selector to.
  */
 void setRangeSelector(QtDoublePropertyManager *dblPropertyManager, MantidWidgets::RangeSelector *rs, QtProperty *lower,
-                      QtProperty *upper, const QPair<double, double> &range,
-                      const std::optional<QPair<double, double>> &bounds) {
+                      QtProperty *upper, const std::pair<double, double> &range,
+                      const std::optional<std::pair<double, double>> &bounds) {
   dblPropertyManager->setValue(lower, range.first);
   dblPropertyManager->setValue(upper, range.second);
   rs->setRange(range.first, range.second);


### PR DESCRIPTION
### Description of work
This PR removes the use of QPair for std::pair in the WorkspaceUtils and InterfaceUtils files used in much of the Spectroscopy code.

### To test:
Code review and follow these tests
https://developer.mantidproject.org/Testing/Inelastic/DataProcessorTests.html

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
