### PR TITLE
Improve test coverage for PolarizationCorrectionsHelpers methods

### DIFF
--- a/Framework/Algorithms/test/PolarizationCorrections/PolarizationCorrectionsHelpersTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/PolarizationCorrectionsHelpersTest.h
@@ -71,6 +71,48 @@ public:
     TS_ASSERT_THROWS(SpinStatesORSO::addORSOLogForSpinState(ws, "invalidSpinState"), std::invalid_argument &);
   }
 
+  void testSplitSpinStateStringSuccessful() { runTestSplitSpinStateString("01,11,10,00", {"01", "11", "10", "00"}); }
+
+  void testSplitSpinStateStringWithSpaces() {
+    runTestSplitSpinStateString(" 01 ,  11 , 10 ,  00 ", {"01", "11", "10", "00"});
+  }
+
+  void testSplitSpinStateStringEmptyString() { runTestSplitSpinStateString("", {}); }
+
+  void testSplitSpinStateStringSingleItem() { runTestSplitSpinStateString("01", {"01"}); }
+
+  void testIndexOfWorkspaceForSpinState_TargetStateExists() {
+    runTestIndexOfWorkspaceForSpinState({"00", "11", "10", "01"}, "10", true, 2);
+  }
+
+  void testIndexOfWorkspaceForSpinState_TargetStateDoesNotExist() {
+    runTestIndexOfWorkspaceForSpinState({"00", "11", "10", "01"}, "invalid_state", false);
+  }
+
+  void testIndexOfWorkspaceForSpinState_EmptySpinStateOrder() { runTestIndexOfWorkspaceForSpinState({}, "10", false); }
+
+  void testIndexOfWorkspaceForSpinState_DuplicateEntries() {
+    runTestIndexOfWorkspaceForSpinState({"10", "10", "11"}, "10", true, 0);
+  }
+
+  void testIndexOfWorkspaceForSpinState_TrimWhitespace() {
+    runTestIndexOfWorkspaceForSpinState({"00", "11", "10", "01"}, " 10 ", true, 2);
+  }
+
+  void testEmptySpinStateOrder() { runTestWorkspaceForSpinState({"01", "11"}, "", true); }
+
+  void testDuplicateSpinStates() { runTestWorkspaceForSpinState({"01", "01", "11"}, "01", false, "01"); }
+
+  void testWorkspaceForSpinStateUsingFredrikzeSpinStates() {
+    runTestWorkspaceForSpinState(FREDRIKZE_SPIN_STATES, SpinStateConfigurationsFredrikze::PARA_ANTI, false,
+                                 SpinStateConfigurationsFredrikze::PARA_ANTI);
+  }
+
+  void testWorkspaceForSpinStateUsingWildesSpinStates() {
+    runTestWorkspaceForSpinState(WILDES_SPIN_STATES, SpinStateConfigurationsWildes::PLUS_MINUS, false,
+                                 SpinStateConfigurationsWildes::PLUS_MINUS);
+  }
+
 private:
   const std::vector<std::string> WILDES_SPIN_STATES{
       SpinStateConfigurationsWildes::PLUS_PLUS,  SpinStateConfigurationsWildes::PLUS_MINUS,
@@ -138,6 +180,42 @@ private:
       const auto &run = ws->run();
       TS_ASSERT(run.hasProperty(SpinStatesORSO::LOG_NAME));
       TS_ASSERT_EQUALS(run.getPropertyValueAsType<std::string>(SpinStatesORSO::LOG_NAME), ORSO_SPIN_STATES[i]);
+    }
+  }
+
+  void runTestSplitSpinStateString(const std::string &spinStates, const std::vector<std::string> &expectedResult) {
+    std::vector<std::string> result = PolarizationCorrectionsHelpers::splitSpinStateString(spinStates);
+    TS_ASSERT_EQUALS(result.size(), expectedResult.size());
+
+    for (size_t i = 0; i < result.size(); ++i) {
+      TS_ASSERT_EQUALS(result[i], expectedResult[i]);
+    }
+  }
+
+  void runTestIndexOfWorkspaceForSpinState(const std::vector<std::string> &spinStateOrder,
+                                           const std::string &targetSpinState, bool expectedHasValue,
+                                           int expectedIndex = -1) {
+    auto index = PolarizationCorrectionsHelpers::indexOfWorkspaceForSpinState(spinStateOrder, targetSpinState);
+
+    if (expectedHasValue) {
+      TS_ASSERT(index.has_value());
+      TS_ASSERT_EQUALS(index.value(), expectedIndex);
+    } else {
+      ASSERT_FALSE(index.has_value());
+    }
+  }
+
+  void runTestWorkspaceForSpinState(const std::vector<std::string> &spinStateOrder, const std::string &targetSpinState,
+                                    bool expectedIsNull, const std::string &expectedWorkspaceName = "") {
+    auto grp = createGroupWorkspaceToMatchSpinStates(spinStateOrder);
+    auto ws =
+        PolarizationCorrectionsHelpers::workspaceForSpinState(grp, boost::join(spinStateOrder, ","), targetSpinState);
+
+    if (expectedIsNull) {
+      TS_ASSERT(ws == nullptr);
+    } else {
+      TS_ASSERT(ws != nullptr);
+      TS_ASSERT_EQUALS(ws->getName(), expectedWorkspaceName);
     }
   }
 };

--- a/Framework/Algorithms/test/PolarizationCorrections/PolarizationCorrectionsHelpersTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrections/PolarizationCorrectionsHelpersTest.h
@@ -48,6 +48,20 @@ public:
     TS_ASSERT(ws == nullptr);
   }
 
