### PR TITLE
Prepare for release candidate v6.11.0.3rc2

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/RebinRaggedTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/RebinRaggedTest.py
@@ -126,6 +126,73 @@ class RebinRaggedTest(unittest.TestCase):
                 # parameters are set so all y-values are 0.6
                 np.testing.assert_almost_equal(14, y, err_msg=label)
 
+    def test_FullBinsOnly(self):
+        xExpected = [0.5, 2.5, 4.5, 6.5]
+        yExpected = [10, 24, 38]
+
+        def Create1DWorkspace(size):
+            xData = []
+            yData = []
+            j = 0.5
+            for i in range(0, size + 1):
+                xData.append(j)
+                yData.append((i + 1) * 2)
+                j = 0.75 + j
+            yData.pop()
+            ws = api.CreateWorkspace(xData, yData)
+            return ws
+
+        inputWs = Create1DWorkspace(10)
+
+        api.RebinRagged(InputWorkspace=inputWs, OutputWorkspace="NotFullBinsOnly", Delta=2.0, PreserveEvents=True, FullBinsOnly=False)
+        fullBinsOnlyWs = api.RebinRagged(
+            InputWorkspace=inputWs, OutputWorkspace="FullBinsOnly", Delta=2.0, PreserveEvents=True, FullBinsOnly=True
+        )
+
+        fullBinsXValues = AnalysisDataService.retrieve("FullBinsOnly").readX(0)
+        fullBinsYValues = AnalysisDataService.retrieve("FullBinsOnly").readY(0)
+
+        notFullBinsXValues = AnalysisDataService.retrieve("NotFullBinsOnly").readX(0)
+
+        assert not fullBinsOnlyWs.isRaggedWorkspace()
+
+        assert len(fullBinsXValues) == len(xExpected)
+        assert len(notFullBinsXValues) != len(fullBinsXValues)
+
+        for i in range(len(fullBinsXValues)):
+            np.testing.assert_almost_equal(fullBinsXValues[i], xExpected[i])
+
+        for i in range(len(fullBinsYValues)):
+            np.testing.assert_almost_equal(fullBinsYValues[i], yExpected[i])
+
+        api.DeleteWorkspace("NotFullBinsOnly")
+        api.DeleteWorkspace("FullBinsOnly")
+        api.DeleteWorkspace(inputWs)
+
+    def test_hist_workspace_fullBinsOnly(self):
+        # numpy 1.7 (on rhel7) doesn't have np.full
+        xmins = np.full((200,), 50.0)
+        xmins[11] = 3000.0
+        xmaxs = np.full((200,), 650.0)
+        xmaxs[12] = 5000.0
+        deltas = np.full(200, -2.0)
+        deltas[13] = 100.0
+
+        inputWs = api.CreateSampleWorkspace(OutputWorkspace="RebinRagged_hist", WorkspaceType="Histogram", BinWidth=75, XMin=50)
+
+        notFullBinsOnlyWs = api.RebinRagged(
+            InputWorkspace=inputWs, OutputWorkspace="NotFullBinsOnly", XMin=xmins, XMax=xmaxs, Delta=deltas, FullBinsOnly=False
+        )
+        fullBinsOnlyWs = api.RebinRagged(
+            InputWorkspace=inputWs, OutputWorkspace="FullBinsOnly", XMin=xmins, XMax=xmaxs, Delta=deltas, FullBinsOnly=True
+        )
+
+        assert len(fullBinsOnlyWs.readX(0)) != len(notFullBinsOnlyWs.readX(0))
+        assert fullBinsOnlyWs.isRaggedWorkspace()
+        api.DeleteWorkspace("NotFullBinsOnly")
+        api.DeleteWorkspace("FullBinsOnly")
+        api.DeleteWorkspace(inputWs)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/algorithms/RebinRagged-v2.rst
+++ b/docs/source/algorithms/RebinRagged-v2.rst
@@ -41,6 +41,40 @@ This particular use-case, which uses the input workspace's binning, could be don
                         Xmax=[10.20, 20.8, nan, nan, nan, 9.35])
 
 
