### PR TITLE
Update Unit Tests in PolarizationEffiency Cor

### DIFF
--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -50,361 +50,303 @@ public:
   void tearDown() override { AnalysisDataService::Instance().clear(); }
 
   void test_input_ws_no_inputs() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
+    auto alg = createAlgorithm();
+    alg->setProperty("OutputWorkspace", "out");
+    alg->setProperty("Efficiencies", createEfficiencies("Wildes"));
     // Error: Input workspaces are missing. Either a workspace group or a list
     // of workspace names must be given
-    TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
+    TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
+
   void test_input_ws_default_group() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 4);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
+    alg->execute();
+    checkWorkspaceGroupSize(4);
   }
+
   void test_input_ws_wildes_group() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 4);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
+    alg->execute();
+    checkWorkspaceGroupSize(4);
   }
+
   void test_input_ws_fredrikze_group() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
-    alg.setProperty("CorrectionMethod", "Fredrikze");
-    alg.setProperty("Efficiencies", createEfficiencies("Fredrikze"));
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 4);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
+    alg->execute();
+    checkWorkspaceGroupSize(4);
   }
+
   void test_input_ws_wildes_wrong_input_size() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
     // Error: Some invalid Properties found
-    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
   }
   void test_input_ws_fredrikze_wrong_input_size() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
-    alg.setProperty("CorrectionMethod", "Fredrikze");
-    alg.setProperty("Efficiencies", createEfficiencies("Fredrikze"));
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
     // Error: For PA analysis, input group must have 4 periods
-    TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
+    TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_input_ws_wildes_list() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(4));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 4);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
+    alg->execute();
+    checkWorkspaceGroupSize(4);
   }
   void test_input_ws_frederikze_needs_group() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(4));
-    alg.setProperty("CorrectionMethod", "Fredrikze");
-    alg.setProperty("Efficiencies", createEfficiencies("Fredrikze"));
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Input workspaces are required to be in a workspace group
-    TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
+    TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_input_ws_cannot_be_both() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(4));
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Input workspaces must be given either as a workspace group or a
     // list of names
-    TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
+    TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_input_ws_wildes_wrong_size() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(2));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(2));
     // Error: Some invalid Properties found
-    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
   }
 
   void test_efficiencies_fredrikze_wrong_efficiencies() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
-    alg.setProperty("CorrectionMethod", "Fredrikze");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Fredrikze");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     // Error: Efficiencey property not found: Rho;
-    TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
+    TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_efficiencies_wildes_wrong_efficiencies() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(4));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Fredrikze"));
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Fredrikze", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Some invalid Properties found
-    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
   }
+
   void test_flippers_full() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(4));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
-    alg.setProperty("Flippers", "00, 01, 10, 11");
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 4);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
+    alg->setProperty("Flippers", "00, 01, 10, 11");
+    alg->execute();
+    checkWorkspaceGroupSize(4);
   }
+
   void test_flippers_missing_01() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(3));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
-    alg.setProperty("Flippers", "00, 10, 11");
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 4);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(3));
+    alg->setProperty("Flippers", "00, 10, 11");
+    alg->execute();
+    checkWorkspaceGroupSize(4);
   }
   void test_flippers_missing_10() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(3));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
-    alg.setProperty("Flippers", "00, 01, 11");
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 4);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(3));
+    alg->setProperty("Flippers", "00, 01, 11");
+    alg->execute();
+    checkWorkspaceGroupSize(4);
   }
   void test_flippers_missing_0110() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(2));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
-    alg.setProperty("Flippers", "00, 11");
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 4);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(2));
+    alg->setProperty("Flippers", "00, 11");
+    alg->execute();
+    checkWorkspaceGroupSize(4);
   }
   void test_flippers_no_analyser() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(2));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
-    alg.setProperty("Flippers", "0, 1");
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 2);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(2));
+    alg->setProperty("Flippers", "0, 1");
+    alg->execute();
+    checkWorkspaceGroupSize(2);
   }
+
   void test_flippers_direct_beam() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(1));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
-    alg.setProperty("Flippers", "0");
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 1);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(1));
+    alg->setProperty("Flippers", "0");
+    alg->execute();
+    checkWorkspaceGroupSize(1);
   }
+
+  void test_that_wildes_can_work_with_spin_states_with_two_workspaces() {
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(2));
+    alg->setProperty("Flippers", "0, 1");
+    alg->setPropertyValue("SpinStatesOutWildes", "++, --");
+    alg->execute();
+    checkWorkspaceGroupSize(2);
+  }
+
+  void test_that_wildes_can_work_with_spin_states_with_four_workspaces() {
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
+    alg->setPropertyValue("SpinStatesOutWildes", "++, --, -+, +-");
+    alg->execute();
+    checkWorkspaceGroupSize(4);
+  }
+
   void test_flippers_wrong_flippers() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(4));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
-    alg.setProperty("Flippers", "00, 10, 11");
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
+    alg->setProperty("Flippers", "00, 10, 11");
     // Error: Some invalid Properties found
-    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
   }
   void test_flippers_wildes_no_pnr() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(4));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
-    alg.setProperty("PolarizationAnalysis", "PNR");
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes", "PNR");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Property PolarizationAnalysis canot be used with the Wildes
     // method
-    TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
+    TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_flippers_wildes_no_pa() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(4));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("Wildes"));
-    alg.setProperty("PolarizationAnalysis", "PA");
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes", "PA");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Property PolarizationAnalysis canot be used with the Wildes
     // method
-    TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
+    TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_polarization_analysis_pnr() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
-    alg.setProperty("CorrectionMethod", "Fredrikze");
-    alg.setProperty("Efficiencies", createEfficiencies("Fredrikze"));
-    alg.setProperty("PolarizationAnalysis", "PNR");
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 2);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze", "PNR");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
+    alg->execute();
+    checkWorkspaceGroupSize(2);
   }
   void test_polarization_analysis_pa() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
-    alg.setProperty("CorrectionMethod", "Fredrikze");
-    alg.setProperty("Efficiencies", createEfficiencies("Fredrikze"));
-    alg.setProperty("PolarizationAnalysis", "PA");
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 4);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze", "PA");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
+    alg->execute();
+    checkWorkspaceGroupSize(4);
   }
   void test_polarization_analysis_pa_with_spinstates() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
