### PR TITLE
Fix bug in validation of PolarizerEfficiency algorithm

### DIFF
--- a/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrections/PolarizerEfficiency.cpp
@@ -125,6 +125,7 @@ std::map<std::string, std::string> PolarizerEfficiency::validateInputs() {
     errorList[PropertyNames::SPIN_STATES] =
         "The number of workspaces in the input WorkspaceGroup (" + std::to_string(inputWsCount) +
         ") does not match the number of spin states provided (" + std::to_string(spinStates.size()) + ").";
+    return errorList;
   }
   const auto &t01WsIndex =
       PolarizationCorrectionsHelpers::indexOfWorkspaceForSpinState(spinStates, FlipperConfigurations::OFF_ON);

--- a/Framework/Algorithms/test/PolarizationCorrections/PolarizerEfficiencyTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/PolarizerEfficiencyTest.h
@@ -114,7 +114,10 @@ public:
     auto grpWs = groupWorkspaces("grpWs", {tPara, tAnti});
 
     auto polariserEfficiency = createPolarizerEfficiencyAlgorithm(grpWs);
-    polariserEfficiency->setProperty("SpinStates", "00, 01, 10");
+    // The 00 spin state is deliberately placed at the end of the input string so that it does not match a workspace in
+    // the group. The algorithm validation normally tries to look up the 00 workspace, so this checks that we don't do
+    // that when the spin states and workspace group length don't match.
+    polariserEfficiency->setProperty("SpinStates", "10, 01, 00");
     TS_ASSERT_THROWS(polariserEfficiency->execute(), const std::runtime_error &);
   }
 

--- a/docs/source/release/v6.12.0/SANS/Bugfixes/38483.rst
+++ b/docs/source/release/v6.12.0/SANS/Bugfixes/38483.rst
@@ -1,0 +1,1 @@
+- Fixed a bug in :ref:`algm-PolarizerEfficiency` where passing in a ``SpinStates`` string that contains more spin states than the number of workspaces in the input workspace group could cause a crash.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Fixes a bug in the validation of algorithm `PolarizerEfficiency` that could result in a crash. See linked issue for further details.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38483. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
See instructions on linked issue.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
