### PR TITLE
38254 add PeakShapeDetectorbin to integration algorithms

### DIFF
--- a/Framework/DataObjects/src/PeakShapeDetectorBin.cpp
+++ b/Framework/DataObjects/src/PeakShapeDetectorBin.cpp
@@ -55,6 +55,6 @@ Mantid::Geometry::PeakShape *PeakShapeDetectorBin::clone() const { return new Pe
 
 std::string PeakShapeDetectorBin::shapeName() const { return PeakShapeDetectorBin::detectorBinShapeName(); }
 
-const std::string PeakShapeDetectorBin::detectorBinShapeName() { return "PeakShapeDetectorBin"; }
+const std::string PeakShapeDetectorBin::detectorBinShapeName() { return "detectorbin"; }
 
 } // namespace Mantid::DataObjects

--- a/Framework/DataObjects/test/PeakShapeDetectorBinTest.h
+++ b/Framework/DataObjects/test/PeakShapeDetectorBinTest.h
@@ -39,7 +39,7 @@ public:
     TS_ASSERT_EQUALS(algorithmName, peakShape->algorithmName());
     TS_ASSERT_EQUALS(version, peakShape->algorithmVersion());
     TS_ASSERT_EQUALS(coordinateSys, peakShape->frame());
-    TS_ASSERT_EQUALS("PeakShapeDetectorBin", peakShape->shapeName());
+    TS_ASSERT_EQUALS("detectorbin", peakShape->shapeName());
     TS_ASSERT_EQUALS(std::nullopt, peakShape->radius(Mantid::Geometry::PeakShape::RadiusType::Radius));
     TS_ASSERT_EQUALS(std::dynamic_pointer_cast<PeakShapeDetectorBin>(peakShape)->getDetectorBinList(), detPeakBinList);
 
@@ -48,7 +48,7 @@ public:
     TS_ASSERT_EQUALS(algorithmName, cloneShape->algorithmName());
     TS_ASSERT_EQUALS(version, cloneShape->algorithmVersion());
     TS_ASSERT_EQUALS(coordinateSys, cloneShape->frame());
-    TS_ASSERT_EQUALS("PeakShapeDetectorBin", cloneShape->shapeName());
+    TS_ASSERT_EQUALS("detectorbin", cloneShape->shapeName());
     TS_ASSERT_EQUALS(std::nullopt, cloneShape->radius(Mantid::Geometry::PeakShape::RadiusType::Radius));
     TS_ASSERT_EQUALS(std::dynamic_pointer_cast<PeakShapeDetectorBin>(cloneShape)->getDetectorBinList(), detPeakBinList);
   }
@@ -62,7 +62,7 @@ public:
     std::string jsonStr = peakShape->toJSON();
     Json::Value output;
     TSM_ASSERT("Should parse as JSON", Mantid::JsonHelpers::parse(jsonStr, &output));
