### PR TITLE
Make qtassistant a compile time option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,8 @@ endif()
 # Docs requirements
 option(ENABLE_DOCS "Enable Building user and developer documentation" ON)
 if(ENABLE_DOCS)
+  option(DOCS_QTHELP "If enabled add a target to build the qthelp documentation for qtassistant" ON)
+
   find_package(Sphinx REQUIRED)
   # run python to see if the theme is installed
   execute_process(

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1125,17 +1125,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/InstrumentSelec
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/ListPropertyWidget.cpp:46
 returnByReference:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/FitDomain.h:35
 virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h:39
-ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:318
-ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:320
-ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:329
-ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:331
-ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:342
-ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:343
-ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:344
-ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:354
-ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:355
-ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:356
-ignoredReturnErrorCode:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:357
 returnByReference:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/Message.h:52
 returnByReference:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/Message.h:56
 constParameterReference:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/MantidHelpWindow.cpp:301

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -9,7 +9,6 @@ set(DOCS_MATH_EXT
 )
 set_property(CACHE DOCS_MATH_EXT PROPERTY STRINGS "sphinx.ext.imgmath" "sphinx.ext.mathjax")
 option(DOCS_PLOTDIRECTIVE "If enabled include plots generated with the plot directive. " OFF)
-option(DOCS_QTHELP "If enabled add a target to build the qthelp documentation" ON)
 option(SPHINX_WARNINGS_AS_ERRORS "non-zero exit if there are sphinx warnings" ON)
 option(SPHINX_FRESH_ENV "Don't use a saved environment, but rebuild it completely" ON)
 

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -80,7 +80,6 @@ set(SRC_FILES
     src/ParseKeyValueString.cpp
     src/pixmaps.cpp
     src/PluginLibraries.cpp
-    src/pqHelpWindow.cxx
     src/ProcessingAlgoWidget.cpp
     src/ProgressableView.cpp
     src/PropertyHandler.cpp
@@ -158,6 +157,9 @@ set(SRC_FILES
     src/Python/Sip.cpp
     src/Python/QHashToDict.cpp
 )
+if(DOCS_QTHELP)
+  list(APPEND SRC_FILES src/pqHelpWindow.cxx)
+endif()
 
 set(QT5_MOC_FILES
     inc/MantidQtWidgets/Common/AddWorkspaceDialog.h
@@ -211,7 +213,6 @@ set(QT5_MOC_FILES
     inc/MantidQtWidgets/Common/FileFinderWidget.h
     inc/MantidQtWidgets/Common/NotificationService.h
     inc/MantidQtWidgets/Common/OptionsPropertyWidget.h
-    inc/MantidQtWidgets/Common/pqHelpWindow.h
     inc/MantidQtWidgets/Common/ProcessingAlgoWidget.h
     inc/MantidQtWidgets/Common/PropertyHandler.h
     inc/MantidQtWidgets/Common/PropertyWidget.h
@@ -348,6 +349,9 @@ set(QT5_INC_FILES
     inc/MantidQtWidgets/Common/Python/Object.h
     inc/MantidQtWidgets/Common/Python/QHashToDict.h
 )
+if(DOCS_QTHELP)
+  list(APPEND QT5_INC_FILES inc/MantidQtWidgets/Common/pqHelpWindow.h)
+endif()
 
 set(QT5_UI_FILES
     inc/MantidQtWidgets/Common/AddWorkspaceDialog.ui
@@ -360,7 +364,6 @@ set(QT5_UI_FILES
     inc/MantidQtWidgets/Common/MuonPeriodInfo.ui
     inc/MantidQtWidgets/Common/FileFinderWidget.ui
     inc/MantidQtWidgets/Common/FitScriptGenerator.ui
-    inc/MantidQtWidgets/Common/pqHelpWindow.ui
     inc/MantidQtWidgets/Common/ProcessingAlgoWidget.ui
     inc/MantidQtWidgets/Common/RenameParDialog.ui
     inc/MantidQtWidgets/Common/ScriptRepositoryView.ui
@@ -369,6 +372,9 @@ set(QT5_UI_FILES
     inc/MantidQtWidgets/Common/SlitCalculator.ui
     inc/MantidQtWidgets/Common/UserFunctionDialog.ui
 )
+if(DOCS_QTHELP)
+  list(APPEND QT5_UI_FILES inc/MantidQtWidgets/Common/pqHelpWindow.ui)
+endif()
 
 set(MOC_FILES
     inc/MantidQtWidgets/Common/AlgorithmDialog.h
@@ -435,7 +441,6 @@ set(MOC_FILES
     inc/MantidQtWidgets/Common/MuonFitPropertyBrowser.h
     inc/MantidQtWidgets/Common/MuonFunctionBrowser.h
     inc/MantidQtWidgets/Common/MuonPeriodInfo.h
-    inc/MantidQtWidgets/Common/pqHelpWindow.h
     inc/MantidQtWidgets/Common/PropertyHandler.h
     inc/MantidQtWidgets/Common/ProcessingAlgoWidget.h
     inc/MantidQtWidgets/Common/QtAlgorithmRunner.h
@@ -627,8 +632,10 @@ set(UI_FILES
     inc/MantidQtWidgets/Common/SlicingAlgorithmDialog.ui
     inc/MantidQtWidgets/Common/SlitCalculator.ui
     inc/MantidQtWidgets/Common/UserFunctionDialog.ui
-    inc/MantidQtWidgets/Common/pqHelpWindow.ui
 )
+if(DOCS_QTHELP)
+  list(APPEND UI_FILES inc/MantidQtWidgets/Common/pqHelpWindow.ui)
+endif()
 
 set(TARGET_LIBRARIES ${CORE_MANTIDLIBS} ${POCO_LIBRARIES} ${Boost_LIBRARIES})
 
@@ -697,6 +704,11 @@ mtd_add_qt_library(
   OSX_INSTALL_RPATH @loader_path/../MacOS @loader_path/../Frameworks
   LINUX_INSTALL_RPATH "\$ORIGIN/../${WORKBENCH_LIB_DIR}"
 )
+# add an extra define to use pqhelpwindow which wraps qtassistant
+if(DOCS_QTHELP)
+  # warning - this is assuming that the output is qt5 only
+  target_compile_definitions(MantidQtWidgetsCommonQt5 PUBLIC -DDOCS_QTHELP)
+endif()
 
 set(TEST_FILES
     test/AlgorithmHintStrategyTest.h

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidHelpWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidHelpWindow.h
@@ -16,7 +16,9 @@
 class QHelpEngine;
 class QString;
 class QWidget;
+#ifdef DOCS_QTHELP
 class pqHelpWindow;
+#endif
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -25,7 +27,7 @@ class EXPORT_OPT_MANTIDQT_COMMON MantidHelpWindow : public API::MantidHelpInterf
   Q_OBJECT
 
 public:
-  static bool helpWindowExists() { return !g_helpWindow.isNull(); }
+  static bool helpWindowExists();
 
   MantidHelpWindow(const Qt::WindowFlags &flags = Qt::WindowFlags());
 
@@ -49,13 +51,15 @@ private:
 
   /// The full path of the collection file.
   std::string m_collectionFile;
+#ifdef DOCS_QTHELP
   /// The window that renders the help information
   static QPointer<pqHelpWindow> g_helpWindow;
+#endif
 
   /// Whether this is the very first startup of the helpwindow.
   bool m_firstRun;
 
-  void findCollectionFile(std::string &binDir);
+  void findCollectionFile(const std::string &binDir);
   void determineFileLocs();
 
 public slots:


### PR DESCRIPTION
This removes the pointer to the qtassistant wrapper as dependent on the variable QT_DOCS. The default behavior is to keep the current functionality.

### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Refs #37248 and [EWM6548](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6548)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
