### PR TITLE
Fix ApplyFloodWorkspace algorithm not preserving values in missing spectra

### DIFF
--- a/Framework/Algorithms/test/ApplyFloodWorkspaceTest.h
+++ b/Framework/Algorithms/test/ApplyFloodWorkspaceTest.h
@@ -9,6 +9,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAlgorithms/ApplyFloodWorkspace.h"
+#include "MantidAlgorithms/CropWorkspace.h"
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Axis.h"
@@ -22,24 +23,55 @@ using namespace Mantid::API;
 using namespace Mantid::Kernel;
 using namespace WorkspaceCreationHelper;
 
+namespace {
+constexpr double MAX_X_REFLECTOMETRY(100000);
+constexpr double DELTA(1e-9);
+
+std::vector<double> generateXRange(const int nBoundaries, double start) {
+  auto xvec = std::vector<double>(nBoundaries + 1);
+  double const interval = MAX_X_REFLECTOMETRY / nBoundaries; // increment
+  std::ranges::for_each(xvec.begin(), xvec.end(), [&start, &interval](double &item) {
+    item = start;
+    start += interval;
+  });
+  return xvec;
+}
+
+MatrixWorkspace_sptr cropWorkspaces(const MatrixWorkspace_sptr &inputWS, const int startIndex = 0) {
+  CropWorkspace alg;
+  alg.initialize();
+  alg.setChild(true);
+  alg.setProperty("InputWorkspace", inputWS);
+  alg.setProperty("StartWorkspaceIndex", startIndex);
+  alg.setProperty("OutputWorkspace", "dummy");
+  alg.execute();
+  MatrixWorkspace_sptr out = alg.getProperty("OutputWorkspace");
+  return out;
+}
+
+MatrixWorkspace_sptr applyFloodWorkspace(const MatrixWorkspace_sptr &inputWS, const MatrixWorkspace_sptr &floodWS) {
+  ApplyFloodWorkspace alg;
+  alg.initialize();
+  alg.setChild(true);
+  alg.setProperty("InputWorkspace", inputWS);
+  alg.setProperty("FloodWorkspace", floodWS);
+  alg.setProperty("OutputWorkspace", "dummy");
+  alg.execute();
+  return alg.getProperty("OutputWorkspace");
+}
+} // namespace
+
 class ApplyFloodWorkspaceTest : public CxxTest::TestSuite {
 public:
   void test_flood_same_x_units() {
     auto inputWS = create2DWorkspaceWithReflectometryInstrumentMultiDetector(0, 0.1);
     auto flood = createFloodWorkspace(inputWS->getInstrument());
 
-    ApplyFloodWorkspace alg;
-    alg.initialize();
-    alg.setChild(true);
-    alg.setProperty("InputWorkspace", inputWS);
-    alg.setProperty("FloodWorkspace", flood);
-    alg.setProperty("OutputWorkspace", "dummy");
-    alg.execute();
-    MatrixWorkspace_sptr out = alg.getProperty("OutputWorkspace");
-    TS_ASSERT_DELTA(out->y(0)[0], 2.8571428575, 1e-9);
-    TS_ASSERT_DELTA(out->y(1)[0], 2.0, 1e-9);
-    TS_ASSERT_DELTA(out->y(2)[0], 2.5, 1e-9);
-    TS_ASSERT_DELTA(out->y(3)[0], 2.2222222222, 1e-9);
+    auto const out = applyFloodWorkspace(inputWS, flood);
+    TS_ASSERT_DELTA(out->y(0)[0], 2.8571428575, DELTA);
+    TS_ASSERT_DELTA(out->y(1)[0], 2.0, DELTA);
+    TS_ASSERT_DELTA(out->y(2)[0], 2.5, DELTA);
+    TS_ASSERT_DELTA(out->y(3)[0], 2.2222222222, DELTA);
     AnalysisDataService::Instance().clear();
   }
 
@@ -47,29 +79,49 @@ public:
     auto inputWS = create2DWorkspaceWithReflectometryInstrumentMultiDetector(0, 0.1);
     auto flood = createFloodWorkspace(inputWS->getInstrument(), "Wavelength");
 
-    ApplyFloodWorkspace alg;
-    alg.initialize();
-    alg.setChild(true);
-    alg.setProperty("InputWorkspace", inputWS);
-    alg.setProperty("FloodWorkspace", flood);
-    alg.setProperty("OutputWorkspace", "dummy");
-    alg.execute();
-    MatrixWorkspace_sptr out = alg.getProperty("OutputWorkspace");
-    TS_ASSERT_DELTA(out->y(0)[0], 2.8571428575, 1e-9);
-    TS_ASSERT_DELTA(out->y(1)[0], 2.0, 1e-9);
-    TS_ASSERT_DELTA(out->y(2)[0], 2.5, 1e-9);
-    TS_ASSERT_DELTA(out->y(3)[0], 2.2222222222, 1e-9);
+    auto const out = applyFloodWorkspace(inputWS, flood);
+    TS_ASSERT_DELTA(out->y(0)[0], 2.8571428575, DELTA);
+    TS_ASSERT_DELTA(out->y(1)[0], 2.0, DELTA);
+    TS_ASSERT_DELTA(out->y(2)[0], 2.5, DELTA);
+    TS_ASSERT_DELTA(out->y(3)[0], 2.2222222222, DELTA);
+    AnalysisDataService::Instance().clear();
+  }
+
+  void test_flood_doesnt_transform_spectra_that_are_missing_in_flood_workspace_for_multiple_bin_file() {
+    auto inputWS = create2DWorkspaceWithReflectometryInstrumentMultiDetector(0, 0.1);
+    auto flood = createFloodWorkspace(inputWS->getInstrument(), "TOF", 4);
+
+    auto const cropped = cropWorkspaces(flood, 2);
+    auto const out = applyFloodWorkspace(inputWS, cropped);
+
+    // Histograms without Flood Spectra data are not modified
+    TS_ASSERT_DELTA(out->readY(0), inputWS->readY(0), DELTA);
+    TS_ASSERT_DELTA(out->readY(1), inputWS->readY(1), DELTA);
+
+    int const refactor = 5; // how bigger is bin size in input with respect to initial flood ws
+    // Histograms with Flood Spectra are rebinned prior to flood correction
+    TS_ASSERT_DELTA(out->readY(2), std::vector<double>(20, 2 / 0.8 * refactor), DELTA);
+    TS_ASSERT_DELTA(out->readY(3), std::vector<double>(20, 2 / 0.9 * refactor), DELTA);
     AnalysisDataService::Instance().clear();
   }
 
 private:
   MatrixWorkspace_sptr createFloodWorkspace(const Mantid::Geometry::Instrument_const_sptr &instrument,
-                                            std::string const &xUnit = "TOF") {
-    MatrixWorkspace_sptr flood = create2DWorkspace(4, 1);
-    flood->mutableY(0)[0] = 0.7;
-    flood->mutableY(1)[0] = 1.0;
-    flood->mutableY(2)[0] = 0.8;
-    flood->mutableY(3)[0] = 0.9;
+                                            std::string const &xUnit = "TOF", const int nBoundaries = 1) {
+    MatrixWorkspace_sptr flood = create2DWorkspace(4, nBoundaries);
+    flood->mutableY(0) = std::vector<double>(nBoundaries, 0.7);
+    flood->mutableY(1) = std::vector<double>(nBoundaries, 1.0);
+    flood->mutableY(2) = std::vector<double>(nBoundaries, 0.8);
+    flood->mutableY(3) = std::vector<double>(nBoundaries, 0.9);
+
+    // X values are added ad-hoc to match the bin X range of the default test Reflectometry Instrument workspaces
+    //  This doesn't affect tests with 1 bin per histogram
+    auto const &xvec = generateXRange(nBoundaries, 0);
+    flood->mutableX(0) = xvec;
+    flood->mutableX(1) = xvec;
+    flood->mutableX(2) = xvec;
+    flood->mutableX(3) = xvec;
+
     flood->setInstrument(instrument);
     for (size_t i = 0; i < flood->getNumberHistograms(); ++i) {
       flood->getSpectrum(i).setDetectorID(Mantid::detid_t(i + 1));

--- a/Framework/Algorithms/test/ApplyFloodWorkspaceTest.h
+++ b/Framework/Algorithms/test/ApplyFloodWorkspaceTest.h
@@ -59,10 +59,46 @@ MatrixWorkspace_sptr applyFloodWorkspace(const MatrixWorkspace_sptr &inputWS, co
   alg.execute();
   return alg.getProperty("OutputWorkspace");
 }
+
+MatrixWorkspace_sptr createFloodWorkspace(const Mantid::Geometry::Instrument_const_sptr &instrument,
+                                          std::string const &xUnit = "TOF", const int nBoundaries = 1) {
+  MatrixWorkspace_sptr flood = create2DWorkspace(4, nBoundaries);
+  flood->mutableY(0) = std::vector<double>(nBoundaries, 0.7);
+  flood->mutableY(1) = std::vector<double>(nBoundaries, 1.0);
+  flood->mutableY(2) = std::vector<double>(nBoundaries, 0.8);
+  flood->mutableY(3) = std::vector<double>(nBoundaries, 0.9);
+
+  // X values are added ad-hoc to match the bin X range of the default test Reflectometry Instrument workspaces
+  //  This doesn't affect tests with 1 bin per histogram
+  auto const &xvec = generateXRange(nBoundaries, 0);
+  flood->mutableX(0) = xvec;
+  flood->mutableX(1) = xvec;
+  flood->mutableX(2) = xvec;
+  flood->mutableX(3) = xvec;
+
+  flood->setInstrument(instrument);
+  for (size_t i = 0; i < flood->getNumberHistograms(); ++i) {
+    flood->getSpectrum(i).setDetectorID(Mantid::detid_t(i + 1));
+  }
+  flood->getAxis(0)->setUnit("TOF");
+  if (xUnit != "TOF") {
+    ConvertUnits convert;
+    convert.initialize();
+    convert.setChild(true);
+    convert.setProperty("InputWorkspace", flood);
+    convert.setProperty("Target", xUnit);
+    convert.setProperty("OutputWorkspace", "dummy");
+    convert.execute();
+    flood = convert.getProperty("OutputWorkspace");
+  }
+  return flood;
+}
 } // namespace
 
 class ApplyFloodWorkspaceTest : public CxxTest::TestSuite {
 public:
+  void tearDown() override { AnalysisDataService::Instance().clear(); }
+
   void test_flood_same_x_units() {
     auto inputWS = create2DWorkspaceWithReflectometryInstrumentMultiDetector(0, 0.1);
     auto flood = createFloodWorkspace(inputWS->getInstrument());
@@ -72,7 +108,6 @@ public:
     TS_ASSERT_DELTA(out->y(1)[0], 2.0, DELTA);
     TS_ASSERT_DELTA(out->y(2)[0], 2.5, DELTA);
     TS_ASSERT_DELTA(out->y(3)[0], 2.2222222222, DELTA);
-    AnalysisDataService::Instance().clear();
   }
 
   void test_flood_different_x_units() {
@@ -84,7 +119,6 @@ public:
     TS_ASSERT_DELTA(out->y(1)[0], 2.0, DELTA);
     TS_ASSERT_DELTA(out->y(2)[0], 2.5, DELTA);
     TS_ASSERT_DELTA(out->y(3)[0], 2.2222222222, DELTA);
-    AnalysisDataService::Instance().clear();
   }
 
   void test_flood_doesnt_transform_spectra_that_are_missing_in_flood_workspace_for_multiple_bin_file() {
@@ -102,41 +136,21 @@ public:
     // Histograms with Flood Spectra are rebinned prior to flood correction
     TS_ASSERT_DELTA(out->readY(2), std::vector<double>(20, 2 / 0.8 * refactor), DELTA);
     TS_ASSERT_DELTA(out->readY(3), std::vector<double>(20, 2 / 0.9 * refactor), DELTA);
-    AnalysisDataService::Instance().clear();
   }
 
-private:
-  MatrixWorkspace_sptr createFloodWorkspace(const Mantid::Geometry::Instrument_const_sptr &instrument,
-                                            std::string const &xUnit = "TOF", const int nBoundaries = 1) {
-    MatrixWorkspace_sptr flood = create2DWorkspace(4, nBoundaries);
-    flood->mutableY(0) = std::vector<double>(nBoundaries, 0.7);
-    flood->mutableY(1) = std::vector<double>(nBoundaries, 1.0);
-    flood->mutableY(2) = std::vector<double>(nBoundaries, 0.8);
-    flood->mutableY(3) = std::vector<double>(nBoundaries, 0.9);
+  void test_flood_doesnt_transform_spectra_that_are_missing_in_flood_workspace_for_single_bin_file() {
+    auto inputWS = create2DWorkspaceWithReflectometryInstrumentMultiDetector(0, 0.1);
+    auto flood = createFloodWorkspace(inputWS->getInstrument(), "TOF");
 
-    // X values are added ad-hoc to match the bin X range of the default test Reflectometry Instrument workspaces
-    //  This doesn't affect tests with 1 bin per histogram
-    auto const &xvec = generateXRange(nBoundaries, 0);
-    flood->mutableX(0) = xvec;
-    flood->mutableX(1) = xvec;
-    flood->mutableX(2) = xvec;
-    flood->mutableX(3) = xvec;
+    auto const cropped = cropWorkspaces(flood, 2);
+    auto const out = applyFloodWorkspace(inputWS, cropped);
 
-    flood->setInstrument(instrument);
-    for (size_t i = 0; i < flood->getNumberHistograms(); ++i) {
-      flood->getSpectrum(i).setDetectorID(Mantid::detid_t(i + 1));
-    }
-    flood->getAxis(0)->setUnit("TOF");
-    if (xUnit != "TOF") {
-      ConvertUnits convert;
-      convert.initialize();
-      convert.setChild(true);
-      convert.setProperty("InputWorkspace", flood);
-      convert.setProperty("Target", xUnit);
-      convert.setProperty("OutputWorkspace", "dummy");
-      convert.execute();
-      flood = convert.getProperty("OutputWorkspace");
-    }
-    return flood;
+    // Histograms without Flood Spectra data are not modified
+    TS_ASSERT_DELTA(out->readY(0)[0], 2.0, DELTA);
+    TS_ASSERT_DELTA(out->readY(1)[0], 2.0, DELTA);
+
+    // Histograms with Flood Spectra are divided by correction factor
+    TS_ASSERT_DELTA(out->readY(2)[0], 2 / 0.8, DELTA);
+    TS_ASSERT_DELTA(out->readY(3)[0], 2 / 0.9, DELTA);
   }
 };

--- a/docs/source/release/v6.12.0/Reflectometry/Bugfixes/38393.rst
+++ b/docs/source/release/v6.12.0/Reflectometry/Bugfixes/38393.rst
@@ -1,0 +1,1 @@
+- Fix a bug where :ref:`algm-ApplyFloodWorkspace` was modifying spectra for which there is no flood correction data in multiple bin correction files.


### PR DESCRIPTION
### Description of work
The origin of this issue is very well documented in #38393. 
In summary, scientist assign a value of 1 to spectra in a Flood Workspace which are not to be corrected; most Flood Workspace spectra are a single bin (one data point) factor correction per spectra that is to be applied to the input data. For some instruments like POLREF, the flood workspace may not be a single data point, but a multiple bin spectrum. This time, the spectra which are not to be modified are assigned a vector of 1 in the Flood Workspace, but this value of 1 is changed as the Flood workspace must be rebin prior to applying the flood correction to the input workspace. This operation modifies those Flood spectrum with constant flood value of 1.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
The algorithm first equalizes the sizes of the input workspace and the flood workspace by generating a map of compatible indexes between the two spectra, incompatible indexes are labelled with the values of -1. I have taken these indexes and used them to refactor the missing spectra back to one after rebinning. The changes only affects multiple bin workspaces. 
Additionally, I have added a test that covers this case. 

Other modifications: 
- Doxygen style comments on algorithm file. 
- Add helper functions in the test to apply the algorithms 
- Modify access to workspaces using non-deprecated methods. 

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38393. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Test should pass. 
- The example script in #38393 should not modify input workspace on cropped flood workspace indexes.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*Added release notes*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
