### PR TITLE
Added check to match bins before conjoining workspaces.

### DIFF
--- a/Framework/API/inc/MantidAPI/WorkspaceOpOverloads.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceOpOverloads.h
@@ -54,9 +54,10 @@ MatrixWorkspace_sptr MANTID_API_DLL operator/=(const MatrixWorkspace_sptr &lhs, 
 */
 struct MANTID_API_DLL WorkspaceHelpers {
   // Checks whether the binning is the same in two workspaces
-  static bool matchingBins(const MatrixWorkspace &ws1, const MatrixWorkspace &ws2, const bool firstOnly = false);
+  static bool matchingBins(const std::shared_ptr<const MatrixWorkspace> &ws1,
+                           const std::shared_ptr<const MatrixWorkspace> &ws2, const bool firstOnly = false);
   // Checks whether a the X vectors in a workspace are actually the same vector
-  static bool sharedXData(const MatrixWorkspace &WS);
+  static bool sharedXData(const std::shared_ptr<const MatrixWorkspace> &WS);
   // Divides the data in a workspace by the bin width to make it a distribution
   // (or the reverse)
   static void makeDistribution(const MatrixWorkspace_sptr &workspace, const bool forwards = true);

--- a/Framework/API/src/WorkspaceOpOverloads.cpp
+++ b/Framework/API/src/WorkspaceOpOverloads.cpp
@@ -367,17 +367,18 @@ MatrixWorkspace_sptr operator/=(const MatrixWorkspace_sptr &lhs, const double &r
  * number of spectra
  *  @return True if the test passes
  */
-bool WorkspaceHelpers::matchingBins(const MatrixWorkspace &ws1, const MatrixWorkspace &ws2, const bool firstOnly) {
+bool WorkspaceHelpers::matchingBins(const std::shared_ptr<const MatrixWorkspace> &ws1,
+                                    const std::shared_ptr<const MatrixWorkspace> &ws2, const bool firstOnly) {
   // First of all, the first vector must be the same size
-  if (ws1.x(0).size() != ws2.x(0).size())
+  if (ws1->x(0).size() != ws2->x(0).size())
     return false;
 
   // Now check the first spectrum
-  const double firstWS = std::accumulate(ws1.x(0).begin(), ws1.x(0).end(), 0.);
-  const double secondWS = std::accumulate(ws2.x(0).begin(), ws2.x(0).end(), 0.);
+  const double firstWS = std::accumulate(ws1->x(0).begin(), ws1->x(0).end(), 0.);
+  const double secondWS = std::accumulate(ws2->x(0).begin(), ws2->x(0).end(), 0.);
   if (std::abs(firstWS) < 1.0E-7 && std::abs(secondWS) < 1.0E-7) {
-    for (size_t i = 0; i < ws1.x(0).size(); i++) {
-      if (!Kernel::withinAbsoluteDifference(ws1.x(0)[i], ws2.x(0)[i], 1.0E-7))
+    for (size_t i = 0; i < ws1->x(0).size(); i++) {
+      if (!Kernel::withinAbsoluteDifference(ws1->x(0)[i], ws2->x(0)[i], 1.0E-7))
         return false;
     }
   } else if (!Kernel::withinRelativeDifference(firstWS, secondWS, 1.0E-7))
@@ -388,7 +389,7 @@ bool WorkspaceHelpers::matchingBins(const MatrixWorkspace &ws1, const MatrixWork
     return true;
 
   // Check that total size of workspace is the same
-  if (ws1.size() != ws2.size())
+  if (ws1->size() != ws2->size())
     return false;
   // If that passes then check whether all the X vectors are shared
   if (sharedXData(ws1) && sharedXData(ws2))
@@ -396,7 +397,7 @@ bool WorkspaceHelpers::matchingBins(const MatrixWorkspace &ws1, const MatrixWork
 
   // If that didn't pass then explicitly check 1 in 10 of the vectors (min 10,
   // max 100)
-  const size_t numHist = ws1.getNumberHistograms();
+  const size_t numHist = ws1->getNumberHistograms();
   size_t numberToCheck = numHist / 10;
   if (numberToCheck < 10)
     numberToCheck = 10;
@@ -406,11 +407,11 @@ bool WorkspaceHelpers::matchingBins(const MatrixWorkspace &ws1, const MatrixWork
   if (!step)
     step = 1;
   for (size_t i = step; i < numHist; i += step) {
-    const double firstWSLoop = std::accumulate(ws1.x(i).begin(), ws1.x(i).end(), 0.);
-    const double secondWSLoop = std::accumulate(ws2.x(i).begin(), ws2.x(i).end(), 0.);
+    const double firstWSLoop = std::accumulate(ws1->x(i).begin(), ws1->x(i).end(), 0.);
+    const double secondWSLoop = std::accumulate(ws2->x(i).begin(), ws2->x(i).end(), 0.);
     if (std::abs(firstWSLoop) < 1.0E-7 && std::abs(secondWSLoop) < 1.0E-7) {
-      for (size_t j = 0; j < ws1.x(i).size(); j++) {
-        if (!Kernel::withinAbsoluteDifference(ws1.x(i)[j], ws2.x(i)[j], 1.0E-7))
+      for (size_t j = 0; j < ws1->x(i).size(); j++) {
+        if (!Kernel::withinAbsoluteDifference(ws1->x(i)[j], ws2->x(i)[j], 1.0E-7))
           return false;
       }
     } else if (!Kernel::withinRelativeDifference(firstWSLoop, secondWSLoop, 1.0E-7))
@@ -421,11 +422,11 @@ bool WorkspaceHelpers::matchingBins(const MatrixWorkspace &ws1, const MatrixWork
 }
 
 /// Checks whether all the X vectors in a workspace are the same one underneath
-bool WorkspaceHelpers::sharedXData(const MatrixWorkspace &WS) {
-  const double &first = WS.x(0)[0];
-  const size_t numHist = WS.getNumberHistograms();
+bool WorkspaceHelpers::sharedXData(const std::shared_ptr<const MatrixWorkspace> &WS) {
+  const double &first = WS->x(0)[0];
+  const size_t numHist = WS->getNumberHistograms();
   for (size_t i = 1; i < numHist; ++i) {
-    if (&first != &(WS.x(i)[0]))
+    if (&first != &(WS->x(i)[0]))
       return false;
   }
   return true;

--- a/Framework/API/test/WorkspaceOpOverloadsTest.h
+++ b/Framework/API/test/WorkspaceOpOverloadsTest.h
@@ -23,20 +23,20 @@ public:
   void test_matchingBins() {
     auto ws = std::make_shared<WorkspaceTester>();
     ws->initialize(2, 2, 1);
-    TSM_ASSERT("Passing it the same workspace twice had better work!", WorkspaceHelpers::matchingBins(*ws, *ws));
+    TSM_ASSERT("Passing it the same workspace twice had better work!", WorkspaceHelpers::matchingBins(ws, ws));
 
     // Different size workspaces fail of course
     auto ws2 = std::make_shared<WorkspaceTester>();
     ws2->initialize(3, 2, 1);
     auto ws3 = std::make_shared<WorkspaceTester>();
     ws3->initialize(2, 3, 2);
-    TSM_ASSERT("Different size workspaces should always fail", !WorkspaceHelpers::matchingBins(*ws, *ws2));
-    TSM_ASSERT("Different size workspaces should always fail", !WorkspaceHelpers::matchingBins(*ws, *ws3));
+    TSM_ASSERT("Different size workspaces should always fail", !WorkspaceHelpers::matchingBins(ws, ws2));
+    TSM_ASSERT("Different size workspaces should always fail", !WorkspaceHelpers::matchingBins(ws, ws3));
 
     ws2->dataX(1)[0] = 99.0;
     TSM_ASSERT("First-spectrum-only check should pass even when things differ "
                "in later spectra",
-               WorkspaceHelpers::matchingBins(*ws, *ws2, true));
+               WorkspaceHelpers::matchingBins(ws, ws2, true));
 
     // Check it fails if the sum is zero but the boundaries differ, both for 1st
     // & later spectra.
@@ -48,7 +48,7 @@ public:
     ws5->initialize(2, 3, 2);
     ws5->dataX(0)[0] = -1;
     ws5->dataX(0)[2] = 0;
-    TS_ASSERT(!WorkspaceHelpers::matchingBins(*ws4, *ws5, true))
+    TS_ASSERT(!WorkspaceHelpers::matchingBins(ws4, ws5, true))
     auto ws6 = std::make_shared<WorkspaceTester>();
     ws6->initialize(2, 3, 2);
     ws6->dataX(1)[0] = -1;
@@ -57,7 +57,7 @@ public:
     ws7->initialize(2, 3, 2);
     ws7->dataX(1)[0] = -1;
     ws7->dataX(1)[2] = 0;
-    TS_ASSERT(!WorkspaceHelpers::matchingBins(*ws6, *ws7))
+    TS_ASSERT(!WorkspaceHelpers::matchingBins(ws6, ws7))
 
     // N.B. There are known ways to fool this method, but they are considered
     // acceptable because
@@ -81,25 +81,25 @@ public:
     ws2->getSpectrum(1).dataX()[0] = -2.7;
     ws2->getSpectrum(1).dataX()[1] = -1.7;
 
-    TS_ASSERT(WorkspaceHelpers::matchingBins(*ws1, *ws2, true));
-    TS_ASSERT(!WorkspaceHelpers::matchingBins(*ws1, *ws2));
+    TS_ASSERT(WorkspaceHelpers::matchingBins(ws1, ws2, true));
+    TS_ASSERT(!WorkspaceHelpers::matchingBins(ws1, ws2));
 
     ws1->getSpectrum(0).dataX()[0] = -2.0;
     ws1->getSpectrum(0).dataX()[1] = -1.0;
     ws2->getSpectrum(0).dataX()[0] = -3.0;
     ws2->getSpectrum(0).dataX()[1] = -4.0;
 
-    TS_ASSERT(!WorkspaceHelpers::matchingBins(*ws1, *ws2, true));
+    TS_ASSERT(!WorkspaceHelpers::matchingBins(ws1, ws2, true));
   }
 
   void test_sharedXData() {
     auto ws = std::make_shared<WorkspaceTester>();
     ws->initialize(2, 2, 1);
     // By default the X vectors are different ones
-    TS_ASSERT(!WorkspaceHelpers::sharedXData(*ws));
+    TS_ASSERT(!WorkspaceHelpers::sharedXData(ws));
     // Force both X spectra to point to the same underlying vector
     ws->getSpectrum(1).setX(ws->getSpectrum(0).ptrX());
-    TS_ASSERT(WorkspaceHelpers::sharedXData(*ws));
+    TS_ASSERT(WorkspaceHelpers::sharedXData(ws));
   }
 
   void test_makeDistribution() {

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -385,7 +385,7 @@ std::string BinaryOperation::checkSizeCompatibility(const API::MatrixWorkspace_c
     return "";
   // Past this point, we require the X arrays to match. Note this only checks
   // the first spectrum except for ragged workspaces
-  if (!WorkspaceHelpers::matchingBins(*lhs, *rhs, !m_lhsRagged && !m_rhsRagged)) {
+  if (!WorkspaceHelpers::matchingBins(lhs, rhs, !m_lhsRagged && !m_rhsRagged)) {
     return "X arrays must match when performing this operation on a 2D "
            "workspaces.";
   }

--- a/Framework/Algorithms/src/CalculateTransmission.cpp
+++ b/Framework/Algorithms/src/CalculateTransmission.cpp
@@ -130,7 +130,7 @@ void CalculateTransmission::exec() {
   const bool usingSameInstrument = sampleWS->getInstrument()->getName() == directWS->getInstrument()->getName();
   if (!usingSameInstrument)
     throw std::invalid_argument("The input workspaces do not come from the same instrument.");
-  if (!WorkspaceHelpers::matchingBins(*sampleWS, *directWS))
+  if (!WorkspaceHelpers::matchingBins(sampleWS, directWS))
     throw std::invalid_argument("The input workspaces do not have matching bins.");
 
   bool usingMonitor = !isEmpty(transMonitorID);

--- a/Framework/Algorithms/src/CalculateTransmissionBeamSpreader.cpp
+++ b/Framework/Algorithms/src/CalculateTransmissionBeamSpreader.cpp
@@ -90,9 +90,9 @@ void CalculateTransmissionBeamSpreader::exec() {
     throw std::invalid_argument("The input workspaces do not come from the same instrument");
   }
   // Check that the two inputs have matching binning
-  if (!WorkspaceHelpers::matchingBins(*sample_spreaderWS, *direct_spreaderWS) ||
-      !WorkspaceHelpers::matchingBins(*sample_spreaderWS, *sample_scatterWS) ||
-      !WorkspaceHelpers::matchingBins(*sample_spreaderWS, *direct_scatterWS)) {
+  if (!WorkspaceHelpers::matchingBins(sample_spreaderWS, direct_spreaderWS) ||
+      !WorkspaceHelpers::matchingBins(sample_spreaderWS, sample_scatterWS) ||
+      !WorkspaceHelpers::matchingBins(sample_spreaderWS, direct_scatterWS)) {
     g_log.error("Input workspaces do not have matching binning");
     throw std::invalid_argument("Input workspaces do not have matching binning");
   }

--- a/Framework/Algorithms/src/ConjoinWorkspaces.cpp
+++ b/Framework/Algorithms/src/ConjoinWorkspaces.cpp
@@ -59,6 +59,14 @@ void ConjoinWorkspaces::exec() {
     g_log.error(message);
     throw std::invalid_argument(message);
   }
+  // Check if bins match
+  if (!WorkspaceHelpers::matchingBins(*ws1, *ws2)) {
+    const std::string message("The bins do not match in the input workspaces. "
+                              "Consider using RebinToWorkspace to preprocess "
+                              "the workspaces before conjoining them.");
+    g_log.error(message);
+    throw std::invalid_argument(message);
+  }
 
   if (eventWs1 && eventWs2) {
     this->checkCompatibility(*eventWs1, *eventWs2);

--- a/Framework/Algorithms/src/ConjoinWorkspaces.cpp
+++ b/Framework/Algorithms/src/ConjoinWorkspaces.cpp
@@ -35,6 +35,8 @@ void ConjoinWorkspaces::init() {
                   "The label to set the Y axis to");
   declareProperty(std::make_unique<PropertyWithValue<std::string>>("YAxisUnit", "", Direction::Input),
                   "The unit to set the Y axis to");
+  declareProperty(std::make_unique<PropertyWithValue<bool>>("CheckMatchingBins", true, Direction::Input),
+                  "If true, the algorithm will check that the two input workspaces have matching bins.");
 }
 
 //----------------------------------------------------------------------------------------------
@@ -60,7 +62,8 @@ void ConjoinWorkspaces::exec() {
     throw std::invalid_argument(message);
   }
   // Check if bins match
-  if (!WorkspaceHelpers::matchingBins(*ws1, *ws2)) {
+  bool checkBins = getProperty("CheckMatchingBins");
+  if (!WorkspaceHelpers::matchingBins(*ws1, *ws2) && checkBins) {
     const std::string message("The bins do not match in the input workspaces. "
                               "Consider using RebinToWorkspace to preprocess "
                               "the workspaces before conjoining them.");

--- a/Framework/Algorithms/src/ConjoinWorkspaces.cpp
+++ b/Framework/Algorithms/src/ConjoinWorkspaces.cpp
@@ -63,7 +63,7 @@ void ConjoinWorkspaces::exec() {
   }
   // Check if bins match
   bool checkBins = getProperty("CheckMatchingBins");
-  if (!WorkspaceHelpers::matchingBins(*ws1, *ws2) && checkBins) {
+  if (!WorkspaceHelpers::matchingBins(ws1, ws2) && checkBins) {
     const std::string message("The bins do not match in the input workspaces. "
                               "Consider using RebinToWorkspace to preprocess "
                               "the workspaces before conjoining them.");

--- a/Framework/Algorithms/src/Divide.cpp
+++ b/Framework/Algorithms/src/Divide.cpp
@@ -81,7 +81,7 @@ void Divide::setOutputUnits(const API::MatrixWorkspace_const_sptr lhs, const API
     // if both workspaces are ragged, output workspace `isDistribution` flag will be true
     out->setDistribution(true);
   }
-  if (rhs->YUnit().empty() || !WorkspaceHelpers::matchingBins(*lhs, *rhs, true)) {
+  if (rhs->YUnit().empty() || !WorkspaceHelpers::matchingBins(lhs, rhs, true)) {
     // Do nothing
   }
 
@@ -207,7 +207,7 @@ std::string Divide::checkSizeCompatibility(const API::MatrixWorkspace_const_sptr
   if (m_matchXSize) {
     // Past this point, for a 2D WS operation, we require the X arrays to match.
     // Note this only checks the first spectrum except for ragged workspaces
-    if (!WorkspaceHelpers::matchingBins(*lhs, *rhs, !m_lhsRagged && !m_rhsRagged)) {
+    if (!WorkspaceHelpers::matchingBins(lhs, rhs, !m_lhsRagged && !m_rhsRagged)) {
       return "X arrays must match when dividing 2D workspaces.";
     }
   }

--- a/Framework/Algorithms/src/MergeRuns.cpp
+++ b/Framework/Algorithms/src/MergeRuns.cpp
@@ -447,7 +447,7 @@ std::optional<std::vector<double>> MergeRuns::checkRebinning() {
   std::optional<std::vector<double>> rebinParams{std::nullopt};
   std::vector<double> bins{(*it)->x(0).rawData()};
   for (++it; it != inputsSortedByX.cend(); ++it) {
-    if (!WorkspaceHelpers::matchingBins(*inputsSortedByX.front(), **it, true)) {
+    if (!WorkspaceHelpers::matchingBins(inputsSortedByX.front(), *it, true)) {
       if (rebinBehaviour != REBIN_BEHAVIOUR) {
         if (sampleLogsFailBehaviour == SKIP_BEHAVIOUR) {
           g_log.error() << "Could not merge run: " << (*it)->getName()

--- a/Framework/Algorithms/src/Multiply.cpp
+++ b/Framework/Algorithms/src/Multiply.cpp
@@ -172,7 +172,7 @@ std::string Multiply::checkSizeCompatibility(const API::MatrixWorkspace_const_sp
     if (m_matchXSize) {
       // Past this point, for a 2D WS operation, we require the X arrays to
       // match. Note this only checks the first spectrum except for ragged workspaces
-      if (!WorkspaceHelpers::matchingBins(*lhs, *rhs, !m_lhsRagged && !m_rhsRagged)) {
+      if (!WorkspaceHelpers::matchingBins(lhs, rhs, !m_lhsRagged && !m_rhsRagged)) {
         return "X arrays must match when multiplying 2D workspaces.";
       }
     }

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -467,7 +467,7 @@ MatrixWorkspace_sptr NormaliseToMonitor::getMonitorWorkspace(const MatrixWorkspa
   m_workspaceIndexes = std::vector<size_t>(1, wsID);
   // In this case we need to test whether the bins in the monitor workspace
   // match
-  m_commonBins = (m_commonBins && WorkspaceHelpers::matchingBins(*inputWorkspace, *monitorWS, true));
+  m_commonBins = (m_commonBins && WorkspaceHelpers::matchingBins(inputWorkspace, monitorWS, true));
   // Copy the monitor spectrum because it will get changed
   return monitorWS;
 }

--- a/Framework/Algorithms/src/PerformIndexOperations.cpp
+++ b/Framework/Algorithms/src/PerformIndexOperations.cpp
@@ -37,6 +37,7 @@ public:
       conjoinWorkspaceAlg->initialize();
       conjoinWorkspaceAlg->setProperty("InputWorkspace1", toAppend);
       conjoinWorkspaceAlg->setProperty("InputWorkspace2", current);
+      conjoinWorkspaceAlg->setProperty("CheckMatchingBins", false);
       conjoinWorkspaceAlg->execute();
       MatrixWorkspace_sptr outWS = conjoinWorkspaceAlg->getProperty("InputWorkspace1");
       return outWS;
@@ -118,6 +119,7 @@ public:
         conjoinWorkspaceAlg->initialize();
         conjoinWorkspaceAlg->setProperty("InputWorkspace1", outWS);
         conjoinWorkspaceAlg->setProperty("InputWorkspace2", subRange);
+        conjoinWorkspaceAlg->setProperty("CheckMatchingBins", false);
         conjoinWorkspaceAlg->execute();
         outWS = conjoinWorkspaceAlg->getProperty("InputWorkspace1");
       }

--- a/Framework/Algorithms/src/PointByPointVCorrection.cpp
+++ b/Framework/Algorithms/src/PointByPointVCorrection.cpp
@@ -158,7 +158,7 @@ void PointByPointVCorrection::check_validity(API::MatrixWorkspace_const_sptr &w1
     throw std::runtime_error("The input workspaces are not the same size");
   }
   // Now check that the bins match
-  if (!WorkspaceHelpers::matchingBins(*w1, *w2)) {
+  if (!WorkspaceHelpers::matchingBins(w1, w2)) {
     g_log.error("The input workspaces have different binning");
     throw std::runtime_error("The input workspaces have different binning");
   }

--- a/Framework/Algorithms/src/PolarizationCorrections/DepolarizedAnalyserTransmission.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/DepolarizedAnalyserTransmission.cpp
@@ -122,7 +122,7 @@ std::map<std::string, std::string> DepolarizedAnalyserTransmission::validateInpu
   }
   validateWorkspace(mtWs, PropNames::MT_WORKSPACE, result);
 
-  if (!WorkspaceHelpers::matchingBins(*depWs, *mtWs, true)) {
+  if (!WorkspaceHelpers::matchingBins(depWs, mtWs, true)) {
     result[PropNames::DEP_WORKSPACE] = "The bins in the " + std::string(PropNames::DEP_WORKSPACE) + " and " +
                                        PropNames::MT_WORKSPACE + " do not match.";
   }

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizationEfficienciesWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizationEfficienciesWildes.cpp
@@ -129,7 +129,7 @@ void PolarizationEfficienciesWildes::init() {
 namespace {
 bool hasMatchingBins(const Mantid::API::MatrixWorkspace_sptr &workspace, const Mantid::API::MatrixWorkspace_sptr &refWs,
                      const std::string &propertyName, std::map<std::string, std::string> &problems) {
-  if (!WorkspaceHelpers::matchingBins(*workspace, *refWs, true)) {
+  if (!WorkspaceHelpers::matchingBins(workspace, refWs, true)) {
     problems[propertyName] = "All input workspaces must have the same X values.";
     return false;
   }

--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
@@ -137,7 +137,7 @@ std::map<std::string, std::string> PolarizerEfficiency::validateInputs() {
   } else {
     const MatrixWorkspace_sptr t00Ws =
         std::dynamic_pointer_cast<MatrixWorkspace>(inputWorkspace->getItem(t00WsIndex.value()));
-    if (!WorkspaceHelpers::matchingBins(*t00Ws, *analyserWs, true)) {
+    if (!WorkspaceHelpers::matchingBins(t00Ws, analyserWs, true)) {
       errorList[PropertyNames::ANALYSER_EFFICIENCY] = "The bins in the " + std::string(PropertyNames::INPUT_WORKSPACE) +
                                                       " and " + PropertyNames::ANALYSER_EFFICIENCY +
                                                       "workspace do not match.";

--- a/Framework/Algorithms/src/XDataConverter.cpp
+++ b/Framework/Algorithms/src/XDataConverter.cpp
@@ -57,7 +57,7 @@ void XDataConverter::exec() {
   const auto numSpectra = static_cast<int>(inputWS->getNumberHistograms());
   const size_t numYValues = getNewYSize(inputWS);
   const size_t numXValues = getNewXSize(numYValues);
-  m_sharedX = API::WorkspaceHelpers::sharedXData(*inputWS);
+  m_sharedX = API::WorkspaceHelpers::sharedXData(inputWS);
   // Create the new workspace
   MatrixWorkspace_sptr outputWS = WorkspaceFactory::Instance().create(inputWS, numSpectra, numXValues, numYValues);
 

--- a/Framework/Algorithms/test/ConjoinWorkspacesTest.h
+++ b/Framework/Algorithms/test/ConjoinWorkspacesTest.h
@@ -98,12 +98,14 @@ public:
     // Check it fails if input overlap
     TS_ASSERT_THROWS_NOTHING(conj.setPropertyValue("InputWorkspace1", "top"));
     TS_ASSERT_THROWS_NOTHING(conj.setPropertyValue("InputWorkspace2", "top"));
+    TS_ASSERT_THROWS_NOTHING(conj.setProperty("CheckMatchingBins", false));
     TS_ASSERT_THROWS_NOTHING(conj.execute());
     TS_ASSERT(!conj.isExecuted());
 
     // Now it should succeed
     TS_ASSERT_THROWS_NOTHING(conj.setPropertyValue("InputWorkspace1", "top"));
     TS_ASSERT_THROWS_NOTHING(conj.setPropertyValue("InputWorkspace2", "bottom"));
+    TS_ASSERT_THROWS_NOTHING(conj.setProperty("CheckMatchingBins", false));
     TS_ASSERT_THROWS_NOTHING(conj.execute());
     TS_ASSERT(conj.isExecuted());
 
@@ -157,6 +159,7 @@ public:
 
     ConjoinWorkspaces conj;
     conj.initialize();
+    conj.setProperty("CheckMatchingBins", false);
     conj.setRethrows(true);
 
     conj.setProperty("InputWorkspace1", "testMismatchedEventWorkspace1");
@@ -180,6 +183,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(conj.setPropertyValue("InputWorkspace1", ws1Name));
     TS_ASSERT_THROWS_NOTHING(conj.setProperty("InputWorkspace2", ws2));
     TS_ASSERT_THROWS_NOTHING(conj.setProperty("CheckOverlapping", true));
+    TS_ASSERT_THROWS_NOTHING(conj.setProperty("CheckMatchingBins", false));
     TS_ASSERT_THROWS_NOTHING(conj.execute());
     // Falls over as they overlap
     TS_ASSERT(!conj.isExecuted());
@@ -228,6 +232,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(conj.setPropertyValue("InputWorkspace1", ws1Name));
     TS_ASSERT_THROWS_NOTHING(conj.setPropertyValue("InputWorkspace2", ws2Name));
     TS_ASSERT_THROWS_NOTHING(conj.setProperty("CheckOverlapping", false));
+    TS_ASSERT_THROWS_NOTHING(conj.setProperty("CheckMatchingBins", false));
     TS_ASSERT_THROWS_NOTHING(conj.execute();)
     TS_ASSERT(conj.isExecuted());
 
@@ -267,6 +272,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(conj.setPropertyValue("InputWorkspace1", ws1Name));
     TS_ASSERT_THROWS_NOTHING(conj.setPropertyValue("InputWorkspace2", ws2Name));
     TS_ASSERT_THROWS_NOTHING(conj.setProperty("CheckOverlapping", false));
+    TS_ASSERT_THROWS_NOTHING(conj.setProperty("CheckMatchingBins", false));
     TS_ASSERT_THROWS_NOTHING(conj.execute();)
     TS_ASSERT(conj.isExecuted());
 
@@ -316,6 +322,7 @@ public:
 
     TS_ASSERT_THROWS_NOTHING(conj.setPropertyValue("YAxisLabel", label));
     TS_ASSERT_THROWS_NOTHING(conj.setPropertyValue("YAxisUnit", unit));
+    TS_ASSERT_THROWS_NOTHING(conj.setProperty("CheckMatchingBins", false));
 
     TS_ASSERT_THROWS_NOTHING(conj.execute());
 
@@ -341,6 +348,7 @@ public:
     const std::string unit = "Modified y unit";
 
     TS_ASSERT_THROWS_NOTHING(conj.setPropertyValue("YAxisUnit", unit));
+    TS_ASSERT_THROWS_NOTHING(conj.setProperty("CheckMatchingBins", false));
     TS_ASSERT_THROWS_NOTHING(conj.execute());
 
     auto result = getWSFromADS(ws1Name);
@@ -363,6 +371,7 @@ public:
     const std::string label = "Modified y label";
 
     TS_ASSERT_THROWS_NOTHING(conj.setPropertyValue("YAxisLabel", label));
+    TS_ASSERT_THROWS_NOTHING(conj.setProperty("CheckMatchingBins", false));
     TS_ASSERT_THROWS_NOTHING(conj.execute());
 
     auto result = getWSFromADS(ws1Name);

--- a/Framework/Algorithms/test/ConjoinWorkspacesTest.h
+++ b/Framework/Algorithms/test/ConjoinWorkspacesTest.h
@@ -169,6 +169,29 @@ public:
     TS_ASSERT(!conj.isExecuted());
   }
 
+  void testCheckMatchingBinsError() {
+    MatrixWorkspace_sptr ws1, ws2;
+    ws1 = WorkspaceCreationHelper::createEventWorkspace(10, 5);
+    ws2 = WorkspaceCreationHelper::createEventWorkspace(10, 10);
+
+    ConjoinWorkspaces conj;
+    conj.initialize();
+    TS_ASSERT_THROWS_NOTHING(conj.setProperty("InputWorkspace1", ws1));
+    TS_ASSERT_THROWS_NOTHING(conj.setProperty("InputWorkspace2", ws2));
+    conj.setRethrows(true);
+
+    try {
+      conj.execute();
+      TS_FAIL("Expected an exception but none was thrown.");
+    } catch (const std::invalid_argument &e) {
+      std::string expectedMessage = "The bins do not match in the input workspaces. "
+                                    "Consider using RebinToWorkspace to preprocess "
+                                    "the workspaces before conjoining them.";
+      TS_ASSERT_EQUALS(std::string(e.what()), expectedMessage);
+      TS_ASSERT(!conj.isExecuted());
+    }
+  }
+
   void testDoCheckForOverlap() {
     MatrixWorkspace_sptr ws1, ws2;
     int numPixels = 10;

--- a/Framework/PythonInterface/plugins/algorithms/ConjoinSpectra.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConjoinSpectra.py
@@ -92,7 +92,7 @@ class ConjoinSpectra(PythonAlgorithm):
             ta.setLabel(loopIndex, labelString)
             loopIndex += 1
             if mtd.doesExist(wsOutput):
-                ConjoinWorkspaces(InputWorkspace1=wsOutput, InputWorkspace2=wsTemp, CheckOverlapping=False)
+                ConjoinWorkspaces(InputWorkspace1=wsOutput, InputWorkspace2=wsTemp, CheckOverlapping=False, CheckMatchingBins=False)
                 if mtd.doesExist(wsTemp):
                     DeleteWorkspace(Workspace=wsTemp)
             else:

--- a/Framework/PythonInterface/plugins/algorithms/LoadVisionElasticBS.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVisionElasticBS.py
@@ -75,7 +75,7 @@ class LoadVisionElasticBS(PythonAlgorithm):
                     mantid.simpleapi.RenameWorkspace(InputWorkspace=bank, OutputWorkspace=wksp_cache)
                     first_bank = False
                 else:
-                    mantid.simpleapi.ConjoinWorkspaces(wksp_cache, bank)
+                    mantid.simpleapi.ConjoinWorkspaces(wksp_cache, bank, CheckMatchingBins=False)
 
             ws = mantid.simpleapi.RenameWorkspace(InputWorkspace=wksp_cache, OutputWorkspace=wksp_name)
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVisionElasticEQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVisionElasticEQ.py
@@ -75,7 +75,7 @@ class LoadVisionElasticEQ(PythonAlgorithm):
                     mantid.simpleapi.RenameWorkspace(InputWorkspace=bank, OutputWorkspace=wksp_cache)
                     first_bank = False
                 else:
-                    mantid.simpleapi.ConjoinWorkspaces(wksp_cache, bank)
+                    mantid.simpleapi.ConjoinWorkspaces(wksp_cache, bank, CheckMatchingBins=False)
 
             ws = mantid.simpleapi.RenameWorkspace(InputWorkspace=wksp_cache, OutputWorkspace=wksp_name)
 

--- a/Framework/PythonInterface/plugins/algorithms/RebinRagged.py
+++ b/Framework/PythonInterface/plugins/algorithms/RebinRagged.py
@@ -190,6 +190,7 @@ class RebinRagged(PythonAlgorithm):
                         startProgress=(progStart + 2 * progStep),
                         endProgress=(progStart + 3 * progStep),
                         EnableLogging=False,
+                        CheckMatchingBins=False,
                     )
             self.setProperty("OutputWorkspace", mtd[accumulationWS])
             DeleteWorkspace(accumulationWS, EnableLogging=False)

--- a/Framework/PythonInterface/plugins/algorithms/SortByQVectors.py
+++ b/Framework/PythonInterface/plugins/algorithms/SortByQVectors.py
@@ -72,7 +72,7 @@ class SortByQVectors(PythonAlgorithm):
             for norm, spec in sortStat:
                 ms.ExtractSingleSpectrum(InputWorkspace=wsName, OutputWorkspace=wsTemp, WorkspaceIndex=spec)
                 if wsOutput in mtd:
-                    ms.ConjoinWorkspaces(InputWorkspace1=wsOutput, InputWorkspace2=wsTemp, CheckOverlapping=False)
+                    ms.ConjoinWorkspaces(InputWorkspace1=wsOutput, InputWorkspace2=wsTemp, CheckOverlapping=False, CheckMatchingBins=False)
                     if wsTemp in mtd:
                         ms.DeleteWorkspace(Workspace=wsTemp)
                 else:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/D7YIGPositionCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/D7YIGPositionCalibration.py
@@ -493,6 +493,7 @@ class D7YIGPositionCalibration(PythonAlgorithm):
                         CheckOverlapping=False,
                         YAxisLabel="TwoTheta_fit",
                         YAxisUnit="degrees",
+                        CheckMatchingBins=False,
                     )
                 except ValueError:
                     RenameWorkspace(InputWorkspace="ws", OutputWorkspace=conjoined_peak_fit_name)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspaces.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspaces.py
@@ -89,7 +89,7 @@ class MatchAndMergeWorkspaces(DataProcessorAlgorithm):
         for ws in flattened_list[1:]:
             temp = CloneWorkspace(InputWorkspace=ws)
             temp = Rebin(InputWorkspace=temp, Params=rebin_param)
-            ConjoinWorkspaces(InputWorkspace1="ws_conjoined", InputWorkspace2=temp, CheckOverlapping=False)
+            ConjoinWorkspaces(InputWorkspace1="ws_conjoined", InputWorkspace2=temp, CheckOverlapping=False, CheckMatchingBins=False)
         ws_conjoined = AnalysisDataService.retrieve("ws_conjoined")
         ref_spec = ws_conjoined.getSpectrum(largest_range_spectrum).getSpectrumNo()
         ws_conjoined, offset, scale, chisq = MatchSpectra(

--- a/Framework/PythonInterface/test/python/mantid/plots/axesfunctions3DTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/axesfunctions3DTest.py
@@ -65,7 +65,7 @@ class PlotFunctions3DTest(unittest.TestCase):
         )
         cls.ws2d_point_uneven = CreateWorkspace(DataX=[10, 20, 30], DataY=[1, 2, 3], NSpec=1, OutputWorkspace="ws2d_point_uneven")
         wp = CreateWorkspace(DataX=[15, 25, 35, 45], DataY=[1, 2, 3, 4], NSpec=1)
-        ConjoinWorkspaces(cls.ws2d_point_uneven, wp, CheckOverlapping=False)
+        ConjoinWorkspaces(cls.ws2d_point_uneven, wp, CheckOverlapping=False, CheckMatchingBins=False)
         cls.ws2d_point_uneven = mantid.mtd["ws2d_point_uneven"]
         cls.ws2d_histo_uneven = CreateWorkspace(DataX=[10, 20, 30, 40], DataY=[1, 2, 3], NSpec=1, OutputWorkspace="ws2d_histo_uneven")
 

--- a/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
@@ -97,7 +97,7 @@ class PlotFunctionsTest(unittest.TestCase):
             OutputWorkspace="ws_spec",
         )
         wp = CreateWorkspace(DataX=[15, 25, 35, 45], DataY=[1, 2, 3, 4], NSpec=1)
-        ConjoinWorkspaces(cls.ws2d_point_uneven, wp, CheckOverlapping=False)
+        ConjoinWorkspaces(cls.ws2d_point_uneven, wp, CheckOverlapping=False, CheckMatchingBins=False)
         cls.ws2d_point_uneven = mantid.mtd["ws2d_point_uneven"]
         cls.ws2d_histo_uneven = CreateWorkspace(DataX=[10, 20, 30, 40], DataY=[1, 2, 3], NSpec=1, OutputWorkspace="ws2d_histo_uneven")
         AddTimeSeriesLog(cls.ws2d_histo, Name="my_log", Time="2010-01-01T00:00:00", Value=100)

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -158,11 +158,11 @@ class DataFunctionsTest(unittest.TestCase):
             OutputWorkspace="ws2d_high_counting_detector",
         )
         wp = CreateWorkspace(DataX=[15, 25, 35, 45], DataY=[1, 2, 3, 4], NSpec=1)
-        ConjoinWorkspaces(cls.ws2d_point_uneven, wp, CheckOverlapping=False)
+        ConjoinWorkspaces(cls.ws2d_point_uneven, wp, CheckOverlapping=False, CheckMatchingBins=False)
         cls.ws2d_point_uneven = mantid.mtd["ws2d_point_uneven"]
         cls.ws2d_histo_uneven = CreateWorkspace(DataX=[10, 20, 30, 40], DataY=[1, 2, 3], NSpec=1, OutputWorkspace="ws2d_histo_uneven")
         wp = CreateWorkspace(DataX=[15, 25, 35, 45, 55], DataY=[1, 2, 3, 4], NSpec=1)
-        ConjoinWorkspaces(cls.ws2d_histo_uneven, wp, CheckOverlapping=False)
+        ConjoinWorkspaces(cls.ws2d_histo_uneven, wp, CheckOverlapping=False, CheckMatchingBins=False)
         cls.ws2d_histo_uneven = mantid.mtd["ws2d_histo_uneven"]
         newYAxis = mantid.api.NumericAxis.create(3)
         newYAxis.setValue(0, 10)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspacesTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspacesTest.py
@@ -74,7 +74,7 @@ class MatchAndMergeWorkspacesTest(unittest.TestCase):
         x_min = np.array([2, 5, 10, 15, 20])
         x_max = np.array([10, 20, 30, 40, 45])
         ws_group = AnalysisDataService.retrieve("ws_group")
-        ConjoinWorkspaces(InputWorkspace1=ws_group[3], InputWorkspace2=ws_group[4], CheckOverlapping=False)
+        ConjoinWorkspaces(InputWorkspace1=ws_group[3], InputWorkspace2=ws_group[4], CheckOverlapping=False, CheckMatchingBins=False)
         ws_list = [ws_group[0], ws_group[1], ws_group[2], ws_group[3]]
         ws_merged = MatchAndMergeWorkspaces(InputWorkspaces=ws_list, XMin=x_min, XMax=x_max)
         self.assertIsInstance(ws_merged, MatrixWorkspace)

--- a/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSDarkRunSubtractionTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS/SANS/WORKFLOWS/SANSDarkRunSubtractionTest.py
@@ -572,6 +572,7 @@ class DarkRunSubtractionTest(unittest.TestCase):
         alg_conjoined.setProperty("InputWorkspace1", monitor_ws)
         alg_conjoined.setProperty("InputWorkspace2", sample_ws_copy)
         alg_conjoined.setProperty("CheckOverlapping", True)
+        alg_conjoined.setProperty("CheckMatchingBins", False)
         alg_conjoined.execute()
         monitor_ws = alg_conjoined.getProperty("InputWorkspace1").value
 
@@ -616,6 +617,7 @@ class DarkRunSubtractionTest(unittest.TestCase):
         alg_conjoined.setProperty("InputWorkspace1", monitor)
         alg_conjoined.setProperty("InputWorkspace2", detector)
         alg_conjoined.setProperty("CheckOverlapping", True)
+        alg_conjoined.setProperty("CheckMatchingBins", False)
         alg_conjoined.execute()
         trans_ws = alg_conjoined.getProperty("InputWorkspace1").value
 

--- a/Testing/SystemTests/tests/framework/ISIS_LETReduction.py
+++ b/Testing/SystemTests/tests/framework/ISIS_LETReduction.py
@@ -128,7 +128,7 @@ class ReduceLET_OneRep(ReductionWrapper):
         Rebin(InputWorkspace=sample_ws, OutputWorkspace=sample_ws, Params=tbin, PreserveEvents=True)
         Rebin(InputWorkspace=monitors_ws, OutputWorkspace=monitors_ws, Params=tbin, PreserveEvents=True)
 
-        ConjoinWorkspaces(InputWorkspace1=sample_ws, InputWorkspace2=monitors_ws)
+        ConjoinWorkspaces(InputWorkspace1=sample_ws, InputWorkspace2=monitors_ws, CheckMatchingBins=False)
         prop.bkgd_range = [int(t_elastic), int(tbin[2])]
 
         ebinstring = str(energybin[0]) + "," + str(energybin[1]) + "," + str(energybin[2])

--- a/docs/source/algorithms/ConjoinFiles-v1.rst
+++ b/docs/source/algorithms/ConjoinFiles-v1.rst
@@ -36,7 +36,7 @@ Usage
     print("Number of spectra in first workspace {}".format(ws1.getNumberHistograms()))
     SaveGSS(ws1, ws1Path, SplitFiles=False, Append=False)
 
-    ws2 = CreateSampleWorkspace(WorkspaceType="Histogram", NumBanks=3, BankPixelWidth=1, BinWidth=10, Xmax=50)
+    ws2 = CreateSampleWorkspace(WorkspaceType="Histogram", NumBanks=2, BankPixelWidth=1, BinWidth=10, Xmax=50)
     print("Number of spectra in second workspace {}".format(ws2.getNumberHistograms()))
     SaveGSS(ws2,ws2Path, SplitFiles=False, Append=False)
 
@@ -51,8 +51,8 @@ Output:
 .. testoutput:: ConjoinFilesEx
 
     Number of spectra in first workspace 2
-    Number of spectra in second workspace 3
-    Number of spectra after ConjoinWorkspaces 5
+    Number of spectra in second workspace 2
+    Number of spectra after ConjoinWorkspaces 4
 
 
 .. categories::

--- a/docs/source/algorithms/ConjoinWorkspaces-v1.rst
+++ b/docs/source/algorithms/ConjoinWorkspaces-v1.rst
@@ -69,8 +69,8 @@ is supplied.
 Exceptions
 ##########
 
-If property 'CheckMatchingBins' is set to true, and the bins in the two input workspaces
-do not match, then an 'invalid_argument' exception will be thrown from the 'exec' method.
+If property ``CheckMatchingBins`` is set to true, and the bins in the two input workspaces
+do not match, then an ``invalid_argument`` exception will be thrown from the ``exec`` method.
 
 If property 'CheckOverlapping' is set to true, and there are spectra and/or detectors
 are overlapping between two input workspaces,

--- a/docs/source/algorithms/ConjoinWorkspaces-v1.rst
+++ b/docs/source/algorithms/ConjoinWorkspaces-v1.rst
@@ -66,12 +66,15 @@ y axis unit and label when conjoining workspaces. Changing YAxisUnit updates
 YAxisLabel automatically with the value of YAxisUnit, unless a separate value
 is supplied.
 
-Exception
-#########
+Exceptions
+##########
+
+If property 'CheckMatchingBins' is set to true, and the bins in the two input workspaces
+do not match, then an 'invalid_argument' exception will be thrown from the 'exec' method.
 
 If property 'CheckOverlapping' is set to true, and there are spectra and/or detectors
 are overlapping between two input workspaces,
-then an 'invalid_argument' exception will be thrown from function 'CheckForOverlap'.
+then an 'invalid_argument' exception will be thrown from 'CheckForOverlap' method.
 
 Usage
 -----
@@ -82,7 +85,7 @@ Usage
 
     ws1 = CreateSampleWorkspace(WorkspaceType="Histogram", NumBanks=2, BankPixelWidth=1, BinWidth=10, Xmax=50)
     print("Number of spectra in first workspace = {}".format(ws1.getNumberHistograms()))
-    ws2 = CreateSampleWorkspace(WorkspaceType="Histogram", NumBanks=3, BankPixelWidth=1, BinWidth=10, Xmax=50)
+    ws2 = CreateSampleWorkspace(WorkspaceType="Histogram", NumBanks=2, BankPixelWidth=1, BinWidth=10, Xmax=50)
     print("Number of spectra in second workspace = {}".format(ws2.getNumberHistograms()))
     ConjoinWorkspaces(InputWorkspace1=ws1, InputWorkspace2=ws2, CheckOverlapping=False, YAxisUnit="New unit", YAxisLabel="New label")
     ws = mtd['ws1'] # Have to update workspace from ADS, as it is an in-out parameter
@@ -95,8 +98,8 @@ Output:
 .. testoutput:: ConjoinWorkspacesEx
 
     Number of spectra in first workspace = 2
-    Number of spectra in second workspace = 3
-    Number of spectra after ConjoinWorkspaces = 5
+    Number of spectra in second workspace = 2
+    Number of spectra after ConjoinWorkspaces = 4
     Y unit is New unit
     Y label New label
 

--- a/docs/source/release/6.12.0/Framework/Algorithms/Bugfixes/38090.rst
+++ b/docs/source/release/6.12.0/Framework/Algorithms/Bugfixes/38090.rst
@@ -1,1 +1,1 @@
-- Fixed workbench crash when conjoined workspaces with mismatched bins are passed to SaveNexusProcessed.
+- :ref:`ConjoinWorkspaces <algm-ConjoinWorkspaces>` has been updated to check for mismatched bins before conjoining the input workspaces.

--- a/docs/source/release/6.12.0/Framework/Algorithms/Bugfixes/38090.rst
+++ b/docs/source/release/6.12.0/Framework/Algorithms/Bugfixes/38090.rst
@@ -1,0 +1,1 @@
+- Fixed workbench crash when conjoined workspaces with mismatched bins are passed to SaveNexusProcessed.

--- a/docs/source/release/6.12.0/Framework/Algorithms/Bugfixes/38090.rst
+++ b/docs/source/release/6.12.0/Framework/Algorithms/Bugfixes/38090.rst
@@ -1,1 +1,1 @@
-- :ref:`ConjoinWorkspaces <algm-ConjoinWorkspaces>` has been updated to check for mismatched bins before conjoining the input workspaces.
+- :ref:`ConjoinWorkspaces <algm-ConjoinWorkspaces>` now performs a check and throws an error if input workspace's bins are mismatched. The mismatch check can be disabled setting the ``CheckMatchingBins`` property to ``False``.

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -52,7 +52,7 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
         # Create ragged workspace
         ws2d_ragged = CreateWorkspace(DataX=[10, 20, 30], DataY=[1, 2, 3], NSpec=1, OutputWorkspace="Ragged")
         temp = CreateWorkspace(DataX=[15, 25, 35, 45], DataY=[1, 2, 3, 4], NSpec=1)
-        ConjoinWorkspaces(ws2d_ragged, temp, CheckOverlapping=False)
+        ConjoinWorkspaces(ws2d_ragged, temp, CheckOverlapping=False, CheckMatchingBins=False)
         ws2d_ragged = AnalysisDataService.retrieve("Ragged")
 
         cls.w_spaces = [mat_ws, table_ws, group_ws, single_val_ws]

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/test/test_workspacedisplay_view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/test/test_workspacedisplay_view.py
@@ -27,8 +27,8 @@ def create_test_workspace(workspace_name, ragged=False):
     if ragged:
         CreateWorkspace([1, 2, 3, 4], [1, 2, 3, 4], NSpec=1, OutputWorkspace="__temp1")
         CreateWorkspace([2, 3, 4, 5, 6], [3, 4, 5, 6, 7], NSpec=1, OutputWorkspace="__temp2")
-        ConjoinWorkspaces(workspace_name, "__temp1", CheckOverlapping=False)
-        ConjoinWorkspaces(workspace_name, "__temp2", CheckOverlapping=False)
+        ConjoinWorkspaces(workspace_name, "__temp1", CheckOverlapping=False, CheckMatchingBins=False)
+        ConjoinWorkspaces(workspace_name, "__temp2", CheckOverlapping=False, CheckMatchingBins=False)
     return AnalysisDataService.retrieve(workspace_name)
 
 

--- a/qt/scientific_interfaces/Direct/ALFInstrumentModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentModel.cpp
@@ -165,7 +165,7 @@ bool ALFInstrumentModel::isALFData(MatrixWorkspace_const_sptr const &workspace) 
 }
 
 bool ALFInstrumentModel::binningMismatch() const {
-  return m_vanadium && !WorkspaceHelpers::matchingBins(*m_sample, *m_vanadium);
+  return m_vanadium && !WorkspaceHelpers::matchingBins(m_sample, m_vanadium);
 }
 
 bool ALFInstrumentModel::axisIsDSpacing() const { return m_sample->getAxis(0)->unit()->unitID() == D_SPACING_UNIT; }

--- a/scripts/Inelastic/Direct/DirectEnergyConversion.py
+++ b/scripts/Inelastic/Direct/DirectEnergyConversion.py
@@ -836,7 +836,7 @@ class DirectEnergyConversion(object):
             ConjoinWorkspaces(InputWorkspace1="spectr_ws1", InputWorkspace2="spectr_ws2")
             RenameWorkspace(InputWorkspace="spectr_ws1", OutputWorkspace=monitor_ws_name)
             if "_OtherMon" in mtd:
-                ConjoinWorkspaces(InputWorkspace1=monitor_ws_name, InputWorkspace2="_OtherMon")
+                ConjoinWorkspaces(InputWorkspace1=monitor_ws_name, InputWorkspace2="_OtherMon", CheckMatchingBins=False)
             else:
                 pass
 

--- a/scripts/Inelastic/Direct/RunDescriptor.py
+++ b/scripts/Inelastic/Direct/RunDescriptor.py
@@ -1345,7 +1345,7 @@ class RunDescriptor(PropDescriptor):
         mon_ws_name = mon_ws.name()
         if not homo_binning:
             Rebin(InputWorkspace=mon_ws_name, OutputWorkspace=mon_ws_name, Params=bins, PreserveEvents="0")
-        ConjoinWorkspaces(InputWorkspace1=mon_ws_name, InputWorkspace2="tmp_mon")
+        ConjoinWorkspaces(InputWorkspace1=mon_ws_name, InputWorkspace2="tmp_mon", CheckMatchingBins=False)
         mon_ws = mtd[mon_ws_name]
 
         if "tmp_mon" in mtd:

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -373,7 +373,7 @@ def fromEvent2Histogram(ws_event, ws_monitor, binning=""):
         aux_hist = RebinToWorkspace(WorkspaceToRebin=ws_event, WorkspaceToMatch=ws_monitor, PreserveEvents=False)
         ws_monitor.clone(OutputWorkspace=name)
 
-    ConjoinWorkspaces(name, aux_hist, CheckOverlapping=True)
+    ConjoinWorkspaces(name, aux_hist, CheckOverlapping=True, CheckMatchingBins=False)
     CopyInstrumentParameters(ws_event, OutputWorkspace=name)
 
     ws_hist = RenameWorkspace(name, OutputWorkspace=str(ws_event))

--- a/scripts/SANS/SANSadd2.py
+++ b/scripts/SANS/SANSadd2.py
@@ -272,7 +272,7 @@ def handle_saving_event_workspace_when_saving_as_histogram(binning, runs, def_ty
     for i in range(mon_n):
         wsOut.setY(i, ws_in_monitor.dataY(i))
         wsOut.setE(i, ws_in_monitor.dataE(i))
-    ConjoinWorkspaces(wsOut, ws_in_detector, CheckOverlapping=True)
+    ConjoinWorkspaces(wsOut, ws_in_detector, CheckOverlapping=True, CheckMatchingBins=False)
 
     if "AddFilesSumTemporary_Rebin" in mtd:
         DeleteWorkspace("AddFilesSumTemporary_Rebin")

--- a/scripts/SANS/isis_reduction_steps.py
+++ b/scripts/SANS/isis_reduction_steps.py
@@ -1774,6 +1774,7 @@ class DarkRunSubtraction(object):
         alg_conjoined.setChild(True)
         alg_conjoined.setProperty("InputWorkspace1", monitor)
         alg_conjoined.setProperty("InputWorkspace2", detector)
+        alg_conjoined.setProperty("CheckMatchingBins", False)
         alg_conjoined.execute()
         return alg_conjoined.getProperty("InputWorkspace1").value
 


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38090 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

**Manual Test**
1) `cd build`
2) `ninja`
3) `workbench` -> to launch workbench
4) Run the following in the editor
```
ws1 = CreateSampleWorkspace(WorkspaceType="Histogram", NumBanks=2, BankPixelWidth=1, BinWidth=10, Xmax=50)
ws2 = CreateSampleWorkspace(WorkspaceType="Histogram", NumBanks=3, BankPixelWidth=1, BinWidth=10, Xmax=50)
ConjoinWorkspaces(InputWorkspace1=ws1, InputWorkspace2=ws2, CheckOverlapping=False, YAxisUnit="New unit", YAxisLabel="New label")
```
5) Verify that error is shown.
<img width="469" alt="image" src="https://github.com/user-attachments/assets/fa4c7a77-328d-4661-9f74-46e94192e28b">



**Run Test**
1) `cd build`
2) `ninja AllTests`
3) Run the following in the terminal
```
ctest -R ConjoinWorkspacesTest
```
4) Verify that the test passes.
<img width="548" alt="image" src="https://github.com/user-attachments/assets/97a29fd5-803a-464d-b571-669eab48dfbc">



<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