+  void testEmptySpinState() { runTestWorkspaceForSpinState({"01", "11"}, "", true); }
+
+  void testDuplicateSpinStates() { runTestWorkspaceForSpinState({"01", "01", "11"}, "01", false, "01"); }
+
+  void testWorkspaceForSpinStateUsingFredrikzeSpinStates() {
+    runTestWorkspaceForSpinState(FREDRIKZE_SPIN_STATES, SpinStateConfigurationsFredrikze::PARA_ANTI, false,
+                                 SpinStateConfigurationsFredrikze::PARA_ANTI);
+  }
+
+  void testWorkspaceForSpinStateUsingWildesSpinStates() {
+    runTestWorkspaceForSpinState(WILDES_SPIN_STATES, SpinStateConfigurationsWildes::PLUS_MINUS, false,
+                                 SpinStateConfigurationsWildes::PLUS_MINUS);
+  }
+
   void testGetORSONotationForSpinStateForWildes() { runTestGetORSONotationForSpinStates(WILDES_SPIN_STATES); }
 
   void testGetORSONotationForSpinStateForFredrikze() { runTestGetORSONotationForSpinStates(FREDRIKZE_SPIN_STATES); }
@@ -82,35 +96,21 @@ public:
   void testSplitSpinStateStringSingleItem() { runTestSplitSpinStateString("01", {"01"}); }
 
   void testIndexOfWorkspaceForSpinState_TargetStateExists() {
-    runTestIndexOfWorkspaceForSpinState({"00", "11", "10", "01"}, "10", true, 2);
+    runTestIndexOfWorkspaceForSpinState({"00", "11", "10", "01"}, "10", 2);
   }
 
   void testIndexOfWorkspaceForSpinState_TargetStateDoesNotExist() {
-    runTestIndexOfWorkspaceForSpinState({"00", "11", "10", "01"}, "invalid_state", false);
+    runTestIndexOfWorkspaceForSpinState({"00", "11", "10", "01"}, "invalid_state");
   }
 
-  void testIndexOfWorkspaceForSpinState_EmptySpinStateOrder() { runTestIndexOfWorkspaceForSpinState({}, "10", false); }
+  void testIndexOfWorkspaceForSpinState_EmptySpinStateOrder() { runTestIndexOfWorkspaceForSpinState({}, "10"); }
 
   void testIndexOfWorkspaceForSpinState_DuplicateEntries() {
-    runTestIndexOfWorkspaceForSpinState({"10", "10", "11"}, "10", true, 0);
+    runTestIndexOfWorkspaceForSpinState({"10", "10", "11"}, "10", 0);
   }
 
   void testIndexOfWorkspaceForSpinState_TrimWhitespace() {
-    runTestIndexOfWorkspaceForSpinState({"00", "11", "10", "01"}, " 10 ", true, 2);
-  }
-
-  void testEmptySpinStateOrder() { runTestWorkspaceForSpinState({"01", "11"}, "", true); }
-
-  void testDuplicateSpinStates() { runTestWorkspaceForSpinState({"01", "01", "11"}, "01", false, "01"); }
-
-  void testWorkspaceForSpinStateUsingFredrikzeSpinStates() {
-    runTestWorkspaceForSpinState(FREDRIKZE_SPIN_STATES, SpinStateConfigurationsFredrikze::PARA_ANTI, false,
-                                 SpinStateConfigurationsFredrikze::PARA_ANTI);
-  }
-
-  void testWorkspaceForSpinStateUsingWildesSpinStates() {
-    runTestWorkspaceForSpinState(WILDES_SPIN_STATES, SpinStateConfigurationsWildes::PLUS_MINUS, false,
-                                 SpinStateConfigurationsWildes::PLUS_MINUS);
+    runTestIndexOfWorkspaceForSpinState({"00", "11", "10", "01"}, " 10 ", 2);
   }
 
 private:
@@ -193,16 +193,10 @@ private:
   }
 
   void runTestIndexOfWorkspaceForSpinState(const std::vector<std::string> &spinStateOrder,
-                                           const std::string &targetSpinState, bool expectedHasValue,
-                                           int expectedIndex = -1) {
+                                           const std::string &targetSpinState,
+                                           const std::optional<size_t> expectedIndex = std::nullopt) {
     auto index = PolarizationCorrectionsHelpers::indexOfWorkspaceForSpinState(spinStateOrder, targetSpinState);
-
-    if (expectedHasValue) {
-      TS_ASSERT(index.has_value());
-      TS_ASSERT_EQUALS(index.value(), expectedIndex);
-    } else {
-      ASSERT_FALSE(index.has_value());
-    }
+    TS_ASSERT_EQUALS(index, expectedIndex);
   }
 
   void runTestWorkspaceForSpinState(const std::vector<std::string> &spinStateOrder, const std::string &targetSpinState,
@@ -211,10 +205,8 @@ private:
     auto ws =
         PolarizationCorrectionsHelpers::workspaceForSpinState(grp, boost::join(spinStateOrder, ","), targetSpinState);
 
-    if (expectedIsNull) {
-      TS_ASSERT(ws == nullptr);
-    } else {
-      TS_ASSERT(ws != nullptr);
+    TS_ASSERT_EQUALS(ws == nullptr, expectedIsNull);
+    if (!expectedIsNull) {
       TS_ASSERT_EQUALS(ws->getName(), expectedWorkspaceName);
     }
   }


### PR DESCRIPTION
### Description of work
- added unit tests to test splitSpinStateString 
- added unit tests to test indexOfWorkspaceForSpinState
- added unit tests to test workSpaceForSpinState

Fixes #37749

### To test:
- review unit tests
- tests should pass 

This does not require release notes because it involves updating the unit tests