### PR TITLE
solve the interpolation issue

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/InterpolateBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/InterpolateBackground.py
@@ -74,8 +74,9 @@ class InterpolateBackground(PythonAlgorithm):
         lowWS = mtd[self.low_ws]
         highWS = mtd[self.high_ws]
 
-        scalar = (self.interpo_temp - self.low_temp) / (self.high_temp - self.interpo_temp)
-        outputWS = lowWS + scalar * highWS - scalar * lowWS
+        scalar1 = (self.interpo_temp - self.low_temp) / (self.high_temp - self.low_temp)
+        scalar2 = (self.high_temp - self.interpo_temp) / (self.high_temp - self.low_temp)
+        outputWS = scalar1 * highWS + scalar2 * lowWS
 
         output_ws_name = self.getProperty("OutputWorkspace").value
         RenameWorkspace(InputWorkspace=outputWS, OutputWorkspace=output_ws_name)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/InterpolateBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/InterpolateBackground.py
@@ -74,9 +74,8 @@ class InterpolateBackground(PythonAlgorithm):
         lowWS = mtd[self.low_ws]
         highWS = mtd[self.high_ws]
 
-        scalar1 = (self.interpo_temp - self.low_temp) / (self.high_temp - self.low_temp)
-        scalar2 = (self.high_temp - self.interpo_temp) / (self.high_temp - self.low_temp)
-        outputWS = scalar1 * highWS + scalar2 * lowWS
+        scalar = (self.interpo_temp - self.low_temp) / (self.high_temp - self.low_temp)
+        outputWS = scalar * highWS + (1 - scalar) * lowWS
 
         output_ws_name = self.getProperty("OutputWorkspace").value
         RenameWorkspace(InputWorkspace=outputWS, OutputWorkspace=output_ws_name)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/InterpolateBackgroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/InterpolateBackgroundTest.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 import unittest
+import numpy as np
 from mantid.simpleapi import DeleteWorkspace, InterpolateBackground, CreateWorkspace, GroupWorkspaces
 
 
@@ -26,8 +27,9 @@ class InterpolateBackgroundTest(unittest.TestCase):
         self.ws1.getRun().addProperty("SampleTemp", "100", False)
         self.ws2.getRun().addProperty("SampleTemp", "400", False)
         outputWS = InterpolateBackground(self.wsGroup, self.interpo)
-        expected = [15, 30, 45, 60, 75, 90, 105, 120, 135, 150]
-        self.assertListEqual(list(outputWS.readY(0)), expected)
+        expected = [8.33333333, 16.66666667, 25.0, 33.33333333, 41.66666667, 50.0, 58.33333333, 66.66666667, 75.0, 83.33333333]
+        tolerance = 1.0e-8
+        np.testing.assert_allclose(list(outputWS.readY(0)), expected, rtol=tolerance)
 
     def test_bad_input(self):
         # Test raises Runtime error if a workspace is missing SampleTemp property

--- a/docs/source/algorithms/InterpolateBackground-v1.rst
+++ b/docs/source/algorithms/InterpolateBackground-v1.rst
@@ -20,7 +20,9 @@ Below is the function used for the interpolation:
 
 .. math::
 
-	WS_{interpolated} = WS_{low} + (temp_{interpo} - temp_{low}) / (temp_{high} - temp_{interpo}) * (WS_{high} - WS_{low}),
+    factor1 = (temp_{interpo} - temp_{low}) / (temp_{high} - temp_{low})
+    factor2 = (temp_{high} - temp_{interpo}) / (temp_{high} - temp_{low})
+    WS_{interpolated} = WS_{high} * factor1 + WS_{low} * factor2
 
 where :math:`WS_{low}` and :math:`WS_{high}` are the workspaces containing the run data, :math:`temp_{low}` and
 :math:`temp_{high}` are the two extreme temperatures the empty containers were measured at, and
@@ -44,10 +46,10 @@ Usage
    ws1 = CreateWorkspace(dataX, dataY1)
    ws2 = CreateWorkspace(dataX, dataY2)
    wsGroup = GroupWorkspaces("ws1,ws2")
-   interpoTemp = "300"
+   interpoTemp = "200"
    # CreateWorkspace does not add the "SampleTemp" property so we need to add it here
    ws1.getRun().addProperty("SampleTemp", "100", False)
-   ws2.getRun().addProperty("SampleTemp", "400", False)
+   ws2.getRun().addProperty("SampleTemp", "300", False)
 
    # Perform the background interpolation
    outputWS = InterpolateBackground(wsGroup, interpoTemp)
@@ -59,7 +61,7 @@ Output:
 
 .. testoutput::
 
-   Interpolated Y values are: [3. 3. 3. 3. 3. 3. 3. 3. 3. 3.]
+   Interpolated Y values are: [1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5 1.5]
 
 
 .. categories::

--- a/docs/source/algorithms/InterpolateBackground-v1.rst
+++ b/docs/source/algorithms/InterpolateBackground-v1.rst
@@ -20,9 +20,8 @@ Below is the function used for the interpolation:
 
 .. math::
 
-    factor1 = (temp_{interpo} - temp_{low}) / (temp_{high} - temp_{low})
-    factor2 = (temp_{high} - temp_{interpo}) / (temp_{high} - temp_{low})
-    WS_{interpolated} = WS_{high} * factor1 + WS_{low} * factor2
+    factor = (temp_{interpo} - temp_{low}) / (temp_{high} - temp_{low})
+    WS_{interpolated} = WS_{high} * factor + WS_{low} * (1 - factor)
 
 where :math:`WS_{low}` and :math:`WS_{high}` are the workspaces containing the run data, :math:`temp_{low}` and
 :math:`temp_{high}` are the two extreme temperatures the empty containers were measured at, and

--- a/docs/source/release/v6.12.0/Diffraction/Powder/Bugfixes/38534.rst
+++ b/docs/source/release/v6.12.0/Diffraction/Powder/Bugfixes/38534.rst
@@ -1,0 +1,1 @@
+- Fix the issue with the :ref:`InterpolateBackground <algm-InterpolateBackground>` algorithm.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

To solve the problem with the `InterpolateBackground` algorithm. The previous implementation was wrong, giving nonsense result.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->


<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

# create workspace
dataX = [0,1,2,3,4,5,6,7,8,9] # or use dataX=range(0,10)
dataY1 = [1,1,1,1,1,1,1,1,1,1] # or use dataY=[1]*10
dataY2 = [2,2,2,2,2,2,2,2,2,2] # or use dataY=[2]*10
ws1 = CreateWorkspace(dataX, dataY1)
ws2 = CreateWorkspace(dataX, dataY2)
wsGroup = GroupWorkspaces("ws1,ws2")
interpoTemp = "200"
# CreateWorkspace does not add the "SampleTemp" property so we need to add it here
ws1.getRun().addProperty("SampleTemp", "100", False)
ws2.getRun().addProperty("SampleTemp", "300", False)

# Perform the background interpolation
outputWS = InterpolateBackground(wsGroup, interpoTemp)

# Check output
print("Interpolated Y values are: {}".format(outputWS.readY(0)))
```

For every point, we are expected a returned value of `1.5`, obviously.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