-    alg.setProperty("CorrectionMethod", "Fredrikze");
-    alg.setProperty("Efficiencies", createEfficiencies("Fredrikze"));
-    alg.setProperty("PolarizationAnalysis", "PA");
-    alg.setProperty("SpinStatesInFredrikze", "pp,pa,ap,aa");
-    alg.setProperty("SpinStatesOutFredrikze", "pa,pp,ap,aa");
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 4);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze", "PA");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
+    alg->setProperty("SpinStatesInFredrikze", "pp,pa,ap,aa");
+    alg->setProperty("SpinStatesOutFredrikze", "pa,pp,ap,aa");
+    alg->execute();
+    checkWorkspaceGroupSize(4);
   }
   void test_polarization_analysis_pnr_with_spinstates() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
-    alg.setProperty("CorrectionMethod", "Fredrikze");
-    alg.setProperty("Efficiencies", createEfficiencies("Fredrikze"));
-    alg.setProperty("PolarizationAnalysis", "PNR");
-    alg.setProperty("SpinStatesInFredrikze", "p, a");
-    alg.setProperty("SpinStatesOutFredrikze", "a, p");
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 2);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze", "PNR");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
+    alg->setProperty("SpinStatesInFredrikze", "p, a");
+    alg->setProperty("SpinStatesOutFredrikze", "a, p");
+    alg->execute();
+    checkWorkspaceGroupSize(2);
   }
+
+  void test_that_fredrikze_input_spinstates_cannot_be_used_with_wildes() {
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
+    alg->setProperty("SpinStatesInFredrikze", "p, a");
+
+    try {
+      alg->execute();
+    } catch (const std::invalid_argument &e) {
+      TSM_ASSERT_EQUALS("Incorrect exception message.", std::string(e.what()),
+                        "Property SpinStatesInFredrikze cannot be used with the Wildes method.");
+    }
+  }
+
+  void test_that_fredrikze_output_spinstates_cannot_be_used_with_wildes() {
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(1));
+    alg->setProperty("SpinStatesOutFredrikze", "p, a");
+
+    try {
+      alg->execute();
+    } catch (const std::invalid_argument &e) {
+      TSM_ASSERT_EQUALS("Incorrect exception message.", std::string(e.what()),
+                        "Property SpinStatesOutFredrikze cannot be used with the Wildes method.");
+    }
+  }
+
   void test_polarization_analysis_wrong_group_size() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
-    alg.setProperty("CorrectionMethod", "Fredrikze");
-    alg.setProperty("Efficiencies", createEfficiencies("Fredrikze"));
-    alg.setProperty("PolarizationAnalysis", "PNR");
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze", "PNR");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     // Error: For PNR analysis, input group must have 2 periods
-    TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
+    TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
+
   void test_polarization_analysis_no_flippers() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
-    alg.setProperty("CorrectionMethod", "Fredrikze");
-    alg.setProperty("Efficiencies", createEfficiencies("Fredrikze"));
-    alg.setProperty("Flippers", "00, 01, 10, 11");
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
+    alg->setProperty("Flippers", "00, 01, 10, 11");
     // Error: Property Flippers canot be used with the Fredrikze method
-    TS_ASSERT_THROWS(alg.execute(), const std::invalid_argument &);
+    try {
+      alg->execute();
+    } catch (const std::invalid_argument &e) {
+      TSM_ASSERT_EQUALS("Incorrect exception message.", std::string(e.what()),
+                        "Property Flippers cannot be used with the Fredrikze method.");
+    }
+  }
+
+  void test_that_wildes_output_spinstates_cannot_be_used_with_fredrikze() {
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze");
+    alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
+    alg->setPropertyValue("SpinStatesOutWildes", "+, -");
+
+    try {
+      alg->execute();
+    } catch (const std::invalid_argument &e) {
+      TSM_ASSERT_EQUALS("Incorrect exception message.", std::string(e.what()),
+                        "Property SpinStatesOutWildes cannot be used with the Fredrikze method.");
+    }
   }
 
   void test_histo() {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(4));
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("histo"));
-    alg.execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 4);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, "histo", "Wildes");
+    alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
+    alg->execute();
+    checkWorkspaceGroupSize(4);
   }
 
   void test_points() {
-    PolarizationEfficiencyCor alg;
+    auto alg = createAlgorithm();
     auto const inputs = createWorkspacesInADS(4);
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", inputs);
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("points"));
-    alg.execute();
+    setAlgorithmProperties(alg, "points", "Wildes");
+    alg->setProperty("InputWorkspaces", inputs);
+    alg->execute();
     WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
     TS_ASSERT_EQUALS(out->size(), 4);
 