+Sometimes due to the data or logarithmic rebinning, there are incomplete bins left over at the end of the spectrum.  These incomplete bins may result in artificats at the tail end.  This can be removed by setting the `FullBinsOnly` parameter to `True`.
+
+.. code-block:: python
+
+    from mantid.simpleapi import *
+
+    from time import time
+
+
+    ## create a workspace to be rebin-ragged
+    wsname = "ws"
+    CreateSampleWorkspace(
+        OutputWorkspace=wsname,
+        BankPixelWidth=3,
+    )
+    GroupDetectors(
+        InputWorkspace=wsname,
+        OutputWorkspace=wsname,
+        GroupingPattern="0-3,4-5,6-8,9-12,13-14,15-17",
+    )
+
+    # rebin the workspace raggedly
+    xMin = [0.05,0.06,0.1,0.07,0.04, 0.04]
+    xMax = [0.36,0.41,0.64,0.48,0.48,0.48]
+    delta = [-0.000401475,-0.000277182,-0.000323453,-0.000430986,-0.000430986,-0.000430986]
+    RebinRagged(
+        InputWorkspace=wsname,
+        XMin=xMin,
+        XMax=xMax,
+        Delta=delta,
+        FullBinsOnly=True,
+        OutputWorkspace=wsname,
+    )
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/algorithms/RebinRagged-v2.rst
+++ b/docs/source/algorithms/RebinRagged-v2.rst
@@ -41,7 +41,7 @@ This particular use-case, which uses the input workspace's binning, could be don
                         Xmax=[10.20, 20.8, nan, nan, nan, 9.35])
 
 
-Sometimes due to the data or logarithmic rebinning, there are incomplete bins left over at the end of the spectrum.  These incomplete bins may result in artificats at the tail end.  This can be removed by setting the `FullBinsOnly` parameter to `True`.
+Sometimes due to the data or logarithmic rebinning, there are incomplete bins left over at the end of the spectrum.  These incomplete bins may result in artifacts at the tail end.  This can be removed by setting the `FullBinsOnly` parameter to `True`.
 
 .. code-block:: python
 

--- a/docs/source/algorithms/RebinRagged-v2.rst
+++ b/docs/source/algorithms/RebinRagged-v2.rst
@@ -20,6 +20,8 @@ The minimum and maximum values that are specified are interpreted as follows:
 The ``Delta`` parameter is required and can either be a single number which is common to all, or one number per spectra.
 Positive values are interpreted as constant step-size. Negative are logorithmic.
 
+Please refer to :ref:`Rebin <algm-Rebin>` for a more analytical explanation of `FullBinsOnly`.
+
 Usage
 -----
 

--- a/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38550.rst
+++ b/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38550.rst
@@ -1,0 +1,1 @@
+:ref:`RebinRagged <algm-RebinRagged>` exposes FullBinsOnly from Rebin Algo.

--- a/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38550.rst
+++ b/docs/source/release/v6.12.0/Framework/Algorithms/New_features/38550.rst
@@ -1,1 +1,1 @@
-:ref:`RebinRagged <algm-RebinRagged>` exposes FullBinsOnly from Rebin Algo.
+- :ref:`RebinRagged <algm-RebinRagged>` exposes FullBinsOnly from Rebin Algo.

--- a/docs/source/release/v6.12.0/Workbench/Bugfixes/38587.rst
+++ b/docs/source/release/v6.12.0/Workbench/Bugfixes/38587.rst
@@ -1,0 +1,1 @@
+- The colorbar (used in Sliceviewer) has been updated to again allow the registration of custom matplotlib colormaps in scripts.

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -182,7 +182,11 @@ class ColorbarWidget(QWidget):
         self.colorbar = Colorbar(ax=self.ax, mappable=mappable)
         self.cmin_value, self.cmax_value = mappable.get_clim()
         self.update_clim_text()
-        self.cmap_changed(cmap, False)
+        try:
+            self.cmap_changed(cmap, False)
+        except ValueError:
+            # the default mantid colormap is not available, just use matplotlib default
+            pass
 
         mappable_cmap = get_current_cmap(mappable)
 

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -45,15 +45,16 @@ class ColorbarWidget(QWidget):
     scaleNormChanged = Signal()
     # register additional color maps from file
     register_customized_colormaps()
-    # create the list
-    cmap_list = sorted([cmap for cmap in colormaps.keys() if not cmap.endswith("_r")])
 
     def __init__(self, parent=None, default_norm_scale=None):
         """
         :param default_scale: None uses linear, else either a string or tuple(string, other arguments), e.g. tuple('Power', exponent)
         """
 
-        super(ColorbarWidget, self).__init__(parent)
+        super().__init__(parent)
+
+        # create the list. Initialize in the init so that it can be updated if new colormaps are added
+        self.cmap_list = sorted([cmap for cmap in colormaps.keys() if not cmap.endswith("_r")])
 
         self.setWindowTitle("Colorbar")
         self.setMaximumWidth(100)

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
@@ -13,7 +13,7 @@ from unittest import TestCase, mock
 
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.colorbar.colorbar import ColorbarWidget, NORM_OPTS
-from matplotlib.colors import LogNorm, Normalize, SymLogNorm
+from matplotlib.colors import LogNorm, Normalize, SymLogNorm, ListedColormap
 
 
 @start_qapplication
