### PR TITLE
added and propagated FullBinsOnly flag

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/RebinRaggedTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/RebinRaggedTest.py
@@ -126,6 +126,73 @@ class RebinRaggedTest(unittest.TestCase):
                 # parameters are set so all y-values are 0.6
                 np.testing.assert_almost_equal(14, y, err_msg=label)
 
+    def test_FullBinsOnly(self):
+        xExpected = [0.5, 2.5, 4.5, 6.5]
+        yExpected = [10, 24, 38]
+
+        def Create1DWorkspace(size):
+            xData = []
+            yData = []
+            j = 0.5
+            for i in range(0, size + 1):
+                xData.append(j)
+                yData.append((i + 1) * 2)
+                j = 0.75 + j
+            yData.pop()
+            ws = api.CreateWorkspace(xData, yData)
+            return ws
+
+        inputWs = Create1DWorkspace(10)
+
+        api.RebinRagged(InputWorkspace=inputWs, OutputWorkspace="NotFullBinsOnly", Delta=2.0, PreserveEvents=True, FullBinsOnly=False)
+        fullBinsOnlyWs = api.RebinRagged(
+            InputWorkspace=inputWs, OutputWorkspace="FullBinsOnly", Delta=2.0, PreserveEvents=True, FullBinsOnly=True
+        )
+
+        fullBinsXValues = AnalysisDataService.retrieve("FullBinsOnly").readX(0)
+        fullBinsYValues = AnalysisDataService.retrieve("FullBinsOnly").readY(0)
+
+        notFullBinsXValues = AnalysisDataService.retrieve("NotFullBinsOnly").readX(0)
+
+        assert not fullBinsOnlyWs.isRaggedWorkspace()
+
+        assert len(fullBinsXValues) == len(xExpected)
+        assert len(notFullBinsXValues) != len(fullBinsXValues)
+
+        for i in range(len(fullBinsXValues)):
+            np.testing.assert_almost_equal(fullBinsXValues[i], xExpected[i])
+
+        for i in range(len(fullBinsYValues)):
+            np.testing.assert_almost_equal(fullBinsYValues[i], yExpected[i])
+
+        api.DeleteWorkspace("NotFullBinsOnly")
+        api.DeleteWorkspace("FullBinsOnly")
+        api.DeleteWorkspace(inputWs)
+
+    def test_hist_workspace_fullBinsOnly(self):
+        # numpy 1.7 (on rhel7) doesn't have np.full
+        xmins = np.full((200,), 50.0)
+        xmins[11] = 3000.0
+        xmaxs = np.full((200,), 650.0)
+        xmaxs[12] = 5000.0
+        deltas = np.full(200, -2.0)
+        deltas[13] = 100.0
+
+        inputWs = api.CreateSampleWorkspace(OutputWorkspace="RebinRagged_hist", WorkspaceType="Histogram", BinWidth=75, XMin=50)
+
+        notFullBinsOnlyWs = api.RebinRagged(
+            InputWorkspace=inputWs, OutputWorkspace="NotFullBinsOnly", XMin=xmins, XMax=xmaxs, Delta=deltas, FullBinsOnly=False
+        )
+        fullBinsOnlyWs = api.RebinRagged(
+            InputWorkspace=inputWs, OutputWorkspace="FullBinsOnly", XMin=xmins, XMax=xmaxs, Delta=deltas, FullBinsOnly=True
+        )
+
+        assert len(fullBinsOnlyWs.readX(0)) != len(notFullBinsOnlyWs.readX(0))
+        assert fullBinsOnlyWs.isRaggedWorkspace()
+        api.DeleteWorkspace("NotFullBinsOnly")
+        api.DeleteWorkspace("FullBinsOnly")
+        api.DeleteWorkspace(inputWs)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/algorithms/RebinRagged-v2.rst
+++ b/docs/source/algorithms/RebinRagged-v2.rst
@@ -41,6 +41,40 @@ This particular use-case, which uses the input workspace's binning, could be don
                         Xmax=[10.20, 20.8, nan, nan, nan, 9.35])
 
 
