### PR TITLE
Adjust expected string for different time zones

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveISISReflectometryORSOTest.py
@@ -10,6 +10,7 @@ import tempfile
 import numpy as np
 from unittest.mock import Mock, patch
 from pathlib import Path
+from datetime import datetime, timezone, date, time
 
 from mantid import config
 from mantid.simpleapi import (
@@ -105,6 +106,7 @@ class SaveISISReflectometryORSOTest(unittest.TestCase):
     def test_file_populates_software_version_and_reduction_timestamp(self, mock_alg_histories):
         input_ws = self._create_sample_workspace()
         history = self._create_mock_alg_history(self._REDUCTION_ALG, {"InputWorkspace": "input_ws"}, [Mock()])
+        expected_value = datetime.combine(date(2024, 2, 13), time(12, 14, 36)).replace(tzinfo=timezone.utc).astimezone(tz=None)
         history.executionDate = Mock(return_value=DateAndTime("2024-02-13T12:14:36.073814000"))
         mock_alg_histories.return_value = [history]
 
@@ -113,7 +115,7 @@ class SaveISISReflectometryORSOTest(unittest.TestCase):
         self._check_file_header(
             [
                 f"reduction:\n#   software: {{name: {MantidORSODataset.SOFTWARE_NAME}, version: {version()}}}\n"
-                f"#   timestamp: 2024-02-13T12:14:36+00:00\n#"
+                f"#   timestamp: {expected_value.isoformat()}\n#"
             ]
         )
 


### PR DESCRIPTION
Running this test with your computer set to a non-UTC time zone will result in a different output, because the time is written out in local time. Hence we have to adjust our expected output.

### To test:

Tests should pass

If you want to experience the test failing, then on Linux you can set the `TZ` environment variable to e.g. `Asia/Singapore`, then run the test. On Windows you will need to change your system time zone, which you can do e.g. from a command prompt with `tzutil /s "Pacific Standard Time"`, (don't forget to change it back).

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **it's only a change to test code**.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
