### PR TITLE
LoadEventNexus error when loading single vulcan bank

### DIFF
--- a/Framework/DataHandling/test/LoadEventNexusIndexSetupTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusIndexSetupTest.h
@@ -190,6 +190,24 @@ public:
     TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(3));
   }
 
+  /* compare this test body with test_makeIndexInfo_from_bank. The main difference is that the instrument components are
+   * specifed backwards. This is consistent with VULCAN IDF */
+  void test_makeIndexInfo_from_bank_backwards() {
+    LoadEventNexusIndexSetup indexSetup(m_ws, EMPTY_INT(), EMPTY_INT(), {});
+    const auto indexInfo = indexSetup.makeIndexInfo({"det-12", "det-2"}); // intentionally backwards
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().first, EMPTY_INT());
+    TS_ASSERT_EQUALS(indexSetup.eventIDLimits().second, EMPTY_INT());
+    TS_ASSERT_EQUALS(indexInfo.size(), 2);
+    // these match the spectrum numbers of the full instrument
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(0), SpectrumNumber(2));
+    TS_ASSERT_EQUALS(indexInfo.spectrumNumber(1), SpectrumNumber(4));
+    // this may actually be wrong, but it appears as though the order of the spectrum definitions match the way they
+    // were requested while the spectrum numbers (just above) are always in increasing order
+    const auto specDefs = indexInfo.spectrumDefinitions();
+    TS_ASSERT_EQUALS(specDefs->at(0), SpectrumDefinition(3));
+    TS_ASSERT_EQUALS(specDefs->at(1), SpectrumDefinition(1));
+  }
+
   void test_makeIndexInfo_from_bank_filter_ignored() {
     LoadEventNexusIndexSetup indexSetup(m_ws, 12, EMPTY_INT(), {1});
     // This variant ignores any filter in the index/workspace setup phase,

--- a/Framework/Indexing/inc/MantidIndexing/IndexType.h
+++ b/Framework/Indexing/inc/MantidIndexing/IndexType.h
@@ -41,6 +41,12 @@ private:
   Int m_data;
 };
 
+template <class Derived, class Int, class = typename std::enable_if<std::is_integral<Int>::value>::type>
+std::ostream &operator<<(std::ostream &ostr, const IndexType<Derived, Int> object) {
+  ostr << object.str();
+  return ostr;
+}
+
 } // namespace detail
 } // namespace Indexing
 } // namespace Mantid

--- a/Framework/Indexing/src/IndexInfo.cpp
+++ b/Framework/Indexing/src/IndexInfo.cpp
@@ -12,7 +12,6 @@
 #include "MantidTypes/SpectrumDefinition.h"
 
 #include <algorithm>
