### PR TITLE
Remove deprecation warning engineering interface fitting tab

### DIFF
--- a/docs/source/release/6.12.0/Diffraction/Engineering Diffraction/Bugfixes/35596.rst
+++ b/docs/source/release/6.12.0/Diffraction/Engineering Diffraction/Bugfixes/35596.rst
@@ -1,0 +1,1 @@
+- Fix Deprecation Warning for getSampleDetails in :ref:`Fitting tab <ui engineering fitting>`

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/data_handling/data_model.py
@@ -246,7 +246,7 @@ class FittingDataModel(object):
     # =================
 
     def get_sample_log_from_ws(self, ws_name, log_name):
-        return self._data_workspaces[ws_name].loaded_ws.getSampleDetails().getLogData(log_name).value
+        return self._data_workspaces[ws_name].loaded_ws.getRun().getLogData(log_name).value
 
     def get_all_log_workspaces_names(self):
         return (


### PR DESCRIPTION
### Description of work
Remove deprecation warning engineering interface fitting tab, as described by the warning itself. Small change to utility function "no additional unit test required"

Fixes #35596. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->
### To test:

Test 4 and 5 in manual testing instructions
https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html

In test 4 at step 4 warning should no longer appear in the log.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
