### PR TITLE
account for lines sharing graphs with workspaces in mantidaxes

### DIFF
--- a/docs/source/release/6.12.0/Framework/PythonInterface/Bugfixes/38486.rst
+++ b/docs/source/release/6.12.0/Framework/PythonInterface/Bugfixes/38486.rst
@@ -1,0 +1,1 @@
+:class:`~mantid.plots.MantidAxes` accounts for plotting both workspaces and lines on the same axis in the rename case

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -861,7 +861,7 @@ class FigureInteraction(object):
                         raise RuntimeError("No spectrum number associated with plot of " "workspace '{}'".format(workspace.name()))
 
                 arg_set_copy = copy(arg_set)
-                for key in ["function", "workspaces", "autoscale_on_update", "norm"]:
+                for key in ["function", "workspaces", "autoscale_on_update", "norm", "argType"]:
                     try:
                         del arg_set_copy[key]
                     except KeyError:


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Adds an additional kwarg value to the `creation_args` collected as part of plotting on a mantidaxes to track the type of plotting that had occurred.  This is notable because we record different data depending on if we plotted a workspace or a line.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

If an `axline` is plotted on the same axes as a workspace and we update the name of the workspace with ADS or some algorithm, this causes a python exception.  In practice I didnt notice any misbehavior besides the stacktrace, but I was asked to fix it.

 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

This can be recreated by running the following in workbench:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from workbench.plotting.figuremanager import MantidFigureCanvas
from workbench.plotting.toolbar import WorkbenchNavigationToolbar
from qtpy.QtWidgets import (
    QApplication,
)
zelf = QApplication.instance().topLevelWidgets()[0]
figure = plt.figure(constrained_layout=True)
canvas = MantidFigureCanvas(figure)
navigationBar = WorkbenchNavigationToolbar(canvas, zelf)

ws = "test_ws"

CreateSampleWorkspace(
            OutputWorkspace=ws,
            # WorkspaceType="Histogram",
            Function="User Defined",
            UserDefinedFunction=f"name=Gaussian,Height=10,PeakCentre=1,Sigma=1",
            Xmin=0,
            Xmax=10,
            BinWidth=1,
            XUnit="TOF",
            NumBanks=4,  # must produce same number of pixels as fake instrument
            BankPixelWidth=2,  # each bank has 4 pixels, 4 banks, 16 total
            Random=False,
        )
wkspIndex = 1
ax = figure.add_subplot(1, 1, wkspIndex, projection="mantid")
ax.axvline(x=1, label="label", color="red")
RenameWorkspace(ws, "renamed_ws")
``` 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
