### PR TITLE
Fix error on create_vanadium if no sample details in ISIS powder reduction

### DIFF
--- a/docs/source/release/v6.12.0/Diffraction/Powder/Bugfixes/38399.rst
+++ b/docs/source/release/v6.12.0/Diffraction/Powder/Bugfixes/38399.rst
@@ -1,0 +1,1 @@
+- Fix bug where unable to call `create_vanadium` without setting sample details in :ref:`ISIS Powder Diffraction Scripts <isis-powder-diffraction-ref>`.

--- a/scripts/Diffraction/isis_powder/abstract_inst.py
+++ b/scripts/Diffraction/isis_powder/abstract_inst.py
@@ -198,7 +198,8 @@ class AbstractInst(object):
         return self._generate_inst_filename(run_number=run_number, file_ext=file_ext)
 
     def _check_sample_details(self):
-        if self._sample_details is None:
+        # note vanadium sample details are set using advanced configs
+        if self._sample_details is None and not self._is_vanadium:
             raise ValueError(
                 "Absorption corrections cannot be run without sample details."
                 " Please set sample details using set_sample before running absorption corrections."

--- a/scripts/Diffraction/isis_powder/test/ISISPowderAbstractInstrumentTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderAbstractInstrumentTest.py
@@ -274,6 +274,18 @@ class ISISPowderAbstractInstrumentTest(unittest.TestCase):
         expected_calls = 2 * [call(d_spacing_group=run_string, tof_group=run_string, unit_to_keep=None)]
         mock_keep_unit.assert_has_calls(expected_calls)
 
+    def test_check_sample_details_is_vanadium(self):
+        mock_inst = self._setup_mock_inst(calibration_dir="ignored", output_dir="ignored", yaml_file_path="ISISPowderRunDetailsTest.yaml")
+        mock_inst._is_vanadium = True
+        mock_inst._sample_details = None
+        mock_inst._check_sample_details()  # does not throw
+
+    def test_check_sample_details_is_not_vanadium(self):
+        mock_inst = self._setup_mock_inst(calibration_dir="ignored", output_dir="ignored", yaml_file_path="ISISPowderRunDetailsTest.yaml")
+        mock_inst._is_vanadium = False
+        mock_inst._sample_details = None
+        self.assertRaises(ValueError, mock_inst._check_sample_details)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description of work

Fix error on create_vanadium if no sample details in ISIS powder reduction - was checking if the sample details had been set on the class, but the sample details for vanadium are set in the advanced config automatically.

#### Purpose of work
Bug report from Helen Playford (POLARIS, ISIS) - was getting `ValueError` when calling `create_vanadium` and no sample details set. 

It seems to have been introduced in this PR #36809 in v6.11

*There is no associated issue.*

**Report to:** Helen Playford (POLARIS, ISIS)

### To test:
(1) Ask me for the config files 

(2) Run this script with updated paths
```
from isis_powder import polaris, SampleDetails

config_file_path = r"C:\Users\xhg73778\Downloads\POLARISPowderDiffractionFolderSmall\polaris_config_example.yaml"
polaris = polaris.Polaris(config_file=config_file_path, user_name="test", mode="PDF")

polaris.create_vanadium(first_cycle_run_no="98533", multiple_scattering=True, 
                         do_absorb_corrections=True, mayers_mult_scat_events=1)   
```

Should execute without error.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