@@ -422,15 +364,11 @@ public:
   }
 
   void test_points_short() {
-    PolarizationEfficiencyCor alg;
+    auto alg = createAlgorithm();
     auto const inputs = createWorkspacesInADS(4);
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", inputs);
-    alg.setProperty("CorrectionMethod", "Wildes");
-    alg.setProperty("Efficiencies", createEfficiencies("points-short"));
-    alg.execute();
+    setAlgorithmProperties(alg, "points-short", "Wildes");
+    alg->setProperty("InputWorkspaces", inputs);
+    alg->execute();
     WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
     TS_ASSERT_EQUALS(out->size(), 4);
 
@@ -451,8 +389,11 @@ public:
 
   void test_spin_state_log_added_when_requested_Wildes() { runSpinStateLogTest(WILDES_METHOD, true); }
 
+  void test_spin_state_log_not_added_by_default_Fredrikze() { runSpinStateLogTest(FREDRIKZE_METHOD, false); }
+
 private:
   const std::string WILDES_METHOD{"Wildes"};
+  const std::string FREDRIKZE_METHOD{"Fredrikze"};
 
   std::vector<MatrixWorkspace_sptr> createWorkspaces(int n) {
     std::vector<MatrixWorkspace_sptr> workspaces;
@@ -484,6 +425,31 @@ private:
       ++i;
     }
     return names;
+  }
+
+  std::shared_ptr<PolarizationEfficiencyCor> createAlgorithm() {
+    auto alg = std::make_shared<PolarizationEfficiencyCor>();
+    alg->setRethrows(true);
+    alg->initialize();
+    return alg;
+  }
+
+  void setAlgorithmProperties(const std::shared_ptr<PolarizationEfficiencyCor> &alg,
+                              const std::string &efficiencyMethod, const std::string &method = "",
+                              const std::string &analysisMethod = "") {
+    alg->setProperty("OutputWorkspace", "out");
+    if (!method.empty()) {
+      alg->setProperty("CorrectionMethod", method);
+    }
+    alg->setProperty("Efficiencies", createEfficiencies(efficiencyMethod));
+    if (!analysisMethod.empty()) {
+      alg->setProperty("PolarizationAnalysis", analysisMethod);
+    }
+  }
+
+  void checkWorkspaceGroupSize(size_t expectedSize) {
+    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
+    TS_ASSERT_EQUALS(out->size(), expectedSize);
   }
 
   MatrixWorkspace_sptr createEfficiencies(std::string const &kind) {
@@ -578,17 +544,17 @@ private:
   }
 
   void runSpinStateLogTest(const std::string &correctionMethod, const bool expectLog) {
-    PolarizationEfficiencyCor alg;
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("OutputWorkspace", "out");
-    alg.setProperty("InputWorkspaces", createWorkspacesInADS(4));
-    alg.setProperty("CorrectionMethod", correctionMethod);
-    alg.setProperty("Efficiencies", createEfficiencies(correctionMethod));
-    if (expectLog) {
-      alg.setProperty("AddSpinStateToLog", true);
+    auto alg = createAlgorithm();
+    setAlgorithmProperties(alg, correctionMethod, correctionMethod);
+    if (correctionMethod == FREDRIKZE_METHOD) {
+      alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
+    } else {
+      alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     }
-    alg.execute();
+    if (expectLog) {
+      alg->setProperty("AddSpinStateToLog", true);
+    }
+    alg->execute();
     WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
     TS_ASSERT_EQUALS(out->size(), 4);
     for (size_t i = 0; i != 4; ++i) {

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -57,60 +57,52 @@ public:
   }
 
   void test_input_ws_default_group() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->execute();
     checkOutputWorkspaceGroupSize(4);
   }
 
   void test_input_ws_wildes_group() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->execute();
     checkOutputWorkspaceGroupSize(4);
   }
 
   void test_input_ws_fredrikze_group() {
-    auto alg = createAlgorithm(FREDRIKZE_METHOD);
-    setAlgorithmProperties(alg, FREDRIKZE_METHOD);
+    auto alg = createAlgorithm(FREDRIKZE_METHOD, FREDRIKZE_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->execute();
     checkOutputWorkspaceGroupSize(4);
   }
 
   void test_input_ws_wildes_wrong_input_size() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
     // Error: Some invalid Properties found
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
   }
   void test_input_ws_fredrikze_wrong_input_size() {
-    auto alg = createAlgorithm(FREDRIKZE_METHOD);
-    setAlgorithmProperties(alg, FREDRIKZE_METHOD);
+    auto alg = createAlgorithm(FREDRIKZE_METHOD, FREDRIKZE_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
     // Error: For PA analysis, input group must have 4 periods
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_input_ws_wildes_list() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     alg->execute();
     checkOutputWorkspaceGroupSize(4);
   }
   void test_input_ws_frederikze_needs_group() {
-    auto alg = createAlgorithm(FREDRIKZE_METHOD);
-    setAlgorithmProperties(alg, FREDRIKZE_METHOD);
+    auto alg = createAlgorithm(FREDRIKZE_METHOD, FREDRIKZE_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Input workspaces are required to be in a workspace group
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_input_ws_cannot_be_both() {
     auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Input workspaces must be given either as a workspace group or a
@@ -118,31 +110,27 @@ public:
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_input_ws_wildes_wrong_size() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(2));
     // Error: Some invalid Properties found
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
   }
 
   void test_efficiencies_fredrikze_wrong_efficiencies() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, FREDRIKZE_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, FREDRIKZE_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     // Error: Efficiencey property not found: Rho;
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_efficiencies_wildes_wrong_efficiencies() {
-    auto alg = createAlgorithm(FREDRIKZE_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(FREDRIKZE_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Some invalid Properties found
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
   }
 
   void test_flippers_full() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     alg->setProperty("Flippers", "00, 01, 10, 11");
     alg->execute();
@@ -150,32 +138,28 @@ public:
   }
 
   void test_flippers_missing_01() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(3));
     alg->setProperty("Flippers", "00, 10, 11");
     alg->execute();
     checkOutputWorkspaceGroupSize(4);
   }
   void test_flippers_missing_10() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(3));
     alg->setProperty("Flippers", "00, 01, 11");
     alg->execute();
     checkOutputWorkspaceGroupSize(4);
   }
   void test_flippers_missing_0110() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(2));
     alg->setProperty("Flippers", "00, 11");
     alg->execute();
     checkOutputWorkspaceGroupSize(4);
   }
   void test_flippers_no_analyser() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(2));
     alg->setProperty("Flippers", "0, 1");
     alg->execute();
@@ -183,8 +167,7 @@ public:
   }
 
   void test_flippers_direct_beam() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(1));
     alg->setProperty("Flippers", "0");
     alg->execute();
@@ -192,8 +175,7 @@ public:
   }
 
   void test_that_wildes_can_work_with_spin_states_with_two_workspaces() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(2));
     alg->setProperty("Flippers", "0, 1");
     alg->setPropertyValue("SpinStatesOutWildes", "++, --");
@@ -202,8 +184,7 @@ public:
   }
 
   void test_that_wildes_can_work_with_spin_states_with_four_workspaces() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     alg->setPropertyValue("SpinStatesOutWildes", "++, --, -+, +-");
     alg->execute();
