### PR TITLE
Surface Plotting from Multiple Single-Spectrum Workspaces

### DIFF
--- a/docs/source/release/v6.12.0/Workbench/New_features/38171.rst
+++ b/docs/source/release/v6.12.0/Workbench/New_features/38171.rst
@@ -1,2 +1,2 @@
-- Enabled Surface Plotting from Single-Spectrum Workspaces
+- Enabled surface and contour plotting in the `Plot Advanced` dialog when multiple single-spectrum workspaces are selected.
 - Enabled Wireframe Plotting across multiple workspaces.

--- a/docs/source/release/v6.12.0/Workbench/New_features/38171.rst
+++ b/docs/source/release/v6.12.0/Workbench/New_features/38171.rst
@@ -1,2 +1,2 @@
 - Enabled surface and contour plotting in the `Plot Advanced` dialog when multiple single-spectrum workspaces are selected.
-- Enabled Wireframe Plotting across multiple workspaces.
+- Fixed a bug where selecting multiple workspaces in the ADS and plotting a wireframe would only result in one of the workspaces being plotted.

--- a/docs/source/release/v6.12.0/Workbench/New_features/38171.rst
+++ b/docs/source/release/v6.12.0/Workbench/New_features/38171.rst
@@ -1,0 +1,1 @@
+- Enabled Surface Plotting from Single-Spectrum Workspaces

--- a/docs/source/release/v6.12.0/Workbench/New_features/38171.rst
+++ b/docs/source/release/v6.12.0/Workbench/New_features/38171.rst
@@ -1,1 +1,2 @@
 - Enabled Surface Plotting from Single-Spectrum Workspaces
+- Enabled Wireframe Plotting across multiple workspaces.

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -113,6 +113,10 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
     def on_ok_clicked(self):
         self.check_num_spectra()
 
+        if self.selection is None:
+            QMessageBox.warning(self, "Invalid Input", "Please enter a valid workspace index or spectrum number.")
+            return
+
         if self._check_number_of_plots(self.selection):
             self.accept()
 
@@ -145,10 +149,6 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
 
     # ------------------- Private -------------------------
     def _check_number_of_plots(self, selection):
-        if not selection or not selection.wksp_indices:
-            logger.error("Invalid selection or workspace indices are None.")
-            return False
-
         index_length = len(selection.wksp_indices) if selection.wksp_indices else len(selection.spectra)
         number_of_lines_to_plot = len(selection.workspaces) * index_length
         if selection.plot_type == SpectraSelection.Tiled and number_of_lines_to_plot > 12:

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -100,12 +100,15 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
         self._on_specnums_changed()
         self._on_wkspindices_changed()
 
-    # Check if workspace only has a single spectra, if true set default value to 1
+    # Check if workspace only has a single spectra, if true set it as first valid spectrum number
     def check_num_spectra(self):
         if not self._ui.specNums.text():
-            if any(ws.getNumberHistograms() == 1 for ws in self._workspaces):
-                self._ui.specNums.setText("1")
-                self._parse_spec_nums()
+            for ws in self._workspaces:
+                if ws.getNumberHistograms() == 1:
+                    spectrum_number = ws.getSpectrum(0).getSpectrumNo()
+                    self._ui.specNums.setText(str(spectrum_number))
+                    self._parse_spec_nums()
+                    break
 
     def on_ok_clicked(self):
         self.check_num_spectra()

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -145,6 +145,10 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
 
     # ------------------- Private -------------------------
     def _check_number_of_plots(self, selection):
+        if not selection or not selection.wksp_indices:
+            logger.error("Invalid selection or workspace indices are None.")
+            return False
+
         index_length = len(selection.wksp_indices) if selection.wksp_indices else len(selection.spectra)
         number_of_lines_to_plot = len(selection.workspaces) * index_length
         if selection.plot_type == SpectraSelection.Tiled and number_of_lines_to_plot > 12:

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -313,10 +313,7 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
                 if self._ui.advanced_options_widget.ui.plot_axis_label_line_edit.text() == WORKSPACE_NAME:
                     self._ui.advanced_options_widget.ui.plot_axis_label_line_edit.setText(WORKSPACE_REFERENCE_NUMBER)
 
