### PR TITLE
- Maintenance task for polarization correction Fredrikze Algorithm

### DIFF
--- a/Framework/Algorithms/src/PolarizationCorrectionFredrikze.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionFredrikze.cpp
@@ -25,8 +25,6 @@ using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;
 
 namespace Prop {
-constexpr auto PNR_LABEL("PNR");
-constexpr auto PA_LABEL("PA");
 constexpr auto EFFICIENCIES{"Efficiencies"};
 constexpr auto INPUT_WORKSPACE{"InputWorkspace"};
 constexpr auto OUTPUT_WORKSPACE{"OutputWorkspace"};
@@ -47,18 +45,22 @@ static const std::vector<std::string> defaultOrderForPNR = {Mantid::Algorithms::
 
 namespace {
 
-const std::string crhoLabel("Rho");
+const std::string CRHO_LABEL("Rho");
 
-const std::string cppLabel("Pp");
+const std::string CPP_LABEL("Pp");
 
-const std::string cAlphaLabel("Alpha");
+const std::string CALPHA_LABEL("Alpha");
 
-const std::string cApLabel("Ap");
+const std::string CAP_LABEL("Ap");
+
+const std::string PNR_LABEL("PNR");
+
+const std::string PA_LABEL("PA");
 
 std::vector<std::string> modes() {
   std::vector<std::string> modes;
-  modes.emplace_back(Prop::PA_LABEL);
-  modes.emplace_back(Prop::PNR_LABEL);
+  modes.emplace_back(PA_LABEL);
+  modes.emplace_back(PNR_LABEL);
   return modes;
 }
 
@@ -74,7 +76,7 @@ Instrument_const_sptr fetchInstrument(WorkspaceGroup const *const groupWS) {
 
 // Helper function to check valid spin states
 bool isValidSpinState(const std::vector<std::string> &spinStates, const std::string &analysisMode) {
-  if (analysisMode == Prop::PNR_LABEL) {
+  if (analysisMode == PNR_LABEL) {
     // for PR, spinStates must be "p,a", "a,p", or empty vector
     return (spinStates.size() == 2 &&
             ((spinStates[0] == Mantid::Algorithms::SpinStateConfigurationsFredrikze::PARA &&
@@ -82,7 +84,7 @@ bool isValidSpinState(const std::vector<std::string> &spinStates, const std::str
              (spinStates[0] == Mantid::Algorithms::SpinStateConfigurationsFredrikze::ANTI &&
               spinStates[1] == Mantid::Algorithms::SpinStateConfigurationsFredrikze::PARA))) ||
            spinStates.empty();
-  } else if (analysisMode == Prop::PA_LABEL) {
+  } else if (analysisMode == PA_LABEL) {
     // For PA, spinStates size must be 4 or empty
     return (spinStates.size() == 4 || spinStates.empty());
   }
@@ -302,10 +304,10 @@ WorkspaceGroup_sptr PolarizationCorrectionFredrikze::execPA(const WorkspaceGroup
   Ipa->setTitle("Ipa");
   Iap->setTitle("Iap");
 
-  const auto rho = this->getEfficiencyWorkspace(crhoLabel);
-  const auto pp = this->getEfficiencyWorkspace(cppLabel);
-  const auto alpha = this->getEfficiencyWorkspace(cAlphaLabel);
-  const auto ap = this->getEfficiencyWorkspace(cApLabel);
+  const auto rho = this->getEfficiencyWorkspace(CRHO_LABEL);
+  const auto pp = this->getEfficiencyWorkspace(CPP_LABEL);
+  const auto alpha = this->getEfficiencyWorkspace(CALPHA_LABEL);
+  const auto ap = this->getEfficiencyWorkspace(CAP_LABEL);
 
   const auto A0 = (Iaa * pp * ap) + (Ipa * ap * rho * pp) + (Iap * ap * alpha * pp) + (Ipp * ap * alpha * rho * pp);
   const auto A1 = Iaa * pp;
@@ -367,8 +369,8 @@ WorkspaceGroup_sptr PolarizationCorrectionFredrikze::execPNR(const WorkspaceGrou
   MatrixWorkspace_sptr Ip = inputMap[SpinStateConfigurationsFredrikze::PARA];
   MatrixWorkspace_sptr Ia = inputMap[SpinStateConfigurationsFredrikze::ANTI];
 
-  const auto rho = this->getEfficiencyWorkspace(crhoLabel);
-  const auto pp = this->getEfficiencyWorkspace(cppLabel);
+  const auto rho = this->getEfficiencyWorkspace(CRHO_LABEL);
+  const auto pp = this->getEfficiencyWorkspace(CPP_LABEL);
 
   const auto D = pp * (rho + 1);
 
@@ -410,7 +412,7 @@ PolarizationCorrectionFredrikze::getEfficiencyWorkspace(const std::string &label
     // Check if we need to fetch polarization parameters from the instrument's
     // parameters
     static std::map<std::string, std::string> loadableProperties{
-        {crhoLabel, "crho"}, {cppLabel, "cPp"}, {cApLabel, "cAp"}, {cAlphaLabel, "calpha"}};
+        {CRHO_LABEL, "crho"}, {CPP_LABEL, "cPp"}, {CAP_LABEL, "cAp"}, {CALPHA_LABEL, "calpha"}};
     WorkspaceGroup_sptr inWS = getProperty(Prop::INPUT_WORKSPACE);
     Instrument_const_sptr instrument = fetchInstrument(inWS.get());
     auto vals = instrument->getStringParameter(loadableProperties[label]);
@@ -452,13 +454,13 @@ void PolarizationCorrectionFredrikze::exec() {
   validateInputWorkspace(inWS, inputStatesStr, outputStatesStr, analysisMode);
 
   WorkspaceGroup_sptr outWS;
-  if (analysisMode == Prop::PA_LABEL) {
+  if (analysisMode == PA_LABEL) {
     if (nWorkspaces != 4) {
       throw std::invalid_argument("For PA analysis, input group must have 4 periods.");
     }
     g_log.notice("PA polarization correction");
     outWS = execPA(inWS, inputStates, outputStates);
-  } else if (analysisMode == Prop::PNR_LABEL) {
+  } else if (analysisMode == PNR_LABEL) {
     if (nWorkspaces != 2) {
       throw std::invalid_argument("For PNR analysis, input group must have 2 periods.");
     }

--- a/Framework/Algorithms/src/PolarizationCorrectionFredrikze.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionFredrikze.cpp
@@ -25,11 +25,11 @@ using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;
 
 namespace Prop {
-constexpr auto EFFICIENCIES{"Efficiencies"};
-constexpr auto INPUT_WORKSPACE{"InputWorkspace"};
-constexpr auto OUTPUT_WORKSPACE{"OutputWorkspace"};
-constexpr auto INPUT_SPIN_STATES("InputSpinStates");
-constexpr auto OUTPUT_SPIN_STATES("OutputSpinStates");
+static const std::string EFFICIENCIES{"Efficiencies"};
+static const std::string INPUT_WORKSPACE{"InputWorkspace"};
+static const std::string OUTPUT_WORKSPACE{"OutputWorkspace"};
+static const std::string INPUT_SPIN_STATES("InputSpinStates");
+static const std::string OUTPUT_SPIN_STATES("OutputSpinStates");
 
 // Default order for PA anaysis
 static const std::vector<std::string> defaultOrderForPA = {
@@ -45,17 +45,17 @@ static const std::vector<std::string> defaultOrderForPNR = {Mantid::Algorithms::
 
 namespace {
 
-const std::string CRHO_LABEL("Rho");
+static const std::string CRHO_LABEL("Rho");
 
-const std::string CPP_LABEL("Pp");
+static const std::string CPP_LABEL("Pp");
 
-const std::string CALPHA_LABEL("Alpha");
+static const std::string CALPHA_LABEL("Alpha");
 
-const std::string CAP_LABEL("Ap");
+static const std::string CAP_LABEL("Ap");
 
-const std::string PNR_LABEL("PNR");
+static const std::string PNR_LABEL("PNR");
 
-const std::string PA_LABEL("PA");
+static const std::string PA_LABEL("PA");
 
 std::vector<std::string> modes() {
   std::vector<std::string> modes;

--- a/docs/source/algorithms/PolarizationCorrectionFredrikze-v1.rst
+++ b/docs/source/algorithms/PolarizationCorrectionFredrikze-v1.rst
@@ -32,13 +32,10 @@ The algorithm expresses the order of the workspaces in the input and output grou
 This property determines the order of the spin states in the input workspace group
 
 - :literal:`'pp, pa, ap, aa'`
-   Full polarization analysis (:literal:`'PA'`): both parallel, parallel-anti-parallel, anti-parallel-parallel, both  anti-parallel. Four input workspaces are required. The spin states can be provided in any order and should match the order of the workspaces in the input group.
+   Full polarization analysis (:literal:`'PA'`): both parallel, parallel-anti-parallel, anti-parallel-parallel, both  anti-parallel. Four input workspaces are required. The spin states can be provided in any order and should match the order of the workspaces in the input group. the default order is :literal:`pp, pa, ap, aa`
 
 - :literal:`'p, a'`
-   Polarized Neutron Reflectivity (:literal:`'PNR'`):  parallel, anti-parallel. Two input workspaces are required. The spin states can be provided in any order and should match the order of the workspaces in the input group.
-
-.. note::
-    the default order used by the algorithm if none is specified are :literal:`pp, pa, ap, aa` for full polarization analysis or :literal:`p, a` for Polarized Neutron Reflectivity.
+   Polarized Neutron Reflectivity (:literal:`'PNR'`):  parallel, anti-parallel. Two input workspaces are required. The spin states can be provided in any order and should match the order of the workspaces in the input group. the default order is :literal:`p, a`
 
 **Output Spin State Order:**
 This property determines the order of the spin states in the output workspace group. Similar to the input configuration, users can specify output spin states in any order.
@@ -141,7 +138,7 @@ References
 ----------
 
 .. [#FREDRIKZE] Fredrikze, H, et al., *Calibration of a polarized neutron reflectometer*, Physica B 297 (2001)
-             `doi: 10.1016/S0921-4526(00)00823-1 <https://doi.org/10.1016/S0921-4526(00)00823-1>`
+             `doi: 10.1016/S0921-4526(00)00823-1 <https://doi.org/10.1016/S0921-4526(00)00823-1>`_
 
 .. categories::
 

--- a/docs/source/algorithms/PolarizationCorrectionFredrikze-v1.rst
+++ b/docs/source/algorithms/PolarizationCorrectionFredrikze-v1.rst
@@ -32,10 +32,10 @@ The algorithm expresses the order of the workspaces in the input and output grou
 This property determines the order of the spin states in the input workspace group
 
 - :literal:`'pp, pa, ap, aa'`
-   Full polarization analysis (:literal:`'PA'`): both parallel, parallel-anti-parallel, anti-parallel-parallel, both  anti-parallel. Four input workspaces are required. The spin states can be provided in any order and should match the order of the workspaces in the input group. the default order is :literal:`pp, pa, ap, aa`
+   Full polarization analysis (:literal:`'PA'`): both parallel, parallel-anti-parallel, anti-parallel-parallel, both  anti-parallel. Four input workspaces are required. The spin states can be provided in any order and should match the order of the workspaces in the input group. The default order is :literal:`pp, pa, ap, aa`.
 
 - :literal:`'p, a'`
-   Polarized Neutron Reflectivity (:literal:`'PNR'`):  parallel, anti-parallel. Two input workspaces are required. The spin states can be provided in any order and should match the order of the workspaces in the input group. the default order is :literal:`p, a`
+   Polarized Neutron Reflectivity (:literal:`'PNR'`):  parallel, anti-parallel. Two input workspaces are required. The spin states can be provided in any order and should match the order of the workspaces in the input group. The default order is :literal:`p, a`.
 
 **Output Spin State Order:**
 This property determines the order of the spin states in the output workspace group. Similar to the input configuration, users can specify output spin states in any order.


### PR DESCRIPTION
### Description of work
Move the PNR_LABEL and PA_LABEL constants out of the Prop namespace 
Rename some constants to use mantid naming convention 
updated documentation

One of the items in the referenced issue—replacing `'p'` and `'a'` with the constants `SpinStateConfigurationsFredrikze::PARA` and `SpinStateConfigurationsFredrikze::ANTI` in the creation of `spinStateValidator` using `std::make_shared<SpinStateValidator>(std::unordered_set<int>{2, 4}, true, 'p', 'a', true);`—could not be completed. This is because `SpinStateValidator` requires characters as inputs, but both constants are of type `std::string`. Additionally, these constants are used elsewhere in the code, making it difficult to change their type to characters.

Refs #38288 

### To test:
Follow the instructions on https://docs.mantidproject.org/nightly/algorithms/PolarizationCorrectionFredrikze-v1.html
unit tests should pass

*This does not require release notes because it is a maintenance task involving code changes