-    TS_ASSERT_EQUALS("PeakShapeDetectorBin", output["shape"].asString());
+    TS_ASSERT_EQUALS("detectorbin", output["shape"].asString());
     TS_ASSERT_EQUALS("TestSuite", output["algorithm_name"].asString());
     TS_ASSERT_EQUALS(1, output["algorithm_version"].asInt());
     TS_ASSERT_EQUALS(0, output["frame"].asInt());

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
@@ -38,6 +38,5 @@ void export_PeakShapeDetectorBin() {
   class_<PeakShapeDetectorBin, bases<Mantid::Geometry::PeakShape>, boost::noncopyable>("PeakShapeDetectorBin", no_init)
       .def("__init__", make_constructor(&createPeakShapeDetectorBin, default_call_policies(),
                                         (arg("detectorBinList"), arg("frame") = SpecialCoordinateSystem::None,
-                                         arg("algorithmName") = "", arg("algorithmVersion") = -1)))
-      .def("__eq__", &PeakShapeDetectorBin::operator==);
+                                         arg("algorithmName") = "", arg("algorithmVersion") = -1)));
 }

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
@@ -39,5 +39,5 @@ void export_PeakShapeDetectorBin() {
       .def("__init__", make_constructor(&createPeakShapeDetectorBin, default_call_policies(),
                                         (arg("detectorBinList"), arg("frame") = SpecialCoordinateSystem::None,
                                          arg("algorithmName") = "", arg("algorithmVersion") = -1)))
-      .def("__eq__", &PeakShapeDetectorBin::operator==, arg("self"), arg("other"));
+      .def("__eq__", &PeakShapeDetectorBin::operator==);
 }

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/PeakShapeDetectorBin.cpp
@@ -38,5 +38,6 @@ void export_PeakShapeDetectorBin() {
   class_<PeakShapeDetectorBin, bases<Mantid::Geometry::PeakShape>, boost::noncopyable>("PeakShapeDetectorBin", no_init)
       .def("__init__", make_constructor(&createPeakShapeDetectorBin, default_call_policies(),
                                         (arg("detectorBinList"), arg("frame") = SpecialCoordinateSystem::None,
-                                         arg("algorithmName") = "", arg("algorithmVersion") = -1)));
+                                         arg("algorithmName") = "", arg("algorithmVersion") = -1)))
+      .def("__eq__", &PeakShapeDetectorBin::operator==, arg("self"), arg("other"));
 }

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
@@ -386,7 +386,9 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
                     weak_peak_threshold,
                     do_optimise_shoebox,
                 )
-                peaks_spec_and_det_ids[ipk] = [ispecs[ipos[0], ipos[1]], peak_data.detids]
+                if ipos is not None:
+                    peaks_spec_and_det_ids[ipk] = [ispecs[ipos[0], ipos[1]], peak_data.detids]
+
                 if status == PEAK_STATUS.WEAK and do_optimise_shoebox and weak_peak_strategy == "NearestStrongPeak":
                     # look for possible strong peaks at any TOF in the window (won't know if strong until all pks integrated)
                     ipks_near, _ = find_ipks_in_window(ws, peaks, ispecs, ipk)

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
@@ -386,7 +386,7 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
                     weak_peak_threshold,
                     do_optimise_shoebox,
                 )
-                if ipos is not None:
+                if (ipos is not None) and (status is not PEAK_STATUS.WEAK):
                     peaks_spec_and_det_ids[ipk] = [ispecs[ipos[0], ipos[1]], peak_data.detids]
 
                 if status == PEAK_STATUS.WEAK and do_optimise_shoebox and weak_peak_strategy == "NearestStrongPeak":
@@ -438,6 +438,8 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
                 x, y, esq, ispecs = get_and_clip_data_arrays(ws, peak_data, pk_tof, kernel, nshoebox)
                 # integrate at previously found ipos
                 ipos = [*np.argwhere(ispecs == weak_pk.ispec)[0], np.argmin(abs(x - weak_pk.tof))]
+                peaks_spec_and_det_ids[ipk] = [ispecs[ipos[0], ipos[1]], peak_data.detids]
+
                 det_edges = peak_data.det_edges if not integrate_on_edge else None
                 intens, sigma, i_over_sig, status = integrate_shoebox_at_pos(y, esq, kernel, ipos, weak_peak_threshold, det_edges)
                 # scale summed intensity by bin width to get integrated area

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksShoeboxTOF.py
@@ -63,6 +63,7 @@ class ShoeboxResult:
         self.ipos_pk = list(ipk_pos)
         self.labels = ["Row", "Col", "TOF"]
         self.ysum = []
+        self.x = x
         self.xmin, self.xmax = np.round(x[0], 1), np.round(x[-1], 1)
         self.status = status
         # integrate y over each dim
@@ -334,7 +335,7 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
         weak_peaks_list = []
         ipks_strong = []
         results = np.full(peaks.getNumberPeaks(), None)
