### PR TITLE
Restore lost legend when dragged out of figure

### DIFF
--- a/docs/source/release/v6.12.0/Workbench/Bugfixes/38580.rst
+++ b/docs/source/release/v6.12.0/Workbench/Bugfixes/38580.rst
@@ -1,0 +1,1 @@
+- Legends now automatically snap back to the default position if dragged off-screen.

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -268,10 +268,7 @@ class FigureInteraction(object):
             bbox_fig = fig.get_window_extent()
             bbox_legend = legend1.get_window_extent()
 
-            x0_fig, y0_fig, x1_fig, y1_fig = bbox_fig.x0, bbox_fig.y0, bbox_fig.x1, bbox_fig.y1
-            x0_leg, y0_leg, x1_leg, y1_leg = bbox_legend.x0, bbox_legend.y0, bbox_legend.x1, bbox_legend.y1
-
-            outside_window = x1_leg < x0_fig or x0_leg > x1_fig or y1_leg < y0_fig or y0_leg > y1_fig
+            outside_window = bbox_legend.x1 < bbox_fig.x0 or bbox_legend.x0 > bbox_fig.x1 or bbox_legend.y1 < bbox_fig.y0 or bbox_legend.y0 > bbox_fig.y1
 
             # Snap back legend
             if outside_window:

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -268,7 +268,9 @@ class FigureInteraction(object):
             bbox_fig = fig.get_window_extent()
             bbox_legend = legend1.get_window_extent()
 
-            outside_window = bbox_legend.x1 < bbox_fig.x0 or bbox_legend.x0 > bbox_fig.x1 or bbox_legend.y1 < bbox_fig.y0 or bbox_legend.y0 > bbox_fig.y1
+            outside_window = (
+                bbox_legend.x1 < bbox_fig.x0 or bbox_legend.x0 > bbox_fig.x1 or bbox_legend.y1 < bbox_fig.y0 or bbox_legend.y0 > bbox_fig.y1
+            )
 
             # Snap back legend
             if outside_window:

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -84,6 +84,7 @@ class FigureInteractionTest(unittest.TestCase):
         expected_call = [
             call("button_press_event", interactor.on_mouse_button_press),
             call("button_release_event", interactor.on_mouse_button_release),
+            call("button_release_event", interactor.on_button_release_legend_bounds_check),
             call("draw_event", interactor.draw_callback),
             call("motion_notify_event", interactor.motion_event),
             call("resize_event", interactor.mpl_redraw_annotations),

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -84,7 +84,6 @@ class FigureInteractionTest(unittest.TestCase):
         expected_call = [
             call("button_press_event", interactor.on_mouse_button_press),
             call("button_release_event", interactor.on_mouse_button_release),
-            call("button_release_event", interactor.on_button_release_legend_bounds_check),
             call("draw_event", interactor.draw_callback),
             call("motion_notify_event", interactor.motion_event),
             call("resize_event", interactor.mpl_redraw_annotations),


### PR DESCRIPTION
It compares the size of the figure with the coordinates of the legend to see if it's out of range and if it is it snaps it back to its default position.

### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
--> Snaps back legend to default position if it's dragged out of the figure. Compares the DPI (dots per inch - pixels) of the figure with the position of the legend. If the legend is outside the figure it snaps it back to the top left of the screen.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #37699. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
--> 
1. Drag Legend outside the figure.
2. Edit the legend and then drag it outside the figure
3. Read the code

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
