### PR TITLE
38254 Introducing PeakShapeDetectorBin peak shape

### DIFF
--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -21,6 +21,7 @@
 #include "MantidDataObjects/LeanElasticPeaksWorkspace.h"
 #include "MantidDataObjects/Peak.h"
 #include "MantidDataObjects/PeakNoShapeFactory.h"
+#include "MantidDataObjects/PeakShapeDetectorBinFactory.h"
 #include "MantidDataObjects/PeakShapeEllipsoidFactory.h"
 #include "MantidDataObjects/PeakShapeSphericalFactory.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
@@ -1164,10 +1165,12 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
 
       PeakShapeFactory_sptr peakFactoryEllipsoid = std::make_shared<PeakShapeEllipsoidFactory>();
       PeakShapeFactory_sptr peakFactorySphere = std::make_shared<PeakShapeSphericalFactory>();
+      PeakShapeFactory_sptr peakFactoryDetectorBin = std::make_shared<PeakShapeDetectorBinFactory>();
       PeakShapeFactory_sptr peakFactoryNone = std::make_shared<PeakNoShapeFactory>();
 
       peakFactoryEllipsoid->setSuccessor(peakFactorySphere);
-      peakFactorySphere->setSuccessor(peakFactoryNone);
+      peakFactorySphere->setSuccessor(peakFactoryDetectorBin);
+      peakFactoryDetectorBin->setSuccessor(peakFactoryNone);
 
       NXInfo info = nx_tw.getDataSetInfo(str);
       NXChar data = nx_tw.openNXChar(str);
@@ -1456,10 +1459,12 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
 
       PeakShapeFactory_sptr peakFactoryEllipsoid = std::make_shared<PeakShapeEllipsoidFactory>();
       PeakShapeFactory_sptr peakFactorySphere = std::make_shared<PeakShapeSphericalFactory>();
+      PeakShapeFactory_sptr peakFactoryDetectorBin = std::make_shared<PeakShapeDetectorBinFactory>();
       PeakShapeFactory_sptr peakFactoryNone = std::make_shared<PeakNoShapeFactory>();
 
       peakFactoryEllipsoid->setSuccessor(peakFactorySphere);
-      peakFactorySphere->setSuccessor(peakFactoryNone);
+      peakFactorySphere->setSuccessor(peakFactoryDetectorBin);
+      peakFactoryDetectorBin->setSuccessor(peakFactoryNone);
 
       NXInfo info = nx_tw.getDataSetInfo(str);
       NXChar data = nx_tw.openNXChar(str);

