### PR TITLE
Ignore in-source build of conda - ornl-next

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,6 +208,15 @@ rel/
 mambaforge/
 miniconda3/
 
+# in source build of conda pacakges
+conda/recipes/channeldata.json
+conda/recipes/index.html
+conda/recipes/linux-64/
+conda/recipes/noarch/
+conda/recipes/osx-64/
+conda/recipes/tmp/
+conda/recipes/win-64/
+
 # in source building of windows packages
 installers/conda/win/_conda_env
 installers/conda/win/_package_build


### PR DESCRIPTION
This is a version of #38480 into `ornl-next`