### PR TITLE
Add back in the pystog test data copy

### DIFF
--- a/buildconfig/CMake/PyStoG.cmake
+++ b/buildconfig/CMake/PyStoG.cmake
@@ -57,6 +57,9 @@ foreach(_py_file ${_test_files_support})
   file(COPY ${_PyStoG_source_test_dir}/${_py_file} DESTINATION ${_PyStoG_test_dir})
 endforeach()
 
+# copy over the test data
+file(COPY ${_PyStoG_download_dir}/src/PyStoG/data/test_data DESTINATION ${_PyStoG_test_dir})
+
 # register the tests
 set(PYUNITTEST_PYTHONPATH_EXTRA ${_PyStoG_test_root_dir})
 pyunittest_add_test(${_PyStoG_test_dir} python.scripts.pystog ${_test_files})


### PR DESCRIPTION
I think this shouldn't have been removed from here https://github.com/mantidproject/mantid/pull/38404/files

Looks related to this nightly failure.
https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment/926/

This build is running the linux tests to make sure its fixed
https://builds.mantidproject.org/job/build_packages_from_branch/949/

*There is no associated issue.*

### To test:

- Tests pass

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
