### PR TITLE
Update pystog to v0.4.7

### DIFF
--- a/buildconfig/CMake/PyStoG.cmake
+++ b/buildconfig/CMake/PyStoG.cmake
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(_PyStoG_VERSION 4ad6d316bb94221e52b9a57fccbb65f4959972d3)
+set(_PyStoG_VERSION f184ebf9a72aae48ae0d5267fd6ab2e7df0988f6) # v0.4.7
 set(_PyStoG_download_dir ${CMAKE_CURRENT_BINARY_DIR}/../PyStoG-download)
 set(_PyStoG_source_dir ${_PyStoG_download_dir}/src/PyStoG/pystog)
 set(_PyStoG_source_test_dir ${_PyStoG_download_dir}/src/PyStoG/tests)
@@ -56,9 +56,6 @@ endforeach()
 foreach(_py_file ${_test_files_support})
   file(COPY ${_PyStoG_source_test_dir}/${_py_file} DESTINATION ${_PyStoG_test_dir})
 endforeach()
-
-# copy over the test data
-file(COPY ${_PyStoG_download_dir}/src/PyStoG/data/test_data DESTINATION ${_PyStoG_test_dir})
 
 # register the tests
 set(PYUNITTEST_PYTHONPATH_EXTRA ${_PyStoG_test_root_dir})

--- a/docs/source/release/v6.12.0/Diffraction/Powder/New_features/38404.rst
+++ b/docs/source/release/v6.12.0/Diffraction/Powder/New_features/38404.rst
@@ -1,0 +1,1 @@
+- Move `pystog <https://github.com/neutrons/pystog>`_ from v0.2.7 to v0.4.7


### PR DESCRIPTION
Previously it was pinned to v0.2.7 and this moves it to v0.4.7. 

*There is no associated issue.*

### To test:

The new version should still pass all the tests.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
