### PR TITLE
Allow users to register custom matplotlib colormaps

### DIFF
--- a/docs/source/release/v6.12.0/Workbench/Bugfixes/38587.rst
+++ b/docs/source/release/v6.12.0/Workbench/Bugfixes/38587.rst
@@ -1,0 +1,1 @@
+- The colorbar (used in Sliceviewer) has been updated to again allow the registration of custom matplotlib colormaps in scripts.

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -182,7 +182,11 @@ class ColorbarWidget(QWidget):
         self.colorbar = Colorbar(ax=self.ax, mappable=mappable)
         self.cmin_value, self.cmax_value = mappable.get_clim()
         self.update_clim_text()
-        self.cmap_changed(cmap, False)
+        try:
+            self.cmap_changed(cmap, False)
+        except ValueError:
+            # the default mantid colormap is not available, just use matplotlib default
+            pass
 
         mappable_cmap = get_current_cmap(mappable)
 

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -45,15 +45,16 @@ class ColorbarWidget(QWidget):
     scaleNormChanged = Signal()
     # register additional color maps from file
     register_customized_colormaps()
-    # create the list
-    cmap_list = sorted([cmap for cmap in colormaps.keys() if not cmap.endswith("_r")])
 
     def __init__(self, parent=None, default_norm_scale=None):
         """
         :param default_scale: None uses linear, else either a string or tuple(string, other arguments), e.g. tuple('Power', exponent)
         """
 
-        super(ColorbarWidget, self).__init__(parent)
+        super().__init__(parent)
+
+        # create the list. Initialize in the init so that it can be updated if new colormaps are added
+        self.cmap_list = sorted([cmap for cmap in colormaps.keys() if not cmap.endswith("_r")])
 
         self.setWindowTitle("Colorbar")
         self.setMaximumWidth(100)

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
@@ -13,7 +13,7 @@ from unittest import TestCase, mock
 
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.colorbar.colorbar import ColorbarWidget, NORM_OPTS
-from matplotlib.colors import LogNorm, Normalize, SymLogNorm
+from matplotlib.colors import LogNorm, Normalize, SymLogNorm, ListedColormap
 
 
 @start_qapplication
@@ -239,3 +239,18 @@ class ColorbarWidgetTest(TestCase):
             self.widget.clim_changed()
 
             self.assertEqual("0.0", self.widget.cmin.text())
+
+    def test_custom_colormaps(self):
+        # test that users can register custom colormaps and have it as an option in the colorbar
+        cmap_name = "custom_cmap"
+        self.assertFalse(cmap_name in plt.colormaps)
+        self.assertTrue(self.widget.cmap.findText(cmap_name) == -1)
+
+        plt.colormaps.register(cmap=ListedColormap([[0, 0, 0], [0, 0, 1]]), name=cmap_name)
+        self.assertTrue(cmap_name in plt.colormaps)
+
+        # now when you create a colorbar widget, the custom colormap should now be available
+        cb = ColorbarWidget()
+        self.assertTrue(cb.cmap.findText(cmap_name) != -1)
+
+        plt.colormaps.unregister(cmap_name)


### PR DESCRIPTION
### Description of work

This apparently work previously but stopped working at some point. The problem is that the list of available colormaps is initialized once when ColorbarWidget is first imported and we have users that like loaded register new colormaps in their scripts. This change makes it work again.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [8690: [Defect] Add MDF colormap to workbench and slice viewer](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8690)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

```python
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from matplotlib.colors import ListedColormap

plt.colormaps.register(cmap=ListedColormap([[0, 0, 0], [0, 0, 1], [0, 1, 0], [1, 0, 0], [1,1,1]]), name="CUSTOM_MAP")

S  =range(0,100);
ERR=range(0,100);
ws=CreateMDHistoWorkspace(Dimensionality=2,Extents='-10,10,-10,10',SignalInput=S,ErrorInput=ERR,\
                           NumberOfBins='10,10',Names='Dim1,Dim2',Units='MomentumTransfer,EnergyTransfer')
```

then open `ws` with Sliceviewer and check if `CUSTOM_MAP` is now one of the available Colormaps.

This will throw an error if you select the `Reverse` option unless a map named  `CUSTOM_MAP_r` is also added.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
