### PR TITLE
Parial move of reflectometry gui to std::optional

### DIFF
--- a/Framework/API/inc/MantidAPI/BoostOptionalToAlgorithmProperty.h
+++ b/Framework/API/inc/MantidAPI/BoostOptionalToAlgorithmProperty.h
@@ -10,7 +10,7 @@
 #include "MantidAPI/DllConfig.h"
 #include "MantidGeometry/Instrument.h"
 #include <boost/lexical_cast.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 
 namespace Mantid {
@@ -18,7 +18,7 @@ namespace API {
 /** BoostOptionalToAlgorithmProperty : Checks for default values of an
 algorithm property if the user has not supplied the value. If it is a mandatory
 property then the value will be returned, if the property is optional then a
-value of type boost::optional<T> will be returned.
+value of type std::optional<T> will be returned.
 */
 
 /**
@@ -62,24 +62,24 @@ T checkForMandatoryInstrumentDefault(Mantid::API::Algorithm *const alg, const st
  * @param instrument : A pointer to the instrument
  * @param idf_name : The name of the property in the Instrument Defintion
  * @return A boost optional value of type T that is either the default value,
- * the user supplied value or an uninitialized boost::optional.
+ * the user supplied value or an uninitialized std::optional.
  *
  */
 template <typename T>
-boost::optional<T> checkForOptionalInstrumentDefault(Mantid::API::Algorithm *const alg, const std::string &propName,
-                                                     const Mantid::Geometry::Instrument_const_sptr &instrument,
-                                                     const std::string &idf_name) {
+std::optional<T> checkForOptionalInstrumentDefault(Mantid::API::Algorithm *const alg, const std::string &propName,
+                                                   const Mantid::Geometry::Instrument_const_sptr &instrument,
+                                                   const std::string &idf_name) {
   auto algProperty = alg->getPointerToProperty(propName);
   if (algProperty->isDefault()) {
     auto defaults = instrument->getNumberParameter(idf_name);
     if (!defaults.empty()) {
-      return boost::optional<T>(static_cast<T>(defaults[0]));
+      return std::optional<T>(static_cast<T>(defaults[0]));
     } else {
-      return boost::optional<T>();
+      return std::nullopt;
     }
   } else {
     double value = boost::lexical_cast<double, std::string>(algProperty->value());
-    return boost::optional<T>(static_cast<T>(value));
+    return std::optional<T>(static_cast<T>(value));
   }
 }
 
@@ -93,7 +93,7 @@ MANTID_API_DLL std::string checkForMandatoryInstrumentDefault(Mantid::API::Algor
                                                               const std::string &idf_name);
 
 template <>
-MANTID_API_DLL boost::optional<std::string>
+MANTID_API_DLL std::optional<std::string>
 checkForOptionalInstrumentDefault(Mantid::API::Algorithm *const alg, const std::string &propName,
                                   const Mantid::Geometry::Instrument_const_sptr &instrument,
                                   const std::string &idf_name);

--- a/Framework/API/src/BoostOptionalToAlgorithmProperty.cpp
+++ b/Framework/API/src/BoostOptionalToAlgorithmProperty.cpp
@@ -26,20 +26,20 @@ std::string checkForMandatoryInstrumentDefault(Mantid::API::Algorithm *const alg
 }
 
 template <>
-boost::optional<std::string>
-checkForOptionalInstrumentDefault(Mantid::API::Algorithm *const alg, const std::string &propName,
-                                  const Mantid::Geometry::Instrument_const_sptr &instrument,
-                                  const std::string &idf_name) {
+std::optional<std::string> checkForOptionalInstrumentDefault(Mantid::API::Algorithm *const alg,
+                                                             const std::string &propName,
+                                                             const Mantid::Geometry::Instrument_const_sptr &instrument,
+                                                             const std::string &idf_name) {
   auto algProperty = alg->getPointerToProperty(propName);
   if (algProperty->isDefault()) {
     auto defaults = instrument->getStringParameter(idf_name);
     if (!defaults.empty()) {
-      return boost::optional<std::string>(defaults[0]);
+      return std::optional<std::string>(defaults[0]);
     } else {
-      return boost::optional<std::string>();
+      return std::nullopt;
     }
   } else {
-    return boost::optional<std::string>(algProperty->value());
+    return std::optional<std::string>(algProperty->value());
   }
 }
 } // namespace Mantid::API

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1123,7 +1123,7 @@ virtualCallInConstructor:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflec
 missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SaveAlgorithmRunner.h:18
 returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h:54
 missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.h:31
-missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/IGroup.h:18
+missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/IGroup.h:19
 returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h:34
 returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferData.h:42
 returnByReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferData.h:43

--- a/qt/scientific_interfaces/ISISReflectometry/Common/IndexOf.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/IndexOf.h
@@ -6,29 +6,29 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include <algorithm>
-#include <boost/optional.hpp>
 #include <iterator>
+#include <optional>
 
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
 
 template <typename Container, typename Predicate>
-boost::optional<int> indexOf(Container const &container, Predicate pred) {
+std::optional<int> indexOf(Container const &container, Predicate pred) {
   auto maybeItemIt = std::find_if(container.cbegin(), container.cend(), pred);
   if (maybeItemIt != container.cend())
     return static_cast<int>(std::distance(container.cbegin(), maybeItemIt));
   else
-    return boost::none;
+    return std::nullopt;
 }
 
 template <typename Container, typename ValueType>
-boost::optional<int> indexOfValue(Container const &container, ValueType value) {
+std::optional<int> indexOfValue(Container const &container, ValueType value) {
   auto maybeItemIt = std::find(container.cbegin(), container.cend(), value);
   if (maybeItemIt != container.cend())
     return static_cast<int>(std::distance(container.cbegin(), maybeItemIt));
   else
-    return boost::none;
+    return std::nullopt;
 }
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Map.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Map.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <boost/optional.hpp>
 #include <iterator>
+#include <optional>
 #include <sstream>
 #include <type_traits>
 #include <vector>
@@ -33,6 +34,14 @@ boost::optional<Out> map(boost::optional<In> const &in, Transform transform) {
     return boost::none;
 }
 
+template <typename In, typename Transform, typename Out = typename std::invoke_result<Transform, In>::type>
+std::optional<Out> map(std::optional<In> const &in, Transform transform) {
+  if (in.has_value())
+    return transform(in.value());
+  else
+    return std::nullopt;
+}
+
 /** Converts an optional value to string
  *
  * @param maybeValue optional value
@@ -42,6 +51,16 @@ boost::optional<Out> map(boost::optional<In> const &in, Transform transform) {
 template <typename T> std::string optionalToString(boost::optional<T> maybeValue) {
   return map(maybeValue, [](T const &value) -> std::string { return std::to_string(value); })
       .get_value_or(std::string());
+}
+
+/** Converts an optional value to string
+ *
+ * @param maybeValue optional value
+ * @return The value as a string or an empty string
+ *
+ */
+template <typename T> std::string optionalToString(std::optional<T> maybeValue) {
+  return map(maybeValue, [](T const &value) -> std::string { return std::to_string(value); }).value_or(std::string());
 }
 
 /** Converts value to string with specified precision
@@ -83,6 +102,24 @@ template <typename T> std::string optionalToString(boost::optional<T> maybeValue
   if (maybeValue.is_initialized()) {
     if (precision.is_initialized()) {
       return valueToString(maybeValue.get(), precision.get());
+    }
+    return optionalToString(maybeValue);
+  }
+  return std::string();
+}
+
+/** Converts optional value to string with optional precision
+ *
+ * @param maybeValue optional input value
+ * @param precision optional output precision
+ * @return The value as a string (with specified precision if given) or empty
+ * string
+ *
+ */
+template <typename T> std::string optionalToString(std::optional<T> maybeValue, std::optional<int> precision) {
+  if (maybeValue.has_value()) {
+    if (precision.has_value()) {
+      return valueToString(maybeValue.value(), precision.value());
     }
     return optionalToString(maybeValue);
   }

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Map.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Map.h
@@ -84,9 +84,9 @@ template <typename T> std::string valueToString(T value, int precision) {
  * @return The value as a string (with specified precision if given)
  *
  */
-template <typename T> std::string valueToString(T value, boost::optional<int> precision) {
-  if (precision.is_initialized())
-    return valueToString(value, precision.get());
+template <typename T> std::string valueToString(T value, std::optional<int> precision) {
+  if (precision.has_value())
+    return valueToString(value, precision.value());
   return std::to_string(value);
 }
 
@@ -98,10 +98,10 @@ template <typename T> std::string valueToString(T value, boost::optional<int> pr
  * string
  *
  */
-template <typename T> std::string optionalToString(boost::optional<T> maybeValue, boost::optional<int> precision) {
+template <typename T> std::string optionalToString(boost::optional<T> maybeValue, std::optional<int> precision) {
   if (maybeValue.is_initialized()) {
-    if (precision.is_initialized()) {
-      return valueToString(maybeValue.get(), precision.get());
+    if (precision.has_value()) {
+      return valueToString(maybeValue.get(), precision.value());
     }
     return optionalToString(maybeValue);
   }

--- a/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
@@ -5,9 +5,9 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
-#include "Common/DllConfig.h"
 #include "MantidAPI/BoostOptionalToAlgorithmProperty.h"
 #include "MantidGeometry/Instrument_fwd.h"
+#include <optional>
 #include <string>
 
 namespace MantidQt {
@@ -25,7 +25,7 @@ public:
   template <typename T>
   T getValueOrDefault(std::string const &propertyName, std::string const &parameterName, T defaultValue) const;
   template <typename T>
-  boost::optional<T> getOptionalValue(std::string const &propertyName, std::string const &parameterName) const;
+  std::optional<T> getOptionalValue(std::string const &propertyName, std::string const &parameterName) const;
   template <typename T> T getValue(std::string const &propertyName, std::string const &parameterName) const;
 
   int getIntOrZero(std::string const &propertyName, std::string const &parameterName) const;
@@ -47,14 +47,14 @@ T OptionDefaults::getValueOrDefault(std::string const &propertyName, std::string
                                     T defaultValue) const {
   auto maybeValue =
       Mantid::API::checkForOptionalInstrumentDefault<T>(m_algorithm.get(), propertyName, m_instrument, parameterName);
-  if (maybeValue.is_initialized())
-    return maybeValue.get();
+  if (maybeValue.has_value())
+    return maybeValue.value();
   return defaultValue;
 }
 
 template <typename T>
-boost::optional<T> OptionDefaults::getOptionalValue(std::string const &propertyName,
-                                                    std::string const &parameterName) const {
+std::optional<T> OptionDefaults::getOptionalValue(std::string const &propertyName,
+                                                  std::string const &parameterName) const {
   return Mantid::API::checkForOptionalInstrumentDefault<T>(m_algorithm.get(), propertyName, m_instrument,
                                                            parameterName);
 }

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Parse.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Parse.cpp
@@ -13,7 +13,7 @@ bool isEntirelyWhitespace(std::string const &string) {
   return std::all_of(string.cbegin(), string.cend(), [](unsigned char c) { return std::isspace(c); });
 }
 
-boost::optional<double> parseDouble(std::string string) {
+std::optional<double> parseDouble(std::string string) {
   boost::trim(string);
   auto end = std::size_t();
   try {
@@ -21,31 +21,31 @@ boost::optional<double> parseDouble(std::string string) {
     if (end == string.size())
       return result;
     else
-      return boost::none;
+      return std::nullopt;
   } catch (std::invalid_argument &) {
-    return boost::none;
+    return std::nullopt;
   } catch (std::out_of_range &) {
-    return boost::none;
+    return std::nullopt;
   }
 }
 
-boost::optional<double> parseNonNegativeDouble(std::string string) {
+std::optional<double> parseNonNegativeDouble(std::string string) {
   auto maybeNegative = parseDouble(std::move(string));
-  if (maybeNegative.is_initialized() && maybeNegative.get() >= 0.0)
-    return maybeNegative.get();
+  if (maybeNegative.has_value() && maybeNegative.value() >= 0.0)
+    return maybeNegative.value();
   else
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<double> parseNonNegativeNonZeroDouble(std::string string) {
+std::optional<double> parseNonNegativeNonZeroDouble(std::string string) {
   auto maybeNegative = parseDouble(std::move(string));
-  if (maybeNegative.is_initialized() && maybeNegative.get() > 0.0)
-    return maybeNegative.get();
+  if (maybeNegative.has_value() && maybeNegative.value() > 0.0)
+    return maybeNegative.value();
   else
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<int> parseInt(std::string string) {
+std::optional<int> parseInt(std::string string) {
   boost::trim(string);
   auto end = std::size_t();
   try {
@@ -53,19 +53,19 @@ boost::optional<int> parseInt(std::string string) {
     if (end == string.size())
       return result;
     else
-      return boost::none;
+      return std::nullopt;
   } catch (std::invalid_argument &) {
-    return boost::none;
+    return std::nullopt;
   } catch (std::out_of_range &) {
-    return boost::none;
+    return std::nullopt;
   }
 }
 
-boost::optional<int> parseNonNegativeInt(std::string string) {
+std::optional<int> parseNonNegativeInt(std::string string) {
   auto maybeNegative = parseInt(std::move(string));
-  if (maybeNegative.is_initialized() && maybeNegative.get() >= 0)
-    return maybeNegative.get();
+  if (maybeNegative.has_value() && maybeNegative.value() >= 0)
+    return maybeNegative.value();
   else
-    return boost::none;
+    return std::nullopt;
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Parse.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Parse.h
@@ -7,27 +7,27 @@
 #pragma once
 #include "DllConfig.h"
 #include <boost/algorithm/string.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include <vector>
 
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<double> parseDouble(std::string string);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<double> parseDouble(std::string string);
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<double> parseNonNegativeDouble(std::string string);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<double> parseNonNegativeDouble(std::string string);
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<double> parseNonNegativeNonZeroDouble(std::string string);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<double> parseNonNegativeNonZeroDouble(std::string string);
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<int> parseInt(std::string string);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<int> parseInt(std::string string);
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<int> parseNonNegativeInt(std::string string);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<int> parseNonNegativeInt(std::string string);
 
 bool MANTIDQT_ISISREFLECTOMETRY_DLL isEntirelyWhitespace(std::string const &string);
 
 template <typename ParseItemFunction>
-boost::optional<std::vector<typename std::invoke_result<ParseItemFunction, std::string const &>::type::value_type>>
+std::optional<std::vector<typename std::invoke_result<ParseItemFunction, std::string const &>::type::value_type>>
 parseList(std::string commaSeparatedValues, ParseItemFunction parseItem) {
   using ParsedItem = typename std::invoke_result<ParseItemFunction, std::string const &>::type::value_type;
   if (!commaSeparatedValues.empty()) {
@@ -37,10 +37,10 @@ parseList(std::string commaSeparatedValues, ParseItemFunction parseItem) {
     parsedItems.reserve(items.size());
     for (auto const &item : items) {
       auto maybeParsedItem = parseItem(item);
-      if (maybeParsedItem.is_initialized())
-        parsedItems.emplace_back(maybeParsedItem.get());
+      if (maybeParsedItem.has_value())
+        parsedItems.emplace_back(maybeParsedItem.value());
       else
-        return boost::none;
+        return std::nullopt;
     }
     return parsedItems;
   } else {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
@@ -64,12 +64,12 @@ void updateGroupFromOutputProperties(const IAlgorithm_sptr &algorithm, Item &gro
   group.setOutputNames(std::vector<std::string>{stitched});
 }
 
-void updateParamsFromResolution(AlgorithmRuntimeProps &properties, boost::optional<double> const &resolution) {
-  if (!resolution.is_initialized())
+void updateParamsFromResolution(AlgorithmRuntimeProps &properties, std::optional<double> const &resolution) {
+  if (!resolution.has_value())
     return;
 
   // Negate the resolution to give logarithmic binning
-  AlgorithmProperties::update("Params", -(resolution.get()), properties);
+  AlgorithmProperties::update("Params", -(resolution.value()), properties);
 }
 
 void updateLookupRowProperties(AlgorithmRuntimeProps &properties, boost::optional<LookupRow> lookupRow) {
@@ -80,22 +80,22 @@ void updateLookupRowProperties(AlgorithmRuntimeProps &properties, boost::optiona
 }
 
 void updateGroupProperties(AlgorithmRuntimeProps &properties, Group const &group) {
-  auto resolution = boost::make_optional<double>(false, double());
+  std::optional<double> resolution = std::nullopt;
 
   for (auto const &row : group.rows()) {
     if (!row.is_initialized())
       continue;
 
     // Use the input Q step if provided, or the output Q step otherwise, if set
-    if (row->qRange().step().is_initialized())
+    if (row->qRange().step().has_value())
       resolution = row->qRange().step();
-    else if (row->qRangeOutput().step().is_initialized())
+    else if (row->qRangeOutput().step().has_value())
       resolution = row->qRangeOutput().step();
 
     // For now just use the first resolution found. Longer term it would be
     // better to check that all rows have the same resolution and set a warning
     // if not.
-    if (resolution.is_initialized())
+    if (resolution.has_value())
       break;
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -229,7 +229,7 @@ void updateEventProperties(AlgorithmRuntimeProps &properties, Slicing const &sli
   boost::apply_visitor(UpdateEventPropertiesVisitor(properties), slicing);
 }
 
-boost::optional<double> getDouble(const IAlgorithm_sptr &algorithm, std::string const &property) {
+std::optional<double> getDouble(const IAlgorithm_sptr &algorithm, std::string const &property) {
   double result = algorithm->getProperty(property);
   return result;
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -148,7 +148,7 @@ void updateLookupRowProperties(AlgorithmRuntimeProps &properties, LookupRow cons
 }
 
 void updateWavelengthRangeProperties(AlgorithmRuntimeProps &properties,
-                                     boost::optional<RangeInLambda> const &rangeInLambda) {
+                                     std::optional<RangeInLambda> const &rangeInLambda) {
   if (!rangeInLambda)
     return;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -210,13 +210,13 @@ void Decoder::decodeRuns(QtRunsView *gui, ReductionJobs *redJobs, RunsTablePrese
 }
 
 namespace {
-using ValueFunction = boost::optional<double> (RangeInQ::*)() const;
+using ValueFunction = std::optional<double> (RangeInQ::*)() const;
 
 MantidWidgets::Batch::Cell qRangeCellOrDefault(RangeInQ const &qRangeInput, RangeInQ const &qRangeOutput,
-                                               ValueFunction valueFunction, boost::optional<int> precision) {
+                                               ValueFunction valueFunction, std::optional<int> precision) {
   auto maybeValue = (qRangeInput.*valueFunction)();
   auto useOutputValue = false;
-  if (!maybeValue.is_initialized()) {
+  if (!maybeValue.has_value()) {
     maybeValue = (qRangeOutput.*valueFunction)();
     useOutputValue = true;
   }
@@ -229,14 +229,17 @@ MantidWidgets::Batch::Cell qRangeCellOrDefault(RangeInQ const &qRangeInput, Rang
 }
 
 std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, const boost::optional<int> &precision) {
+  std::optional<int> precisionStd = std::nullopt;
+  if (precision)
+    precisionStd = precision.get();
   return std::vector<MantidQt::MantidWidgets::Batch::Cell>(
       {MantidQt::MantidWidgets::Batch::Cell(boost::join(row.runNumbers(), "+")),
        MantidQt::MantidWidgets::Batch::Cell(valueToString(row.theta(), precision)),
        MantidQt::MantidWidgets::Batch::Cell(row.transmissionWorkspaceNames().firstRunList()),
        MantidQt::MantidWidgets::Batch::Cell(row.transmissionWorkspaceNames().secondRunList()),
-       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::min, precision),
-       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::max, precision),
-       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::step, precision),
+       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::min, precisionStd),
+       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::max, precisionStd),
+       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::step, precisionStd),
        MantidQt::MantidWidgets::Batch::Cell(optionalToString(row.scaleFactor(), precision)),
        MantidQt::MantidWidgets::Batch::Cell(MantidWidgets::optionsToString(row.reductionOptions())),
        MantidQt::MantidWidgets::Batch::Cell(optionalToString(row.lookupIndex(), precision))});
@@ -394,17 +397,17 @@ RangeInQ Decoder::decodeRangeInQ(const QMap<QString, QVariant> &map) {
   if (minPresent && maxPresent && stepPresent) {
     return RangeInQ(min, step, max);
   } else if (minPresent && maxPresent) {
-    return RangeInQ(min, boost::none, max);
+    return RangeInQ(min, std::nullopt, max);
   } else if (minPresent && stepPresent) {
     return RangeInQ(min, step);
   } else if (minPresent) {
     return RangeInQ(min);
   } else if (stepPresent && maxPresent) {
-    return RangeInQ(boost::none, step, max);
+    return RangeInQ(std::nullopt, step, max);
   } else if (stepPresent) {
-    return RangeInQ(boost::none, step);
+    return RangeInQ(std::nullopt, step);
   } else if (maxPresent) {
-    return RangeInQ(boost::none, boost::none, max);
+    return RangeInQ(std::nullopt, std::nullopt, max);
   } else {
     return RangeInQ();
   }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -195,7 +195,7 @@ void Decoder::decodeInstrument(const QtInstrumentView *gui, const QMap<QString, 
 }
 
 void Decoder::decodeRuns(QtRunsView *gui, ReductionJobs *redJobs, RunsTablePresenter *presenter,
-                         const QMap<QString, QVariant> &map, boost::optional<int> precision,
+                         const QMap<QString, QVariant> &map, std::optional<int> precision,
                          QtCatalogSearcher *searcher) {
   decodeRunsTable(gui->m_tableView, redJobs, presenter, map[QString("runsTable")].toMap(), std::move(precision));
   gui->m_ui.comboSearchInstrument->setCurrentIndex(map[QString("comboSearchInstrument")].toInt());
@@ -228,26 +228,23 @@ MantidWidgets::Batch::Cell qRangeCellOrDefault(RangeInQ const &qRangeInput, Rang
   return result;
 }
 
-std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, const boost::optional<int> &precision) {
-  std::optional<int> precisionStd = std::nullopt;
-  if (precision)
-    precisionStd = precision.get();
+std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, const std::optional<int> &precision) {
   return std::vector<MantidQt::MantidWidgets::Batch::Cell>(
       {MantidQt::MantidWidgets::Batch::Cell(boost::join(row.runNumbers(), "+")),
        MantidQt::MantidWidgets::Batch::Cell(valueToString(row.theta(), precision)),
        MantidQt::MantidWidgets::Batch::Cell(row.transmissionWorkspaceNames().firstRunList()),
        MantidQt::MantidWidgets::Batch::Cell(row.transmissionWorkspaceNames().secondRunList()),
-       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::min, precisionStd),
-       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::max, precisionStd),
-       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::step, precisionStd),
+       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::min, precision),
+       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::max, precision),
+       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::step, precision),
        MantidQt::MantidWidgets::Batch::Cell(optionalToString(row.scaleFactor(), precision)),
        MantidQt::MantidWidgets::Batch::Cell(MantidWidgets::optionsToString(row.reductionOptions())),
-       MantidQt::MantidWidgets::Batch::Cell(optionalToString(row.lookupIndex(), precisionStd))});
+       MantidQt::MantidWidgets::Batch::Cell(optionalToString(row.lookupIndex(), precision))});
 }
 } // namespace
 
 void Decoder::updateRunsTableViewFromModel(QtRunsTableView *view, const ReductionJobs *model,
-                                           const boost::optional<int> &precision) {
+                                           const std::optional<int> &precision) {
   auto jobTreeView = view->m_jobs.get();
   auto const &groups = model->groups();
   for (auto groupIndex = 0u; groupIndex < groups.size(); ++groupIndex) {
@@ -277,7 +274,7 @@ void Decoder::updateRunsTableViewFromModel(QtRunsTableView *view, const Reductio
 }
 
 void Decoder::decodeRunsTable(QtRunsTableView *gui, ReductionJobs *redJobs, RunsTablePresenter *presenter,
-                              const QMap<QString, QVariant> &map, boost::optional<int> precision) {
+                              const QMap<QString, QVariant> &map, std::optional<int> precision) {
   QSignalBlocker signalBlockerView(gui);
 
   m_projectSave = map[QString("projectSave")].toBool();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -242,7 +242,7 @@ std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, c
        qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::step, precisionStd),
        MantidQt::MantidWidgets::Batch::Cell(optionalToString(row.scaleFactor(), precision)),
        MantidQt::MantidWidgets::Batch::Cell(MantidWidgets::optionsToString(row.reductionOptions())),
-       MantidQt::MantidWidgets::Batch::Cell(optionalToString(row.lookupIndex(), precision))});
+       MantidQt::MantidWidgets::Batch::Cell(optionalToString(row.lookupIndex(), precisionStd))});
 }
 } // namespace
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.h
@@ -65,9 +65,9 @@ private:
   void decodePerAngleDefaultsRows(QTableWidget *tab, int rowsNum, int columnsNum, const QList<QVariant> &list);
   void decodeInstrument(const QtInstrumentView *gui, const QMap<QString, QVariant> &map);
   void decodeRuns(QtRunsView *gui, ReductionJobs *redJobs, RunsTablePresenter *presenter,
-                  const QMap<QString, QVariant> &map, boost::optional<int> precision, QtCatalogSearcher *searcher);
+                  const QMap<QString, QVariant> &map, std::optional<int> precision, QtCatalogSearcher *searcher);
   void decodeRunsTable(QtRunsTableView *gui, ReductionJobs *redJobs, RunsTablePresenter *presenter,
-                       const QMap<QString, QVariant> &map, boost::optional<int> precision);
+                       const QMap<QString, QVariant> &map, std::optional<int> precision);
   void decodeRunsTableModel(ReductionJobs *jobs, const QList<QVariant> &list);
   MantidQt::CustomInterfaces::ISISReflectometry::Group decodeGroup(const QMap<QString, QVariant> &map);
   std::vector<boost::optional<MantidQt::CustomInterfaces::ISISReflectometry::Row>>
@@ -81,7 +81,7 @@ private:
   void decodeSave(const QtSaveView *gui, const QMap<QString, QVariant> &map);
   void decodeEvent(const QtEventView *gui, const QMap<QString, QVariant> &map);
   void updateRunsTableViewFromModel(QtRunsTableView *view, const ReductionJobs *model,
-                                    const boost::optional<int> &precision);
+                                    const std::optional<int> &precision);
 
   bool m_projectSave = false;
   size_t m_currentBatchVersion = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
@@ -137,13 +137,13 @@ QMap<QString, QVariant> Encoder::encodeRangeInQ(const RangeInQ &rangeInQ) {
   auto step = rangeInQ.step();
   qRangeMap.insert(QString("minPresent"), QVariant(static_cast<bool>(min)));
   if (min)
-    qRangeMap.insert(QString("min"), QVariant(min.get()));
+    qRangeMap.insert(QString("min"), QVariant(min.value()));
   qRangeMap.insert(QString("maxPresent"), QVariant(static_cast<bool>(max)));
   if (max)
-    qRangeMap.insert(QString("max"), QVariant(max.get()));
+    qRangeMap.insert(QString("max"), QVariant(max.value()));
   qRangeMap.insert(QString("stepPresent"), QVariant(static_cast<bool>(step)));
   if (step)
-    qRangeMap.insert(QString("step"), QVariant(step.get()));
+    qRangeMap.insert(QString("step"), QVariant(step.value()));
   return qRangeMap;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.cpp
@@ -101,9 +101,9 @@ void EventPresenter::setUniformSlicingByNumberOfSlicesFromView() {
 
 void EventPresenter::setCustomSlicingFromView() {
   auto maybeCustomBreakpoints = parseList(m_view->customBreakpoints(), parseNonNegativeDouble);
-  if (maybeCustomBreakpoints.is_initialized()) {
+  if (maybeCustomBreakpoints.has_value()) {
     m_view->showCustomBreakpointsValid();
-    m_slicing = CustomSlicingByList(maybeCustomBreakpoints.get());
+    m_slicing = CustomSlicingByList(maybeCustomBreakpoints.value());
   } else {
     m_view->showCustomBreakpointsInvalid();
     m_slicing = InvalidSlicing();
@@ -117,9 +117,9 @@ void EventPresenter::setLogValueSlicingFromView() {
   // more than one item in the list then show that as invalid. We intend to add
   // this though which is why this is still a free text field rather than a
   // spin box
-  if (maybeBreakpoints.is_initialized() && maybeBreakpoints.get().size() <= 1) {
+  if (maybeBreakpoints.has_value() && maybeBreakpoints.value().size() <= 1) {
     m_view->showLogBreakpointsValid();
-    m_slicing = SlicingByEventLog(maybeBreakpoints.get(), blockName);
+    m_slicing = SlicingByEventLog(maybeBreakpoints.value(), blockName);
   } else {
     m_view->showLogBreakpointsInvalid();
     m_slicing = InvalidSlicing();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
@@ -19,7 +19,7 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 namespace {
 Mantid::Kernel::Logger g_log("Reflectometry GUI");
 
-std::string stringValueOrEmpty(boost::optional<double> value) { return value ? std::to_string(*value) : ""; }
+std::string stringValueOrEmpty(std::optional<double> value) { return value ? std::to_string(value.value()) : ""; }
 
 std::map<std::string, std::string> getStitchParams(OptionDefaults const &stitchDefaults) {
   std::map<std::string, std::string> initialStitchParameters;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -290,7 +290,7 @@ void ExperimentPresenter::disableFloodCorrectionInputs() {
   m_view->disableFloodCorrectionInputs();
 }
 
-boost::optional<RangeInLambda> ExperimentPresenter::transmissionRunRangeFromView() {
+std::optional<RangeInLambda> ExperimentPresenter::transmissionRunRangeFromView() {
   auto const range = RangeInLambda(m_view->getTransmissionStartOverlap(), m_view->getTransmissionEndOverlap());
   auto const bothOrNoneMustBeSet = false;
 
@@ -300,7 +300,7 @@ boost::optional<RangeInLambda> ExperimentPresenter::transmissionRunRangeFromView
     m_view->showTransmissionRangeInvalid();
 
   if (range.unset() || !range.isValid(bothOrNoneMustBeSet))
-    return boost::none;
+    return std::nullopt;
   else
     return range;
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -316,7 +316,7 @@ std::string ExperimentPresenter::transmissionStitchParamsFromView() {
   // If set, the params should be a list containing an odd number of double
   // values (as per the Params property of Rebin)
   auto maybeParamsList = parseList(stitchParams, parseDouble);
-  if (maybeParamsList.is_initialized() && maybeParamsList->size() % 2 != 0) {
+  if (maybeParamsList.has_value() && maybeParamsList->size() % 2 != 0) {
     m_view->showTransmissionStitchParamsValid();
     return stitchParams;
   }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -12,7 +12,6 @@
 #include "Reduction/ParseReflectometryStrings.h"
 #include "Reduction/PreviewRow.h"
 #include "Reduction/RowExceptions.h"
-#include "Reduction/ValidateLookupRow.h"
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 // unnamed namespace
@@ -443,7 +442,7 @@ void ExperimentPresenter::updateViewFromModel() {
     m_view->setPolarizationEfficienciesWorkspace(m_model.polarizationCorrections().workspace().get());
   m_view->setFloodCorrectionType(floodCorrectionTypeToString(m_model.floodCorrections().correctionType()));
   if (m_model.floodCorrections().workspace())
-    m_view->setFloodWorkspace(m_model.floodCorrections().workspace().get());
+    m_view->setFloodWorkspace(m_model.floodCorrections().workspace().value());
   else
     m_view->setFloodWorkspace("");
   m_view->setFloodFilePath("");

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
@@ -16,7 +16,7 @@
 #include "LookupTableValidationError.h"
 #include "Reduction/Experiment.h"
 #include "Reduction/PreviewRow.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -81,7 +81,7 @@ private:
   BackgroundSubtraction backgroundSubtractionFromView();
   PolarizationCorrections polarizationCorrectionsFromView();
   FloodCorrections floodCorrectionsFromView();
-  boost::optional<RangeInLambda> transmissionRunRangeFromView();
+  std::optional<RangeInLambda> transmissionRunRangeFromView();
   std::string transmissionStitchParamsFromView();
   TransmissionStitchOptions transmissionStitchOptionsFromView();
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/LookupTableValidator.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/LookupTableValidator.cpp
@@ -118,8 +118,8 @@ void LookupTableValidator::sortInPlaceByThetaThenTitleMatcher(LookupTableRows &l
     if (*lhs.thetaOrWildcard() != *rhs.thetaOrWildcard()) {
       return *lhs.thetaOrWildcard() < *rhs.thetaOrWildcard();
     }
-    auto const lhsTitle = lhs.titleMatcher().get_value_or(boost::regex());
-    auto const rhsTitle = rhs.titleMatcher().get_value_or(boost::regex());
+    auto const lhsTitle = lhs.titleMatcher().value_or(boost::regex());
+    auto const rhsTitle = rhs.titleMatcher().value_or(boost::regex());
     return lhsTitle < rhsTitle;
   };
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -441,9 +441,9 @@ void QtExperimentView::setText(QLineEdit &lineEdit, boost::optional<double> valu
     setText(lineEdit, value.get());
 }
 
-void QtExperimentView::setText(QLineEdit &lineEdit, boost::optional<int> value) {
+void QtExperimentView::setText(QLineEdit &lineEdit, std::optional<int> value) {
   if (value)
-    setText(lineEdit, value.get());
+    setText(lineEdit, value.value());
 }
 
 void QtExperimentView::setText(QLineEdit &lineEdit, boost::optional<std::string> const &text) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -182,7 +182,7 @@ private:
   void setText(QLineEdit &lineEdit, int value);
   void setText(QLineEdit &lineEdit, double value);
   void setText(QLineEdit &lineEdit, std::string const &value);
-  void setText(QLineEdit &lineEdit, boost::optional<int> value);
+  void setText(QLineEdit &lineEdit, std::optional<int> value);
   void setText(QLineEdit &lineEdit, boost::optional<double> value);
   void setText(QLineEdit &lineEdit, boost::optional<std::string> const &value);
   std::string textFromCell(QTableWidgetItem const *maybeNullItem) const;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
@@ -15,9 +15,9 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 namespace {
 Mantid::Kernel::Logger g_log("Reflectometry GUI");
 
-boost::optional<RangeInLambda> rangeOrNone(const RangeInLambda &range, const bool bothOrNoneMustBeSet) {
+std::optional<RangeInLambda> rangeOrNone(const RangeInLambda &range, const bool bothOrNoneMustBeSet) {
   if (range.unset() || !range.isValid(bothOrNoneMustBeSet))
-    return boost::none;
+    return std::nullopt;
   else
     return range;
 }
@@ -132,7 +132,7 @@ void InstrumentPresenter::restoreDefaults() {
   updateViewFromModel();
 }
 
-boost::optional<RangeInLambda> InstrumentPresenter::wavelengthRangeFromView() {
+std::optional<RangeInLambda> InstrumentPresenter::wavelengthRangeFromView() {
   auto range = RangeInLambda(m_view->getLambdaMin(), m_view->getLambdaMax());
   bool const bothOrNoneMustBeSet = false;
 
@@ -144,7 +144,7 @@ boost::optional<RangeInLambda> InstrumentPresenter::wavelengthRangeFromView() {
   return rangeOrNone(range, bothOrNoneMustBeSet);
 }
 
-boost::optional<RangeInLambda> InstrumentPresenter::monitorBackgroundRangeFromView() {
+std::optional<RangeInLambda> InstrumentPresenter::monitorBackgroundRangeFromView() {
   auto range = RangeInLambda(m_view->getMonitorBackgroundMin(), m_view->getMonitorBackgroundMax());
   bool const bothOrNoneMustBeSet = true;
 
@@ -156,7 +156,7 @@ boost::optional<RangeInLambda> InstrumentPresenter::monitorBackgroundRangeFromVi
   return rangeOrNone(range, bothOrNoneMustBeSet);
 }
 
-boost::optional<RangeInLambda> InstrumentPresenter::monitorIntegralRangeFromView() {
+std::optional<RangeInLambda> InstrumentPresenter::monitorIntegralRangeFromView() {
   auto range = RangeInLambda(m_view->getMonitorIntegralMin(), m_view->getMonitorIntegralMax());
   bool const bothOrNoneMustBeSet = false;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
@@ -57,9 +57,9 @@ private:
   IFileHandler *m_fileHandler;
   IReflMessageHandler *m_messageHandler;
 
-  boost::optional<RangeInLambda> wavelengthRangeFromView();
-  boost::optional<RangeInLambda> monitorBackgroundRangeFromView();
-  boost::optional<RangeInLambda> monitorIntegralRangeFromView();
+  std::optional<RangeInLambda> wavelengthRangeFromView();
+  std::optional<RangeInLambda> monitorBackgroundRangeFromView();
+  std::optional<RangeInLambda> monitorIntegralRangeFromView();
   MonitorCorrections monitorCorrectionsFromView();
   DetectorCorrectionType detectorCorrectionTypeFromView();
   DetectorCorrections detectorCorrectionsFromView();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
@@ -183,9 +183,9 @@ void QtInstrumentView::setText(QLineEdit &lineEdit, boost::optional<double> valu
     setText(lineEdit, value.get());
 }
 
-void QtInstrumentView::setText(QLineEdit &lineEdit, boost::optional<int> value) {
+void QtInstrumentView::setText(QLineEdit &lineEdit, std::optional<int> value) {
   if (value)
-    setText(lineEdit, value.get());
+    setText(lineEdit, value.value());
 }
 
 void QtInstrumentView::setText(QLineEdit &lineEdit, boost::optional<std::string> const &text) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
@@ -98,7 +98,7 @@ private:
   void setText(QLineEdit &lineEdit, int value);
   void setText(QLineEdit &lineEdit, double value);
   void setText(QLineEdit &lineEdit, std::string const &value);
-  void setText(QLineEdit &lineEdit, boost::optional<int> value);
+  void setText(QLineEdit &lineEdit, std::optional<int> value);
   void setText(QLineEdit &lineEdit, boost::optional<double> value);
   void setText(QLineEdit &lineEdit, boost::optional<std::string> const &value);
   void setChecked(QCheckBox &checkBox, bool checked);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
@@ -31,7 +31,7 @@ public:
   virtual bool isProcessPartialGroupPrevented() const = 0;
   virtual bool isRoundChecked() const = 0;
   virtual int &getRoundPrecision() const = 0;
-  virtual boost::optional<int> roundPrecision() const = 0;
+  virtual std::optional<int> roundPrecision() const = 0;
   virtual bool isCloseEventPrevented() = 0;
   virtual bool isCloseBatchPrevented(int batchIndex) const = 0;
   virtual bool isOverwriteBatchPrevented(int tabIndex) const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -180,10 +180,10 @@ int &MainWindowPresenter::getRoundPrecision() const {
   return m_optionsDialogPresenter->getIntOption(std::string("RoundPrecision"));
 }
 
-boost::optional<int> MainWindowPresenter::roundPrecision() const {
+std::optional<int> MainWindowPresenter::roundPrecision() const {
   if (isRoundChecked())
     return getRoundPrecision();
-  return boost::none;
+  return std::nullopt;
 }
 
 bool MainWindowPresenter::discardChanges(std::string const &message) const {
@@ -268,12 +268,12 @@ void MainWindowPresenter::addNewBatch(IBatchView *batchView) {
 }
 
 void MainWindowPresenter::initNewBatch(IBatchPresenter *batchPresenter, std::string const &instrument,
-                                       boost::optional<int> precision) {
+                                       std::optional<int> precision) {
 
   batchPresenter->initInstrumentList(instrument);
   batchPresenter->notifyInstrumentChanged(instrument);
-  if (precision.is_initialized())
-    batchPresenter->notifySetRoundPrecision(precision.get());
+  if (precision.has_value())
+    batchPresenter->notifySetRoundPrecision(precision.value());
 
   // starts in the paused state
   batchPresenter->notifyReductionPaused();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
@@ -99,7 +99,7 @@ private:
   bool isAnyBatchUnsaved() const override;
   bool isRoundChecked() const override;
   int &getRoundPrecision() const override;
-  boost::optional<int> roundPrecision() const override;
+  std::optional<int> roundPrecision() const override;
   bool isWarnProcessAllChecked() const override;
   bool isWarnProcessPartialGroupChecked() const override;
   bool isCloseBatchPrevented(int batchIndex) const override;
@@ -108,7 +108,7 @@ private:
   void optionsChanged() const;
   void showHelp();
   void addNewBatch(IBatchView *batchView);
-  void initNewBatch(IBatchPresenter *batchPresenter, std::string const &instrument, boost::optional<int> precision);
+  void initNewBatch(IBatchPresenter *batchPresenter, std::string const &instrument, std::optional<int> precision);
   void updateInstrument(const std::string &instrumentName);
   void setDefaultInstrument(const std::string &newInstrument);
   void onInstrumentChanged();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.cpp
@@ -35,9 +35,9 @@ MantidWidgets::Batch::Cell qRangeCellOrDefault(RangeInQ const &qRangeInput, Rang
   return result;
 }
 
-boost::optional<size_t> incrementIndex(const Row &row) {
+std::optional<size_t> incrementIndex(const Row &row) {
   auto lookupIndex = row.lookupIndex();
-  return lookupIndex.is_initialized() ? boost::optional<size_t>(lookupIndex.get() + 1) : boost::none;
+  return lookupIndex.has_value() ? std::optional<size_t>(lookupIndex.value() + 1) : std::nullopt;
 }
 
 std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, boost::optional<int> precision) {
@@ -57,7 +57,7 @@ std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, b
        qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::step, precisionStd),
        MantidQt::MantidWidgets::Batch::Cell(optionalToString(row.scaleFactor(), precision)),
        MantidQt::MantidWidgets::Batch::Cell(MantidWidgets::optionsToString(row.reductionOptions())),
-       MantidQt::MantidWidgets::Batch::Cell(optionalToString(lookupIndex, precision))});
+       MantidQt::MantidWidgets::Batch::Cell(optionalToString(lookupIndex, precisionStd))});
 }
 } // namespace
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.cpp
@@ -40,24 +40,19 @@ std::optional<size_t> incrementIndex(const Row &row) {
   return lookupIndex.has_value() ? std::optional<size_t>(lookupIndex.value() + 1) : std::nullopt;
 }
 
-std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, boost::optional<int> precision) {
-  // convert type for precision
-  std::optional<int> precisionStd = std::nullopt;
-  if (precision)
-    precisionStd = precision.get();
-
+std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, std::optional<int> precision) {
   auto lookupIndex = incrementIndex(row);
   return std::vector<MantidQt::MantidWidgets::Batch::Cell>(
       {MantidQt::MantidWidgets::Batch::Cell(boost::join(row.runNumbers(), "+")),
        MantidQt::MantidWidgets::Batch::Cell(valueToString(row.theta(), precision)),
        MantidQt::MantidWidgets::Batch::Cell(row.transmissionWorkspaceNames().firstRunList()),
        MantidQt::MantidWidgets::Batch::Cell(row.transmissionWorkspaceNames().secondRunList()),
-       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::min, precisionStd),
-       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::max, precisionStd),
-       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::step, precisionStd),
+       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::min, precision),
+       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::max, precision),
+       qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::step, precision),
        MantidQt::MantidWidgets::Batch::Cell(optionalToString(row.scaleFactor(), precision)),
        MantidQt::MantidWidgets::Batch::Cell(MantidWidgets::optionsToString(row.reductionOptions())),
-       MantidQt::MantidWidgets::Batch::Cell(optionalToString(lookupIndex, precisionStd))});
+       MantidQt::MantidWidgets::Batch::Cell(optionalToString(lookupIndex, precision))});
 }
 } // namespace
 
@@ -85,6 +80,6 @@ void JobsViewUpdater::rowModified(int groupIndex, int rowIndex, Row const &row) 
 
 void JobsViewUpdater::setPrecision(const int &precision) { m_precision = precision; }
 
-void JobsViewUpdater::resetPrecision() { m_precision = boost::none; }
+void JobsViewUpdater::resetPrecision() { m_precision = std::nullopt; }
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.h
@@ -32,7 +32,7 @@ public:
 
 private:
   MantidQt::MantidWidgets::Batch::IJobTreeView &m_view;
-  boost::optional<int> m_precision;
+  std::optional<int> m_precision;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.cpp
@@ -245,6 +245,6 @@ RunsTableViewFactory::RunsTableViewFactory(std::vector<std::string> instruments)
 QtRunsTableView *RunsTableViewFactory::operator()() const { return new QtRunsTableView(m_instruments); }
 
 int RunsTableViewFactory::indexOfElseFirst(std::string const &instrument) const {
-  return indexOf(m_instruments, [&instrument](std::string const &inst) { return instrument == inst; }).get_value_or(0);
+  return indexOf(m_instruments, [&instrument](std::string const &inst) { return instrument == inst; }).value_or(0);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -57,11 +57,11 @@ bool groupNameExists(std::string const &groupName, ReductionJobs const &jobs,
 
   // Check if the group name exists in the jobs
   auto maybeExistingGroupIndex = jobs.indexOfGroupWithName(groupName);
-  if (!maybeExistingGroupIndex.is_initialized())
+  if (!maybeExistingGroupIndex.has_value())
     return false;
 
   // If it exists but in one of the roots to ignore, return false
-  auto existingGroupLocation = MantidWidgets::Batch::RowLocation({maybeExistingGroupIndex.get()});
+  auto existingGroupLocation = MantidWidgets::Batch::RowLocation({maybeExistingGroupIndex.value()});
   if (std::find(rootsToIgnore.cbegin(), rootsToIgnore.cend(), existingGroupLocation) != rootsToIgnore.cend())
     return false;
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
@@ -19,7 +19,7 @@ Experiment::Experiment()
       m_polarizationCorrections(PolarizationCorrections(PolarizationCorrectionType::None)),
       m_floodCorrections(FloodCorrections(FloodCorrectionType::Workspace)), m_transmissionStitchOptions(),
       m_stitchParameters(std::map<std::string, std::string>()),
-      m_lookupTable(LookupTable({LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none, RangeInQ(),
+      m_lookupTable(LookupTable({LookupRow(boost::none, std::nullopt, TransmissionRunPair(), boost::none, RangeInQ(),
                                            boost::none, ProcessingInstructions(), boost::none, boost::none)})) {}
 
 Experiment::Experiment(AnalysisMode analysisMode, ReductionType reductionType, SummationType summationType,

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
@@ -73,11 +73,11 @@ void Experiment::updateLookupRow(LookupRow lookupRow, double tolerance) {
   m_lookupTable.updateLookupRow(std::move(lookupRow), tolerance);
 }
 
-boost::optional<size_t> Experiment::getLookupRowIndexFromRow(Row const &row, double tolerance) const {
+std::optional<size_t> Experiment::getLookupRowIndexFromRow(Row const &row, double tolerance) const {
   if (auto const lookupRow = m_lookupTable.findLookupRow(row, tolerance)) {
     return m_lookupTable.getIndex(lookupRow.get());
   }
-  return boost::none;
+  return std::nullopt;
 }
 
 bool operator!=(Experiment const &lhs, Experiment const &rhs) { return !operator==(lhs, rhs); }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
@@ -62,7 +62,7 @@ public:
 
   void updateLookupRow(LookupRow lookupRow, double tolerance);
 
-  boost::optional<size_t> getLookupRowIndexFromRow(Row const &row, double tolerance) const;
+  std::optional<size_t> getLookupRowIndexFromRow(Row const &row, double tolerance) const;
 
 private:
   AnalysisMode m_analysisMode;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.cpp
@@ -10,12 +10,12 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-FloodCorrections::FloodCorrections(FloodCorrectionType correctionType, boost::optional<std::string> workspace)
+FloodCorrections::FloodCorrections(FloodCorrectionType correctionType, std::optional<std::string> workspace)
     : m_correctionType(correctionType), m_workspace(std::move(workspace)) {}
 
 FloodCorrectionType FloodCorrections::correctionType() const { return m_correctionType; }
 
-boost::optional<std::string> FloodCorrections::workspace() const { return m_workspace; }
+std::optional<std::string> FloodCorrections::workspace() const { return m_workspace; }
 
 bool operator!=(FloodCorrections const &lhs, FloodCorrections const &rhs) { return !(lhs == rhs); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.h
@@ -6,8 +6,10 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include "Common/DllConfig.h"
-#include <boost/optional.hpp>
+#include <optional>
+#include <stdexcept>
 #include <string>
+
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
@@ -47,14 +49,14 @@ inline bool floodCorrectionRequiresInputs(FloodCorrectionType correctionType) {
  */
 class MANTIDQT_ISISREFLECTOMETRY_DLL FloodCorrections {
 public:
-  FloodCorrections(FloodCorrectionType correctionType, boost::optional<std::string> workspace = boost::none);
+  FloodCorrections(FloodCorrectionType correctionType, std::optional<std::string> workspace = std::nullopt);
 
   FloodCorrectionType correctionType() const;
-  boost::optional<std::string> workspace() const;
+  std::optional<std::string> workspace() const;
 
 private:
   FloodCorrectionType m_correctionType;
-  boost::optional<std::string> m_workspace;
+  std::optional<std::string> m_workspace;
 };
 
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(FloodCorrections const &lhs, FloodCorrections const &rhs);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.cpp
@@ -91,7 +91,7 @@ bool Group::requiresPostprocessing(bool reprocessFailed) const {
 
 std::string Group::postprocessedWorkspaceName() const { return m_postprocessedWorkspaceName; }
 
-boost::optional<int> Group::indexOfRowWithTheta(double theta, double tolerance) const {
+std::optional<int> Group::indexOfRowWithTheta(double theta, double tolerance) const {
   return indexOf(m_rows, [theta, tolerance](boost::optional<Row> const &row) -> bool {
     return row.is_initialized() && std::abs(row.get().theta() - theta) < tolerance;
   });

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.h
@@ -72,7 +72,7 @@ public:
 
   void resetSkipped() override;
 
-  boost::optional<int> indexOfRowWithTheta(double angle, double tolerance) const override;
+  std::optional<int> indexOfRowWithTheta(double angle, double tolerance) const override;
 
   boost::optional<Row> const &operator[](int rowIndex) const override;
   std::vector<boost::optional<Row>> const &rows() const override;
@@ -103,8 +103,8 @@ void mergeRowsInto(Group &intoHere, Group const &fromHere, int groupIndex, doubl
     if (maybeRow.is_initialized()) {
       auto const &fromRow = maybeRow.get();
       auto index = intoHere.indexOfRowWithTheta(fromRow.theta(), thetaTolerance);
-      if (index.is_initialized()) {
-        auto const updateAtIndex = index.get();
+      if (index.has_value()) {
+        auto const updateAtIndex = index.value();
         auto const &intoRow = intoHere[updateAtIndex].get();
         auto updatedRow = mergedRow(intoRow, fromRow);
         intoHere.updateRow(updateAtIndex, updatedRow);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/IGroup.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/IGroup.h
@@ -9,6 +9,7 @@
 #include "Item.h"
 #include "Row.h"
 #include <boost/optional.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -32,7 +33,7 @@ public:
 
   virtual void resetSkipped() = 0;
 
-  virtual boost::optional<int> indexOfRowWithTheta(double angle, double tolerance) const = 0;
+  virtual std::optional<int> indexOfRowWithTheta(double angle, double tolerance) const = 0;
 
   virtual boost::optional<Row> const &operator[](int rowIndex) const = 0;
   virtual std::vector<boost::optional<Row>> const &rows() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
@@ -13,12 +13,12 @@ Instrument::Instrument()
       m_detectorCorrections(DetectorCorrections(false, DetectorCorrectionType::VerticalShift)),
       m_calibrationFilePath("") {}
 
-Instrument::Instrument(boost::optional<RangeInLambda> wavelengthRange, MonitorCorrections monitorCorrections,
+Instrument::Instrument(std::optional<RangeInLambda> wavelengthRange, MonitorCorrections monitorCorrections,
                        DetectorCorrections detectorCorrections, std::string calibrationFilePath)
     : m_wavelengthRange(std::move(wavelengthRange)), m_monitorCorrections(std::move(monitorCorrections)),
       m_detectorCorrections(detectorCorrections), m_calibrationFilePath(std::move(calibrationFilePath)) {}
 
-boost::optional<RangeInLambda> const &Instrument::wavelengthRange() const { return m_wavelengthRange; }
+const std::optional<RangeInLambda> &Instrument::wavelengthRange() const { return m_wavelengthRange; }
 
 MonitorCorrections const &Instrument::monitorCorrections() const { return m_monitorCorrections; }
 
@@ -30,9 +30,9 @@ size_t Instrument::monitorIndex() const { return m_monitorCorrections.monitorInd
 
 bool Instrument::integratedMonitors() const { return m_monitorCorrections.integrate(); }
 
-boost::optional<RangeInLambda> Instrument::monitorIntegralRange() const { return m_monitorCorrections.integralRange(); }
+std::optional<RangeInLambda> Instrument::monitorIntegralRange() const { return m_monitorCorrections.integralRange(); }
 
-boost::optional<RangeInLambda> Instrument::monitorBackgroundRange() const {
+std::optional<RangeInLambda> Instrument::monitorBackgroundRange() const {
   return m_monitorCorrections.backgroundRange();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.h
@@ -10,7 +10,7 @@
 #include "DetectorCorrections.h"
 #include "MonitorCorrections.h"
 #include "RangeInLambda.h"
-
+#include <optional>
 #include <string>
 
 namespace MantidQt {
@@ -25,23 +25,23 @@ namespace ISISReflectometry {
 class MANTIDQT_ISISREFLECTOMETRY_DLL Instrument {
 public:
   Instrument();
-  Instrument(boost::optional<RangeInLambda> wavelengthRange, MonitorCorrections monitorCorrections,
+  Instrument(std::optional<RangeInLambda> wavelengthRange, MonitorCorrections monitorCorrections,
              DetectorCorrections detectorCorrections, std::string calibrationFilePath);
 
-  boost::optional<RangeInLambda> const &wavelengthRange() const;
+  std::optional<RangeInLambda> const &wavelengthRange() const;
   bool integratedMonitors() const;
   MonitorCorrections const &monitorCorrections() const;
   DetectorCorrections const &detectorCorrections() const;
   std::string const &calibrationFilePath() const;
 
   size_t monitorIndex() const;
-  boost::optional<RangeInLambda> monitorIntegralRange() const;
-  boost::optional<RangeInLambda> monitorBackgroundRange() const;
+  std::optional<RangeInLambda> monitorIntegralRange() const;
+  std::optional<RangeInLambda> monitorBackgroundRange() const;
   bool correctDetectors() const;
   DetectorCorrectionType detectorCorrectionType() const;
 
 private:
-  boost::optional<RangeInLambda> m_wavelengthRange;
+  std::optional<RangeInLambda> m_wavelengthRange;
   MonitorCorrections m_monitorCorrections;
   DetectorCorrections m_detectorCorrections;
   std::string m_calibrationFilePath;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.cpp
@@ -13,7 +13,7 @@ constexpr double EPSILON = std::numeric_limits<double>::epsilon();
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-LookupRow::LookupRow(boost::optional<double> theta, boost::optional<boost::regex> titleMatcher,
+LookupRow::LookupRow(boost::optional<double> theta, std::optional<boost::regex> titleMatcher,
                      TransmissionRunPair transmissionRuns,
                      boost::optional<ProcessingInstructions> transmissionProcessingInstructions, RangeInQ qRange,
                      boost::optional<double> scaleFactor,
@@ -30,11 +30,11 @@ LookupRow::LookupRow(boost::optional<double> theta, boost::optional<boost::regex
 
 TransmissionRunPair const &LookupRow::transmissionWorkspaceNames() const { return m_transmissionRuns; }
 
-bool LookupRow::isWildcard() const { return !m_theta.is_initialized() && !m_titleMatcher.is_initialized(); }
+bool LookupRow::isWildcard() const { return !m_theta.is_initialized() && !m_titleMatcher.has_value(); }
 
 boost::optional<double> LookupRow::thetaOrWildcard() const { return m_theta; }
 
-boost::optional<boost::regex> LookupRow::titleMatcher() const { return m_titleMatcher; }
+std::optional<boost::regex> LookupRow::titleMatcher() const { return m_titleMatcher; }
 
 RangeInQ const &LookupRow::qRange() const { return m_qRange; }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.h
@@ -47,7 +47,7 @@ public:
     ROI_DETECTOR_IDS = 11
   };
 
-  LookupRow(boost::optional<double> theta, boost::optional<boost::regex> titleMatcher,
+  LookupRow(boost::optional<double> theta, std::optional<boost::regex> titleMatcher,
             TransmissionRunPair tranmissionRuns,
             boost::optional<ProcessingInstructions> transmissionProcessingInstructions, RangeInQ qRange,
             boost::optional<double> scaleFactor, boost::optional<ProcessingInstructions> processingInstructions,
@@ -57,7 +57,7 @@ public:
   TransmissionRunPair const &transmissionWorkspaceNames() const;
   bool isWildcard() const;
   boost::optional<double> thetaOrWildcard() const;
-  boost::optional<boost::regex> titleMatcher() const;
+  std::optional<boost::regex> titleMatcher() const;
   RangeInQ const &qRange() const;
   boost::optional<double> scaleFactor() const;
   boost::optional<ProcessingInstructions> transmissionProcessingInstructions() const;
@@ -73,7 +73,7 @@ public:
 
 private:
   boost::optional<double> m_theta;
-  boost::optional<boost::regex> m_titleMatcher;
+  std::optional<boost::regex> m_titleMatcher;
   TransmissionRunPair m_transmissionRuns;
   RangeInQ m_qRange;
   boost::optional<double> m_scaleFactor;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -96,7 +96,7 @@ std::vector<LookupRow> LookupTable::findMatchingRegexes(std::string const &title
   auto results = std::vector<LookupRow>();
   std::copy_if(m_lookupRows.cbegin(), m_lookupRows.cend(), std::back_inserter(results),
                [&title](auto const &candidate) {
-                 return candidate.titleMatcher() && boost::regex_search(title, candidate.titleMatcher().get());
+                 return candidate.titleMatcher() && boost::regex_search(title, candidate.titleMatcher().value());
                });
   return results;
 }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.cpp
@@ -11,8 +11,8 @@
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 MonitorCorrections::MonitorCorrections(size_t monitorIndex, bool integrate,
-                                       boost::optional<RangeInLambda> backgroundRange,
-                                       boost::optional<RangeInLambda> integralRange)
+                                       std::optional<RangeInLambda> backgroundRange,
+                                       std::optional<RangeInLambda> integralRange)
     : m_monitorIndex(monitorIndex), m_integrate(integrate), m_backgroundRange(std::move(backgroundRange)),
       m_integralRange(std::move(integralRange)) {}
 
@@ -20,9 +20,9 @@ size_t MonitorCorrections::monitorIndex() const { return m_monitorIndex; }
 
 bool MonitorCorrections::integrate() const { return m_integrate; }
 
-boost::optional<RangeInLambda> MonitorCorrections::backgroundRange() const { return m_backgroundRange; }
+std::optional<RangeInLambda> MonitorCorrections::backgroundRange() const { return m_backgroundRange; }
 
-boost::optional<RangeInLambda> MonitorCorrections::integralRange() const { return m_integralRange; }
+std::optional<RangeInLambda> MonitorCorrections::integralRange() const { return m_integralRange; }
 
 bool operator!=(MonitorCorrections const &lhs, MonitorCorrections const &rhs) { return !(lhs == rhs); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.h
@@ -8,6 +8,7 @@
 #include "Common/DllConfig.h"
 #include "RangeInLambda.h"
 #include <boost/optional.hpp>
+#include <optional>
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
@@ -19,19 +20,19 @@ namespace ISISReflectometry {
  */
 class MANTIDQT_ISISREFLECTOMETRY_DLL MonitorCorrections {
 public:
-  MonitorCorrections(size_t monitorIndex, bool integrate, boost::optional<RangeInLambda> backgroundRange,
-                     boost::optional<RangeInLambda> integralRange);
+  MonitorCorrections(size_t monitorIndex, bool integrate, std::optional<RangeInLambda> backgroundRange,
+                     std::optional<RangeInLambda> integralRange);
 
   size_t monitorIndex() const;
   bool integrate() const;
-  boost::optional<RangeInLambda> backgroundRange() const;
-  boost::optional<RangeInLambda> integralRange() const;
+  std::optional<RangeInLambda> backgroundRange() const;
+  std::optional<RangeInLambda> integralRange() const;
 
 private:
   size_t m_monitorIndex;
   bool m_integrate;
-  boost::optional<RangeInLambda> m_backgroundRange;
-  boost::optional<RangeInLambda> m_integralRange;
+  std::optional<RangeInLambda> m_backgroundRange;
+  std::optional<RangeInLambda> m_integralRange;
 };
 
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(MonitorCorrections const &lhs, MonitorCorrections const &rhs);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
@@ -11,7 +11,6 @@
 #include "MantidQtWidgets/Common/ParseKeyValueString.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
-#include <set>
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 namespace { // unnamed
@@ -59,8 +58,8 @@ boost::optional<std::string> parseRunNumberOrWhitespace(std::string const &runNu
 
 boost::optional<double> parseTheta(std::string const &theta) {
   auto maybeTheta = parseNonNegativeDouble(theta);
-  if (maybeTheta.is_initialized() && maybeTheta.get() > 0.0)
-    return maybeTheta;
+  if (maybeTheta.has_value() && maybeTheta.value() > 0.0)
+    return maybeTheta.value();
   else
     return boost::none;
 }
@@ -120,8 +119,8 @@ boost::optional<boost::optional<double>> parseScaleFactor(std::string const &sca
   }
 
   auto value = parseDouble(scaleFactor);
-  if (value.is_initialized() && value != 0.0)
-    return value;
+  if (value.has_value() && value != 0.0)
+    return boost::optional<double>(value.value());
   return boost::none;
 }
 
@@ -134,20 +133,26 @@ boost::variant<RangeInQ, std::vector<int>> parseQRange(std::string const &min, s
 
   // If any values are set, check they parse ok
   if (!isEntirelyWhitespace(min)) {
-    minimum = parseNonNegativeDouble(min);
-    if (!minimum.is_initialized())
+    auto minLocal = parseNonNegativeDouble(min);
+    if (minLocal.has_value())
+      minimum = minLocal.value();
+    else
       invalidParams.emplace_back(0);
   }
 
   if (!isEntirelyWhitespace(max)) {
-    maximum = parseNonNegativeDouble(max);
-    if (!maximum.is_initialized())
+    auto maxLocal = parseNonNegativeDouble(max);
+    if (maxLocal.has_value())
+      maximum = maxLocal.value();
+    else
       invalidParams.emplace_back(1);
   }
 
   if (!isEntirelyWhitespace(step)) {
-    stepValue = parseDouble(step);
-    if (!stepValue.is_initialized())
+    auto stepLocal = parseDouble(step);
+    if (stepLocal.has_value())
+      stepValue = stepLocal.value();
+    else
       invalidParams.emplace_back(2);
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
@@ -64,14 +64,14 @@ boost::optional<double> parseTheta(std::string const &theta) {
     return boost::none;
 }
 
-boost::optional<boost::regex> parseTitleMatcher(std::string const &titleMatcher) {
+std::optional<boost::regex> parseTitleMatcher(std::string const &titleMatcher) {
   if (isEntirelyWhitespace(titleMatcher)) {
-    return boost::none;
+    return std::nullopt;
   }
   try {
     return boost::regex(titleMatcher);
   } catch (boost::regex_error const &) {
-    return boost::none;
+    return std::nullopt;
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
@@ -127,37 +127,31 @@ boost::optional<boost::optional<double>> parseScaleFactor(std::string const &sca
 boost::variant<RangeInQ, std::vector<int>> parseQRange(std::string const &min, std::string const &max,
                                                        std::string const &step) {
   auto invalidParams = std::vector<int>();
-  auto minimum = boost::make_optional(false, double());
-  auto maximum = boost::make_optional(false, double());
-  auto stepValue = boost::make_optional(false, double());
+  std::optional<double> minimum = std::nullopt;
+  std::optional<double> maximum = std::nullopt;
+  std::optional<double> stepValue = std::nullopt;
 
   // If any values are set, check they parse ok
   if (!isEntirelyWhitespace(min)) {
-    auto minLocal = parseNonNegativeDouble(min);
-    if (minLocal.has_value())
-      minimum = minLocal.value();
-    else
+    minimum = parseNonNegativeDouble(min);
+    if (!minimum.has_value())
       invalidParams.emplace_back(0);
   }
 
   if (!isEntirelyWhitespace(max)) {
-    auto maxLocal = parseNonNegativeDouble(max);
-    if (maxLocal.has_value())
-      maximum = maxLocal.value();
-    else
+    maximum = parseNonNegativeDouble(max);
+    if (!maximum.has_value())
       invalidParams.emplace_back(1);
   }
 
   if (!isEntirelyWhitespace(step)) {
-    auto stepLocal = parseDouble(step);
-    if (stepLocal.has_value())
-      stepValue = stepLocal.value();
-    else
+    stepValue = parseDouble(step);
+    if (!stepValue.has_value())
       invalidParams.emplace_back(2);
   }
 
   // Check max is not less than min
-  if (maximum.is_initialized() && minimum.is_initialized() && maximum.get() < minimum.get()) {
+  if (maximum.has_value() && minimum.has_value() && maximum.value() < minimum.value()) {
     invalidParams.emplace_back(0);
     invalidParams.emplace_back(1);
   }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.h
@@ -28,7 +28,7 @@ parseRunNumberOrWhitespace(std::string const &runNumberString);
 
 MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<double> parseTheta(std::string const &theta);
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<boost::regex> parseTitleMatcher(std::string const &titleMatcher);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<boost::regex> parseTitleMatcher(std::string const &titleMatcher);
 
 MANTIDQT_ISISREFLECTOMETRY_DLL
 boost::variant<TransmissionRunPair, std::vector<int>> parseTransmissionRuns(std::string const &firstTransmissionRun,

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.cpp
@@ -10,16 +10,17 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-RangeInQ::RangeInQ(boost::optional<double> min, boost::optional<double> step, boost::optional<double> max)
+RangeInQ::RangeInQ(std::optional<double> min, std::optional<double> step, std::optional<double> max)
     : m_min(std::move(min)), m_step(std::move(step)), m_max(std::move(max)) {
-  assert(!(m_min.is_initialized() && m_max.is_initialized() && m_max < m_min));
+  // only executes in DEBUG builds
+  assert(!(m_min.has_value() && m_max.has_value() && m_max < m_min));
 }
 
-boost::optional<double> RangeInQ::min() const { return m_min; }
+std::optional<double> RangeInQ::min() const { return m_min; }
 
-boost::optional<double> RangeInQ::max() const { return m_max; }
+std::optional<double> RangeInQ::max() const { return m_max; }
 
-boost::optional<double> RangeInQ::step() const { return m_step; }
+std::optional<double> RangeInQ::step() const { return m_step; }
 
 bool operator==(RangeInQ const &lhs, RangeInQ const &rhs) {
   return lhs.min() == rhs.min() && lhs.max() == rhs.max() && lhs.step() == rhs.step();

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.h
@@ -7,6 +7,7 @@
 #pragma once
 #include "Common/DllConfig.h"
 #include <boost/optional.hpp>
+#include <optional>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -14,17 +15,17 @@ namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL RangeInQ {
 public:
-  RangeInQ(boost::optional<double> min = boost::none, boost::optional<double> step = boost::none,
-           boost::optional<double> max = boost::none);
+  RangeInQ(std::optional<double> min = std::nullopt, std::optional<double> step = std::nullopt,
+           std::optional<double> max = std::nullopt);
 
-  boost::optional<double> min() const;
-  boost::optional<double> max() const;
-  boost::optional<double> step() const;
+  std::optional<double> min() const;
+  std::optional<double> max() const;
+  std::optional<double> step() const;
 
 private:
-  boost::optional<double> m_min;
-  boost::optional<double> m_step;
-  boost::optional<double> m_max;
+  std::optional<double> m_min;
+  std::optional<double> m_step;
+  std::optional<double> m_max;
 };
 
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(RangeInQ const &lhs, RangeInQ const &rhs);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.cpp
@@ -17,8 +17,8 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 namespace {
 Group &findOrMakeGroupWithName(ReductionJobs &jobs, std::string const &groupName) {
   auto maybeGroupIndex = jobs.indexOfGroupWithName(groupName);
-  if (maybeGroupIndex.is_initialized())
-    return jobs.mutableGroups()[maybeGroupIndex.get()];
+  if (maybeGroupIndex.has_value())
+    return jobs.mutableGroups()[maybeGroupIndex.value()];
   else
     return jobs.appendGroup(Group(groupName));
 }
@@ -44,7 +44,7 @@ Group &ReductionJobs::appendGroup(Group group) {
   return m_groups.back();
 }
 
-boost::optional<int> ReductionJobs::indexOfGroupWithName(std::string const &groupName) const {
+std::optional<int> ReductionJobs::indexOfGroupWithName(std::string const &groupName) const {
   return indexOf(m_groups, [&groupName](Group const &group) -> bool { return group.name() == groupName; });
 }
 
@@ -148,11 +148,11 @@ void mergeRowIntoGroup(ReductionJobs &jobs, Row const &row, double thetaToleranc
   auto &group = findOrMakeGroupWithName(jobs, groupName);
   auto indexOfRowToUpdate = group.indexOfRowWithTheta(row.theta(), thetaTolerance);
 
-  if (indexOfRowToUpdate.is_initialized()) {
-    auto rowToUpdate = group[indexOfRowToUpdate.get()].get();
+  if (indexOfRowToUpdate.has_value()) {
+    auto rowToUpdate = group[indexOfRowToUpdate.value()].get();
     auto newRowValue = mergedRow(rowToUpdate, row);
     if (newRowValue.runNumbers() != rowToUpdate.runNumbers())
-      group.updateRow(indexOfRowToUpdate.get(), newRowValue);
+      group.updateRow(indexOfRowToUpdate.value(), newRowValue);
   } else {
     group.insertRowSortedByAngle(row);
   }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.h
@@ -28,7 +28,7 @@ public:
   Group &insertGroup(Group group, int beforeIndex);
   bool hasGroupWithName(std::string const &groupName) const;
   bool containsSingleEmptyGroup() const;
-  boost::optional<int> indexOfGroupWithName(std::string const &groupName) const;
+  std::optional<int> indexOfGroupWithName(std::string const &groupName) const;
   void removeGroup(int index);
   void removeAllGroups();
   void resetState();
@@ -87,8 +87,8 @@ void mergeJobsInto(ReductionJobs &intoHere, ReductionJobs const &fromHere, doubl
   auto removeFirstGroup = intoHere.containsSingleEmptyGroup();
   for (auto const &group : fromHere.groups()) {
     auto maybeGroupIndex = intoHere.indexOfGroupWithName(group.name());
-    if (maybeGroupIndex.is_initialized()) {
-      auto indexToUpdateAt = maybeGroupIndex.get();
+    if (maybeGroupIndex.has_value()) {
+      auto indexToUpdateAt = maybeGroupIndex.value();
       auto &intoGroup = intoHere.mutableGroups()[indexToUpdateAt];
       mergeRowsInto(intoGroup, group, indexToUpdateAt, thetaTolerance, listener);
     } else {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.cpp
@@ -21,7 +21,7 @@ Row::Row(std::vector<std::string> runNumbers, double theta,
     : Item(), m_runNumbers(std::move(runNumbers)), m_theta(theta), m_qRange(std::move(qRange)), m_qRangeOutput(),
       m_scaleFactor(std::move(scaleFactor)), m_transmissionRuns(std::move(transmissionRuns)),
       m_reducedWorkspaceNames(std::move(reducedWorkspaceNames)), m_reductionOptions(std::move(reductionOptions)),
-      m_lookupIndex(boost::none), m_parent(nullptr) {
+      m_lookupIndex(std::nullopt), m_parent(nullptr) {
   std::sort(m_runNumbers.begin(), m_runNumbers.end());
 }
 
@@ -45,7 +45,7 @@ ReductionOptionsMap const &Row::reductionOptions() const { return m_reductionOpt
 
 ReductionWorkspaces const &Row::reducedWorkspaceNames() const { return m_reducedWorkspaceNames; }
 
-boost::optional<size_t> const &Row::lookupIndex() const { return m_lookupIndex; }
+const std::optional<size_t> &Row::lookupIndex() const { return m_lookupIndex; }
 
 void Row::setOutputNames(std::vector<std::string> const &outputNames) {
   if (outputNames.size() != 3)
@@ -56,7 +56,7 @@ void Row::setOutputNames(std::vector<std::string> const &outputNames) {
 
 void Row::setOutputQRange(RangeInQ qRange) { m_qRangeOutput = std::move(qRange); }
 
-void Row::setLookupIndex(boost::optional<size_t> lookupIndex) { m_lookupIndex = std::move(lookupIndex); }
+void Row::setLookupIndex(std::optional<size_t> lookupIndex) { m_lookupIndex = std::move(lookupIndex); }
 
 void Row::resetOutputs() {
   m_reducedWorkspaceNames.resetOutputNames();

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.h
@@ -13,6 +13,7 @@
 #include <boost/optional.hpp>
 #include <boost/range/algorithm/set_algorithm.hpp>
 #include <boost/variant.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -43,11 +44,11 @@ public:
   boost::optional<double> scaleFactor() const;
   ReductionOptionsMap const &reductionOptions() const;
   ReductionWorkspaces const &reducedWorkspaceNames() const;
-  boost::optional<size_t> const &lookupIndex() const;
+  std::optional<size_t> const &lookupIndex() const;
 
   void setOutputNames(std::vector<std::string> const &outputNames) override;
   void setOutputQRange(RangeInQ qRange);
-  void setLookupIndex(boost::optional<size_t> lookupIndex);
+  void setLookupIndex(std::optional<size_t> lookupIndex);
   void resetOutputs() override;
   bool hasOutputWorkspace(std::string const &wsName) const;
   void renameOutputWorkspace(std::string const &oldName, std::string const &newName) override;
@@ -75,7 +76,7 @@ private:
   TransmissionRunPair m_transmissionRuns;
   ReductionWorkspaces m_reducedWorkspaceNames;
   ReductionOptionsMap m_reductionOptions;
-  boost::optional<size_t> m_lookupIndex;
+  std::optional<size_t> m_lookupIndex;
   mutable IGroup *m_parent;
   friend class Encoder;
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.cpp
@@ -9,13 +9,13 @@
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 TransmissionStitchOptions::TransmissionStitchOptions()
-    : m_overlapRange(boost::none), m_rebinParameters(), m_scaleRHS(false) {}
+    : m_overlapRange(std::nullopt), m_rebinParameters(), m_scaleRHS(false) {}
 
-TransmissionStitchOptions::TransmissionStitchOptions(boost::optional<RangeInLambda> overlapRange,
+TransmissionStitchOptions::TransmissionStitchOptions(std::optional<RangeInLambda> overlapRange,
                                                      RebinParameters rebinParameters, bool scaleRHS)
     : m_overlapRange(std::move(overlapRange)), m_rebinParameters(std::move(rebinParameters)), m_scaleRHS(scaleRHS) {}
 
-boost::optional<RangeInLambda> TransmissionStitchOptions::overlapRange() const { return m_overlapRange; }
+std::optional<RangeInLambda> TransmissionStitchOptions::overlapRange() const { return m_overlapRange; }
 
 RebinParameters TransmissionStitchOptions::rebinParameters() const { return m_rebinParameters; }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h
@@ -9,6 +9,7 @@
 #include "ProcessingInstructions.h"
 #include "RangeInLambda.h"
 #include <boost/optional.hpp>
+#include <optional>
 #include <string>
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -27,15 +28,14 @@ using RebinParameters = std::string;
 class MANTIDQT_ISISREFLECTOMETRY_DLL TransmissionStitchOptions {
 public:
   TransmissionStitchOptions();
-  TransmissionStitchOptions(boost::optional<RangeInLambda> overlapRange, RebinParameters rebinParameters,
-                            bool scaleRHS);
+  TransmissionStitchOptions(std::optional<RangeInLambda> overlapRange, RebinParameters rebinParameters, bool scaleRHS);
 
-  boost::optional<RangeInLambda> overlapRange() const;
+  std::optional<RangeInLambda> overlapRange() const;
   RebinParameters rebinParameters() const;
   bool scaleRHS() const;
 
 private:
-  boost::optional<RangeInLambda> m_overlapRange;
+  std::optional<RangeInLambda> m_overlapRange;
   RebinParameters m_rebinParameters;
   bool m_scaleRHS;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateLookupRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateLookupRow.cpp
@@ -54,11 +54,11 @@ ValidatorT<boost::optional<double>> LookupRowValidator::parseThetaOrWhitespace(C
   return boost::none;
 }
 
-ValidatorT<boost::optional<boost::regex>> LookupRowValidator::parseTitleMatcherOrWhitespace(CellText const &cellText) {
+ValidatorT<std::optional<boost::regex>> LookupRowValidator::parseTitleMatcherOrWhitespace(CellText const &cellText) {
   auto const &text = cellText[LookupRow::Column::TITLE];
   if (isEntirelyWhitespace(text)) {
     // Mark validator as passed, but the enclosed value empty
-    return boost::optional<boost::regex>(boost::none);
+    return boost::make_optional<std::optional<boost::regex>>(std::nullopt);
   }
 
   // This check relies on us checking for whitespace chars before calling parseTitleMatcher
@@ -131,7 +131,7 @@ void LookupRowValidator::validateThetaAndRegex() {
     return;
 
   // Check we have a theta value, when we have a titleMatcher
-  if (m_titleMatcherOrInvalid.get().is_initialized() && !m_thetaOrInvalid.get().is_initialized()) {
+  if (m_titleMatcherOrInvalid.get().has_value() && !m_thetaOrInvalid.get().is_initialized()) {
     m_invalidColumns.insert(LookupRow::Column::THETA);
     m_invalidColumns.insert(LookupRow::Column::TITLE);
     m_thetaOrInvalid = boost::none;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateLookupRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateLookupRow.h
@@ -31,7 +31,7 @@ public:
 
 private:
   ValidatorT<boost::optional<double>> parseThetaOrWhitespace(LookupRow::ValueArray const &cellText);
-  ValidatorT<boost::optional<boost::regex>> parseTitleMatcherOrWhitespace(LookupRow::ValueArray const &cellText);
+  ValidatorT<std::optional<boost::regex>> parseTitleMatcherOrWhitespace(LookupRow::ValueArray const &cellText);
   ValidatorT<TransmissionRunPair> parseTransmissionRuns(LookupRow::ValueArray const &cellText);
   ValidatorT<boost::optional<std::string>>
   parseTransmissionProcessingInstructions(LookupRow::ValueArray const &cellText);
@@ -46,7 +46,7 @@ private:
 
   std::unordered_set<int> m_invalidColumns;
   ValidatorT<boost::optional<double>> m_thetaOrInvalid;
-  ValidatorT<boost::optional<boost::regex>> m_titleMatcherOrInvalid;
+  ValidatorT<std::optional<boost::regex>> m_titleMatcherOrInvalid;
 };
 
 ValidationResult<LookupRow, std::unordered_set<int>> validateLookupRow(LookupRow::ValueArray const &cellText);

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -48,7 +48,7 @@ Row makeSimpleRow(std::string const &run, double theta) {
 }
 
 Row makeRow(std::string const &run, double theta, std::string const &trans1, std::string const &trans2,
-            boost::optional<double> qMin, boost::optional<double> qMax, boost::optional<double> qStep,
+            std::optional<double> qMin, std::optional<double> qMax, std::optional<double> qStep,
             boost::optional<double> scale, ReductionOptionsMap const &optionsMap) {
   return Row({run}, theta, TransmissionRunPair({trans1, trans2}),
              RangeInQ(std::move(qMin), std::move(qMax), std::move(qStep)), std::move(scale), optionsMap,
@@ -360,7 +360,7 @@ LookupTable makeEmptyLookupTable() { return LookupTable{}; }
 LookupTable makeLookupTable() {
   auto lookupRow =
       LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none,
-                RangeInQ(boost::none, boost::none, boost::none), boost::none, boost::none, boost::none, boost::none);
+                RangeInQ(std::nullopt, std::nullopt, std::nullopt), boost::none, boost::none, boost::none, boost::none);
   return LookupTable{std::move(lookupRow)};
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -345,7 +345,7 @@ ReductionJobs oneGroupWithTwoRowsWithOutputNamesModel() {
 
 /* Experiment */
 
-LookupRow makeLookupRow(boost::optional<double> angle, boost::optional<boost::regex> titleMatcher) {
+LookupRow makeLookupRow(boost::optional<double> angle, std::optional<boost::regex> titleMatcher) {
   return LookupRow(
       std::move(angle), std::move(titleMatcher),
       TransmissionRunPair(std::vector<std::string>{"22348", "22349"}, std::vector<std::string>{"22358", "22359"}),
@@ -353,19 +353,19 @@ LookupRow makeLookupRow(boost::optional<double> angle, boost::optional<boost::re
       ProcessingInstructions("2-3,7-8"), ProcessingInstructions("3-22"));
 }
 
-LookupRow makeWildcardLookupRow() { return makeLookupRow(boost::none, boost::none); }
+LookupRow makeWildcardLookupRow() { return makeLookupRow(boost::none, std::nullopt); }
 
 LookupTable makeEmptyLookupTable() { return LookupTable{}; }
 
 LookupTable makeLookupTable() {
   auto lookupRow =
-      LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none,
+      LookupRow(boost::none, std::nullopt, TransmissionRunPair(), boost::none,
                 RangeInQ(std::nullopt, std::nullopt, std::nullopt), boost::none, boost::none, boost::none, boost::none);
   return LookupTable{std::move(lookupRow)};
 }
 
 LookupTable makeLookupTableWithTwoAngles() {
-  return LookupTable{LookupRow(0.5, boost::none, TransmissionRunPair("22347", ""), boost::none,
+  return LookupTable{LookupRow(0.5, std::nullopt, TransmissionRunPair("22347", ""), boost::none,
                                RangeInQ(0.008, 0.02, 1.2), 0.8, ProcessingInstructions("2-3"), boost::none,
                                boost::none),
                      makeLookupRow(2.3)};
@@ -374,11 +374,11 @@ LookupTable makeLookupTableWithTwoAngles() {
 LookupTable makeLookupTableWithTwoAnglesAndWildcard() {
   return LookupTable{
       // wildcard row with no angle
-      LookupRow(boost::none, boost::none, TransmissionRunPair("22345", "22346"), ProcessingInstructions("5-6"),
+      LookupRow(boost::none, std::nullopt, TransmissionRunPair("22345", "22346"), ProcessingInstructions("5-6"),
                 RangeInQ(0.007, 0.01, 1.1), 0.7, ProcessingInstructions("1"), ProcessingInstructions("3,7"),
                 ProcessingInstructions("3-22")),
       // two angle rows
-      LookupRow(0.5, boost::none, TransmissionRunPair("22347", ""), boost::none, RangeInQ(0.008, 0.02, 1.2), 0.8,
+      LookupRow(0.5, std::nullopt, TransmissionRunPair("22347", ""), boost::none, RangeInQ(0.008, 0.02, 1.2), 0.8,
                 ProcessingInstructions("2-3"), boost::none, boost::none),
       LookupRow(makeLookupRow(2.3))};
 }

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -413,9 +413,7 @@ PolarizationCorrections makeEmptyPolarizationCorrections() {
   return PolarizationCorrections(PolarizationCorrectionType::None);
 }
 
-FloodCorrections makeFloodCorrections() {
-  return FloodCorrections(FloodCorrectionType::Workspace, boost::optional<std::string>("test_workspace"));
-}
+FloodCorrections makeFloodCorrections() { return FloodCorrections(FloodCorrectionType::Workspace, "test_workspace"); }
 
 TransmissionStitchOptions makeTransmissionStitchOptions() {
   return TransmissionStitchOptions(RangeInLambda{7.5, 9.2}, RebinParameters("-0.02"), true);

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
@@ -27,9 +27,9 @@ MANTIDQT_ISISREFLECTOMETRY_DLL Row makeRow(double theta = 0.5);
 MANTIDQT_ISISREFLECTOMETRY_DLL Row makeRow(std::string const &run, double theta = 0.5);
 MANTIDQT_ISISREFLECTOMETRY_DLL Row makeSimpleRow(std::string const &run, double theta = 0.5);
 MANTIDQT_ISISREFLECTOMETRY_DLL Row makeRow(std::string const &run, double theta, std::string const &trans1,
-                                           std::string const &trans2, boost::optional<double> qMin = boost::none,
-                                           boost::optional<double> qMax = boost::none,
-                                           boost::optional<double> qStep = boost::none,
+                                           std::string const &trans2, std::optional<double> qMin = std::nullopt,
+                                           std::optional<double> qMax = std::nullopt,
+                                           std::optional<double> qStep = std::nullopt,
                                            boost::optional<double> scale = boost::none,
                                            ReductionOptionsMap const &optionsMap = ReductionOptionsMap());
 MANTIDQT_ISISREFLECTOMETRY_DLL Row makeRow(std::vector<std::string> const &runs, double theta = 0.5);

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
@@ -75,7 +75,7 @@ ReductionJobs oneGroupWithTwoRowsWithOutputNamesModel();
 /* Experiment */
 MANTIDQT_ISISREFLECTOMETRY_DLL LookupRow makeWildcardLookupRow();
 MANTIDQT_ISISREFLECTOMETRY_DLL LookupRow makeLookupRow(boost::optional<double> angle,
-                                                       boost::optional<boost::regex> titleMatcher = boost::none);
+                                                       std::optional<boost::regex> titleMatcher = std::nullopt);
 MANTIDQT_ISISREFLECTOMETRY_DLL LookupTable makeEmptyLookupTable();
 MANTIDQT_ISISREFLECTOMETRY_DLL LookupTable makeLookupTable();
 MANTIDQT_ISISREFLECTOMETRY_DLL LookupTable makeLookupTableWithTwoAngles();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
@@ -205,11 +205,11 @@ private:
     TS_ASSERT_EQUALS(static_cast<bool>(max), map[QString("maxPresent")].toBool())
     TS_ASSERT_EQUALS(static_cast<bool>(step), map[QString("stepPresent")].toBool())
     if (min)
-      TS_ASSERT_EQUALS(min.get(), map[QString("min")].toDouble())
+      TS_ASSERT_EQUALS(min.value(), map[QString("min")].toDouble())
     if (max)
-      TS_ASSERT_EQUALS(max.get(), map[QString("max")].toDouble())
+      TS_ASSERT_EQUALS(max.value(), map[QString("max")].toDouble())
     if (step)
-      TS_ASSERT_EQUALS(step.get(), map[QString("step")].toDouble())
+      TS_ASSERT_EQUALS(step.value(), map[QString("step")].toDouble())
   }
 
   void testTransmissionRunPair(const TransmissionRunPair &pair, const QMap<QString, QVariant> &map) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
@@ -72,7 +72,7 @@ public:
 
   void testDefaultLookupRowOptions() {
     auto result = getDefaults();
-    auto expected = LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none,
+    auto expected = LookupRow(boost::none, std::nullopt, TransmissionRunPair(), boost::none,
                               RangeInQ(std::nullopt, std::nullopt, std::nullopt), boost::none, boost::none, boost::none,
                               boost::none);
     auto foundLookupRows = result.lookupTableRows();
@@ -83,7 +83,7 @@ public:
 
   void testValidLookupRowOptionsFromParamsFile() {
     auto result = getDefaultsFromParamsFile("Experiment");
-    auto expected = LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2),
+    auto expected = LookupRow(boost::none, std::nullopt, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2),
                               0.7, std::string("390-415"), std::string("370-389,416-430"), boost::none);
     auto foundLookupRows = result.lookupTableRows();
     TS_ASSERT_EQUALS(foundLookupRows.size(), 1);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
@@ -72,9 +72,9 @@ public:
 
   void testDefaultLookupRowOptions() {
     auto result = getDefaults();
-    auto expected =
-        LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none,
-                  RangeInQ(boost::none, boost::none, boost::none), boost::none, boost::none, boost::none, boost::none);
+    auto expected = LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none,
+                              RangeInQ(std::nullopt, std::nullopt, std::nullopt), boost::none, boost::none, boost::none,
+                              boost::none);
     auto foundLookupRows = result.lookupTableRows();
     TS_ASSERT_EQUALS(foundLookupRows.size(), 1);
     if (!foundLookupRows.empty())

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -658,7 +658,7 @@ public:
   }
 
   void testInstrumentChangedUpdatesLookupRowInView() {
-    auto lookupRow = LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2),
+    auto lookupRow = LookupRow(boost::none, std::nullopt, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2),
                                0.7, std::string("390-415"), std::string("370-389,416-430"), boost::none);
     auto model = makeModelWithLookupRow(std::move(lookupRow));
     auto defaultOptions = expectDefaults(model);
@@ -670,13 +670,13 @@ public:
   }
 
   void testInstrumentChangedUpdatesLookupRowInModel() {
-    auto model = makeModelWithLookupRow(LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none,
+    auto model = makeModelWithLookupRow(LookupRow(boost::none, std::nullopt, TransmissionRunPair(), boost::none,
                                                   RangeInQ(0.01, 0.03, 0.2), 0.7, std::string("390-415"),
                                                   std::string("370-389,416-430"), boost::none));
     auto defaultOptions = expectDefaults(model);
     auto presenter = makePresenter(std::move(defaultOptions));
     presenter.notifyInstrumentChanged("POLREF");
-    auto expected = LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2),
+    auto expected = LookupRow(boost::none, std::nullopt, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2),
                               0.7, std::string("390-415"), std::string("370-389,416-430"), boost::none);
     auto lookupRows = presenter.experiment().lookupTableRows();
     TS_ASSERT_EQUALS(lookupRows.size(), 1);
@@ -1140,13 +1140,13 @@ private:
   // either as an input array of strings or an output model
   OptionsRow optionsRowWithFirstAngle() { return {"0.5", "", "13463", ""}; }
   LookupRow defaultsWithFirstAngle() {
-    return LookupRow(0.5, boost::none, TransmissionRunPair("13463", ""), boost::none, RangeInQ(), boost::none,
+    return LookupRow(0.5, std::nullopt, TransmissionRunPair("13463", ""), boost::none, RangeInQ(), boost::none,
                      boost::none, boost::none, boost::none);
   }
 
   OptionsRow optionsRowWithSecondAngle() { return {"2.3", "", "13463", "13464"}; }
   LookupRow defaultsWithSecondAngle() {
-    return LookupRow(2.3, boost::none, TransmissionRunPair("13463", "13464"), boost::none, RangeInQ(), boost::none,
+    return LookupRow(2.3, std::nullopt, TransmissionRunPair("13463", "13464"), boost::none, RangeInQ(), boost::none,
                      boost::none, boost::none, boost::none);
   }
   OptionsRow optionsRowWithWildcard() { return {"", "", "13463", "13464"}; }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -239,7 +239,7 @@ public:
     auto presenter = makePresenter();
     FloodCorrections floodCorr(FloodCorrectionType::Workspace, std::string{"testWS"});
     EXPECT_CALL(m_view, getFloodCorrectionType()).Times(2).WillRepeatedly(Return("Workspace"));
-    EXPECT_CALL(m_view, getFloodWorkspace()).WillOnce(Return(floodCorr.workspace().get()));
+    EXPECT_CALL(m_view, getFloodWorkspace()).WillOnce(Return(floodCorr.workspace().value()));
     EXPECT_CALL(m_view, setFloodCorrectionWorkspaceMode()).Times(1);
     presenter.notifySettingsChanged();
 
@@ -251,10 +251,10 @@ public:
     FloodCorrections floodCorr(FloodCorrectionType::Workspace, std::string{"path/to/testWS"});
 
     EXPECT_CALL(m_view, getFloodCorrectionType()).Times(2).WillRepeatedly(Return("FilePath"));
-    EXPECT_CALL(m_fileHandler, getFullFilePath(floodCorr.workspace().get()))
-        .WillOnce(Return(floodCorr.workspace().get()));
-    EXPECT_CALL(m_fileHandler, fileExists(floodCorr.workspace().get())).WillOnce(Return(true));
-    EXPECT_CALL(m_view, getFloodFilePath()).WillOnce(Return(floodCorr.workspace().get()));
+    EXPECT_CALL(m_fileHandler, getFullFilePath(floodCorr.workspace().value()))
+        .WillOnce(Return(floodCorr.workspace().value()));
+    EXPECT_CALL(m_fileHandler, fileExists(floodCorr.workspace().value())).WillOnce(Return(true));
+    EXPECT_CALL(m_view, getFloodFilePath()).WillOnce(Return(floodCorr.workspace().value()));
     EXPECT_CALL(m_view, setFloodCorrectionFilePathMode()).Times(1);
     presenter.notifySettingsChanged();
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -340,7 +340,7 @@ public:
 
   void testTransmissionRunRangeIsValidButNotUpdatedIfUnset() {
     RangeInLambda range(0.0, 0.0);
-    runTestForValidTransmissionRunRange(range, boost::none);
+    runTestForValidTransmissionRunRange(range, std::nullopt);
   }
 
   void testTransmissionParamsAreValidWithPositiveValue() { runTestForValidTransmissionParams("0.02"); }
@@ -1118,7 +1118,7 @@ private:
     presenter.notifySettingsChanged();
   }
 
-  void runTestForValidTransmissionRunRange(RangeInLambda const &range, boost::optional<RangeInLambda> const &result) {
+  void runTestForValidTransmissionRunRange(RangeInLambda const &range, std::optional<RangeInLambda> const &result) {
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, getTransmissionStartOverlap()).WillOnce(Return(range.min()));
     EXPECT_CALL(m_view, getTransmissionEndOverlap()).WillOnce(Return(range.max()));
@@ -1133,7 +1133,7 @@ private:
     EXPECT_CALL(m_view, getTransmissionEndOverlap()).WillOnce(Return(range.max()));
     EXPECT_CALL(m_view, showTransmissionRangeInvalid()).Times(1);
     presenter.notifySettingsChanged();
-    TS_ASSERT_EQUALS(presenter.experiment().transmissionStitchOptions().overlapRange(), boost::none);
+    TS_ASSERT_EQUALS(presenter.experiment().transmissionStitchOptions().overlapRange(), std::nullopt);
   }
 
   // These functions create various rows in the per-theta defaults tables,

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/LookupTableValidatorTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/LookupTableValidatorTest.h
@@ -74,8 +74,8 @@ public:
     TS_ASSERT(results[0].thetaOrWildcard().is_initialized());
     TS_ASSERT(results[1].thetaOrWildcard().is_initialized());
     TS_ASSERT_EQUALS(results[0].thetaOrWildcard().get(), results[1].thetaOrWildcard().get());
-    TS_ASSERT_EQUALS(results[0].titleMatcher().get().expression(), title1);
-    TS_ASSERT_EQUALS(results[1].titleMatcher().get().expression(), title2);
+    TS_ASSERT_EQUALS(results[0].titleMatcher().value().expression(), title1);
+    TS_ASSERT_EQUALS(results[1].titleMatcher().value().expression(), title2);
   }
 
   void testDuplicateAnglesAndTitleMatchersAreInvalid() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
@@ -75,7 +75,7 @@ public:
 
   void testWavelengthRangeIsValidButNotUpdatedIfUnset() {
     auto const range = RangeInLambda(0.0, 0.0);
-    runTestForValidWavelengthRange(range, boost::none);
+    runTestForValidWavelengthRange(range, std::nullopt);
   }
 
   void testIntegratedMonitorsToggled() {
@@ -125,7 +125,7 @@ public:
 
   void testMonitorIntegralRangeIsValidButNotUpdatedIfUnset() {
     auto const range = RangeInLambda(0.0, 0.0);
-    runTestForValidMonitorIntegralRange(range, boost::none);
+    runTestForValidMonitorIntegralRange(range, std::nullopt);
   }
 
   void testSetValidMonitorBackgroundRange() {
@@ -155,7 +155,7 @@ public:
 
   void testMonitorBackgroundRangeIsValidButNotUpdatedIfUnset() {
     auto const range = RangeInLambda(0.0, 0.0);
-    runTestForValidMonitorBackgroundRange(range, boost::none);
+    runTestForValidMonitorBackgroundRange(range, std::nullopt);
   }
 
   void testCorrectDetectorsToggledUpdatesModel() {
@@ -398,7 +398,7 @@ private:
     EXPECT_CALL(m_mainPresenter, isAutoreducing()).Times(1).WillOnce(Return(false));
   }
 
-  void runTestForValidWavelengthRange(RangeInLambda const &range, boost::optional<RangeInLambda> const &result) {
+  void runTestForValidWavelengthRange(RangeInLambda const &range, std::optional<RangeInLambda> const &result) {
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, getLambdaMin()).WillOnce(Return(range.min()));
     EXPECT_CALL(m_view, getLambdaMax()).WillOnce(Return(range.max()));
@@ -413,10 +413,10 @@ private:
     EXPECT_CALL(m_view, getLambdaMax()).WillOnce(Return(range.max()));
     EXPECT_CALL(m_view, showLambdaRangeInvalid()).Times(1);
     presenter.notifySettingsChanged();
-    TS_ASSERT_EQUALS(presenter.instrument().wavelengthRange(), boost::none);
+    TS_ASSERT_EQUALS(presenter.instrument().wavelengthRange(), std::nullopt);
   }
 
-  void runTestForValidMonitorIntegralRange(RangeInLambda const &range, boost::optional<RangeInLambda> const &result) {
+  void runTestForValidMonitorIntegralRange(RangeInLambda const &range, std::optional<RangeInLambda> const &result) {
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, getMonitorIntegralMin()).WillOnce(Return(range.min()));
     EXPECT_CALL(m_view, getMonitorIntegralMax()).WillOnce(Return(range.max()));
@@ -431,10 +431,10 @@ private:
     EXPECT_CALL(m_view, getMonitorIntegralMax()).WillOnce(Return(range.max()));
     EXPECT_CALL(m_view, showMonitorIntegralRangeInvalid()).Times(1);
     presenter.notifySettingsChanged();
-    TS_ASSERT_EQUALS(presenter.instrument().monitorIntegralRange(), boost::none);
+    TS_ASSERT_EQUALS(presenter.instrument().monitorIntegralRange(), std::nullopt);
   }
 
-  void runTestForValidMonitorBackgroundRange(RangeInLambda const &range, boost::optional<RangeInLambda> const &result) {
+  void runTestForValidMonitorBackgroundRange(RangeInLambda const &range, std::optional<RangeInLambda> const &result) {
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, getMonitorBackgroundMin()).WillOnce(Return(range.min()));
     EXPECT_CALL(m_view, getMonitorBackgroundMax()).WillOnce(Return(range.max()));
@@ -449,6 +449,6 @@ private:
     EXPECT_CALL(m_view, getMonitorBackgroundMax()).WillOnce(Return(range.max()));
     EXPECT_CALL(m_view, showMonitorBackgroundRangeInvalid()).Times(1);
     presenter.notifySettingsChanged();
-    TS_ASSERT_EQUALS(presenter.instrument().monitorBackgroundRange(), boost::none);
+    TS_ASSERT_EQUALS(presenter.instrument().monitorBackgroundRange(), std::nullopt);
   }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MockMainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MockMainWindowPresenter.h
@@ -25,7 +25,7 @@ public:
   MOCK_CONST_METHOD0(isWarnDiscardChangesChecked, bool());
   MOCK_CONST_METHOD0(isRoundChecked, bool());
   MOCK_CONST_METHOD0(getRoundPrecision, int &());
-  MOCK_CONST_METHOD0(roundPrecision, boost::optional<int>());
+  MOCK_CONST_METHOD0(roundPrecision, std::optional<int>());
   MOCK_METHOD0(isCloseEventPrevented, bool());
   MOCK_CONST_METHOD1(isCloseBatchPrevented, bool(int));
   MOCK_CONST_METHOD1(isOverwriteBatchPrevented, bool(int));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/BatchLookupIndexTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/BatchLookupIndexTest.h
@@ -28,30 +28,30 @@ public:
     constexpr auto angle = 0.5;
     auto row = ModelCreationHelper::makeRow(angle);
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
-    TS_ASSERT_EQUALS(row.lookupIndex(), boost::none);
+    TS_ASSERT_EQUALS(row.lookupIndex(), std::nullopt);
     model.updateLookupIndex(row);
-    TS_ASSERT(row.lookupIndex().is_initialized());
-    TS_ASSERT_EQUALS(row.lookupIndex().get(), size_t(1));
+    TS_ASSERT(row.lookupIndex().has_value());
+    TS_ASSERT_EQUALS(row.lookupIndex().value(), size_t(1));
   }
 
   void test_update_lookup_index_single_row_wildcard() {
     constexpr auto angle = 0.1;
     auto row = ModelCreationHelper::makeRow(angle);
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
-    TS_ASSERT_EQUALS(row.lookupIndex(), boost::none);
+    TS_ASSERT_EQUALS(row.lookupIndex(), std::nullopt);
     model.updateLookupIndex(row);
-    TS_ASSERT(row.lookupIndex().is_initialized());
-    TS_ASSERT_EQUALS(row.lookupIndex().get(), size_t(0));
+    TS_ASSERT(row.lookupIndex().has_value());
+    TS_ASSERT_EQUALS(row.lookupIndex().value(), size_t(0));
   }
 
   void test_update_lookup_index_single_row_no_match() {
     constexpr auto angle = 0.1;
     auto row = ModelCreationHelper::makeRow(angle);
     auto model = Batch(ModelCreationHelper::makeEmptyExperiment(), m_instrument, m_runsTable, m_slicing);
-    TS_ASSERT_EQUALS(row.lookupIndex(), boost::none);
+    TS_ASSERT_EQUALS(row.lookupIndex(), std::nullopt);
     model.updateLookupIndex(row);
-    TS_ASSERT(!row.lookupIndex().is_initialized());
-    TS_ASSERT_EQUALS(row.lookupIndex(), boost::none);
+    TS_ASSERT(!row.lookupIndex().has_value());
+    TS_ASSERT_EQUALS(row.lookupIndex(), std::nullopt);
   }
 
   void test_update_lookup_index_group_updates_all_rows() {
@@ -63,18 +63,18 @@ public:
     group.appendRow(std::move(rowB));
     group.appendRow(std::move(rowW));
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
-    TS_ASSERT_EQUALS(group.mutableRows()[0].get().lookupIndex(), boost::none);
-    TS_ASSERT_EQUALS(group.mutableRows()[1].get().lookupIndex(), boost::none);
-    TS_ASSERT_EQUALS(group.mutableRows()[2].get().lookupIndex(), boost::none);
+    TS_ASSERT_EQUALS(group.mutableRows()[0].get().lookupIndex(), std::nullopt);
+    TS_ASSERT_EQUALS(group.mutableRows()[1].get().lookupIndex(), std::nullopt);
+    TS_ASSERT_EQUALS(group.mutableRows()[2].get().lookupIndex(), std::nullopt);
 
     model.updateLookupIndexesOfGroup(group);
 
-    TS_ASSERT(group.mutableRows()[0].get().lookupIndex().is_initialized());
-    TS_ASSERT_EQUALS(group.mutableRows()[0].get().lookupIndex().get(), size_t(1));
-    TS_ASSERT(group.mutableRows()[1].get().lookupIndex().is_initialized());
-    TS_ASSERT_EQUALS(group.mutableRows()[1].get().lookupIndex().get(), size_t(2));
-    TS_ASSERT(group.mutableRows()[2].get().lookupIndex().is_initialized());
-    TS_ASSERT_EQUALS(group.mutableRows()[2].get().lookupIndex().get(), size_t(0));
+    TS_ASSERT(group.mutableRows()[0].get().lookupIndex().has_value());
+    TS_ASSERT_EQUALS(group.mutableRows()[0].get().lookupIndex().value(), size_t(1));
+    TS_ASSERT(group.mutableRows()[1].get().lookupIndex().has_value());
+    TS_ASSERT_EQUALS(group.mutableRows()[1].get().lookupIndex().value(), size_t(2));
+    TS_ASSERT(group.mutableRows()[2].get().lookupIndex().has_value());
+    TS_ASSERT_EQUALS(group.mutableRows()[2].get().lookupIndex().value(), size_t(0));
   }
 
   void test_update_lookup_index_table_updates_all_groups() {
@@ -82,7 +82,7 @@ public:
 
     for (auto const &group : m_runsTable.reductionJobs().groups()) {
       for (auto const &row : group.rows()) {
-        TS_ASSERT_EQUALS(row.get().lookupIndex(), boost::none);
+        TS_ASSERT_EQUALS(row.get().lookupIndex(), std::nullopt);
       }
     }
 
@@ -90,7 +90,7 @@ public:
 
     for (auto const &group : m_runsTable.reductionJobs().groups()) {
       for (auto const &row : group.rows()) {
-        TS_ASSERT(row.is_initialized());
+        TS_ASSERT(row.has_value());
         if (row.get().theta() == 0.5) {
           TS_ASSERT_EQUALS(row.get().lookupIndex(), size_t(1));
         } else {
@@ -110,9 +110,9 @@ public:
 
     auto model = Batch(exp, m_instrument, m_runsTable, m_slicing);
 
-    TS_ASSERT_EQUALS(group.rows()[0].get().lookupIndex(), boost::none);
+    TS_ASSERT_EQUALS(group.rows()[0].get().lookupIndex(), std::nullopt);
     model.updateLookupIndex(group.mutableRows()[0].get());
-    TS_ASSERT(!group.rows()[0].get().lookupIndex().is_initialized());
+    TS_ASSERT(!group.rows()[0].get().lookupIndex().has_value());
     TS_ASSERT_EQUALS(group.rows()[0].get().state(), State::ITEM_ERROR);
     TS_ASSERT_EQUALS(group.rows()[0].get().message(), "Multiple matching Experiment Setting rows")
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/GroupTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/GroupTest.h
@@ -498,23 +498,23 @@ public:
   void test_index_of_row_with_theta_exact_match() {
     auto group = makeGroupWithThreeRows();
     auto maybeIndex = group.indexOfRowWithTheta(0.2, 0.01);
-    TS_ASSERT(maybeIndex.is_initialized());
-    if (maybeIndex.is_initialized())
+    TS_ASSERT(maybeIndex.has_value());
+    if (maybeIndex.has_value())
       TS_ASSERT_EQUALS(*maybeIndex, 1);
   }
 
   void test_index_of_row_with_theta_within_tolerance() {
     auto group = makeGroupWithThreeRows();
     auto maybeIndex = group.indexOfRowWithTheta(0.209, 0.01);
-    TS_ASSERT(maybeIndex.is_initialized());
-    if (maybeIndex.is_initialized())
+    TS_ASSERT(maybeIndex.has_value());
+    if (maybeIndex.has_value())
       TS_ASSERT_EQUALS(*maybeIndex, 1);
   }
 
   void test_index_of_row_with_theta_outside_tolerance() {
     auto group = makeGroupWithThreeRows();
     auto maybeIndex = group.indexOfRowWithTheta(0.23, 0.01);
-    TS_ASSERT(!maybeIndex.is_initialized());
+    TS_ASSERT(!maybeIndex.has_value());
   }
 
   void test_find_row_with_output_name() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
@@ -291,7 +291,7 @@ public:
 
   void test_searching_by_title_matches_empty_regex() {
     auto constexpr angle = 2.3;
-    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
+    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, std::nullopt);
     auto table = LookupTable{emptyRegexRow};
 
     auto group = Group("En Oh", {ModelCreationHelper::makeRow(angle)});
@@ -302,7 +302,7 @@ public:
 
   void test_searching_by_title_matches_empty_regex_for_preview_row() {
     auto constexpr angle = 2.3;
-    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
+    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, std::nullopt);
     auto table = LookupTable{emptyRegexRow};
 
     auto row = ModelCreationHelper::makePreviewRow(angle, "En Oh"s);
@@ -313,7 +313,7 @@ public:
 
   void test_empty_title_matches_only_empty_regex() {
     auto constexpr angle = 2.3;
-    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
+    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, std::nullopt);
     auto regexRow = ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay"));
     auto table = LookupTable{emptyRegexRow, regexRow};
 
@@ -325,7 +325,7 @@ public:
 
   void test_empty_title_matches_only_empty_regex_for_preview_row() {
     auto constexpr angle = 2.3;
-    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
+    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, std::nullopt);
     auto regexRow = ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay"));
     auto table = LookupTable{emptyRegexRow, regexRow};
 
@@ -337,7 +337,7 @@ public:
 
   void test_no_loaded_ws_matches_only_empty_regex_for_preview_row() {
     auto constexpr angle = 2.3;
-    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
+    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, std::nullopt);
     auto regexRow = ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay"));
     auto table = LookupTable{emptyRegexRow, regexRow};
 
@@ -370,7 +370,7 @@ public:
   void test_searching_with_no_matching_title_but_matching_theta_with_matching_title_present() {
     auto angle = 0.7;
     auto regexRow = ModelCreationHelper::makeLookupRow(2.3, boost::regex("Ay"));
-    auto nonRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
+    auto nonRegexRow = ModelCreationHelper::makeLookupRow(angle, std::nullopt);
     auto table = LookupTable{regexRow, nonRegexRow};
 
     auto group = Group("Ay Bee", {ModelCreationHelper::makeRow(angle)});
@@ -382,7 +382,7 @@ public:
   void test_searching_with_no_matching_title_but_matching_theta_with_matching_title_present_for_preview_row() {
     auto angle = 0.7;
     auto regexRow = ModelCreationHelper::makeLookupRow(2.3, boost::regex("Ay"));
-    auto nonRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
+    auto nonRegexRow = ModelCreationHelper::makeLookupRow(angle, std::nullopt);
     auto table = LookupTable{regexRow, nonRegexRow};
 
     auto row = ModelCreationHelper::makePreviewRow(angle, "Ay Bee"s);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/MockGroup.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/MockGroup.h
@@ -39,7 +39,7 @@ public:
 
   MOCK_METHOD(void, resetSkipped, (), (override));
 
-  MOCK_METHOD(boost::optional<int>, indexOfRowWithTheta, (double, double), (const, override));
+  MOCK_METHOD(std::optional<int>, indexOfRowWithTheta, (double, double), (const, override));
 
   MOCK_METHOD(boost::optional<Row> const &, bracketOp, (int), (const));
   MOCK_METHOD(std::vector<boost::optional<Row>> const &, rows, (), (const, override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ParseReflectometryStringsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ParseReflectometryStringsTest.h
@@ -81,17 +81,17 @@ public:
 
   void testParseTitleMatcherEmpty() {
     auto result = parseTitleMatcher("      \t  ");
-    TS_ASSERT(!result.is_initialized());
+    TS_ASSERT(!result.has_value());
   }
 
   void testParseTitleMatcher() {
     auto result = parseTitleMatcher(".*");
-    TS_ASSERT(result.is_initialized());
+    TS_ASSERT(result.has_value());
   }
 
   void testParseTitleMatcherHandlesInvalidRegex() {
     auto result = parseTitleMatcher("[");
-    TS_ASSERT(!result.is_initialized());
+    TS_ASSERT(!result.has_value());
   }
 
   void testParseOptions() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/RowTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/RowTest.h
@@ -77,17 +77,17 @@ public:
 
   void test_set_get_lookup_row_index() {
     auto row = makeEmptyRow();
-    auto index = boost::optional<size_t>{1};
+    auto index = std::optional<size_t>{1};
     row.setLookupIndex(index);
-    TS_ASSERT(row.lookupIndex().is_initialized());
-    TS_ASSERT_EQUALS(row.lookupIndex().get(), index.get());
+    TS_ASSERT(row.lookupIndex().has_value());
+    TS_ASSERT_EQUALS(row.lookupIndex().value(), index.value());
   }
 
   void test_set_get_no_lookup_row_index() {
     auto row = makeEmptyRow();
-    auto index = boost::none;
+    std::optional<size_t> index = std::nullopt;
     row.setLookupIndex(index);
-    TS_ASSERT(!row.lookupIndex().is_initialized());
-    TS_ASSERT_EQUALS(row.lookupIndex(), boost::none);
+    TS_ASSERT(!row.lookupIndex().has_value());
+    TS_ASSERT_EQUALS(row.lookupIndex(), std::nullopt);
   }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ValidateLookupRowTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ValidateLookupRowTest.h
@@ -44,8 +44,8 @@ public:
   void testParseTitleMatcherEmpty() {
     LookupRowValidator validator;
     auto result = validator({"0.5", ""});
-    TS_ASSERT(result.isValid());                                     // Outer initialized (not invalid)
-    TS_ASSERT(!result.assertValid().titleMatcher().is_initialized()) // Inner not initialized (empty)
+    TS_ASSERT(result.isValid());                                // Outer initialized (not invalid)
+    TS_ASSERT(!result.assertValid().titleMatcher().has_value()) // Inner not initialized (empty)
   }
 
   void testParseTitleMatcherWhitespace() {
@@ -53,7 +53,7 @@ public:
     auto result = validator({"0.5", "    \t"});
     TS_ASSERT(result.isValid());
     // All whitespace is the equivalent of an empty string
-    TS_ASSERT(!result.assertValid().titleMatcher().is_initialized())
+    TS_ASSERT(!result.assertValid().titleMatcher().has_value())
   }
 
   void testParseTitleMatcherSimpleValid() {
@@ -63,8 +63,8 @@ public:
     TS_ASSERT(result.isValid());
 
     auto const &titleMatcher = result.assertValid().titleMatcher();
-    TS_ASSERT(titleMatcher.is_initialized())
-    TS_ASSERT_EQUALS(expected, titleMatcher.get().expression())
+    TS_ASSERT(titleMatcher.has_value())
+    TS_ASSERT_EQUALS(expected, titleMatcher.value().expression())
   }
 
   void testParseTitleMatcherRegexCharsValid() {
@@ -74,8 +74,8 @@ public:
     TS_ASSERT(result.isValid());
 
     auto const &titleMatcher = result.assertValid().titleMatcher();
-    TS_ASSERT(titleMatcher.is_initialized())
-    TS_ASSERT_EQUALS(expected, titleMatcher.get().expression())
+    TS_ASSERT(titleMatcher.has_value())
+    TS_ASSERT_EQUALS(expected, titleMatcher.value().expression())
   }
 
   void testParseTitleMatcherInvalid() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ValidateRowTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ValidateRowTest.h
@@ -23,104 +23,104 @@ public:
   void test() {}
 
   void testParsesTriviallyValidDoubles() {
-    TS_ASSERT_DELTA(1.0, parseDouble("1.0").get(), TOLERANCE);
-    TS_ASSERT_DELTA(6.4, parseDouble("6.4").get(), TOLERANCE);
-    TS_ASSERT_DELTA(0.0, parseDouble("0").get(), TOLERANCE);
-    TS_ASSERT_DELTA(-7000.3, parseDouble("-7000.3").get(), TOLERANCE);
+    TS_ASSERT_DELTA(1.0, parseDouble("1.0").value(), TOLERANCE);
+    TS_ASSERT_DELTA(6.4, parseDouble("6.4").value(), TOLERANCE);
+    TS_ASSERT_DELTA(0.0, parseDouble("0").value(), TOLERANCE);
+    TS_ASSERT_DELTA(-7000.3, parseDouble("-7000.3").value(), TOLERANCE);
   }
 
   void testParsesValidDoublesWithLeadingAndTrailingWhitespace() {
-    TS_ASSERT_DELTA(1.0, parseDouble("  1.0  ").get(), TOLERANCE);
-    TS_ASSERT_DELTA(6.4, parseDouble("\n   6.4").get(), TOLERANCE);
-    TS_ASSERT_DELTA(0.0, parseDouble("0").get(), TOLERANCE);
-    TS_ASSERT_DELTA(-7000.3, parseDouble("\t-7000.3\t").get(), TOLERANCE);
+    TS_ASSERT_DELTA(1.0, parseDouble("  1.0  ").value(), TOLERANCE);
+    TS_ASSERT_DELTA(6.4, parseDouble("\n   6.4").value(), TOLERANCE);
+    TS_ASSERT_DELTA(0.0, parseDouble("0").value(), TOLERANCE);
+    TS_ASSERT_DELTA(-7000.3, parseDouble("\t-7000.3\t").value(), TOLERANCE);
   }
 
   void testFailsForTriviallyInvalidDoubles() {
-    TS_ASSERT_EQUALS(boost::none, parseDouble(""));
-    TS_ASSERT_EQUALS(boost::none, parseDouble("ABCD"));
-    TS_ASSERT_EQUALS(boost::none, parseDouble("A0.12"));
-    TS_ASSERT_EQUALS(boost::none, parseDouble("O.12"));
+    TS_ASSERT_EQUALS(std::nullopt, parseDouble(""));
+    TS_ASSERT_EQUALS(std::nullopt, parseDouble("ABCD"));
+    TS_ASSERT_EQUALS(std::nullopt, parseDouble("A0.12"));
+    TS_ASSERT_EQUALS(std::nullopt, parseDouble("O.12"));
   }
 
   void testFailsForOutOfRangeDoubles() {
     auto bigPositiveDoubleAsString = std::string(380, '9');
-    TS_ASSERT_EQUALS(boost::none, parseDouble(bigPositiveDoubleAsString));
+    TS_ASSERT_EQUALS(std::nullopt, parseDouble(bigPositiveDoubleAsString));
     auto smallNegativeDoubleAsString = "-" + bigPositiveDoubleAsString;
-    TS_ASSERT_EQUALS(boost::none, parseDouble(smallNegativeDoubleAsString));
+    TS_ASSERT_EQUALS(std::nullopt, parseDouble(smallNegativeDoubleAsString));
   }
 
   void testParsesTriviallyValidInts() {
-    TS_ASSERT_EQUALS(1, parseInt("1").get());
-    TS_ASSERT_EQUALS(64, parseInt("64").get());
-    TS_ASSERT_EQUALS(0, parseInt("0").get());
-    TS_ASSERT_EQUALS(-7000, parseInt("-7000").get());
+    TS_ASSERT_EQUALS(1, parseInt("1").value());
+    TS_ASSERT_EQUALS(64, parseInt("64").value());
+    TS_ASSERT_EQUALS(0, parseInt("0").value());
+    TS_ASSERT_EQUALS(-7000, parseInt("-7000").value());
   }
 
   void testParsesValidIntsWithLeadingAndTrailingWhitespace() {
-    TS_ASSERT_EQUALS(10, parseInt("  10  ").get());
-    TS_ASSERT_EQUALS(64, parseInt("\n   64").get());
-    TS_ASSERT_EQUALS(0, parseInt("  0\r\n").get());
-    TS_ASSERT_EQUALS(-7003, parseInt("\t-7003\t").get());
+    TS_ASSERT_EQUALS(10, parseInt("  10  ").value());
+    TS_ASSERT_EQUALS(64, parseInt("\n   64").value());
+    TS_ASSERT_EQUALS(0, parseInt("  0\r\n").value());
+    TS_ASSERT_EQUALS(-7003, parseInt("\t-7003\t").value());
   }
 
   void testParsesValidIntsWithLeadingZeroes() {
-    TS_ASSERT_EQUALS(30, parseInt("000030").get());
-    TS_ASSERT_EQUALS(64, parseInt(" 00064").get());
-    TS_ASSERT_EQUALS(100, parseInt("00100").get());
+    TS_ASSERT_EQUALS(30, parseInt("000030").value());
+    TS_ASSERT_EQUALS(64, parseInt(" 00064").value());
+    TS_ASSERT_EQUALS(100, parseInt("00100").value());
   }
 
   void testFailsForTriviallyInvalidInts() {
-    TS_ASSERT_EQUALS(boost::none, parseInt(""));
-    TS_ASSERT_EQUALS(boost::none, parseInt("ABCD"));
-    TS_ASSERT_EQUALS(boost::none, parseInt("A0"));
-    TS_ASSERT_EQUALS(boost::none, parseInt("O.12"));
+    TS_ASSERT_EQUALS(std::nullopt, parseInt(""));
+    TS_ASSERT_EQUALS(std::nullopt, parseInt("ABCD"));
+    TS_ASSERT_EQUALS(std::nullopt, parseInt("A0"));
+    TS_ASSERT_EQUALS(std::nullopt, parseInt("O.12"));
   }
 
   void testFailsForOutOfRangeInts() {
     auto bigPositiveIntAsString = std::string(380, '9');
-    TS_ASSERT_EQUALS(boost::none, parseInt(bigPositiveIntAsString));
+    TS_ASSERT_EQUALS(std::nullopt, parseInt(bigPositiveIntAsString));
     auto smallNegativeIntAsString = "-" + bigPositiveIntAsString;
-    TS_ASSERT_EQUALS(boost::none, parseInt(smallNegativeIntAsString));
+    TS_ASSERT_EQUALS(std::nullopt, parseInt(smallNegativeIntAsString));
   }
 
   void testParsesTriviallyValidNonNegativeInts() {
-    TS_ASSERT_EQUALS(1, parseNonNegativeInt("1").get());
-    TS_ASSERT_EQUALS(64, parseNonNegativeInt("64").get());
-    TS_ASSERT_EQUALS(0, parseNonNegativeInt("0").get());
-    TS_ASSERT_EQUALS(6999, parseNonNegativeInt("6999").get());
+    TS_ASSERT_EQUALS(1, parseNonNegativeInt("1").value());
+    TS_ASSERT_EQUALS(64, parseNonNegativeInt("64").value());
+    TS_ASSERT_EQUALS(0, parseNonNegativeInt("0").value());
+    TS_ASSERT_EQUALS(6999, parseNonNegativeInt("6999").value());
   }
 
   void testParsesValidNonNegativeIntsWithLeadingAndTrailingWhitespace() {
-    TS_ASSERT_EQUALS(13, parseNonNegativeInt("  13  ").get());
-    TS_ASSERT_EQUALS(58, parseNonNegativeInt("\n   58").get());
-    TS_ASSERT_EQUALS(0, parseNonNegativeInt("  0\r\n").get());
-    TS_ASSERT_EQUALS(7003, parseNonNegativeInt("\t7003\t").get());
+    TS_ASSERT_EQUALS(13, parseNonNegativeInt("  13  ").value());
+    TS_ASSERT_EQUALS(58, parseNonNegativeInt("\n   58").value());
+    TS_ASSERT_EQUALS(0, parseNonNegativeInt("  0\r\n").value());
+    TS_ASSERT_EQUALS(7003, parseNonNegativeInt("\t7003\t").value());
   }
 
   void testParsesValidNonNegativeIntsWithLeadingZeroes() {
-    TS_ASSERT_EQUALS(30, parseNonNegativeInt("000030").get());
-    TS_ASSERT_EQUALS(64, parseNonNegativeInt(" 00064").get());
-    TS_ASSERT_EQUALS(100, parseNonNegativeInt("00100").get());
+    TS_ASSERT_EQUALS(30, parseNonNegativeInt("000030").value());
+    TS_ASSERT_EQUALS(64, parseNonNegativeInt(" 00064").value());
+    TS_ASSERT_EQUALS(100, parseNonNegativeInt("00100").value());
   }
 
   void testFailsForTriviallyInvalidNonNegativeInts() {
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt(""));
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt("ABCD"));
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt("A0"));
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt("O.12"));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt(""));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt("ABCD"));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt("A0"));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt("O.12"));
   }
 
   void testFailsForOutOfRangeNonNegativeInts() {
     auto bigPositiveIntAsString = std::string(380, '9');
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt(bigPositiveIntAsString));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt(bigPositiveIntAsString));
     auto smallNegativeIntAsString = "-" + bigPositiveIntAsString;
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt(smallNegativeIntAsString));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt(smallNegativeIntAsString));
   }
 
   void testFailsForNegativeInts() {
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt("-1"));
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt("-3400"));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt("-1"));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt("-3400"));
   }
 
   void testParsesSingleRunNumber() {


### PR DESCRIPTION
As part of the modernization work laid out in #37875, this migrates more of the reflectometry interface from `boost::optional` to `std::optional`. 

The things being intentionally skipped use the following classes as optional:
* `string` which is involved in the `boost::optional<boost::optional<string>>` and breaks tests
* `double` which prompts changes in the sip bindings
* `Item`
* `LookupCriteriaError`
* `LookupRow`
* `ProcessingInstructions`
* `Row`
* `RowLocation`
* `Subtree`

### To test:

This is a refactor so all tests should pass, but poking around with the ISIS reflectometry GUI is a good idea.


*This does not require release notes.*

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
