### PR TITLE
Fix logic for checking bin consistency in ConjoinWorkspaces algorithm

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ConjoinWorkspaces.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ConjoinWorkspaces.h
@@ -55,6 +55,7 @@ private:
   void init() override;
   void exec() override;
 
+  bool checkBinning(const API::MatrixWorkspace_const_sptr &ws1, const API::MatrixWorkspace_const_sptr &ws2) const;
   void checkForOverlap(const API::MatrixWorkspace &ws1, const API::MatrixWorkspace &ws2, bool checkSpectra) const;
   API::MatrixWorkspace_sptr conjoinEvents(const DataObjects::EventWorkspace &ws1,
                                           const DataObjects::EventWorkspace &ws2);

--- a/Framework/Algorithms/src/AppendSpectra.cpp
+++ b/Framework/Algorithms/src/AppendSpectra.cpp
@@ -68,8 +68,8 @@ void AppendSpectra::exec() {
   if (((eventWs1) && (!eventWs2)) || ((!eventWs1) && (eventWs2))) {
     const std::string message("Only one of the input workspaces are of type "
                               "EventWorkspace; please use matching workspace "
-                              "types (both EventWorkspace's or both "
-                              "Workspace2D's).");
+                              "types (both EventWorkspace or both "
+                              "Workspace2D).");
     g_log.error(message);
     throw std::invalid_argument(message);
   }

--- a/Framework/Algorithms/src/ConjoinWorkspaces.cpp
+++ b/Framework/Algorithms/src/ConjoinWorkspaces.cpp
@@ -56,8 +56,8 @@ void ConjoinWorkspaces::exec() {
   if (((eventWs1) && (!eventWs2)) || ((!eventWs1) && (eventWs2))) {
     const std::string message("Only one of the input workspaces are of type "
                               "EventWorkspace; please use matching workspace "
-                              "types (both EventWorkspace's or both "
-                              "Workspace2D's).");
+                              "types (both EventWorkspace or both "
+                              "Workspace2D).");
     g_log.error(message);
     throw std::invalid_argument(message);
   }

--- a/Framework/Algorithms/src/ConjoinWorkspaces.cpp
+++ b/Framework/Algorithms/src/ConjoinWorkspaces.cpp
@@ -61,9 +61,10 @@ void ConjoinWorkspaces::exec() {
     g_log.error(message);
     throw std::invalid_argument(message);
   }
-  // Check if bins match
+
+  // Check whether bins match
   bool checkBins = getProperty("CheckMatchingBins");
