### PR TITLE
Ensure variable is initialised in Nexus code

### DIFF
--- a/Framework/NexusCpp/src/napi5.cpp
+++ b/Framework/NexusCpp/src/napi5.cpp
@@ -1051,7 +1051,7 @@ NXstatus NX5putattr(NXhandle fid, CONSTCHAR *name, const void *data, int datalen
   pNexusFile5 pFile;
   hid_t attr1, aid1, aid2;
   hid_t type;
-  herr_t iRet;
+  herr_t iRet = 0;
   hid_t vid, attRet;
 
   pFile = NXI5assert(fid);


### PR DESCRIPTION
### Description of work

#### Summary of work
System tests with SaveNexus steps were failing with: `Process finished with exit code -214748364`. As advised: Changing `herr_t iRet = 0`; has fixed it, the reasons are unknown to me 

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
System tests with SaveNexus steps were failing with: `Process finished with exit code -214748364`. Specifically `ISIS_PowderPolarisTest` but also others.
-->

*There is no associated issue.*

### To test:

In PyCharm run `C:/Users/kcd17618/Documents/dev/mantid/mantid/Testing/SystemTests/scripts/runSystemTests.py` with script parameters: `-R "PolarisTest.FocusTestNoAbsorption"`. This was failing, now should not be.

*This does not require release notes(?)* because it is a one line bug fix that will not impact user experience

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