-                self._ui.buttonBox.button(QDialogButtonBox.YesToAll).setEnabled(False)
-
-                if self._ui.plotType.currentText() == SURFACE:
-                    self._ui.buttonBox.button(QDialogButtonBox.YesToAll).setEnabled(True)
+                self._ui.buttonBox.button(QDialogButtonBox.YesToAll).setEnabled(True)
 
             else:
                 self._ui.advanced_options_widget.ui.error_bars_check_box.setEnabled(True)

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -284,10 +284,6 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
             ui.specNumsValid.setVisible(True)
             ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(False)
 
-            if self._advanced:
-                ui.advanced_options_widget._validate_custom_logs(ui.advanced_options_widget.ui.custom_log_line_edit.text())
-            return
-
         spectrum_numbers = [ws.getSpectrumNumbers() for ws in self._workspaces]
         unique_spectra = {tuple(numbers) for numbers in spectrum_numbers}
 
@@ -300,6 +296,9 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
 
         ui.specNumsValid.setVisible(not self._is_input_valid())
         ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(self._is_input_valid())
+
+        if self._advanced:
+            ui.advanced_options_widget._validate_custom_logs(ui.advanced_options_widget.ui.custom_log_line_edit.text())
 
     def _on_plot_type_changed(self, new_index):
         if self._overplot:

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -169,7 +169,7 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
         # overwrite the "Yes to All" button text
         ui.buttonBox.button(QDialogButtonBox.YesToAll).setText("Plot All")
         # ok disabled by default
-        ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(False)
+        ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
 
         # validity markers
         ui.wkspIndicesValid.setIcon(red_asterisk())
@@ -548,7 +548,7 @@ class AdvancedPlottingOptionsWidget(AdvancedPlottingOptionsWidgetUIBase):
                 if self._parent._ui.specNums.text() or self._parent._ui.wkspIndices.text():
                     self._parent._ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
             else:
-                self._parent._ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(False)
+                self._parent._ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
 
             return valid_options
 

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -180,7 +180,7 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
         # overwrite the "Yes to All" button text
         ui.buttonBox.button(QDialogButtonBox.YesToAll).setText("Plot All")
         # ok disabled by default
-        ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
+        ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(False)
 
         # validity markers
         ui.wkspIndicesValid.setIcon(red_asterisk())
@@ -301,7 +301,11 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
                 if self._ui.advanced_options_widget.ui.plot_axis_label_line_edit.text() == WORKSPACE_NAME:
                     self._ui.advanced_options_widget.ui.plot_axis_label_line_edit.setText(WORKSPACE_REFERENCE_NUMBER)
 
-                self._ui.buttonBox.button(QDialogButtonBox.YesToAll).setEnabled(True)
+                self._ui.buttonBox.button(QDialogButtonBox.YesToAll).setEnabled(False)
+
+                if self._ui.plotType.currentText() == SURFACE:
+                    self._ui.buttonBox.button(QDialogButtonBox.YesToAll).setEnabled(True)
+
             else:
                 self._ui.advanced_options_widget.ui.error_bars_check_box.setEnabled(True)
                 self._ui.advanced_options_widget.ui.plot_axis_label_line_edit.setEnabled(False)
@@ -556,7 +560,10 @@ class AdvancedPlottingOptionsWidget(AdvancedPlottingOptionsWidgetUIBase):
                     values = [float(value) for value in values]
                     self._parent.selection.custom_log_values = values
 
-                self._parent._ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
+                if self._parent._ui.specNums.text() or self._parent._ui.wkspIndices.text():
+                    self._parent._ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
+            else:
+                self._parent._ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(False)
 
             return valid_options
 

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -301,9 +301,6 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
         ui.specNumsValid.setVisible(not self._is_input_valid())
         ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(self._is_input_valid())
 
