### PR TITLE
Change atom labels to the ones that were supplied

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Crystal/IsotropicAtomBraggScatterer.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/IsotropicAtomBraggScatterer.h
@@ -82,7 +82,9 @@ public:
   std::string name() const override { return "IsotropicAtomBraggScatterer"; }
   BraggScatterer_sptr clone() const override;
 
+  // cppcheck-suppress returnByReference
   std::string getElement() const;
+  // cppcheck-suppress returnByReference
   PhysicalConstants::NeutronAtom getNeutronAtom() const;
 
   double getOccupancy() const;

--- a/Framework/Geometry/src/Crystal/IsotropicAtomBraggScatterer.cpp
+++ b/Framework/Geometry/src/Crystal/IsotropicAtomBraggScatterer.cpp
@@ -41,7 +41,7 @@ void IsotropicAtomBraggScatterer::setElement(const std::string &element) {
   PhysicalConstants::Atom atom = PhysicalConstants::getAtom(element);
 
   m_atom = atom.neutron;
-  m_label = atom.symbol;
+  m_label = element;
 }
 
 /// Returns the string representation of the contained element.

--- a/Framework/Geometry/test/IsotropicAtomBraggScattererTest.h
+++ b/Framework/Geometry/test/IsotropicAtomBraggScattererTest.h
@@ -37,10 +37,18 @@ public:
   void testGetSetElement() {
     IsotropicAtomBraggScatterer_sptr scatterer = getInitializedScatterer();
 
+    // Silicon
     TS_ASSERT_THROWS_NOTHING(scatterer->setProperty("Element", "Si"));
     TS_ASSERT_EQUALS(scatterer->getElement(), "Si");
     TS_ASSERT_EQUALS(scatterer->getNeutronAtom().z_number, 14);
 
+    // Deuterated Hydrogen is a special case
+    TS_ASSERT_THROWS_NOTHING(scatterer->setProperty("Element", "D"));
+    TS_ASSERT_EQUALS(scatterer->getElement(), "D");
+    TS_ASSERT_EQUALS(scatterer->getNeutronAtom().z_number, 1);
+    TS_ASSERT_EQUALS(scatterer->getNeutronAtom().a_number, 2);
+
+    // non-existant element should error
     TS_ASSERT_THROWS_ANYTHING(scatterer->setProperty("Element", "Random"));
   }
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -724,8 +724,6 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventWorkspac
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventWorkspace.cpp:738
 shadowVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/OrientedLattice.cpp:236
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/NiggliCell.cpp:233
-returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/IsotropicAtomBraggScatterer.h:85
-returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/IsotropicAtomBraggScatterer.h:86
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h:51
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/PointGroup.h:41
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/SymmetryElement.h:45

--- a/docs/source/release/v6.12.0/Framework/Data_Objects/Bugfixes/38519.rst
+++ b/docs/source/release/v6.12.0/Framework/Data_Objects/Bugfixes/38519.rst
@@ -1,0 +1,1 @@
+- Fix ``CrystalStructure`` to display deuterium when it is one of the atoms


### PR DESCRIPTION
While playing with `CrystalStructure` (see testing instructions for the script), it was confusing that the atoms printed by the script had different names than the ones supplied. This adds a test that supplying deuterium gets back deuterium.

*There is no associated issue,* but this addresses [EWM8669](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8669)

### To test:

Before this change the Deuterium was returned as Hydrogen (not an isotope). Run this script
```python
from mantid.geometry import CrystalStructure

print("### example from Zach")
silicon = CrystalStructure("5.431 5.431 5.431", "F d -3 m", "D 0 0 0 1.0 0.05")

unitCell = silicon.getUnitCell()
print('Crystal structure of silicon:')
print('  Unit cell: {0} {1} {2} {3} {4} {5}'.format(unitCell.a(), unitCell.b(), unitCell.c(), unitCell.alpha(), unitCell.beta(), unitCell.gamma()))

spaceGroup = silicon.getSpaceGroup()
print('  Space group: {0}'.format(spaceGroup.getHMSymbol()))
print('  Point group: {0}'.format(spaceGroup.getPointGroup().getHMSymbol()))

scatterers = silicon.getScatterers()
print('  Total number of scatterers: {0}'.format(len(scatterers)))

for i, scatterer in enumerate(scatterers):
    print('    {0}: {1}'.format(i,scatterer))

print("### example from Malcolm")

latticeString = "7.469 7.469 6.976 90. 90. 90."
sgString = "I -4 2 d"
atomString = "K 0 0 0.5 1. 0.0235;P 0 0 0 1. 0.0146;D 0.14861 0.22011 0.12041 0.5 0.0225;O 0.14888 0.08073 0.12643 1. 0.0176"

print("input atomString: ",atomString)
crystal = CrystalStructure(latticeString,sgString,atomString)
print("output atoms: ")
for atom in crystal.getScatterers():
    print(atom)
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
