### PR TITLE
Remove off-putting error prompt that appears when canceling a MaxEnt calculation in the Muon FDA interface

### DIFF
--- a/docs/source/release/v6.12.0/Muon/FDA/Bugfixes/38514.rst
+++ b/docs/source/release/v6.12.0/Muon/FDA/Bugfixes/38514.rst
@@ -1,0 +1,1 @@
+- Remove off-putting error prompt that appears when canceling a MaxEnt calculation in the :ref:`Muon FDA interface <Frequency_Domain_Analysis-ref>`

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter.py
@@ -188,7 +188,11 @@ class MaxEntPresenter(object):
             # this is caught as part of the calculation thread
             raise ValueError("Please select groups in the grouping tab")
         else:
-            maxent_workspace = run_MuonMaxent(maxent_parameters, alg, base_name)
+            try:
+                maxent_workspace = run_MuonMaxent(maxent_parameters, alg, base_name)
+            except KeyboardInterrupt:
+                return
+
             self.add_maxent_workspace_to_ADS(maxent_parameters["InputWorkspace"], maxent_workspace, alg)
 
     def _create_group_table(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/max_ent_presenter_load_interaction_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/max_ent_presenter_load_interaction_test.py
@@ -209,6 +209,20 @@ class MaxEntPresenterTest(unittest.TestCase):
         self.assertEqual(self.presenter.add_maxent_workspace_to_ADS.call_count, 0)
         self.assertEqual(mock_maxent.call_count, 0)
 
+    @mock.patch("mantidqtinterfaces.Muon.GUI.FrequencyDomainAnalysis.MaxEnt.maxent_presenter.run_MuonMaxent")
+    def test_calculate_maxent_ignores_keyboardinterrupt(self, mock_maxent):
+        mock_maxent.side_effect = KeyboardInterrupt()
+        params = {"InputWorkspace": "test"}
+        self.presenter.get_parameters_for_maxent_calculation = mock.Mock(return_value=params)
+        type(self.presenter).use_groups = mock.PropertyMock(return_value=True)
+        type(self.presenter).get_num_groups = mock.PropertyMock(return_value=2)
+        self.presenter.add_maxent_workspace_to_ADS = mock.Mock()
+        alg = mock.Mock()
+
+        self.presenter.calculate_maxent(alg)
+        self.assertEqual(self.presenter.add_maxent_workspace_to_ADS.call_count, 0)
+        self.assertEqual(mock_maxent.call_count, 1)
+
     def test_create_group_table(self):
         group1 = MuonGroup("fwd", [1, 2, 3])
         type(self.presenter).get_selected_groups = mock.PropertyMock(return_value=[group1])


### PR DESCRIPTION
### Description of work
This PR removes unnecessary error prompts when cancelling a MaxEnt calculation in the Muon FDA interface. The cancellation is now handled by greying out the cancel button again and enabling the Cancel MaxEnt button. 

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38030. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:
1- Follow instructions in [Maxent Test]
2- After "Click the Calculate MaxEnt button" step click cancel
3- The cancel button should be greyed out again, and the Calculate MaxEnt button will be re-enabled.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
