### PR TITLE
Import externally generated files on Muon ALC interface

### DIFF
--- a/docs/source/release/v6.12.0/Muon/ALC/New_features/38398.rst
+++ b/docs/source/release/v6.12.0/Muon/ALC/New_features/38398.rst
@@ -1,0 +1,1 @@
+- The :ref:`Muon ALC <MuonALC-ref>` interface can now import data from a matrix workspace which was externally generated (i.e. not previously exported from the Muon ALC interface).

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.cpp
@@ -23,7 +23,7 @@ void ALCBaselineModellingPresenter::initialize() {
   m_view->subscribePresenter(this);
 }
 
-void ALCBaselineModellingPresenter::subscribe(IALCBaselineModellingPresenterSubscriber *subscriber) {
+void ALCBaselineModellingPresenter::setSubscriber(IALCBaselineModellingPresenterSubscriber *subscriber) {
   m_subscriber = subscriber;
 }
 

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.h
@@ -44,7 +44,7 @@ public:
   void onSectionSelectorModified(int index) override;
 
   /// Subscribe to updates on changes to the corrected data.
-  void subscribe(IALCBaselineModellingPresenterSubscriber *subscriber);
+  void setSubscriber(IALCBaselineModellingPresenterSubscriber *subscriber);
 
   /// Updates data curve from the model
   void updateDataCurve();

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -28,7 +28,9 @@ void ALCDataLoadingPresenter::initialize() {
   m_view->setFileExtensions(ADDITIONAL_EXTENSIONS);
 }
 
-void ALCDataLoadingPresenter::subscribe(IALCDataLoadingPresenterSubscriber *subscriber) { m_subscriber = subscriber; }
+void ALCDataLoadingPresenter::setSubscriber(IALCDataLoadingPresenterSubscriber *subscriber) {
+  m_subscriber = subscriber;
+}
 
 void ALCDataLoadingPresenter::handleRunsEditing() {
   m_view->enableLoad(false);
@@ -140,6 +142,7 @@ void ALCDataLoadingPresenter::loadFilesCurrentlyInModel() {
   } catch (std::exception &e) {
     throw std::runtime_error(e.what()); // Caught in handle load request
   }
+  assert(m_subscriber);
   m_subscriber->loadedDataChanged();
   m_view->enableAll();
   m_model->setLoadingData(false);

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
@@ -9,7 +9,6 @@
 #include "DllConfig.h"
 #include "IALCDataLoadingModel.h"
 #include "IALCDataLoadingPresenter.h"
-#include "IALCDataLoadingView.h"
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/System.h"
@@ -17,6 +16,8 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+class IALCDataLoadingPresenterSubscriber;
+class IALCDataLoadingView;
 
 /** ALCDataLoadingPresenter : Presenter for ALC Data Loading step
  */
@@ -26,6 +27,8 @@ public:
   ALCDataLoadingPresenter(IALCDataLoadingView *view, std::unique_ptr<IALCDataLoadingModel> model);
 
   void initialize() override;
+
+  void subscribe(IALCDataLoadingPresenterSubscriber *subscriber) override;
 
   /// @return Last loaded data workspace
   Mantid::API::MatrixWorkspace_sptr loadedData() const override { return m_model->getLoadedData(); }
@@ -77,6 +80,9 @@ private:
 
   /// Update info on MuonPeriodInfo widget using sample logs from ws
   void updateAvailablePeriodInfo(const Mantid::API::MatrixWorkspace_sptr &ws);
+
+  /// Subscriber to notify of loaded data changes.
+  IALCDataLoadingPresenterSubscriber *m_subscriber;
 
   /// View which the object works with
   IALCDataLoadingView *m_view;

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
@@ -28,7 +28,7 @@ public:
 
   void initialize() override;
 
-  void subscribe(IALCDataLoadingPresenterSubscriber *subscriber) override;
+  void setSubscriber(IALCDataLoadingPresenterSubscriber *subscriber) override;
 
   /// @return Last loaded data workspace
   Mantid::API::MatrixWorkspace_sptr loadedData() const override { return m_model->getLoadedData(); }

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -190,8 +190,6 @@ void ALCDataLoadingView::setDataCurve(MatrixWorkspace_sptr workspace, std::size_
     m_ui.dataPlot->tickLabelFormat("x", "sci", true);
 
   m_ui.dataPlot->addSpectrum("Data", workspace, workspaceIndex, Qt::black, kwargs);
-
-  emit dataChanged();
 }
 
 void ALCDataLoadingView::displayError(const std::string &error) {

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.h
@@ -101,10 +101,6 @@ private slots:
   void notifyPeriodInfoClicked() override;
   void notifyTimerEvent() override;
 
-signals:
-  /// New data has been loaded
-  void dataChanged();
-
 private:
   /// Common function to set available items in a combo box
   void setAvailableItems(QComboBox *comboBox, const std::vector<std::string> &items);

--- a/qt/scientific_interfaces/Muon/ALCInterface.cpp
+++ b/qt/scientific_interfaces/Muon/ALCInterface.cpp
@@ -121,8 +121,8 @@ void ALCInterface::initLayout() {
   m_peakFitting = std::make_unique<ALCPeakFittingPresenter>(m_peakFittingView, m_peakFittingModel.get());
   m_peakFitting->initialize();
 
-  m_dataLoading->subscribe(this);
-  m_baselineModelling->subscribe(this);
+  m_dataLoading->setSubscriber(this);
+  m_baselineModelling->setSubscriber(this);
 
   assert(m_ui.stepView->count() == STEP_NAMES.count()); // Should have names for all steps
 

--- a/qt/scientific_interfaces/Muon/ALCInterface.cpp
+++ b/qt/scientific_interfaces/Muon/ALCInterface.cpp
@@ -103,7 +103,6 @@ void ALCInterface::initLayout() {
 
   auto dataLoadingModel = std::make_unique<ALCDataLoadingModel>();
   auto dataLoadingView = new ALCDataLoadingView(m_ui.dataLoadingView);
-  connect(dataLoadingView, &ALCDataLoadingView::dataChanged, this, &ALCInterface::updateBaselineData);
 
   m_dataLoading = std::make_unique<ALCDataLoadingPresenter>(dataLoadingView, std::move(dataLoadingModel));
   m_dataLoading->initialize();
@@ -122,6 +121,7 @@ void ALCInterface::initLayout() {
   m_peakFitting = std::make_unique<ALCPeakFittingPresenter>(m_peakFittingView, m_peakFittingModel.get());
   m_peakFitting->initialize();
 
+  m_dataLoading->subscribe(this);
   m_baselineModelling->subscribe(this);
 
   assert(m_ui.stepView->count() == STEP_NAMES.count()); // Should have names for all steps
@@ -129,7 +129,7 @@ void ALCInterface::initLayout() {
   switchStep(0); // We always start from the first step
 }
 
-void ALCInterface::updateBaselineData() {
+void ALCInterface::loadedDataChanged() {
 
   // Make sure we do have some data
   if (m_dataLoading->loadedData()) {
@@ -147,9 +147,7 @@ void ALCInterface::updateBaselineData() {
   }
 }
 
-void ALCInterface::correctedDataChanged() { updatePeakData(); }
-
-void ALCInterface::updatePeakData() {
+void ALCInterface::correctedDataChanged() {
 
   // Make sure we do have some data
   if (m_baselineModelling->correctedData()) {
@@ -295,7 +293,6 @@ void ALCInterface::importBaselineData(const std::string &workspaceName) {
   if (const auto baselineWS = getWorkspace(workspaceName)) {
     m_baselineModelling->setData(baselineWS);
     m_baselineModelling->setCorrectedData(baselineWS);
-    updatePeakData();
   }
 }
 

--- a/qt/scientific_interfaces/Muon/ALCInterface.h
+++ b/qt/scientific_interfaces/Muon/ALCInterface.h
@@ -17,6 +17,7 @@
 #include "ALCDataLoadingPresenter.h"
 #include "ALCPeakFittingPresenter.h"
 #include "IALCBaselineModellingPresenterSubscriber.h"
+#include "IALCDataLoadingPresenterSubscriber.h"
 
 #include "ui_ALCInterface.h"
 
@@ -34,12 +35,14 @@ class ALCPeakFittingModel;
 /** ALCInterface : Custom interface for Avoided Level Crossing analysis
  */
 class MANTIDQT_MUONINTERFACE_DLL ALCInterface : public API::UserSubWindow,
+                                                public IALCDataLoadingPresenterSubscriber,
                                                 public IALCBaselineModellingPresenterSubscriber {
   Q_OBJECT
 
 public:
   ALCInterface(QWidget *parent = nullptr);
 
+  void loadedDataChanged() override;
   void correctedDataChanged() override;
   void closeEvent(QCloseEvent *event) override;
   static std::string name() { return "ALC"; }
@@ -57,8 +60,6 @@ private slots:
   void exportResults();
   void importResults();
 
-  void updateBaselineData();
-  void updatePeakData();
   void externalPlotRequested();
 
 private:

--- a/qt/scientific_interfaces/Muon/CMakeLists.txt
+++ b/qt/scientific_interfaces/Muon/CMakeLists.txt
@@ -45,6 +45,7 @@ set(INC_FILES
     IALCDataLoadingView.h
     IALCDataLoadingModel.h
     IALCDataLoadingPresenter.h
+    IALCDataLoadingPresenterSubscriber.h
     IALCPeakFittingModel.h
     IALCPeakFittingView.h
     IALCPeakFittingModelSubscriber.h

--- a/qt/scientific_interfaces/Muon/IALCDataLoadingPresenter.h
+++ b/qt/scientific_interfaces/Muon/IALCDataLoadingPresenter.h
@@ -17,7 +17,7 @@ public:
 
   virtual void initialize() = 0;
 
-  virtual void subscribe(IALCDataLoadingPresenterSubscriber *subscriber) = 0;
+  virtual void setSubscriber(IALCDataLoadingPresenterSubscriber *subscriber) = 0;
 
   /// @return Last loaded data workspace
   virtual Mantid::API::MatrixWorkspace_sptr loadedData() const = 0;

--- a/qt/scientific_interfaces/Muon/IALCDataLoadingPresenter.h
+++ b/qt/scientific_interfaces/Muon/IALCDataLoadingPresenter.h
@@ -6,6 +6,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+class IALCDataLoadingPresenterSubscriber;
 
 /** IALCDataLoadingPresenter : Abstract Presenter for ALC Data Loading step
  */
@@ -15,6 +16,8 @@ public:
   virtual ~IALCDataLoadingPresenter() = default;
 
   virtual void initialize() = 0;
+
+  virtual void subscribe(IALCDataLoadingPresenterSubscriber *subscriber) = 0;
 
   /// @return Last loaded data workspace
   virtual Mantid::API::MatrixWorkspace_sptr loadedData() const = 0;

--- a/qt/scientific_interfaces/Muon/IALCDataLoadingPresenterSubscriber.h
+++ b/qt/scientific_interfaces/Muon/IALCDataLoadingPresenterSubscriber.h
@@ -1,0 +1,27 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllConfig.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+/** IALCDataLoadingPresenterSubscriber : Subscriber's interface for getting updates from
+ * ALCDataLoadingPresenter
+ */
+class MANTIDQT_MUONINTERFACE_DLL IALCDataLoadingPresenterSubscriber {
+
+public:
+  virtual ~IALCDataLoadingPresenterSubscriber() = default;
+
+  /// Notify the subscriber that the loaded data has changed.
+  virtual void loadedDataChanged() = 0;
+};
+
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Muon/test/ALCBaselineModellingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCBaselineModellingPresenterTest.h
@@ -134,7 +134,7 @@ public:
 
     m_presenter = std::make_unique<ALCBaselineModellingPresenter>(m_view.get(), std::move(model));
     m_presenter->initialize();
-    m_presenter->subscribe(m_parentPresenter.get());
+    m_presenter->setSubscriber(m_parentPresenter.get());
   }
 
   void tearDown() override {

--- a/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
@@ -15,6 +15,7 @@
 
 #include "../Muon/ALCDataLoadingModel.h"
 #include "../Muon/ALCDataLoadingPresenter.h"
+#include "../Muon/IALCDataLoadingPresenterSubscriber.h"
 #include "../Muon/IALCDataLoadingView.h"
 
 using namespace Mantid::API;
@@ -103,6 +104,11 @@ public:
   MOCK_METHOD(std::shared_ptr<MantidQt::MantidWidgets::MuonPeriodInfo>, getPeriodInfo, (), (override));
 };
 
+class MockALCDataLoadingPresenterSubscriber : public IALCDataLoadingPresenterSubscriber {
+public:
+  MOCK_METHOD(void, loadedDataChanged, (), (override));
+};
+
 MATCHER_P4(WorkspaceX, i, j, value, delta, "") {
   if (fabs(arg->x(i)[j] - value) < delta) {
     return true;
@@ -125,6 +131,7 @@ GNU_DIAG_ON_SUGGEST_OVERRIDE
 class ALCDataLoadingPresenterTest : public CxxTest::TestSuite {
 
   std::unique_ptr<MockALCDataLoadingView> m_view;
+  std::unique_ptr<MockALCDataLoadingPresenterSubscriber> m_subscriber;
   std::unique_ptr<ALCDataLoadingPresenter> m_presenter;
   ALCDataLoadingModel *m_model;
 
@@ -152,8 +159,10 @@ public:
     m_view = std::make_unique<NiceMock<MockALCDataLoadingView>>();
     auto model = std::make_unique<ALCDataLoadingModel>();
     m_model = model.get();
+    m_subscriber = std::make_unique<NiceMock<MockALCDataLoadingPresenterSubscriber>>();
     m_presenter = std::make_unique<ALCDataLoadingPresenter>(m_view.get(), std::move(model));
     m_presenter->initialize();
+    m_presenter->subscribe(m_subscriber.get());
 
     m_watcher = new QFileSystemWatcher();
     m_timer = new QTimer();

--- a/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
@@ -11,6 +11,7 @@
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidKernel/WarningSuppressions.h"
 
 #include "../Muon/ALCDataLoadingModel.h"
@@ -215,6 +216,15 @@ public:
     auto presenter = std::make_unique<ALCDataLoadingPresenter>(view.get(), std::move(model));
     TS_ASSERT_THROWS_EQUALS(presenter->setData(nullptr), const std::invalid_argument &e, std::string(e.what()),
                             "Cannot load an empty workspace");
+  }
+
+  void test_setData_notifies_the_subscriber() {
+    const MatrixWorkspace_sptr workspace = WorkspaceCreationHelper::create2DWorkspace(1, 5);
+
+    EXPECT_CALL(*m_view, setDataCurve(workspace, 0u)).Times(1);
+    EXPECT_CALL(*m_subscriber, loadedDataChanged()).Times(1);
+
+    m_presenter->setData(workspace);
   }
 
   void test_defaultLoad() {

--- a/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
@@ -163,7 +163,7 @@ public:
     m_subscriber = std::make_unique<NiceMock<MockALCDataLoadingPresenterSubscriber>>();
     m_presenter = std::make_unique<ALCDataLoadingPresenter>(m_view.get(), std::move(model));
     m_presenter->initialize();
-    m_presenter->subscribe(m_subscriber.get());
+    m_presenter->setSubscriber(m_subscriber.get());
 
     m_watcher = new QFileSystemWatcher();
     m_timer = new QTimer();


### PR DESCRIPTION
**Report to:** Adam Berlie

### Description of work
This PR makes it possible to import a workspace from the ADS into the Muon ALC interface if it has 1 histogram. The data can be loaded into Mantid from a *.dat or *.txt file for example, and then imported into the Muon ALC interface as long as its a matrix workspace.

Fixes #38353 

### To test:
1. Load the following data into workbench
[QLCR150K.zip](https://github.com/user-attachments/files/17749673/QLCR150K.zip)

3. Open `Muon`->`ALC` interface
4. Click `Import results...` in the bottom left
5. Enter the name of the workspace you loaded and click Okay
6. The plot should be populated with the data


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