@@ -211,45 +192,39 @@ public:
   }
 
   void test_flippers_wrong_flippers() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     alg->setProperty("Flippers", "00, 10, 11");
     // Error: Some invalid Properties found
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
   }
   void test_flippers_wildes_no_pnr() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD, "PNR");
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD, "PNR");
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Property PolarizationAnalysis canot be used with the Wildes
     // method
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_flippers_wildes_no_pa() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD, "PA");
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD, "PA");
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Property PolarizationAnalysis canot be used with the Wildes
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_polarization_analysis_pnr() {
-    auto alg = createAlgorithm(FREDRIKZE_METHOD);
-    setAlgorithmProperties(alg, FREDRIKZE_METHOD, "PNR");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD, FREDRIKZE_METHOD, "PNR");
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
     alg->execute();
     checkOutputWorkspaceGroupSize(2);
   }
   void test_polarization_analysis_pa() {
-    auto alg = createAlgorithm(FREDRIKZE_METHOD);
-    setAlgorithmProperties(alg, FREDRIKZE_METHOD, "PA");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD, FREDRIKZE_METHOD, "PA");
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->execute();
     checkOutputWorkspaceGroupSize(4);
   }
   void test_polarization_analysis_pa_with_spinstates() {
-    auto alg = createAlgorithm(FREDRIKZE_METHOD);
-    setAlgorithmProperties(alg, FREDRIKZE_METHOD, "PA");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD, FREDRIKZE_METHOD, "PA");
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->setProperty("SpinStatesInFredrikze", "pp,pa,ap,aa");
     alg->setProperty("SpinStatesOutFredrikze", "pa,pp,ap,aa");
@@ -257,8 +232,7 @@ public:
     checkOutputWorkspaceGroupSize(4);
   }
   void test_polarization_analysis_pnr_with_spinstates() {
-    auto alg = createAlgorithm(FREDRIKZE_METHOD);
-    setAlgorithmProperties(alg, FREDRIKZE_METHOD, "PNR");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD, FREDRIKZE_METHOD, "PNR");
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
     alg->setProperty("SpinStatesInFredrikze", "p, a");
     alg->setProperty("SpinStatesOutFredrikze", "a, p");
@@ -267,8 +241,7 @@ public:
   }
 
   void test_that_fredrikze_input_spinstates_cannot_be_used_with_wildes() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     alg->setProperty("SpinStatesInFredrikze", "p, a");
 
