### PR TITLE
Fix SANS move test failure

### DIFF
--- a/scripts/test/SANS/algorithm_detail/move_sans_instrument_component_test.py
+++ b/scripts/test/SANS/algorithm_detail/move_sans_instrument_component_test.py
@@ -21,8 +21,23 @@ from sans.state.StateObjects.state_instrument_info import StateInstrumentInfo
 from sans.test_helper.file_information_mock import SANSFileInformationMock
 
 
+def get_idf_filename_for_instrument(instrument_name):
+    """For the given instrument, return the file name for the version of the IDF that we're using in these tests."""
+    if instrument_name == "LOQ":
+        return "LOQ_Definition_20151016.xml"
+
+    if instrument_name == "SANS2D":
+        return "SANS2D_Definition_Tubes.xml"
+
+    if instrument_name == "LARMOR":
+        return "LARMOR_Definition_SEMSANS_SESANS.xml"
+
+    if instrument_name == "ZOOM":
+        return "ZOOM_Definition.xml"
+
+
 def load_empty_instrument(instrument_name):
-    sans_move_test_workspace = LoadEmptyInstrument(InstrumentName=instrument_name)
+    sans_move_test_workspace = LoadEmptyInstrument(Filename=get_idf_filename_for_instrument(instrument_name))
     return sans_move_test_workspace
 
 


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
The SANS move unit tests load the latest version of the IDF but have hard-coded values that mean they actually rely on specific versions of the SANS IDFs. This PR ensures that the tests are using the required IDF versions.

#### Purpose of work
To fix test failures after merging of PR #38532.

*There is no associated issue.*

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
Ideally I think we would create some test versions of the SANS IDFs in `mantid\instrument\unit_testing` rather than use any of the real versions (or refactor the test in some other way that removes any reliance on a particular IDF). However, a quick fix is needed and this approach should still be robust over the long-term. It could be improved as a maintenance task in future if desired.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
All tests should pass.

*This does not require release notes* because **it is a fix for a unit test, so there are no user-facing changes.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
