### PR TITLE
Fix bug in retrieving exponential correction parameters in auto detection mode of Reflectometry Reduction  One Auto algorithm

### DIFF
--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -558,7 +558,6 @@ void ReflectometryReductionOneAuto3::populateAlgorithmicCorrectionProperties(con
 
   // With algorithmic corrections, monitors should not be integrated, see below
   const std::string correctionAlgorithm = getProperty("CorrectionAlgorithm");
-
   if (correctionAlgorithm == "PolynomialCorrection") {
     alg->setProperty("NormalizeByIntegratedMonitors", false);
     alg->setProperty("CorrectionAlgorithm", "PolynomialCorrection");
@@ -587,17 +586,22 @@ void ReflectometryReductionOneAuto3::populateAlgorithmicCorrectionProperties(con
           throw std::runtime_error("Could not find parameter 'polystring' in "
                                    "parameter file. Cannot apply polynomial "
                                    "correction.");
+        setProperty("Polynomial", polyVec[0]);
         alg->setProperty("CorrectionAlgorithm", "PolynomialCorrection");
         alg->setProperty("Polynomial", polyVec[0]);
       } else if (correctionStr == "exponential") {
-        const auto c0Vec = instrument->getStringParameter("C0");
+        const auto c0Vec = instrument->getNumberParameter("C0");
         if (c0Vec.empty())
           throw std::runtime_error("Could not find parameter 'C0' in parameter "
                                    "file. Cannot apply exponential correction.");
-        const auto c1Vec = instrument->getStringParameter("C1");
+        const auto c1Vec = instrument->getNumberParameter("C1");
         if (c1Vec.empty())
           throw std::runtime_error("Could not find parameter 'C1' in parameter "
                                    "file. Cannot apply exponential correction.");
+
+        setProperty("C0", c0Vec[0]);
+        setProperty("C1", c1Vec[0]);
+        alg->setProperty("CorrectionAlgorithm", "ExponentialCorrection");
         alg->setProperty("C0", c0Vec[0]);
         alg->setProperty("C1", c1Vec[0]);
       }

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -607,7 +607,7 @@ void ReflectometryReductionOneAuto3::populateAlgorithmicCorrectionProperties(con
       }
       alg->setProperty("NormalizeByIntegratedMonitors", false);
     } catch (std::runtime_error &e) {
-      g_log.error() << e.what() << ". Polynomial correction will not be performed.";
+      g_log.error() << e.what() << ". Algorithmic correction will not be performed.";
       alg->setProperty("CorrectionAlgorithm", "None");
     }
   } else {

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -586,7 +586,6 @@ void ReflectometryReductionOneAuto3::populateAlgorithmicCorrectionProperties(con
           throw std::runtime_error("Could not find parameter 'polystring' in "
                                    "parameter file. Cannot apply polynomial "
                                    "correction.");
-        setProperty("Polynomial", polyVec[0]);
         alg->setProperty("CorrectionAlgorithm", "PolynomialCorrection");
         alg->setProperty("Polynomial", polyVec[0]);
       } else if (correctionStr == "exponential") {
@@ -599,8 +598,6 @@ void ReflectometryReductionOneAuto3::populateAlgorithmicCorrectionProperties(con
           throw std::runtime_error("Could not find parameter 'C1' in parameter "
                                    "file. Cannot apply exponential correction.");
 
-        setProperty("C0", c0Vec[0]);
-        setProperty("C1", c1Vec[0]);
         alg->setProperty("CorrectionAlgorithm", "ExponentialCorrection");
         alg->setProperty("C0", c0Vec[0]);
         alg->setProperty("C1", c1Vec[0]);

--- a/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
@@ -8,7 +8,6 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidDataHandling/LoadEmptyInstrument.h"
 #include "MantidReflectometry/ReflectometryReductionOneAuto3.h"
 
 #include "MantidAPI/AnalysisDataService.h"

--- a/docs/source/release/v6.12.0/Reflectometry/Bugfixes/38204.rst
+++ b/docs/source/release/v6.12.0/Reflectometry/Bugfixes/38204.rst
@@ -1,0 +1,1 @@
+- Fix a bug where :ref:`algm-ReflectometryReductionOneLiveData` was not retrieving correctly the exponential correction parameters from the instrument definition file.

--- a/instrument/unit_testing/REFL_Parameters_ExponentialCorrection.xml
+++ b/instrument/unit_testing/REFL_Parameters_ExponentialCorrection.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<parameter-file instrument="REFL" valid-from="forever">
+
+<component-link name="REFL" >
+
+   <!-- parameters for testing exponential efficiency corrections-->
+  <parameter name="correction" type="string">
+    <value val="exponential"/>
+  </parameter>
+
+  <parameter name="C0">
+    <value val="36.5688"/>
+  </parameter>
+
+  <parameter name="C1">
+    <value val="0.188676"/>
+  </parameter>
+
+</component-link>
+
+</parameter-file>

--- a/instrument/unit_testing/REFL_Parameters_PolynomialCorrection.xml
+++ b/instrument/unit_testing/REFL_Parameters_PolynomialCorrection.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<parameter-file instrument="REFL" valid-from="forever">
+
+<component-link name="REFL" >
+
+   <!-- parameters for testing polynomial efficiency corrections-->
+  <parameter name="correction" type="string">
+    <value val="polynomial"/>
+  </parameter>
+
+  <parameter name="polystring" type="string">
+    <value val="35.5893,-24.5591,9.20375,-1.89265,0.222291,-0.0148746,0.00052709,-7.66807e-6"/>
+    <!--<value val="28.0051,-19.396,7.5629,-1.624,0.1986,-0.013783,0.00050478,-7.56647e-6"/>-->
+  </parameter>
+
+</component-link>
+
+</parameter-file>


### PR DESCRIPTION
### Description of work
The issue is explained in #38204 : parameters for exponential correction were not being correctly retrieved when in autodetect mode, as the instrument parameters were being retrieved as string, but in the case of the exponential parameters, these are better retrieved as numbers. On the other hand, the polynomial parameters have the flexibility of being input as a double list or string with comma separated values for the parameters. 

Additional changes: 
- I have re-set the value of the correction parameters in the calling algorithm `ReflectometryReductionOneAuto`. 
- I have added two tests to check that the correction parameters are being properly called in `AutoDetect` mode both for exponential corrections and polynomial corrections. 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38204 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
- Follow testing instructions on #38204 and make sure that the parameters are properly set by looking at the history. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