@@ -277,8 +250,7 @@ public:
   }
 
   void test_that_fredrikze_output_spinstates_cannot_be_used_with_wildes() {
-    auto alg = createAlgorithm(WILDES_METHOD);
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm(WILDES_METHOD, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(1));
     alg->setProperty("SpinStatesOutFredrikze", "p, a");
 
@@ -287,16 +259,14 @@ public:
   }
 
   void test_polarization_analysis_wrong_group_size() {
-    auto alg = createAlgorithm(FREDRIKZE_METHOD);
-    setAlgorithmProperties(alg, FREDRIKZE_METHOD, "PNR");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD, FREDRIKZE_METHOD, "PNR");
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     // Error: For PNR analysis, input group must have 2 periods
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
 
   void test_polarization_analysis_no_flippers() {
-    auto alg = createAlgorithm(FREDRIKZE_METHOD);
-    setAlgorithmProperties(alg, FREDRIKZE_METHOD);
+    auto alg = createAlgorithm(FREDRIKZE_METHOD, FREDRIKZE_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->setProperty("Flippers", "00, 01, 10, 11");
     // Error: Property Flippers canot be used with the Fredrikze method
@@ -305,8 +275,7 @@ public:
   }
 
   void test_that_wildes_output_spinstates_cannot_be_used_with_fredrikze() {
-    auto alg = createAlgorithm(FREDRIKZE_METHOD);
-    setAlgorithmProperties(alg, FREDRIKZE_METHOD);
+    auto alg = createAlgorithm(FREDRIKZE_METHOD, FREDRIKZE_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->setPropertyValue("SpinStatesOutWildes", "+, -");
 
@@ -315,17 +284,15 @@ public:
   }
 
   void test_histo() {
-    auto alg = createAlgorithm("histo");
-    setAlgorithmProperties(alg, WILDES_METHOD);
+    auto alg = createAlgorithm("histo", WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     alg->execute();
     checkOutputWorkspaceGroupSize(4);
   }
 
   void test_points() {
-    auto alg = createAlgorithm("points");
+    auto alg = createAlgorithm("points", WILDES_METHOD);
     auto const inputs = createWorkspacesInADS(4);
-    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", inputs);
     alg->execute();
     WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(OUTPUT_GRP_NAME);
@@ -345,9 +312,8 @@ public:
   }
 
   void test_points_short() {
-    auto alg = createAlgorithm("points-short");
+    auto alg = createAlgorithm("points-short", WILDES_METHOD);
     auto const inputs = createWorkspacesInADS(4);
-    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", inputs);
     alg->execute();
     WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(OUTPUT_GRP_NAME);
@@ -409,29 +375,47 @@ private:
     return names;
   }
 
-  std::shared_ptr<PolarizationEfficiencyCor> createAlgorithm(const std::string &efficiencyMethod) {
+  std::shared_ptr<PolarizationEfficiencyCor> createAlgorithm(const std::string &efficiencyMethod,
+                                                             const std::string &method = "",
+                                                             const std::string &analysisMethod = "") {
     auto alg = std::make_shared<PolarizationEfficiencyCor>();
     alg->setRethrows(true);
     alg->initialize();
     alg->setProperty("OutputWorkspace", OUTPUT_GRP_NAME);
     alg->setProperty("Efficiencies", createEfficiencies(efficiencyMethod));
-    return alg;
-  }
-
-  void setAlgorithmProperties(const std::shared_ptr<PolarizationEfficiencyCor> &alg, const std::string &method = "",
-                              const std::string &analysisMethod = "") {
-    alg->setProperty("OutputWorkspace", OUTPUT_GRP_NAME);
     if (!method.empty()) {
       alg->setProperty("CorrectionMethod", method);
     }
     if (!analysisMethod.empty()) {
       alg->setProperty("PolarizationAnalysis", analysisMethod);
     }
+    return alg;
   }
 
   void checkOutputWorkspaceGroupSize(size_t expectedSize) {
     WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(OUTPUT_GRP_NAME);
     TS_ASSERT_EQUALS(out->size(), expectedSize);
+  }
+
+  MatrixWorkspace_sptr createEfficiencyOutputWorkspace(size_t size = 10, double endX = 10) {
+    auto ws1 = createPointWS(size, 0, endX);
+    auto ws2 = createPointWS(size, 0, endX);
+    auto ws3 = createPointWS(size, 0, endX);
+    auto ws4 = createPointWS(size, 0, endX);
+
+    auto alg = AlgorithmFactory::Instance().create("JoinISISPolarizationEfficiencies", -1);
+    alg->initialize();
+    alg->setChild(true);
+    alg->setRethrows(true);
+    alg->setProperty("P1", ws1);
+    alg->setProperty("P2", ws2);
+    alg->setProperty("F1", ws3);
+    alg->setProperty("F2", ws4);
+    alg->setPropertyValue("OutputWorkspace", OUTPUT_GRP_NAME);
+    alg->execute();
+
+    MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
+    return outWS;
   }
 
   MatrixWorkspace_sptr createEfficiencies(std::string const &kind) {
@@ -450,61 +434,16 @@ private:
       }
       return ws;
     } else if (kind == "histo") {
-      auto ws1 = createHistoWS(10, 0, 10);
-      auto ws2 = createHistoWS(10, 0, 10);
-      auto ws3 = createHistoWS(10, 0, 10);
-      auto ws4 = createHistoWS(10, 0, 10);
-
-      auto alg = AlgorithmFactory::Instance().create("JoinISISPolarizationEfficiencies", -1);
-      alg->initialize();
-      alg->setChild(true);
-      alg->setRethrows(true);
-      alg->setProperty("P1", ws1);
-      alg->setProperty("P2", ws2);
-      alg->setProperty("F1", ws3);
-      alg->setProperty("F2", ws4);
-      alg->setPropertyValue("OutputWorkspace", OUTPUT_GRP_NAME);
-      alg->execute();
-      MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
+      auto outWS = createEfficiencyOutputWorkspace();
       return outWS;
     } else if (kind == "points") {
-      auto ws1 = createPointWS(10, 0, 10);
-      auto ws2 = createPointWS(10, 0, 10);
-      auto ws3 = createPointWS(10, 0, 10);
-      auto ws4 = createPointWS(10, 0, 10);
-
-      auto alg = AlgorithmFactory::Instance().create("JoinISISPolarizationEfficiencies", -1);
-      alg->initialize();
-      alg->setChild(true);
-      alg->setRethrows(true);
-      alg->setProperty("P1", ws1);
-      alg->setProperty("P2", ws2);
-      alg->setProperty("F1", ws3);
-      alg->setProperty("F2", ws4);
-      alg->setPropertyValue("OutputWorkspace", OUTPUT_GRP_NAME);
-      alg->execute();
-      MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
+      auto outWS = createEfficiencyOutputWorkspace();
       return outWS;
     } else if (kind == "points-short") {
-      auto ws1 = createPointWS(4, 0, 10);
-      auto ws2 = createPointWS(4, 0, 10);
-      auto ws3 = createPointWS(4, 0, 10);
-      auto ws4 = createPointWS(4, 0, 10);
-
-      auto alg = AlgorithmFactory::Instance().create("JoinISISPolarizationEfficiencies", -1);
-      alg->initialize();
-      alg->setChild(true);
-      alg->setRethrows(true);
-      alg->setProperty("P1", ws1);
-      alg->setProperty("P2", ws2);
-      alg->setProperty("F1", ws3);
-      alg->setProperty("F2", ws4);
-      alg->setPropertyValue("OutputWorkspace", OUTPUT_GRP_NAME);
-      alg->execute();
-      MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
+      auto outWS = createEfficiencyOutputWorkspace(4, 10);
       return outWS;
     }
-    throw std::logic_error("Unknown efficeincy test kind");
+    throw std::logic_error("Unknown efficiency test kind");
   }
 
   MatrixWorkspace_sptr createHistoWS(size_t size, double startX, double endX) const {
@@ -526,8 +465,7 @@ private:
   }
 
   void runSpinStateLogTest(const std::string &correctionMethod, const bool expectLog) {
-    auto alg = createAlgorithm(correctionMethod);
-    setAlgorithmProperties(alg, correctionMethod);
+    auto alg = createAlgorithm(correctionMethod, correctionMethod);
     if (correctionMethod == FREDRIKZE_METHOD) {
       alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     } else {

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -455,7 +455,7 @@ private:
   MatrixWorkspace_sptr createEfficiencies(std::string const &kind) {
     static std::map<std::string, std::vector<std::string>> const labels = {{"Wildes", {"P1", "P2", "F1", "F2"}},
                                                                            {"Fredrikze", {"Pp", "Ap", "Rho", "Alpha"}}};
-    if (kind == "Wildes" || kind == "Fredrikze") {
+    if (kind == WILDES_METHOD || kind == FREDRIKZE_METHOD) {
       auto inWS = createWorkspaces(1)[0];
       MatrixWorkspace_sptr ws = WorkspaceFactory::Instance().create(inWS, 4);
       ws->getAxis(0)->setUnit("Wavelength");

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -359,17 +359,27 @@ private:
     TS_ASSERT_EQUALS(out->size(), expectedSize);
   }
 
-  MatrixWorkspace_sptr createEfficiencyOutputWorkspace(size_t size, double endX, std::string const &kind) {
+  MatrixWorkspace_sptr createEfficiencyOutputWorkspace(std::string const &kind) {
+    const auto numWorkspaces = 4;
+    const double endX = 10;
+
     std::vector<MatrixWorkspace_sptr> workspaces;
     if (kind == "histo") {
-      for (int i = 0; i < 4; ++i) {
-        workspaces.push_back(createHistoWS(size, 0, endX));
+      for (int i = 0; i < numWorkspaces; ++i) {
+        workspaces.push_back(createHistoWS(10, 0, endX));
       }
-    } else if (kind == "points" || kind == "points-short") {
-      for (int i = 0; i < 4; ++i) {
-        workspaces.push_back(createPointWS(size, 0, endX));
+    } else if (kind == "points") {
+      for (int i = 0; i < numWorkspaces; ++i) {
+        workspaces.push_back(createPointWS(10, 0, endX));
       }
+    } else if (kind == "points-short") {
+      for (int i = 0; i < numWorkspaces; ++i) {
+        workspaces.push_back(createPointWS(4, 0, endX));
+      }
+    } else {
+      throw std::logic_error("Unknown efficiency test kind");
     }
+
     auto alg = AlgorithmFactory::Instance().create("JoinISISPolarizationEfficiencies", -1);
     alg->initialize();
     alg->setChild(true);
@@ -399,17 +409,9 @@ private:
         axis1Raw->setLabel(i, current_labels[i]);
       }
       return ws;
-    } else if (kind == "histo") {
-      auto outWS = createEfficiencyOutputWorkspace(10, 10, "histo");
-      return outWS;
-    } else if (kind == "points") {
-      auto outWS = createEfficiencyOutputWorkspace(10, 10, "points");
-      return outWS;
-    } else if (kind == "points-short") {
-      auto outWS = createEfficiencyOutputWorkspace(4, 10, "points-short");
-      return outWS;
     }
-    throw std::logic_error("Unknown efficiency test kind");
+
+    return createEfficiencyOutputWorkspace(kind);
   }
 
   MatrixWorkspace_sptr createHistoWS(size_t size, double startX, double endX) const {

--- a/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
+++ b/Framework/Algorithms/test/PolarizationEfficiencyCorTest.h
@@ -50,69 +50,67 @@ public:
   void tearDown() override { AnalysisDataService::Instance().clear(); }
 
   void test_input_ws_no_inputs() {
-    auto alg = createAlgorithm();
-    alg->setProperty("OutputWorkspace", "out");
-    alg->setProperty("Efficiencies", createEfficiencies("Wildes"));
+    auto alg = createAlgorithm(WILDES_METHOD);
     // Error: Input workspaces are missing. Either a workspace group or a list
     // of workspace names must be given
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
 
   void test_input_ws_default_group() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->execute();
-    checkWorkspaceGroupSize(4);
+    checkOutputWorkspaceGroupSize(4);
   }
 
   void test_input_ws_wildes_group() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->execute();
-    checkWorkspaceGroupSize(4);
+    checkOutputWorkspaceGroupSize(4);
   }
 
   void test_input_ws_fredrikze_group() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD);
+    setAlgorithmProperties(alg, FREDRIKZE_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->execute();
-    checkWorkspaceGroupSize(4);
+    checkOutputWorkspaceGroupSize(4);
   }
 
   void test_input_ws_wildes_wrong_input_size() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
     // Error: Some invalid Properties found
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
   }
   void test_input_ws_fredrikze_wrong_input_size() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD);
+    setAlgorithmProperties(alg, FREDRIKZE_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
     // Error: For PA analysis, input group must have 4 periods
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_input_ws_wildes_list() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     alg->execute();
-    checkWorkspaceGroupSize(4);
+    checkOutputWorkspaceGroupSize(4);
   }
   void test_input_ws_frederikze_needs_group() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD);
+    setAlgorithmProperties(alg, FREDRIKZE_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Input workspaces are required to be in a workspace group
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_input_ws_cannot_be_both() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Input workspaces must be given either as a workspace group or a
@@ -120,235 +118,218 @@ public:
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_input_ws_wildes_wrong_size() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(2));
     // Error: Some invalid Properties found
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
   }
 
   void test_efficiencies_fredrikze_wrong_efficiencies() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Fredrikze");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, FREDRIKZE_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     // Error: Efficiencey property not found: Rho;
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_efficiencies_wildes_wrong_efficiencies() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Fredrikze", "Wildes");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Some invalid Properties found
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
   }
 
   void test_flippers_full() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     alg->setProperty("Flippers", "00, 01, 10, 11");
     alg->execute();
-    checkWorkspaceGroupSize(4);
+    checkOutputWorkspaceGroupSize(4);
   }
 
   void test_flippers_missing_01() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(3));
     alg->setProperty("Flippers", "00, 10, 11");
     alg->execute();
