### PR TITLE
Change atom labels to the ones that were supplied - ornl-next

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Crystal/IsotropicAtomBraggScatterer.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/IsotropicAtomBraggScatterer.h
@@ -82,7 +82,9 @@ public:
   std::string name() const override { return "IsotropicAtomBraggScatterer"; }
   BraggScatterer_sptr clone() const override;
 
+  // cppcheck-suppress returnByReference
   std::string getElement() const;
+  // cppcheck-suppress returnByReference
   PhysicalConstants::NeutronAtom getNeutronAtom() const;
 
   double getOccupancy() const;

--- a/Framework/Geometry/src/Crystal/IsotropicAtomBraggScatterer.cpp
+++ b/Framework/Geometry/src/Crystal/IsotropicAtomBraggScatterer.cpp
@@ -41,7 +41,7 @@ void IsotropicAtomBraggScatterer::setElement(const std::string &element) {
   PhysicalConstants::Atom atom = PhysicalConstants::getAtom(element);
 
   m_atom = atom.neutron;
-  m_label = atom.symbol;
+  m_label = element;
 }
 
 /// Returns the string representation of the contained element.

--- a/Framework/Geometry/test/IsotropicAtomBraggScattererTest.h
+++ b/Framework/Geometry/test/IsotropicAtomBraggScattererTest.h
@@ -37,10 +37,18 @@ public:
   void testGetSetElement() {
     IsotropicAtomBraggScatterer_sptr scatterer = getInitializedScatterer();
 
+    // Silicon
     TS_ASSERT_THROWS_NOTHING(scatterer->setProperty("Element", "Si"));
     TS_ASSERT_EQUALS(scatterer->getElement(), "Si");
     TS_ASSERT_EQUALS(scatterer->getNeutronAtom().z_number, 14);
 
+    // Deuterated Hydrogen is a special case
+    TS_ASSERT_THROWS_NOTHING(scatterer->setProperty("Element", "D"));
+    TS_ASSERT_EQUALS(scatterer->getElement(), "D");
+    TS_ASSERT_EQUALS(scatterer->getNeutronAtom().z_number, 1);
+    TS_ASSERT_EQUALS(scatterer->getNeutronAtom().a_number, 2);
+
+    // non-existant element should error
     TS_ASSERT_THROWS_ANYTHING(scatterer->setProperty("Element", "Random"));
   }
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -724,8 +724,6 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventWorkspac
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/EventWorkspace.cpp:738
 shadowVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/OrientedLattice.cpp:236
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Crystal/NiggliCell.cpp:233
-returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/IsotropicAtomBraggScatterer.h:85
-returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/IsotropicAtomBraggScatterer.h:86
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h:51
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/PointGroup.h:41
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Crystal/SymmetryElement.h:45

--- a/docs/source/release/v6.12.0/Framework/Data_Objects/Bugfixes/38519.rst
+++ b/docs/source/release/v6.12.0/Framework/Data_Objects/Bugfixes/38519.rst
@@ -1,0 +1,1 @@
+- Fix ``CrystalStructure`` to display deuterium when it is one of the atoms


### PR DESCRIPTION
This is a version of #38519 into `ornl-next`