### PR TITLE
Fix crash when setting invalid filepaths in Flood Corrections and Polarization Corrections settings on Reflectometry interface

### DIFF
--- a/docs/source/release/v6.12.0/Reflectometry/Bugfixes/36469.rst
+++ b/docs/source/release/v6.12.0/Reflectometry/Bugfixes/36469.rst
@@ -1,0 +1,1 @@
+- Fix a bug in the :ref:`Experiment Settings<refl_exp_instrument_settings>` tab of the :ref:`Reflectometry Interface<interface-isis-refl>` where the input of certain File Paths (such as `"C:"`) in the `Polarization Correction` and `Flood Correction` text edits could cause a crash in Mantid from Windows.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -19,7 +19,7 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
 
-/** ExperiementView : Provides an interface for the "Experiement" tab in the
+/** ExperimentView : Provides an interface for the "Experiment" tab in the
 ISIS Reflectometry interface.
 */
 class MANTIDQT_ISISREFLECTOMETRY_DLL QtExperimentView : public QWidget, public IExperimentView {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
@@ -261,7 +261,11 @@ bool QtMainWindowView::fileExists(std::string const &filepath) const {
 }
 
 std::string QtMainWindowView::getFullFilePath(const std::string &filename) const {
-  return FileFinder::Instance().getFullPath(filename);
+  try {
+    return FileFinder::Instance().getFullPath(filename);
+  } catch (const Poco::PathSyntaxException &) {
+    return "";
+  }
 }
 
 } // namespace CustomInterfaces::ISISReflectometry


### PR DESCRIPTION
### Description of work
For certain input characters on windows, `Poco::Path` classes throw. The `FloodWorkspace` and `Polarization Efficiencies` slots are calling back to the `getFullFilePath`  on the file handler, which essentially wraps the equivalent function in the file finder api. I have added a try/catch block to handle this exception and avoid mantid crashing for invalid paths. 
This seems to be related to this issue on Poco libraries: https://github.com/pocoproject/poco/issues/4680


Fixes #36469 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
-Follow test instructions on #36469 , no crash should happen on windows. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*Added release notes*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