-        peaks_spec_and_det_ids = np.full(peaks.getNumberPeaks(), None)
+        peaks_det_ids = np.full(peaks.getNumberPeaks(), None)
         prog_reporter = Progress(self, start=0.0, end=1.0, nreports=peaks.getNumberPeaks())
         for ipk, peak in enumerate(peaks):
             prog_reporter.report("Integrating")
@@ -368,6 +369,7 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
                 ix = np.argmin(abs(x - pk_tof))
                 ipos_predicted = [peak_data.irow, peak_data.icol, ix]
                 det_edges = peak_data.det_edges if not integrate_on_edge else None
+                peaks_det_ids[ipk] = peak_data.detids
 
                 intens, sigma, i_over_sig, status, ipos, nrows, ncols, nbins = integrate_peak(
                     ws,
@@ -386,8 +388,6 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
                     weak_peak_threshold,
                     do_optimise_shoebox,
                 )
-                if (ipos is not None) and (status is not PEAK_STATUS.WEAK):
-                    peaks_spec_and_det_ids[ipk] = [ispecs[ipos[0], ipos[1]], peak_data.detids]
 
                 if status == PEAK_STATUS.WEAK and do_optimise_shoebox and weak_peak_strategy == "NearestStrongPeak":
                     # look for possible strong peaks at any TOF in the window (won't know if strong until all pks integrated)
@@ -438,7 +438,7 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
                 x, y, esq, ispecs = get_and_clip_data_arrays(ws, peak_data, pk_tof, kernel, nshoebox)
                 # integrate at previously found ipos
                 ipos = [*np.argwhere(ispecs == weak_pk.ispec)[0], np.argmin(abs(x - weak_pk.tof))]
-                peaks_spec_and_det_ids[ipk] = [ispecs[ipos[0], ipos[1]], peak_data.detids]
+                peaks_det_ids[ipk] = peak_data.detids
 
                 det_edges = peak_data.det_edges if not integrate_on_edge else None
                 intens, sigma, i_over_sig, status = integrate_shoebox_at_pos(y, esq, kernel, ipos, weak_peak_threshold, det_edges)
@@ -461,7 +461,7 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
             )
 
         # Sets PeakShapeDetectorBin shapes for successfully integrated peaks
-        self._set_peak_shapes(results, peaks_spec_and_det_ids, ws, peaks)
+        self._set_peak_shapes(results, peaks_det_ids, peaks)
 
         # plot output
         if output_file:
@@ -471,24 +471,23 @@ class IntegratePeaksShoeboxTOF(DataProcessorAlgorithm):
         # assign output
         self.setProperty("OutputWorkspace", peaks)
 
-    def _set_peak_shapes(self, shoebox_results, peaks_spec_and_det_ids, input_ws, peaks_ws):
+    def _set_peak_shapes(self, shoebox_results, peaks_det_ids, peaks_ws):
         """
-        Sets PeakShapeDetectorBin - shapes for the successfully integrated peaks
+        Sets PeakShapeDetectorBin shapes for the successfully integrated peaks
         @param shoebox_results - ShoeboxResult array for each peak
-        @param peaks_spec_and_det_ids - array of (spectrum id, detector ids) related to each peak
-        @param input_ws - input workspace
+        @param peaks_det_ids - detector ids related to each peak
         @param peaks_ws - peaks workspace
         """
-        for ipk, (shoebox_res, spec_detids) in enumerate(zip(shoebox_results, peaks_spec_and_det_ids)):
-            if shoebox_res is not None and spec_detids is not None:
+        for ipk, (shoebox_res, peak_detids) in enumerate(zip(shoebox_results, peaks_det_ids)):
+            if shoebox_res is not None and peak_detids is not None:
                 if shoebox_res.status != PEAK_STATUS.ON_EDGE and shoebox_res.status != PEAK_STATUS.NO_PEAK:
                     det_id_row_start = shoebox_res.ipos[0] - shoebox_res.peak_shape[0] // 2