-        if self._advanced:
-            ui.advanced_options_widget._validate_custom_logs(ui.advanced_options_widget.ui.custom_log_line_edit.text())
-
     def _on_plot_type_changed(self, new_index):
         if self._overplot:
             self._ui.plotType.setCurrentIndex(0)

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -100,11 +100,21 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
         self._on_specnums_changed()
         self._on_wkspindices_changed()
 
+    # Check if workspace only has 1 spectra, if true set default value to 1
+    def check_num_spectra(self):
+        if not self._ui.specNums.text():
+            if any(ws.getNumberHistograms() == 1 for ws in self._workspaces):
+                self._ui.specNums.setText("1")
+
     def on_ok_clicked(self):
+        self.check_num_spectra()
+
         if self._check_number_of_plots(self.selection):
             self.accept()
 
     def on_plot_all_clicked(self):
+        self.check_num_spectra()
+
         selection = SpectraSelection(self._workspaces)
         selection.spectra = self._plottable_spectra
         selection.plot_type = self._ui.plotType.currentIndex()
@@ -290,7 +300,7 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
                 if self._ui.advanced_options_widget.ui.plot_axis_label_line_edit.text() == WORKSPACE_NAME:
                     self._ui.advanced_options_widget.ui.plot_axis_label_line_edit.setText(WORKSPACE_REFERENCE_NUMBER)
 
-                self._ui.buttonBox.button(QDialogButtonBox.YesToAll).setEnabled(False)
+                self._ui.buttonBox.button(QDialogButtonBox.YesToAll).setEnabled(True)
             else:
                 self._ui.advanced_options_widget.ui.error_bars_check_box.setEnabled(True)
                 self._ui.advanced_options_widget.ui.plot_axis_label_line_edit.setEnabled(False)
@@ -545,9 +555,6 @@ class AdvancedPlottingOptionsWidget(AdvancedPlottingOptionsWidgetUIBase):
                     values = [float(value) for value in values]
                     self._parent.selection.custom_log_values = values
 
-                if self._parent._ui.specNums.text() or self._parent._ui.wkspIndices.text():
-                    self._parent._ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
-            else:
                 self._parent._ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(True)
 
             return valid_options

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -102,6 +102,12 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
 
     # Check if workspace only has a single spectra, if true set it as first valid spectrum number
     def check_num_spectra(self):
+        if self.selection and (
+            (self.selection.wksp_indices and len(self.selection.wksp_indices) > 0)
+            or (self.selection.spectra and len(self.selection.spectra) > 0)
+        ):
+            return
+
         if not self._ui.specNums.text():
             for ws in self._workspaces:
                 if ws.getNumberHistograms() == 1:

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -263,17 +263,26 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
         ui.wkspIndices.clear()
         ui.wkspIndicesValid.hide()
 
-        self._parse_spec_nums()
+        try:
+            # Parse spectrum numbers
+            self._parse_spec_nums()
+            spectrum_numbers = [ws.getSpectrumNumbers() for ws in self._workspaces]
+            unique_spectra = {tuple(numbers) for numbers in spectrum_numbers}
+
+            if len(unique_spectra) > 1:
+                # Spectrum numbers differ between workspaces
+                ui.specNums.setEnabled(False)
+                ui.specNumsValid.setToolTip("Spectrum numbers differ across workspaces. Use 'Plot All' or workspace indices instead.")
+            else:
+                ui.specNums.setEnabled(True)
+                ui.specNumsValid.setToolTip("")
+
+        except Exception as e:
+            logger.error(f"Error parsing spectrum numbers: {e}")
+            ui.specNumsValid.setToolTip("Invalid spectrum number input.")
+            ui.specNumsValid.setVisible(True)
+
         ui.specNumsValid.setVisible(not self._is_input_valid())
