### PR TITLE
Fix for instrument view axes orientation.

### DIFF
--- a/docs/source/release/v6.12.0/Workbench/InstrumentViewer/Bugfixes/38593.rst
+++ b/docs/source/release/v6.12.0/Workbench/InstrumentViewer/Bugfixes/38593.rst
@@ -1,0 +1,1 @@
+- Fix for instrument view axes orientation

--- a/qt/widgets/instrumentview/src/Projection3D.cpp
+++ b/qt/widgets/instrumentview/src/Projection3D.cpp
@@ -287,7 +287,7 @@ void Projection3D::componentSelected(size_t componentIndex) {
   Quat rot;
   try {
     const auto compDir = normalize(pos - componentInfo.samplePosition());
-    V3D up(0, 0, 1);
+    V3D up(0, 1, 0);
     V3D x = up.cross_prod(compDir);
     up = compDir.cross_prod(x);
     InstrumentActor::BasisRotation(x, up, compDir, V3D(-1, 0, 0), V3D(0, 1, 0), V3D(0, 0, -1), rot);


### PR DESCRIPTION
### Description of work
[8875: [MANTID] The display of BIOSANS "detector1" in Mantid's instrument-viewer has an incorrect orientation](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8875)
- When viewing the instrument, if we select tab "instrument" then component "detector1", [the component is show with the horizontal axis (X) along the vertical]
<img width="683" alt="CG3_detector1_view" src="https://github.com/user-attachments/assets/546129ac-8d8a-4a52-9f17-e88286a54701" />



#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
The function which calculates 3D projections of instrument components was modified.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Open a run file, select tab  "Instrument" , and "detector1". The Y-axis should point up.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