-  if (!WorkspaceHelpers::matchingBins(ws1, ws2) && checkBins) {
+  if (checkBins && !checkBinning(ws1, ws2)) {
     const std::string message("The bins do not match in the input workspaces. "
                               "Consider using RebinToWorkspace to preprocess "
                               "the workspaces before conjoining them.");
@@ -86,6 +87,24 @@ void ConjoinWorkspaces::exec() {
 
   // Delete the second input workspace from the ADS
   AnalysisDataService::Instance().remove(getPropertyValue("InputWorkspace2"));
+}
+
+//----------------------------------------------------------------------------------------------
+/** Checks whether the binning is consistent between two workspaces
+ *  @param ws1 :: The first input workspace
+ *  @param ws2 :: The second input workspace
+ *  @return :: true if both workspaces have consistent binning.
+ */
+bool ConjoinWorkspaces::checkBinning(const API::MatrixWorkspace_const_sptr &ws1,
+                                     const API::MatrixWorkspace_const_sptr &ws2) const {
+  if (ws1->isRaggedWorkspace() || ws2->isRaggedWorkspace()) {
+    return false;
+  }
+
+  // If neither workspace is ragged, we only need to check the first specrum.
+  // Otherwise the matchingBins() function requires the two workspaces to have
+  // the same number of spectra.
+  return WorkspaceHelpers::matchingBins(ws1, ws2, true);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -148,8 +148,7 @@ DataObjects::EventWorkspace_sptr WorkspaceJoiners::execEvent(const DataObjects::
   return output;
 }
 
-/** Checks that the two input workspace have common size and the same
- * instrument & unit.
+/** Checks that the two input workspace have the same instrument, unit and distribution flag.
  *  @param ws1 :: The first input workspace
  *  @param ws2 :: The second input workspace
  *  @throw std::invalid_argument If the workspaces are not compatible

--- a/Framework/Algorithms/test/ConjoinWorkspacesTest.h
+++ b/Framework/Algorithms/test/ConjoinWorkspacesTest.h
@@ -412,7 +412,6 @@ private:
     MatrixWorkspace_sptr ews = WorkspaceCreationHelper::createEventWorkspace(10, 10);
     AnalysisDataService::Instance().addOrReplace(name, ews);
 
-    // Crop ews to have first 3 spectra, ews2 to have second 3
     CropWorkspace crop;
     crop.setChild(true);
     crop.initialize();

--- a/Framework/Algorithms/test/ConjoinWorkspacesTest.h
+++ b/Framework/Algorithms/test/ConjoinWorkspacesTest.h
@@ -169,7 +169,7 @@ public:
     TS_ASSERT(!conj.isExecuted());
   }
 
-  void testCheckMatchingBinsError() {
+  void testNonMatchingBinsThrowsError() {
     MatrixWorkspace_sptr ws1, ws2;
     ws1 = WorkspaceCreationHelper::createEventWorkspace(10, 5);
     ws2 = WorkspaceCreationHelper::createEventWorkspace(10, 10);
@@ -190,6 +190,22 @@ public:
       TS_ASSERT_EQUALS(std::string(e.what()), expectedMessage);
       TS_ASSERT(!conj.isExecuted());
     }
+  }
+
+  void testMatchingBinsThrowsNoError() {
+    MatrixWorkspace_sptr ws1 = WorkspaceCreationHelper::createEventWorkspace(10, 5);
+    MatrixWorkspace_sptr ws2 = WorkspaceCreationHelper::createEventWorkspace(10, 5);
+
+    // CheckMatchingBins is true by default, so don't set it here.
+    ConjoinWorkspaces conj;
+    conj.initialize();
+    conj.setProperty("CheckOverlapping", false);
+    conj.setProperty("InputWorkspace1", ws1);
+    conj.setProperty("InputWorkspace2", ws2);
+    conj.setAlwaysStoreInADS(false);
+    conj.setRethrows(true);
+
+    TS_ASSERT_THROWS_NOTHING(conj.execute());
   }
 
   void testDoCheckForOverlap() {


### PR DESCRIPTION
### Description of work
A check was added to  `ConjoinWorkspaces` [here](https://github.com/mantidproject/mantid/pull/38478) to verify that the input workspaces have consistent binning. It was using the function `WorkspaceHelpers::matchingBins`, but this also enforces that the number of histograms is the same for both input workspaces. This is not what we wanted. It is fixed in this PR.

*There is no associated issue.*

### To test:

1. The test instructions (running the code below) should work without any error message, since the bins match:
```
ws1 = CreateSampleWorkspace(WorkspaceType="Histogram", NumBanks=2, BankPixelWidth=1, BinWidth=10, Xmax=50)
ws2 = CreateSampleWorkspace(WorkspaceType="Histogram", NumBanks=3, BankPixelWidth=1, BinWidth=10, Xmax=50)
ConjoinWorkspaces(InputWorkspace1=ws1, InputWorkspace2=ws2, CheckOverlapping=False, YAxisUnit="New unit", YAxisLabel="New label")
```
2. Try changing the `BinWidth` parameter of one of the input workspaces and verify that you get the error about non-matching bins.
3. Still with different `BinWidth`s, add the parameter `CheckMatchingBins=False` as an argument to the ConjoinWorkspaces call and verify that the algorithm runs as expected without any error messages.


*This does not require release notes* because **it was a bug that was introduced as part of another fix**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