-    checkWorkspaceGroupSize(4);
+    checkOutputWorkspaceGroupSize(4);
   }
   void test_flippers_missing_10() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(3));
     alg->setProperty("Flippers", "00, 01, 11");
     alg->execute();
-    checkWorkspaceGroupSize(4);
+    checkOutputWorkspaceGroupSize(4);
   }
   void test_flippers_missing_0110() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(2));
     alg->setProperty("Flippers", "00, 11");
     alg->execute();
-    checkWorkspaceGroupSize(4);
+    checkOutputWorkspaceGroupSize(4);
   }
   void test_flippers_no_analyser() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(2));
     alg->setProperty("Flippers", "0, 1");
     alg->execute();
-    checkWorkspaceGroupSize(2);
+    checkOutputWorkspaceGroupSize(2);
   }
 
   void test_flippers_direct_beam() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(1));
     alg->setProperty("Flippers", "0");
     alg->execute();
-    checkWorkspaceGroupSize(1);
+    checkOutputWorkspaceGroupSize(1);
   }
 
   void test_that_wildes_can_work_with_spin_states_with_two_workspaces() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(2));
     alg->setProperty("Flippers", "0, 1");
     alg->setPropertyValue("SpinStatesOutWildes", "++, --");
     alg->execute();
-    checkWorkspaceGroupSize(2);
+    checkOutputWorkspaceGroupSize(2);
   }
 
   void test_that_wildes_can_work_with_spin_states_with_four_workspaces() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     alg->setPropertyValue("SpinStatesOutWildes", "++, --, -+, +-");
     alg->execute();
-    checkWorkspaceGroupSize(4);
+    checkOutputWorkspaceGroupSize(4);
   }
 
   void test_flippers_wrong_flippers() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     alg->setProperty("Flippers", "00, 10, 11");
     // Error: Some invalid Properties found
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &);
   }
   void test_flippers_wildes_no_pnr() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes", "PNR");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD, "PNR");
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Property PolarizationAnalysis canot be used with the Wildes
     // method
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_flippers_wildes_no_pa() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes", "PA");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD, "PA");
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     // Error: Property PolarizationAnalysis canot be used with the Wildes
-    // method
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
   void test_polarization_analysis_pnr() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze", "PNR");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD);
