### PR TITLE
Move from matplotlib 3.8 to 3.9

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
@@ -651,16 +651,16 @@ class PeakData:
             xmask, ymask = np.where(self.peak_mask.T)
             ax[0].lines[0].set_xdata(xmask)
             ax[0].lines[0].set_ydata(ymask)
-            ax[0].lines[1].set_xdata(self.icol)
-            ax[0].lines[1].set_ydata(self.irow)
+            ax[0].lines[1].set_xdata([self.icol])
+            ax[0].lines[1].set_ydata([self.irow])
             img.set_extent([-0.5, self.x_integrated_data.shape[1] - 0.5, self.x_integrated_data.shape[0] - 0.5, -0.5])
             # update 1D focused spectrum
             # vlines
             xmin_line, xmax_line, data, xpos_line, xmin_init_line, xmax_init_line, y0 = ax[1].lines
-            xmin_line.set_xdata(self.xmin_opt)
-            xmax_line.set_xdata(self.xmax_opt)
-            xmin_init_line.set_xdata(self.xmin)
-            xmax_init_line.set_xdata(self.xmax)
+            xmin_line.set_xdata([self.xmin_opt])
+            xmax_line.set_xdata([self.xmax_opt])
+            xmin_init_line.set_xdata([self.xmin])
+            xmax_init_line.set_xdata([self.xmax])
             xpos_line.set_xdata([self.xpos])
             # spectrum
             yerr = np.sqrt(self.epk_sq[istart:iend])

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -66,7 +66,7 @@ numpy:
   - 2.0.*
 
 matplotlib:
-  - 3.8.*
+  - 3.9.*
 
 mslice:
   - '2.10'

--- a/docs/source/release/v6.12.0/Framework/Dependencies/New_features/38077.rst
+++ b/docs/source/release/v6.12.0/Framework/Dependencies/New_features/38077.rst
@@ -1,1 +1,1 @@
-- Updated Matplotlib from version 3.7 to version 3.8. The release notes for version 3.8 can be found `here <https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.8.0.html>`_ .
+- Updated Matplotlib from version 3.7 to version 3.9. The release notes for `version 3.8 <https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.8.0.html>`_  and `version 3.9 <https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.9.0.html>`_

--- a/qt/python/mantidqt/mantidqt/plotting/test/test_sample_shape.py
+++ b/qt/python/mantidqt/mantidqt/plotting/test/test_sample_shape.py
@@ -8,7 +8,7 @@
 #
 #
 
-from numpy.testing import assert_array_equal, assert_allclose, assert_almost_equal
+from numpy.testing import assert_array_equal, assert_allclose, assert_array_less
 from os import path, remove
 from tempfile import gettempdir
 from unittest import TestCase, main
@@ -268,7 +268,7 @@ class PlotSampleShapeTest(TestCase):
         xlim = axes.get_xlim()
         ylim = axes.get_ylim()
         zlim = axes.get_zlim()
-        assert_almost_equal(xlim, (-0.165, 0.165), 5)  # extra 5%
+        assert_array_less((0.15, 0.15), np.abs(xlim))  # window is bigger than object 15cm
         assert_allclose(xlim, ylim, rtol=self.RELATIVE_TOLERANCE)
         assert_allclose(xlim, zlim, rtol=self.RELATIVE_TOLERANCE)
 

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/__init__.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/__init__.py
@@ -7,7 +7,7 @@
 #  This file is part of the mantid workbench.
 
 from mantid.plots.utility import row_num, col_num
-from matplotlib.axes import ErrorbarContainer
+from matplotlib.container import ErrorbarContainer
 from matplotlib.collections import QuadMesh
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
@@ -7,7 +7,7 @@
 #  This file is part of the mantid workbench.
 
 from matplotlib import rcParams
-from matplotlib.axes import ErrorbarContainer
+from matplotlib.container import ErrorbarContainer
 from matplotlib.lines import Line2D
 from numpy import isclose
 from qtpy.QtCore import Qt


### PR DESCRIPTION
With the move to numpy v2 in #38420, we can move to the latest stable of release of matplotlib. According to the [matplotlib 3.9 notes on runtime dependencies](https://matplotlib.org/stable/install/dependencies.html#optional-dependencies), qt5 is still supported. Let's see what happens.

[Link to changes in matplotlib 3.9](https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.9.0.html)

*There is no associated issue* but this is associated with [EWM8431](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8431)

### To test:

Probably should do some quick testing of things that rely on matplotlib like SliceViewer, otherwise if the tests pass it should be good to go.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
