### PR TITLE
Log cppcheck command during configure step

### DIFF
--- a/buildconfig/CMake/CppCheckSetup.cmake
+++ b/buildconfig/CMake/CppCheckSetup.cmake
@@ -60,6 +60,13 @@ if(CPPCHECK_EXECUTABLE)
     list(APPEND _cppcheck_xml_args "${_cppcheck_source_dirs}")
   endif(CPPCHECK_GENERATE_XML)
 
+  if(NOT WIN32)
+    message(STATUS "cppcheck configured to run (ignoring xml arguments)")
+    message(STATUS "remove the project argument to supply files to check")
+    list(JOIN _cppcheck_args " " _cppcheck_args_for_printing)
+    message(STATUS "${CPPCHECK_EXECUTABLE} ${_cppcheck_args_for_printing}")
+  endif()
+
   # generate the target
   if(NOT TARGET cppcheck)
     add_custom_target(


### PR DESCRIPTION
To aid developers in running cppcheck locally rather than waiting for the build server, print the command with arguments to the console during the cmake configure step. This includes some nearby text which gives advice on how to modify the provided command. 

*There is no associated issue.*

### To test:

Run
```sh
cmake .
```
and see the new messages go by. Bonus points for copy/paste and run cppcheck against a single file.

*This does not require release notes* because this adds an informational message for developers and changes nothing in how mantid is build/run.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