+    setAlgorithmProperties(alg, FREDRIKZE_METHOD, "PNR");
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
     alg->execute();
-    checkWorkspaceGroupSize(2);
+    checkOutputWorkspaceGroupSize(2);
   }
   void test_polarization_analysis_pa() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze", "PA");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD);
+    setAlgorithmProperties(alg, FREDRIKZE_METHOD, "PA");
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->execute();
-    checkWorkspaceGroupSize(4);
+    checkOutputWorkspaceGroupSize(4);
   }
   void test_polarization_analysis_pa_with_spinstates() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze", "PA");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD);
+    setAlgorithmProperties(alg, FREDRIKZE_METHOD, "PA");
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->setProperty("SpinStatesInFredrikze", "pp,pa,ap,aa");
     alg->setProperty("SpinStatesOutFredrikze", "pa,pp,ap,aa");
     alg->execute();
-    checkWorkspaceGroupSize(4);
+    checkOutputWorkspaceGroupSize(4);
   }
   void test_polarization_analysis_pnr_with_spinstates() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze", "PNR");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD);
+    setAlgorithmProperties(alg, FREDRIKZE_METHOD, "PNR");
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(2));
     alg->setProperty("SpinStatesInFredrikze", "p, a");
     alg->setProperty("SpinStatesOutFredrikze", "a, p");
     alg->execute();
-    checkWorkspaceGroupSize(2);
+    checkOutputWorkspaceGroupSize(2);
   }
 
   void test_that_fredrikze_input_spinstates_cannot_be_used_with_wildes() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     alg->setProperty("SpinStatesInFredrikze", "p, a");
 
-    try {
-      alg->execute();
-    } catch (const std::invalid_argument &e) {
-      TSM_ASSERT_EQUALS("Incorrect exception message.", std::string(e.what()),
-                        "Property SpinStatesInFredrikze cannot be used with the Wildes method.");
-    }
+    TS_ASSERT_THROWS_EQUALS(alg->execute(), const std::invalid_argument &e, std::string(e.what()),
+                            "Property SpinStatesInFredrikze cannot be used with the Wildes method.");
   }
 
   void test_that_fredrikze_output_spinstates_cannot_be_used_with_wildes() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Wildes", "Wildes");
+    auto alg = createAlgorithm(WILDES_METHOD);
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(1));
     alg->setProperty("SpinStatesOutFredrikze", "p, a");
 
-    try {
-      alg->execute();
-    } catch (const std::invalid_argument &e) {
-      TSM_ASSERT_EQUALS("Incorrect exception message.", std::string(e.what()),
-                        "Property SpinStatesOutFredrikze cannot be used with the Wildes method.");
-    }
+    TS_ASSERT_THROWS_EQUALS(alg->execute(), const std::invalid_argument &e, std::string(e.what()),
+                            "Property SpinStatesOutFredrikze cannot be used with the Wildes method.");
   }
 
   void test_polarization_analysis_wrong_group_size() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze", "PNR");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD);
+    setAlgorithmProperties(alg, FREDRIKZE_METHOD, "PNR");
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     // Error: For PNR analysis, input group must have 2 periods
     TS_ASSERT_THROWS(alg->execute(), const std::invalid_argument &);
   }
 
   void test_polarization_analysis_no_flippers() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD);
+    setAlgorithmProperties(alg, FREDRIKZE_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->setProperty("Flippers", "00, 01, 10, 11");
     // Error: Property Flippers canot be used with the Fredrikze method
-    try {
-      alg->execute();
-    } catch (const std::invalid_argument &e) {
-      TSM_ASSERT_EQUALS("Incorrect exception message.", std::string(e.what()),
-                        "Property Flippers cannot be used with the Fredrikze method.");
-    }
+    TS_ASSERT_THROWS_EQUALS(alg->execute(), const std::invalid_argument &e, std::string(e.what()),
+                            "Property Flippers cannot be used with the Fredrikze method.");
   }
 
   void test_that_wildes_output_spinstates_cannot_be_used_with_fredrikze() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "Fredrikze", "Fredrikze");
+    auto alg = createAlgorithm(FREDRIKZE_METHOD);
+    setAlgorithmProperties(alg, FREDRIKZE_METHOD);
     alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     alg->setPropertyValue("SpinStatesOutWildes", "+, -");
 
-    try {
-      alg->execute();
-    } catch (const std::invalid_argument &e) {
-      TSM_ASSERT_EQUALS("Incorrect exception message.", std::string(e.what()),
-                        "Property SpinStatesOutWildes cannot be used with the Fredrikze method.");
-    }
+    TS_ASSERT_THROWS_EQUALS(alg->execute(), const std::invalid_argument &e, std::string(e.what()),
+                            "Property SpinStatesOutWildes cannot be used with the Fredrikze method.");
   }
 
   void test_histo() {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, "histo", "Wildes");
+    auto alg = createAlgorithm("histo");
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", createWorkspacesInADS(4));
     alg->execute();
-    checkWorkspaceGroupSize(4);
+    checkOutputWorkspaceGroupSize(4);
   }
 
   void test_points() {
-    auto alg = createAlgorithm();
+    auto alg = createAlgorithm("points");
     auto const inputs = createWorkspacesInADS(4);
-    setAlgorithmProperties(alg, "points", "Wildes");
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", inputs);
     alg->execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 4);