-        if self._is_input_valid() or ui.specNums.text() == "":
-            ui.specNumsValid.setVisible(False)
-            ui.specNumsValid.setToolTip("")
-        elif ui.plotType.currentText() == SURFACE or ui.plotType.currentText() == CONTOUR:
-            ui.specNumsValid.setVisible(True)
-            ui.specNumsValid.setToolTip("Enter one spectrum number in " + ui.specNums.placeholderText())
-        else:
-            ui.specNumsValid.setVisible(True)
-            ui.specNumsValid.setToolTip("Not in " + ui.specNums.placeholderText())
         ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(self._is_input_valid())
 
         if self._advanced:

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -293,7 +293,7 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
 
         if len(unique_spectra) > 1:
             ui.specNums.setEnabled(False)
-            ui.specNumsValid.setToolTip("Spectrum numbers differ across workspaces. " "Use 'Plot All' or workspace indices instead.")
+            ui.specNumsValid.setToolTip("Spectrum numbers differ across workspaces. Use 'Plot All' or workspace indices instead.")
         else:
             ui.specNums.setEnabled(True)
             ui.specNumsValid.setToolTip("")

--- a/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/spectraselectordialog.py
@@ -100,11 +100,12 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
         self._on_specnums_changed()
         self._on_wkspindices_changed()
 
-    # Check if workspace only has 1 spectra, if true set default value to 1
+    # Check if workspace only has a single spectra, if true set default value to 1
     def check_num_spectra(self):
         if not self._ui.specNums.text():
             if any(ws.getNumberHistograms() == 1 for ws in self._workspaces):
                 self._ui.specNums.setText("1")
+                self._parse_spec_nums()
 
     def on_ok_clicked(self):
         self.check_num_spectra()

--- a/qt/python/mantidqt/mantidqt/dialogs/test/test_spectraselectiondialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/test/test_spectraselectiondialog.py
@@ -281,7 +281,7 @@ class SpectraSelectionDialogTest(unittest.TestCase):
         ssd._ui.advanced_options_widget.ui.custom_log_line_edit.setText("2,1,3")
         self.assertFalse(ssd._ui.buttonBox.button(QDialogButtonBox.Ok).isEnabled())
 
-    def test_plot_all_button_disabled_when_plot_type_is_surface(self):
+    def test_plot_all_button_enabled_when_plot_type_is_surface(self):
         workspaces = [self._single_spec_ws] * 3
         ssd = SpectraSelectionDialog(workspaces, advanced=True)
         ssd._ui.plotType.setCurrentIndex(3)

--- a/qt/python/mantidqt/mantidqt/dialogs/test/test_spectraselectiondialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/test/test_spectraselectiondialog.py
@@ -287,11 +287,11 @@ class SpectraSelectionDialogTest(unittest.TestCase):
         ssd._ui.plotType.setCurrentIndex(3)
         self.assertTrue(ssd._ui.buttonBox.button(QDialogButtonBox.YesToAll).isEnabled())
 
-    def test_plot_all_button_disabled_when_plot_type_is_contour(self):
+    def test_plot_all_button_enabled_when_plot_type_is_contour(self):
         workspaces = [self._single_spec_ws] * 3
         ssd = SpectraSelectionDialog(workspaces, advanced=True)
         ssd._ui.plotType.setCurrentIndex(4)
-        self.assertFalse(ssd._ui.buttonBox.button(QDialogButtonBox.YesToAll).isEnabled())
+        self.assertTrue(ssd._ui.buttonBox.button(QDialogButtonBox.YesToAll).isEnabled())
 
     def test_ok_button_disabled_when_plot_type_is_surface_and_more_than_one_spectrum_number_entered(self):
         workspaces = [self._multi_spec_ws] * 3

--- a/qt/python/mantidqt/mantidqt/dialogs/test/test_spectraselectiondialog.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/test/test_spectraselectiondialog.py
@@ -285,7 +285,7 @@ class SpectraSelectionDialogTest(unittest.TestCase):
         workspaces = [self._single_spec_ws] * 3
         ssd = SpectraSelectionDialog(workspaces, advanced=True)
         ssd._ui.plotType.setCurrentIndex(3)
