### PR TITLE
Switch to HTTPSClientSession constructor available in Poco 1.14

### DIFF
--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -477,9 +477,9 @@ public:
     TS_ASSERT(fileOn3.exists());
     TS_ASSERT(fileOn4.exists());
 #else
-    TS_ASSERT_THROWS_ANYTHING(fileOn2.exists());
-    TS_ASSERT_THROWS_ANYTHING(fileOn3.exists());
-    TS_ASSERT_THROWS_ANYTHING(fileOn4.exists());
+    TS_ASSERT(!fileOn2.exists());
+    TS_ASSERT(!fileOn3.exists());
+    TS_ASSERT(!fileOn4.exists());
 #endif
 
     fileFinder.setCaseSensitive(startingCaseOption);

--- a/Framework/ICat/src/CatalogDownloadDataFiles.cpp
+++ b/Framework/ICat/src/CatalogDownloadDataFiles.cpp
@@ -155,9 +155,7 @@ std::string CatalogDownloadDataFiles::doDownloadandSavetoLocalDrive(const std::s
 
     // Session takes ownership of socket
     Poco::Net::SecureStreamSocket socket{context};
-    Poco::Net::HTTPSClientSession session{socket};
-    session.setHost(uri.getHost());
-    session.setPort(uri.getPort());
+    Poco::Net::HTTPSClientSession session{socket, uri.getHost(), uri.getPort()};
 
     Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, path, Poco::Net::HTTPMessage::HTTP_1_1);
     session.sendRequest(request);

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -82,8 +82,7 @@ if(BUILD_MANTIDFRAMEWORK OR BUILD_MANTIDQT)
   # The new interface is not available in Clang yet so we haven't migrated
   add_definitions(-D_SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING)
 
-  find_package(Poco 1.4.6 REQUIRED)
-  add_definitions(-DPOCO_ENABLE_CPP11)
+  find_package(Poco REQUIRED)
   find_package(TBB REQUIRED)
   find_package(OpenSSL REQUIRED)
 endif()

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -82,10 +82,9 @@ occt:
 orsopy:
   - 1.2.1
 
-# 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning.
-# It's resolved on their devel branch but not yet included in a release, as of 1.12.5.
+# An API change to HTTPSClientSession was introduced in 1.14.0
 poco:
-  - '>=1.12.6'
+  - '>=1.14'
 
 psutil:
   - '>=5.8.0'

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -85,7 +85,7 @@ orsopy:
 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning.
 # It's resolved on their devel branch but not yet included in a release, as of 1.12.5.
 poco:
-  - '1.12.1|>=1.12.6'
+  - '>=1.12.6'
 
 psutil:
   - '>=5.8.0'

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -85,7 +85,7 @@ orsopy:
 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning.
 # It's resolved on their devel branch but not yet included in a release, as of 1.12.5.
 poco:
-  - '1.12.1|>=1.12.6,!=1.14.0'
+  - '1.12.1|>=1.12.6'
 
 psutil:
   - '>=5.8.0'


### PR DESCRIPTION
Following `Poco` updating to 1.14, the constructor we were using for `HTTPSClientSession` is no longer available, so I've changed it over to one that works, it's also neater.

I removed the pin for `Poco` 1.12.1, because we're now on 1.14, so no need for the old pin.

I also removed some `CMake` code that was causing compilation errors on Windows.


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
