### PR TITLE
Move `H5Util` file to Mantid::Nexus library

### DIFF
--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -27,7 +27,6 @@ set(SRC_FILES
     src/GenerateGroupingPowder2.cpp
     src/GroupDetectors.cpp
     src/GroupDetectors2.cpp
-    src/H5Util.cpp
     src/ISISDataArchive.cpp
     src/ISISJournal.cpp
     src/ISISJournalGetExperimentRuns.cpp
@@ -251,7 +250,6 @@ set(INC_FILES
     inc/MantidDataHandling/GenerateGroupingPowder2.h
     inc/MantidDataHandling/GroupDetectors.h
     inc/MantidDataHandling/GroupDetectors2.h
-    inc/MantidDataHandling/H5Util.h
     inc/MantidDataHandling/ISISDataArchive.h
     inc/MantidDataHandling/ISISJournal.h
     inc/MantidDataHandling/ISISJournalGetExperimentRuns.h
@@ -475,7 +473,6 @@ set(TEST_FILES
     GenerateGroupingPowder2Test.h
     GroupDetectors2Test.h
     GroupDetectorsTest.h
-    H5UtilTest.h
     ISISDataArchiveTest.h
     ISISJournalGetExperimentRunsTest.h
     ISISJournalTest.h

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadHelper.h
@@ -6,8 +6,10 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/Run.h"
 #include "MantidDataHandling/DllConfig.h"
+#include "MantidKernel/Quat.h"
 #include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
@@ -116,7 +116,8 @@ private:
   void validateMultiPeriodLogs(const Mantid::API::MatrixWorkspace_sptr &);
 
   // build the list of spectra numbers to load and include in the spectra list
-  void buildSpectraInd2SpectraNumMap(bool range_supplied, bool hasSpectraList, DataBlockComposite &dataBlockComposite);
+  void buildSpectraInd2SpectraNumMap(bool range_supplied, bool hasSpectraList,
+                                     const DataBlockComposite &dataBlockComposite);
 
   /// Check if any of the spectra block ranges overlap
   void checkOverlappingSpectraRange();
@@ -171,8 +172,8 @@ private:
   boost::scoped_ptr< ::NeXus::File> m_nexusFile;
   // clang-format on
 
-  bool findSpectraDetRangeInFile(NeXus::NXEntry &entry, std::vector<specnum_t> &spectrum_index, int64_t ndets,
-                                 int64_t n_vms_compat_spectra, std::map<specnum_t, std::string> &monitors,
+  bool findSpectraDetRangeInFile(const NeXus::NXEntry &entry, std::vector<specnum_t> &spectrum_index, int64_t ndets,
+                                 int64_t n_vms_compat_spectra, const std::map<specnum_t, std::string> &monitors,
                                  bool excludeMonitors, bool separateMonitors);
 
   /// Check if is the file is a multiple time regime file

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMLZ.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMLZ.h
@@ -42,14 +42,14 @@ private:
 
   std::vector<std::vector<int>> getMonitorInfo(NeXus::NXEntry &firstEntry);
 
-  void initWorkSpace(NeXus::NXEntry &entry);
+  void initWorkspace(const NeXus::NXEntry &entry);
   void initInstrumentSpecific();
   void loadRunDetails(NeXus::NXEntry &entry);
   void loadExperimentDetails(const NeXus::NXEntry &entry);
 
   NeXus::NXData loadNexusFileData(NeXus::NXEntry &entry);
   void maskDetectors(const NeXus::NXEntry &entry);
-  void loadDataIntoTheWorkSpace(NeXus::NXEntry &entry); //, int ElasticPeakPosition = -1);
+  void loadDataIntoTheWorkSpace(const NeXus::NXEntry &entry); //, int ElasticPeakPosition = -1);
 
   void runLoadInstrument();
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
@@ -13,6 +13,7 @@
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/NexusFileLoader.h"
+#include "MantidAPI/Sample.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidHistogramData/BinEdges.h"
 #include "MantidKernel/cow_ptr.h"

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSINQFocus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSINQFocus.h
@@ -46,7 +46,7 @@ private:
   void init() override;
   void exec() override;
   void setInstrumentName(const NeXus::NXEntry &entry);
-  void initWorkSpace(NeXus::NXEntry &);
+  void initWorkSpace(const NeXus::NXEntry &);
   void loadDataIntoTheWorkSpace(NeXus::NXEntry &);
   /// Calculate error for y
   static double calculateError(double in) { return sqrt(in); }

--- a/Framework/DataHandling/src/DataBlockComposite.cpp
+++ b/Framework/DataHandling/src/DataBlockComposite.cpp
@@ -6,8 +6,10 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidDataHandling/DataBlockComposite.h"
 #include "MantidDataHandling/DataBlockGenerator.h"
+
 #include <algorithm>
 #include <cassert>
+#include <numeric>
 
 namespace {
 

--- a/Framework/DataHandling/src/DataBlockComposite.cpp
+++ b/Framework/DataHandling/src/DataBlockComposite.cpp
@@ -382,7 +382,7 @@ void DataBlockComposite::removeSpectra(DataBlockComposite &toRemove) {
   // Now create the new intervals which don't include the removeInterval
   // values
   std::vector<SpectrumPair> newIntervals;
-  for (auto &originalInterval : originalIntervals) {
+  for (const auto &originalInterval : originalIntervals) {
     // Find all relevant remove intervals. In principal this could
     // be made more efficient.
     auto currentRemovalIntervals =

--- a/Framework/DataHandling/src/LoadDiffCal.cpp
+++ b/Framework/DataHandling/src/LoadDiffCal.cpp
@@ -11,7 +11,6 @@
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidDataHandling/H5Util.h"
 #include "MantidDataHandling/LoadCalFile.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidDataObjects/MaskWorkspace.h"
@@ -21,6 +20,7 @@
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/Unit.h"
+#include "MantidNexus/H5Util.h"
 
 #include <H5Cpp.h>
 #include <cmath>
@@ -44,6 +44,7 @@ using Mantid::Kernel::PropertyWithValue;
 using Mantid::Kernel::Exception::FileError;
 
 using namespace H5;
+using namespace NeXus;
 
 namespace {
 enum class CalibFilenameExtensionEnum { H5, HD5, HDF, CAL, enum_count };

--- a/Framework/DataHandling/src/LoadILLDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLDiffraction.cpp
@@ -11,7 +11,6 @@
 #include "MantidAPI/RegisterFileLoader.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceFactory.h"
-#include "MantidDataHandling/H5Util.h"
 #include "MantidDataHandling/LoadHelper.h"
 #include "MantidDataObjects/ScanningWorkspaceBuilder.h"
 #include "MantidGeometry/Instrument/ComponentHelper.h"
@@ -22,6 +21,7 @@
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/TimeSeriesProperty.h"
+#include "MantidNexus/H5Util.h"
 
 #include <H5Cpp.h>
 #include <Poco/Path.h>

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -16,6 +16,7 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/RegisterFileLoader.h"
+#include "MantidAPI/Sample.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/Detector.h"

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -605,7 +605,7 @@ below have to be processed rather then spectra list
 intervals
 **/
 void LoadISISNexus2::buildSpectraInd2SpectraNumMap(bool range_supplied, bool hasSpectraList,
-                                                   DataBlockComposite &dataBlockComposite) {
+                                                   const DataBlockComposite &dataBlockComposite) {
 
   if (range_supplied || hasSpectraList || true) {
     auto generator = dataBlockComposite.getGenerator();
@@ -944,9 +944,10 @@ double LoadISISNexus2::dblSqrt(double in) { return sqrt(in); }
  *                               (contain different number of time channels)
  *
  */
-bool LoadISISNexus2::findSpectraDetRangeInFile(NXEntry &entry, std::vector<specnum_t> &spectrum_index, int64_t ndets,
-                                               int64_t n_vms_compat_spectra, std::map<specnum_t, std::string> &monitors,
-                                               bool excludeMonitors, bool separateMonitors) {
+bool LoadISISNexus2::findSpectraDetRangeInFile(const NXEntry &entry, std::vector<specnum_t> &spectrum_index,
+                                               int64_t ndets, int64_t n_vms_compat_spectra,
+                                               const std::map<specnum_t, std::string> &monitors, bool excludeMonitors,
+                                               bool separateMonitors) {
   size_t nmons = monitors.size();
 
   if (nmons > 0) {

--- a/Framework/DataHandling/src/LoadInstrumentFromNexus.cpp
+++ b/Framework/DataHandling/src/LoadInstrumentFromNexus.cpp
@@ -9,6 +9,7 @@
 //----------------------------------------------------------------------
 #include "MantidDataHandling/LoadInstrumentFromNexus.h"
 #include "MantidAPI/FileProperty.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/CompAssembly.h"
 #include "MantidGeometry/Instrument/Component.h"

--- a/Framework/DataHandling/src/LoadMLZ.cpp
+++ b/Framework/DataHandling/src/LoadMLZ.cpp
@@ -78,7 +78,7 @@ void LoadMLZ::exec() {
   loadInstrumentDetails(dataFirstEntry);
   loadTimeDetails(dataFirstEntry);
 
-  initWorkSpace(dataFirstEntry);
+  initWorkspace(dataFirstEntry);
 
   // load the instrument from the IDF
   runLoadInstrument();
@@ -170,7 +170,7 @@ void LoadMLZ::loadInstrumentDetails(const NeXus::NXEntry &firstEntry) {
  * @param entry :: The Nexus entry
  *
  */
-void LoadMLZ::initWorkSpace(NeXus::NXEntry &entry) //, const std::vector<std::vector<int> >&monitors)
+void LoadMLZ::initWorkspace(const NeXus::NXEntry &entry) //, const std::vector<std::vector<int> >&monitors)
 {
   // read in the data
   NXData dataGroup = entry.openNXData("data");
@@ -353,7 +353,7 @@ void LoadMLZ::loadExperimentDetails(const NXEntry &entry) {
  *
  * @param entry :: The Nexus entry
  */
-void LoadMLZ::loadDataIntoTheWorkSpace(NeXus::NXEntry &entry) {
+void LoadMLZ::loadDataIntoTheWorkSpace(const NeXus::NXEntry &entry) {
   // read in the data
   NXData dataGroup = entry.openNXData("data");
   NXInt data = dataGroup.openIntData();

--- a/Framework/DataHandling/src/LoadMLZ.cpp
+++ b/Framework/DataHandling/src/LoadMLZ.cpp
@@ -10,6 +10,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/RegisterFileLoader.h"
+#include "MantidAPI/Sample.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataHandling/LoadHelper.h"

--- a/Framework/DataHandling/src/LoadMcStas.cpp
+++ b/Framework/DataHandling/src/LoadMcStas.cpp
@@ -13,7 +13,6 @@
 #include "MantidAPI/RegisterFileLoader.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
-#include "MantidDataHandling/H5Util.h"
 #include "MantidDataHandling/LoadEventNexus.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/InstrumentDefinitionParser.h"
@@ -21,6 +20,7 @@
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
+#include "MantidNexus/H5Util.h"
 
 #include <H5Cpp.h>
 #include <boost/algorithm/string.hpp>
@@ -29,6 +29,7 @@ namespace Mantid::DataHandling {
 using namespace Kernel;
 using namespace API;
 using namespace DataObjects;
+using namespace NeXus;
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_NEXUS_HDF5_FILELOADER_ALGORITHM(LoadMcStas)

--- a/Framework/DataHandling/src/LoadMuonNexus2.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus2.cpp
@@ -5,11 +5,13 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidDataHandling/LoadMuonNexus2.h"
+
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/RegisterFileLoader.h"
 #include "MantidAPI/Run.h"
+#include "MantidAPI/Sample.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataHandling/LoadMuonNexus1.h"
@@ -24,6 +26,7 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/UnitLabelTypes.h"
 #include "MantidNexus/NexusClasses.h"
+
 #include <Poco/Path.h>
 #include <memory>
 // clang-format off

--- a/Framework/DataHandling/src/LoadMuonNexus2.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus2.cpp
@@ -148,7 +148,7 @@ void LoadMuonNexus2::doExec() {
 
   std::string detectorName;
   // Only the first NXdata found
-  for (auto &group : entry.groups()) {
+  for (const auto &group : entry.groups()) {
     std::string className = group.nxclass;
     if (className == "NXdata") {
       detectorName = group.nxname;
@@ -486,7 +486,7 @@ std::map<int, std::set<int>> LoadMuonNexus2::loadDetectorMapping(const Mantid::N
   NXEntry entry = root.openEntry(m_entry_name);
   const std::string detectorName = [&entry]() {
     // Only the first NXdata found
-    for (auto &group : entry.groups()) {
+    for (const auto &group : entry.groups()) {
       std::string className = group.nxclass;
       if (className == "NXdata") {
         return group.nxname;

--- a/Framework/DataHandling/src/LoadQKK.cpp
+++ b/Framework/DataHandling/src/LoadQKK.cpp
@@ -13,6 +13,7 @@
 #include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
+#include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
 #include "MantidIndexing/IndexInfo.h"
 #include "MantidKernel/UnitFactory.h"

--- a/Framework/DataHandling/src/LoadSINQFocus.cpp
+++ b/Framework/DataHandling/src/LoadSINQFocus.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/RegisterFileLoader.h"
+#include "MantidAPI/Sample.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataHandling/LoadHelper.h"
 #include "MantidGeometry/Instrument.h"

--- a/Framework/DataHandling/src/LoadSINQFocus.cpp
+++ b/Framework/DataHandling/src/LoadSINQFocus.cpp
@@ -122,7 +122,7 @@ void LoadSINQFocus::setInstrumentName(const NeXus::NXEntry &entry) {
   m_instrumentName = m_instrumentName.substr(0, pos);
 }
 
-void LoadSINQFocus::initWorkSpace(NeXus::NXEntry &entry) {
+void LoadSINQFocus::initWorkSpace(const NeXus::NXEntry &entry) {
 
   // read in the data
   NXData dataGroup = entry.openNXData("merged");

--- a/Framework/DataHandling/src/SaveDiffCal.cpp
+++ b/Framework/DataHandling/src/SaveDiffCal.cpp
@@ -7,9 +7,9 @@
 #include "MantidDataHandling/SaveDiffCal.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/ITableWorkspace.h"
-#include "MantidDataHandling/H5Util.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidDataObjects/MaskWorkspace.h"
+#include "MantidNexus/H5Util.h"
 
 #include <H5Cpp.h>
 #include <Poco/File.h>
@@ -30,6 +30,7 @@ using Mantid::DataObjects::MaskWorkspace_const_sptr;
 using Mantid::Kernel::Direction;
 
 using namespace H5;
+using namespace NeXus;
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(SaveDiffCal)

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -316,7 +316,7 @@ std::string getDate() {
 void addPropertyFromRunIfExists(Run const &run, std::string const &propertyName, H5::Group &sasGroup,
                                 std::string const &sasTerm) {
   if (run.hasProperty(propertyName)) {
-    auto property = run.getProperty(propertyName);
+    const auto *property = run.getProperty(propertyName);
     Mantid::NeXus::H5Util::write(sasGroup, sasTerm, property->value());
   }
 }
@@ -408,7 +408,7 @@ WorkspaceDimensionality getWorkspaceDimensionality(const Mantid::API::MatrixWork
 
 //------- SASdata
 
-std::string getIntensityUnitLabel(std::string intensityUnitLabel) {
+std::string getIntensityUnitLabel(const std::string &intensityUnitLabel) {
   if (intensityUnitLabel == "I(q) (cm-1)") {
     return sasIntensity;
   } else {
@@ -424,7 +424,7 @@ std::string getIntensityUnit(const Mantid::API::MatrixWorkspace_sptr &workspace)
   return iUnit;
 }
 
-std::string getMomentumTransferLabel(std::string momentumTransferLabel) {
+std::string getMomentumTransferLabel(const std::string &momentumTransferLabel) {
   if (momentumTransferLabel == "Angstrom^-1") {
     return sasMomentumTransfer;
   } else {

--- a/Framework/DataHandling/test/LoadISISNexusTest.h
+++ b/Framework/DataHandling/test/LoadISISNexusTest.h
@@ -10,6 +10,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Sample.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataHandling/LoadISISNexus2.h"

--- a/Framework/DataHandling/test/LoadMuonNexus2Test.h
+++ b/Framework/DataHandling/test/LoadMuonNexus2Test.h
@@ -19,6 +19,7 @@
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/Run.h"
+#include "MantidAPI/Sample.h"
 #include "MantidDataHandling/LoadMuonNexus2.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/TimeSeriesProperty.h"

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -11,12 +11,12 @@
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidDataHandling/H5Util.h"
 #include "MantidDataHandling/NXcanSASDefinitions.h"
 #include "MantidDataHandling/SaveNXcanSAS.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/UnitFactory.h"
+#include "MantidNexus/H5Util.h"
 
 #include "NXcanSASTestHelper.h"
 
@@ -434,29 +434,29 @@ private:
 
     // canSAS_class and NX_class attribute
     std::string classAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(entry, sasclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(entry, sasclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be SASentry class", classAttribute, sasEntryClassAttr);
-    Mantid::DataHandling::H5Util::readStringAttribute(entry, nxclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(entry, nxclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be NXentr class", classAttribute, nxEntryClassAttr);
 
     // Version attribute
     std::string versionAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(entry, sasEntryVersionAttr, versionAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(entry, sasEntryVersionAttr, versionAttribute);
     TSM_ASSERT_EQUALS("Version should be 1.0", versionAttribute, sasEntryVersionAttrValue);
 
     // Definition data set
     auto definitionDataSet = entry.openDataSet(sasEntryDefinition);
-    auto definitionValue = Mantid::DataHandling::H5Util::readString(definitionDataSet);
+    auto definitionValue = Mantid::NeXus::H5Util::readString(definitionDataSet);
     TSM_ASSERT_EQUALS("File definition should be NXcanSAS", definitionValue, sasEntryDefinitionFormat);
 
     // Run data set
     auto runDataSet = entry.openDataSet(sasEntryRun);
-    auto runValue = Mantid::DataHandling::H5Util::readString(runDataSet);
+    auto runValue = Mantid::NeXus::H5Util::readString(runDataSet);
     TSM_ASSERT_EQUALS("Run number should have been stored.", runValue, run);
 
     // Title data set
     auto titleDataSet = entry.openDataSet(sasEntryTitle);
-    auto titleValue = Mantid::DataHandling::H5Util::readString(titleDataSet);
+    auto titleValue = Mantid::NeXus::H5Util::readString(titleDataSet);
     TSM_ASSERT_EQUALS("The title should have been stored as the workspace name.", titleValue, title);
   }
 
@@ -467,14 +467,14 @@ private:
 
     // canSAS_class and NX_class attribute
     std::string classAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(source, sasclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(source, sasclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be SASsource class", classAttribute, sasInstrumentSourceClassAttr);
-    Mantid::DataHandling::H5Util::readStringAttribute(source, nxclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(source, nxclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be NXsource class", classAttribute, nxInstrumentSourceClassAttr);
 
     // Radiation data set
     auto radiationDataSet = source.openDataSet(sasInstrumentSourceRadiation);
-    auto radiationValue = Mantid::DataHandling::H5Util::readString(radiationDataSet);
+    auto radiationValue = Mantid::NeXus::H5Util::readString(radiationDataSet);
     TSM_ASSERT_EQUALS("Radiation sources should match.", radiationValue, radiationSource);
   }
 
@@ -486,26 +486,26 @@ private:
 
     // canSAS_class and NX_class attribute
     std::string classAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(aperture, sasclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(aperture, sasclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be SASaperture class", classAttribute, sasInstrumentApertureClassAttr);
-    Mantid::DataHandling::H5Util::readStringAttribute(aperture, nxclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(aperture, nxclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be NXaperture class", classAttribute, nxInstrumentApertureClassAttr);
 
     // beam_shape data set
     auto beamShapeDataSet = aperture.openDataSet(sasInstrumentApertureShape);
-    auto beamShapeValue = Mantid::DataHandling::H5Util::readString(beamShapeDataSet);
+    auto beamShapeValue = Mantid::NeXus::H5Util::readString(beamShapeDataSet);
     TSM_ASSERT_EQUALS("Beam Shapes should match.", beamShapeValue, beamShape);
 
     // beam_height data set
     auto beamHeightDataSet = aperture.openDataSet(sasInstrumentApertureGapHeight);
     std::vector<double> beamHeightValue;
-    Mantid::DataHandling::H5Util::readArray1DCoerce(beamHeightDataSet, beamHeightValue);
+    Mantid::NeXus::H5Util::readArray1DCoerce(beamHeightDataSet, beamHeightValue);
     TSM_ASSERT_EQUALS("Beam height should match.", beamHeightValue[0], beamHeight);
 
     // beam_width data set
     auto beamWidthDataSet = aperture.openDataSet(sasInstrumentApertureGapWidth);
     std::vector<double> beamWidthValue;
-    Mantid::DataHandling::H5Util::readArray1DCoerce(beamWidthDataSet, beamWidthValue);
+    Mantid::NeXus::H5Util::readArray1DCoerce(beamWidthDataSet, beamWidthValue);
     TSM_ASSERT_EQUALS("Beam width should match.", beamWidthValue[0], beamWidth);
   }
 
@@ -520,19 +520,19 @@ private:
 
       // canSAS_class and NX_class attribute
       std::string classAttribute;
-      Mantid::DataHandling::H5Util::readStringAttribute(detectorGroup, sasclass, classAttribute);
+      Mantid::NeXus::H5Util::readStringAttribute(detectorGroup, sasclass, classAttribute);
       TSM_ASSERT_EQUALS("Should be SASdetector class", classAttribute, sasInstrumentDetectorClassAttr);
-      Mantid::DataHandling::H5Util::readStringAttribute(detectorGroup, nxclass, classAttribute);
+      Mantid::NeXus::H5Util::readStringAttribute(detectorGroup, nxclass, classAttribute);
       TSM_ASSERT_EQUALS("Should be NXdetector class", classAttribute, nxInstrumentDetectorClassAttr);
 
       // Detector name data set
       auto name = detectorGroup.openDataSet(sasInstrumentDetectorName);
-      auto nameValue = Mantid::DataHandling::H5Util::readString(name);
+      auto nameValue = Mantid::NeXus::H5Util::readString(name);
       TSM_ASSERT_EQUALS("Radiation sources should match.", nameValue, detector);
 
       // SDD  data set
       auto sdd = detectorGroup.openDataSet(sasInstrumentDetectorSdd);
-      TS_ASSERT_THROWS_NOTHING(Mantid::DataHandling::H5Util::readString(sdd));
+      TS_ASSERT_THROWS_NOTHING(Mantid::NeXus::H5Util::readString(sdd));
     }
   }
 
@@ -546,7 +546,7 @@ private:
         auto subGroup = instrument.openGroup(subGroupName);
         // canSAS_class and NX_class attribute
         std::string classAttribute;
-        Mantid::DataHandling::H5Util::readStringAttribute(subGroup, sasclass, classAttribute);
+        Mantid::NeXus::H5Util::readStringAttribute(subGroup, sasclass, classAttribute);
         TSM_ASSERT("Should not be a detector", classAttribute != sasInstrumentDetectorClassAttr);
       }
     }
@@ -560,19 +560,19 @@ private:
 
     // canSAS_class and NX_class attribute
     std::string classAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(instrument, sasclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(instrument, sasclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be SASentry class", classAttribute, sasInstrumentClassAttr);
-    Mantid::DataHandling::H5Util::readStringAttribute(instrument, nxclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(instrument, nxclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be NXentry class", classAttribute, nxInstrumentClassAttr);
 
     // Name data set
     auto instrumentNameDataSet = instrument.openDataSet(sasInstrumentName);
-    auto instrumentNameValue = Mantid::DataHandling::H5Util::readString(instrumentNameDataSet);
+    auto instrumentNameValue = Mantid::NeXus::H5Util::readString(instrumentNameDataSet);
     TSM_ASSERT_EQUALS("Name of the instrument should have been stored", instrumentNameValue, instrumentName);
 
     // IDF data set
     auto idfDataSet = instrument.openDataSet(sasInstrumentIDF);
-    auto idfValue = Mantid::DataHandling::H5Util::readString(idfDataSet);
+    auto idfValue = Mantid::NeXus::H5Util::readString(idfDataSet);
     TSM_ASSERT_EQUALS("The idf should have been stored", idfValue, idf);
 
     // Check source
@@ -599,7 +599,7 @@ private:
     // sample thickness data set
     auto thicknessDataSet = sample.openDataSet(sasInstrumentSampleThickness);
     std::vector<double> thicknessValue;
-    Mantid::DataHandling::H5Util::readArray1DCoerce<double>(thicknessDataSet, thicknessValue);
+    Mantid::NeXus::H5Util::readArray1DCoerce<double>(thicknessDataSet, thicknessValue);
     TSM_ASSERT_EQUALS("Sample thickness should match.", thicknessValue[0], thickness);
   }
 
@@ -612,48 +612,48 @@ private:
 
     // canSAS_class and NX_class attribute
     std::string classAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(process, sasclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(process, sasclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be SASprocess class", classAttribute, sasProcessClassAttr);
-    Mantid::DataHandling::H5Util::readStringAttribute(process, nxclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(process, nxclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be NXprocess class", classAttribute, nxProcessClassAttr);
 
     // Date data set
     auto dateDataSet = process.openDataSet(sasProcessDate);
-    TS_ASSERT_THROWS_NOTHING(Mantid::DataHandling::H5Util::readString(dateDataSet));
+    TS_ASSERT_THROWS_NOTHING(Mantid::NeXus::H5Util::readString(dateDataSet));
 
     // SVN data set
     auto svnDataSet = process.openDataSet(sasProcessTermSvn);
-    TS_ASSERT_THROWS_NOTHING(Mantid::DataHandling::H5Util::readString(svnDataSet));
+    TS_ASSERT_THROWS_NOTHING(Mantid::NeXus::H5Util::readString(svnDataSet));
 
     // Name data set
     auto nameDataSet = process.openDataSet(sasProcessName);
-    auto nameValue = Mantid::DataHandling::H5Util::readString(nameDataSet);
+    auto nameValue = Mantid::NeXus::H5Util::readString(nameDataSet);
     TSM_ASSERT_EQUALS("Should have the Mantid NXcanSAS process name", nameValue, sasProcessNameValue);
 
     // User file
     auto userFileDataSet = process.openDataSet(sasProcessTermUserFile);
-    auto userFileValue = Mantid::DataHandling::H5Util::readString(userFileDataSet);
+    auto userFileValue = Mantid::NeXus::H5Util::readString(userFileDataSet);
     TSM_ASSERT_EQUALS("Should have the Mantid NXcanSAS process name", userFileValue, userFile);
 
     if (hasSampleRuns) {
       auto sampleDirectRunDataSet = process.openDataSet(sasProcessTermSampleDirect);
-      auto sampleDirectRunValue = Mantid::DataHandling::H5Util::readString(sampleDirectRunDataSet);
+      auto sampleDirectRunValue = Mantid::NeXus::H5Util::readString(sampleDirectRunDataSet);
       TSM_ASSERT_EQUALS("Should have correct sample direct run number", sampleDirectRunValue, sampleDirectRun);
     }
 
     if (hasCanRuns) {
       auto canDirectRunDataSet = process.openDataSet(sasProcessTermCanDirect);
-      auto canDirectRunValue = Mantid::DataHandling::H5Util::readString(canDirectRunDataSet);
+      auto canDirectRunValue = Mantid::NeXus::H5Util::readString(canDirectRunDataSet);
       TSM_ASSERT_EQUALS("Should have correct can direct run number", canDirectRunValue, canDirectRun);
     }
 
     if (hasBgSub) {
       auto scaledBgSubWorkspaceDataSet = process.openDataSet(sasProcessTermScaledBgSubWorkspace);
-      auto scaledBgSubWorkspaceValue = Mantid::DataHandling::H5Util::readString(scaledBgSubWorkspaceDataSet);
+      auto scaledBgSubWorkspaceValue = Mantid::NeXus::H5Util::readString(scaledBgSubWorkspaceDataSet);
       TSM_ASSERT_EQUALS("Should have correct scaled background subtraction workspace", scaledBgSubWorkspaceValue,
                         scaledBgSubWorkspace);
       auto scaledBgSubScaleFactorDataSet = process.openDataSet(sasProcessTermScaledBgSubScaleFactor);
-      auto scaledBgSubScaleFactorValue = Mantid::DataHandling::H5Util::readString(scaledBgSubScaleFactorDataSet);
+      auto scaledBgSubScaleFactorValue = Mantid::NeXus::H5Util::readString(scaledBgSubScaleFactorDataSet);
       TSM_ASSERT_EQUALS("Should have correct scaled background subtraction scale factor",
                         stod(scaledBgSubScaleFactorValue), scaledBgSubScaleFactor);
     }
@@ -661,14 +661,14 @@ private:
 
   void do_assert_1D_vector_with_same_entries(H5::DataSet &dataSet, double referenceValue, int size) {
     std::vector<double> data;
-    Mantid::DataHandling::H5Util::readArray1DCoerce<double>(dataSet, data);
+    Mantid::NeXus::H5Util::readArray1DCoerce<double>(dataSet, data);
     TS_ASSERT_EQUALS(data.size(), static_cast<size_t>(size));
     TS_ASSERT_EQUALS(data[0], referenceValue);
   }
 
   void do_assert_1D_vector_with_increasing_entries(H5::DataSet &dataSet, double min, double increment, int size) {
     std::vector<double> data;
-    Mantid::DataHandling::H5Util::readArray1DCoerce<double>(dataSet, data);
+    Mantid::NeXus::H5Util::readArray1DCoerce<double>(dataSet, data);
     TS_ASSERT_EQUALS(data.size(), static_cast<size_t>(size));
     for (size_t index = 0; index < data.size(); ++index) {
       TS_ASSERT_EQUALS(data[index], min);
@@ -736,33 +736,33 @@ private:
 
     // canSAS_class and NX_class attribute
     std::string classAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(data, sasclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(data, sasclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be SASdata class", classAttribute, sasDataClassAttr);
-    Mantid::DataHandling::H5Util::readStringAttribute(data, nxclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(data, nxclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be NXdata class", classAttribute, nxDataClassAttr);
 
     // I_axes attribute
     std::string intensityAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(data, sasDataIAxesAttr, intensityAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(data, sasDataIAxesAttr, intensityAttribute);
     TSM_ASSERT_EQUALS("Should be just Q", intensityAttribute, sasDataQ);
 
     // I_uncertainty attribute
     std::string errorAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(data, sasDataIUncertaintyAttr, errorAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(data, sasDataIUncertaintyAttr, errorAttribute);
     TSM_ASSERT_EQUALS("Should be just Idev", errorAttribute, sasDataIdev);
 
     // I_uncertainties attribute
     std::string errorAlternativeAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(data, sasDataIUncertaintiesAttr, errorAlternativeAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(data, sasDataIUncertaintiesAttr, errorAlternativeAttribute);
     TSM_ASSERT_EQUALS("Should be just Idev", errorAlternativeAttribute, sasDataIdev);
 
     // Q_indices attribute
-    auto qAttribute = Mantid::DataHandling::H5Util::readNumArrayAttributeCoerce<int>(data, sasDataQIndicesAttr);
+    auto qAttribute = Mantid::NeXus::H5Util::readNumArrayAttributeCoerce<int>(data, sasDataQIndicesAttr);
     TSM_ASSERT_EQUALS("Should be just 0", qAttribute, std::vector<int>{0});
 
     // Signal attribute
     std::string signalAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(data, sasSignal, signalAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(data, sasSignal, signalAttribute);
     TSM_ASSERT_EQUALS("Should be just I", signalAttribute, sasDataI);
 
     // I data set
@@ -771,12 +771,12 @@ private:
 
     // I data set uncertainty attribute
     std::string uncertaintyIAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(intensityDataSet, sasUncertaintyAttr, uncertaintyIAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(intensityDataSet, sasUncertaintyAttr, uncertaintyIAttribute);
     TSM_ASSERT_EQUALS("Should be just Idev", uncertaintyIAttribute, sasDataIdev);
 
     // I data set uncertainties attribute
     std::string uncertaintiesIAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(intensityDataSet, sasUncertaintiesAttr, uncertaintiesIAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(intensityDataSet, sasUncertaintiesAttr, uncertaintiesIAttribute);
     TSM_ASSERT_EQUALS("Should be just Idev", uncertaintiesIAttribute, sasDataIdev);
 
     // I dev data set
@@ -791,12 +791,12 @@ private:
     if (hasDx) {
       // Q data set uncertainty attribute
       std::string uncertaintyQAttribute;
-      Mantid::DataHandling::H5Util::readStringAttribute(qDataSet, sasUncertaintyAttr, uncertaintyQAttribute);
+      Mantid::NeXus::H5Util::readStringAttribute(qDataSet, sasUncertaintyAttr, uncertaintyQAttribute);
       TSM_ASSERT_EQUALS("Should be just Qdev", uncertaintyQAttribute, sasDataQdev);
 
       // Q data set uncertainties attribute
       std::string uncertaintiesQAttribute;
-      Mantid::DataHandling::H5Util::readStringAttribute(qDataSet, sasUncertaintiesAttr, uncertaintiesQAttribute);
+      Mantid::NeXus::H5Util::readStringAttribute(qDataSet, sasUncertaintiesAttr, uncertaintiesQAttribute);
       TSM_ASSERT_EQUALS("Should be just Qdev", uncertaintiesQAttribute, sasDataQdev);
 
       // Q error data set
@@ -805,12 +805,12 @@ private:
 
       // Q_uncertainty attribute on the SASdata group
       std::string qErrorAttribute;
-      Mantid::DataHandling::H5Util::readStringAttribute(data, sasDataQUncertaintyAttr, qErrorAttribute);
+      Mantid::NeXus::H5Util::readStringAttribute(data, sasDataQUncertaintyAttr, qErrorAttribute);
       TSM_ASSERT_EQUALS("Should be just Qdev", qErrorAttribute, sasDataQdev);
 
       // Q_uncertainties attribute on the SASdata group
       std::string qErrorAlternativeAttribute;
-      Mantid::DataHandling::H5Util::readStringAttribute(data, sasDataQUncertaintiesAttr, qErrorAlternativeAttribute);
+      Mantid::NeXus::H5Util::readStringAttribute(data, sasDataQUncertaintiesAttr, qErrorAlternativeAttribute);
       TSM_ASSERT_EQUALS("Should be just Qdev", qErrorAlternativeAttribute, sasDataQdev);
     } else {
       do_assert_that_Q_dev_information_is_not_present(data);
@@ -823,34 +823,34 @@ private:
 
     // canSAS_class and NX_class attribute
     std::string classAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(data, sasclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(data, sasclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be SASdata class", classAttribute, sasDataClassAttr);
-    Mantid::DataHandling::H5Util::readStringAttribute(data, nxclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(data, nxclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be NXdata class", classAttribute, nxDataClassAttr);
 
     // I_axes attribute
     std::string intensityAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(data, sasDataIAxesAttr, intensityAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(data, sasDataIAxesAttr, intensityAttribute);
     TSM_ASSERT_EQUALS("Should be just Q,Q", intensityAttribute, sasDataQ + sasSeparator + sasDataQ);
 
     // I_uncertainty attribute
     std::string errorAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(data, sasDataIUncertaintyAttr, errorAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(data, sasDataIUncertaintyAttr, errorAttribute);
     TSM_ASSERT_EQUALS("Should be just Idev", errorAttribute, sasDataIdev);
 
     // I_uncertainties attribute
     std::string errorAlternativeAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(data, sasDataIUncertaintiesAttr, errorAlternativeAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(data, sasDataIUncertaintiesAttr, errorAlternativeAttribute);
     TSM_ASSERT_EQUALS("Should be just Idev", errorAlternativeAttribute, sasDataIdev);
 
     // Q_indices attribute
-    auto qAttribute = Mantid::DataHandling::H5Util::readNumArrayAttributeCoerce<int>(data, sasDataQIndicesAttr);
+    auto qAttribute = Mantid::NeXus::H5Util::readNumArrayAttributeCoerce<int>(data, sasDataQIndicesAttr);
     std::vector<int> expectedQIndices{0, 1};
     TSM_ASSERT_EQUALS("Should be just 0,1", qAttribute, expectedQIndices);
 
     // Signal attribute
     std::string signalAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(data, sasSignal, signalAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(data, sasSignal, signalAttribute);
     TSM_ASSERT_EQUALS("Should be just I", signalAttribute, sasDataI);
 
     // Note: Acutal Values are being testin in LoadNXcanSAS to avoid redundant
@@ -866,41 +866,41 @@ private:
 
     // canSAS_class and NX_class attribute
     std::string classAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(transmission, sasclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(transmission, sasclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be SAStransmission_spectrum class", classAttribute, sasTransmissionSpectrumClassAttr);
-    Mantid::DataHandling::H5Util::readStringAttribute(transmission, nxclass, classAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(transmission, nxclass, classAttribute);
     TSM_ASSERT_EQUALS("Should be NXdata class", classAttribute, nxTransmissionSpectrumClassAttr);
 
     // Name attribute
     std::string nameAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(transmission, sasTransmissionSpectrumNameAttr, nameAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(transmission, sasTransmissionSpectrumNameAttr, nameAttribute);
     TSM_ASSERT_EQUALS("Should be either can or sample", nameAttribute, parameters.name);
 
     // T indices attribute
     std::string tIndicesAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(transmission, sasTransmissionSpectrumTIndices, tIndicesAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(transmission, sasTransmissionSpectrumTIndices, tIndicesAttribute);
     TSM_ASSERT_EQUALS("Should be T", tIndicesAttribute, sasTransmissionSpectrumT);
 
     // T uncertainty attribute
     std::string tUncertaintyIndicesAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(transmission, sasTransmissionSpectrumTUncertainty,
-                                                      tUncertaintyIndicesAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(transmission, sasTransmissionSpectrumTUncertainty,
+                                               tUncertaintyIndicesAttribute);
     TSM_ASSERT_EQUALS("Should be Tdev", tUncertaintyIndicesAttribute, sasTransmissionSpectrumTdev);
 
     // T uncertainties attribute
     std::string tUncertaintiesIndicesAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(transmission, sasTransmissionSpectrumTUncertainties,
-                                                      tUncertaintiesIndicesAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(transmission, sasTransmissionSpectrumTUncertainties,
+                                               tUncertaintiesIndicesAttribute);
     TSM_ASSERT_EQUALS("Should be Tdev", tUncertaintiesIndicesAttribute, sasTransmissionSpectrumTdev);
 
     // Signal attribute
     std::string signalAttribute;
-    Mantid::DataHandling::H5Util::readStringAttribute(transmission, sasSignal, signalAttribute);
+    Mantid::NeXus::H5Util::readStringAttribute(transmission, sasSignal, signalAttribute);
     TSM_ASSERT_EQUALS("Should be T", signalAttribute, sasTransmissionSpectrumT);
 
     // Timestamp attribute
     std::string transmissionAttribute;
-    TS_ASSERT_THROWS_NOTHING(Mantid::DataHandling::H5Util::readStringAttribute(
+    TS_ASSERT_THROWS_NOTHING(Mantid::NeXus::H5Util::readStringAttribute(
         transmission, sasTransmissionSpectrumTimeStampAttr, transmissionAttribute));
 
     // T data set

--- a/Framework/DataHandling/test/SaveNexusESSTest.h
+++ b/Framework/DataHandling/test/SaveNexusESSTest.h
@@ -12,7 +12,6 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceGroup.h"
-#include "MantidDataHandling/H5Util.h"
 #include "MantidDataHandling/LoadEmptyInstrument.h"
 #include "MantidDataHandling/LoadNexusProcessed2.h"
 #include "MantidDataHandling/SaveNexusESS.h"
@@ -28,6 +27,7 @@
 #include "MantidHistogramData/Histogram.h"
 #include "MantidIndexing/IndexInfo.h"
 #include "MantidKernel/Logger.h"
+#include "MantidNexus/H5Util.h"
 #include "MantidNexusGeometry/NexusGeometryParser.h"
 #include "MantidNexusGeometry/NexusGeometrySave.h"
 #include <memory>
@@ -303,7 +303,7 @@ public:
         entryName << "/mantid_workspace_" << n;
         std::cout << "creating: " << entryName.str() << std::endl;
         H5::Group g = h5.createGroup(entryName.str());
-        H5Util::writeStrAttribute(g, NX_CLASS, NX_ENTRY);
+        Mantid::NeXus::H5Util::writeStrAttribute(g, NX_CLASS, NX_ENTRY);
       }
       h5.close();
     }
@@ -352,7 +352,7 @@ public:
         std::ostringstream entryName;
         entryName << "/mantid_workspace_" << n;
         H5::Group g = h5.createGroup(entryName.str());
-        H5Util::writeStrAttribute(g, NX_CLASS, NX_ENTRY);
+        Mantid::NeXus::H5Util::writeStrAttribute(g, NX_CLASS, NX_ENTRY);
         h5.close();
       }
       {
@@ -463,9 +463,9 @@ private:
     for (const auto &pathWithClass : pathsWithClasses) {
       const std::string &groupPath = pathWithClass.first;
       const std::string &className = pathWithClass.second;
-      TS_ASSERT(H5Util::groupExists(file, groupPath));
+      TS_ASSERT(Mantid::NeXus::H5Util::groupExists(file, groupPath));
       H5::Group g = file.openGroup(groupPath);
-      TS_ASSERT(H5Util::keyHasValue(g, NX_CLASS, className));
+      TS_ASSERT(Mantid::NeXus::H5Util::keyHasValue(g, NX_CLASS, className));
     }
   }
 };

--- a/Framework/Nexus/CMakeLists.txt
+++ b/Framework/Nexus/CMakeLists.txt
@@ -1,10 +1,10 @@
-set(SRC_FILES src/MuonNexusReader.cpp src/NexusClasses.cpp src/NexusFileIO.cpp)
+set(SRC_FILES src/H5Util.cpp src/MuonNexusReader.cpp src/NexusClasses.cpp src/NexusFileIO.cpp)
 
-set(INC_FILES inc/MantidNexus/MuonNexusReader.h inc/MantidNexus/NexusClasses.h inc/MantidNexus/NexusFileIO.h
-              inc/MantidNexus/NexusIOHelper.h
+set(INC_FILES inc/MantidNexus/H5Util.h inc/MantidNexus/MuonNexusReader.h inc/MantidNexus/NexusClasses.h
+              inc/MantidNexus/NexusFileIO.h inc/MantidNexus/NexusIOHelper.h
 )
 
-set(TEST_FILES NexusIOHelperTest.h)
+set(TEST_FILES H5UtilTest.h NexusIOHelperTest.h)
 
 if(COVERAGE)
   foreach(loop_var ${SRC_FILES} ${INC_FILES})

--- a/Framework/Nexus/inc/MantidNexus/H5Util.h
+++ b/Framework/Nexus/inc/MantidNexus/H5Util.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "MantidDataHandling/DllConfig.h"
+#include "MantidNexus/DllConfig.h"
 
 #include <map>
 #include <string>
@@ -24,13 +24,13 @@ class H5Object;
 } // namespace H5
 
 namespace Mantid {
-namespace DataHandling {
+namespace NeXus {
 namespace H5Util {
 /** H5Util : TODO: DESCRIPTION
  */
 
 /// Create a 1D data-space to hold data of length.
-MANTID_DATAHANDLING_DLL H5::DataSpace getDataSpace(const size_t length);
+MANTID_NEXUS_DLL H5::DataSpace getDataSpace(const size_t length);
 
 /// Create a 1D data-space that will hold the supplied vector.
 template <typename NumT> H5::DataSpace getDataSpace(const std::vector<NumT> &data);
@@ -38,15 +38,15 @@ template <typename NumT> H5::DataSpace getDataSpace(const std::vector<NumT> &dat
 /// Convert a primitive type to the appropriate H5::DataType.
 template <typename NumT> H5::DataType getType();
 
-MANTID_DATAHANDLING_DLL H5::Group createGroupNXS(H5::H5File &file, const std::string &name, const std::string &nxtype);
+MANTID_NEXUS_DLL H5::Group createGroupNXS(H5::H5File &file, const std::string &name, const std::string &nxtype);
 
-MANTID_DATAHANDLING_DLL H5::Group createGroupNXS(H5::Group &group, const std::string &name, const std::string &nxtype);
+MANTID_NEXUS_DLL H5::Group createGroupNXS(H5::Group &group, const std::string &name, const std::string &nxtype);
 
-MANTID_DATAHANDLING_DLL H5::Group createGroupCanSAS(H5::Group &group, const std::string &name,
-                                                    const std::string &nxtype, const std::string &cstype);
+MANTID_NEXUS_DLL H5::Group createGroupCanSAS(H5::Group &group, const std::string &name, const std::string &nxtype,
+                                             const std::string &cstype);
 
-MANTID_DATAHANDLING_DLL H5::Group createGroupCanSAS(H5::H5File &file, const std::string &name,
-                                                    const std::string &nxtype, const std::string &cstype);
+MANTID_NEXUS_DLL H5::Group createGroupCanSAS(H5::H5File &file, const std::string &name, const std::string &nxtype,
+                                             const std::string &cstype);
 
 /**
  * Sets up the chunking and compression rate.
@@ -54,18 +54,16 @@ MANTID_DATAHANDLING_DLL H5::Group createGroupCanSAS(H5::H5File &file, const std:
  * @param deflateLevel
  * @return The configured property list
  */
-MANTID_DATAHANDLING_DLL H5::DSetCreatPropList setCompressionAttributes(const std::size_t length,
-                                                                       const int deflateLevel = 6);
+MANTID_NEXUS_DLL H5::DSetCreatPropList setCompressionAttributes(const std::size_t length, const int deflateLevel = 6);
 
-MANTID_DATAHANDLING_DLL void writeStrAttribute(const H5::H5Object &object, const std::string &name,
-                                               const std::string &value);
+MANTID_NEXUS_DLL void writeStrAttribute(const H5::H5Object &object, const std::string &name, const std::string &value);
 
 template <typename NumT> void writeNumAttribute(const H5::H5Object &object, const std::string &name, const NumT &value);
 
 template <typename NumT>
 void writeNumAttribute(const H5::H5Object &object, const std::string &name, const std::vector<NumT> &value);
 
-MANTID_DATAHANDLING_DLL void write(H5::Group &group, const std::string &name, const std::string &value);
+MANTID_NEXUS_DLL void write(H5::Group &group, const std::string &name, const std::string &value);
 
 template <typename T>
 void writeScalarDataSetWithStrAttributes(H5::Group &group, const std::string &name, const T &value,
@@ -73,18 +71,18 @@ void writeScalarDataSetWithStrAttributes(H5::Group &group, const std::string &na
 
 template <typename NumT> void writeArray1D(H5::Group &group, const std::string &name, const std::vector<NumT> &values);
 
-MANTID_DATAHANDLING_DLL std::string readString(H5::H5File &file, const std::string &path);
+MANTID_NEXUS_DLL std::string readString(H5::H5File &file, const std::string &path);
 
-MANTID_DATAHANDLING_DLL std::string readString(H5::Group &group, const std::string &name);
+MANTID_NEXUS_DLL std::string readString(H5::Group &group, const std::string &name);
 
-MANTID_DATAHANDLING_DLL std::string readString(const H5::DataSet &dataset);
+MANTID_NEXUS_DLL std::string readString(const H5::DataSet &dataset);
 
-MANTID_DATAHANDLING_DLL std::vector<std::string> readStringVector(H5::Group &, const std::string &);
+MANTID_NEXUS_DLL std::vector<std::string> readStringVector(H5::Group &, const std::string &);
 
-MANTID_DATAHANDLING_DLL bool hasAttribute(const H5::H5Object &object, const char *attributeName);
+MANTID_NEXUS_DLL bool hasAttribute(const H5::H5Object &object, const char *attributeName);
 
-MANTID_DATAHANDLING_DLL void readStringAttribute(const H5::H5Object &object, const std::string &attributeName,
-                                                 std::string &output);
+MANTID_NEXUS_DLL void readStringAttribute(const H5::H5Object &object, const std::string &attributeName,
+                                          std::string &output);
 
 template <typename NumT> NumT readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 
@@ -98,21 +96,21 @@ template <typename NumT> std::vector<NumT> readArray1DCoerce(const H5::Group &gr
 template <typename NumT> void readArray1DCoerce(const H5::DataSet &dataset, std::vector<NumT> &output);
 
 /// Test if a group already exists within an HDF5 file or parent group.
-MANTID_DATAHANDLING_DLL bool groupExists(H5::H5Object &h5, const std::string &groupPath);
+MANTID_NEXUS_DLL bool groupExists(H5::H5Object &h5, const std::string &groupPath);
 
 /// Test if an attribute is present and has a specific string value for an HDF5 group or dataset.
-MANTID_DATAHANDLING_DLL bool keyHasValue(H5::H5Object &h5, const std::string &key, const std::string &value);
+MANTID_NEXUS_DLL bool keyHasValue(H5::H5Object &h5, const std::string &key, const std::string &value);
 
 /// Copy a group and all of its contents, between the same or different HDF5 files or groups.
-MANTID_DATAHANDLING_DLL void copyGroup(H5::H5Object &dest, const std::string &destGroupPath, H5::H5Object &src,
-                                       const std::string &srcGroupPath);
+MANTID_NEXUS_DLL void copyGroup(H5::H5Object &dest, const std::string &destGroupPath, H5::H5Object &src,
+                                const std::string &srcGroupPath);
 
 /**
  * Delete a target link for a group or dataset from a parent group.
  * If this is the last link to the target in the HDF5 graph, then it will be removed from the file.
  */
-MANTID_DATAHANDLING_DLL void deleteObjectLink(H5::H5Object &h5, const std::string &target);
+MANTID_NEXUS_DLL void deleteObjectLink(H5::H5Object &h5, const std::string &target);
 
 } // namespace H5Util
-} // namespace DataHandling
+} // namespace NeXus
 } // namespace Mantid

--- a/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h
+++ b/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h
@@ -6,9 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "MantidAPI/Algorithm.h"
-#include "MantidDataObjects/Workspace2D.h"
 #include "MantidNexus/DllConfig.h"
+
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <climits>
 #include <nexus/NeXusFile.hpp>

--- a/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h
+++ b/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h
@@ -74,7 +74,7 @@ public:
   void getTimeChannels(float *timebnds,
                        const int &nbnds) const; ///< get time bin boundaries
                                                 /// return sample name
-  std::string getSampleName() const { return m_nexusSampleName; };
+  std::string const &getSampleName() const { return m_nexusSampleName; };
   int numberOfLogs() const;                  ///< Number of NXlog sections read from file
   int getLogLength(const int i) const;       ///< Lenght of i'th log
   std::string getLogName(const int i) const; ///< Name of i'th log
@@ -89,11 +89,11 @@ public:
   int t_ntc1 = 0; ///< number of time channels in time regime 1
   int t_nper = 0; ///< number of periods in file (=1 at present)
   // for nexus histogram data
-  std::vector<float> m_correctedTimes;   ///< temp store for corrected times
-  std::vector<int> m_counts;             ///< temp store of histogram data
-  std::vector<int> m_detectorGroupings;  ///< detector grouping info
-  int m_numDetectors = 0;                ///< detector count
-  std::string getInstrumentName() const; ///< return instrument name
+  std::vector<float> m_correctedTimes;          ///< temp store for corrected times
+  std::vector<int> m_counts;                    ///< temp store of histogram data
+  std::vector<int> m_detectorGroupings;         ///< detector grouping info
+  int m_numDetectors = 0;                       ///< detector count
+  std::string const &getInstrumentName() const; ///< return instrument name
   int m_numPeriodSequences = 0;
   std::string m_periodNames;
   std::string m_periodTypes;

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -96,7 +96,7 @@ public:
   // definition.
   // virtual bool isStandard()const = 0;
   /// Returns the absolute path to the object
-  std::string path() const { return m_path; }
+  std::string const &path() const { return m_path; }
   /// Returns the name of the object
   std::string name() const;
   /// Attributes

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -6,11 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
-#include "MantidAPI/Algorithm.h"
-#include "MantidAPI/Sample.h"
 #include "MantidKernel/DateAndTimeHelpers.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidNexus/DllConfig.h"
@@ -22,9 +17,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-//----------------------------------------------------------------------
-// Forward declaration
-//----------------------------------------------------------------------
 
 namespace Mantid {
 namespace NeXus {

--- a/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
@@ -5,13 +5,17 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
+#include "MantidAPI/Column.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/Progress.h"
-#include "MantidDataObjects/EventWorkspace.h"
-#include "MantidDataObjects/VectorColumn.h"
+#include "MantidAPI/Run.h"
+#include "MantidDataObjects/EventList.h"
+#include "MantidDataObjects/EventWorkspace_fwd.h"
 #include "MantidKernel/TimeSeriesProperty.h"
+#include "MantidKernel/cow_ptr.h"
 #include "MantidNexus/DllConfig.h"
+
 #include <boost/date_time/c_local_time_adjustor.hpp>
 #include <boost/date_time/local_time_adjustor.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
@@ -209,10 +209,10 @@ bool NexusFileIO::writeNxValue(const std::string &name, const TYPE &value, const
   if (NXopendata(fileID, name.c_str()) == NX_ERROR)
     return false;
   for (unsigned int it = 0; it < attributes.size(); ++it) {
-    NXputattr(fileID, attributes[it].c_str(), (void *)avalues[it].c_str(), static_cast<int>(avalues[it].size() + 1),
-              NX_CHAR);
+    NXputattr(fileID, attributes[it].c_str(), static_cast<const void *>(avalues[it].c_str()),
+              static_cast<int>(avalues[it].size() + 1), NX_CHAR);
   }
-  NXputdata(fileID, (void *)&value);
+  NXputdata(fileID, static_cast<const void *>(&value));
   NXclosedata(fileID);
   return true;
 }
@@ -274,10 +274,10 @@ bool NexusFileIO::writeSingleValueNXLog(const std::string &name, const TYPE &val
   if (NXopendata(fileID, "value") == NX_ERROR)
     return false;
   for (unsigned int it = 0; it < attributes.size(); ++it) {
-    NXputattr(fileID, attributes[it].c_str(), (void *)avalues[it].c_str(), static_cast<int>(avalues[it].size() + 1),
-              NX_CHAR);
+    NXputattr(fileID, attributes[it].c_str(), static_cast<const void *>(avalues[it].c_str()),
+              static_cast<int>(avalues[it].size() + 1), NX_CHAR);
   }
-  NXputdata(fileID, (void *)&value);
+  NXputdata(fileID, static_cast<const void *>(&value));
   NXclosedata(fileID);
   NXclosegroup(fileID);
   return true;

--- a/Framework/Nexus/src/H5Util.cpp
+++ b/Framework/Nexus/src/H5Util.cpp
@@ -4,7 +4,7 @@
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
-#include "MantidDataHandling/H5Util.h"
+#include "MantidNexus/H5Util.h"
 #include "MantidAPI/LogManager.h"
 #include "MantidKernel/System.h"
 
@@ -17,7 +17,7 @@
 
 using namespace H5;
 
-namespace Mantid::DataHandling::H5Util {
+namespace Mantid::NeXus::H5Util {
 
 namespace {
 /// static logger object
@@ -33,17 +33,17 @@ const std::string CAN_SAS_ATTR_CLASS("canSAS_class");
 
 template <typename NumT> DataType getType() { throw DataTypeIException(); }
 
-template <> MANTID_DATAHANDLING_DLL DataType getType<float>() { return PredType::NATIVE_FLOAT; }
+template <> MANTID_NEXUS_DLL DataType getType<float>() { return PredType::NATIVE_FLOAT; }
 
-template <> MANTID_DATAHANDLING_DLL DataType getType<double>() { return PredType::NATIVE_DOUBLE; }
+template <> MANTID_NEXUS_DLL DataType getType<double>() { return PredType::NATIVE_DOUBLE; }
 
-template <> MANTID_DATAHANDLING_DLL DataType getType<int32_t>() { return PredType::NATIVE_INT32; }
+template <> MANTID_NEXUS_DLL DataType getType<int32_t>() { return PredType::NATIVE_INT32; }
 
-template <> MANTID_DATAHANDLING_DLL DataType getType<uint32_t>() { return PredType::NATIVE_UINT32; }
+template <> MANTID_NEXUS_DLL DataType getType<uint32_t>() { return PredType::NATIVE_UINT32; }
 
-template <> MANTID_DATAHANDLING_DLL DataType getType<int64_t>() { return PredType::NATIVE_INT64; }
+template <> MANTID_NEXUS_DLL DataType getType<int64_t>() { return PredType::NATIVE_INT64; }
 
-template <> MANTID_DATAHANDLING_DLL DataType getType<uint64_t>() { return PredType::NATIVE_UINT64; }
+template <> MANTID_NEXUS_DLL DataType getType<uint64_t>() { return PredType::NATIVE_UINT64; }
 
 DataSpace getDataSpace(const size_t length) {
   hsize_t dims[] = {length};
@@ -470,146 +470,136 @@ void deleteObjectLink(H5::H5Object &h5, const std::string &target) {
 // instantiations for writeNumAttribute
 // -------------------------------------------------------------------
 
-template MANTID_DATAHANDLING_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
-                                                        const float &value);
-template MANTID_DATAHANDLING_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
-                                                        const double &value);
-template MANTID_DATAHANDLING_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
-                                                        const int32_t &value);
-template MANTID_DATAHANDLING_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
-                                                        const uint32_t &value);
-template MANTID_DATAHANDLING_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
-                                                        const int64_t &value);
-template MANTID_DATAHANDLING_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
-                                                        const uint64_t &value);
+template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
+                                                 const float &value);
+template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
+                                                 const double &value);
+template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
+                                                 const int32_t &value);
+template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
+                                                 const uint32_t &value);
+template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
+                                                 const int64_t &value);
+template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
+                                                 const uint64_t &value);
 
-template MANTID_DATAHANDLING_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
-                                                        const std::vector<float> &value);
-template MANTID_DATAHANDLING_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
-                                                        const std::vector<double> &value);
-template MANTID_DATAHANDLING_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
-                                                        const std::vector<int32_t> &value);
-template MANTID_DATAHANDLING_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
-                                                        const std::vector<uint32_t> &value);
-template MANTID_DATAHANDLING_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
-                                                        const std::vector<int64_t> &value);
-template MANTID_DATAHANDLING_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
-                                                        const std::vector<uint64_t> &value);
+template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
+                                                 const std::vector<float> &value);
+template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
+                                                 const std::vector<double> &value);
+template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
+                                                 const std::vector<int32_t> &value);
+template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
+                                                 const std::vector<uint32_t> &value);
+template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
+                                                 const std::vector<int64_t> &value);
+template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, const std::string &name,
+                                                 const std::vector<uint64_t> &value);
 
 // -------------------------------------------------------------------
 // instantiations for readNumAttributeCoerce
 // -------------------------------------------------------------------
-template MANTID_DATAHANDLING_DLL float readNumAttributeCoerce(const H5::H5Object &object,
-                                                              const std::string &attributeName);
-template MANTID_DATAHANDLING_DLL double readNumAttributeCoerce(const H5::H5Object &object,
-                                                               const std::string &attributeName);
-template MANTID_DATAHANDLING_DLL int32_t readNumAttributeCoerce(const H5::H5Object &object,
-                                                                const std::string &attributeName);
-template MANTID_DATAHANDLING_DLL uint32_t readNumAttributeCoerce(const H5::H5Object &object,
-                                                                 const std::string &attributeName);
-template MANTID_DATAHANDLING_DLL int64_t readNumAttributeCoerce(const H5::H5Object &object,
-                                                                const std::string &attributeName);
-template MANTID_DATAHANDLING_DLL uint64_t readNumAttributeCoerce(const H5::H5Object &object,
-                                                                 const std::string &attributeName);
+template MANTID_NEXUS_DLL float readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
+template MANTID_NEXUS_DLL double readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
+template MANTID_NEXUS_DLL int32_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
+template MANTID_NEXUS_DLL uint32_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
+template MANTID_NEXUS_DLL int64_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
+template MANTID_NEXUS_DLL uint64_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 
 // -------------------------------------------------------------------
 // instantiations for readNumArrayAttributeCoerce
 // -------------------------------------------------------------------
-template MANTID_DATAHANDLING_DLL std::vector<float> readNumArrayAttributeCoerce(const H5::H5Object &object,
-                                                                                const std::string &attributeName);
-template MANTID_DATAHANDLING_DLL std::vector<double> readNumArrayAttributeCoerce(const H5::H5Object &object,
-                                                                                 const std::string &attributeName);
-template MANTID_DATAHANDLING_DLL std::vector<int32_t> readNumArrayAttributeCoerce(const H5::H5Object &object,
-                                                                                  const std::string &attributeName);
-template MANTID_DATAHANDLING_DLL std::vector<uint32_t> readNumArrayAttributeCoerce(const H5::H5Object &object,
-                                                                                   const std::string &attributeName);
-template MANTID_DATAHANDLING_DLL std::vector<int64_t> readNumArrayAttributeCoerce(const H5::H5Object &object,
-                                                                                  const std::string &attributeName);
-template MANTID_DATAHANDLING_DLL std::vector<uint64_t> readNumArrayAttributeCoerce(const H5::H5Object &object,
-                                                                                   const std::string &attributeName);
+template MANTID_NEXUS_DLL std::vector<float> readNumArrayAttributeCoerce(const H5::H5Object &object,
+                                                                         const std::string &attributeName);
+template MANTID_NEXUS_DLL std::vector<double> readNumArrayAttributeCoerce(const H5::H5Object &object,
+                                                                          const std::string &attributeName);
+template MANTID_NEXUS_DLL std::vector<int32_t> readNumArrayAttributeCoerce(const H5::H5Object &object,
+                                                                           const std::string &attributeName);
+template MANTID_NEXUS_DLL std::vector<uint32_t> readNumArrayAttributeCoerce(const H5::H5Object &object,
+                                                                            const std::string &attributeName);
+template MANTID_NEXUS_DLL std::vector<int64_t> readNumArrayAttributeCoerce(const H5::H5Object &object,
+                                                                           const std::string &attributeName);
+template MANTID_NEXUS_DLL std::vector<uint64_t> readNumArrayAttributeCoerce(const H5::H5Object &object,
+                                                                            const std::string &attributeName);
 
 // -------------------------------------------------------------------
 // instantiations for writeArray1D
 // -------------------------------------------------------------------
-template MANTID_DATAHANDLING_DLL void writeArray1D(H5::Group &group, const std::string &name,
-                                                   const std::vector<float> &values);
-template MANTID_DATAHANDLING_DLL void writeArray1D(H5::Group &group, const std::string &name,
-                                                   const std::vector<double> &values);
-template MANTID_DATAHANDLING_DLL void writeArray1D(H5::Group &group, const std::string &name,
-                                                   const std::vector<int32_t> &values);
-template MANTID_DATAHANDLING_DLL void writeArray1D(H5::Group &group, const std::string &name,
-                                                   const std::vector<uint32_t> &values);
-template MANTID_DATAHANDLING_DLL void writeArray1D(H5::Group &group, const std::string &name,
-                                                   const std::vector<int64_t> &values);
-template MANTID_DATAHANDLING_DLL void writeArray1D(H5::Group &group, const std::string &name,
-                                                   const std::vector<uint64_t> &values);
+template MANTID_NEXUS_DLL void writeArray1D(H5::Group &group, const std::string &name,
+                                            const std::vector<float> &values);
+template MANTID_NEXUS_DLL void writeArray1D(H5::Group &group, const std::string &name,
+                                            const std::vector<double> &values);
+template MANTID_NEXUS_DLL void writeArray1D(H5::Group &group, const std::string &name,
+                                            const std::vector<int32_t> &values);
+template MANTID_NEXUS_DLL void writeArray1D(H5::Group &group, const std::string &name,
+                                            const std::vector<uint32_t> &values);
+template MANTID_NEXUS_DLL void writeArray1D(H5::Group &group, const std::string &name,
+                                            const std::vector<int64_t> &values);
+template MANTID_NEXUS_DLL void writeArray1D(H5::Group &group, const std::string &name,
+                                            const std::vector<uint64_t> &values);
 
 // -------------------------------------------------------------------
 // Instantiations for writeScalarWithStrAttributes
 // -------------------------------------------------------------------
-template MANTID_DATAHANDLING_DLL void
+template MANTID_NEXUS_DLL void
 writeScalarDataSetWithStrAttributes(H5::Group &group, const std::string &name, const std::string &value,
                                     const std::map<std::string, std::string> &attributes);
-template MANTID_DATAHANDLING_DLL void
+template MANTID_NEXUS_DLL void
 writeScalarDataSetWithStrAttributes(H5::Group &group, const std::string &name, const float &value,
                                     const std::map<std::string, std::string> &attributes);
-template MANTID_DATAHANDLING_DLL void
+template MANTID_NEXUS_DLL void
 writeScalarDataSetWithStrAttributes(H5::Group &group, const std::string &name, const double &value,
                                     const std::map<std::string, std::string> &attributes);
-template MANTID_DATAHANDLING_DLL void
+template MANTID_NEXUS_DLL void
 writeScalarDataSetWithStrAttributes(H5::Group &group, const std::string &name, const int32_t &value,
                                     const std::map<std::string, std::string> &attributes);
-template MANTID_DATAHANDLING_DLL void
+template MANTID_NEXUS_DLL void
 writeScalarDataSetWithStrAttributes(H5::Group &group, const std::string &name, const uint32_t &value,
                                     const std::map<std::string, std::string> &attributes);
-template MANTID_DATAHANDLING_DLL void
+template MANTID_NEXUS_DLL void
 writeScalarDataSetWithStrAttributes(H5::Group &group, const std::string &name, const int64_t &value,
                                     const std::map<std::string, std::string> &attributes);
-template MANTID_DATAHANDLING_DLL void
+template MANTID_NEXUS_DLL void
 writeScalarDataSetWithStrAttributes(H5::Group &group, const std::string &name, const uint64_t &value,
                                     const std::map<std::string, std::string> &attributes);
 
 // -------------------------------------------------------------------
 // instantiations for getDataSpace
 // -------------------------------------------------------------------
-template MANTID_DATAHANDLING_DLL DataSpace getDataSpace(const std::vector<float> &data);
-template MANTID_DATAHANDLING_DLL DataSpace getDataSpace(const std::vector<double> &data);
-template MANTID_DATAHANDLING_DLL DataSpace getDataSpace(const std::vector<int32_t> &data);
-template MANTID_DATAHANDLING_DLL DataSpace getDataSpace(const std::vector<uint32_t> &data);
-template MANTID_DATAHANDLING_DLL DataSpace getDataSpace(const std::vector<int64_t> &data);
-template MANTID_DATAHANDLING_DLL DataSpace getDataSpace(const std::vector<uint64_t> &data);
+template MANTID_NEXUS_DLL DataSpace getDataSpace(const std::vector<float> &data);
+template MANTID_NEXUS_DLL DataSpace getDataSpace(const std::vector<double> &data);
+template MANTID_NEXUS_DLL DataSpace getDataSpace(const std::vector<int32_t> &data);
+template MANTID_NEXUS_DLL DataSpace getDataSpace(const std::vector<uint32_t> &data);
+template MANTID_NEXUS_DLL DataSpace getDataSpace(const std::vector<int64_t> &data);
+template MANTID_NEXUS_DLL DataSpace getDataSpace(const std::vector<uint64_t> &data);
 
 // -------------------------------------------------------------------
 // instantiations for readArray1DCoerce
 // -------------------------------------------------------------------
-template MANTID_DATAHANDLING_DLL void readArray1DCoerce(const H5::Group &group, const std::string &name,
-                                                        std::vector<float> &output);
-template MANTID_DATAHANDLING_DLL void readArray1DCoerce(const H5::Group &group, const std::string &name,
-                                                        std::vector<double> &output);
-template MANTID_DATAHANDLING_DLL void readArray1DCoerce(const H5::Group &group, const std::string &name,
-                                                        std::vector<int32_t> &output);
-template MANTID_DATAHANDLING_DLL void readArray1DCoerce(const H5::Group &group, const std::string &name,
-                                                        std::vector<uint32_t> &output);
-template MANTID_DATAHANDLING_DLL void readArray1DCoerce(const H5::Group &group, const std::string &name,
-                                                        std::vector<int64_t> &output);
-template MANTID_DATAHANDLING_DLL void readArray1DCoerce(const H5::Group &group, const std::string &name,
-                                                        std::vector<uint64_t> &output);
+template MANTID_NEXUS_DLL void readArray1DCoerce(const H5::Group &group, const std::string &name,
+                                                 std::vector<float> &output);
+template MANTID_NEXUS_DLL void readArray1DCoerce(const H5::Group &group, const std::string &name,
+                                                 std::vector<double> &output);
+template MANTID_NEXUS_DLL void readArray1DCoerce(const H5::Group &group, const std::string &name,
+                                                 std::vector<int32_t> &output);
+template MANTID_NEXUS_DLL void readArray1DCoerce(const H5::Group &group, const std::string &name,
+                                                 std::vector<uint32_t> &output);
+template MANTID_NEXUS_DLL void readArray1DCoerce(const H5::Group &group, const std::string &name,
+                                                 std::vector<int64_t> &output);
+template MANTID_NEXUS_DLL void readArray1DCoerce(const H5::Group &group, const std::string &name,
+                                                 std::vector<uint64_t> &output);
 
-template MANTID_DATAHANDLING_DLL std::vector<float> readArray1DCoerce(const H5::Group &group, const std::string &name);
-template MANTID_DATAHANDLING_DLL std::vector<double> readArray1DCoerce(const H5::Group &group, const std::string &name);
-template MANTID_DATAHANDLING_DLL std::vector<int32_t> readArray1DCoerce(const H5::Group &group,
-                                                                        const std::string &name);
-template MANTID_DATAHANDLING_DLL std::vector<uint32_t> readArray1DCoerce(const H5::Group &group,
-                                                                         const std::string &name);
-template MANTID_DATAHANDLING_DLL std::vector<int64_t> readArray1DCoerce(const H5::Group &group,
-                                                                        const std::string &name);
-template MANTID_DATAHANDLING_DLL std::vector<uint64_t> readArray1DCoerce(const H5::Group &group,
-                                                                         const std::string &name);
+template MANTID_NEXUS_DLL std::vector<float> readArray1DCoerce(const H5::Group &group, const std::string &name);
+template MANTID_NEXUS_DLL std::vector<double> readArray1DCoerce(const H5::Group &group, const std::string &name);
+template MANTID_NEXUS_DLL std::vector<int32_t> readArray1DCoerce(const H5::Group &group, const std::string &name);
+template MANTID_NEXUS_DLL std::vector<uint32_t> readArray1DCoerce(const H5::Group &group, const std::string &name);
+template MANTID_NEXUS_DLL std::vector<int64_t> readArray1DCoerce(const H5::Group &group, const std::string &name);
+template MANTID_NEXUS_DLL std::vector<uint64_t> readArray1DCoerce(const H5::Group &group, const std::string &name);
 
-template MANTID_DATAHANDLING_DLL void readArray1DCoerce(const DataSet &dataset, std::vector<float> &output);
-template MANTID_DATAHANDLING_DLL void readArray1DCoerce(const DataSet &dataset, std::vector<double> &output);
-template MANTID_DATAHANDLING_DLL void readArray1DCoerce(const DataSet &dataset, std::vector<int32_t> &output);
-template MANTID_DATAHANDLING_DLL void readArray1DCoerce(const DataSet &dataset, std::vector<uint32_t> &output);
-template MANTID_DATAHANDLING_DLL void readArray1DCoerce(const DataSet &dataset, std::vector<int64_t> &output);
-template MANTID_DATAHANDLING_DLL void readArray1DCoerce(const DataSet &dataset, std::vector<uint64_t> &output);
-} // namespace Mantid::DataHandling::H5Util
+template MANTID_NEXUS_DLL void readArray1DCoerce(const DataSet &dataset, std::vector<float> &output);
+template MANTID_NEXUS_DLL void readArray1DCoerce(const DataSet &dataset, std::vector<double> &output);
+template MANTID_NEXUS_DLL void readArray1DCoerce(const DataSet &dataset, std::vector<int32_t> &output);
+template MANTID_NEXUS_DLL void readArray1DCoerce(const DataSet &dataset, std::vector<uint32_t> &output);
+template MANTID_NEXUS_DLL void readArray1DCoerce(const DataSet &dataset, std::vector<int64_t> &output);
+template MANTID_NEXUS_DLL void readArray1DCoerce(const DataSet &dataset, std::vector<uint64_t> &output);
+} // namespace Mantid::NeXus::H5Util

--- a/Framework/Nexus/src/MuonNexusReader.cpp
+++ b/Framework/Nexus/src/MuonNexusReader.cpp
@@ -222,7 +222,7 @@ void MuonNexusReader::getTimeChannels(float *timebnds, const int &nbnds) const {
   timebnds[nbnds - 1] = timebnds[nbnds - 2] + float(2.0) * binHalfWidth;
 }
 
-string MuonNexusReader::getInstrumentName() const { return (m_nexusInstrumentName); }
+std::string const &MuonNexusReader::getInstrumentName() const { return m_nexusInstrumentName; }
 
 // NeXus Muon file reader for NXlog data.
 // Read the given Nexus file into temp storage.
@@ -246,7 +246,7 @@ void MuonNexusReader::readLogData(const string &filename) {
   // memory
   // Also get the start_time string needed to change these times into ISO times
   std::map<string, string> entries = handle.getEntries();
-  for (auto &entrie : entries) {
+  for (const auto &entrie : entries) {
     string nxname = entrie.first;
     string nxclass = entrie.second;
 

--- a/Framework/Nexus/src/MuonNexusReader.cpp
+++ b/Framework/Nexus/src/MuonNexusReader.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidNexus/MuonNexusReader.h"
+#include "MantidKernel/Logger.h"
 #include "MantidKernel/System.h"
 #include <boost/scoped_array.hpp>
 #include <nexus/NeXusException.hpp>

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -4,10 +4,11 @@
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
-//----------------------------------------------------------------------
-// Includes
-//----------------------------------------------------------------------
 #include "MantidNexus/NexusClasses.h"
+
+#include "MantidKernel/Exception.h"
+#include "MantidKernel/PropertyWithValue.h"
+
 #include <memory>
 #include <utility>
 

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -16,6 +16,7 @@
 #define NAME_MAX 260
 #endif /* _WIN32 */
 #include "MantidAPI/NumericAxis.h"
+#include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidDataObjects/RebinnedOutput.h"
 #include "MantidDataObjects/TableWorkspace.h"

--- a/Framework/Nexus/test/CMakeLists.txt
+++ b/Framework/Nexus/test/CMakeLists.txt
@@ -4,6 +4,7 @@ if(CXXTEST_FOUND)
   cxxtest_add_test(NexusTest ${TEST_FILES})
 
   target_link_libraries(NexusTest PRIVATE Mantid::API Mantid::Nexus gmock)
+  add_framework_test_helpers(NexusTest)
   add_dependencies(FrameworkTests NexusTest)
   add_dependencies(NexusTest StandardTestData)
   # Add to the 'FrameworkTests' group in VS

--- a/Framework/Nexus/test/H5UtilTest.h
+++ b/Framework/Nexus/test/H5UtilTest.h
@@ -8,9 +8,9 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidDataHandling/H5Util.h"
 #include "MantidFrameworkTestHelpers/FileResource.h"
 #include "MantidKernel/System.h"
+#include "MantidNexus/H5Util.h"
 
 #include <H5Cpp.h>
 #include <boost/numeric/conversion/cast.hpp>
@@ -18,7 +18,7 @@
 #include <limits>
 
 using namespace H5;
-using namespace Mantid::DataHandling;
+using namespace Mantid::NeXus;
 
 class H5UtilTest : public CxxTest::TestSuite {
 public:

--- a/Framework/NexusGeometry/test/NexusGeometryParserTest.h
+++ b/Framework/NexusGeometry/test/NexusGeometryParserTest.h
@@ -8,7 +8,6 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidDataHandling/H5Util.h"
 #include "MantidFrameworkTestHelpers/FileResource.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
@@ -19,6 +18,7 @@
 #include "MantidGeometry/Surfaces/Cylinder.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/EigenConversionHelpers.h"
+#include "MantidNexus/H5Util.h"
 #include "MantidNexusGeometry/NexusGeometryDefinitions.h"
 #include "MantidNexusGeometry/NexusGeometryParser.h"
 
@@ -31,7 +31,7 @@
 
 using namespace Mantid;
 using namespace NexusGeometry;
-using namespace DataHandling;
+using namespace Mantid::NeXus;
 
 namespace {
 std::unique_ptr<Geometry::DetectorInfo> extractDetectorInfo(const Mantid::Geometry::Instrument &instrument) {

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -562,7 +562,6 @@ missingOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandlin
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/MSVesuvioHelpers.cpp:369
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/MSVesuvioHelpers.cpp:370
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/ISISJournal.h:35
-returnByReference:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/NexusClasses.h:107
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/DataBlockComposite.cpp:383
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/CreatePolarizationEfficienciesBase.h:30
 containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/CreatePolarizationEfficiencies.cpp:119
@@ -606,7 +605,6 @@ uninitMemberVarPrivate:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidData
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadGSS.cpp:449
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLIndirect2.cpp:181
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLIndirect2.cpp:254
-returnByReference:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h:78
 mismatchingContainerExpression:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadInstrument.cpp:148
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadLog.cpp:448
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadANSTOEventFile.h:132
@@ -634,19 +632,10 @@ unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/vms_co
 variableScope:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/isisraw.cpp:474
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/isisraw.cpp:906
 uninitdata:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/isisraw.cpp:518
-constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadISISNexus2.cpp:607
-constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadISISNexus2.cpp:946
-constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadISISNexus2.cpp:947
-constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadMLZ.cpp:172
-constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadMLZ.cpp:355
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadPSIMuonBin.h:74
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadMuonStrategy.cpp:119
 stlIfStrFind:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRKH.cpp:521
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNexusMonitors2.cpp:452
-cstyleCast:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/NexusFileIO.h:208
-cstyleCast:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/NexusFileIO.h:211
-cstyleCast:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/NexusFileIO.h:273
-cstyleCast:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/NexusFileIO.h:276
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed2.h:38
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus1.h:60
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus1.h:62
@@ -660,8 +649,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadMuonNe
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadMuonNexus1.cpp:551
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadMuonNexus1.cpp:641
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadMuonNexus1.cpp:661
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadMuonNexus2.cpp:148
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadMuonNexus2.cpp:486
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadTBL.cpp:133
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadPreNexus.cpp:244
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadSpiceXML2DDet.h:30
@@ -681,8 +668,7 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadSpiceX
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp:897
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadSpiceAscii.cpp:330
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadSpice2D.cpp:613
-constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadSINQFocus.cpp:124
-uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadSINQFocus.cpp:121
+uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadSINQFocus.cpp:122
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCSV.cpp:107
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCSV.cpp:139
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveCSV.cpp:155
@@ -720,9 +706,6 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/CoordTransfor
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/CoordTransformAffine.cpp:357
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/CoordTransformAffine.cpp:368
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/SaveOpenGenieAscii.h:23
-passedByValue:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNXcanSAS.cpp:412
-passedByValue:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNXcanSAS.cpp:428
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveNXcanSAS.cpp:320
 uninitMemberVarPrivate:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/SaveReflectometryAscii.h:79
 internalError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/MDBoxSaveable.cpp:0
 internalError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/MDLeanEvent.cpp:0
@@ -891,11 +874,9 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/ISIS/ISISHisto
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/Muon/inc/MantidMuon/ApplyMuonDetectorGroupPairing.h:28
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/Muon/inc/MantidMuon/ApplyMuonDetectorGrouping.h:28
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/GlobalInterpreterLock.cpp:24
-returnByReference:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h:97
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/NDArray.cpp:111
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/ReleaseGlobalInterpreterLock.cpp:17
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/UninstallTrace.cpp:16
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/MuonNexusReader.cpp:248
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/Converters/CloneToNDArray.cpp:123
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/NexusGeometry/src/NexusShapeFactory.cpp:33
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/src/Converters/NDArrayToVector.cpp:126


### PR DESCRIPTION
### Description of work
This PR moves the `H5Util` files from the Mantid::DataHandling library to Mantid::Nexus because it is used for loading nexus data using the H5Cpp library. This PR also removes a couple of unused includes in some of the Mantid::Nexus library files.

Part of #38332

### To test:
Mainly code review. Tests should pass.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
