### PR TITLE
Correct typo in default trans workspace name in pearl powder script

### DIFF
--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -98,7 +98,7 @@ class Pearl(AbstractInst):
 
     def get_trans_module_indices(self):
         default_imods = list(range(9))  # all modules 1-9 in transverse banks (tth~90 deg)
-        default_mod_nums_str = ""
+        default_mod_nums_str = "1-9"
         if self._inst_settings.focus_mode != "trans_custom" or not self._inst_settings.trans_mod_nums:
             return default_imods, default_mod_nums_str
         mod_nums = common.generate_run_numbers(run_number_string=self._inst_settings.trans_mod_nums)

--- a/scripts/Diffraction/isis_powder/test/ISISPowderPearlTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderPearlTest.py
@@ -99,7 +99,7 @@ class ISISPowderPearlTest(unittest.TestCase):
         imods, mod_nums = inst_obj.get_trans_module_indices()
 
         self.assertListEqual(imods, list(range(9)))
-        self.assertEqual(mod_nums, "")
+        self.assertEqual(mod_nums, "1-9")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of work

Correct typo in default workspace name produced by pearl powder reduction with `focus_mode="trans"` introduced by  #38344

*There is no associated issue.*

**Report to:** Nick Funnell (PEARL)

### To test:

Follow instructions in #38344

*This does not require release notes* because **bug introduced this release**


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