-                    det_id_row_end = shoebox_res.ipos[0] + shoebox_res.peak_shape[0] // 2
+                    det_id_row_end = shoebox_res.ipos[0] + shoebox_res.peak_shape[0] // 2 + 1
                     det_id_col_start = shoebox_res.ipos[1] - shoebox_res.peak_shape[1] // 2
-                    det_id_col_end = shoebox_res.ipos[1] + shoebox_res.peak_shape[1] // 2
-                    selected_det_ids = spec_detids[-1][det_id_row_start:det_id_row_end, det_id_col_start:det_id_col_end]
-                    xstart = input_ws.readX(int(spec_detids[0]))[shoebox_res.ipos[2] - shoebox_res.peak_shape[2] // 2]
-                    xend = input_ws.readX(int(spec_detids[0]))[shoebox_res.ipos[2] + shoebox_res.peak_shape[2] // 2]
+                    det_id_col_end = shoebox_res.ipos[1] + shoebox_res.peak_shape[1] // 2 + 1
+                    selected_det_ids = peak_detids[det_id_row_start:det_id_row_end, det_id_col_start:det_id_col_end]
+                    xstart = shoebox_res.x[shoebox_res.ipos[2] - shoebox_res.peak_shape[2] // 2]
+                    xend = shoebox_res.x[shoebox_res.ipos[2] + shoebox_res.peak_shape[2] // 2]
                     det_bin_list = [(int(det_id), xstart, xend) for det_id in selected_det_ids.ravel()]
                     peak_shape = PeakShapeDetectorBin(det_bin_list, SpecialCoordinateSystem.NONE, self.name(), self.version())
                     peak = peaks_ws.getPeak(ipk)

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
@@ -1182,9 +1182,11 @@ class IntegratePeaksSkew(DataProcessorAlgorithm):
         """
         Sets PeakShapeDetectorBin shape for a peak
         @param ws - Input workspace
-        @param peak - peak to add the peak shape
+        @param peak - peak to add the shape
         @param peak_data - PeakData object containing details of the integrated peak
         """
+        if not peak_data.peak_mask.any():
+            return
         det_bin_list = []
         for det in peak_data.detids[peak_data.peak_mask]:
             ispec = ws.getIndicesFromDetectorIDs([int(det)])[0]

--- a/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
@@ -189,7 +189,7 @@ class IPeakTest(unittest.TestCase):
         self.assertEqual(self._peak.getPeakShape().shapeName(), "none")
 
         self._peak.setPeakShape(detector_bin)
-        self.assertEqual(self._peak.getPeakShape().shapeName(), "PeakShapeDetectorBin")
+        self.assertEqual(self._peak.getPeakShape().shapeName(), "detectorbin")
         self.assertEqual(self._peak.getPeakShape().algorithmVersion(), 1)
         self.assertEqual(self._peak.getPeakShape().algorithmName(), "test")
         det_bin_dict = json.loads(self._peak.getPeakShape().toJSON())

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksShoeboxTOFTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksShoeboxTOFTest.py
@@ -265,13 +265,13 @@ class IntegratePeaksShoeboxTOFTest(unittest.TestCase):
             for i_pk, pk in enumerate(peaksws):
                 self.assertEqual(pk.getPeakShape().shapeName(), "detectorbin")
                 pk_shape_dict = json.loads(pk.getPeakShape().toJSON())
-                self.assertEqual(len(pk_shape_dict["detectors"]), 4)
+                self.assertEqual(len(pk_shape_dict["detectors"]), 9)
                 self.assertEqual(pk_shape_dict["algorithm_name"], "IntegratePeaksShoeboxTOF")
                 for det in pk_shape_dict["detectors"]:
                     self.assertEqual(det["startX"], start_end_points[i_pk][0])
                     self.assertEqual(det["endX"], start_end_points[i_pk][1])
 
-        _test_shapes(out, ((2, 4), (7, 9)))
+        _test_shapes(out, ((2.5, 4.5), (8.5, 10.5)))
 
 
 if __name__ == "__main__":

--- a/docs/source/release/v6.12.0/Diffraction/Single_Crystal/New_features/38254.rst
+++ b/docs/source/release/v6.12.0/Diffraction/Single_Crystal/New_features/38254.rst
@@ -1,1 +1,2 @@
 - A new peak shape named PeakShapeDetectorBin was introduced to save the detector IDs and bin indices of either TOF or dSpacing domains. This peak shape could be used for Overlap detection, Two-step integration and Eventual visualisation on instrument view.
+- The new peak shape has been associated with the peaks integrated with :ref:`algm-IntegratePeaksShoeboxTOF` and :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>` integration algorithms.

--- a/docs/source/release/v6.12.0/Diffraction/Single_Crystal/New_features/38254.rst
+++ b/docs/source/release/v6.12.0/Diffraction/Single_Crystal/New_features/38254.rst
@@ -1,2 +1,3 @@
-- A new peak shape named PeakShapeDetectorBin was introduced to save the detector IDs and bin indices of either TOF or dSpacing domains. This peak shape could be used for Overlap detection, Two-step integration and Eventual visualisation on instrument view.
+- A new peak shape named `detectorbin` was introduced to save the detector IDs and bin indices of either TOF or dSpacing domains. This peak shape could be used for Overlap detection, Two-step integration and Eventual visualisation on instrument view.
 - The new peak shape has been associated with the peaks integrated with :ref:`algm-IntegratePeaksShoeboxTOF` and :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>` integration algorithms.
+- By accessing the `detectorbin` peak shape users now can view the detector ids associated for each integrated peak from the above algorithms.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/representation/draw.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/representation/draw.py
@@ -23,6 +23,7 @@ _PEAK_REPRESENTATION_FACTORY = {
     "none": NonIntegratedPeakRepresentation,
     "spherical": EllipsoidalIntegratedPeakRepresentation,
     "ellipsoid": EllipsoidalIntegratedPeakRepresentation,
+    "detectorbin": NonIntegratedPeakRepresentation,
 }
 
 

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -692,7 +692,7 @@ class BaseSX(ABC):
             with PdfPages(filename) as pdf:
                 for ipk, pk in enumerate(peaks):
                     peak_shape = pk.getPeakShape()
-                    if peak_shape.shapeName().lower() == "none":
+                    if peak_shape.shapeName().lower() == "none" or peak_shape.shapeName().lower() == "detectorbin":
                         continue
                     ws_cut, radii, bg_inner_radii, bg_outer_radii, box_lengths, imax = BaseSX._bin_MD_around_peak(
                         wsMD, pk, peak_shape, nbins_max, extent, frame_to_peak_centre_attr


### PR DESCRIPTION
### Description of work

#### Summary of work
The new peak shape `PeakShapeDetectorBin` is added to `IntegratePeaksShoeboxTOF` and `IntegratePeaksSkew` algorithms so that the detector ids and the limits of the integration are made available on the valid peaks integrated from those algorithms.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38254. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

`IntegratePeaksShoeboxTOF` and `IntegratePeaksSkew` integration algorithms should run without making any errors and peaks of the the resulting peaks workspace should have the peak shape `PeakShapeDetectorBin` set for the valid peaks. ex:
```
ws=Load(Filename="SXD34361.nxs")
peaks=FindSXPeaksConvolve(InputWorkspace=ws, PeaksWorkspace="peaks")
int_peaks=IntegratePeaksShoeboxTOF(Inputworkspace=ws, PeaksWorkspace=peaks, OutputWorkspace="shoebox")
for pk in int_peaks:
    if pk.getIntensity() > 0:
        assert pk.getPeakShape().shapeName()=="detectorbin" 
    else:
        assert pk.getPeakShape().shapeName()=="none" 
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