+    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(OUTPUT_GRP_NAME);
+    checkOutputWorkspaceGroupSize(4);
 
     for (size_t i = 0; i < out->size(); ++i) {
       auto ws = AnalysisDataService::Instance().retrieve(inputs[i]);
@@ -364,13 +345,13 @@ public:
   }
 
   void test_points_short() {
-    auto alg = createAlgorithm();
+    auto alg = createAlgorithm("points-short");
     auto const inputs = createWorkspacesInADS(4);
-    setAlgorithmProperties(alg, "points-short", "Wildes");
+    setAlgorithmProperties(alg, WILDES_METHOD);
     alg->setProperty("InputWorkspaces", inputs);
     alg->execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
-    TS_ASSERT_EQUALS(out->size(), 4);
+    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(OUTPUT_GRP_NAME);
+    checkOutputWorkspaceGroupSize(4);
 
     for (size_t i = 0; i < out->size(); ++i) {
       auto ws = AnalysisDataService::Instance().retrieve(inputs[i]);
@@ -394,6 +375,7 @@ public:
 private:
   const std::string WILDES_METHOD{"Wildes"};
   const std::string FREDRIKZE_METHOD{"Fredrikze"};
+  const std::string OUTPUT_GRP_NAME{"out"};
 
   std::vector<MatrixWorkspace_sptr> createWorkspaces(int n) {
     std::vector<MatrixWorkspace_sptr> workspaces;
@@ -427,34 +409,34 @@ private:
     return names;
   }
 
-  std::shared_ptr<PolarizationEfficiencyCor> createAlgorithm() {
+  std::shared_ptr<PolarizationEfficiencyCor> createAlgorithm(const std::string &efficiencyMethod) {
     auto alg = std::make_shared<PolarizationEfficiencyCor>();
     alg->setRethrows(true);
     alg->initialize();
+    alg->setProperty("OutputWorkspace", OUTPUT_GRP_NAME);
+    alg->setProperty("Efficiencies", createEfficiencies(efficiencyMethod));
     return alg;
   }
 
-  void setAlgorithmProperties(const std::shared_ptr<PolarizationEfficiencyCor> &alg,
-                              const std::string &efficiencyMethod, const std::string &method = "",
+  void setAlgorithmProperties(const std::shared_ptr<PolarizationEfficiencyCor> &alg, const std::string &method = "",
                               const std::string &analysisMethod = "") {
-    alg->setProperty("OutputWorkspace", "out");
+    alg->setProperty("OutputWorkspace", OUTPUT_GRP_NAME);
     if (!method.empty()) {
       alg->setProperty("CorrectionMethod", method);
     }
-    alg->setProperty("Efficiencies", createEfficiencies(efficiencyMethod));
     if (!analysisMethod.empty()) {
       alg->setProperty("PolarizationAnalysis", analysisMethod);
     }
   }
 
-  void checkWorkspaceGroupSize(size_t expectedSize) {
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
+  void checkOutputWorkspaceGroupSize(size_t expectedSize) {
+    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(OUTPUT_GRP_NAME);
     TS_ASSERT_EQUALS(out->size(), expectedSize);
   }
 
   MatrixWorkspace_sptr createEfficiencies(std::string const &kind) {
-    static std::map<std::string, std::vector<std::string>> const labels = {{"Wildes", {"P1", "P2", "F1", "F2"}},
-                                                                           {"Fredrikze", {"Pp", "Ap", "Rho", "Alpha"}}};
+    static std::map<std::string, std::vector<std::string>> const labels = {
+        {WILDES_METHOD, {"P1", "P2", "F1", "F2"}}, {FREDRIKZE_METHOD, {"Pp", "Ap", "Rho", "Alpha"}}};
     if (kind == WILDES_METHOD || kind == FREDRIKZE_METHOD) {
       auto inWS = createWorkspaces(1)[0];
       MatrixWorkspace_sptr ws = WorkspaceFactory::Instance().create(inWS, 4);
@@ -481,7 +463,7 @@ private:
       alg->setProperty("P2", ws2);
       alg->setProperty("F1", ws3);
       alg->setProperty("F2", ws4);
-      alg->setPropertyValue("OutputWorkspace", "dummy");
+      alg->setPropertyValue("OutputWorkspace", OUTPUT_GRP_NAME);
       alg->execute();
       MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
       return outWS;
@@ -499,7 +481,7 @@ private:
       alg->setProperty("P2", ws2);
       alg->setProperty("F1", ws3);
       alg->setProperty("F2", ws4);
-      alg->setPropertyValue("OutputWorkspace", "dummy");
+      alg->setPropertyValue("OutputWorkspace", OUTPUT_GRP_NAME);
       alg->execute();
       MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
       return outWS;
@@ -517,7 +499,7 @@ private:
       alg->setProperty("P2", ws2);
       alg->setProperty("F1", ws3);
       alg->setProperty("F2", ws4);
-      alg->setPropertyValue("OutputWorkspace", "dummy");
+      alg->setPropertyValue("OutputWorkspace", OUTPUT_GRP_NAME);
       alg->execute();
       MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
       return outWS;
@@ -544,8 +526,8 @@ private:
   }
 
   void runSpinStateLogTest(const std::string &correctionMethod, const bool expectLog) {
-    auto alg = createAlgorithm();
-    setAlgorithmProperties(alg, correctionMethod, correctionMethod);
+    auto alg = createAlgorithm(correctionMethod);
+    setAlgorithmProperties(alg, correctionMethod);
     if (correctionMethod == FREDRIKZE_METHOD) {
       alg->setProperty("InputWorkspaceGroup", createWorkspaceGroup(4));
     } else {
@@ -555,9 +537,9 @@ private:
       alg->setProperty("AddSpinStateToLog", true);
     }
     alg->execute();
-    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("out");
+    WorkspaceGroup_sptr out = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(OUTPUT_GRP_NAME);
     TS_ASSERT_EQUALS(out->size(), 4);
-    for (size_t i = 0; i != 4; ++i) {
+    for (size_t i = 0; i < 4; ++i) {
       MatrixWorkspace_sptr ws = std::dynamic_pointer_cast<MatrixWorkspace>(out->getItem(i));
       TS_ASSERT(ws)
       TS_ASSERT_EQUALS(ws->run().hasProperty(SpinStatesORSO::LOG_NAME), expectLog)


### PR DESCRIPTION
### Description of work
- wrote unit tests to check that wildes method perform well when spinstates is added
- wrote unit tests to check that fredrik method throws exception when tested with wildes-only properties spinstates and flippers
- wrote unit tests to check that fredrikze method can take AddSpinStateToLog property
- refactored unit tests for maintainability

Fixes #38287 

### To test:
- review unit tests
- ensure all unit tests pass

This does not require release notes because it involves updating the unit tests