### PR TITLE
H5Util read 1d slices of data

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/H5Util.h
+++ b/Framework/Nexus/inc/MantidNexus/H5Util.h
@@ -95,6 +95,9 @@ template <typename NumT> std::vector<NumT> readArray1DCoerce(const H5::Group &gr
 
 template <typename NumT> void readArray1DCoerce(const H5::DataSet &dataset, std::vector<NumT> &output);
 
+template <typename NumT>
+void readArray1DCoerce(const H5::DataSet &dataset, std::vector<NumT> &output, const size_t length, const size_t offset);
+
 /// Test if a group already exists within an HDF5 file or parent group.
 MANTID_NEXUS_DLL bool groupExists(H5::H5Object &h5, const std::string &groupPath);
 

--- a/Framework/Nexus/inc/MantidNexus/H5Util.h
+++ b/Framework/Nexus/inc/MantidNexus/H5Util.h
@@ -8,6 +8,7 @@
 
 #include "MantidNexus/DllConfig.h"
 
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
@@ -91,12 +92,13 @@ std::vector<NumT> readNumArrayAttributeCoerce(const H5::H5Object &object, const 
 
 template <typename NumT>
 void readArray1DCoerce(const H5::Group &group, const std::string &name, std::vector<NumT> &output);
+
 template <typename NumT> std::vector<NumT> readArray1DCoerce(const H5::Group &group, const std::string &name);
 
-template <typename NumT> void readArray1DCoerce(const H5::DataSet &dataset, std::vector<NumT> &output);
-
 template <typename NumT>
-void readArray1DCoerce(const H5::DataSet &dataset, std::vector<NumT> &output, const size_t length, const size_t offset);
+void readArray1DCoerce(const H5::DataSet &dataset, std::vector<NumT> &output,
+                       const size_t length = std::numeric_limits<size_t>::max(),
+                       const size_t offset = static_cast<size_t>(0));
 
 /// Test if a group already exists within an HDF5 file or parent group.
 MANTID_NEXUS_DLL bool groupExists(H5::H5Object &h5, const std::string &groupPath);

--- a/Framework/Nexus/src/H5Util.cpp
+++ b/Framework/Nexus/src/H5Util.cpp
@@ -380,15 +380,13 @@ std::vector<NumT> readNumArrayAttributeCoerce(const H5::H5Object &object, const 
 }
 
 template <typename NumT> void readArray1DCoerce(const DataSet &dataset, std::vector<NumT> &output) {
-  DataType dataType = dataset.getDataType();
+  const DataType dataType = dataset.getDataType();
 
   if (getType<NumT>() == dataType) { // no conversion necessary
-    DataSpace dataSpace = dataset.getSpace();
-    output.resize(dataSpace.getSelectNpoints());
+    const DataSpace dataSpace = dataset.getSpace();
+    output.resize(static_cast<size_t>(dataSpace.getSelectNpoints()));
     dataset.read(output.data(), dataType, dataSpace);
-  }
-
-  if (PredType::NATIVE_INT32 == dataType) {
+  } else if (PredType::NATIVE_INT32 == dataType) {
     convertingRead<int32_t>(dataset, dataType, output);
   } else if (PredType::NATIVE_UINT32 == dataType) {
     convertingRead<uint32_t>(dataset, dataType, output);

--- a/Framework/Nexus/test/H5UtilTest.h
+++ b/Framework/Nexus/test/H5UtilTest.h
@@ -135,7 +135,7 @@ public:
 
     TS_ASSERT(std::filesystem::exists(FILENAME));
 
-    { // read tests
+    { // ---------- simple read tests
       H5File file(FILENAME, H5F_ACC_RDONLY);
       auto group = file.openGroup(GRP_NAME);
 
@@ -150,6 +150,63 @@ public:
       TS_ASSERT_THROWS(H5Util::readArray1DCoerce<int32_t>(group, "array1d_uint32"),
                        const boost::numeric::positive_overflow &);
       TS_ASSERT_THROWS_NOTHING(H5Util::readArray1DCoerce<uint32_t>(group, "array1d_int32"));
+
+      // ---------- slicing read tests
+      auto dataSetFloat = group.openDataSet("array1d_float");
+      auto dataSetDouble = group.openDataSet("array1d_double");
+
+      std::vector<double> output;
+      // full dataset
+      output.clear();
+      H5Util::readArray1DCoerce(dataSetFloat, output, array1d_double.size(), 0);
+      TS_ASSERT_EQUALS(output, array1d_double); // whole thing w/ coercion
+      output.clear();
+      H5Util::readArray1DCoerce(dataSetDouble, output, array1d_double.size(), 0);
+      TS_ASSERT_EQUALS(output, array1d_double); // whole thing w/o coercion
+      output.clear();
+      H5Util::readArray1DCoerce(dataSetFloat, output, array1d_double.size() + 1, 0);
+      TS_ASSERT_EQUALS(output, array1d_double); // more than the whole thing w/ coercion
+      output.clear();
+      H5Util::readArray1DCoerce(dataSetDouble, output, array1d_double.size() + 1, 0);
+      TS_ASSERT_EQUALS(output, array1d_double); // more than the whole thing w/o coercion
+
+      { // partial dataset from front 1->end
+        const std::vector<double> expected({1, 2, 3, 4});
+        output.clear();
+        H5Util::readArray1DCoerce(dataSetFloat, output, array1d_double.size() - 1, 1);
+        TS_ASSERT_EQUALS(output, expected); // w/ coercion
+        output.clear();
+        H5Util::readArray1DCoerce(dataSetDouble, output, array1d_double.size() - 1, 1);
+        TS_ASSERT_EQUALS(output, expected); // w/o coercion
+      }
+
+      { // partial dataset from front 0->end-1
+        const std::vector<double> expected({0, 1, 2, 3});
+        output.clear();
+        H5Util::readArray1DCoerce(dataSetFloat, output, array1d_double.size() - 1, 0);
+        TS_ASSERT_EQUALS(output, expected); // w/ coercion
+        output.clear();
+        H5Util::readArray1DCoerce(dataSetDouble, output, array1d_double.size() - 1, 0);
+        TS_ASSERT_EQUALS(output, expected); // w/o coercion
+      }
+      { // partial dataset from front 1->end-1
+        const std::vector<double> expected({1, 2, 3});
+        output.clear();
+        H5Util::readArray1DCoerce(dataSetFloat, output, array1d_double.size() - 2, 1);
+        TS_ASSERT_EQUALS(output, expected); // w/ coercion
+        output.clear();
+        H5Util::readArray1DCoerce(dataSetDouble, output, array1d_double.size() - 2, 1);
+        TS_ASSERT_EQUALS(output, expected); // w/o coercion
+      }
+      { // from 1->end+1
+        const std::vector<double> expected({1, 2, 3, 4});
+        output.clear();
+        H5Util::readArray1DCoerce(dataSetFloat, output, array1d_double.size() + 1, 1);
+        TS_ASSERT_EQUALS(output, expected); // w/ coercion
+        output.clear();
+        H5Util::readArray1DCoerce(dataSetDouble, output, array1d_double.size() + 1, 1);
+        TS_ASSERT_EQUALS(output, expected); // w/o coercion
+      }
 
       file.close();
     }


### PR DESCRIPTION
While working with some data processing prototypes, it was discovered that there was not a function for reading parts of 1d arrays. This adds the methods for that. Also, there was a bug in `H5Util::readArray1DCoerce` that would read the data twice in the case of the requested data type matching the one on file.

Refs #38332

### To test:

This is split off from changes that use it to reduce the difficulty in reviewing it. Since it is a new function it is probably best to review the code and tests.

*This does not require release notes* because it is an additional internal function.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
