### PR TITLE
Pin Poco away from 1.14.0 - ornl-next

### DIFF
--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -477,9 +477,9 @@ public:
     TS_ASSERT(fileOn3.exists());
     TS_ASSERT(fileOn4.exists());
 #else
-    TS_ASSERT_THROWS_ANYTHING(fileOn2.exists());
-    TS_ASSERT_THROWS_ANYTHING(fileOn3.exists());
-    TS_ASSERT_THROWS_ANYTHING(fileOn4.exists());
+    TS_ASSERT(!fileOn2.exists());
+    TS_ASSERT(!fileOn3.exists());
+    TS_ASSERT(!fileOn4.exists());
 #endif
 
     fileFinder.setCaseSensitive(startingCaseOption);

--- a/Framework/ICat/src/CatalogDownloadDataFiles.cpp
+++ b/Framework/ICat/src/CatalogDownloadDataFiles.cpp
@@ -155,9 +155,7 @@ std::string CatalogDownloadDataFiles::doDownloadandSavetoLocalDrive(const std::s
 
     // Session takes ownership of socket
     Poco::Net::SecureStreamSocket socket{context};
-    Poco::Net::HTTPSClientSession session{socket};
-    session.setHost(uri.getHost());
-    session.setPort(uri.getPort());
+    Poco::Net::HTTPSClientSession session{socket, uri.getHost(), uri.getPort()};
 
     Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, path, Poco::Net::HTTPMessage::HTTP_1_1);
     session.sendRequest(request);

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -82,8 +82,7 @@ if(BUILD_MANTIDFRAMEWORK OR BUILD_MANTIDQT)
   # The new interface is not available in Clang yet so we haven't migrated
   add_definitions(-D_SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING)
 
-  find_package(Poco 1.4.6 REQUIRED)
-  add_definitions(-DPOCO_ENABLE_CPP11)
+  find_package(Poco REQUIRED)
   find_package(TBB REQUIRED)
   find_package(OpenSSL REQUIRED)
 endif()

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -85,7 +85,7 @@ orsopy:
 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning.
 # It's resolved on their devel branch but not yet included in a release, as of 1.12.5.
 poco:
-  - 1.12.1|>=1.12.6
+  - '1.12.1|>=1.12.6,!=1.14.0'
 
 psutil:
   - '>=5.8.0'

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -82,10 +82,9 @@ occt:
 orsopy:
   - 1.2.1
 
-# 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning.
-# It's resolved on their devel branch but not yet included in a release, as of 1.12.5.
+# An API change to HTTPSClientSession was introduced in 1.14.0
 poco:
-  - '1.12.1|>=1.12.6,!=1.14.0'
+  - '>=1.14'
 
 psutil:
   - '>=5.8.0'


### PR DESCRIPTION
This is a version of #38460 into `ornl-next`