@@ -239,3 +239,18 @@ class ColorbarWidgetTest(TestCase):
             self.widget.clim_changed()
 
             self.assertEqual("0.0", self.widget.cmin.text())
+
+    def test_custom_colormaps(self):
+        # test that users can register custom colormaps and have it as an option in the colorbar
+        cmap_name = "custom_cmap"
+        self.assertFalse(cmap_name in plt.colormaps)
+        self.assertTrue(self.widget.cmap.findText(cmap_name) == -1)
+
+        plt.colormaps.register(cmap=ListedColormap([[0, 0, 0], [0, 0, 1]]), name=cmap_name)
+        self.assertTrue(cmap_name in plt.colormaps)
+
+        # now when you create a colorbar widget, the custom colormap should now be available
+        cb = ColorbarWidget()
+        self.assertTrue(cb.cmap.findText(cmap_name) != -1)
+
+        plt.colormaps.unregister(cmap_name)


### PR DESCRIPTION
In prep for ORNL fork release candidate: v6.11.0.3rc2

---
> summary generated by AI
This pull request introduces a new feature to the `RebinRagged` algorithm and includes updates to the documentation and tests. Additionally, it addresses a bug in the colorbar widget used in the Sliceviewer. The most important changes are summarized below:

### `RebinRagged` Algorithm Enhancements:

* Added a new property `FullBinsOnly` to the `RebinRagged` algorithm to allow users to omit the final bin if its width is smaller than the step size. This change affects both the initialization and execution of the algorithm. [[1]](diffhunk://#diff-cb23ad76294b1d07cb62bcbd0eba7883e8e80b239eb814900c1c7334c33bd0dbR60) [[2]](diffhunk://#diff-cb23ad76294b1d07cb62bcbd0eba7883e8e80b239eb814900c1c7334c33bd0dbR111) [[3]](diffhunk://#diff-cb23ad76294b1d07cb62bcbd0eba7883e8e80b239eb814900c1c7334c33bd0dbR128) [[4]](diffhunk://#diff-cb23ad76294b1d07cb62bcbd0eba7883e8e80b239eb814900c1c7334c33bd0dbL167-R171) [[5]](diffhunk://#diff-cb23ad76294b1d07cb62bcbd0eba7883e8e80b239eb814900c1c7334c33bd0dbL191-R196) [[6]](diffhunk://#diff-cb23ad76294b1d07cb62bcbd0eba7883e8e80b239eb814900c1c7334c33bd0dbL245-R251)

### Documentation Updates:

* Updated the `RebinRagged` documentation to include an explanation of the `FullBinsOnly` parameter and provided an example of its usage. [[1]](diffhunk://#diff-62cef5fa5e574b6b6b3307975579f2186ebd1fa3caa0e6006d481c5f7481d86dR23-R24) [[2]](diffhunk://#diff-62cef5fa5e574b6b6b3307975579f2186ebd1fa3caa0e6006d481c5f7481d86dR44-R77)
* Added a note in the release notes to highlight the new `FullBinsOnly` feature in the `RebinRagged` algorithm.

### Testing Enhancements:

* Added new tests in `RebinRaggedTest.py` to verify the behavior of the `FullBinsOnly` parameter for both event and histogram workspaces.

### Bug Fixes:

* Fixed an issue in the colorbar widget used in Sliceviewer to allow the registration of custom matplotlib colormaps in scripts. This involved updating the initialization of the colormap list and handling potential errors when setting the colormap. [[1]](diffhunk://#diff-fb7cb2e6b0dd9df278b0a97a7414a7a7f6d1183291175bcb2b04345f88fe1519L48-R57) [[2]](diffhunk://#diff-fb7cb2e6b0dd9df278b0a97a7414a7a7f6d1183291175bcb2b04345f88fe1519R185-R189) [[3]](diffhunk://#diff-3d5a6b19f6890cbc9217c8eeb952c875ae1da803911ba0cd938b8e0c1438773dL16-R16) [[4]](diffhunk://#diff-3d5a6b19f6890cbc9217c8eeb952c875ae1da803911ba0cd938b8e0c1438773dR242-R256)
* Updated the release notes to reflect the bug fix for the colorbar widget.