+Sometimes due to the data or logarithmic rebinning, there are incomplete bins left over at the end of the spectrum.  These incomplete bins may result in artificats at the tail end.  This can be removed by setting the `FullBinsOnly` parameter to `True`.
+
+.. code-block:: python
+
+    from mantid.simpleapi import *
+
+    from time import time
+
+
+    ## create a workspace to be rebin-ragged
+    wsname = "ws"
+    CreateSampleWorkspace(
+        OutputWorkspace=wsname,
+        BankPixelWidth=3,
+    )
+    GroupDetectors(
+        InputWorkspace=wsname,
+        OutputWorkspace=wsname,
+        GroupingPattern="0-3,4-5,6-8,9-12,13-14,15-17",
+    )
+
+    # rebin the workspace raggedly
+    xMin = [0.05,0.06,0.1,0.07,0.04, 0.04]
+    xMax = [0.36,0.41,0.64,0.48,0.48,0.48]
+    delta = [-0.000401475,-0.000277182,-0.000323453,-0.000430986,-0.000430986,-0.000430986]
+    RebinRagged(
+        InputWorkspace=wsname,
+        XMin=xMin,
+        XMax=xMax,
+        Delta=delta,
+        FullBinsOnly=True,
+        OutputWorkspace=wsname,
+    )
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/algorithms/RebinRagged-v2.rst
+++ b/docs/source/algorithms/RebinRagged-v2.rst
@@ -41,7 +41,7 @@ This particular use-case, which uses the input workspace's binning, could be don
                         Xmax=[10.20, 20.8, nan, nan, nan, 9.35])
 
 
-Sometimes due to the data or logarithmic rebinning, there are incomplete bins left over at the end of the spectrum.  These incomplete bins may result in artificats at the tail end.  This can be removed by setting the `FullBinsOnly` parameter to `True`.
+Sometimes due to the data or logarithmic rebinning, there are incomplete bins left over at the end of the spectrum.  These incomplete bins may result in artifacts at the tail end.  This can be removed by setting the `FullBinsOnly` parameter to `True`.
 
 .. code-block:: python
 

--- a/docs/source/algorithms/RebinRagged-v2.rst
+++ b/docs/source/algorithms/RebinRagged-v2.rst
@@ -20,6 +20,8 @@ The minimum and maximum values that are specified are interpreted as follows:
 The ``Delta`` parameter is required and can either be a single number which is common to all, or one number per spectra.
 Positive values are interpreted as constant step-size. Negative are logorithmic.
 
+Please refer to :ref:`Rebin <algm-Rebin>` for a more analytical explanation of `FullBinsOnly`.
+
 Usage
 -----
 

--- a/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38550.rst
+++ b/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38550.rst
@@ -1,0 +1,1 @@
+:ref:`RebinRagged <algm-RebinRagged>` exposes FullBinsOnly from Rebin Algo.

--- a/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38550.rst
+++ b/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38550.rst
@@ -1,1 +1,1 @@
-:ref:`RebinRagged <algm-RebinRagged>` exposes FullBinsOnly from Rebin Algo.
+- :ref:`RebinRagged <algm-RebinRagged>` exposes FullBinsOnly from Rebin Algo.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

This simply adds the FullBinsOnly parameter to RebinRagged and passes it to the appropriate functions in RebinRagged.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

This change was motivated by differences observed in the outputs of the application SNAPRed, and the algorithm SNAPReduce.
It was determined that the binning had actually produced artifacts at the end of the spectra, which is most notable in how the normalization is handled.  This artifact is able to be removed via the FullBinsOnly param.

*There is no associated issue.*
Refs: [EWM 8879](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=8879)

### To test:

Open RebinRagged in the Workbench. Observe the new param has been exposed.
Refer to [FullBinsOnly test](https://github.com/mantidproject/mantid/blob/865df3c9f8ff86a9be717bf45595b273feca25e7/Framework/Algorithms/test/RebinTest.h#L503C2-L508C4) for how to confirm this pass through was effective for RebinRagged. 


while not a 1-1 copy of the unit test, you can still observe that this param is being passed by running the following script in workbench:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

xExpected = [0.5, 2.5, 4.5, 6.5]
yExpected = [3, 8.0]
params = "2.0"

def Create1DWorkspace(size):
    xData = []
    yData = []
    j = .5
    for i in range(0, size+1):
        xData.append(j)
        yData.append((i+1)*2)
        j = .75 + j
    yData.pop()
    ws = CreateWorkspace(xData, yData)
    return ws

inputWs = Create1DWorkspace(10)

RebinRagged(InputWorkspace=inputWs, OutputWorkspace="NotFullBinsOnly", Delta=2.0, PreserveEvents=True, FullBinsOnly=False)

RebinRagged(InputWorkspace=inputWs, OutputWorkspace="FullBinsOnly", Delta=2.0, PreserveEvents=True, FullBinsOnly=True)
```

You will see a difference if you just "View Data", one has an additional x value.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
