### PR TITLE
Add support for histogram ragged workspaces with density=true

### DIFF
--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -88,8 +88,8 @@ void ConvertUnits::exec() {
   const bool acceptPointData = getProperty("ConvertFromPointData");
   bool workspaceWasConverted = false;
 
-  // we can do that before anything else, because it doesn't
-  // setup any blocksize, which is the one that changes with conversion
+  // we can do that before anything else, because it doesn't setup any blocksize, which is the one that changes with
+  // conversion
   this->setupMemberVariables(inputWS);
 
   // Check that the input workspace doesn't already have the desired unit.
@@ -97,11 +97,9 @@ void ConvertUnits::exec() {
     const std::string outputWSName = getPropertyValue("OutputWorkspace");
     const std::string inputWSName = getPropertyValue("InputWorkspace");
     if (outputWSName == inputWSName) {
-      // If it does, just set the output workspace to point to the input one and
-      // be done.
+      // If it does, just set the output workspace to point to the input one and be done
       g_log.information() << "Input workspace already has target unit (" << m_outputUnit->unitID()
-                          << "), so just pointing the output workspace "
-                             "property to the input workspace.\n";
+                          << "), so just pointing the output workspace property to the input workspace.\n";
       setProperty("OutputWorkspace", std::const_pointer_cast<MatrixWorkspace>(inputWS));
       return;
     } else {
@@ -136,8 +134,7 @@ void ConvertUnits::exec() {
         throw std::runtime_error("Failed to convert workspace from Points to Bins");
       }
     } else {
-      throw std::runtime_error("Workspace contains points, you can either run "
-                               "ConvertToHistogram on it, or set "
+      throw std::runtime_error("Workspace contains points, you can either run ConvertToHistogram on it, or set "
                                "ConvertFromPointData to enabled");
     }
   } else {
@@ -161,8 +158,7 @@ void ConvertUnits::exec() {
   }
 
   // Point the output property to the right place.
-  // Do right at end (workspace could could change in removeUnphysicalBins or
-  // alignBins methods)
+  // Do right at end (workspace could could change in removeUnphysicalBins or alignBins methods)
   setProperty("OutputWorkspace", outputWS);
 }
 
@@ -178,9 +174,7 @@ MatrixWorkspace_sptr ConvertUnits::executeUnitConversion(const API::MatrixWorksp
   // 2 edges, having less than 2 values would mean that the WS contains Points
   if (inputWS->x(0).size() < 2) {
     std::stringstream msg;
-    msg << "Input workspace has invalid X axis binning parameters. Should "
-           "have "
-           "at least 2 values. Found "
+    msg << "Input workspace has invalid X axis binning parameters. Should have at least 2 values. Found "
         << inputWS->x(0).size() << ".";
     throw std::runtime_error(msg.str());
   }
@@ -193,17 +187,14 @@ MatrixWorkspace_sptr ConvertUnits::executeUnitConversion(const API::MatrixWorksp
   // Check whether there is a quick conversion available
   double factor, power;
   if (m_inputUnit->quickConversion(*m_outputUnit, factor, power))
-  // If test fails, could also check whether a quick conversion in the
-  // opposite
-  // direction has been entered
+  // If test fails, could also check whether a quick conversion in the opposite direction has been entered
   {
     outputWS = this->convertQuickly(inputWS, factor, power);
   } else {
     outputWS = this->convertViaTOF(m_inputUnit, inputWS);
   }
 
-  // If the units conversion has flipped the ascending direction of X, reverse
-  // all the vectors
+  // If the units conversion has flipped the ascending direction of X, reverse all the vectors
   if (!outputWS->x(0).empty() &&
       (outputWS->x(0).front() > outputWS->x(0).back() ||
        outputWS->x(m_numberOfSpectra / 2).front() > outputWS->x(m_numberOfSpectra / 2).back())) {
@@ -211,21 +202,19 @@ MatrixWorkspace_sptr ConvertUnits::executeUnitConversion(const API::MatrixWorksp
   }
 
   // Need to lop bins off if converting to energy transfer.
-  // Don't do for EventWorkspaces, where you can easily rebin to recover the
-  // situation without losing information
+  // Don't do for EventWorkspaces, where you can easily rebin to recover the situation without losing information
   /* This is an ugly test - could be made more general by testing for DBL_MAX
   values at the ends of all spectra, but that would be less efficient */
   if (m_outputUnit->unitID().find("Delta") == 0 && !m_inputEvents)
     outputWS = this->removeUnphysicalBins(outputWS);
 
   // Rebin the data to common bins if requested, and if necessary
-  bool doAlignBins = getProperty("AlignBins");
+  const bool doAlignBins = getProperty("AlignBins");
   if (doAlignBins && !outputWS->isCommonBins())
     outputWS = this->alignBins(outputWS);
 
   // If appropriate, put back the bin width division into Y/E.
-  if (m_distribution && !m_inputEvents) // Never do this for event workspaces
-  {
+  if (m_distribution && !m_inputEvents) { // Never do this for event workspaces
     this->putBackBinWidth(outputWS);
   }
 
@@ -255,9 +244,7 @@ void ConvertUnits::setupMemberVariables(const API::MatrixWorkspace_const_sptr &i
 API::MatrixWorkspace_sptr ConvertUnits::setupOutputWorkspace(const API::MatrixWorkspace_const_sptr &inputWS) {
   MatrixWorkspace_sptr outputWS = getProperty("OutputWorkspace");
 
-  // If input and output workspaces are NOT the same, create a new workspace
-  // for
-  // the output
+  // If input and output workspaces are NOT the same, create a new workspace for the output
   if (outputWS != inputWS) {
     outputWS = inputWS->clone();
   }
@@ -670,9 +657,8 @@ API::MatrixWorkspace_sptr ConvertUnits::removeUnphysicalBins(const Mantid::API::
  *  @param outputWS The workspace to operate on
  */
 void ConvertUnits::putBackBinWidth(const API::MatrixWorkspace_sptr &outputWS) {
-  const size_t outSize = outputWS->blocksize();
-
   for (size_t i = 0; i < m_numberOfSpectra; ++i) {
+    const size_t outSize = outputWS->getNumberBins(i);
     for (size_t j = 0; j < outSize; ++j) {
       const double width = std::abs(outputWS->x(i)[j + 1] - outputWS->x(i)[j]);
       outputWS->mutableY(i)[j] = outputWS->y(i)[j] / width;

--- a/Framework/Algorithms/test/ConvertUnitsTest.h
+++ b/Framework/Algorithms/test/ConvertUnitsTest.h
@@ -39,6 +39,11 @@ using Mantid::HistogramData::Points;
 
 namespace {
 
+namespace TestUnits {
+const std::string MOMENTUM_TRANSFER("MomentumTransfer");
+const std::string TOF("TOF");
+} // namespace TestUnits
+
 /// Creates a BinEdges workspace with TOF XUnits
 void setup_WS(std::string &inputSpace) {
   // Set up a small workspace for testing
@@ -55,7 +60,7 @@ void setup_WS(std::string &inputSpace) {
     space2D->getSpectrum(j).setSpectrumNo(j);
     space2D->getSpectrum(j).setDetectorID(j);
   }
-  space2D->getAxis(0)->unit() = UnitFactory::Instance().create("TOF");
+  space2D->getAxis(0)->unit() = UnitFactory::Instance().create(TestUnits::TOF);
 
   // Register the workspace in the data service
   AnalysisDataService::Instance().addOrReplace(inputSpace, space2D);
@@ -89,7 +94,7 @@ void setup_Points_WS(std::string &inputSpace) {
     space2D->getSpectrum(j).setSpectrumNo(j);
     space2D->getSpectrum(j).setDetectorID(j);
   }
-  space2D->getAxis(0)->unit() = UnitFactory::Instance().create("TOF");
+  space2D->getAxis(0)->unit() = UnitFactory::Instance().create(TestUnits::TOF);
 
   // Register the workspace in the data service
   AnalysisDataService::Instance().addOrReplace(inputSpace, space2D);
@@ -207,7 +212,7 @@ public:
     // Convert back to TOF
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspace", temp_ws_name));
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "outWS"));
-    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Target", "TOF"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Target", TestUnits::TOF));
     TS_ASSERT_THROWS_NOTHING(alg.execute());
     TS_ASSERT(alg.isExecuted());
 
@@ -225,7 +230,7 @@ public:
     TS_ASSERT(!output2D->isHistogramData());
 
     // check if the units are successfully converted
-    TS_ASSERT_EQUALS(output2D->getAxis(0)->unit()->unitID(), "TOF");
+    TS_ASSERT_EQUALS(output2D->getAxis(0)->unit()->unitID(), TestUnits::TOF);
 
     // Test that X data is still Points (it was converted back)
     TS_ASSERT_EQUALS(output2D->x(101).size(), 10);
@@ -270,8 +275,8 @@ public:
     alg.setRethrows(true);
     alg.setPropertyValue("InputWorkspace", inputSpace);
     alg.setPropertyValue("OutputWorkspace",
-                         inputSpace);      // OutputWorkspace == InputWorkspace
-    alg.setPropertyValue("Target", "TOF"); // Same as the input workspace.
+                         inputSpace);               // OutputWorkspace == InputWorkspace
+    alg.setPropertyValue("Target", TestUnits::TOF); // Same as the input workspace.
     alg.execute();
 
     auto outWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(inputSpace);
@@ -296,8 +301,8 @@ public:
     alg.setPropertyValue("InputWorkspace", inputSpace);
     const std::string outputWorkspaceName = "OutWSName";
     alg.setPropertyValue("OutputWorkspace",
-                         outputWorkspaceName); // OutputWorkspace == InputWorkspace
-    alg.setPropertyValue("Target", "TOF");     // Same as the input workspace.
+                         outputWorkspaceName);      // OutputWorkspace == InputWorkspace
+    alg.setPropertyValue("Target", TestUnits::TOF); // Same as the input workspace.
     alg.execute();
 
     auto outWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outputWorkspaceName);
@@ -388,7 +393,7 @@ public:
 
   void testConvertQuicklyCommonBins() {
     Workspace2D_sptr input = WorkspaceCreationHelper::create2DWorkspace123(3, 10, 1);
-    input->getAxis(0)->unit() = UnitFactory::Instance().create("MomentumTransfer");
+    input->getAxis(0)->unit() = UnitFactory::Instance().create(TestUnits::MOMENTUM_TRANSFER);
     AnalysisDataService::Instance().add("quickIn", input);
     ConvertUnits quickly;
     quickly.initialize();
@@ -427,7 +432,7 @@ public:
     // the scaling of Y and E for the distribution case is not testable.
     double deltax = 0.123;
     Workspace2D_sptr input = WorkspaceCreationHelper::create2DWorkspaceBinned(2, 10, x0, deltax);
-    input->getAxis(0)->unit() = UnitFactory::Instance().create("MomentumTransfer");
+    input->getAxis(0)->unit() = UnitFactory::Instance().create(TestUnits::MOMENTUM_TRANSFER);
     // Y must have units, otherwise ConvertUnits does not treat data as
     // distribution.
     input->setYUnit("Counts");
@@ -455,13 +460,13 @@ public:
     TS_ASSERT(convert2.isInitialized());
     convert2.setProperty("InputWorkspace", tmp_ws_name);
     convert2.setPropertyValue("OutputWorkspace", "output");
-    convert2.setPropertyValue("Target", "MomentumTransfer");
+    convert2.setPropertyValue("Target", TestUnits::MOMENTUM_TRANSFER);
     TS_ASSERT_THROWS_NOTHING(convert2.execute());
     TS_ASSERT(convert2.isExecuted());
 
     MatrixWorkspace_const_sptr output;
     TS_ASSERT_THROWS_NOTHING(output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("output"));
-    TS_ASSERT_EQUALS(output->getAxis(0)->unit()->unitID(), "MomentumTransfer");
+    TS_ASSERT_EQUALS(output->getAxis(0)->unit()->unitID(), TestUnits::MOMENTUM_TRANSFER);
     // What is this testing? Does it have to do with copy-on-write dataX?
     TS_ASSERT_EQUALS(&(output->x(0)[0]), &(output->x(0)[0]));
     const size_t xsize = output->blocksize();
@@ -495,7 +500,7 @@ public:
 
   void testDeltaE() {
     MatrixWorkspace_sptr ws = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 2663, 5, 7.5);
-    ws->getAxis(0)->unit() = UnitFactory::Instance().create("TOF");
+    ws->getAxis(0)->unit() = UnitFactory::Instance().create(TestUnits::TOF);
 
     Instrument_sptr testInst(new Instrument);
     // Make it look like MARI (though not bin boundaries are different to the
@@ -584,7 +589,7 @@ public:
 
   void testZeroLengthVectorExecutesWithNaNOutput() {
     MatrixWorkspace_sptr ws = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 2663, 5, 7.5);
-    ws->getAxis(0)->unit() = UnitFactory::Instance().create("TOF");
+    ws->getAxis(0)->unit() = UnitFactory::Instance().create(TestUnits::TOF);
 
     Instrument_sptr testInst(new Instrument);
     // Make it look like MARI (though not bin boundaries are different to the
@@ -612,14 +617,14 @@ public:
     conv.setProperty("InputWorkspace", ws);
     std::string outputSpace = "outWorkspace";
     conv.setPropertyValue("OutputWorkspace", outputSpace);
-    conv.setPropertyValue("Target", "MomentumTransfer");
+    conv.setPropertyValue("Target", TestUnits::MOMENTUM_TRANSFER);
     conv.setPropertyValue("Emode", "Direct");
     conv.setPropertyValue("Efixed", "12.95");
     conv.execute();
 
     MatrixWorkspace_const_sptr output;
     TS_ASSERT_THROWS_NOTHING(output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outputSpace));
-    TS_ASSERT_EQUALS(output->getAxis(0)->unit()->unitID(), "MomentumTransfer");
+    TS_ASSERT_EQUALS(output->getAxis(0)->unit()->unitID(), TestUnits::MOMENTUM_TRANSFER);
     TS_ASSERT_EQUALS(Mantid::Kernel::DeltaEMode::Direct, output->getEMode());
 
     // conversion fails due to error in two theta calculation and leaves
@@ -704,7 +709,7 @@ public:
    */
   void do_testExecEvent_RemainsSorted(EventSortType sortType, const std::string &targetUnit) {
     EventWorkspace_sptr ws = WorkspaceCreationHelper::createEventWorkspaceWithFullInstrument(1, 10, false);
-    ws->getAxis(0)->setUnit("TOF");
+    ws->getAxis(0)->setUnit(TestUnits::TOF);
     ws->sortAll(sortType, nullptr);
 
     // 0th detector unfortunately has difc=0 which doesn't support conversion to
@@ -826,14 +831,13 @@ public:
 
   void test_ragged_Workspace2D_edges() {
     const std::string outname("raggedWSout_edges");
-    const std::string TOF("TOF");
     constexpr bool bin_edges(true);
 
-    for (const auto distribution : {true, false}) {
+    for (const bool distribution : {true, false}) {
       MatrixWorkspace_sptr raggedWS = createRaggedWS(bin_edges, distribution); // not registered with ADS
 
       // d->Q avoids the toTof branch, d->TOF goes right to it
-      for (const auto &targetUnits : {std::string("MomentumTransfer"), TOF}) {
+      for (const std::string &targetUnits : {TestUnits::MOMENTUM_TRANSFER, TestUnits::TOF}) {
         // run the algorithm - out-of-place to force creating new output workspace
         ConvertUnits convertUnits;
         TS_ASSERT_THROWS_NOTHING(convertUnits.initialize());
@@ -858,7 +862,7 @@ public:
             TS_ASSERT_EQUALS(raggedWS->readY(1).size(), outputWS->readY(1).size());
           } else {
             // counts are the same
-            if (targetUnits.compare(TOF) == 0) {
+            if (targetUnits.compare(TestUnits::TOF) == 0) {
               TS_ASSERT_EQUALS(raggedWS->readY(0), outputWS->readY(0));
               TS_ASSERT_EQUALS(raggedWS->readY(1), outputWS->readY(1));
             } else { // reversed for MomentumTransfer
@@ -888,14 +892,13 @@ public:
    */
   void xtest_ragged_Workspace2D_centers() {
     const std::string outname("raggedWSout_edges");
-    const std::string TOF("TOF");
     constexpr bool bin_edges(false);
 
-    for (const auto distribution : {true, false}) {
+    for (const bool distribution : {true, false}) {
       MatrixWorkspace_sptr raggedWS = createRaggedWS(bin_edges, distribution); // not registered with ADS
 
       // d->Q avoids the toTof branch, d->TOF goes right to it
-      for (const auto &targetUnits : {std::string("MomentumTransfer"), TOF}) {
+      for (const std::string &targetUnits : {TestUnits::MOMENTUM_TRANSFER, TestUnits::TOF}) {
         // run the algorithm - out-of-place to force creating new output workspace
         ConvertUnits convertUnits;
         TS_ASSERT_THROWS_NOTHING(convertUnits.initialize());
@@ -920,7 +923,7 @@ public:
             TS_ASSERT_EQUALS(raggedWS->readY(1).size(), outputWS->readY(1).size());
           } else {
             // counts are the same
-            if (targetUnits.compare(TOF) == 0) {
+            if (targetUnits.compare(TestUnits::TOF) == 0) {
               TS_ASSERT_EQUALS(raggedWS->readY(0), outputWS->readY(0));
               TS_ASSERT_EQUALS(raggedWS->readY(1), outputWS->readY(1));
             } else { // reversed for MomentumTransfer

--- a/docs/source/release/v6.12.0/Framework/Algorithms/Bugfixes/38551.rst
+++ b/docs/source/release/v6.12.0/Framework/Algorithms/Bugfixes/38551.rst
@@ -1,0 +1,1 @@
+- Add support for histogram :ref:`ragged workspaces <Ragged_Workspace>` to :ref:`ConvertUnits <algm-ConvertUnits>`. Ragged workspaces with bin centers (Point rather than BinEdges) still generate errors.


### PR DESCRIPTION
It was discovered that `ConvertUnits` generates an error (i.e. doesn't execute) for [ragged workspaces](https://docs.mantidproject.org/nightly/concepts/Ragged_Workspace.html). This adds tests for ragged histogram workspaces (density true or false) and makes it pass.

This pull request does not attempt to fix the issue with point data which requires modifying `ConvertToHistogram` and its parent, `XDataConverter`. That will be a more substantial change that is not by the current use case. A disabled test for it has been added for this case `xtest_ragged_Workspace2D_centers`

*There is no associated issue,* but this is associated with [EWM8789](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8789)


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

To reproduce the original issue
1. Create a ragged workspace in d-spacing
2. `ConvertUnits` to time-of-flight

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
