### PR TITLE
Add Output SpinState to SampleLog in PolarizationCorrectionFredrikze Algorithm

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrectionFredrikze.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrectionFredrikze.h
@@ -39,11 +39,13 @@ private:
   std::shared_ptr<Mantid::API::MatrixWorkspace> getEfficiencyWorkspace(const std::string &label);
   std::shared_ptr<Mantid::API::WorkspaceGroup> execPA(const std::shared_ptr<Mantid::API::WorkspaceGroup> &inWS,
                                                       const std::vector<std::string> &inputOrder,
-                                                      const std::vector<std::string> &outputOrder);
+                                                      const std::vector<std::string> &outputOrder,
+                                                      const std::string &outputWSName, const bool addSpinStateLog);
 
   std::shared_ptr<Mantid::API::WorkspaceGroup> execPNR(const std::shared_ptr<Mantid::API::WorkspaceGroup> &inWS,
                                                        const std::vector<std::string> &inputOrder,
-                                                       const std::vector<std::string> &outputOrder);
+                                                       const std::vector<std::string> &outputOrder,
+                                                       const std::string &outputWSName, const bool addSpinStateLog);
   std::shared_ptr<Mantid::API::MatrixWorkspace> add(const std::shared_ptr<Mantid::API::MatrixWorkspace> &lhsWS,
                                                     const double &rhs);
   std::shared_ptr<Mantid::API::MatrixWorkspace> multiply(const std::shared_ptr<Mantid::API::MatrixWorkspace> &lhsWS,

--- a/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrectionFredrikze.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PolarizationCorrectionFredrikze.h
@@ -38,14 +38,14 @@ private:
   void exec() override;
   std::shared_ptr<Mantid::API::MatrixWorkspace> getEfficiencyWorkspace(const std::string &label);
   std::shared_ptr<Mantid::API::WorkspaceGroup> execPA(const std::shared_ptr<Mantid::API::WorkspaceGroup> &inWS,
-                                                      const std::vector<std::string> &inputOrder,
-                                                      const std::vector<std::string> &outputOrder,
-                                                      const std::string &outputWSName, const bool addSpinStateLog);
+                                                      const std::vector<std::string> &inputSpinStates,
+                                                      const std::vector<std::string> &outputSpinStates,
+                                                      const bool addSpinStateLog);
 
   std::shared_ptr<Mantid::API::WorkspaceGroup> execPNR(const std::shared_ptr<Mantid::API::WorkspaceGroup> &inWS,
-                                                       const std::vector<std::string> &inputOrder,
-                                                       const std::vector<std::string> &outputOrder,
-                                                       const std::string &outputWSName, const bool addSpinStateLog);
+                                                       const std::vector<std::string> &inputSpinStates,
+                                                       const std::vector<std::string> &outputSpinStates,
+                                                       const bool addSpinStateLog);
   std::shared_ptr<Mantid::API::MatrixWorkspace> add(const std::shared_ptr<Mantid::API::MatrixWorkspace> &lhsWS,
                                                     const double &rhs);
   std::shared_ptr<Mantid::API::MatrixWorkspace> multiply(const std::shared_ptr<Mantid::API::MatrixWorkspace> &lhsWS,

--- a/Framework/Algorithms/src/PolarizationCorrectionFredrikze.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionFredrikze.cpp
@@ -475,7 +475,6 @@ void PolarizationCorrectionFredrikze::exec() {
 
   const std::string inputStatesStr = getProperty(Prop::INPUT_SPIN_STATES);
   const std::string outputStatesStr = getProperty(Prop::OUTPUT_SPIN_STATES);
-  const auto &outWSName = getPropertyValue(Prop::OUTPUT_WORKSPACE);
   const bool addSpinStateLog = getProperty(Prop::ADD_SPIN_STATE_LOG);
 
   const auto inputStates = PolarizationCorrectionsHelpers::splitSpinStateString(inputStatesStr);
@@ -489,12 +488,12 @@ void PolarizationCorrectionFredrikze::exec() {
       throw std::invalid_argument("For PA analysis, input group must have 4 periods.");
     }
     g_log.notice("PA polarization correction");
-    outWS = execPA(inWS, inputStates, outputStates, outWSName, addSpinStateLog);
+    outWS = execPA(inWS, inputStates, outputStates, addSpinStateLog);
   } else if (analysisMode == PNR_LABEL) {
     if (nWorkspaces != 2) {
       throw std::invalid_argument("For PNR analysis, input group must have 2 periods.");
     }
-    outWS = execPNR(inWS, inputStates, outputStates, outWSName, addSpinStateLog);
+    outWS = execPNR(inWS, inputStates, outputStates, addSpinStateLog);
     g_log.notice("PNR polarization correction");
   }
 

--- a/Framework/Algorithms/src/PolarizationCorrectionFredrikze.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionFredrikze.cpp
@@ -30,16 +30,18 @@ static const std::string INPUT_WORKSPACE{"InputWorkspace"};
 static const std::string OUTPUT_WORKSPACE{"OutputWorkspace"};
 static const std::string INPUT_SPIN_STATES("InputSpinStates");
 static const std::string OUTPUT_SPIN_STATES("OutputSpinStates");
+static const std::string ADD_SPIN_STATE_LOG{"AddSpinStateToLog"};
 
 // Default order for PA anaysis
-static const std::vector<std::string> defaultOrderForPA = {
+static const std::vector<std::string> defaultSpinStatesForPA = {
     Mantid::Algorithms::SpinStateConfigurationsFredrikze::PARA_PARA,
     Mantid::Algorithms::SpinStateConfigurationsFredrikze::PARA_ANTI,
     Mantid::Algorithms::SpinStateConfigurationsFredrikze::ANTI_PARA,
     Mantid::Algorithms::SpinStateConfigurationsFredrikze::ANTI_ANTI};
 // Default order for PNR analysis
-static const std::vector<std::string> defaultOrderForPNR = {Mantid::Algorithms::SpinStateConfigurationsFredrikze::PARA,
-                                                            Mantid::Algorithms::SpinStateConfigurationsFredrikze::ANTI};
+static const std::vector<std::string> defaultSpinStatesForPNR = {
+    Mantid::Algorithms::SpinStateConfigurationsFredrikze::PARA,
+    Mantid::Algorithms::SpinStateConfigurationsFredrikze::ANTI};
 
 } // namespace Prop
 
@@ -158,33 +160,53 @@ void validateInputWorkspace(WorkspaceGroup_sptr &ws, const std::string &inputSta
 }
 
 /**
- * Map the input workspaces according to the specified input order.
+ * Map the input workspaces according to the specified input spinStates.
  * @param inWS :: The input WorkspaceGroup.
- * @param order :: The vector of strings representing the order.
+ * @param spinStates :: The vector of strings representing the spinStates.
  * @return A map of spin state to MatrixWorkspace shared pointers.
  */
-std::map<std::string, MatrixWorkspace_sptr> mapOrderToWorkspaces(const WorkspaceGroup_sptr &inWS,
-                                                                 const std::vector<std::string> &order) {
+std::map<std::string, MatrixWorkspace_sptr> mapSpinStatesToWorkspaces(const WorkspaceGroup_sptr &inWS,
+                                                                      const std::vector<std::string> &spinStates) {
   std::map<std::string, MatrixWorkspace_sptr> workspaceMap;
 
-  for (size_t i = 0; i < order.size(); ++i) {
-    workspaceMap[order[i]] = std::dynamic_pointer_cast<MatrixWorkspace>(inWS->getItem(i));
+  for (size_t i = 0; i < spinStates.size(); ++i) {
+    workspaceMap[spinStates[i]] = std::dynamic_pointer_cast<MatrixWorkspace>(inWS->getItem(i));
   }
 
   return workspaceMap;
 }
 
 /**
- * Map the corrected workspaces to the specified output order.
- * @param workspaces :: The map of spin state to MatrixWorkspace shared pointers.
- * @param order :: The vector of strings representing the output order.
- * @return A WorkspaceGroup with workspaces in the specified order.
+ * Adds a sample log to the workspace that gives the spin state of the data using Reflectometry ORSO notation.
+ * @param ws The workspace to add the sample log to.
+ * @param spinState The spin state the workspace represents.
  */
-WorkspaceGroup_sptr mapWorkspacesToOrder(const std::map<std::string, MatrixWorkspace_sptr> &workspaces,
-                                         const std::vector<std::string> &order) {
+void addSpinStateLogToWs(const Mantid::API::MatrixWorkspace_sptr &ws, const std::string &spinState) {
+  Mantid::Algorithms::SpinStatesORSO::addORSOLogForSpinState(ws, spinState);
+}
+
+/**
+ * Map the corrected workspaces to the specified output spinStates.
+ * @param workspaces :: The map of spin state to MatrixWorkspace shared pointers.
+ * @param spinStates :: The vector of strings representing the output spinStates.
+ * @return A WorkspaceGroup with workspaces in the specified spinStates.
+ */
+WorkspaceGroup_sptr mapWorkspacesToSpinStates(const std::map<std::string, MatrixWorkspace_sptr> &workspaces,
+                                              const std::vector<std::string> &spinStates, const bool addSpinStateLog) {
+
   auto dataOut = std::make_shared<WorkspaceGroup>();
 
-  std::for_each(order.begin(), order.end(), [&](const auto &state) { dataOut->addWorkspace(workspaces.at(state)); });
+  std::for_each(spinStates.begin(), spinStates.end(), [&](const auto &spinState) {
+    // Retrieve the workspace corresponding to the current spin state
+    auto workspace = workspaces.at(spinState);
+
+    dataOut->addWorkspace(workspace);
+
+    if (addSpinStateLog) {
+      // Log the spin state into the sample logs of the current workspace
+      addSpinStateLogToWs(workspace, spinState);
+    }
+  });
 
   return dataOut;
 }
@@ -283,16 +305,21 @@ void PolarizationCorrectionFredrikze::init() {
   declareProperty(Prop::OUTPUT_SPIN_STATES, "", spinStateValidator,
                   "The order of spin states in the output workspace group. The possible values are 'pp,pa,ap,aa' or "
                   "'p,a', in any order.");
+
+  declareProperty(
+      Prop::ADD_SPIN_STATE_LOG, false,
+      "Whether to add the final spin state into the sample log of each child workspace in the output group.");
 }
 
 WorkspaceGroup_sptr PolarizationCorrectionFredrikze::execPA(const WorkspaceGroup_sptr &inWS,
-                                                            const std::vector<std::string> &inputOrder,
-                                                            const std::vector<std::string> &outputOrder) {
+                                                            const std::vector<std::string> &inputSpinStates,
+                                                            const std::vector<std::string> &outputSpinStates,
+                                                            const bool addSpinStateLog) {
 
-  // If the input order vector is empty, use the default order
-  const auto &effectiveInputOrder = inputOrder.empty() ? Prop::defaultOrderForPA : inputOrder;
-  // Map the input workspaces according to the specified input order
-  auto inputMap = mapOrderToWorkspaces(inWS, effectiveInputOrder);
+  // If the input spinStates vector is empty, use the default spinStates.
+  const auto &effectiveInputSpinStates = inputSpinStates.empty() ? Prop::defaultSpinStatesForPA : inputSpinStates;
+  // Map the input workspaces according to the specified input spinStates
+  auto inputMap = mapSpinStatesToWorkspaces(inWS, effectiveInputSpinStates);
 
   MatrixWorkspace_sptr Ipp = inputMap[SpinStateConfigurationsFredrikze::PARA_PARA];
   MatrixWorkspace_sptr Ipa = inputMap[SpinStateConfigurationsFredrikze::PARA_ANTI];
@@ -326,16 +353,16 @@ WorkspaceGroup_sptr PolarizationCorrectionFredrikze::execPA(const WorkspaceGroup
   const auto nIap = (A0 - A1 + A2 + A3 - A4 - A5 + A6 + A7 - A8 - Ipp - Iaa + Ipa + Iap) / D;
   const auto nIpa = (A0 + A1 - A2 - A3 + A4 + A5 - A6 - A7 + A8 - Ipp - Iaa + Ipa + Iap) / D;
 
-  // Map the corrected workspaces to the specified output order
+  // Map the corrected workspaces to the specified output spinStates
   std::map<std::string, MatrixWorkspace_sptr> outputMap;
   outputMap[SpinStateConfigurationsFredrikze::PARA_PARA] = nIpp;
   outputMap[SpinStateConfigurationsFredrikze::PARA_ANTI] = nIpa;
   outputMap[SpinStateConfigurationsFredrikze::ANTI_PARA] = nIap;
   outputMap[SpinStateConfigurationsFredrikze::ANTI_ANTI] = nIaa;
 
-  // If the output order vector is empty, use the default order
-  const auto &effectiveOutputOrder = outputOrder.empty() ? Prop::defaultOrderForPA : outputOrder;
-  auto dataOut = mapWorkspacesToOrder(outputMap, effectiveOutputOrder);
+  // If the output spinStates vector is empty, use the default spinStates
+  const auto &effectiveOutputSpinStates = outputSpinStates.empty() ? Prop::defaultSpinStatesForPA : outputSpinStates;
+  auto dataOut = mapWorkspacesToSpinStates(outputMap, effectiveOutputSpinStates, addSpinStateLog);
 
   size_t totalGroupEntries(dataOut->getNumberOfEntries());
   for (size_t i = 1; i < totalGroupEntries; i++) {
@@ -358,13 +385,14 @@ WorkspaceGroup_sptr PolarizationCorrectionFredrikze::execPA(const WorkspaceGroup
 }
 
 WorkspaceGroup_sptr PolarizationCorrectionFredrikze::execPNR(const WorkspaceGroup_sptr &inWS,
-                                                             const std::vector<std::string> &inputOrder,
-                                                             const std::vector<std::string> &outputOrder) {
+                                                             const std::vector<std::string> &inputSpinStates,
+                                                             const std::vector<std::string> &outputSpinStates,
+                                                             const bool addSpinStateLog) {
 
-  // If the input order vector is empty, use the default order
-  const auto &effectiveInputOrder = inputOrder.empty() ? Prop::defaultOrderForPNR : inputOrder;
-  // Map the input workspaces according to the specified input order
-  auto inputMap = mapOrderToWorkspaces(inWS, effectiveInputOrder);
+  // If the input spinStates vector is empty, use the default spinStates
+  const auto &effectiveInputOrder = inputSpinStates.empty() ? Prop::defaultSpinStatesForPNR : inputSpinStates;
+  // Map the input workspaces according to the specified input spinStates
+  auto inputMap = mapSpinStatesToWorkspaces(inWS, effectiveInputOrder);
 
   MatrixWorkspace_sptr Ip = inputMap[SpinStateConfigurationsFredrikze::PARA];
   MatrixWorkspace_sptr Ia = inputMap[SpinStateConfigurationsFredrikze::ANTI];
@@ -385,9 +413,9 @@ WorkspaceGroup_sptr PolarizationCorrectionFredrikze::execPNR(const WorkspaceGrou
   outputMap[SpinStateConfigurationsFredrikze::PARA] = nIp;
   outputMap[SpinStateConfigurationsFredrikze::ANTI] = nIa;
 
-  // If the output order vector is empty, use the default order
-  const auto &effectiveOutputOrder = outputOrder.empty() ? Prop::defaultOrderForPNR : outputOrder;
-  auto dataOut = mapWorkspacesToOrder(outputMap, effectiveOutputOrder);
+  // If the output order vector is empty, use the default spinStates
+  const auto &effectiveOutputSpinStates = outputSpinStates.empty() ? Prop::defaultSpinStatesForPNR : outputSpinStates;
+  auto dataOut = mapWorkspacesToSpinStates(outputMap, effectiveOutputSpinStates, addSpinStateLog);
 
   return dataOut;
 }
@@ -447,6 +475,8 @@ void PolarizationCorrectionFredrikze::exec() {
 
   const std::string inputStatesStr = getProperty(Prop::INPUT_SPIN_STATES);
   const std::string outputStatesStr = getProperty(Prop::OUTPUT_SPIN_STATES);
+  const auto &outWSName = getPropertyValue(Prop::OUTPUT_WORKSPACE);
+  const bool addSpinStateLog = getProperty(Prop::ADD_SPIN_STATE_LOG);
 
   const auto inputStates = PolarizationCorrectionsHelpers::splitSpinStateString(inputStatesStr);
   const auto outputStates = PolarizationCorrectionsHelpers::splitSpinStateString(outputStatesStr);
@@ -459,12 +489,12 @@ void PolarizationCorrectionFredrikze::exec() {
       throw std::invalid_argument("For PA analysis, input group must have 4 periods.");
     }
     g_log.notice("PA polarization correction");
-    outWS = execPA(inWS, inputStates, outputStates);
+    outWS = execPA(inWS, inputStates, outputStates, outWSName, addSpinStateLog);
   } else if (analysisMode == PNR_LABEL) {
     if (nWorkspaces != 2) {
       throw std::invalid_argument("For PNR analysis, input group must have 2 periods.");
     }
-    outWS = execPNR(inWS, inputStates, outputStates);
+    outWS = execPNR(inWS, inputStates, outputStates, outWSName, addSpinStateLog);
     g_log.notice("PNR polarization correction");
   }
 

--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -138,7 +138,7 @@ void PolarizationEfficiencyCor::init() {
 
   declareProperty(Prop::ADD_SPIN_STATE_LOG, false,
                   "Whether to add the final spin state into the sample log of each child workspace in the output "
-                  "group. (Wildes method only).");
+                  "group.");
 
   setPropertySettings(
       Prop::OUTPUT_WILDES_SPIN_STATES,

--- a/Framework/Algorithms/test/PolarizationCorrectionFredrikzeTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrectionFredrikzeTest.h
@@ -286,10 +286,10 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg->execute());
     const Mantid::API::WorkspaceGroup_sptr outputWS = alg->getProperty("OutputWorkspace");
     TS_ASSERT_EQUALS(outputWS->getNumberOfEntries(), PA_GROUP_SIZE)
-    const std::vector<std::string> EXPECTED_LOG_VALUES{
+    const std::vector<std::string> expectedLogValues{
         {SpinStatesORSO::PP, SpinStatesORSO::PM, SpinStatesORSO::MP, SpinStatesORSO::MM}};
 
-    validateWorkspaceLogs(outputWS, EXPECTED_LOG_VALUES);
+    validateWorkspaceLogs(outputWS, expectedLogValues);
   }
 
   void test_spin_state_not_added_to_sample_log_by_default_for_PA() {
@@ -345,7 +345,7 @@ public:
         SpinStateConfigurationsFredrikze::ANTI_ANTI + "," + SpinStateConfigurationsFredrikze::ANTI_PARA + "," +
             SpinStateConfigurationsFredrikze::PARA_PARA + "," + SpinStateConfigurationsFredrikze::PARA_ANTI};
 
-    const std::vector<std::vector<std::string>> EXPECTED_LOG_VALUES = {
+    const std::vector<std::vector<std::string>> expectedLogValues = {
         {SpinStatesORSO::PP, SpinStatesORSO::PM, SpinStatesORSO::MP, SpinStatesORSO::MM},
         {SpinStatesORSO::PM, SpinStatesORSO::PP, SpinStatesORSO::MM, SpinStatesORSO::MP},
         {SpinStatesORSO::MP, SpinStatesORSO::MM, SpinStatesORSO::PM, SpinStatesORSO::PP},
@@ -358,7 +358,7 @@ public:
       TS_ASSERT_THROWS_NOTHING(alg->execute());
       const Mantid::API::WorkspaceGroup_sptr outputWS = alg->getProperty("OutputWorkspace");
 
-      validateWorkspaceLogs(outputWS, EXPECTED_LOG_VALUES[orderIdx]);
+      validateWorkspaceLogs(outputWS, expectedLogValues[orderIdx]);
     }
   }
 
@@ -384,9 +384,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg->execute());
     const Mantid::API::WorkspaceGroup_sptr outputWS = alg->getProperty("OutputWorkspace");
 
-    const std::vector<std::string> EXPECTED_LOG_VALUES = {SpinStatesORSO::PO, SpinStatesORSO::MO};
+    const std::vector<std::string> expectedLogValues = {SpinStatesORSO::PO, SpinStatesORSO::MO};
 
-    validateWorkspaceLogs(outputWS, EXPECTED_LOG_VALUES);
+    validateWorkspaceLogs(outputWS, expectedLogValues);
   }
 
   void test_spin_state_not_added_to_sample_log_by_default_for_PNR() {

--- a/Framework/Algorithms/test/PolarizationCorrectionFredrikzeTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrectionFredrikzeTest.h
@@ -28,8 +28,8 @@ using namespace WorkspaceCreationHelper;
 
 namespace {
 
-static const int PA_GROUP_SIZE = 4;
-static const int PNR_GROUP_SIZE = 2;
+constexpr int PA_GROUP_SIZE = 4;
+constexpr int PNR_GROUP_SIZE = 2;
 } // namespace
 
 class PolarizationCorrectionFredrikzeTest : public CxxTest::TestSuite {
@@ -330,6 +330,7 @@ public:
   void test_valid_spin_state_order_for_PA() {
     auto groupWS = createGroupWorkspace(4, 4, 1, 1);
     auto alg = initializeAlgorithm(groupWS, "PA", "1,0,0,0");
+    alg->setProperty("AddSpinStateToLog", true);
 
     const std::vector<std::string> spinStateOrders = {
         SpinStateConfigurationsFredrikze::PARA_PARA + "," + SpinStateConfigurationsFredrikze::PARA_ANTI + "," +
@@ -353,7 +354,6 @@ public:
     for (size_t orderIdx = 0; orderIdx < spinStateOrders.size(); ++orderIdx) {
       alg->setProperty("InputSpinStates", spinStateOrders[orderIdx]);
       alg->setProperty("OutputSpinStates", spinStateOrders[orderIdx]);
-      alg->setProperty("AddSpinStateToLog", true);
 
       TS_ASSERT_THROWS_NOTHING(alg->execute());
       const Mantid::API::WorkspaceGroup_sptr outputWS = alg->getProperty("OutputWorkspace");
@@ -403,8 +403,8 @@ public:
 
   void test_valid_spin_state_order_for_PNR() {
     auto groupWS = createGroupWorkspace(2, 4, 1, 1);
-    auto eff = makeEfficiencies(create1DWorkspace(4, 1, 1), "1,0,0,0", "1,0,0,0");
     auto alg = initializeAlgorithm(groupWS, "PNR", "1,0,0,0");
+    alg->setProperty("AddSpinStateToLog", true);
 
     std::vector<std::string> spinStateOrders = {
         SpinStateConfigurationsFredrikze::PARA + "," + SpinStateConfigurationsFredrikze::ANTI,
@@ -416,7 +416,6 @@ public:
     for (size_t orderIdx = 0; orderIdx < spinStateOrders.size(); ++orderIdx) {
       alg->setProperty("InputSpinStates", spinStateOrders[orderIdx]);
       alg->setProperty("OutputSpinStates", spinStateOrders[orderIdx]);
-      alg->setProperty("AddSpinStateToLog", true);
 
       TS_ASSERT_THROWS_NOTHING(alg->execute());
       const Mantid::API::WorkspaceGroup_sptr outputWS = alg->getProperty("OutputWorkspace");

--- a/docs/source/algorithms/PolarizationCorrectionFredrikze-v1.rst
+++ b/docs/source/algorithms/PolarizationCorrectionFredrikze-v1.rst
@@ -28,7 +28,7 @@ Spin State Configurations
 #########################
 The algorithm expresses the order of the workspaces in the input and output groups in terms of spin states. These orders are specified using two properties:
 
-**Input Spin State Order:**
+**Input Spin State:**
 This property determines the order of the spin states in the input workspace group
 
 - :literal:`'pp, pa, ap, aa'`
@@ -37,8 +37,11 @@ This property determines the order of the spin states in the input workspace gro
 - :literal:`'p, a'`
    Polarized Neutron Reflectivity (:literal:`'PNR'`):  parallel, anti-parallel. Two input workspaces are required. The spin states can be provided in any order and should match the order of the workspaces in the input group. The default order is :literal:`p, a`.
 
-**Output Spin State Order:**
+**Output Spin State:**
 This property determines the order of the spin states in the output workspace group. Similar to the input configuration, users can specify output spin states in any order.
+
+If the ``AddSpinStateToLog`` property has been set to ``True`` then a sample log entry called ``spin_state_ORSO`` is added to each output child workspace.
+This log entry specifies the spin state of the data using the notation from the Reflectometry ORSO data standard [#ORSO]_.
 
 Output from Full Polarization Analysis
 --------------------------------------
@@ -87,7 +90,7 @@ Usage
     eff = ConvertUnits(eff, "Wavelength")
     eff = RebinToWorkspace(eff, run.getItem(0), True)
 
-    out = PolarizationCorrectionFredrikze(run, eff, "PNR", InputSpinStates="p, a", OutputSpinStates="p, a")
+    out = PolarizationCorrectionFredrikze(run, eff, "PNR", InputSpinStates="p, a", OutputSpinStates="p, a", AddSpinStateToLog=True)
 
     for i, orig in enumerate(run):
     	corrected = out[i]
@@ -119,7 +122,7 @@ Output:
     eff = ConvertUnits(eff, "Wavelength")
     eff = RebinToWorkspace(eff, run.getItem(0), True)
 
-    out = PolarizationCorrectionFredrikze(run, eff, "PA", InputSpinStates="pp, pa, ap, aa", OutputSpinStates="pp, pa, ap, aa")
+    out = PolarizationCorrectionFredrikze(run, eff, "PA", InputSpinStates="pp, pa, ap, aa", OutputSpinStates="pp, pa, ap, aa", AddSpinStateToLog=True)
 
     for i, orig in enumerate(run):
     	corrected = out[i]
@@ -139,6 +142,7 @@ References
 
 .. [#FREDRIKZE] Fredrikze, H, et al., *Calibration of a polarized neutron reflectometer*, Physica B 297 (2001)
              `doi: 10.1016/S0921-4526(00)00823-1 <https://doi.org/10.1016/S0921-4526(00)00823-1>`_
+.. [#ORSO] ORSO file format specification: `https://www.reflectometry.org/file_format/specification <https://www.reflectometry.org/file_format/specification>`_
 
 .. categories::
 

--- a/docs/source/algorithms/PolarizationCorrectionFredrikze-v1.rst
+++ b/docs/source/algorithms/PolarizationCorrectionFredrikze-v1.rst
@@ -28,7 +28,7 @@ Spin State Configurations
 #########################
 The algorithm expresses the order of the workspaces in the input and output groups in terms of spin states. These orders are specified using two properties:
 
-**Input Spin State:**
+**InputSpinStates:**
 This property determines the order of the spin states in the input workspace group
 
 - :literal:`'pp, pa, ap, aa'`
@@ -37,7 +37,7 @@ This property determines the order of the spin states in the input workspace gro
 - :literal:`'p, a'`
    Polarized Neutron Reflectivity (:literal:`'PNR'`):  parallel, anti-parallel. Two input workspaces are required. The spin states can be provided in any order and should match the order of the workspaces in the input group. The default order is :literal:`p, a`.
 
-**Output Spin State:**
+**OutputSpinStates:**
 This property determines the order of the spin states in the output workspace group. Similar to the input configuration, users can specify output spin states in any order.
 
 If the ``AddSpinStateToLog`` property has been set to ``True`` then a sample log entry called ``spin_state_ORSO`` is added to each output child workspace.

--- a/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38265.rst
+++ b/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38265.rst
@@ -1,0 +1,1 @@
+- A new property ``AddSpinStateToLog`` was added to :ref:`PolarizationCorrectionFredrikze <algm-PolarizationCorrectionFredrikze>` to give the option to add the final spin state into the sample log of each child workspace in the output group.


### PR DESCRIPTION
### Description of work
- Added functions to include spin state information in the PolarizationCorrectionFredrikZe algorithm.
- Modified mapOutputWorkspaceToSpinState to append output spin states to the sample log when requested.
- Updated unit tests to verify that the order of output workspaces aligns with the specified output spin states and that spin state information is correctly recorded in the sample log.
- Updated documentation to reflect the new functionality and clarify its usage

Fixes #38265 

### To test:
## Test for PA
1) Run the following script. It will output a group of workspaces called "out". Check that the sample log of each child workspace **does not** contain an entry with the name `spin_state_ORSO`.
```
run1 = Load("POLREF00004699.nxs")
run2 = run1 * 1.2
run = GroupWorkspaces([run1, run2])
ws1 = CreateWorkspace([0.01, 17.0, 34.0], [50000, 50000])
eff = JoinISISPolarizationEfficiencies(Pp=ws1,   Rho=ws1, Ap=ws1, Alpha=ws1)
run = ConvertUnits(run, "Wavelength")
eff = ConvertUnits(eff, "Wavelength")
eff = RebinToWorkspace(eff, run.getItem(0), True)

out = PolarizationCorrectionFredrikze(run, eff, "PA", InputSpinStates="pp, pa, ap, aa", OutputSpinStates="pp, pa, ap, aa")
```

2) Without clearing any of your workspaces, run the following:

```
with_log = PolarizationCorrectionFredrikze(run, eff, "PA", InputSpinStates="pp, pa, ap, aa", OutputSpinStates="pp, pa, ap, aa", AddSpinStateToLog=True)
```
Check that the sample log of each child workspace in the "with_log" group **does** contain an entry with the name `spin_state_ORSO`. The log values should be as follows:

- `with_log_1` workspace has value `pp`
- `with_log_2` workspace has value `pm`
- `with_log_3` workspace has value `mp`
- `with_log_4` workspace has value `mm`

3) Test the functionality on the GUI using the same input workspaces and spinstates
- when AddSpinStateToLog checkbox is not enabled: Check that the sample log of each child workspace **does not** contain an entry with the name `spin_state_ORSO`.
- 
- when addSpinStateToLog checkbox is enabled: Check that the sample log of each child workspace in the "with_log" group **does** contain an entry with the name `spin_state_ORSO`. The log values should be as follows:

- `with_log_1` workspace has value `pp`
- `with_log_2` workspace has value `pm`
- `with_log_3` workspace has value `mp`
- `with_log_4` workspace has value `mm`

## Test for PNR
1) clear your workspaces and run the following script. It will output a group of workspaces called "out". Check that the sample log of each child workspace **does not** contain an entry with the name `spin_state_ORSO`.
```
run = Load("POLREF00004699.nxs")
ws1 = CreateWorkspace([0.01, 17.0, 34.0], [50000, 50000])
eff = JoinISISPolarizationEfficiencies(Pp=ws1,   Rho=ws1, Ap=ws1, Alpha=ws1)
run = ConvertUnits(run, "Wavelength")
eff = ConvertUnits(eff, "Wavelength")
eff = RebinToWorkspace(eff, run.getItem(0), True)

out = PolarizationCorrectionFredrikze(run, eff, "PNR", InputSpinStates="p, a", OutputSpinStates="p, a")
```

2) Without clearing any of your workspaces, run the following:

```
with_log = out = PolarizationCorrectionFredrikze(run, eff, "PNR", InputSpinStates="p, a", OutputSpinStates="p, a", AddSpinStateToLog=True)
```
Check that the sample log of each child workspace in the "with_log" group **does** contain an entry with the name `spin_state_ORSO`. The log values should be as follows:

- `with_log_1` workspace has value `po`
- `with_log_2` workspace has value `mo`

3) Test the functionality on the GUI using the same input workspaces and spinstates
- when AddSpinStateToLog checkbox is not enabled: Check that the sample log of each child workspace **does not** contain an entry with the name `spin_state_ORSO`.

- when addSpinStateToLog checkbox is enabled: Check that the sample log of each child workspace in the "with_log" group **does** contain an entry with the name `spin_state_ORSO`. The log values should be as follows:

- `with_log_1` workspace has value `po`
- `with_log_2` workspace has value `mo`