### PR TITLE
Fix input runs for LoadVesuvio

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -437,7 +437,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 Filename=run_str,
                 OutputWorkspace=SUMMED_WS,
                 SpectrumList=all_spectra,
-                # LoadLogFiles=self._load_log_files,
+                LoadLogFiles=self._load_log_files,
                 EnableLogging=_LOGGING_,
             )
         else:
@@ -447,7 +447,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 Filename=run_str,
                 OutputWorkspace=SUMMED_WS,
                 SpectrumList=all_spec_inc_mon,
-                # LoadLogFiles=self._load_log_files,
+                LoadLogFiles=self._load_log_files,
                 LoadMonitors="Separate",
                 EnableLogging=_LOGGING_,
             )
@@ -612,7 +612,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 SpectrumList=spec_inc_mon,
                 OutputWorkspace=out_name,
                 LoadMonitors="Separate",
-                # LoadLogFiles=self._load_log_files,
+                LoadLogFiles=self._load_log_files,
                 EnableLogging=_LOGGING_,
             )
 

--- a/Testing/SystemTests/tests/framework/LoadVesuvioTest.py
+++ b/Testing/SystemTests/tests/framework/LoadVesuvioTest.py
@@ -199,6 +199,18 @@ class VesuvioTests(unittest.TestCase):
         self.assertAlmostEqual(0.0013599866184859088, evs_raw.readY(63)[1188], places=DIFF_PLACES)
         self.assertAlmostEqual(0.16935354944452052, evs_raw.readE(0)[1], places=DIFF_PLACES)
 
+    def test_consecutive_and_non_consecutive_runs_with_forward_scattering_spectra_gives_expected_numbers(self):
+        # Skips runs 14190, 91
+        self._run_load("14188, 14189-14190", "135-198", "SingleDifference")
+
+        # Check some data
+        evs_raw = mtd[self.ws_name]
+
+        self.assertAlmostEqual(-0.3302367568682385, evs_raw.readY(0)[1], places=DIFF_PLACES)
+        self.assertAlmostEqual(0.1383918129898758, evs_raw.readE(0)[1], places=DIFF_PLACES)
+        self.assertAlmostEqual(-0.0005762703884557574, evs_raw.readY(63)[1188], places=DIFF_PLACES)
+        self.assertAlmostEqual(0.1383918129898758, evs_raw.readE(0)[1], places=DIFF_PLACES)
+
     def test_foilout_mode_gives_expected_numbers(self):
         self._run_load("14188", "3", "FoilOut")
 

--- a/docs/source/release/v6.12.0/Indirect/Algorithms/Bugfixes/38442.rst
+++ b/docs/source/release/v6.12.0/Indirect/Algorithms/Bugfixes/38442.rst
@@ -1,0 +1,2 @@
+- :ref:`LoadVesuvio <algm-LoadVesuvio-v1>` now accepts multiple consecutive runs for the ``Filename`` property,
+  for example ``43066-43070, 43072-43074`` is the same as running ``43066-43074`` except the run ``43071`` will not be included.


### PR DESCRIPTION
### Description of work
Putting several ranges as inputs to LoadVesuvio was causing Mantid to crash.
It is now fixed so that input can handle several ranges specified.

#### Summary of work
Allow for inputs to have several commas and several ranges.

#### Purpose of work
This issue was reported by a Vesuvio instrument scientist, and should get fixed.


**Report to:** Anna Marsicano

### To test:

Run the script

```python
from mantid.simpleapi import *

LoadVesuvio(Filename='43066-43070, 43072-43074', SpectrumList='144-182', Mode='SingleDifference', InstrumentParFile='/home/ljg28444/.mvesuvio/ip_files/ip2018_3.par', OutputWorkspace='ws')
``` 

with the path to this instrument file (unzip it): 
[ip2018_3.zip](https://github.com/user-attachments/files/17905563/ip2018_3.zip)


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