--- a/Framework/DataObjects/CMakeLists.txt
+++ b/Framework/DataObjects/CMakeLists.txt
@@ -54,6 +54,8 @@ set(SRC_FILES
     src/WorkspaceCreation.cpp
     src/WorkspaceProperty.cpp
     src/WorkspaceSingleValue.cpp
+    src/PeakShapeDetectorBin.cpp
+    src/PeakShapeDetectorBinFactory.cpp
 )
 
 set(INC_FILES
@@ -138,6 +140,8 @@ set(INC_FILES
     inc/MantidDataObjects/Workspace2D_fwd.h
     inc/MantidDataObjects/WorkspaceCreation.h
     inc/MantidDataObjects/WorkspaceSingleValue.h
+    inc/MantidDataObjects/PeakShapeDetectorBin.h
+    inc/MantidDataObjects/PeakShapeDetectorBinFactory.h
 )
 
 set(TEST_FILES
@@ -205,6 +209,8 @@ set(TEST_FILES
     WorkspaceSingleValueTest.h
     WorkspaceValidatorsTest.h
     MortonIndex/BitInterleavingTest.h
+    PeakShapeDetectorBinTest.h
+    PeakShapeDetectorBinFactoryTest.h
 )
 
 if(COVERAGE)

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeDetectorBin.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeDetectorBin.h
@@ -1,0 +1,47 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidDataObjects/PeakShapeBase.h"
+#include <vector>
+
+namespace Mantid {
+namespace DataObjects {
+
+/** PeakShapeDetectorBin : PeakShape representing detector ids and integration limits of a peak
+ */
+class MANTID_DATAOBJECTS_DLL PeakShapeDetectorBin : public PeakShapeBase {
+public:
+  PeakShapeDetectorBin(std::vector<std::tuple<int32_t, double, double>> detectorBinList,
+                       Kernel::SpecialCoordinateSystem frame, std::string algorithmName = std::string(),
+                       int algorithmVersion = -1);
+  /// Equals operator
+  bool operator==(const PeakShapeDetectorBin &other) const;
+
+  /// PeakShape interface
+  std::string toJSON() const override;
+  /// Clone PeakShapeDetectorBin
+  Mantid::Geometry::PeakShape *clone() const override;
+  /// Get the peak shape
+  std::string shapeName() const override;
+
+  /// PeakBase interface
+  std::optional<double> radius(RadiusType type = RadiusType::Radius) const override;
+
+  static const std::string detectorBinShapeName();
+
+  const std::vector<std::tuple<int32_t, double, double>> &getDetectorBinList() const { return m_detectorBinList; }
+
+private:
+  std::vector<std::tuple<int32_t, double, double>> m_detectorBinList;
+};
+
+using PeakShapeDetectorTOF_sptr = std::shared_ptr<PeakShapeDetectorBin>;
+using PeakShapeDetectorTOF_const_sptr = std::shared_ptr<const PeakShapeDetectorBin>;
+
+} // namespace DataObjects
+} // namespace Mantid

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeDetectorBin.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeDetectorBin.h
@@ -30,7 +30,7 @@ public:
   std::string shapeName() const override;
 
   /// PeakBase interface
-  std::optional<double> radius(RadiusType type = RadiusType::Radius) const override;
+  std::optional<double> radius(RadiusType) const override { return std::nullopt; }
 
   static const std::string detectorBinShapeName();
 

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeDetectorBin.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeDetectorBin.h
@@ -16,7 +16,7 @@ namespace DataObjects {
  */
 class MANTID_DATAOBJECTS_DLL PeakShapeDetectorBin : public PeakShapeBase {
 public:
-  PeakShapeDetectorBin(std::vector<std::tuple<int32_t, double, double>> detectorBinList,
+  PeakShapeDetectorBin(const std::vector<std::tuple<int32_t, double, double>> &detectorBinList,
                        Kernel::SpecialCoordinateSystem frame, std::string algorithmName = std::string(),
                        int algorithmVersion = -1);
   /// Equals operator

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeDetectorBinFactory.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeDetectorBinFactory.h
@@ -1,0 +1,35 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidDataObjects/PeakShapeFactory.h"
+
+namespace Mantid {
+namespace Geometry {
+// Forward declare
+class PeakShape;
+} // namespace Geometry
+namespace DataObjects {
+
+/** PeakShapeDetectorBinFactory : Factory for DetectorBin peak shapes for
+ de-serializing from JSON.
+ *
+*/
+class MANTID_DATAOBJECTS_DLL PeakShapeDetectorBinFactory : public PeakShapeFactory {
+public:
+  /// Make product
+  Mantid::Geometry::PeakShape *create(const std::string &source) const override;
+  /// Set a successor should this factory be unsuitable
+  void setSuccessor(PeakShapeFactory_const_sptr successorFactory) override;
+
+private:
+  /// Successor factory
+  PeakShapeFactory_const_sptr m_successor;
+};
+
+} // namespace DataObjects
+} // namespace Mantid

--- a/Framework/DataObjects/src/PeakShapeDetectorBin.cpp
+++ b/Framework/DataObjects/src/PeakShapeDetectorBin.cpp
@@ -55,8 +55,6 @@ Mantid::Geometry::PeakShape *PeakShapeDetectorBin::clone() const { return new Pe
 
 std::string PeakShapeDetectorBin::shapeName() const { return PeakShapeDetectorBin::detectorBinShapeName(); }
 
-std::optional<double> PeakShapeDetectorBin::radius(RadiusType type) const { return std::nullopt; }
-
 const std::string PeakShapeDetectorBin::detectorBinShapeName() { return "PeakShapeDetectorBin"; }
 
 } // namespace Mantid::DataObjects

--- a/Framework/DataObjects/src/PeakShapeDetectorBin.cpp
+++ b/Framework/DataObjects/src/PeakShapeDetectorBin.cpp
@@ -21,7 +21,7 @@ namespace Mantid::DataObjects {
  * @param algorithmName Name of the algorithm using this shape
  * @param algorithmVersion Version of the above algorithm
  */
-PeakShapeDetectorBin::PeakShapeDetectorBin(std::vector<std::tuple<int32_t, double, double>> detectorBinList,
+PeakShapeDetectorBin::PeakShapeDetectorBin(const std::vector<std::tuple<int32_t, double, double>> &detectorBinList,
                                            Kernel::SpecialCoordinateSystem frame, std::string algorithmName,
                                            int algorithmVersion)
     : PeakShapeBase(frame, std::move(algorithmName), algorithmVersion), m_detectorBinList(detectorBinList) {

--- a/Framework/DataObjects/src/PeakShapeDetectorBin.cpp
+++ b/Framework/DataObjects/src/PeakShapeDetectorBin.cpp
@@ -1,0 +1,62 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataObjects/PeakShapeDetectorBin.h"
+#include "MantidJson/Json.h"
+#include "MantidKernel/cow_ptr.h"
+#include <json/json.h>
+
+#include <utility>
+
+namespace Mantid::DataObjects {
+
+/**
+ * Create PeakShapeDetectorBin
+ * @param detectorBinList The list containing each detector Ids associated with its start and end points in TOF or
+ * dSpacing domains
+ * @param frame SpecialCoordinateSystem frame, default is None
+ * @param algorithmName Name of the algorithm using this shape
+ * @param algorithmVersion Version of the above algorithm
+ */
+PeakShapeDetectorBin::PeakShapeDetectorBin(std::vector<std::tuple<int32_t, double, double>> detectorBinList,
+                                           Kernel::SpecialCoordinateSystem frame, std::string algorithmName,
+                                           int algorithmVersion)
+    : PeakShapeBase(frame, std::move(algorithmName), algorithmVersion), m_detectorBinList(detectorBinList) {
+
+  if (detectorBinList.size() == 0) {
+    throw std::invalid_argument("No data provided for detector data");
+  }
+}
+
+bool PeakShapeDetectorBin::operator==(const PeakShapeDetectorBin &other) const {
+  return PeakShapeBase::operator==(other) && (this->m_detectorBinList == other.m_detectorBinList);
+}
+
+std::string PeakShapeDetectorBin::toJSON() const {
+  Json::Value root;
+  PeakShapeBase::buildCommon(root);
+  Json::Value detBinList;
+  for (auto const &[detectorId, startX, endX] : m_detectorBinList) {
+    Json::Value detBinVal;
+    detBinVal["detId"] = Json::Value(detectorId);
+    detBinVal["startX"] = Json::Value(startX);
+    detBinVal["endX"] = Json::Value(endX);
+    detBinList.append(detBinVal);
+  }
+
+  root["detectors"] = detBinList;
+  return Mantid::JsonHelpers::jsonToString(root);
+}
+
+Mantid::Geometry::PeakShape *PeakShapeDetectorBin::clone() const { return new PeakShapeDetectorBin(*this); }
+
+std::string PeakShapeDetectorBin::shapeName() const { return PeakShapeDetectorBin::detectorBinShapeName(); }
+
+std::optional<double> PeakShapeDetectorBin::radius(RadiusType type) const { return std::nullopt; }
+
+const std::string PeakShapeDetectorBin::detectorBinShapeName() { return "PeakShapeDetectorBin"; }
+
+} // namespace Mantid::DataObjects

--- a/Framework/DataObjects/src/PeakShapeDetectorBinFactory.cpp
+++ b/Framework/DataObjects/src/PeakShapeDetectorBinFactory.cpp
@@ -1,0 +1,67 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataObjects/PeakShapeDetectorBinFactory.h"
+#include "MantidDataObjects/PeakShapeDetectorBin.h"
+#include "MantidJson/Json.h"
+#include "MantidKernel/SpecialCoordinateSystem.h"
+
+#include <json/json.h>
+#include <stdexcept>
+
+using namespace Mantid::Kernel;
+
+namespace Mantid::DataObjects {
+
+/**
+ * @brief Create the PeakShapeDetectorBin
+ * @param source : source JSON
+ * @return PeakShape via this factory or it's successors
+ */
+Mantid::Geometry::PeakShape *PeakShapeDetectorBinFactory::create(const std::string &source) const {
+  Json::Value root;
+  Mantid::Geometry::PeakShape *peakShape = nullptr;
+  if (Mantid::JsonHelpers::parse(source, &root)) {
+    const std::string shape = root["shape"].asString();
+    if (shape == PeakShapeDetectorBin::detectorBinShapeName()) {
+      const std::string algorithmName(root["algorithm_name"].asString());
+      const int algorithmVersion(root["algorithm_version"].asInt());
+      const auto frame(static_cast<SpecialCoordinateSystem>(root["frame"].asInt()));
+
+      std::vector<std::tuple<int32_t, double, double>> detectorBinList;
+      const Json::Value detectorList = root["detectors"];
+      for (int index = 0; index < detectorList.size(); index++) {
+        const Json::Value detBinVal = detectorList[index];
+        detectorBinList.emplace_back(detBinVal["detId"].asInt(), detBinVal["startX"].asDouble(),
+                                     detBinVal["endX"].asDouble());
+      }
+      peakShape = new PeakShapeDetectorBin(detectorBinList, frame, algorithmName, algorithmVersion);
+    } else {
+      if (m_successor) {
+        peakShape = m_successor->create(source);
+      } else {
+        throw std::invalid_argument("PeakShapeDetectorBinFactory:: No successor "
+                                    "factory able to process : " +
+                                    source);
+      }
+    }
+  } else {
+    throw std::invalid_argument("PeakShapeDetectorBinFactory:: Source JSON for "
+                                "the peak shape is not valid: " +
+                                source);
+  }
+  return peakShape;
+}
+
+/**
+ * @brief Set successor
+ * @param successorFactory : successor
+ */
+void PeakShapeDetectorBinFactory::setSuccessor(std::shared_ptr<const PeakShapeFactory> successorFactory) {
+  this->m_successor = successorFactory;
+}
+
+} // namespace Mantid::DataObjects

--- a/Framework/DataObjects/src/PeakShapeDetectorBinFactory.cpp
+++ b/Framework/DataObjects/src/PeakShapeDetectorBinFactory.cpp
@@ -33,7 +33,7 @@ Mantid::Geometry::PeakShape *PeakShapeDetectorBinFactory::create(const std::stri
 
       std::vector<std::tuple<int32_t, double, double>> detectorBinList;
       const Json::Value detectorList = root["detectors"];
-      for (int index = 0; index < detectorList.size(); index++) {
+      for (uint32_t index = 0; index < detectorList.size(); index++) {
         const Json::Value detBinVal = detectorList[index];
         detectorBinList.emplace_back(detBinVal["detId"].asInt(), detBinVal["startX"].asDouble(),
                                      detBinVal["endX"].asDouble());

--- a/Framework/DataObjects/src/PeakShapeDetectorBinFactory.cpp
+++ b/Framework/DataObjects/src/PeakShapeDetectorBinFactory.cpp
@@ -24,34 +24,34 @@ namespace Mantid::DataObjects {
 Mantid::Geometry::PeakShape *PeakShapeDetectorBinFactory::create(const std::string &source) const {
   Json::Value root;
   Mantid::Geometry::PeakShape *peakShape = nullptr;
-  if (Mantid::JsonHelpers::parse(source, &root)) {
-    const std::string shape = root["shape"].asString();
-    if (shape == PeakShapeDetectorBin::detectorBinShapeName()) {
-      const std::string algorithmName(root["algorithm_name"].asString());
-      const int algorithmVersion(root["algorithm_version"].asInt());
-      const auto frame(static_cast<SpecialCoordinateSystem>(root["frame"].asInt()));
-
-      std::vector<std::tuple<int32_t, double, double>> detectorBinList;
-      const Json::Value detectorList = root["detectors"];
-      for (uint32_t index = 0; index < detectorList.size(); index++) {
-        const Json::Value detBinVal = detectorList[index];
-        detectorBinList.emplace_back(detBinVal["detId"].asInt(), detBinVal["startX"].asDouble(),
-                                     detBinVal["endX"].asDouble());
-      }
-      peakShape = new PeakShapeDetectorBin(detectorBinList, frame, algorithmName, algorithmVersion);
-    } else {
-      if (m_successor) {
-        peakShape = m_successor->create(source);
-      } else {
-        throw std::invalid_argument("PeakShapeDetectorBinFactory:: No successor "
-                                    "factory able to process : " +
-                                    source);
-      }
-    }
-  } else {
+  if (!Mantid::JsonHelpers::parse(source, &root)) {
     throw std::invalid_argument("PeakShapeDetectorBinFactory:: Source JSON for "
                                 "the peak shape is not valid: " +
                                 source);
+  }
+
+  const std::string shape = root["shape"].asString();
+  if (shape == PeakShapeDetectorBin::detectorBinShapeName()) {
+    const std::string algorithmName(root["algorithm_name"].asString());
+    const int algorithmVersion(root["algorithm_version"].asInt());
+    const auto frame(static_cast<SpecialCoordinateSystem>(root["frame"].asInt()));
+
+    std::vector<std::tuple<int32_t, double, double>> detectorBinList;
+    const Json::Value detectorList = root["detectors"];
+    for (uint32_t index = 0; index < detectorList.size(); index++) {
+      const Json::Value detBinVal = detectorList[index];
+      detectorBinList.emplace_back(detBinVal["detId"].asInt(), detBinVal["startX"].asDouble(),
+                                   detBinVal["endX"].asDouble());
+    }
+    peakShape = new PeakShapeDetectorBin(detectorBinList, frame, algorithmName, algorithmVersion);
+  } else {
+    if (m_successor) {
+      peakShape = m_successor->create(source);
+    } else {
+      throw std::invalid_argument("PeakShapeDetectorBinFactory:: No successor "
+                                  "factory able to process : " +
+                                  source);
+    }
   }
   return peakShape;
 }

--- a/Framework/DataObjects/test/PeakShapeDetectorBinFactoryTest.h
+++ b/Framework/DataObjects/test/PeakShapeDetectorBinFactoryTest.h
@@ -1,0 +1,76 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+#include <json/json.h>
+
+#include "MantidDataObjects/PeakShapeDetectorBin.h"
+#include "MantidDataObjects/PeakShapeDetectorBinFactory.h"
+#include "MantidJson/Json.h"
+#include "MantidKernel/SpecialCoordinateSystem.h"
+#include "MantidKernel/cow_ptr.h"
+#include "MockObjects.h"
+
+using namespace Mantid;
+using namespace Mantid::DataObjects;
+using namespace Mantid::Kernel;
+using Mantid::DataObjects::PeakShapeDetectorBin;
+using Mantid::Kernel::SpecialCoordinateSystem;
+
+class PeakShapeDetectorBinFactoryTest : public CxxTest::TestSuite {
+public:
+  static PeakShapeDetectorBinFactoryTest *createSuite() { return new PeakShapeDetectorBinFactoryTest(); }
+  static void destroySuite(PeakShapeDetectorBinFactoryTest *suite) { delete suite; }
+
+  void test_invalid_json_with_no_successor() {
+    PeakShapeDetectorBinFactory factory;
+    TS_ASSERT_THROWS(factory.create(""), std::invalid_argument &);
+  }
+
+  void test_successor_calling_when_shape_is_unhandled() {
+    using namespace testing;
+    MockPeakShapeFactory *delegate = new MockPeakShapeFactory;
+    EXPECT_CALL(*delegate, create(_)).Times(1);
+
+    PeakShapeDetectorBinFactory factory;
+    factory.setSuccessor(PeakShapeFactory_const_sptr(delegate));
+
+    // Minimal valid JSON for describing the shape.
+    Json::Value root;
+    root["shape"] = "NotHandled";
+    const std::string str_json = Mantid::JsonHelpers::jsonToString(root);
+
+    TS_ASSERT_THROWS_NOTHING(factory.create(str_json));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(delegate));
+  }
+
+  void test_when_no_successor() {
+    PeakShapeDetectorBinFactory factory;
+
+    // Minimal valid JSON for describing the shape.
+    Json::Value root;
+    root["shape"] = "NotHandled";
+    const std::string str_json = Mantid::JsonHelpers::jsonToString(root);
+
+    TS_ASSERT_THROWS(factory.create(str_json), std::invalid_argument &);
+  }
+
+  void test_factory_create() {
+    PeakShapeDetectorBin shape({{100, 10, 50}, {200, 34, 55}}, SpecialCoordinateSystem::None, "test", 1);
+
+    PeakShapeDetectorBinFactory factory;
+    std::shared_ptr<Mantid::Geometry::PeakShape> productShape(factory.create(shape.toJSON()));
+
+    std::shared_ptr<PeakShapeDetectorBin> factoryShape = std::dynamic_pointer_cast<PeakShapeDetectorBin>(productShape);
+    TS_ASSERT(factoryShape);
+
+    TS_ASSERT_EQUALS(shape, *factoryShape);
+    TS_ASSERT_EQUALS(factoryShape->getDetectorBinList(), shape.getDetectorBinList())
+  }
+};

--- a/Framework/DataObjects/test/PeakShapeDetectorBinTest.h
+++ b/Framework/DataObjects/test/PeakShapeDetectorBinTest.h
@@ -111,4 +111,14 @@ public:
     TS_ASSERT_EQUALS(shape2.getDetectorBinList(), shape1.getDetectorBinList());
     TS_ASSERT_EQUALS(shape2.toJSON(), shape1.toJSON());
   }
+
+  void test_equal_operator() {
+    std::vector<std::tuple<int32_t, double, double>> detPeakBinList1 = {{100, 10, 50}, {200, 34, 55}};
+    PeakShapeDetectorBin shape1(detPeakBinList1, SpecialCoordinateSystem::None, "algo1", 1);
+
+    std::vector<std::tuple<int32_t, double, double>> detPeakBinList2 = {{100, 10, 50}, {200, 34, 55}};
+    PeakShapeDetectorBin shape2(detPeakBinList2, SpecialCoordinateSystem::None, "algo2", 2);
+
+    TS_ASSERT_EQUALS(shape1, shape2);
+  }
 };

--- a/Framework/DataObjects/test/PeakShapeDetectorBinTest.h
+++ b/Framework/DataObjects/test/PeakShapeDetectorBinTest.h
@@ -1,0 +1,114 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidDataObjects/PeakShapeDetectorBin.h"
+#include "MantidJson/Json.h"
+#include "MantidKernel/cow_ptr.h"
+#include <json/json.h>
+#include <vector>
+
+using Mantid::DataObjects::PeakShapeDetectorBin;
+using Mantid::Kernel::SpecialCoordinateSystem;
+using namespace Mantid;
+using namespace Mantid::Kernel;
+
+class PeakShapeDetectorBinTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static PeakShapeDetectorBinTest *createSuite() { return new PeakShapeDetectorBinTest(); }
+  static void destroySuite(PeakShapeDetectorBinTest *suite) { delete suite; }
+
+  void test_constructor() {
+    std::vector<std::tuple<int32_t, double, double>> detPeakBinList = {
+        {100, 20.55, 40.52}, {102, 33.0, 55.67}, {104, 50.9, 70.5}};
+    std::string algorithmName = "TestSuite";
+    int version = 1;
+    auto coordinateSys = SpecialCoordinateSystem::None;
+
+    std::shared_ptr<DataObjects::PeakShapeBase> peakShape =
+        std::make_shared<PeakShapeDetectorBin>(detPeakBinList, coordinateSys, algorithmName, version);
+
+    TS_ASSERT_EQUALS(algorithmName, peakShape->algorithmName());
+    TS_ASSERT_EQUALS(version, peakShape->algorithmVersion());
+    TS_ASSERT_EQUALS(coordinateSys, peakShape->frame());
+    TS_ASSERT_EQUALS("PeakShapeDetectorBin", peakShape->shapeName());
+    TS_ASSERT_EQUALS(std::nullopt, peakShape->radius(Mantid::Geometry::PeakShape::RadiusType::Radius));
+    TS_ASSERT_EQUALS(std::dynamic_pointer_cast<PeakShapeDetectorBin>(peakShape)->getDetectorBinList(), detPeakBinList);
+
+    std::shared_ptr<Mantid::Geometry::PeakShape> cloneShape(peakShape->clone());
+
+    TS_ASSERT_EQUALS(algorithmName, cloneShape->algorithmName());
+    TS_ASSERT_EQUALS(version, cloneShape->algorithmVersion());
+    TS_ASSERT_EQUALS(coordinateSys, cloneShape->frame());
+    TS_ASSERT_EQUALS("PeakShapeDetectorBin", cloneShape->shapeName());
+    TS_ASSERT_EQUALS(std::nullopt, cloneShape->radius(Mantid::Geometry::PeakShape::RadiusType::Radius));
+    TS_ASSERT_EQUALS(std::dynamic_pointer_cast<PeakShapeDetectorBin>(cloneShape)->getDetectorBinList(), detPeakBinList);
+  }
+
+  void test_json_serialization() {
+    std::vector<std::tuple<int32_t, double, double>> detPeakBinList = {
+        {100, 20.55, 40.52}, {102, 33.0, 55.67}, {104, 50.9, 70.5}};
+    std::shared_ptr<DataObjects::PeakShapeBase> peakShape =
+        std::make_shared<PeakShapeDetectorBin>(detPeakBinList, SpecialCoordinateSystem::None, "TestSuite", 1);
+
+    std::string jsonStr = peakShape->toJSON();
+    Json::Value output;
+    TSM_ASSERT("Should parse as JSON", Mantid::JsonHelpers::parse(jsonStr, &output));
+    TS_ASSERT_EQUALS("PeakShapeDetectorBin", output["shape"].asString());
+    TS_ASSERT_EQUALS("TestSuite", output["algorithm_name"].asString());
+    TS_ASSERT_EQUALS(1, output["algorithm_version"].asInt());
+    TS_ASSERT_EQUALS(0, output["frame"].asInt());
+
+    Json::Value detectorBinList = output["detectors"];
+    TS_ASSERT_EQUALS(detectorBinList[0]["detId"].asInt(), 100);
+    TS_ASSERT_EQUALS(detectorBinList[0]["startX"].asDouble(), 20.55);
+    TS_ASSERT_EQUALS(detectorBinList[0]["endX"].asDouble(), 40.52);
+
+    TS_ASSERT_EQUALS(detectorBinList[1]["detId"].asInt(), 102);
+    TS_ASSERT_EQUALS(detectorBinList[1]["startX"].asDouble(), 33.0);
+    TS_ASSERT_EQUALS(detectorBinList[1]["endX"].asDouble(), 55.67);
+
+    TS_ASSERT_EQUALS(detectorBinList[2]["detId"].asInt(), 104);
+    TS_ASSERT_EQUALS(detectorBinList[2]["startX"].asDouble(), 50.9);
+    TS_ASSERT_EQUALS(detectorBinList[2]["endX"].asDouble(), 70.5);
+  }
+
+  void test_constructor_throws() {
+    std::vector<std::tuple<int32_t, double, double>> detPeakBinList = {};
+
+    TSM_ASSERT_THROWS("Should throw, bad directions",
+                      PeakShapeDetectorBin(detPeakBinList, SpecialCoordinateSystem::None, "test", 1);
+                      , std::invalid_argument &);
+  }
+
+  void test_copy_constructor() {
+    std::vector<std::tuple<int32_t, double, double>> detPeakBinList = {{100, 10, 50}, {200, 34, 55}};
+    PeakShapeDetectorBin shape1(detPeakBinList, SpecialCoordinateSystem::None, "test", 1);
+    PeakShapeDetectorBin shape2(shape1);
+
+    TS_ASSERT_EQUALS(shape1.getDetectorBinList(), detPeakBinList);
+    TS_ASSERT_EQUALS(shape2.getDetectorBinList(), detPeakBinList);
+    TS_ASSERT_EQUALS(shape1, shape2);
+  }
+
+  void test_assignment() {
+    std::vector<std::tuple<int32_t, double, double>> detPeakBinList1 = {{100, 10, 50}, {200, 34, 55}};
+    PeakShapeDetectorBin shape1(detPeakBinList1, SpecialCoordinateSystem::None, "test", 1);
+
+    std::vector<std::tuple<int32_t, double, double>> detPeakBinList2 = {{500, 68, 77}};
+    PeakShapeDetectorBin shape2(detPeakBinList2, SpecialCoordinateSystem::None, "test", 1);
+
+    shape2 = shape1;
+
+    TS_ASSERT_EQUALS(shape2.getDetectorBinList(), shape1.getDetectorBinList());
+    TS_ASSERT_EQUALS(shape2.toJSON(), shape1.toJSON());
+  }
+};

--- a/Framework/PythonInterface/mantid/dataobjects/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/dataobjects/CMakeLists.txt
@@ -34,6 +34,7 @@ set(EXPORT_FILES
     src/Exports/PeakShapeSpherical.cpp
     src/Exports/PeakShapeEllipsoid.cpp
     src/Exports/WorkspaceValidators.cpp
+    src/Exports/PeakShapeDetectorBin.cpp
 )
 
 set(MODULE_DEFINITION ${CMAKE_CURRENT_BINARY_DIR}/dataobjects.cpp)

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
@@ -38,6 +38,5 @@ void export_PeakShapeDetectorBin() {
   class_<PeakShapeDetectorBin, bases<Mantid::Geometry::PeakShape>, boost::noncopyable>("PeakShapeDetectorBin", no_init)
       .def("__init__", make_constructor(&createPeakShapeDetectorBin, default_call_policies(),
                                         (arg("detectorBinList"), arg("frame") = SpecialCoordinateSystem::None,
-                                         arg("algorithmName") = "", arg("algorithmVersion") = -1)))
-      .def("__eq__", &PeakShapeDetectorBin::operator==);
+                                         arg("algorithmName") = "", arg("algorithmVersion") = -1)));
 }

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
@@ -1,0 +1,42 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataObjects/PeakShapeDetectorBin.h"
+#include "MantidPythonInterface/core/Converters/PySequenceToVector.h"
+#include <boost/python/class.hpp>
+#include <boost/python/list.hpp>
+#include <boost/python/make_constructor.hpp>
+#include <boost/python/tuple.hpp>
+#include <vector>
+
+using namespace boost::python;
+using namespace Mantid::DataObjects;
+using Mantid::Kernel::SpecialCoordinateSystem;
+using Mantid::PythonInterface::Converters::PySequenceToVector;
+
+PeakShapeDetectorBin *createPeakShapeDetectorBin(const boost::python::list &pyList, SpecialCoordinateSystem frame,
+                                                 const std::string &algorithmName = std::string(),
+                                                 int algorithmVersion = -1) {
+  // Convert Python list of tuples to std::vector<std::tuple<int32_t, double, double>>
+  std::vector<std::tuple<int32_t, double, double>> detectorBinList;
+
+  for (int i = 0; i < boost::python::len(pyList); ++i) {
+    boost::python::tuple pyTuple = boost::python::extract<boost::python::tuple>(pyList[i]);
+    int32_t detectorID = boost::python::extract<int32_t>(pyTuple[0]);
+    double startX = boost::python::extract<double>(pyTuple[1]);
+    double endX = boost::python::extract<double>(pyTuple[2]);
+    detectorBinList.emplace_back(detectorID, startX, endX);
+  }
+
+  return new PeakShapeDetectorBin(detectorBinList, frame, algorithmName, algorithmVersion);
+}
+
+void export_PeakShapeDetectorBin() {
+  class_<PeakShapeDetectorBin, bases<Mantid::Geometry::PeakShape>, boost::noncopyable>("PeakShapeDetectorBin", no_init)
+      .def("__init__", make_constructor(&createPeakShapeDetectorBin, default_call_policies(),
+                                        (arg("detectorBinList"), arg("frame") = SpecialCoordinateSystem::None,
+                                         arg("algorithmName") = "", arg("algorithmVersion") = -1)));
+}

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
@@ -39,5 +39,5 @@ void export_PeakShapeDetectorBin() {
       .def("__init__", make_constructor(&createPeakShapeDetectorBin, default_call_policies(),
                                         (arg("detectorBinList"), arg("frame") = SpecialCoordinateSystem::None,
                                          arg("algorithmName") = "", arg("algorithmVersion") = -1)))
-      .def("__eq__", &PeakShapeDetectorBin::operator==, arg("self"), arg("other"));
+      .def("__eq__", &PeakShapeDetectorBin::operator==);
 }

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
@@ -38,5 +38,6 @@ void export_PeakShapeDetectorBin() {
   class_<PeakShapeDetectorBin, bases<Mantid::Geometry::PeakShape>, boost::noncopyable>("PeakShapeDetectorBin", no_init)
       .def("__init__", make_constructor(&createPeakShapeDetectorBin, default_call_policies(),
                                         (arg("detectorBinList"), arg("frame") = SpecialCoordinateSystem::None,
-                                         arg("algorithmName") = "", arg("algorithmVersion") = -1)));
+                                         arg("algorithmName") = "", arg("algorithmVersion") = -1)))
+      .def("__eq__", &PeakShapeDetectorBin::operator==, arg("self"), arg("other"));
 }

--- a/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
@@ -5,11 +5,12 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-from mantid.kernel import V3D
-from mantid.dataobjects import NoShape, PeakShapeSpherical, PeakShapeEllipsoid
+from mantid.kernel import V3D, SpecialCoordinateSystem
+from mantid.dataobjects import NoShape, PeakShapeSpherical, PeakShapeEllipsoid, PeakShapeDetectorBin
 from mantid.simpleapi import CreateSimulationWorkspace, CreatePeaksWorkspace, LoadInstrument
 import numpy as np
 import numpy.testing as npt
+import json
 
 
 class IPeakTest(unittest.TestCase):
@@ -173,6 +174,8 @@ class IPeakTest(unittest.TestCase):
         no_shape = NoShape()
         sphere = PeakShapeSpherical(1)
         ellipse = PeakShapeEllipsoid([V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)], [0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9])
+        detectorXList = [(14500, 20.45, 50.89), (45670, 109.88, 409.56), (60995, 56009.89, 70988.89)]
+        detectorBin = PeakShapeDetectorBin(detectorXList, SpecialCoordinateSystem.NONE, "test", 1)
 
         self.assertEqual(self._peak.getPeakShape().shapeName(), "none")
 
@@ -184,6 +187,16 @@ class IPeakTest(unittest.TestCase):
 
         self._peak.setPeakShape(no_shape)
         self.assertEqual(self._peak.getPeakShape().shapeName(), "none")
+
+        self._peak.setPeakShape(detectorBin)
+        self.assertEqual(self._peak.getPeakShape().shapeName(), "PeakShapeDetectorBin")
+        self.assertEqual(self._peak.getPeakShape().algorithmVersion(), 1)
+        self.assertEqual(self._peak.getPeakShape().algorithmName(), "test")
+        det_bin_dict = json.loads(self._peak.getPeakShape().toJSON())
+        for i in range(3):
+            self.assertEqual(det_bin_dict["detectors"][i]["detId"], detectorXList[i][0])
+            self.assertEqual(det_bin_dict["detectors"][i]["startX"], detectorXList[i][1])
+            self.assertEqual(det_bin_dict["detectors"][i]["endX"], detectorXList[i][2])
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
@@ -174,8 +174,8 @@ class IPeakTest(unittest.TestCase):
         no_shape = NoShape()
         sphere = PeakShapeSpherical(1)
         ellipse = PeakShapeEllipsoid([V3D(1, 0, 0), V3D(0, 1, 0), V3D(0, 0, 1)], [0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9])
-        detectorXList = [(14500, 20.45, 50.89), (45670, 109.88, 409.56), (60995, 56009.89, 70988.89)]
-        detectorBin = PeakShapeDetectorBin(detectorXList, SpecialCoordinateSystem.NONE, "test", 1)
+        detector_x_list = [(14500, 20.45, 50.89), (45670, 109.88, 409.56), (60995, 56009.89, 70988.89)]
+        detector_bin = PeakShapeDetectorBin(detector_x_list, SpecialCoordinateSystem.NONE, "test", 1)
 
         self.assertEqual(self._peak.getPeakShape().shapeName(), "none")
 
@@ -188,15 +188,17 @@ class IPeakTest(unittest.TestCase):
         self._peak.setPeakShape(no_shape)
         self.assertEqual(self._peak.getPeakShape().shapeName(), "none")
 
-        self._peak.setPeakShape(detectorBin)
+        self._peak.setPeakShape(detector_bin)
         self.assertEqual(self._peak.getPeakShape().shapeName(), "PeakShapeDetectorBin")
         self.assertEqual(self._peak.getPeakShape().algorithmVersion(), 1)
         self.assertEqual(self._peak.getPeakShape().algorithmName(), "test")
         det_bin_dict = json.loads(self._peak.getPeakShape().toJSON())
         for i in range(3):
-            self.assertEqual(det_bin_dict["detectors"][i]["detId"], detectorXList[i][0])
-            self.assertEqual(det_bin_dict["detectors"][i]["startX"], detectorXList[i][1])
-            self.assertEqual(det_bin_dict["detectors"][i]["endX"], detectorXList[i][2])
+            self.assertEqual(det_bin_dict["detectors"][i]["detId"], detector_x_list[i][0])
+            self.assertEqual(det_bin_dict["detectors"][i]["startX"], detector_x_list[i][1])
+            self.assertEqual(det_bin_dict["detectors"][i]["endX"], detector_x_list[i][2])
+        detector_bin_copy = PeakShapeDetectorBin(detector_x_list, SpecialCoordinateSystem.NONE, "test2", 2)
+        self.assertEqual(detector_bin, detector_bin_copy)
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
@@ -197,8 +197,6 @@ class IPeakTest(unittest.TestCase):
             self.assertEqual(det_bin_dict["detectors"][i]["detId"], detector_x_list[i][0])
             self.assertEqual(det_bin_dict["detectors"][i]["startX"], detector_x_list[i][1])
             self.assertEqual(det_bin_dict["detectors"][i]["endX"], detector_x_list[i][2])
-        detector_bin_copy = PeakShapeDetectorBin(detector_x_list, SpecialCoordinateSystem.NONE, "test2", 2)
-        self.assertEqual(detector_bin, detector_bin_copy)
 
 
 if __name__ == "__main__":

--- a/docs/source/api/python/mantid/dataobjects/PeakShapeDetectorBin.rst
+++ b/docs/source/api/python/mantid/dataobjects/PeakShapeDetectorBin.rst
@@ -1,0 +1,14 @@
+======================
+ PeakShapeDetectorBin
+======================
+
+This is a Python binding to the C++ class Mantid::DataObjects::PeakShapeDetectorBin.
+
+*bases:* :py:obj:`mantid.geometry.PeakShape`
+
+.. module:`mantid.dataobjects`
+
+.. autoclass:: mantid.dataobjects.PeakShapeDetectorBin
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/source/release/v6.12.0/Diffraction/Single_Crystal/New_features/38254.rst
+++ b/docs/source/release/v6.12.0/Diffraction/Single_Crystal/New_features/38254.rst
@@ -1,0 +1,1 @@
+- A new peak shape named PeakShapeDetectorBin was introduced to save the detector IDs and bin indices of either TOF or dSpacing domains. This peak shape could be used for Overlap detection, Two-step integration and Eventual visualisation on instrument view.


### PR DESCRIPTION
### Description of work
A new peak shape `PeakShapeDetectorBin` was introduced to save the shape of each peak including the detector IDs and limits of either `TOF` or `dSpacing`. This shape can be used for

- Overlap detection post integration (peaks could be excluded or flagged as combined)
- Two-step integration - re-integrate weak peaks using strong peak dimensions
- Eventual visualisation on instrument view (i.e. show bounding box of peak)


Partially fixes #38254. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1. Code review
2. Unit tests should pass in python and c++
3. `PeakShapeDetectorBin` should be visible to python and can be inspected with below code snippet
```
from mantid.dataobjects import PeakShapeDetectorBin
from mantid.kernel import SpecialCoordinateSystem
detBinList = [(101, 27.0, 100.0), (202, 3000.0, 5000.0)]
shape = PeakShapeDetectorBin(detBinList, SpecialCoordinateSystem.NONE, "ParentAlgoName", 1)
print(shape.toJSON())
print(shape.algorithmName())
print(shape.algorithmVersion())
print(shape.shapeName())
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
