### PR TITLE
New MagneticFormFactorCorrectionMD algorithm

### DIFF
--- a/Framework/MDAlgorithms/CMakeLists.txt
+++ b/Framework/MDAlgorithms/CMakeLists.txt
@@ -96,6 +96,7 @@ set(SRC_FILES
     src/PolarizationAngleCorrectionMD.cpp
     src/PowerMD.cpp
     src/PreprocessDetectorsToMD.cpp
+    src/QTransform.cpp
     src/QueryMDWorkspace.cpp
     src/RecalculateTrajectoriesExtents.cpp
     src/ReplicateMD.cpp
@@ -216,6 +217,7 @@ set(INC_FILES
     inc/MantidMDAlgorithms/PolarizationAngleCorrectionMD.h
     inc/MantidMDAlgorithms/PowerMD.h
     inc/MantidMDAlgorithms/PreprocessDetectorsToMD.h
+    inc/MantidMDAlgorithms/QTransform.h
     inc/MantidMDAlgorithms/QueryMDWorkspace.h
     inc/MantidMDAlgorithms/RecalculateTrajectoriesExtents.h
     inc/MantidMDAlgorithms/ReplicateMD.h
@@ -329,6 +331,7 @@ set(TEST_FILES
     PolarizationAngleCorrectionMDTest.h
     PowerMDTest.h
     PreprocessDetectorsToMDTest.h
+    QTransformTest.h
     QueryMDWorkspaceTest.h
     RecalculateTrajectoriesExtentsTest.h
     ReplicateMDTest.h

--- a/Framework/MDAlgorithms/CMakeLists.txt
+++ b/Framework/MDAlgorithms/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SRC_FILES
     src/MDTransfQ3D.cpp
     src/MDWSDescription.cpp
     src/MDWSTransform.cpp
+    src/MagneticFormFactorCorrectionMD.cpp
     src/MaskMD.cpp
     src/MergeMD.cpp
     src/MergeMDFiles.cpp
@@ -206,6 +207,7 @@ set(INC_FILES
     inc/MantidMDAlgorithms/MDTransfQ3D.h
     inc/MantidMDAlgorithms/MDWSDescription.h
     inc/MantidMDAlgorithms/MDWSTransform.h
+    inc/MantidMDAlgorithms/MagneticFormFactorCorrectionMD.h
     inc/MantidMDAlgorithms/MaskMD.h
     inc/MantidMDAlgorithms/MergeMD.h
     inc/MantidMDAlgorithms/MergeMDFiles.h
@@ -320,6 +322,7 @@ set(TEST_FILES
     MDTransfQ3DTest.h
     MDWSDescriptionTest.h
     MDWSTransfTest.h
+    MagneticFormFactorCorrectionMDTest.h
     MaskMDTest.h
     MergeMDFilesTest.h
     MergeMDTest.h

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MagneticFormFactorCorrectionMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MagneticFormFactorCorrectionMD.h
@@ -1,0 +1,32 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidKernel/MagneticIon.h"
+#include "MantidMDAlgorithms/QTransform.h"
+
+namespace Mantid {
+namespace MDAlgorithms {
+
+/** MagneticFormFactorCorrectionMD : TODO: DESCRIPTION
+ */
+class MANTID_MDALGORITHMS_DLL MagneticFormFactorCorrectionMD : public QTransform {
+public:
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
+  double correction(const double) const override;
+
+private:
+  void init() override;
+  void exec() override;
+  Mantid::PhysicalConstants::MagneticIon ion;
+};
+
+} // namespace MDAlgorithms
+} // namespace Mantid

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MagneticFormFactorCorrectionMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MagneticFormFactorCorrectionMD.h
@@ -12,7 +12,7 @@
 namespace Mantid {
 namespace MDAlgorithms {
 
-/** MagneticFormFactorCorrectionMD : TODO: DESCRIPTION
+/** MagneticFormFactorCorrectionMD : Correct event signal and error values for magnetic form factor.
  */
 class MANTID_MDALGORITHMS_DLL MagneticFormFactorCorrectionMD : public QTransform {
 public:
@@ -21,6 +21,7 @@ public:
   const std::string category() const override;
   const std::string summary() const override;
   double correction(const double) const override;
+  const std::vector<std::string> seeAlso() const override;
 
 private:
   void init() override;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/QTransform.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/QTransform.h
@@ -1,0 +1,36 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidDataObjects/MDEventWorkspace.h"
+#include "MantidMDAlgorithms/DllConfig.h"
+
+namespace Mantid {
+namespace MDAlgorithms {
+
+/** QTransform : TODO: DESCRIPTION
+ */
+class MANTID_MDALGORITHMS_DLL QTransform : public API::Algorithm {
+public:
+protected:
+  std::map<std::string, std::string> validateInputs() override;
+  void init() override;
+  void exec() override;
+
+  template <typename MDE, size_t nd>
+  void applyCorrection(typename Mantid::DataObjects::MDEventWorkspace<MDE, nd>::sptr);
+
+  // correction method to be implemented by derived classes. Input parameter is |Q|^2.
+  virtual double correction(const double) const = 0;
+
+private:
+  size_t m_numQDims;
+};
+
+} // namespace MDAlgorithms
+} // namespace Mantid

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/QTransform.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/QTransform.h
@@ -13,7 +13,7 @@
 namespace Mantid {
 namespace MDAlgorithms {
 
-/** QTransform : TODO: DESCRIPTION
+/** QTransform : Base algorithm for transforming |Q| values in an MD workspace.
  */
 class MANTID_MDALGORITHMS_DLL QTransform : public API::Algorithm {
 public:

--- a/Framework/MDAlgorithms/src/MagneticFormFactorCorrectionMD.cpp
+++ b/Framework/MDAlgorithms/src/MagneticFormFactorCorrectionMD.cpp
@@ -26,11 +26,13 @@ const std::string MagneticFormFactorCorrectionMD::name() const { return "Magneti
 int MagneticFormFactorCorrectionMD::version() const { return 1; }
 
 /// Algorithm's category for identification. @see Algorithm::category
-const std::string MagneticFormFactorCorrectionMD::category() const { return "TODO: FILL IN A CATEGORY"; }
+const std::string MagneticFormFactorCorrectionMD::category() const { return "MDAlgorithms"; }
 
 /// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
-const std::string MagneticFormFactorCorrectionMD::summary() const { return "TODO: FILL IN A SUMMARY"; }
-
+const std::string MagneticFormFactorCorrectionMD::summary() const {
+  return "Apply magnetic form factor correction to MD events by dividing signal with F(Q)^2";
+}
+const std::vector<std::string> MagneticFormFactorCorrectionMD::seeAlso() const { return {"MagFormFactorCorrection"}; }
 // //----------------------------------------------------------------------------------------------
 // /** Initialize the algorithm's properties.
 //  */

--- a/Framework/MDAlgorithms/src/MagneticFormFactorCorrectionMD.cpp
+++ b/Framework/MDAlgorithms/src/MagneticFormFactorCorrectionMD.cpp
@@ -1,0 +1,60 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidMDAlgorithms/MagneticFormFactorCorrectionMD.h"
+#include "MantidKernel/ListValidator.h"
+
+namespace Mantid {
+namespace MDAlgorithms {
+using Mantid::API::WorkspaceProperty;
+using Mantid::Kernel::Direction;
+using Mantid::Kernel::StringListValidator;
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(MagneticFormFactorCorrectionMD)
+
+//----------------------------------------------------------------------------------------------
+
+/// Algorithms name for identification. @see Algorithm::name
+const std::string MagneticFormFactorCorrectionMD::name() const { return "MagneticFormFactorCorrectionMD"; }
+
+/// Algorithm's version for identification. @see Algorithm::version
+int MagneticFormFactorCorrectionMD::version() const { return 1; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string MagneticFormFactorCorrectionMD::category() const { return "TODO: FILL IN A CATEGORY"; }
+
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string MagneticFormFactorCorrectionMD::summary() const { return "TODO: FILL IN A SUMMARY"; }
+
+// //----------------------------------------------------------------------------------------------
+// /** Initialize the algorithm's properties.
+//  */
+void MagneticFormFactorCorrectionMD::init() {
+  QTransform::init();
+  std::vector<std::string> keys = Mantid::PhysicalConstants::getMagneticIonList();
+  declareProperty("IonName", "Cu2", std::make_shared<StringListValidator>(keys),
+                  "The name of the ion: an element symbol with a number "
+                  "indicating the valence, e.g. Fe2 for Fe2+ / Fe(II)");
+}
+
+// //----------------------------------------------------------------------------------------------
+// /** Execute the algorithm.
+//  */
+void MagneticFormFactorCorrectionMD::exec() {
+  ion = Mantid::PhysicalConstants::getMagneticIon(getProperty("IonName"));
+  QTransform::exec();
+}
+
+// implement correction method
+double MagneticFormFactorCorrectionMD::correction(const double q2) const {
+  const auto ff = ion.analyticalFormFactor(q2);
+  return 1. / (ff * ff);
+}
+
+} // namespace MDAlgorithms
+} // namespace Mantid

--- a/Framework/MDAlgorithms/src/QTransform.cpp
+++ b/Framework/MDAlgorithms/src/QTransform.cpp
@@ -1,0 +1,124 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidMDAlgorithms/QTransform.h"
+#include "MantidAPI/IMDEventWorkspace_fwd.h"
+#include "MantidDataObjects/MDEventFactory.h"
+#include "MantidKernel/SpecialCoordinateSystem.h"
+#include "MantidMDAlgorithms/MDWSDescription.h"
+
+using namespace Mantid::DataObjects;
+
+namespace Mantid {
+namespace MDAlgorithms {
+using Mantid::API::IMDEventWorkspace;
+using Mantid::API::IMDEventWorkspace_sptr;
+using Mantid::API::WorkspaceProperty;
+using Mantid::Kernel::Direction;
+
+//----------------------------------------------------------------------------------------------
+namespace { // anonymous
+size_t getNumQDimensions(const IMDEventWorkspace_sptr ws) {
+  // Check that the input workspace has units in Q_sample or Q_lab or |Q| frame
+  // Check the assumption that the Q dimensions are the first
+  if (ws->getSpecialCoordinateSystem() == Mantid::Kernel::SpecialCoordinateSystem::QSample ||
+      ws->getSpecialCoordinateSystem() == Mantid::Kernel::SpecialCoordinateSystem::QLab) {
+    // check that the first 3 dimensions are in Q
+    if (ws->getNumDims() < 3)
+      return 0;
+
+    for (size_t i = 0; i < 3; ++i)
+      if (!ws->getDimension(i)->getMDFrame().isQ())
+        return 0;
+
+    return 3;
+  } else if (ws->getDimension(0)->getName() == "|Q|") {
+    return 1;
+  }
+
+  return 0;
+}
+} // namespace
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void QTransform::init() {
+  declareProperty(std::make_unique<WorkspaceProperty<IMDEventWorkspace>>("InputWorkspace", "", Direction::Input),
+                  "n input MDEventWorkspace. Must be in Q_sample/Q_lab frame.");
+  declareProperty(std::make_unique<WorkspaceProperty<IMDEventWorkspace>>("OutputWorkspace", "", Direction::Output),
+                  "The output MDEventWorkspace with correction applied.");
+}
+
+std::map<std::string, std::string> QTransform::validateInputs() {
+  std::map<std::string, std::string> result;
+  // check that the input workspace has units in Q_sample or Q_lab frame
+  API::IMDEventWorkspace_sptr input_ws = getProperty("InputWorkspace");
+  if (getNumQDimensions(input_ws) == 0)
+    result["InputWorkspace"] = "Input workspace must be in Q_sample or Q_lab frame. Either Q3D or Q1D with |Q|.";
+
+  return result;
+}
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void QTransform::exec() {
+  IMDEventWorkspace_sptr input_ws = getProperty("InputWorkspace");
+  IMDEventWorkspace_sptr output_ws = getProperty("OutputWorkspace");
+
+  if (output_ws != input_ws)
+    output_ws = input_ws->clone();
+
+  m_numQDims = getNumQDimensions(output_ws);
+
+  CALL_MDEVENT_FUNCTION(applyCorrection, output_ws);
+
+  // refresh cache for MDBoxes: set correct Box signal
+  output_ws->refreshCache();
+
+  setProperty("OutputWorkspace", output_ws);
+}
+
+template <typename MDE, size_t nd>
+void QTransform::applyCorrection(typename Mantid::DataObjects::MDEventWorkspace<MDE, nd>::sptr ws) {
+  // Get Box from MDEventWorkspace
+  MDBoxBase<MDE, nd> *box1 = ws->getBox();
+  std::vector<API::IMDNode *> boxes;
+  box1->getBoxes(boxes, 1000, true);
+  auto numBoxes = int(boxes.size());
+
+  PRAGMA_OMP(parallel for if (!ws->isFileBacked()))
+  for (int i = 0; i < numBoxes; ++i) {
+    PARALLEL_START_INTERRUPT_REGION
+    auto *box = dynamic_cast<MDBox<MDE, nd> *>(boxes[i]);
+    if (box && !box->getIsMasked()) {
+      std::vector<MDE> &events = box->getEvents();
+      for (auto it = events.begin(); it != events.end(); ++it) {
+
+        double qsqr{0};
+        for (size_t d = 0; d < m_numQDims; ++d)
+          qsqr += it->getCenter(d) * it->getCenter(d);
+
+        const auto correction = this->correction(qsqr);
+
+        // apply the correction
+        const auto intensity = it->getSignal() * correction;
+        it->setSignal(static_cast<float>(intensity));
+        const auto error2 = it->getErrorSquared() * correction * correction;
+        it->setErrorSquared(static_cast<float>(error2));
+      }
+    }
+    if (box) {
+      box->releaseEvents();
+    }
+    PARALLEL_END_INTERRUPT_REGION
+  }
+
+  return;
+}
+
+} // namespace MDAlgorithms
+} // namespace Mantid

--- a/Framework/MDAlgorithms/src/QTransform.cpp
+++ b/Framework/MDAlgorithms/src/QTransform.cpp
@@ -48,7 +48,7 @@ size_t getNumQDimensions(const IMDEventWorkspace_sptr ws) {
  */
 void QTransform::init() {
   declareProperty(std::make_unique<WorkspaceProperty<IMDEventWorkspace>>("InputWorkspace", "", Direction::Input),
-                  "n input MDEventWorkspace. Must be in Q_sample/Q_lab frame.");
+                  "An input MDEventWorkspace. Must be in Q.");
   declareProperty(std::make_unique<WorkspaceProperty<IMDEventWorkspace>>("OutputWorkspace", "", Direction::Output),
                   "The output MDEventWorkspace with correction applied.");
 }

--- a/Framework/MDAlgorithms/test/MagneticFormFactorCorrectionMDTest.h
+++ b/Framework/MDAlgorithms/test/MagneticFormFactorCorrectionMDTest.h
@@ -1,0 +1,52 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidMDAlgorithms/MagneticFormFactorCorrectionMD.h"
+
+using Mantid::MDAlgorithms::MagneticFormFactorCorrectionMD;
+
+class MagneticFormFactorCorrectionMDTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static MagneticFormFactorCorrectionMDTest *createSuite() { return new MagneticFormFactorCorrectionMDTest(); }
+  static void destroySuite(MagneticFormFactorCorrectionMDTest *suite) { delete suite; }
+
+  void test_Init() {
+    MagneticFormFactorCorrectionMD alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
+
+  void test_exec() {
+    // Create test input if necessary by filling in appropriate code below.
+    // Consider using MantidFrameworkTestHelpers/WorkspaceCreationHelper.h
+    // MatrixWorkspace_sptr inputWS =
+
+    MagneticFormFactorCorrectionMD alg;
+    // Don't put output in ADS by default
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", "inputWS"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
+    // // be the type using in declareProperty for the "OutputWorkspace" type.
+    // // We can't use auto as it's an implicit conversion.
+    // Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    // TS_ASSERT(outputWS);
+    // TS_FAIL("TODO: Check the results and remove this line");
+  }
+
+  void test_Something() { TS_FAIL("You forgot to write a test!"); }
+};

--- a/Framework/MDAlgorithms/test/MagneticFormFactorCorrectionMDTest.h
+++ b/Framework/MDAlgorithms/test/MagneticFormFactorCorrectionMDTest.h
@@ -8,7 +8,10 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "MantidDataObjects/MDEventInserter.h"
+#include "MantidKernel/MagneticIon.h"
 #include "MantidMDAlgorithms/MagneticFormFactorCorrectionMD.h"
+#include "QTransformTest.h"
 
 using Mantid::MDAlgorithms::MagneticFormFactorCorrectionMD;
 
@@ -19,34 +22,114 @@ public:
   static MagneticFormFactorCorrectionMDTest *createSuite() { return new MagneticFormFactorCorrectionMDTest(); }
   static void destroySuite(MagneticFormFactorCorrectionMDTest *suite) { delete suite; }
 
-  void test_Init() {
-    MagneticFormFactorCorrectionMD alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
-  }
+  void test_exec_1D() {
+    // create a 1D MD workspace
+    auto create_alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged("CreateMDWorkspace");
+    create_alg->setChild(true);
+    create_alg->initialize();
+    create_alg->setProperty("Dimensions", 1);
+    create_alg->setProperty("Extents", "1,4");
+    create_alg->setProperty("Names", "|Q|");
+    create_alg->setProperty("Units", "A");
+    create_alg->setPropertyValue("OutputWorkspace", "_unused_for_child");
+    create_alg->execute();
 
-  void test_exec() {
-    // Create test input if necessary by filling in appropriate code below.
-    // Consider using MantidFrameworkTestHelpers/WorkspaceCreationHelper.h
-    // MatrixWorkspace_sptr inputWS =
+    Mantid::API::Workspace_sptr inputWS = create_alg->getProperty("OutputWorkspace");
+
+    // add MD events with Q values 1, 2, 3, 4
+    MDEventWorkspace<MDLeanEvent<1>, 1>::sptr mdws_mdevt_1 =
+        std::dynamic_pointer_cast<MDEventWorkspace<MDLeanEvent<1>, 1>>(inputWS);
+    MDEventInserter<MDEventWorkspace<MDLeanEvent<1>, 1>::sptr> inserter(mdws_mdevt_1);
+
+    for (Mantid::coord_t q = 1; q < 5; ++q) {
+      Mantid::coord_t coord[1] = {q};
+      inserter.insertMDEvent(1.0, 1.0, 0, 0, 0, coord);
+    }
+
+    // run the algorithm with U5 ion
+    std::string ionName = "U5";
 
     MagneticFormFactorCorrectionMD alg;
-    // Don't put output in ADS by default
     alg.setChild(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", "inputWS"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("IonName", ionName));
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
+    Mantid::API::IMDEventWorkspace_sptr outputWS = alg.getProperty("OutputWorkspace");
 
-    // // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
-    // // be the type using in declareProperty for the "OutputWorkspace" type.
-    // // We can't use auto as it's an implicit conversion.
-    // Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
-    // TS_ASSERT(outputWS);
-    // TS_FAIL("TODO: Check the results and remove this line");
+    // get the events from the output workspace and check the signal, error, and center values
+    auto output_events = QTransformTest::get_events_helper(outputWS);
+
+    TS_ASSERT_EQUALS(output_events.size(), 4);
+
+    auto ion = Mantid::PhysicalConstants::getMagneticIon(ionName);
+
+    for (size_t i = 0; i < output_events.size(); ++i) {
+      const double q = static_cast<double>(i + 1);
+      const double ff = ion.analyticalFormFactor(q * q);
+      TS_ASSERT_DELTA(output_events[i][0], 1. / (ff * ff), 1e-5); // signal
+      TS_ASSERT_DELTA(output_events[i][1], 1. / (ff * ff), 1e-5); // error
+      TS_ASSERT_EQUALS(output_events[i][2], q);                   // center
+    }
   }
 
-  void test_Something() { TS_FAIL("You forgot to write a test!"); }
+  void test_exec_3D() {
+    // create a 3D MD workspace
+    auto create_alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged("CreateMDWorkspace");
+    create_alg->setChild(true);
+    create_alg->initialize();
+    create_alg->setProperty("Dimensions", 3);
+    create_alg->setProperty("Extents", "0,10,0,10,0,10");
+    create_alg->setProperty("Names", "Qx,Qy,Qz");
+    create_alg->setProperty("Units", "A,A,A");
+    create_alg->setProperty("Frames", "QSample,QSample,QSample");
+    create_alg->setPropertyValue("OutputWorkspace", "_unused_for_child");
+    create_alg->execute();
+
+    Mantid::API::Workspace_sptr inputWS = create_alg->getProperty("OutputWorkspace");
+
+    // add MD events with Q values (1,1,1), (2,2,2), (3,3,3), (4,4,4)
+    MDEventWorkspace<MDLeanEvent<3>, 3>::sptr mdws_mdevt_3 =
+        std::dynamic_pointer_cast<MDEventWorkspace<MDLeanEvent<3>, 3>>(inputWS);
+    MDEventInserter<MDEventWorkspace<MDLeanEvent<3>, 3>::sptr> inserter(mdws_mdevt_3);
+
+    for (Mantid::coord_t q = 1; q < 5; ++q) {
+      Mantid::coord_t coord[3] = {q, q, q};
+      inserter.insertMDEvent(1.0, 1.0, 0, 0, 0, coord);
+    }
+
+    // run the algorithm with Pu5 ion
+    std::string ionName = "Pu5";
+
+    MagneticFormFactorCorrectionMD alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("IonName", ionName));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+    Mantid::API::IMDEventWorkspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+
+    // get the events from the output workspace and check the signal, error, and center values
+    auto output_events = QTransformTest::get_events_helper(outputWS);
+
+    TS_ASSERT_EQUALS(output_events.size(), 4);
+
+    auto ion = Mantid::PhysicalConstants::getMagneticIon(ionName);
+
+    for (size_t i = 0; i < output_events.size(); ++i) {
+      const double q = static_cast<double>(i + 1);
+      const double ff = ion.analyticalFormFactor((q * q) * 3);
+      TS_ASSERT_DELTA(output_events[i][0], 1. / (ff * ff), 1e-5); // signal
+      TS_ASSERT_DELTA(output_events[i][1], 1. / (ff * ff), 1e-5); // error
+      TS_ASSERT_EQUALS(output_events[i][2], q);                   // center x
+      TS_ASSERT_EQUALS(output_events[i][3], q);                   // center y
+      TS_ASSERT_EQUALS(output_events[i][4], q);                   // center z
+    }
+  }
 };

--- a/Framework/MDAlgorithms/test/QTransformTest.h
+++ b/Framework/MDAlgorithms/test/QTransformTest.h
@@ -6,47 +6,212 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidDataObjects/MDEventFactory.h"
+#include "MantidMDAlgorithms/QTransform.h"
 #include <cxxtest/TestSuite.h>
 
-#include "MantidMDAlgorithms/QTransform.h"
-
 using Mantid::MDAlgorithms::QTransform;
+using namespace Mantid::DataObjects;
 
 class QTransformTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
   static QTransformTest *createSuite() { return new QTransformTest(); }
-  static void destroySuite(QQTransformTest *suite) { delete suite; }
+  static void destroySuite(QTransformTest *suite) { delete suite; }
 
-  void test_Init() {
-    QTransform alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
+  void test_exec_1Q() {
+    auto inputWS = createMDWorkspace("QTransformTest1", 1, "1,4", "|Q|", "A");
+
+    auto outputWS = runQTransform("QTransformTest1");
+    TS_ASSERT(outputWS);
+
+    compare_input_and_outputWS(inputWS, outputWS);
   }
 
-  void test_exec() {
-    // Create test input if necessary by filling in appropriate code below.
-    // Consider using MantidFrameworkTestHelpers/WorkspaceCreationHelper.h
-    // MatrixWorkspace_sptr inputWS =
+  void test_exec_1Q_1E() {
+    auto inputWS = createMDWorkspace("QTransformTest2", 2, "1,4,1,4", "|Q|,E", "A,B");
 
-    QTransform alg;
-    // Don't put output in ADS by default
+    auto outputWS = runQTransform("QTransformTest2");
+    TS_ASSERT(outputWS);
+
+    compare_input_and_outputWS(inputWS, outputWS, true);
+  }
+
+  void test_exec_3Q() {
+    auto inputWS =
+        createMDWorkspace("QTransformTest3", 3, "1,4,1,4,1,4", "Q_lab_x,Q_lab_y,Q_lab_z", "A,B,C", "QLab,QLab,QLab");
+
+    auto outputWS = runQTransform("QTransformTest3");
+    TS_ASSERT(outputWS);
+
+    compare_input_and_outputWS(inputWS, outputWS);
+  }
+
+  void test_exec_3Q_1E() {
+    auto inputWS = createMDWorkspace("QTransformTest4", 4, "1,4,1,4,1,4,1,4", "Q_sample_x,Q_sample_y,Q_sample_z,DeltaE",
+                                     "A,B,C,D", "QSample,QSample,QSample,General Frame");
+
+    auto outputWS = runQTransform("QTransformTest4");
+    TS_ASSERT(outputWS);
+
+    compare_input_and_outputWS(inputWS, outputWS, true);
+  }
+
+  void test_exec_bad_2Q() {
+    // this should throw as invalid input WS, only 2 q dimensions
+    auto inputWS =
+        createMDWorkspace("QTransformTest5", 2, "1,4,1,4", "Q_sample_x,Q_sample_y", "A,B", "QSample,QSample");
+
+    runQTransform("QTransformTest5", true);
+  }
+
+  void test_exec_bad_1Q() {
+    // this should throw as invalid input WS, name is "Q" not "|Q|"
+    auto inputWS = createMDWorkspace("QTransformTest6", 1, "1,4", "Q", "A");
+
+    runQTransform("QTransformTest6", true);
+  }
+
+  void test_exec_bad_order() {
+    // this should throw as invalid input WS, q diemnsions are not the first 3
+    auto inputWS = createMDWorkspace("QTransformTest7", 4, "1,4,1,4,1,4,1,4", "DeltaE,Q_sample_x,Q_sample_y,Q_sample_z",
+                                     "A,B,C,D", "General Frame,QSample,QSample,QSample");
+
+    runQTransform("QTransformTest7", true);
+  }
+
+private:
+  Mantid::API::IMDEventWorkspace_sptr runQTransform(std::string inputWS, bool expect_throw = false) {
+    QTransformTestClass alg;
     alg.setChild(true);
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspace", inputWS));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
-    TS_ASSERT_THROWS_NOTHING(alg.execute(););
-    TS_ASSERT(alg.isExecuted());
+    if (expect_throw) {
+      TS_ASSERT_THROWS(alg.execute();, const std::runtime_error &);
+    } else {
+      TS_ASSERT_THROWS_NOTHING(alg.execute(););
+      TS_ASSERT(alg.isExecuted());
+    }
 
-    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
-    // be the type using in declareProperty for the "OutputWorkspace" type.
-    // We can't use auto as it's an implicit conversion.
-    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
-    TS_ASSERT(outputWS);
-    TS_FAIL("TODO: Check the results and remove this line");
+    return alg.getProperty("OutputWorkspace");
   }
 
-  void test_Something() { TS_FAIL("You forgot to write a test!"); }
+  Mantid::API::IMDEventWorkspace_sptr createMDWorkspace(std::string wsName, int dim, std::string extents,
+                                                        std::string names, std::string units, std::string frames = "") {
+    auto create_alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged("CreateMDWorkspace");
+    create_alg->initialize();
+    create_alg->setProperty("Dimensions", dim);
+    create_alg->setProperty("Extents", extents);
+    create_alg->setProperty("Names", names);
+    create_alg->setProperty("Units", units);
+    create_alg->setProperty("Frames", frames);
+    create_alg->setPropertyValue("OutputWorkspace", wsName);
+    create_alg->execute();
+
+    auto fake_md_events = Mantid::API::AlgorithmManager::Instance().createUnmanaged("FakeMDEventData");
+    fake_md_events->initialize();
+    fake_md_events->setProperty("InputWorkspace", wsName);
+    fake_md_events->setPropertyValue("UniformParams", "-100");
+    fake_md_events->execute();
+
+    Mantid::API::IMDEventWorkspace_sptr inputWS =
+        Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::IMDEventWorkspace>(wsName);
+
+    return inputWS;
+  }
+
+  void compare_input_and_outputWS(Mantid::API::IMDEventWorkspace_sptr inputWS,
+                                  Mantid::API::IMDEventWorkspace_sptr outputWS, bool q_skip_last = false) {
+    auto input_events = get_events_helper(inputWS);
+    auto output_events = get_events_helper(outputWS);
+
+    TS_ASSERT_EQUALS(input_events.size(), output_events.size());
+
+    for (size_t i = 0; i < input_events.size(); ++i) {
+      TS_ASSERT_EQUALS(input_events[i].size(), output_events[i].size());
+
+      double q2{0};
+      // check center values do not change
+      for (size_t j = 2; j < input_events[i].size(); ++j) {
+        TS_ASSERT_DELTA(input_events[i][j], output_events[i][j], 1e-6);
+        if (!q_skip_last || j < input_events[i].size() - 1)
+          q2 += input_events[i][j] * input_events[i][j];
+      }
+
+      // signal and error input will be 1, output equal to q^2 since our implemented correction function just returns
+      // q^2
+      TS_ASSERT_EQUALS(input_events[i][0], 1);
+      TS_ASSERT_EQUALS(input_events[i][1], 1);
+      TS_ASSERT_DELTA(output_events[i][0], q2, 1e-5);
+      TS_ASSERT_DELTA(output_events[i][1], q2, 1e-5);
+    }
+  }
+
+  std::vector<std::vector<double>> get_events_helper(Mantid::API::IMDEventWorkspace_sptr workspace) {
+    MDEventWorkspace<MDLeanEvent<1>, 1>::sptr MDEW_MDLEANEVENT_1 =
+        std::dynamic_pointer_cast<MDEventWorkspace<MDLeanEvent<1>, 1>>(workspace);
+    if (MDEW_MDLEANEVENT_1)
+      return get_events<MDLeanEvent<1>, 1>(MDEW_MDLEANEVENT_1);
+
+    MDEventWorkspace<MDLeanEvent<2>, 2>::sptr MDEW_MDLEANEVENT_2 =
+        std::dynamic_pointer_cast<MDEventWorkspace<MDLeanEvent<2>, 2>>(workspace);
+    if (MDEW_MDLEANEVENT_2)
+      return get_events<MDLeanEvent<2>, 2>(MDEW_MDLEANEVENT_2);
+
+    MDEventWorkspace<MDLeanEvent<3>, 3>::sptr MDEW_MDLEANEVENT_3 =
+        std::dynamic_pointer_cast<MDEventWorkspace<MDLeanEvent<3>, 3>>(workspace);
+    if (MDEW_MDLEANEVENT_3)
+      return get_events<MDLeanEvent<3>, 3>(MDEW_MDLEANEVENT_3);
+
+    MDEventWorkspace<MDLeanEvent<4>, 4>::sptr MDEW_MDLEANEVENT_4 =
+        std::dynamic_pointer_cast<MDEventWorkspace<MDLeanEvent<4>, 4>>(workspace);
+    return get_events<MDLeanEvent<4>, 4>(MDEW_MDLEANEVENT_4);
+  }
+
+  template <typename MDE, size_t nd>
+  std::vector<std::vector<double>> get_events(typename Mantid::DataObjects::MDEventWorkspace<MDE, nd>::sptr ws) {
+    // return a vector of events, events being (signal, error, x1, x2, x3, ...)
+    std::vector<std::vector<double>> events_vector;
+    MDBoxBase<MDE, nd> *box1 = ws->getBox();
+    std::vector<Mantid::API::IMDNode *> boxes;
+    box1->getBoxes(boxes, 1000, true);
+    auto numBoxes = int(boxes.size());
+
+    for (int i = 0; i < numBoxes; ++i) {
+      auto *box = dynamic_cast<MDBox<MDE, nd> *>(boxes[i]);
+      if (box && !box->getIsMasked()) {
+        std::vector<MDE> &events = box->getEvents();
+        for (auto it = events.begin(); it != events.end(); ++it) {
+
+          std::vector<double> event;
+          event.push_back(it->getSignal());
+          event.push_back(it->getError());
+          for (size_t d = 0; d < nd; ++d)
+            event.push_back(it->getCenter(d));
+          events_vector.push_back(event);
+        }
+      }
+      if (box) {
+        box->releaseEvents();
+      }
+    }
+    return events_vector;
+  }
+
+  // small helper class to test abstract class
+  class QTransformTestClass : public QTransform {
+  public:
+    const std::string name() const override { return "QTransformTestClass"; };
+    int version() const override { return 1; };
+    const std::string category() const override { return "Test"; };
+    const std::string summary() const override { return "Summary."; };
+
+    // return the input q^2
+    double correction(const double q2) const override { return q2; };
+  };
 };

--- a/Framework/MDAlgorithms/test/QTransformTest.h
+++ b/Framework/MDAlgorithms/test/QTransformTest.h
@@ -1,0 +1,52 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2024 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidMDAlgorithms/QTransform.h"
+
+using Mantid::MDAlgorithms::QTransform;
+
+class QTransformTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static QTransformTest *createSuite() { return new QTransformTest(); }
+  static void destroySuite(QQTransformTest *suite) { delete suite; }
+
+  void test_Init() {
+    QTransform alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
+
+  void test_exec() {
+    // Create test input if necessary by filling in appropriate code below.
+    // Consider using MantidFrameworkTestHelpers/WorkspaceCreationHelper.h
+    // MatrixWorkspace_sptr inputWS =
+
+    QTransform alg;
+    // Don't put output in ADS by default
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
+    // be the type using in declareProperty for the "OutputWorkspace" type.
+    // We can't use auto as it's an implicit conversion.
+    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);
+    TS_FAIL("TODO: Check the results and remove this line");
+  }
+
+  void test_Something() { TS_FAIL("You forgot to write a test!"); }
+};

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1048,6 +1048,7 @@ internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/MDEventWSWrapper.cp
 internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/MDWSTransform.cpp:0
 internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/MDWSDescription.cpp:0
 internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/MDNormDirectSC.cpp:0
+internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/MagneticFormFactorCorrectionMD.cpp:0
 internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/OrMD.cpp:0
 internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/MDNorm.cpp:0
 internalError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/MergeMDFiles.cpp:0

--- a/docs/source/algorithms/MagneticFormFactorCorrectionMD-v1.rst
+++ b/docs/source/algorithms/MagneticFormFactorCorrectionMD-v1.rst
@@ -10,7 +10,15 @@
 Description
 -----------
 
-TODO: Enter a full rst-markup description of your algorithm here.
+Scales the the signal and error of MD events by :math:`1/|F(Q)|^2` where :math:`F(Q)` is
+the magnetic form factor for the ion specified in `IonName`.
+
+`IonName` must be specified as a string with the element name followed
+by a number which indicates the charge / oxidation state. E.g.
+`Fe2` indicates :math:`\mathrm{Fe}^{2+}` or Fe(II).
+
+Input workspace must be in Q with either 1 dimension of \|Q\| or 3 Q_sample/Q_lab dimensions.
+It is assumed that the Q dimensions come first follow by any number of other dimensions.
 
 
 Usage
@@ -24,21 +32,28 @@ Usage
 
 .. testcode:: MagneticFormFactorCorrectionMDExample
 
-   # Create a host workspace
-   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
-   or
-   ws = CreateSampleWorkspace()
+  # Create a test MD workspace
+  ws = CreateMDWorkspace(Dimensions='1', Extents='1,4',
+                         Names='|Q|', Units='A')
+  FakeMDEventData(ws, UniformParams=-6000)
 
-   wsOut = MagneticFormFactorCorrectionMD()
+  # Run the algorithm
+  wsOut = MagneticFormFactorCorrectionMD(ws, IonName="U5")
 
-   # Print the result
-   print "The output workspace has %%i spectra" %% wsOut.getNumberHistograms()
+  # Bin the result so that it can be printed
+  wsOut = BinMD(wsOut, AlignedDim0='|Q|,1,4,6')
+  ws = BinMD(ws, AlignedDim0='|Q|,1,4,6')
+
+  # Print the result
+  print("Input signal:    ", [int(x) for x in ws.getSignalArray()])
+  print("Corrected signal:", [int(x) for x in wsOut.getSignalArray()])
 
 Output:
 
 .. testoutput:: MagneticFormFactorCorrectionMDExample
 
-  The output workspace has ?? spectra
+  Input signal:     [1000, 1000, 1000, 1000, 1000, 1000]
+  Corrected signal: [1137, 1281, 1498, 1813, 2270, 2937]
 
 .. categories::
 

--- a/docs/source/algorithms/MagneticFormFactorCorrectionMD-v1.rst
+++ b/docs/source/algorithms/MagneticFormFactorCorrectionMD-v1.rst
@@ -1,0 +1,45 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+TODO: Enter a full rst-markup description of your algorithm here.
+
+
+Usage
+-----
+..  Try not to use files in your examples,
+    but if you cannot avoid it then the (small) files must be added to
+    autotestdata\UsageData and the following tag unindented
+    .. include:: ../usagedata-note.txt
+
+**Example - MagneticFormFactorCorrectionMD**
+
+.. testcode:: MagneticFormFactorCorrectionMDExample
+
+   # Create a host workspace
+   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
+   or
+   ws = CreateSampleWorkspace()
+
+   wsOut = MagneticFormFactorCorrectionMD()
+
+   # Print the result
+   print "The output workspace has %%i spectra" %% wsOut.getNumberHistograms()
+
+Output:
+
+.. testoutput:: MagneticFormFactorCorrectionMDExample
+
+  The output workspace has ?? spectra
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38511.rst
+++ b/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38511.rst
@@ -1,0 +1,1 @@
+- New algorithm :ref:`algm-MagneticFormFactorCorrectionMD` to scale the MDEvents by the magnetic form factor.


### PR DESCRIPTION
### Description of work

This will apply magnetic form factor correction to MDEvents.

There is a base algorithm QTransform that will be reused for other corrections in the near future.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->


Fixes [7999: [Story]Create MagneticFormFactorCorrectionMD](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/7999) and [8001: [Story] Parent class QTransform](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8001).

<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

```python
we1 = CreateSampleWorkspace(WorkspaceType='Event',
                           Function='Flat background',
                           XUnit='DeltaE',
                           XMin=-10,
                           XMax=19,
                           NumEvents=100)
MoveInstrumentComponent(Workspace=we1, ComponentName='bank1', X=3, Z=3, RelativePosition=False)
MoveInstrumentComponent(Workspace=we1, ComponentName='bank2', X=-3, Z=-3, RelativePosition=False))
AddSampleLog(Workspace=we1,LogName='Ei', LogText='20.', LogType='Number')

md1 = ConvertToMD(InputWorkspace=we1, QDimensions='Q3D')
md2 = ConvertToMD(InputWorkspace=we1, QDimensions='|Q|')

out1 = MagneticFormFactorCorrectionMD(md1)
out2 = MagneticFormFactorCorrectionMD(md2)
```

You can also compare the form factor to the one coming from ``MagFormFactorCorrection``.

Using ``MagFormFactorCorrection``

```python
ws = CreateSampleWorkspace(binWidth = 0.1, XMin = 0, XMax = 50, XUnit = 'DeltaE')
ws = ScaleX(ws, -15, "Add")
AddSampleLog(Workspace=ws,LogName='Ei', LogText='35.', LogType='Number')
LoadInstrument(ws, InstrumentName='MARI', RewriteSpectraMap = True)
ws2 = SofQW(ws, [0, 0.05, 8], 'Direct', 35)
Q = ws2.getAxis(1).extractValues()
for i in range(len(Q)-1):
    qv = ( (Q[i]+Q[i+1])*0.5 ) / 4 / np.pi
    y = ws2.dataY(i)
    y *= np.exp(-16*qv*qv)
ws2_corr, fe3ff = MagFormFactorCorrection(ws2, IonName='Fe3')
```

Using ``MagneticFormFactorCorrectionMD``

```python
# new method
ws = CreateSampleWorkspace(binWidth = 0.1, XMin = 0, XMax = 50, XUnit = 'DeltaE')
ws = ScaleX(ws, -15, "Add")
AddSampleLog(Workspace=ws,LogName='Ei', LogText='35.', LogType='Number')
LoadInstrument(ws, InstrumentName='MARI', RewriteSpectraMap = True)
md = ConvertToMD(InputWorkspace=ws, QDimensions='|Q|')
result = MagneticFormFactorCorrectionMD(md, IonName='Fe3')
```

Get form factor applied 1/sqrt(result/input)

```python
ff = BinMD(result, AlignedDim1='|Q|,0,8,160', AlignedDim0='DeltaE,-15,35,1')
ori = BinMD(md, AlignedDim1='|Q|,0,8,160', AlignedDim0='DeltaE,-15,35,1')
ff = ori / ff
ff = ConvertMDHistoToMatrixWorkspace(ff)
ff.setY(0, np.sqrt(ff.readY(0)))
```

Plotting them you see the values are scaled the same.

```python
fig, axes = plt.subplots(subplot_kw={'projection': 'mantid'})
axes.plot(fe3ff, wkspIndex=0, normalize_by_bin_width=False)
axes.plot(ff,  wkspIndex=0, normalize_by_bin_width=False)
axes.set_xlabel('|Q|')
axes.set_ylabel('Signal')
fig.show()
```

![Figure_1](https://github.com/user-attachments/assets/54ee73db-4cac-4318-b7c0-f91caa6a6984)


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
