### PR TITLE
Fix invalid data when MDHistoworkspace replaced and has original workspace

### DIFF
--- a/docs/source/release/v6.12.0/Workbench/SliceViewer/Bugfixes/38556.rst
+++ b/docs/source/release/v6.12.0/Workbench/SliceViewer/Bugfixes/38556.rst
@@ -1,0 +1,1 @@
+- Fix bug producing invalid data errors when plotting MDHistoWorkspaces with an original workspace in SliceViewer

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -386,9 +386,14 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
         @param workspace_name: the name of the workspace that has changed
         @param workspace: the workspace that has changed
         """
-        if self.model.check_for_removed_original_workspace():
-            self._close_view_with_message("Original workspace has been replaced: Closing Slice Viewer")
-            return
+
+        try:
+            if self.model.check_for_removed_original_workspace():
+                self._close_view_with_message("Original workspace has been replaced: Closing Slice Viewer")
+                return
+        except RuntimeError:
+            # can't check for original workspace if existing models workspace has been replaced
+            pass
 
         if not self.model.workspace_equals(workspace_name):
             # TODO this is a dead branch, since the ADS observer will call this if the
@@ -403,7 +408,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
 
             # New model is OK, proceed with updating Slice Viewer
             self.model = candidate_model
-            self.new_plot, self.update_plot_data = self._decide_plot_update_methods()
+            self._new_plot_method, self.update_plot_data = self._decide_plot_update_methods()
             self.view.delayed_refresh()
         except ValueError as err:
             self._close_view_with_message(f"Closing Sliceviewer as the underlying workspace was changed: {str(err)}")

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -579,6 +579,16 @@ class SliceViewerTest(unittest.TestCase):
         pres.replace_workspace("test1", "test2")
         pres._close_view_with_message.assert_called_once()
 
+    def test_replace_checking_original_workspace_fail(self):
+        mock_model = mock.MagicMock()
+        mock_view = mock.MagicMock()
+        pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
+        mock_model.check_for_removed_original_workspace = mock.Mock(side_effect=RuntimeError)
+        mock_model.workspace_equals.return_value = True
+        with mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewerModel") as mock_model_class:
+            pres.replace_workspace(mock.NonCallableMock(), mock.NonCallableMock())
+            self.assertEqual(mock_model_class.return_value, pres.model)
+
     def test_replace_workspace_does_nothing_if_workspace_is_unchanged(self):
         mock_model = mock.MagicMock()
         mock_view = mock.MagicMock()


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [8423: [Defect] Sliceviewer updated data causes exception](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=8423)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Instructions from issue

The following script will produce workspace ws_svrebinned which can be opened in the slice viewer.
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
ws = CreateMDWorkspace(Dimensions='3',
                       EventType='MDEvent',
                       Extents='-10,10,-10,10,-10,10',
                       Names='Q_lab_x,Q_lab_y,Q_lab_z',
                       Units='A,B,C')
FakeMDEventData(ws, UniformParams='1000000')
BinMD(InputWorkspace='ws',
      AxisAligned=False,
      BasisVector0='Q_lab_x,A,1.0,0.0,0.0',
      BasisVector1='Q_lab_y,B,0.0,1.0,0.0',
      BasisVector2='Q_lab_z,C,0.0,0.0,1.0',
      OutputExtents='-10,10,-10,10,-0.05,0.05',
      OutputBins='100,100,10',
      OutputWorkspace='ws_svrebinned')
mtd['ws_svrebinned'].clearOriginalWorkspaces()
```
Try opening ws_svrebinned in sliceviewer, re-run BinMD , then zoom into the view. You should see a lot of error message

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