-#include <functional>
 #include <numeric>
 
 namespace Mantid::Indexing {
@@ -100,10 +99,8 @@ const std::vector<SpectrumNumber> &IndexInfo::spectrumNumbers() const {
 /// Set a spectrum number for each index.
 void IndexInfo::setSpectrumNumbers(std::vector<SpectrumNumber> &&spectrumNumbers) {
   if (m_spectrumNumberTranslator->globalSize() != spectrumNumbers.size())
-    throw std::runtime_error("IndexInfo::setSpectrumNumbers: Size mismatch. "
-                             "The vector must contain a spectrum number for "
-                             "each spectrum (not just for the local "
-                             "partition).");
+    throw std::runtime_error("IndexInfo::setSpectrumNumbers: Size mismatch. The vector must contain a spectrum number "
+                             "for each spectrum (not just for the local partition).");
   makeSpectrumNumberTranslator(std::move(spectrumNumbers));
 }
 
@@ -111,10 +108,8 @@ void IndexInfo::setSpectrumNumbers(std::vector<SpectrumNumber> &&spectrumNumbers
 void IndexInfo::setSpectrumNumbers(const SpectrumNumber min, const SpectrumNumber max) {
   auto newSize = static_cast<int32_t>(max) - static_cast<int32_t>(min) + 1;
   if (static_cast<int64_t>(m_spectrumNumberTranslator->globalSize()) != newSize)
-    throw std::runtime_error("IndexInfo::setSpectrumNumbers: Size mismatch. "
-                             "The range of spectrum numbers must provide a "
-                             "spectrum number for each spectrum (not just for "
-                             "the local partition).");
+    throw std::runtime_error("IndexInfo::setSpectrumNumbers: Size mismatch. The range of spectrum numbers must provide "
+                             "a spectrum number for each spectrum (not just for the local partition).");
   std::vector<SpectrumNumber> specNums(newSize);
   std::iota(specNums.begin(), specNums.end(), static_cast<int32_t>(min));
   makeSpectrumNumberTranslator(std::move(specNums));
@@ -197,9 +192,8 @@ SpectrumIndexSet IndexInfo::makeIndexSet(const std::vector<GlobalSpectrumIndex> 
 std::vector<GlobalSpectrumIndex>
 IndexInfo::globalSpectrumIndicesFromDetectorIndices(const std::vector<size_t> &detectorIndices) const {
   if (!m_spectrumDefinitions)
-    throw std::runtime_error("IndexInfo::"
-                             "globalSpectrumIndicesFromDetectorIndices -- no "
-                             "spectrum definitions available");
+    throw std::runtime_error(
+        "IndexInfo::globalSpectrumIndicesFromDetectorIndices -- no spectrum definitions available");
   /*
    * We need some way of keeping track of which time indices of given detector
    * have a matching mapping. detectorMap holds pairs; first in the pair
@@ -260,26 +254,22 @@ IndexInfo::globalSpectrumIndicesFromDetectorIndices(const std::vector<size_t> &d
       }
     }
     if (spectrumDefinition.first == -2)
-      throw std::runtime_error("SpectrumDefinition contains multiple entries. "
-                               "No unique mapping from detector to spectrum "
-                               "possible");
+      throw std::runtime_error(
+          "SpectrumDefinition contains multiple entries. No unique mapping from detector to spectrum possible");
   }
 
   if (std::any_of(detectorMap.begin(), detectorMap.end(),
                   [](const std::pair<char, std::vector<char>> &p) { return p.first == 1; })) {
-    throw std::runtime_error("Some of the requested detectors do not have a "
-                             "corresponding spectrum");
+    throw std::runtime_error("Some of the requested detectors do not have a corresponding spectrum");
   }
   if (std::any_of(detectorMap.begin(), detectorMap.end(), [](const std::pair<char, std::vector<char>> &p) {
         return std::any_of(p.second.begin(), p.second.end(), [](char c) { return c > 1; });
       })) {
-    throw std::runtime_error("Some of the spectra map to the same detector "
-                             "at the same time index");
+    throw std::runtime_error("Some of the spectra map to the same detector at the same time index");
   }
 
   if (detectorIndices.size() > spectrumIndices.size())
-    throw std::runtime_error("Some of the requested detectors do not have a "
-                             "corresponding spectrum");
+    throw std::runtime_error("Some of the requested detectors do not have a corresponding spectrum");
   return spectrumIndices;
 }
 

--- a/docs/source/release/v6.12.0/Diffraction/Engineering/Bugfixes/38444.rst
+++ b/docs/source/release/v6.12.0/Diffraction/Engineering/Bugfixes/38444.rst
@@ -1,0 +1,1 @@
+- Fix issue with :ref:`LoadEventNexus <algm-LoadEventNexus>` loading banks 1, 5, 6 as single banks


### PR DESCRIPTION
### Description of work

VULCAN from 2021 on has 3 of its six detector banks that are numbered backwards which violates an assumption in generating the spectra-to-detector map in LoadEventNexus for a single bank. While
```python
LoadEventNexus(
    Filename="VULCAN_218075.nxs.h5",
    OutputWorkspace="vulcanwksp",
    BankName="bank2",
)
```
bank1 will not load
```python
LoadEventNexus(
    Filename="VULCAN_218075.nxs.h5",
    OutputWorkspace="vulcanwksp",
    BankName="bank1",
)
```
and gives an error
```
Error in execution of algorithm LoadEventNexus:
Error in execution of algorithm LoadEventNexus:
IndexInfo::setSpectrumNumbers: Size mismatch. The vector must contain a spectrum number for each spectrum (not just for the local partition).
IndexInfo::setSpectrumNumbers: Size mismatch. The vector must contain a spectrum number for each spectrum (not just for the local partition).
RuntimeError: LoadEventNexus-v1: IndexInfo::setSpectrumNumbers: Size mismatch. The vector must contain a spectrum number for each spectrum (not just for the local partition).
  File "<string>", line 12, in <module>
  File "/opt/anaconda/envs/mantid/lib/python3.10/site-packages/mantid/simpleapi.py", line 1092, in __call__
    raise RuntimeError(msg) from e
```
This is obviously undesirable and needed to be fixed.

There is also small improvements to error messages and minor reformatting.

*There is no associated issue,* but this fixes [EWM8143](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8143)

### To test:

```python
from mantid.simpleapi import *

filename = "VULCAN_218075.nxs.h5"

mtd.clear()

whole="VULCAN_whole"
LoadEventNexus(Filename=filename, OutputWorkspace=whole)

print("="*50)

accum = "VULCAN_accum"
for i in range(1,7):
    bankid = f"bank{i}"
    LoadEventNexus(Filename=filename, OutputWorkspace=f"VULCAN_{bankid}", BankName=bankid, SingleBankPixelsOnly=False)
    if mtd.doesExist(accum):
        Plus(LHSWorkspace=accum, RHSWorkspace=f"VULCAN_{bankid}", OutputWorkspace=accum)
        DeleteWorkspace(f"VULCAN_{bankid}")
    else:
        RenameWorkspace(f"VULCAN_{bankid}", accum)

# match binning because each partial has slightly different tof range
RebinToWorkspace(WorkspaceToRebin=accum, WorkspaceToMatch=whole, OutputWorkspace=accum)

CompareWorkspaces(whole, accum) #, rtol=0.001)
```

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
