### PR TITLE
36863 find global b matrix warnings

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -126,6 +126,10 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
         prog_reporter.report(3, "Done")
 
     def find_initial_indexing(self, a, b, c, alpha, beta, gamma, ws_list):
+        import pydevd_pycharm
+
+        pydevd_pycharm.settrace(stdoutToServer=True, stderrToServer=True)
+
         # check if a UB exists on any run and if so whether it indexes a sufficient number of peaks
         foundUB = False
         ws_with_UB = [
@@ -214,6 +218,17 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
                         residsq[ipk] = np.sum((UB @ pk.getIntHKL() - pk.getQSampleFrame()) ** 2)
                         ipk += 1
         return np.sqrt(residsq / (ipk + 1))
+
+    def exec_child_alg(self, alg_name: str, **kwargs):
+        alg = self.createChildAlgorithm(alg_name, enableLogging=False)
+        alg.setAlwaysStoreInADS(False)
+        alg.initialize()
+        alg.setProperties(kwargs)
+        alg.execute()
+        if len(alg.outputProperties()) == 1:
+            return alg.getProperty(alg.outputProperties()[0]).value
+        else:
+            return tuple(alg.getProperty(prop).value for prop in alg.outputProperties())
 
     def child_IndexPeaks(self, PeaksWorkspace, RoundHKLs=True, CommonUBForAll=False):
         alg = self.createChildAlgorithm("IndexPeaks", enableLogging=False)

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -178,7 +178,16 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
                 foundUB = True  # already know npks >= _MIN_NUM_INDEXED_PEAKS
             else:
                 # copy orientation from sample so as to ensure consistency of indexing
-                self.child_CopySample(InputWorkspace=ws_list[iref], OutputWorkspace=ws_list[iws])
+                self.exec_child_alg(
+                    "CopySample",
+                    InputWorkspace=ws_list[iref],
+                    OutputWorkspace=ws_list[iws],
+                    CopyName=False,
+                    CopyMaterial=False,
+                    CopyEnvironment=False,
+                    CopyShape=False,
+                    CopyOrientationOnly=True,
+                )
                 nindexed = self.exec_child_alg("IndexPeaks", PeaksWorkspace=ws_list[iws], RoundHKLs=True, CommonUBForAll=False)
                 if nindexed < _MIN_NUM_INDEXED_PEAKS:
                     # if gonio matrix is inaccurate we have to find the UB from scratch and transform to correct HKL
@@ -256,26 +265,6 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
             return alg.getProperty(alg.outputProperties()[0]).value
         else:
             return tuple(alg.getProperty(prop).value for prop in alg.outputProperties())
-
-    def child_CopySample(
-        self,
-        InputWorkspace,
-        OutputWorkspace,
-        CopyName=False,
-        CopyMaterial=False,
-        CopyEnvironment=False,
-        CopyShape=False,
-        CopyOrientationOnly=True,
-    ):
-        alg = self.createChildAlgorithm("CopySample", enableLogging=False)
-        alg.setProperty("InputWorkspace", InputWorkspace)
-        alg.setProperty("OutputWorkspace", OutputWorkspace)
-        alg.setProperty("CopyName", CopyName)
-        alg.setProperty("CopyMaterial", CopyMaterial)
-        alg.setProperty("CopyEnvironment", CopyEnvironment)
-        alg.setProperty("CopyShape", CopyShape)
-        alg.setProperty("CopyOrientationOnly", CopyOrientationOnly)
-        alg.execute()
 
 
 # register algorithm with mantid

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -234,16 +234,19 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
             # index peaks with CommonUBForAll=False (optimises a temp. UB when indexing - helps for bad guesses)
             nindexed = self.exec_child_alg("IndexPeaks", PeaksWorkspace=wsname, RoundHKLs=True, CommonUBForAll=False)
             if nindexed >= _MIN_NUM_INDEXED_PEAKS:
-                self.exec_child_alg(
-                    "CalculateUMatrix",
-                    PeaksWorkspace=wsname,
-                    a=x0[0],
-                    b=x0[1],
-                    c=x0[2],
-                    alpha=x0[3],
-                    beta=x0[4],
-                    gamma=x0[5],
-                )
+                try:
+                    self.exec_child_alg(
+                        "CalculateUMatrix",
+                        PeaksWorkspace=wsname,
+                        a=x0[0],
+                        b=x0[1],
+                        c=x0[2],
+                        alpha=x0[3],
+                        beta=x0[4],
+                        gamma=x0[5],
+                    )
+                except ValueError:
+                    logger.error(f"Cannot calculate U Matrix for {wsname} - this workspace should be removed.")
                 # don't index with optimisation after this point and don't round HKL (to calc resids)
                 self.exec_child_alg("IndexPeaks", PeaksWorkspace=wsname, RoundHKLs=True, CommonUBForAll=False)
                 ws = AnalysisDataService.retrieve(wsname)

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -197,7 +197,6 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
         # set this UB and re-index the ws
         for iws, cws in enumerate(ws_list):
             SetUB(cws, UB=ref_ub)
-            self.exec_child_alg("IndexPeaks", PeaksWorkspace=cws, RoundHKLs=True, CommonUBForAll=False)
 
         # for the ws with fewer peaks than threshold, try and find some more by adjusting U slightly
         for iws in np.where(n_indexed_by_ref < _MIN_NUM_INDEXED_PEAKS)[0]:

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -5,7 +5,7 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import DataProcessorAlgorithm, AlgorithmFactory, Progress, ADSValidator, IPeaksWorkspace
-from mantid.simpleapi import AnalysisDataService, logger, SetUB
+from mantid.simpleapi import AnalysisDataService, logger
 from mantid.kernel import Direction, FloatBoundedValidator, StringArrayProperty
 import numpy as np
 from scipy.optimize import leastsq
@@ -196,7 +196,7 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
 
         # set this UB and re-index the ws
         for iws, cws in enumerate(ws_list):
-            SetUB(cws, UB=ref_ub)
+            self.exec_child_alg("SetUB", Workspace=cws, UB=ref_ub)
 
         # for the ws with fewer peaks than threshold, try and find some more by adjusting U slightly
         for iws in np.where(n_indexed_by_ref < _MIN_NUM_INDEXED_PEAKS)[0]:
@@ -236,7 +236,7 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
                 if iws == iref:
                     indexed_peaks[iub, iws] = nindexed_ref[iub]
                 else:
-                    SetUB(cws, UB=ref_ub)
+                    self.exec_child_alg("SetUB", Workspace=cws, UB=ref_ub)
                     indexed_peaks[iub, iws] = self.exec_child_alg("IndexPeaks", PeaksWorkspace=cws, RoundHKLs=True, CommonUBForAll=True)[0]
 
         # find, for each UB, the number of ws that have n_peaks over the threshold and the total sum of these

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -226,9 +226,11 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
 
                     # if still too few, warn user and remove
                     if nindexed < _MIN_NUM_INDEXED_PEAKS:
-                        logger.warning(f"Fewer than the desired {_MIN_NUM_INDEXED_PEAKS} peaks were indexed for Workspace {iws}")
+                        logger.warning(
+                            f"Fewer than the desired {_MIN_NUM_INDEXED_PEAKS} peaks were indexed for Workspace {iws}."
+                            f"Workspace {iws} removed"
+                        )
                         ws_list.pop(iws)
-                        logger.warning(f"Workspace {iws} removed")
 
     def evaluate_best_ref_UB(self, iws_potential_ref_ub, nindexed_ref, ws_list):
         indexed_peaks = np.zeros((len(iws_potential_ref_ub), len(ws_list)))

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -132,7 +132,8 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
                 ws.sample().getOrientedLattice().setError(*err)
                 if n_peaks[iws] < _MIN_NUM_INDEXED_PEAKS:
                     logger.warning(
-                        f"Workspace: {wsname}, has only {n_peaks[iws]} indexed peaks, fewer than the desired {_MIN_NUM_INDEXED_PEAKS}"
+                        f"Workspace: {wsname}, has only {n_peaks[iws]} indexed peaks after optimisation, "
+                        f"fewer than the desired {_MIN_NUM_INDEXED_PEAKS}"
                     )
             logger.notice(
                 f"Lattice parameters successfully refined for workspaces: {ws_list}\n"
@@ -216,8 +217,8 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
                         # otherwise warn the user
                         else:
                             logger.warning(
-                                f"Fewer than the desired {_MIN_NUM_INDEXED_PEAKS} peaks were indexed for Workspace {iws}. "
-                                f"Workspace {iws} removed"
+                                f"Fewer than the desired {_MIN_NUM_INDEXED_PEAKS} peaks were indexed by the reference UB "
+                                f"for Workspace {iws}. Workspace will NOT be included in the optimisation"
                             )
         if len(valid_ws_list) < 2:
             if n_ws_indexed_by_ref_ub <= 1:

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -225,7 +225,16 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
             # index peaks with CommonUBForAll=False (optimises a temp. UB when indexing - helps for bad guesses)
             nindexed = self.exec_child_alg("IndexPeaks", PeaksWorkspace=wsname, RoundHKLs=True, CommonUBForAll=False)
             if nindexed >= _MIN_NUM_INDEXED_PEAKS:
-                self.child_CalculateUMatrix(wsname, *x0)
+                self.exec_child_alg(
+                    "CalculateUMatrix",
+                    PeaksWorkspace=wsname,
+                    a=x0[0],
+                    b=x0[1],
+                    c=x0[2],
+                    alpha=x0[3],
+                    beta=x0[4],
+                    gamma=x0[5],
+                )
                 # don't index with optimisation after this point and don't round HKL (to calc resids)
                 self.exec_child_alg("IndexPeaks", PeaksWorkspace=wsname, RoundHKLs=True, CommonUBForAll=False)
                 ws = AnalysisDataService.retrieve(wsname)
@@ -247,17 +256,6 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
             return alg.getProperty(alg.outputProperties()[0]).value
         else:
             return tuple(alg.getProperty(prop).value for prop in alg.outputProperties())
-
-    def child_CalculateUMatrix(self, PeaksWorkspace, a, b, c, alpha, beta, gamma):
-        alg = self.createChildAlgorithm("CalculateUMatrix", enableLogging=False)
-        alg.setProperty("PeaksWorkspace", PeaksWorkspace)
-        alg.setProperty("a", a)
-        alg.setProperty("b", b)
-        alg.setProperty("c", c)
-        alg.setProperty("alpha", alpha)
-        alg.setProperty("beta", beta)
-        alg.setProperty("gamma", gamma)
-        alg.execute()
 
     def child_TransformHKL(self, PeaksWorkspace, HKLTransform, FindError=False):
         alg = self.createChildAlgorithm("TransformHKL", enableLogging=False)

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -210,7 +210,7 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
         U = AnalysisDataService.retrieve(ws).sample().getOrientedLattice().getU()
         # find transform required  ( U_ref = U T^-1) - see TransformHKL docs for details
         transform = np.linalg.inv(getSignMaxAbsValInCol(np.linalg.inv(U) @ U_ref))
-        self.child_TransformHKL(PeaksWorkspace=ws, HKLTransform=transform, FindError=False)
+        self.exec_child_alg("TransformHKL", PeaksWorkspace=ws, HKLTransform=transform, FindError=False)
 
     def calcResiduals(self, x0, ws_list):
         """
@@ -256,13 +256,6 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
             return alg.getProperty(alg.outputProperties()[0]).value
         else:
             return tuple(alg.getProperty(prop).value for prop in alg.outputProperties())
-
-    def child_TransformHKL(self, PeaksWorkspace, HKLTransform, FindError=False):
-        alg = self.createChildAlgorithm("TransformHKL", enableLogging=False)
-        alg.setProperty("PeaksWorkspace", PeaksWorkspace)
-        alg.setProperty("HKLTransform", HKLTransform)
-        alg.setProperty("FindError", FindError)
-        alg.execute()
 
     def child_CopySample(
         self,

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -79,8 +79,8 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
             issues["PeakWorkspaces"] = (
                 f"Accept only PeaksWorkspaces with either: attached UBs and more than {_MIN_NUM_INDEXED_PEAKS} peaks; "
                 f"or no attached UBs and more than {_MIN_NUM_PEAKS} peaks - "
-                f"there must be at least two valid peak tables provided in total. "
-                f"Currently provided: {n_valid_ws}/{len(ws_list)} valid workspaces, with {ws_n_peaks} total peaks"
+                f"there must be at least 2 valid peak tables provided in total. "
+                f"Currently {n_valid_ws}/{len(ws_list)} of provided workspaces are valid, with {ws_n_peaks} total peaks"
             )
         return issues
 

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -74,15 +74,13 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
                 nindexed, *_ = self.exec_child_alg("IndexPeaks", PeaksWorkspace=wsname, RoundHKLs=True, CommonUBForAll=True)
                 if nindexed < _MIN_NUM_INDEXED_PEAKS:
                     issues["PeakWorkspaces"] = (
-                        f"{wsname} has a UB set, therefore it must contain at least " f"{_MIN_NUM_INDEXED_PEAKS} peaks that can be indexed."
+                        f"{wsname} has a UB set, therefore it must contain at least {_MIN_NUM_INDEXED_PEAKS} peaks that can be indexed."
                     )
                 else:
                     # if it has UB and doesn't have too few peaks it is valid
                     n_valid_ws += 1
             elif ws.getNumberPeaks() < _MIN_NUM_PEAKS:
-                issues["PeakWorkspaces"] = (
-                    f"{wsname} does not have a UB set, therefore it must " f"contain at least {_MIN_NUM_PEAKS} peaks."
-                )
+                issues["PeakWorkspaces"] = f"{wsname} does not have a UB set, therefore it must contain at least {_MIN_NUM_PEAKS} peaks."
             else:
                 # if it doesn't have a UB but does have more than the min num peaks it is also valid
                 n_valid_ws += 1
@@ -134,7 +132,7 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
                 ws.sample().getOrientedLattice().setError(*err)
                 if n_peaks[iws] < _MIN_NUM_INDEXED_PEAKS:
                     logger.warning(
-                        f"Workspace: {wsname}, has only {n_peaks[iws]} indexed peaks, " f"fewer than the desired {_MIN_NUM_INDEXED_PEAKS}"
+                        f"Workspace: {wsname}, has only {n_peaks[iws]} indexed peaks, fewer than the desired {_MIN_NUM_INDEXED_PEAKS}"
                     )
             logger.notice(
                 f"Lattice parameters successfully refined for workspaces: {ws_list}\n"
@@ -209,7 +207,7 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
                     singular_transform = self.make_UB_consistent(ws_list[iref], ws_list[iws])
                     # if calculate transform is singular
                     if singular_transform:
-                        logger.warning(f"Singular transform in make_UB_consistent, " f"{ws_list[iws]} removed")
+                        logger.warning(f"Singular transform in make_UB_consistent, {ws_list[iws]} removed")
                     else:
                         nindexed = self.exec_child_alg("IndexPeaks", PeaksWorkspace=ws_list[iws], RoundHKLs=True, CommonUBForAll=False)[0]
                         # if now enough peaks, add to the list

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -12,7 +12,7 @@ from scipy.optimize import leastsq
 from plugins.algorithms.FindGoniometerFromUB import getSignMaxAbsValInCol
 
 _MIN_NUM_PEAKS = 6  # minimum required to use FindUBUsingLatticeParameters assuming all linearly indep.
-_MIN_NUM_INDEXED_PEAKS = 3  # minimum indexed peaks required for CalculateUMatrix
+_MIN_NUM_INDEXED_PEAKS = 2  # minimum indexed peaks required for CalculateUMatrix
 
 
 class FindGlobalBMatrix(DataProcessorAlgorithm):

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -146,8 +146,16 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
             # loop over all ws and try to find a UB
             for iws, ws in enumerate(ws_list):
                 try:
-                    self.child_FindUBUsingLatticeParameters(
-                        PeaksWorkspace=ws, a=a, b=b, c=c, alpha=alpha, beta=beta, gamma=gamma, FixParameters=False
+                    self.exec_child_alg(
+                        "FindUBUsingLatticeParameters",
+                        PeaksWorkspace=ws,
+                        a=a,
+                        b=b,
+                        c=c,
+                        alpha=alpha,
+                        beta=beta,
+                        gamma=gamma,
+                        FixParameters=False,
                     )
                     nindexed = self.exec_child_alg("IndexPeaks", PeaksWorkspace=ws, RoundHKLs=True, CommonUBForAll=False)
                     foundUB = nindexed >= _MIN_NUM_INDEXED_PEAKS
@@ -174,8 +182,16 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
                 nindexed = self.exec_child_alg("IndexPeaks", PeaksWorkspace=ws_list[iws], RoundHKLs=True, CommonUBForAll=False)
                 if nindexed < _MIN_NUM_INDEXED_PEAKS:
                     # if gonio matrix is inaccurate we have to find the UB from scratch and transform to correct HKL
-                    self.child_FindUBUsingLatticeParameters(
-                        PeaksWorkspace=ws_list[iws], a=a, b=b, c=c, alpha=alpha, beta=beta, gamma=gamma, FixParameters=False
+                    self.exec_child_alg(
+                        "FindUBUsingLatticeParameters",
+                        PeaksWorkspace=ws_list[iws],
+                        a=a,
+                        b=b,
+                        c=c,
+                        alpha=alpha,
+                        beta=beta,
+                        gamma=gamma,
+                        FixParameters=False,
                     )
                     self.make_UB_consistent(ws_list[iref], ws_list[iws])
                     nindexed = self.exec_child_alg("IndexPeaks", PeaksWorkspace=ws_list[iws], RoundHKLs=True, CommonUBForAll=False)
@@ -231,18 +247,6 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
             return alg.getProperty(alg.outputProperties()[0]).value
         else:
             return tuple(alg.getProperty(prop).value for prop in alg.outputProperties())
-
-    def child_FindUBUsingLatticeParameters(self, PeaksWorkspace, a, b, c, alpha, beta, gamma, FixParameters=False):
-        alg = self.createChildAlgorithm("FindUBUsingLatticeParameters", enableLogging=False)
-        alg.setProperty("PeaksWorkspace", PeaksWorkspace)
-        alg.setProperty("a", a)
-        alg.setProperty("b", b)
-        alg.setProperty("c", c)
-        alg.setProperty("alpha", alpha)
-        alg.setProperty("beta", beta)
-        alg.setProperty("gamma", gamma)
-        alg.setProperty("FixParameters", FixParameters)
-        alg.execute()
 
     def child_CalculateUMatrix(self, PeaksWorkspace, a, b, c, alpha, beta, gamma):
         alg = self.createChildAlgorithm("CalculateUMatrix", enableLogging=False)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/FindGlobalBMatrixTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FindGlobalBMatrixTest.py
@@ -201,9 +201,24 @@ class FindGlobalBMatrixTest(unittest.TestCase):
         # Add some peaks
         add_peaksHKL([peaks1, peaks2], range(0, 3), range(0, 3), 4)
 
-        # hard to explicitly test the warning message is flagged when that warning will almost always lead to the error
         with self.assertRaisesRegex(RuntimeError, "Reference UB failed to index peaks in any other run"):
             FindGlobalBMatrix(PeakWorkspaces=[peaks1, peaks2], a=5.0, b=5.0, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15)
+
+    def test_handling_for_unable_to_get_consistent_ub(self):
+        peaks1 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks18")
+        UB = np.diag([0.2, 0.2, 0.1])
+        SetUB(peaks1, UB=UB)
+
+        peaks2 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks19")
+        UB = np.diag([0.33, 0.33, 0.1])
+        SetUB(peaks2, UB=UB)
+        peaks3 = CloneWorkspace(InputWorkspace=peaks1, OutputWorkspace="SXD_peaks20")
+        # Add some peaks
+        add_peaksHKL([peaks1, peaks2, peaks3], range(0, 3), range(0, 3), 4)
+
+        FindGlobalBMatrix(PeakWorkspaces=[peaks1, peaks2, peaks3], a=5.0, b=5.0, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15)
+
+        self.assertWarnsRegex(RuntimeWarning, "Singular transform in make_UB_consistent, .* removed")
 
     def assert_lattice(self, ws_list, a, b, c, alpha, beta, gamma, delta_latt=2e-2, delta_angle=2.5e-1):
         for ws in ws_list:

--- a/Framework/PythonInterface/test/python/plugins/algorithms/FindGlobalBMatrixTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FindGlobalBMatrixTest.py
@@ -96,7 +96,10 @@ class FindGlobalBMatrixTest(unittest.TestCase):
             "FindGlobalBMatrix", PeakWorkspaces=[peaks1], a=4.1, b=4.2, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15
         )
 
-        with self.assertRaisesRegex(RuntimeError, "Accept only PeaksWorkspaces with either:*"):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Fewer than the desired number of .* workspaces " "have valid peak tables. " "Currently .* of provided workspaces are valid",
+        ):
             alg.execute()
 
     def test_peak_workspaces_need_at_least_six_peaks_each_without_ub(self):
@@ -105,42 +108,48 @@ class FindGlobalBMatrixTest(unittest.TestCase):
         SetUB(peaks1, UB=UB)
         # Add 5 peaks
         add_peaksHKL([peaks1], range(0, 5), [0], 4)
+        # Clone peaks1 so we don't throw the too few valid ws error
         peaks2 = CloneWorkspace(InputWorkspace=peaks1, OutputWorkspace="SXD_peaks6")
-        ClearUB(peaks2)
+        # Create a ws with no UB but still only 5 peaks
+        peaks3 = CloneWorkspace(InputWorkspace=peaks1, OutputWorkspace="SXD_peaks7")
+        ClearUB(peaks3)
 
         alg = create_algorithm(
-            "FindGlobalBMatrix", PeakWorkspaces=[peaks1, peaks2], a=4.1, b=4.2, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15
+            "FindGlobalBMatrix", PeakWorkspaces=[peaks1, peaks2, peaks3], a=4.1, b=4.2, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15
         )
 
-        with self.assertRaisesRegex(RuntimeError, "Accept only PeaksWorkspaces with either:*"):
+        with self.assertRaisesRegex(RuntimeError, ".* does not have a UB set, therefore it must " "contain at least 6 peaks."):
             alg.execute()
 
     def test_peak_workspaces_need_at_least_two_peaks_each_with_ub(self):
-        peaks1 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks7")
+        peaks1 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks8")
         UB = np.diag([0.25, 0.25, 0.1])
         SetUB(peaks1, UB=UB)
-        peaks2 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks8")
+        peaks2 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks9")
         SetUB(peaks2, UB=UB)
-        # Add 5 peaks
+        # Add 5 peaks to one
         add_peaksHKL([peaks1], range(0, 5), [0], 4)
+        # Add only 1 peak to other
         add_peaksHKL([peaks2], range(0, 1), [0], 4)
+        # Clone peaks1 so we don't throw the too few valid ws error
+        peaks3 = CloneWorkspace(InputWorkspace=peaks1, OutputWorkspace="SXD_peaks10")
 
         alg = create_algorithm(
-            "FindGlobalBMatrix", PeakWorkspaces=[peaks1, peaks2], a=4.1, b=4.2, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15
+            "FindGlobalBMatrix", PeakWorkspaces=[peaks1, peaks2, peaks3], a=4.1, b=4.2, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15
         )
 
-        with self.assertRaisesRegex(RuntimeError, "Accept only PeaksWorkspaces with either:*"):
+        with self.assertRaisesRegex(RuntimeError, ".* has a UB set, therefore it must contain at least " "2 peaks that can be indexed."):
             alg.execute()
 
     def test_performs_correct_transform_to_ensure_consistent_indexing(self):
         # create peaks tables
-        peaks1 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks9")
+        peaks1 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks11")
         UB = np.diag([0.2, 0.25, 0.1])
         SetUB(peaks1, UB=UB)
         # Add some peaks
         add_peaksHKL([peaks1], range(0, 3), range(0, 3), 4)
         # Clone ws and transform
-        peaks2 = CloneWorkspace(InputWorkspace=peaks1, OutputWorkspace="SXD_peaks10")
+        peaks2 = CloneWorkspace(InputWorkspace=peaks1, OutputWorkspace="SXD_peaks12")
         peaks2.removePeak(0)  # peaks1 will have most peaks indexed so will used as reference
         transform = np.array([[0, 1, 0], [1, 0, 0], [0, 0, -1]])
         TransformHKL(PeaksWorkspace=peaks2, HKLTransform=transform, FindError=False)
@@ -156,16 +165,16 @@ class FindGlobalBMatrixTest(unittest.TestCase):
         # Setup
 
         SetGoniometer(Workspace=self.ws, Axis0="-5,0,1,0,1")
-        peaks = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks11")
+        peaks = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks13")
         UB = np.diag([0.3333, 0.25, 0.09091])  # alatt = [3,4,11]
         SetUB(peaks, UB=UB)
 
-        peaks2 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks12")
+        peaks2 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks14")
         UB = np.diag([0.30, 0.25, 0.1])  # alatt = [3.33,4,10]
         SetUB(peaks2, UB=UB)
 
         SetGoniometer(Workspace=self.ws, Axis0="5,0,1,0,1")
-        peaks3 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks13")
+        peaks3 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks15")
         UB = np.diag([0.3333, 0.25, 0.09091])  # alatt = [3,4,11]
         SetUB(peaks3, UB=UB)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/FindGlobalBMatrixTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FindGlobalBMatrixTest.py
@@ -190,6 +190,21 @@ class FindGlobalBMatrixTest(unittest.TestCase):
 
         self.assertWarnsRegex(RuntimeWarning, "Workspace 1 removed")
 
+    def test_warning_for_poor_reference_ub(self):
+        peaks1 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks16")
+        UB = np.diag([0.2, 0.2, 0.1])
+        SetUB(peaks1, UB=UB)
+
+        peaks2 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks17")
+        UB = np.diag([0.24, 0.24, 0.1])
+        SetUB(peaks2, UB=UB)
+        # Add some peaks
+        add_peaksHKL([peaks1, peaks2], range(0, 3), range(0, 3), 4)
+
+        # hard to explicitly test the warning message is flagged when that warning will almost always lead to the error
+        with self.assertRaisesRegex(RuntimeError, "Reference UB failed to index peaks in any other run"):
+            FindGlobalBMatrix(PeakWorkspaces=[peaks1, peaks2], a=5.0, b=5.0, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15)
+
     def assert_lattice(self, ws_list, a, b, c, alpha, beta, gamma, delta_latt=2e-2, delta_angle=2.5e-1):
         for ws in ws_list:
             cell = ws.sample().getOrientedLattice()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/FindGlobalBMatrixTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FindGlobalBMatrixTest.py
@@ -98,7 +98,7 @@ class FindGlobalBMatrixTest(unittest.TestCase):
 
         with self.assertRaisesRegex(
             RuntimeError,
-            "Fewer than the desired number of .* workspaces " "have valid peak tables. " "Currently .* of provided workspaces are valid",
+            "Fewer than the desired number of .* workspaces have valid peak tables. Currently .* of provided workspaces are valid",
         ):
             alg.execute()
 
@@ -118,7 +118,7 @@ class FindGlobalBMatrixTest(unittest.TestCase):
             "FindGlobalBMatrix", PeakWorkspaces=[peaks1, peaks2, peaks3], a=4.1, b=4.2, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15
         )
 
-        with self.assertRaisesRegex(RuntimeError, ".* does not have a UB set, therefore it must " "contain at least 6 peaks."):
+        with self.assertRaisesRegex(RuntimeError, ".* does not have a UB set, therefore it must contain at least 6 peaks."):
             alg.execute()
 
     def test_peak_workspaces_need_at_least_two_peaks_each_with_ub(self):
@@ -138,7 +138,7 @@ class FindGlobalBMatrixTest(unittest.TestCase):
             "FindGlobalBMatrix", PeakWorkspaces=[peaks1, peaks2, peaks3], a=4.1, b=4.2, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15
         )
 
-        with self.assertRaisesRegex(RuntimeError, ".* has a UB set, therefore it must contain at least " "2 peaks that can be indexed."):
+        with self.assertRaisesRegex(RuntimeError, ".* has a UB set, therefore it must contain at least 2 peaks that can be indexed."):
             alg.execute()
 
     def test_performs_correct_transform_to_ensure_consistent_indexing(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/FindGlobalBMatrixTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FindGlobalBMatrixTest.py
@@ -5,6 +5,7 @@ from mantid.simpleapi import (
     AnalysisDataService,
     SetGoniometer,
     SetUB,
+    ClearUB,
     CreatePeaksWorkspace,
     LoadEmptyInstrument,
     CloneWorkspace,
@@ -95,33 +96,51 @@ class FindGlobalBMatrixTest(unittest.TestCase):
             "FindGlobalBMatrix", PeakWorkspaces=[peaks1], a=4.1, b=4.2, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15
         )
 
-        with self.assertRaisesRegex(RuntimeError, "there must be at least two peak tables provided in total."):
+        with self.assertRaisesRegex(RuntimeError, "Accept only PeaksWorkspaces with either:*"):
             alg.execute()
 
-    def test_peak_workspaces_need_at_least_six_peaks_each(self):
+    def test_peak_workspaces_need_at_least_six_peaks_each_without_ub(self):
         peaks1 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks5")
         UB = np.diag([0.25, 0.25, 0.1])
         SetUB(peaks1, UB=UB)
         # Add 5 peaks
         add_peaksHKL([peaks1], range(0, 5), [0], 4)
         peaks2 = CloneWorkspace(InputWorkspace=peaks1, OutputWorkspace="SXD_peaks6")
+        ClearUB(peaks2)
 
         alg = create_algorithm(
             "FindGlobalBMatrix", PeakWorkspaces=[peaks1, peaks2], a=4.1, b=4.2, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15
         )
 
-        with self.assertRaisesRegex(RuntimeError, "Accept only peaks workspace with more than 6 peaks"):
+        with self.assertRaisesRegex(RuntimeError, "Accept only PeaksWorkspaces with either:*"):
+            alg.execute()
+
+    def test_peak_workspaces_need_at_least_two_peaks_each_with_ub(self):
+        peaks1 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks7")
+        UB = np.diag([0.25, 0.25, 0.1])
+        SetUB(peaks1, UB=UB)
+        peaks2 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks8")
+        SetUB(peaks2, UB=UB)
+        # Add 5 peaks
+        add_peaksHKL([peaks1], range(0, 5), [0], 4)
+        add_peaksHKL([peaks2], range(0, 1), [0], 4)
+
+        alg = create_algorithm(
+            "FindGlobalBMatrix", PeakWorkspaces=[peaks1, peaks2], a=4.1, b=4.2, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "Accept only PeaksWorkspaces with either:*"):
             alg.execute()
 
     def test_performs_correct_transform_to_ensure_consistent_indexing(self):
         # create peaks tables
-        peaks1 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks7")
+        peaks1 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks9")
         UB = np.diag([0.2, 0.25, 0.1])
         SetUB(peaks1, UB=UB)
         # Add some peaks
         add_peaksHKL([peaks1], range(0, 3), range(0, 3), 4)
         # Clone ws and transform
-        peaks2 = CloneWorkspace(InputWorkspace=peaks1, OutputWorkspace="SXD_peaks8")
+        peaks2 = CloneWorkspace(InputWorkspace=peaks1, OutputWorkspace="SXD_peaks10")
         peaks2.removePeak(0)  # peaks1 will have most peaks indexed so will used as reference
         transform = np.array([[0, 1, 0], [1, 0, 0], [0, 0, -1]])
         TransformHKL(PeaksWorkspace=peaks2, HKLTransform=transform, FindError=False)
@@ -132,6 +151,35 @@ class FindGlobalBMatrixTest(unittest.TestCase):
         self.assert_lattice([peaks1, peaks2], 5.0, 4.0, 10.0, 90.0, 90.0, 90.0, delta_latt=5e-2, delta_angle=2.5e-1)
         self.assert_matrix([peaks1], getBMatrix(peaks2), getBMatrix, delta=1e-10)  # should have same B matrix
         self.assert_matrix([peaks1, peaks2], np.eye(3), getUMatrix, delta=5e-2)
+
+    def test_any_workspaces_with_no_peaks_are_excluded(self):
+        # Setup
+
+        SetGoniometer(Workspace=self.ws, Axis0="-5,0,1,0,1")
+        peaks = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks11")
+        UB = np.diag([0.3333, 0.25, 0.09091])  # alatt = [3,4,11]
+        SetUB(peaks, UB=UB)
+
+        peaks2 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks12")
+        UB = np.diag([0.30, 0.25, 0.1])  # alatt = [3.33,4,10]
+        SetUB(peaks2, UB=UB)
+
+        SetGoniometer(Workspace=self.ws, Axis0="5,0,1,0,1")
+        peaks3 = CreatePeaksWorkspace(InstrumentWorkspace=self.ws, NumberOfPeaks=0, OutputWorkspace="SXD_peaks13")
+        UB = np.diag([0.3333, 0.25, 0.09091])  # alatt = [3,4,11]
+        SetUB(peaks3, UB=UB)
+
+        peaks_list = [peaks, peaks2, peaks3]
+        for K in range(1, 6):
+            for L in range(1, 6):
+                for peak_ws in peaks_list:
+                    pk = peak_ws.createPeakHKL([2, K, L])
+                    if pk.getDetectorID() > 0:
+                        peak_ws.addPeak(pk)
+
+        FindGlobalBMatrix(PeakWorkspaces=peaks_list, a=3, b=4, c=11, alpha=90, beta=90, gamma=90, Tolerance=0.15)
+
+        self.assertWarnsRegex(RuntimeWarning, "Workspace 1 removed")
 
     def assert_lattice(self, ws_list, a, b, c, alpha, beta, gamma, delta_latt=2e-2, delta_angle=2.5e-1):
         for ws in ws_list:

--- a/docs/source/release/v6.12.0/Diffraction/Single_Crystal/New_features/36863.rst
+++ b/docs/source/release/v6.12.0/Diffraction/Single_Crystal/New_features/36863.rst
@@ -1,0 +1,1 @@
+- Updated :ref:`FindGlobalBMatrix <algm-FindGlobalBMatrix-v1>` to change how reference UBs are chosen before refinement and improvements made to verbosity of error/ warning reporting for users.


### PR DESCRIPTION
### Description of work

#### Summary of work
Reworking of the algorithm to incorporate some 'quality of life' changes. Mainly code refactoring and updating of error/ warning messaging.

Fixes #36863 .

#### Further detail of work
As per the comment on the issue (https://github.com/mantidproject/mantid/issues/36863#issuecomment-2575775621) the following changes have been made:

1.  Single wrapper function around calling a child algorithm added and replacing individual function calls
2.  Update to the `find_initial_indexing` function:
- If no UB on any table then call `FindUBUsingLatticeParameters` on tables until successful then break
- If there are UBs, copy UB to each workspace to get NUB x NUB triangular matrix of nindexed peaks - find best UB to use as a reference (currently: find UB which gives the most `ws` with `n_peaks` >= thresh. Tie-breaks by choosing the UB which indexes the most peaks across all `ws`).
- Once a reference UB has been found, index peaks in each table using this UB - if a table doesn't have enough indexed peaks then try and call `FindUBUsingLatticeParameters` and `make_UB_consistent` - if still not successful gives warning and excludes this table from optimisation.
3. After optimisation completed, loop over workspaces, call `IndexPeaks` and print warning for any runs which `n_peaks` < `MIN_NUM_INDEXED`
4. Move try/except to be around the call to `CalculateUMatrix` in `calcResiduals`, so we can throw error telling user which workspace/run is problematic
5. Relax `MIN_NUM_INDEXED` = 2
6. In `validateInputs` require each table to have a minimum of 2 indexed peaks if a UB is present, or 6 peaks (don't need to be indexed) if no UB is present (atm just requires total of 6 peaks).
7. Updated the tests to cover the change of `validateInputs` and the exclusion of peak tables with fewer than thresh peaks

### To test:

Following script has been use for developing:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

# generate peak table
ws = LoadEmptyInstrument(InstrumentName='SXD', OutputWorkspace='ws')
axis = ws.getAxis(0)
axis.setUnit("TOF")  # need this to add peak to table

SetGoniometer(Workspace=ws, Axis0='-5,0,1,0,1')
peaks = CreatePeaksWorkspace(InstrumentWorkspace='ws', NumberOfPeaks=0)
UB = np.diag([0.3333, 0.25, 0.09091])  # alatt = [3,4,11] 
SetUB(peaks, UB=UB)

peaks2 = CreatePeaksWorkspace(InstrumentWorkspace='ws', NumberOfPeaks=0)
UB = np.diag([0.30, 0.25, 0.1])  # alatt = [3.3,4,10] 
SetUB(peaks2, UB=UB)

SetGoniometer(Workspace=ws, Axis0='5,0,1,0,1')
peaks3 = CreatePeaksWorkspace(InstrumentWorkspace='ws', NumberOfPeaks=0)
UB = np.diag([0.3333, 0.25, 0.09091])  # alatt = [3,4,11] 
SetUB(peaks3, UB=UB)

peaks_list = [peaks, peaks2, peaks3]
for k in range(1,6):
    for l in range(1,6):
        for peak_ws in peaks_list:
            pk = peak_ws.createPeakHKL([2, k, l])
            if pk.getDetectorID() > 0:
               peak_ws.addPeak(pk)

#ClearUB(peaks2)

FindGlobalBMatrix(PeakWorkspaces = peaks_list,
    a=3, b=4,c=11,alpha=90,beta=90,gamma=90)
    
for ws in peaks_list:
    nindexed, *_ = IndexPeaks(ws, Tolerance=0.15, CommonUBForAll=True, EnableLogging=False)
    print(f"{ws.name()} has {nindexed} indexed peaks")
```

Changing `UB = np.diag([0.30, 0.25, 0.1])` for peaks2 to `UB = np.diag([0.33, 0.25, 0.1])` should see peaks2 included within the refinement.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
