### PR TITLE
Clarify that gtest is pinned to v1.15.2 - ornl-next

### DIFF
--- a/buildconfig/CMake/GoogleTest.cmake
+++ b/buildconfig/CMake/GoogleTest.cmake
@@ -2,7 +2,7 @@
 
 # Make gtest_version available everywhere
 set(gtest_version
-    "b514bdc898e2951020cbdca1304b75f5950d1f59"
+    "v1.15.2"
     CACHE INTERNAL ""
 )
 
@@ -17,7 +17,7 @@ set(gtest_force_shared_crt
 fetchcontent_declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG b514bdc898e2951020cbdca1304b75f5950d1f59
+  GIT_TAG "${gtest_version}"
   EXCLUDE_FROM_ALL
 )
 


### PR DESCRIPTION
This is a version of #38565 into `ornl-next`