### PR TITLE
Add additional support for saving data using the ISIS Sans Command Interface

### DIFF
--- a/docs/source/release/v6.13.0/SANS/New_features/38502.rst
+++ b/docs/source/release/v6.13.0/SANS/New_features/38502.rst
@@ -1,0 +1,2 @@
+- Update SANS Command Line Interface to pass a save algorithm directly to the ``WavRangeReduction`` command.
+- Update documentation for :ref:`scripting SANS reduction<ScriptingSansReductions>` using command line interface.

--- a/docs/source/techniques/ScriptingSANSReductions.rst
+++ b/docs/source/techniques/ScriptingSANSReductions.rst
@@ -13,61 +13,92 @@ SANS data from ISIS can be analysed using :ref:`Python <introduction_to_python>`
 
 .. code-block :: python
 
-    from ISISCommandInterface import *
+    #import Command Interface from sans library
+    from sans.command_interface.ISISCommandInterface import *
+
+    """
+    Test script outlining the use of the command line interface to reduce and save SANS data.
+    Data is taken from the Mantid Training Data Course Set: https://www.mantidproject.org/installation/index#sample-data
+
+    """
 
     LOQ()
-    MaskFile('MASK.094AA')
+    MaskFile('MaskFile.toml')
 
-    AssignSample('54431.raw')
-    TransmissionSample('54435.raw', '54433.raw')
-    AssignCan('54432.raw')
-    TransmissionCan('54434.raw', '54433.raw')
+    AssignSample('LOQ74044.nxs')
+    TransmissionSample('LOQ74024.nxs', 'LOQ74014.nxs')
+    AssignCan('LOQ74019.nxs')
+    TransmissionCan('LOQ74020.nxs', 'LOQ74014.nxs')
 
-    WavRangeReduction(3, 9)
+    #Performs reduction and saves data to path using SaveRKH and SaveNexus algorithms
+    WavRangeReduction(2.2, 10, saveAlgs=["SaveRKH","SaveNexus"])
 
-To configure the reduction the following commands are available once the ISISCommandInterface module has been imported, using the following command:
+The commands are available once the ISISCommandInterface module has been imported, using the following line:
 
 .. code-block :: python
 
-    from ISISCommandInterface import *
+    from sans.command_interface.ISISCommandInterface import *
 
-These commands are given here in the order they are likely to be found in a script file although, except were stated, the order does not matter:
+These commands are given below in the order in which they are likely to be found in a script file although,
+except were stated, the order does not matter.
 
-``LOQ()`` ``SANS2D()``
-----------------------
+Reference Commands
+------------------
+
+LOQ / SANS2D
+^^^^^^^^^^^^
+
+.. code-block :: python
+
+   LOQ() #For LOQ
+   SANS2D() #For SANS2D
 
 This specifies which instrument the data was collected from. Either ``LOQ()`` or ``SANS2D()``.
 The layout of the detector banks and detector efficiency files are stored here.
 
-*This line must be included and before the* ``MaskFile()`` *line.*
+*This line must be included, and before the* ``MaskFile()`` *line.*
 
-``UserPath(path)``
-------------------
+UserPath
+^^^^^^^^
+
+.. code-block :: python
+
+   UserPath(path)
 
 Sets the directory in which Mantid should look for user settings file if a full path was not specified.
 
 *This must be specified before the* ``MaskFile()`` *line to have any effect.*
 
-``DataPath(path)``
-------------------
+DataPath
+^^^^^^^^
+
+.. code-block :: python
+
+   DataPath(path)
 
 This can be used to specify an extra directory in which Mantid will look for run files.
 The directories that have been set in the :ref:`Manage User Directories <ManageUserDirectories>` dialog,
 or equivalently the :ref:`Mantid.user.properties <Properties File>` file, are also checked.
 
-``MaskFile(file_name)``
------------------------
-
-This settings file can be either a full path or a filename found in the ``UserPath()``.
-The settings here are overridden by the commands listed below.
+MaskFile
+^^^^^^^^
 
 .. code-block :: python
 
     UserPath("C:/SANS/masks")
-    MaskFile("MASK.09A") # or MaskFile("C:/SANS/masks/MASK.09A")
+    MaskFile("ExampleMask.toml") # or MaskFile("C:/SANS/masks/ExampleMask.toml")
 
-``AssignSample(sample_run, reload=True, period)``
--------------------------------------------------
+This settings file can be either a full path or a filename found in the ``UserPath()``.
+The settings here are overridden by the commands listed below.
+
+
+
+AssignSample
+^^^^^^^^^^^^
+
+.. code-block :: python
+
+    AssignSample(sample_run, reload=True, period)
 
 Specifies the run to analyse using the format ``InstRun#.extension``, e.g. ``SANS2D7777.nxs``.
 This is one of the few commands that executes :ref:`Mantid algorithms <Algorithm>` when called,
@@ -76,8 +107,12 @@ On calling this function the experimental run is :ref:`loaded <algm-Load>` and c
 (normally the detector bank and sample).
 Currently only ``reload=true`` is supported.
 
-``TransmissionSample(sample, direct, reload=True, period_t, period_d)``
------------------------------------------------------------------------
+TransmissionSample
+^^^^^^^^^^^^^^^^^
+
+.. code-block :: python
+
+    TransmissionSample(sample, direct, relaod=True, period_t, period_d)
 
 Specifies the runs that will be used to calculate the transmission fraction for the sample run.
 ``sample`` contains transmission monitor counts data for the sample when the sample is present,