-        self.assertFalse(ssd._ui.buttonBox.button(QDialogButtonBox.YesToAll).isEnabled())
+        self.assertTrue(ssd._ui.buttonBox.button(QDialogButtonBox.YesToAll).isEnabled())
 
     def test_plot_all_button_disabled_when_plot_type_is_contour(self):
         workspaces = [self._single_spec_ws] * 3

--- a/qt/python/mantidqt/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/functions.py
@@ -364,9 +364,6 @@ def plot_surface(workspaces, fig=None):
 
 @manage_workspace_names
 def plot_wireframe(workspaces, fig=None):
-    """
-    Plot wireframe plots for multiple workspaces on a single 3D plot.
-    """
     import matplotlib.pyplot as plt
     from matplotlib import colormaps
 
@@ -389,7 +386,6 @@ def plot_wireframe(workspaces, fig=None):
         legend = ax.legend(loc="upper right", title="Workspaces")
         legend_set_draggable(legend, True)
 
-    # Set the title to include the names of all workspaces
     workspace_names = ", ".join(ws.name() for ws in workspaces)
     ax.set_title(f"Wireframe Plot: {workspace_names}")
 

--- a/qt/python/mantidqt/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/functions.py
@@ -22,7 +22,7 @@ from mantid.plots.plotfunctions import manage_workspace_names, figure_title, plo
 
 from mantid.kernel import Logger, ConfigService
 from mantid.plots.datafunctions import add_colorbar_label
-from mantid.plots.utility import get_single_workspace_log_value
+from mantid.plots.utility import get_single_workspace_log_value, legend_set_draggable
 from mantidqt.plotting.figuretype import figure_type, FigureType
 from mantidqt.dialogs.spectraselectorutils import get_spectra_selection
 from mantid.api import IMDHistoWorkspace
@@ -364,19 +364,37 @@ def plot_surface(workspaces, fig=None):
 
 @manage_workspace_names
 def plot_wireframe(workspaces, fig=None):
+    """
+    Plot wireframe plots for multiple workspaces on a single 3D plot.
+    """
     import matplotlib.pyplot as plt
+    from matplotlib import colormaps
 
-    for ws in workspaces:
-        if fig:
-            fig.clf()
-            ax = fig.add_subplot(111, projection="mantid3d")
-        else:
-            fig, ax = plt.subplots(subplot_kw={"projection": "mantid3d"})
+    cmap = colormaps["tab10"]
+    colors = [cmap(i / max(1, len(workspaces) - 1)) for i in range(len(workspaces))]
 
-        fig.set_layout_engine(layout="tight")
-        ax.plot_wireframe(ws)
-        ax.set_title(ws.name())
-        fig.show()
+    if fig:
+        fig.clf()
+        ax = fig.add_subplot(111, projection="mantid3d")
+    else:
+        fig, ax = plt.subplots(subplot_kw={"projection": "mantid3d"})
+
+    for i, ws in enumerate(workspaces):
+        try:
+            ax.plot_wireframe(ws, color=colors[i], label=ws.name())
+        except Exception as e:
+            LOGGER.error(f"Failed to plot workspace {ws.name()}: {e}")
+
+    if len(workspaces) > 1:
+        legend = ax.legend(loc="upper right", title="Workspaces")
+        legend_set_draggable(legend, True)
+
+    # Set the title to include the names of all workspaces
+    workspace_names = ", ".join(ws.name() for ws in workspaces)
+    ax.set_title(f"Wireframe Plot: {workspace_names}")
+
+    fig.set_layout_engine(layout="tight")
+    fig.show()
 
     return fig
 


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
--> Made it possible to plot a surface from a number of workspaces with 1 spectrum each, with one axis of the plot being a log value.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38171. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

**Report to:**
@RichardWaiteSTFC @PascalManuel 

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
--> 
1. Follow instructions from Issue #38171 to reproduce.
2. Check that data is plotted correctly.
3. Check that nothing else breaks
4. Read code

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
