### PR TITLE
Fix bug in LoadNGEM where Min/MaxEventsPerFrame were not respected

### DIFF
--- a/Framework/DataHandling/src/LoadNGEM.cpp
+++ b/Framework/DataHandling/src/LoadNGEM.cpp
@@ -84,6 +84,13 @@ void addFrameToOutputWorkspace(int &rawFrames, int &goodFrames, const int &event
         eventsInFrame[i].clear();
       }
     }
+  } else {
+    // clear event list in frame in preparation for next frame
+    PARALLEL_FOR_NO_WSP_CHECK()
+    // Add events that match parameters to workspace
+    for (auto i = 0; i < NUM_OF_SPECTRA; ++i) {
+      eventsInFrame[i].clear();
+    }
   }
 }
 

--- a/Framework/DataHandling/test/LoadNGEMTest.h
+++ b/Framework/DataHandling/test/LoadNGEMTest.h
@@ -158,17 +158,13 @@ public:
 
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", getTestFilePath("GEM000005_00_000_short.edb")));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "ws"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaxEventsPerFrame", 0));
     TS_ASSERT_THROWS_NOTHING(alg.execute());
 
     DataObjects::EventWorkspace_sptr ws;
     ws = AnalysisDataService::Instance().retrieveWS<DataObjects::EventWorkspace>("ws");
     TS_ASSERT(ws);
-    const size_t rawNumEvents = ws->getNumberEvents();
-
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaxEventsPerFrame", 0));
-    TS_ASSERT_THROWS_NOTHING(alg.execute());
-    ws = AnalysisDataService::Instance().retrieveWS<DataObjects::EventWorkspace>("ws");
-    TS_ASSERT(rawNumEvents > ws->getNumberEvents());
+    TS_ASSERT_EQUALS(ws->getNumberEvents(), 0);
   }
 
 private:

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -606,7 +606,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadIsawDe
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadIsawDetCal.cpp:286
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadMask.cpp:431
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLSANS.cpp:720
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNGEM.cpp:288
 integerOverflowCond:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/byte_rel_comp.cpp:59
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadLLB.cpp:114
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadLLB.cpp:156

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -606,7 +606,7 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadIsawDe
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadIsawDetCal.cpp:286
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadMask.cpp:431
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLSANS.cpp:720
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNGEM.cpp:281
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadNGEM.cpp:288
 integerOverflowCond:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/byte_rel_comp.cpp:59
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadLLB.cpp:114
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadLLB.cpp:156

--- a/docs/source/release/6.12.0/Framework/Algorithms/Bugfixes/38564.rst
+++ b/docs/source/release/6.12.0/Framework/Algorithms/Bugfixes/38564.rst
@@ -1,0 +1,1 @@
+- Fixed bug in:ref:`LoadNGEM <algm-LoadNGEM>` where ``Min/MaxEventsPerFrame`` inputs were not being respected.


### PR DESCRIPTION
### Description of work
Added loop to clear events in frame if the current frame is not good (i.e. number of events outside Min/Max limits set) in preparation for next frame (don't know if that is the best way to do it)..

The issue was here
https://github.com/mantidproject/mantid/blob/22bed2110eee1945c2b6a4035bfc81d93e184056/Framework/DataHandling/src/LoadNGEM.cpp#L74-L88
If the statement on L74 is false then `eventsInFrame` doesn't get cleared - such that the sum over all  `eventsInFrame[i].getNumberEvents()` is not equal to `eventCountInFrame`

Fixes #38558

**Report to:** [draspi](https://forum.mantidproject.org/u/draspi)

### To test:

(1) Follow instructions on the issue
(2) For `MinEventsPerFrame=0` and `MaxEventsPerFrame=0` the workspace should have no counts (`ws.getNumberEvents() = 0`)
(3) If  `MinEventsPerFrame` and `MaxEventsPerFrame` are not set then the resulting figure should look like the one in the issue.


### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