@@ -86,42 +121,66 @@ The workspaces are loaded and the transmission :ref:`IDF <InstrumentDefinitionFi
 is loaded into the workspaces when this command is encountered. The transmission fraction is calculated later.
 The ``period_t`` and ``period_d`` are used when there are multi-period files and specify the period to use for the sample and direct run respectively.
 
-``AssignCan(can_run, reload=True, period)``
--------------------------------------------
+AssignCan
+^^^^^^^^^
+
+.. code-block :: python
+
+    AssignCan(can_run, reload=True, period)
 
 The can is a scattering run made under the same conditions as the experimental run but only the sample container is in the sample position.
 Hence allowing the effect of the container to be removed. The run is specified using ``instrumentrunnumber.extension``, e.g. ``SANS2D7777.nxs``.
 On calling this function the run is loaded to a workspace and the detector banks and other components are moved as applicable.
 Currently only ``reload=true`` is supported.
 
-``TransmissionCan(can, direct, reload=True, period_t, period_d)``
------------------------------------------------------------------
+TransmissionCan
+^^^^^^^^^^^^^^^
+
+.. code-block :: python
+
+    TransmissionCan(can, direct, reload=True, period_t, period_d)
 
 Specify the transmission and direct beam runs that will be used for the analysis of the can run.
 The runs are loaded and with transmission :ref:`IDF <InstrumentDefinitionFile>`, if applicable, when Python encounters this command.
 
-``SetMonitorSpectrum(specNum, interp=False)``
----------------------------------------------
+SetMonitorSpectrum
+^^^^^^^^^^^^^^^^^^^
+
+.. code-block :: python
+
+    SetMonitorSpectrum(specNum, interp=False)
 
 Specifies the number of the TOF spectrum that will be used to for monitor normalisation.
 This value will be used in the next reduction that is called (e.g. with :ref:`WavRangeReduction() <SANSScriptingWavRangeReduction>`).
 
-``TransFit(mode, lambdamin, lambdamax)``
-----------------------------------------
+TransFit
+^^^^^^^^
+
+.. code-block :: python
+
+    TransFit(mode, lambdamin, lambdamax)
 
 Sets the method and range over which to calculate a fit for the variation of transmission fraction with wavelength.
 These arguments are passed to the algorithm :ref:`algm-CalculateTransmission`.
 There is an extra fit mode ``Off`` which causes the unfitted workspace produced by :ref:`algm-CalculateTransmission`
 to be used and ``lambdamin`` or ``lambdamax`` then have no effect.
 
-``Detector(det_name)``
-----------------------
+Detector
+^^^^^^^^
+
+.. code-block :: python
+
+    Detector(det_name)
 
 Sets the detector bank to use for the reduction e.g. ``front-detector``.
 The lowest angle detector is assumed if this line is not given.
 
-``SetPhiLimit(phimin, phimax, use_mirror=True)``
-------------------------------------------------
+SetPhiLimit
+^^^^^^^^^^^
+
+.. code-block :: python
+
+    SetPhiLimit(phimin, phimax, use_mirror=True)
 
 Call this function to restrict the analysis to sectors of the detector.
 ``Phimin`` and ``phimax`` define the limits of the sector where ``phi=0`` is the x-axis and ``phi=90`` is the y-axis.
@@ -129,35 +188,76 @@ Setting ``use_mirror`` to true causes the mirror sector to be included.
 
 .. _SANSScriptingWavRangeReduction:
 
-``WavRangeReduction(wav_start, wav_end, full_trans_wav, name_suffix)``
-----------------------------------------------------------------------
+WavRangeReduction
+^^^^^^^^^^^^^^^^^
+
+.. code-block :: python
+
+    WavRangeReduction(wav_start=None, wav_end=None, full_trans_wav=None, name_suffix=None,
+                      combineDet=None, saveAlgs=None, save_as_zero_error_free=False, output_name=None,
+                      output_mode=OutputMode.PUBLISH_TO_ADS, use_reduction_mode_as_suffix=False)
 
 Assuming the mask file contains the correct analysis details one can proceed to calculate :math:`I(Q)` using the
 ``WavRangeReduction()`` function, which can be executed with no arguments.
 The return value of ``WavRangeReduction()`` is the name of the final reduced workspace.
 This function calls many algorithms ending with a call to :ref:`algm-Q1D` or :ref:`algm-Qxy`.
+Several optional parameters can control different aspects of the reduction
+    - ``wav_start``: the first wavelength to be in the output data.
+    - ``wav_end``: the last wavelength in the output data.
+    - ``full_trans_wav``: Whether to use default's instrument wavelength range for transmission correction calculation, default is false.
+    - ``name_suffix``: Appends the created output workspace with this suffix
+    - ``combineDet``: combineDet can be one of the following
 
-- ``wav_start``: the first wavelength to be in the output data.
-- ``wav_end``: the last wavelength in the output data.
+       - 'rear': runs one reduction for the 'rear' detector data
+       - 'front': run one reduction for the 'front' detector data, and rescale+shift 'front' data
+       - 'both': run both the above two reductions
+       - 'merged': run the same reductions as 'both' and additionally create a merged data workspace
+       - None: run one reduction for whatever detector has been set as the current detector before running this method. If front apply rescale+shift)
+    - ``saveAlgs``: A list of strings containing the names of the algorithms to save the data with (ex: ``saveAlgs=['SaveRKH']``).
+    - ``save_as_zero_error_free``: Should the reduced workspaces contain zero errors.
+    - ``output_name``: Name of the output file. Default is sample run number.
+    - ``output_mode``: Decides the output of the reduced data, whether to publish to the ads (``OutputMode.PUBLISH_TO_ADS``), save to file with the chosen algorithm
+      in ``saveAlgs`` (``OutputMode.SAVE_TO_FILE``) or doing both(``OutputMode.BOTH``). ``OutputMode`` can be imported
+      with ``from sans.common.enums import OutputMode``.
+      If this parameter is omitted, the default behaviour will be to publish the output to the ads and save it in a file if there is a ``saveAlgs``.
+    - ``use_reduction_mode_as_suffix``: If ``True``, appends second suffix to output name based on reduction mode.
 
-``BatchReduce(filename, format, plotresults=False, saveAlgs={'SaveRKH':'txt'},verbose=False, centreit=False)``
---------------------------------------------------------------------------------------------------------------
 
-This analyses a list of files to analyse from a file, it calls :ref:`WavRangeReduction <SANSScriptingWavRangeReduction>`.
-The function is available after the following import:
+BatchReduce
+^^^^^^^^^^^
 
 .. code-block :: python
 
-    from SANSBatchMode import *
+    BatchReduce(filename, plotresults=False, saveAlgs={'SaveRKH':'txt'},
+                centreit=False, combineDet=None, save_as_zero_error_Free=False,
+                output_mode=OutputMode.PUBLISH_TO_ADS)
 
-The first argument is the name of a CSV file, where each line specifies the data for a single reduction (:ref:`in this format <ISIS_SANS_Batch_File-ref>`).
-The ``format`` argument is used to specify whether to load raw or nexus files and
-``saveAlgs`` is a Python dictionary that contains the name of the save algorithm to use and the extension that it should have.
-**If two algorithms in the dictionary use the same extension the first file will be overwritten!**
+This parses a list of files to analyse from a batch file, then it calls :ref:`WavRangeReduction <SANSScriptingWavRangeReduction>` to perform each reduction.
+The filename is a mandatory parameter:
+
+    - ``filename``: Name of a CSV file included in the path, where each line specifies the data for a single reduction (:ref:`in this format <ISIS_SANS_Batch_File-ref>`).
+
+Optional parameters:
+
+    - ``plotresults``: If true, a graph with the results from each reduction will be created (only when it is called from Mantid).
+    - ``saveAlgs``: Same as :ref:`WavRangeReduction <SANSScriptingWavRangeReduction>`.
+    - ``centreit``: Do centre finding (False by default).
+    - ``combineDet``: Same as :ref:`WavRangeReduction <SANSScriptingWavRangeReduction>`.
+    - ``save_as_zero_error_free``: Same as :ref:`WavRangeReduction <SANSScriptingWavRangeReduction>`.
+    - ``output_mode``: Same sa Same as :ref:`WavRangeReduction <SANSScriptingWavRangeReduction>`..
+
+Function returns a dictionary with some values from the reduction. (scale and shift as of now).
 
 
-``AddRuns(runs, instrument ='sans2d', saveAsEvent=False, binning = "Monitors", isOverlay = False, time_shifts = None, defType='.nxs', rawTypes=('.raw', '.s*', 'add','.RAW'), lowMem=False)``
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+AddRuns
+^^^^^^^
+
+.. code-block :: python
+
+    AddRuns(runs, instrument ='sans2d', saveAsEvent=False, binning = "Monitors",
+            isOverlay = False, time_shifts = None, defType='.nxs',
+            rawTypes=('.raw', '.s*', 'add','.RAW'), lowMem=False)
+
 
 This file adds a list of run files. The ``runs`` variable holds a list of runs which are to be added.
 The variable ``instrument`` specifies which instrument is currently being used.

--- a/docs/source/techniques/ScriptingSANSReductions.rst
+++ b/docs/source/techniques/ScriptingSANSReductions.rst
@@ -108,7 +108,7 @@ On calling this function the experimental run is :ref:`loaded <algm-Load>` and c
 Currently only ``reload=true`` is supported.
 
 TransmissionSample
-^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^
 
 .. code-block :: python
 
@@ -202,25 +202,26 @@ Assuming the mask file contains the correct analysis details one can proceed to 
 The return value of ``WavRangeReduction()`` is the name of the final reduced workspace.
 This function calls many algorithms ending with a call to :ref:`algm-Q1D` or :ref:`algm-Qxy`.
 Several optional parameters can control different aspects of the reduction
-    - ``wav_start``: the first wavelength to be in the output data.
-    - ``wav_end``: the last wavelength in the output data.
-    - ``full_trans_wav``: Whether to use default's instrument wavelength range for transmission correction calculation, default is false.
-    - ``name_suffix``: Appends the created output workspace with this suffix
-    - ``combineDet``: combineDet can be one of the following
 
-       - 'rear': runs one reduction for the 'rear' detector data
-       - 'front': run one reduction for the 'front' detector data, and rescale+shift 'front' data
-       - 'both': run both the above two reductions
-       - 'merged': run the same reductions as 'both' and additionally create a merged data workspace
-       - None: run one reduction for whatever detector has been set as the current detector before running this method. If front apply rescale+shift)
-    - ``saveAlgs``: A dict of save algorithms containing the names of the algorithms as key and the extension as value(ex: ``saveAlgs={'SaveRKH':'txt'}``).
-    - ``save_as_zero_error_free``: Should the reduced workspaces contain zero errors.
-    - ``output_name``: Name of the output file. Default is sample run number.
-    - ``output_mode``: Decides the output of the reduced data, whether to publish to the ads (``OutputMode.PUBLISH_TO_ADS``), save to file with the chosen algorithm
-      in ``saveAlgs`` (``OutputMode.SAVE_TO_FILE``) or doing both(``OutputMode.BOTH``). ``OutputMode`` can be imported
-      with ``from sans.common.enums import OutputMode``.
-      If this parameter is omitted, the default behaviour will be to publish the output to the ads and save it in a file if there is a ``saveAlgs``.
-    - ``use_reduction_mode_as_suffix``: If ``True``, appends second suffix to output name based on reduction mode.
+- ``wav_start``: the first wavelength to be in the output data.
+- ``wav_end``: the last wavelength in the output data.
+- ``full_trans_wav``: Whether to use default's instrument wavelength range for transmission correction calculation, default is false.
+- ``name_suffix``: Appends the created output workspace with this suffix
+- ``combineDet``: combineDet can be one of the following
+
+   - 'rear': runs one reduction for the 'rear' detector data
+   - 'front': run one reduction for the 'front' detector data, and rescale+shift 'front' data
+   - 'both': run both the above two reductions
+   - 'merged': run the same reductions as 'both' and additionally create a merged data workspace
+   - None: run one reduction for whatever detector has been set as the current detector before running this method. If front apply rescale+shift)
+- ``saveAlgs``: A dict of save algorithms containing the names of the algorithms as key and the extension as value(ex: ``saveAlgs={'SaveRKH':'txt'}``).
+- ``save_as_zero_error_free``: Should the reduced workspaces contain zero errors.
+- ``output_name``: Name of the output file. Default is sample run number.
+- ``output_mode``: Decides the output of the reduced data, whether to publish to the ads (``OutputMode.PUBLISH_TO_ADS``), save to file with the chosen algorithm
+  in ``saveAlgs`` (``OutputMode.SAVE_TO_FILE``) or doing both(``OutputMode.BOTH``). ``OutputMode`` can be imported
+  with ``from sans.common.enums import OutputMode``.
+  If this parameter is omitted, the default behaviour will be to publish the output to the ads and save it in a file if there is a ``saveAlgs``.
+- ``use_reduction_mode_as_suffix``: If ``True``, appends second suffix to output name based on reduction mode.
 
 
 BatchReduce

--- a/docs/source/techniques/ScriptingSANSReductions.rst
+++ b/docs/source/techniques/ScriptingSANSReductions.rst
@@ -31,7 +31,7 @@ SANS data from ISIS can be analysed using :ref:`Python <introduction_to_python>`
     TransmissionCan('LOQ74020.nxs', 'LOQ74014.nxs')
 
     #Performs reduction and saves data to path using SaveRKH and SaveNexus algorithms
-    WavRangeReduction(2.2, 10, saveAlgs=["SaveRKH","SaveNexus"])
+    WavRangeReduction(2.2, 10, saveAlgs={'SaveRKH': 'txt','SaveNexus': 'nxs'})
 
 The commands are available once the ISISCommandInterface module has been imported, using the following line:
 
@@ -213,7 +213,7 @@ Several optional parameters can control different aspects of the reduction
        - 'both': run both the above two reductions
        - 'merged': run the same reductions as 'both' and additionally create a merged data workspace
        - None: run one reduction for whatever detector has been set as the current detector before running this method. If front apply rescale+shift)
-    - ``saveAlgs``: A list of strings containing the names of the algorithms to save the data with (ex: ``saveAlgs=['SaveRKH']``).
+    - ``saveAlgs``: A dict of save algorithms containing the names of the algorithms as key and the extension as value(ex: ``saveAlgs={'SaveRKH':'txt'}``).
     - ``save_as_zero_error_free``: Should the reduced workspaces contain zero errors.
     - ``output_name``: Name of the output file. Default is sample run number.
     - ``output_mode``: Decides the output of the reduced data, whether to publish to the ads (``OutputMode.PUBLISH_TO_ADS``), save to file with the chosen algorithm
@@ -228,7 +228,7 @@ BatchReduce
 
 .. code-block :: python
 
-    BatchReduce(filename, plotresults=False, saveAlgs={'SaveRKH':'txt'},
+    BatchReduce(filename, plotresults=False, saveAlgs=None,
                 centreit=False, combineDet=None, save_as_zero_error_Free=False,
                 output_mode=OutputMode.PUBLISH_TO_ADS)
 
@@ -244,7 +244,7 @@ Optional parameters:
     - ``centreit``: Do centre finding (False by default).
     - ``combineDet``: Same as :ref:`WavRangeReduction <SANSScriptingWavRangeReduction>`.
     - ``save_as_zero_error_free``: Same as :ref:`WavRangeReduction <SANSScriptingWavRangeReduction>`.
-    - ``output_mode``: Same sa Same as :ref:`WavRangeReduction <SANSScriptingWavRangeReduction>`..
+    - ``output_mode``: Same as :ref:`WavRangeReduction <SANSScriptingWavRangeReduction>`..
 
 Function returns a dictionary with some values from the reduction. (scale and shift as of now).
 

--- a/docs/source/techniques/ScriptingSANSReductions.rst
+++ b/docs/source/techniques/ScriptingSANSReductions.rst
@@ -40,7 +40,7 @@ The commands are available once the ISISCommandInterface module has been importe
     from sans.command_interface.ISISCommandInterface import *
 
 These commands are given below in the order in which they are likely to be found in a script file although,
-except were stated, the order does not matter.
+except where stated, the order does not matter.
 
 Reference Commands
 ------------------
@@ -217,10 +217,10 @@ Several optional parameters can control different aspects of the reduction
 - ``saveAlgs``: A dict of save algorithms containing the names of the algorithms as key and the extension as value(ex: ``saveAlgs={'SaveRKH':'txt'}``).
 - ``save_as_zero_error_free``: Should the reduced workspaces contain zero errors.
 - ``output_name``: Name of the output file. Default is sample run number.
-- ``output_mode``: Decides the output of the reduced data, whether to publish to the ads (``OutputMode.PUBLISH_TO_ADS``), save to file with the chosen algorithm
+- ``output_mode``: Decides the output of the reduced data, whether to publish to the ADS (``OutputMode.PUBLISH_TO_ADS``), save to file with the chosen algorithm
   in ``saveAlgs`` (``OutputMode.SAVE_TO_FILE``) or doing both(``OutputMode.BOTH``). ``OutputMode`` can be imported
   with ``from sans.common.enums import OutputMode``.
-  If this parameter is omitted, the default behaviour will be to publish the output to the ads and save it in a file if there is a ``saveAlgs``.
+  If this parameter is omitted, the default behaviour will be to publish the output to the ADS and save it in a file if there is a ``saveAlgs``.
 - ``use_reduction_mode_as_suffix``: If ``True``, appends second suffix to output name based on reduction mode.
 
 
@@ -247,7 +247,7 @@ Optional parameters:
     - ``save_as_zero_error_free``: Same as :ref:`WavRangeReduction <SANSScriptingWavRangeReduction>`.
     - ``output_mode``: Same as :ref:`WavRangeReduction <SANSScriptingWavRangeReduction>`..
 
-Function returns a dictionary with some values from the reduction. (scale and shift as of now).
+Function returns a dictionary with some values from the reduction (scale and shift as of now).
 
 
 AddRuns

--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -30,8 +30,8 @@ import warnings
 warnings.simplefilter("default", category=DeprecationWarning)
 warnings.warn(
     "This ISIS Command Interface is deprecated.\n"
-    "Please change 'import ISISCommandInterface' or 'from ISISCommandInterface'"
-    "to use 'sans.command_interface.ISISCommandInterface' instead.",
+    "Please import using 'sans.command_interface.ISISCommandInterface'"
+    "instead of 'import ISISCommandInterface' or 'from ISISCommandInterface'.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -828,8 +828,9 @@ def WavRangeReduction(
                                               current detector
                                               before running this method. If front apply rescale+shift)
     @param resetSetup: if true reset setup at the end
-    @param saveAlgs: this named algorithm will be passed the name of the results workspace and filename (default = 'SaveRKH').
-        Pass a tuple of strings to save to multiple file formats
+    @param saveAlgs: A list of strings containing the names of the algorithms to save the data with (ex: saveAlgs=['SaveRKH']),
+                      it raises error if the algorithm name is not valid.
+    @param save_as_zero_error_free: Should the reduced workspaces contain zero errors or not
     @param out_fit_settings: An output parameter. It is used, specially when resetSetup is True, in order
                              to remember the 'scale and fit' of the fitting algorithm.
     @param output_name: name of the output workspace/file, if none is specified then one is generated internally.
@@ -904,7 +905,7 @@ def WavRangeReduction(
 
 def BatchReduce(
     filename,
-    format,
+    format=None,
     plotresults=False,
     saveAlgs=None,
     verbose=False,

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -845,8 +845,7 @@ def WavRangeReduction(
     _ = out_fit_settings
 
     # Set the save state
-    if saveAlgs:
-        output_mode = set_save(save_algorithms=saveAlgs, save_as_zero_error_free=save_as_zero_error_free)
+    output_mode = set_save(save_algorithms=saveAlgs, save_as_zero_error_free=save_as_zero_error_free, output_mode=output_mode)
 
     # Set the provided parameters
     if combineDet is None:

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -506,7 +506,7 @@ def set_save(
     save_algorithms: Union[None, Dict] = None, save_as_zero_error_free: bool = False, output_mode: OutputMode = OutputMode.PUBLISH_TO_ADS
 ) -> OutputMode:
     """
-    Mainly used internally by BatchReduce and WavRangeReduction. Prepares the save state on the director
+    Mainly used internally by WavRangeReduction. Prepares the save state on the director.
 
     @param save_algorithms: A dict containing the name of the save algorithms as keys and extension as values.
     @param save_as_zero_error_free: True if a zero error correction should be performed.
@@ -517,21 +517,21 @@ def set_save(
     save_algs = []
     if save_algorithms:
         for key in save_algorithms.keys():
-            if key == "SaveRKH":
-                save_algs.append(SaveType.RKH)
-            elif key == "SaveNexus":
-                save_algs.append(SaveType.NEXUS)
-            elif key == "SaveNistQxy":
-                save_algs.append(SaveType.NIST_QXY)
-            elif key == "SaveCanSAS" or key == "SaveCanSAS1D":
-                save_algs.append(SaveType.CAN_SAS)
-            elif key == "SaveCSV":
-                save_algs.append(SaveType.CSV)
-            elif key == "SaveNXcanSAS":
-                save_algs.append(SaveType.NX_CAN_SAS)
-            else:
-                raise RuntimeError(f"The save format {key} is not known")
-
+            match key:
+                case "SaveRKH":
+                    save_algs.append(SaveType.RKH)
+                case "SaveNexus":
+                    save_algs.append(SaveType.NEXUS)
+                case "SaveNistQxy":
+                    save_algs.append(SaveType.NIST_QXY)
+                case "SaveCanSAS" | "SaveCanSAS1D":
+                    save_algs.append(SaveType.CAN_SAS)
+                case "SaveCSV":
+                    save_algs.append(SaveType.CSV)
+                case "SaveNXCanSAS":
+                    save_algs.append(SaveType.NX_CAN_SAS)
+                case _:
+                    raise RuntimeError(f"The save format {key} is not known")
         output_mode = OutputMode.BOTH if (output_mode == OutputMode.PUBLISH_TO_ADS) else output_mode
     else:
         output_mode = OutputMode.PUBLISH_TO_ADS

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -828,8 +828,8 @@ def WavRangeReduction(
                                               current detector
                                               before running this method. If front apply rescale+shift)
     @param resetSetup: if true reset setup at the end
-    @param saveAlgs: A list of strings containing the names of the algorithms to save the data with (ex: saveAlgs=['SaveRKH']),
-                      it raises error if the algorithm name is not valid.
+    @param saveAlgs: A dictionary  containing the names of the algorithms to save the data  as keys with extension
+                     as values (ex: saveAlgs={'SaveRKH': 'txt'}), it raises error if the algorithm name is not valid.
     @param save_as_zero_error_free: Should the reduced workspaces contain zero errors or not
     @param out_fit_settings: An output parameter. It is used, specially when resetSetup is True, in order
                              to remember the 'scale and fit' of the fitting algorithm.
@@ -919,8 +919,8 @@ def BatchReduce(
     @param filename: the CSV file with the list of runs to analyse
     @param format: type of file to load, nxs for Nexus, etc.
     @param plotresults: if true and this function is run from mantid a graph will be created for the results of each reduction
-    @param saveAlgs: this named algorithm will be passed the name of the results workspace and filename (default = 'SaveRKH').
-        Pass a tuple of strings to save to multiple file formats
+    @param saveAlgs: A dictionary  containing the names of the algorithms to save the data  as keys with extension
+                     as values (ex: saveAlgs={'SaveRKH': 'txt'}), it raises error if the algorithm name is not valid.
     @param verbose: set to true to write more information to the log (default=False)
     @param centreit: do centre finding (default=False)
     @param reducer: if to use the command line (default) or GUI reducer object

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -513,6 +513,10 @@ def set_save(
     @param output_mode: Decides if output_mode publishes to ads and saves to file or only one of the two when save_algorithms are valid
     @return The OutputMode enum: PUBLISH_TO_ADS, SAVE_TO_FILE, BOTH
     """
+
+    if not save_algorithms:
+        return OutputMode.PUBLISH_TO_ADS
+
     # Set up the save algorithms
     save_algs = []
     if save_algorithms:
@@ -532,14 +536,11 @@ def set_save(
                     save_algs.append(SaveType.NX_CAN_SAS)
                 case _:
                     raise RuntimeError(f"The save format {key} is not known")
-        output_mode = OutputMode.BOTH if (output_mode == OutputMode.PUBLISH_TO_ADS) else output_mode
-    else:
-        output_mode = OutputMode.PUBLISH_TO_ADS
 
     save_command = NParameterCommand(command_id=NParameterCommandId.SAVE, values=[save_algs, save_as_zero_error_free])
     director.add_command(save_command)
 
-    return output_mode
+    return output_mode.BOTH if (output_mode == OutputMode.PUBLISH_TO_ADS) else output_mode
 
 
 # --------------------------
@@ -799,12 +800,12 @@ def WavRangeReduction(
     name_suffix=None,
     combineDet=None,
     resetSetup=True,
-    saveAlgs=None,
-    save_as_zero_error_free=False,
     out_fit_settings=None,
     output_name=None,
     output_mode=OutputMode.PUBLISH_TO_ADS,
     use_reduction_mode_as_suffix=False,
+    saveAlgs=None,
+    save_as_zero_error_free=False,
 ):
     """
     Run reduction from loading the raw data to calculating Q. Its optional arguments allows specifics

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -9,7 +9,7 @@ import os
 import re
 
 import types
-from typing import Union, List
+from typing import Union, Dict
 
 from SANSadd2 import add_runs
 from mantid.api import AnalysisDataService, WorkspaceGroup
@@ -503,12 +503,12 @@ def SetPhiLimit(phimin, phimax, use_mirror=True):
 
 
 def set_save(
-    save_algorithms: Union[None, List] = None, save_as_zero_error_free: bool = False, output_mode: OutputMode = OutputMode.PUBLISH_TO_ADS
+    save_algorithms: Union[None, Dict] = None, save_as_zero_error_free: bool = False, output_mode: OutputMode = OutputMode.PUBLISH_TO_ADS
 ) -> OutputMode:
     """
     Mainly used internally by BatchReduce and WavRangeReduction. Prepares the save state on the director
 
-    @param save_algorithms: A list of strings containing the name of the save algorithms.
+    @param save_algorithms: A dict containing the name of the save algorithms as keys and extension as values.
     @param save_as_zero_error_free: True if a zero error correction should be performed.
     @param output_mode: Decides if output_mode publishes to ads and saves to file or only one of the two when save_algorithms are valid
     @return The OutputMode enum: PUBLISH_TO_ADS, SAVE_TO_FILE, BOTH
@@ -516,7 +516,7 @@ def set_save(
     # Set up the save algorithms
     save_algs = []
     if save_algorithms:
-        for key in save_algorithms:
+        for key in save_algorithms.keys():
             if key == "SaveRKH":
                 save_algs.append(SaveType.RKH)
             elif key == "SaveNexus":

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -9,6 +9,7 @@ import os
 import re
 
 import types
+from typing import Union, List
 
 from SANSadd2 import add_runs
 from mantid.api import AnalysisDataService, WorkspaceGroup
@@ -44,12 +45,10 @@ from sans.common.general_functions import (
 from sans.gui_logic.models.RowEntries import RowEntries
 from sans.sans_batch import SANSBatchReduction, SANSCentreFinder
 
-
 # ----------------------------------------------------------------------------------------------------------------------
 # Globals
 # ----------------------------------------------------------------------------------------------------------------------
 DefaultTrans = True
-
 
 # ----------------------------------------------------------------------------------------------------------------------
 # CommandInterfaceStateDirector global instance
@@ -503,15 +502,44 @@ def SetPhiLimit(phimin, phimax, use_mirror=True):
     director.add_command(centre_command)
 
 
-def set_save(save_algorithms, save_as_zero_error_free):
+def set_save(
+    save_algorithms: Union[None, List] = None, save_as_zero_error_free: bool = False, output_mode: OutputMode = OutputMode.PUBLISH_TO_ADS
+) -> OutputMode:
     """
-    Mainly internally used by BatchMode. Provides the save settings.
+    Mainly used internally by BatchReduce and WavRangeReduction. Prepares the save state on the director
 
-    @param save_algorithms: A list of SaveType enums.
+    @param save_algorithms: A list of strings containing the name of the save algorithms.
     @param save_as_zero_error_free: True if a zero error correction should be performed.
+    @param output_mode: Decides if output_mode publishes to ads and saves to file or only one of the two when save_algorithms are valid
+    @return The OutputMode enum: PUBLISH_TO_ADS, SAVE_TO_FILE, BOTH
     """
-    save_command = NParameterCommand(command_id=NParameterCommandId.SAVE, values=[save_algorithms, save_as_zero_error_free])
+    # Set up the save algorithms
+    save_algs = []
+    if save_algorithms:
+        for key in save_algorithms:
+            if key == "SaveRKH":
+                save_algs.append(SaveType.RKH)
+            elif key == "SaveNexus":
+                save_algs.append(SaveType.NEXUS)
+            elif key == "SaveNistQxy":
+                save_algs.append(SaveType.NIST_QXY)
+            elif key == "SaveCanSAS" or key == "SaveCanSAS1D":
+                save_algs.append(SaveType.CAN_SAS)
+            elif key == "SaveCSV":
+                save_algs.append(SaveType.CSV)
+            elif key == "SaveNXcanSAS":
+                save_algs.append(SaveType.NX_CAN_SAS)
+            else:
+                raise RuntimeError(f"The save format {key} is not known")
+
+        output_mode = OutputMode.BOTH if (output_mode == OutputMode.PUBLISH_TO_ADS) else output_mode
+    else:
+        output_mode = OutputMode.PUBLISH_TO_ADS
+
+    save_command = NParameterCommand(command_id=NParameterCommandId.SAVE, values=[save_algs, save_as_zero_error_free])
     director.add_command(save_command)
+
+    return output_mode
 
 
 # --------------------------
@@ -771,6 +799,8 @@ def WavRangeReduction(
     name_suffix=None,
     combineDet=None,
     resetSetup=True,
+    saveAlgs=None,
+    save_as_zero_error_free=False,
     out_fit_settings=None,
     output_name=None,
     output_mode=OutputMode.PUBLISH_TO_ADS,
@@ -798,6 +828,8 @@ def WavRangeReduction(
                                               current detector
                                               before running this method. If front apply rescale+shift)
     @param resetSetup: if true reset setup at the end
+    @param saveAlgs: this named algorithm will be passed the name of the results workspace and filename (default = 'SaveRKH').
+        Pass a tuple of strings to save to multiple file formats
     @param out_fit_settings: An output parameter. It is used, specially when resetSetup is True, in order
                              to remember the 'scale and fit' of the fitting algorithm.
     @param output_name: name of the output workspace/file, if none is specified then one is generated internally.
@@ -809,6 +841,10 @@ def WavRangeReduction(
     print_message("WavRangeReduction(" + str(wav_start) + ", " + str(wav_end) + ", " + str(full_trans_wav) + ")")
     _ = resetSetup
     _ = out_fit_settings
+
+    # Set the save state
+    if saveAlgs:
+        output_mode = set_save(save_algorithms=saveAlgs, save_as_zero_error_free=save_as_zero_error_free)
 
     # Set the provided parameters
     if combineDet is None:
@@ -866,7 +902,7 @@ def WavRangeReduction(
     return output_workspace_base_name
 
 
-def BatchReduce(  # noqa
+def BatchReduce(
     filename,
     format,
     plotresults=False,
@@ -876,6 +912,7 @@ def BatchReduce(  # noqa
     reducer=None,
     combineDet=None,
     save_as_zero_error_free=False,
+    output_mode=OutputMode.PUBLISH_TO_ADS,
 ):
     """
     @param filename: the CSV file with the list of runs to analyse
@@ -888,10 +925,9 @@ def BatchReduce(  # noqa
     @param reducer: if to use the command line (default) or GUI reducer object
     @param combineDet: that will be forward to WavRangeReduction (rear, front, both, merged, None)
     @param save_as_zero_error_free: Should the reduced workspaces contain zero errors or not
-    @return final_setings: A dictionary with some values of the Reduction - Right Now:(scale, shift)
+    @param output_mode: the way the data should be put out: Can be PublishToADS, SaveToFile or Both
+    @return final_settings: A dictionary with some values of the Reduction - Right Now:(scale, shift)
     """
-    if saveAlgs is None:
-        saveAlgs = {"SaveRKH": "txt"}
 
     # From the old interface
     _ = format
@@ -902,29 +938,6 @@ def BatchReduce(  # noqa
         raise RuntimeError("The beam centre finder is currently not supported.")
     if plotresults:
         raise RuntimeError("Plotting the results is currently not supported.")
-
-    # Set up the save algorithms
-    save_algs = []
-
-    if saveAlgs:
-        for key, _ in list(saveAlgs.items()):
-            if key == "SaveRKH":
-                save_algs.append(SaveType.RKH)
-            elif key == "SaveNexus":
-                save_algs.append(SaveType.NEXUS)
-            elif key == "SaveNistQxy":
-                save_algs.append(SaveType.NIST_QXY)
-            elif key == "SaveCanSAS" or key == "SaveCanSAS1D":
-                save_algs.append(SaveType.CAN_SAS)
-            elif key == "SaveCSV":
-                save_algs.append(SaveType.CSV)
-            elif key == "SaveNXcanSAS":
-                save_algs.append(SaveType.NX_CAN_SAS)
-            else:
-                raise RuntimeError("The save format {0} is not known.".format(key))
-        output_mode = OutputMode.BOTH
-    else:
-        output_mode = OutputMode.PUBLISH_TO_ADS
 
     # Get the information from the csv file
     batch_csv_parser = BatchCsvParser()
@@ -977,16 +990,14 @@ def BatchReduce(  # noqa
         # suffix that the user can set already -- was there previously, so we have to provide that)
         use_reduction_mode_as_suffix = combineDet is not None
 
-        # Apply save options
-        if save_algs:
-            set_save(save_algorithms=save_algs, save_as_zero_error_free=save_as_zero_error_free)
-
         # Run the reduction for a single
         reduced_workspace_name = WavRangeReduction(
             combineDet=combineDet,
             output_name=output_name,
             output_mode=output_mode,
             use_reduction_mode_as_suffix=use_reduction_mode_as_suffix,
+            saveAlgs=saveAlgs,
+            save_as_zero_error_free=save_as_zero_error_free,
         )
 
         # Remove the settings which were very specific for this single reduction which are:

--- a/scripts/test/SANS/command_interface/isis_command_interface_test.py
+++ b/scripts/test/SANS/command_interface/isis_command_interface_test.py
@@ -56,12 +56,11 @@ class ISISCommandInterfaceTest(unittest.TestCase):
             self.assertIsNone(MaskFile(file_name))
 
     def test_set_save_raises_an_error_with_wrong_save_algorithms(self):
-        save_algs = [["SaveBad"], ["SaveRKH", "SaveBad"]]
+        save_algs = [{"SaveBad": "txt"}, {"SaveRKH": "txt", "SaveBad": "txt"}]
 
         for alg in save_algs:
-            with self.subTest(test_case=alg):
-                with self.assertRaises(RuntimeError):
-                    set_save(alg)
+            with self.subTest(test_case=alg), self.assertRaises(RuntimeError):
+                set_save(alg)
 
     def test_output_mode_defaults_to_publish_to_ads_if_save_algs_is_none(self):
         output_modes = [OutputMode.BOTH, OutputMode.SAVE_TO_FILE]
@@ -72,7 +71,7 @@ class ISISCommandInterfaceTest(unittest.TestCase):
                 self.assertEqual(output_mode, OutputMode.PUBLISH_TO_ADS)
 
     def test_output_mode_defaults_to_BOTH_if_there_is_a_save_alg(self):
-        output_mode = set_save(["SaveRKH"])
+        output_mode = set_save({"SaveRKH": "txt"})
         self.assertEqual(output_mode, OutputMode.BOTH)
 
 

--- a/scripts/test/SANS/command_interface/isis_command_interface_test.py
+++ b/scripts/test/SANS/command_interface/isis_command_interface_test.py
@@ -10,10 +10,14 @@ import unittest
 import uuid
 
 from unittest import mock
-from sans.command_interface.ISISCommandInterface import MaskFile
+from sans.command_interface.ISISCommandInterface import Clean, MaskFile, set_save
+from sans.common.enums import OutputMode
 
 
 class ISISCommandInterfaceTest(unittest.TestCase):
+    def tearDown(self):
+        Clean()
+
     def test_mask_file_raises_for_empty_file_name(self):
         with self.assertRaises(ValueError):
             MaskFile(file_name="")
@@ -50,6 +54,26 @@ class ISISCommandInterfaceTest(unittest.TestCase):
         with mock.patch("sans.command_interface.ISISCommandInterface.find_full_file_path") as mocked_finder:
             mocked_finder.return_value = tmp_file.name
             self.assertIsNone(MaskFile(file_name))
+
+    def test_set_save_raises_an_error_with_wrong_save_algorithms(self):
+        save_algs = [["SaveBad"], ["SaveRKH", "SaveBad"]]
+
+        for alg in save_algs:
+            with self.subTest(test_case=alg):
+                with self.assertRaises(RuntimeError):
+                    set_save(alg)
+
+    def test_output_mode_defaults_to_publish_to_ads_if_save_algs_is_none(self):
+        output_modes = [OutputMode.BOTH, OutputMode.SAVE_TO_FILE]
+
+        for mode in output_modes:
+            with self.subTest(test_case=mode):
+                output_mode = set_save(None, mode)
+                self.assertEqual(output_mode, OutputMode.PUBLISH_TO_ADS)
+
+    def test_output_mode_defaults_to_BOTH_if_there_is_a_save_alg(self):
+        output_mode = set_save(["SaveRKH"])
+        self.assertEqual(output_mode, OutputMode.BOTH)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description of work
This PR modifies the ```WavRangeReduction``` function to allow it to have the same input for saving algorithms (A dictionary of save algorithms) as the ```BatchReduce``` function. This will give more flexibility to scientist using the CLI to save without having to create a batch file, as ```BatchReduce``` basically prepares the data to be sent to ```WavRangeReduction```.  
To do this change, I have refactored the ```set_save``` function, which technically can be used as a command too, to process the dictionary of save algorithms.


Fixes #38502. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
There are two things to notice that can be further discussed in the review: 
- At some point in the preparation, I changed the dictionary argument with input save algorithms to a list of save algorithms, as I couldn't see that the extension value of the dictionary was being used anywhere. I decided to revert back those changes just in case some scientist are using it that way (as you can already save using ```BatchReduce```) and this would  their scripts. 
- I have changed somewhat the documentation page (https://docs.mantidproject.org/nightly/techniques/ScriptingSANSReductions.html) to try to make it a little bit easier to navigate, additionally updating the new call signature for ```WavRangeReduction``` and changing the example test to use the new interface with data from the LOQ demo in the Training Course Set data. This also uses an example Mask file with ```.toml``` extension , which I think is the currently supported format in the SANS group in ISIS. 
- I have reworded the ``deprecated`` warning if trying to use the old interface. 

### To test:

- Build the docs. 
- Check the scripting page on the built docs> ``../ScriptingSANSReductions.html``, everything should be well formatted and typo free. 
- Run the example on the scripting page on Mantid. It should save the LOQDemo reduced files as intended. 
- Check code. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*Added release notes*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
