### PR TITLE
Clarify that gtest is pinned to v1.15.2

### DIFF
--- a/buildconfig/CMake/GoogleTest.cmake
+++ b/buildconfig/CMake/GoogleTest.cmake
@@ -2,7 +2,7 @@
 
 # Make gtest_version available everywhere
 set(gtest_version
-    "b514bdc898e2951020cbdca1304b75f5950d1f59"
+    "v1.15.2"
     CACHE INTERNAL ""
 )
 
@@ -17,7 +17,7 @@ set(gtest_force_shared_crt
 fetchcontent_declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG b514bdc898e2951020cbdca1304b75f5950d1f59
+  GIT_TAG "${gtest_version}"
   EXCLUDE_FROM_ALL
 )
 


### PR DESCRIPTION
This was unclear with using the sha1. [v1.15.2](https://github.com/google/googletest/releases/tag/v1.15.2) is the first tag that includes the sha1 and is 2 years old. This also modifies the function call in cmake to re-use the variable rather than copy/paste the refspec.

This looks bigger than it is because it also pulls in the changes from #38536 so it can be merged into `ornl-next` more easily.

*There is no associated issue.*

### To test:

This is updating a refspec for a developer dependency. The builds should pass and it *does not require release notes.*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
