### PR TITLE
Detect unwriteable Abins cache, raise better error

### DIFF
--- a/docs/source/release/v6.12.0/Indirect/Algorithms/Bugfixes/38606.rst
+++ b/docs/source/release/v6.12.0/Indirect/Algorithms/Bugfixes/38606.rst
@@ -1,0 +1,1 @@
+- :ref:`Abins <algm-Abins-v1>` / :ref:`Abins2D <algm-Abins2D-v1>` now gives a more helpful error message when the Default Save Directory is unwriteable. (A writeable save directory is required for caching data.)

--- a/scripts/abins/io.py
+++ b/scripts/abins/io.py
@@ -8,6 +8,7 @@ import hashlib
 import io
 import json
 import os
+from pathlib import Path
 import subprocess
 import shutil
 from typing import List, Optional
@@ -35,6 +36,23 @@ class IO(BaseModel):
     autoconvolution: int = 10
     temperature: float = None
 
+    @staticmethod
+    def _dir_is_not_writeable(directory: Path):
+        """Check write permissions of directory by writing a temporary file
+
+        This is the only _really_ reliable way of knowing; checking attributes can
+        still give incorrect answers depending on OS, network drive status etc.
+        """
+        from tempfile import NamedTemporaryFile
+
+        try:
+            with NamedTemporaryFile(mode="w", dir=directory) as fd:
+                print("check this directory is writeable", file=fd)
+        except IOError:
+            return True
+
+        return False
+
     def model_post_init(self, __context):
         try:
             self._hash_input_filename = self.calculate_ab_initio_file_hash()
@@ -51,6 +69,12 @@ class IO(BaseModel):
         else:
             core_name = filename  # e.g. OUTCAR -> OUTCAR (core_name) -> OUTCAR.hdf5
 
+        if self._dir_is_not_writeable(self.get_save_dir_path()):
+            raise Exception(
+                "Could not write a file to the default save directory: "
+                "this is required for caching. Please set 'Default Save Directory' to "
+                "a writeable location using the File/Manage User Directories interface."
+            )
         self._hdf_filename = os.path.join(self.get_save_dir_path(), core_name + ".hdf5")  # name of hdf file
 
         self._attributes = {}  # attributes for group

--- a/scripts/abins/io.py
+++ b/scripts/abins/io.py
@@ -8,7 +8,6 @@ import hashlib
 import io
 import json
 import os
-from pathlib import Path
 import subprocess
 import shutil
 from typing import List, Optional
@@ -37,7 +36,7 @@ class IO(BaseModel):
     temperature: float = None
 
     @staticmethod
-    def _dir_is_not_writeable(directory: Path):
+    def _dir_is_not_writeable(directory: str):
         """Check write permissions of directory by writing a temporary file
 
         This is the only _really_ reliable way of knowing; checking attributes can


### PR DESCRIPTION
### Description of work

Quality-of-life improvement for a common user issue with Abins: in some installations the default user save directory is not writeable.

I am working on a better solution to allow the Abins cache directory to be set more explicitly, but in the hope of getting something that helps users in before the code freeze this should be a good start.

#### Summary of work
This is related to #38084 ; AbINS users sometimes have an unwriteable default save directory which leads to an unhelpful error message, and need support to fix it. Here we explicitly check that the directory is writeable and raise a more useful error message if not.

Ideally this validation would be part of an explicit input field in the Algorithm and give a nice red asterisk; I'm working on that but it is more involved to test and review. Here is a small fix that provides 50% of the benefits in a small fraction of the case.


### To test:

You will need an Abins input file, e.g. *ExternalData/Testing/Data/UnitTest/benzene_abins.phonon*. Run the Abins algorithm with this VibrationalOrPhononFile and set the appropriate AbInitioProgram (CASTEP for that file) and some name for OutputWorkspace. Other parameters don't matter; run the algorithm and if you have a reasonable user directory set up there should be no error.

Then go to File/Manage User Directories and set the default save directory to somewhere unwriteable like /lib64. Run Abins again (with a different workspace name); it should present a useful error message.

This should work exactly the same for Abins2D

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
