### PR TITLE
Allow loading ILL data into S(Q,w) tab of Data Processor

### DIFF
--- a/dev-docs/source/Testing/Inelastic/DataProcessorTests.rst
+++ b/dev-docs/source/Testing/Inelastic/DataProcessorTests.rst
@@ -46,7 +46,7 @@ Symmetrise tab
 :math:`S(Q, \omega)` tab
 ------------------------
 
-**Time required 5-10 minutes**
+**Time required 10-15 minutes**
 
 --------------
 

--- a/dev-docs/source/Testing/Inelastic/DataProcessorTests.rst
+++ b/dev-docs/source/Testing/Inelastic/DataProcessorTests.rst
@@ -50,6 +50,8 @@ Symmetrise tab
 
 --------------
 
+1. ISIS data
+############
 
 #. Go to ``Interfaces`` > ``Inelastic`` > ``Data Processor``
 #. Go to the ``S(Q,w)`` tab
@@ -67,6 +69,20 @@ Symmetrise tab
 #. The resulting 3D plot should range in the Energy Transfer axis from -0.2 to 0.2 :math:`meV`.
 #. Don't remove yet the workspace with suffix ``_sqw`` from the ADS as you will use it for the Moments interface test.
 #. Repeat instructions 4 to 10, but loading instead the ``MAR27691_red.nxs`` file from the ISIS Sample Data set.
+
+2. ILL data
+###########
+
+#. Go to ``Interfaces`` > ``Inelastic`` > ``Data Processor``
+#. Go to the ``S(Q,w)`` tab
+#. Open the Settings widget from the bottom left of the interface, and untick `Restrict allowed input files by name (recommended)`
+#. On the File Input, click on ``Browse``, a dialog window should prompt.
+#. Find the file ``243489-243506ElwinHeat_H2O-HSA-stw.nxs`` from the SystemTest data directory and Load it.
+#. The data will be plot as a contour plot in the interface.
+#. The `Q Low`, `Q Width` and `Q High` will be automatically set to 0.2, 0.05 and 2.25 respectively.
+#. Click `Run` button.
+#. There should be two new workspaces in the ADS with the prefixes ``_sqw`` and ``_rqw``.
+#. Open the Settings widget from the bottom left of the interface, and tick `Restrict allowed input files by name (recommended)`
 
 .. _sqw_inelastic_test:
 

--- a/docs/source/release/v6.12.0/Inelastic/New_features/38413.rst
+++ b/docs/source/release/v6.12.0/Inelastic/New_features/38413.rst
@@ -1,0 +1,1 @@
+- Added the ability to load ILL data into the :math:`S(Q, \omega)` tab of the `Inelastic Data Processor <interface-inelastic-data-processor>` interface.

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwModel.h
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwModel.h
@@ -26,6 +26,7 @@ public:
   virtual API::IConfiguredAlgorithm_sptr setupSofQWAlgorithm() const = 0;
   virtual API::IConfiguredAlgorithm_sptr setupAddSampleLogAlgorithm() const = 0;
   virtual void setInputWorkspace(const std::string &workspace) = 0;
+  virtual MatrixWorkspace_sptr inputWorkspace() const = 0;
   virtual void setQMin(double qMin) = 0;
   virtual void setQWidth(double qWidth) = 0;
   virtual void setQMax(double qMax) = 0;
@@ -54,6 +55,7 @@ public:
   API::IConfiguredAlgorithm_sptr setupSofQWAlgorithm() const override;
   API::IConfiguredAlgorithm_sptr setupAddSampleLogAlgorithm() const override;
   void setInputWorkspace(const std::string &workspace) override;
+  MatrixWorkspace_sptr inputWorkspace() const override;
   void setQMin(double qMin) override;
   void setQWidth(double qWidth) override;
   void setQMax(double qMax) override;
@@ -73,7 +75,7 @@ public:
                                                const std::string &reflection) const override;
 
 private:
-  std::string m_inputWorkspace;
+  MatrixWorkspace_sptr m_inputWorkspace;
   std::string m_baseName;
   double m_eFixed;
   double m_qLow;

--- a/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.cpp
+++ b/qt/scientific_interfaces/Inelastic/Processor/SqwPresenter.cpp
@@ -47,19 +47,19 @@ SqwPresenter::SqwPresenter(QWidget *parent, std::unique_ptr<MantidQt::API::IAlgo
  *
  */
 void SqwPresenter::handleDataReady(std::string const &dataName) {
-  if (m_view->validate()) {
-    m_model->setInputWorkspace(dataName);
-    auto &ads = AnalysisDataService::Instance();
-    if (auto const eFixed = getEFixed(ads.retrieveWS<MatrixWorkspace>(dataName))) {
-      m_model->setEFixed(*eFixed);
-    } else {
-      m_view->showMessageBox("An 'Efixed' value could not be found in the provided workspace.");
-      return;
-    }
-
-    plotRqwContour();
-    m_view->setDefaultQAndEnergy();
+  if (!m_view->validate()) {
+    return;
   }
+  m_model->setInputWorkspace(dataName);
+  if (auto const eFixed = getEFixed(m_model->inputWorkspace())) {
+    m_model->setEFixed(*eFixed);
+  } else {
+    m_view->showMessageBox("An 'Efixed' value could not be found in the provided workspace.");
+    return;
+  }
+
+  plotRqwContour();
+  m_view->setDefaultQAndEnergy();
 }
 
 void SqwPresenter::handleValidation(IUserInputValidator *validator) const {

--- a/qt/scientific_interfaces/Inelastic/test/Processor/SqwModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/Processor/SqwModelTest.h
@@ -6,7 +6,10 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/Axis.h"
+#include "MantidAPI/NumericAxis.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "Processor/SqwModel.h"
 #include <cxxtest/TestSuite.h>
@@ -111,6 +114,19 @@ public:
 
     TS_ASSERT(AnalysisDataService::Instance().doesExist("Workspace_name_r"));
     TS_ASSERT(AnalysisDataService::Instance().doesExist("Workspace_name_sqw"));
+  }
+
+  void test_setInputWorkspace_will_convert_a_non_spectrum_axis_to_a_spectrum_axis() {
+    auto workspace = WorkspaceCreationHelper::createProcessedWorkspaceWithCylComplexInstrument(5, 6, true);
+    auto numericAxis = std::make_unique<NumericAxis>(5);
+    workspace->replaceAxis(1, std::move(numericAxis));
+
+    TS_ASSERT(!workspace->getAxis(1)->isSpectra());
+    AnalysisDataService::Instance().addOrReplace("non_spectrum_workspace", workspace);
+
+    m_model->setInputWorkspace("non_spectrum_workspace");
+
+    TS_ASSERT(m_model->inputWorkspace()->getAxis(1)->isSpectra());
   }
 
 private:


### PR DESCRIPTION
### Description of work
This PR makes it possible to load ILL data into the S(Q,w) tab of the Inelastic Data Processor interface for processing. Previously this was not possible because the ILL data had a non-spectrum axis, whereas this interface is designed to work for reduced files produced in Indirect Data Reduction. These reduced files always have a spectrum axis.

Fixes #38038

### To test:
Follow the test instructions in the updated `DataProcessorTests` file for the S(Q,w) tab.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
