### PR TITLE
Fixing face centered lattice reflection condition

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Crystal/ReflectionCondition.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/ReflectionCondition.h
@@ -106,9 +106,8 @@ public:
   std::string getSymbol() override { return "F"; }
   /// Return true if the hkl is allowed.
   bool isAllowed(int h, int k, int l) override {
-    return (((((h + k) % 2) == 0) && (((h + l) % 2) == 0) && (((k + l) % 2) == 0)) |
-                ((h % 2 == 0) && (k % 2 == 0) && (l % 2 == 0)) ||
-            ((h % 2 == 1) && (k % 2 == 1) && (l % 2 == 1)));
+    return (((((h + k) % 2) == 0) && (((h + l) % 2) == 0) && (((k + l) % 2) == 0)) ||
+            ((h % 2 == 0) && (k % 2 == 0) && (l % 2 == 0)) || ((h % 2 == 1) && (k % 2 == 1) && (l % 2 == 1)));
   }
 };
 

--- a/docs/source/release/v6.12.0/Diffraction/Single_Crystal/Bugfixes/38512.rst
+++ b/docs/source/release/v6.12.0/Diffraction/Single_Crystal/Bugfixes/38512.rst
@@ -1,0 +1,1 @@
+- Fix bug in reflection condition affecting all-face centered lattice


### PR DESCRIPTION
### Description of work

There is an issue with the reflection condition check for the face-centered lattice
https://dictionary.iucr.org/Reflection_conditions
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

Small typo in the condition forgot to correctly use "logical_or".

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Occasional crash using `StatisticsOfPeaksWorkspace`. It was not clear what was happening until it was isolated to using "F" lattice centering.

```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *

from mantid.geometry import CrystalStructure
import numpy as np

# Generate a workspace with an instrument definition
ws = CreateSimulationWorkspace(Instrument='WISH',
                               BinParams='0,10000,20000',
                               UnitX='TOF')

# Set a random UB, in this case for an orthorhombic structure
SetUB(ws, a=5.5, b=6.5, c=8.1, u='12,1,1', v='0,4,9')

# Set an arbitrary crystal structure with 2 atoms and some
# systematic absences due to space group Pbca
cs = CrystalStructure('5.5 6.5 8.1', 'P b c a',
                      """Ni 0.232 0.114 0.543 1.0 0.00843;
                         Al 0.434 0.041 0.854 1.0 0.01120""")
ws.sample().setCrystalStructure(cs)

predicted = PredictPeaks(InputWorkspace=ws,
                         CalculateStructureFactors=True,
                         MinDSpacing=0.5,
                         WavelengthMin=0.9, WavelengthMax=6.0)

for peak in predicted:
    peak.setSigmaIntensity(np.sqrt(peak.getIntensity()))

StatisticsOfPeaksWorkspace(InputWorkspace='predicted', 
                           LatticeCentering='All-face centred',
                           OutputWorkspace='test')
```

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
