### PR TITLE
Abins: explicit cache directory management

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/Abins.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins.py
@@ -108,7 +108,9 @@ class Abins(AbinsAlgorithm, PythonAlgorithm):
         prog_reporter.report("Input data from the user has been collected.")
 
         # 2) read ab initio data
-        ab_initio_data = abins.AbinsData.from_calculation_data(self._vibrational_or_phonon_data_file, self._ab_initio_program)
+        ab_initio_data = abins.AbinsData.from_calculation_data(
+            self._vibrational_or_phonon_data_file, self._ab_initio_program, cache_directory=self._cache_directory
+        )
         prog_reporter.report("Vibrational/phonon data has been read.")
 
         # 3) calculate S

--- a/Framework/PythonInterface/plugins/algorithms/Abins.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins.py
@@ -131,6 +131,7 @@ class Abins(AbinsAlgorithm, PythonAlgorithm):
             instrument=self._instrument,
             quantum_order_num=self._num_quantum_order_events,
             autoconvolution_max=autoconvolution_max,
+            cache_directory=self._cache_directory,
         )
         s_calculator.progress_reporter = prog_reporter
         s_data = s_calculator.get_formatted_data()

--- a/Framework/PythonInterface/plugins/algorithms/Abins2D.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins2D.py
@@ -118,7 +118,11 @@ class Abins2D(AbinsAlgorithm, PythonAlgorithm):
         prog_reporter.report("Input data from the user has been collected.")
 
         # 2) read ab initio data
-        ab_initio_data = abins.AbinsData.from_calculation_data(self._vibrational_or_phonon_data_file, self._ab_initio_program)
+        ab_initio_data = abins.AbinsData.from_calculation_data(
+            self._vibrational_or_phonon_data_file,
+            self._ab_initio_program,
+            cache_directory=self._cache_directory,
+        )
         prog_reporter.report("Vibrational/phonon data has been read.")
 
         # 3) calculate S
@@ -139,6 +143,7 @@ class Abins2D(AbinsAlgorithm, PythonAlgorithm):
             autoconvolution_max=autoconvolution_max,
             instrument=self._instrument,
             quantum_order_num=self._num_quantum_order_events,
+            cache_directory=self._cache_directory,
         )
         s_calculator.progress_reporter = prog_reporter
         s_data = s_calculator.get_formatted_data()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/Abins2BasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/Abins2BasicTest.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import logging
+from pathlib import Path
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -40,7 +41,7 @@ class AbinsBasicTest(unittest.TestCase):
     _tmp_cache_dir = None
 
     def get_cache_dir(self):
-        return self._tmp_cache_dir.name
+        return Path(self._tmp_cache_dir.name)
 
     @classmethod
     def setUpClass(cls):
@@ -63,7 +64,8 @@ class AbinsBasicTest(unittest.TestCase):
                 "benzene_exp",
                 "benzene_Abins",
                 "numbered",
-            ]
+            ],
+            directory=self.get_cache_dir(),
         )
         mtd.clear()
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsAdvancedParametersTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsAdvancedParametersTest.py
@@ -23,8 +23,8 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
         # set up input for Abins
         self._Si2 = "Si2-sc_AbinsAdvancedParameters"
         self._wrk_name = self._Si2 + "_ref"
-        self._tmpdir = TemporaryDirectory()
-        self._cache_directory = self._tmpdir.name
+        self.tempdir = TemporaryDirectory()
+        self._cache_directory = self.tempdir.name
 
         # before each test set abins.parameters to default values
         abins.parameters.instruments = {
@@ -55,7 +55,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
         abins.parameters.performance = {"optimal_size": int(5e6), "threads": 1}
 
     def tearDown(self):
-        self._tmpdir.cleanup()
+        self.tempdir.cleanup()
         mtd.clear()
 
     def test_wrong_fwhm(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsAdvancedParametersTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsAdvancedParametersTest.py
@@ -4,8 +4,10 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from pathlib import Path
 import unittest
 from mantid.simpleapi import Abins, mtd
+from mantid.kernel import ConfigService
 
 from abins import test_helpers
 import abins.parameters
@@ -23,6 +25,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
         # set up input for Abins
         self._Si2 = "Si2-sc_AbinsAdvancedParameters"
         self._wrk_name = self._Si2 + "_ref"
+        self._cache_directory = ConfigService.getString("defaultsave.directory")
 
         # before each test set abins.parameters to default values
         abins.parameters.instruments = {
@@ -53,7 +56,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
         abins.parameters.performance = {"optimal_size": int(5e6), "threads": 1}
 
     def tearDown(self):
-        test_helpers.remove_output_files(list_of_names=["_AbinsAdvanced"])
+        test_helpers.remove_output_files(list_of_names=["_AbinsAdvanced"], directory=Path(self._cache_directory))
         mtd.clear()
 
     def test_wrong_fwhm(self):
@@ -83,6 +86,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
                 Abins,
                 VibrationalOrPhononFile=self._Si2 + ".phonon",
                 OutputWorkspace=self._wrk_name,
+                CacheDirectory=self._cache_directory,
             )
 
     def test_wrong_tosca_cos_scattering_angle(self):
@@ -99,6 +103,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
                 Abins,
                 VibrationalOrPhononFile=self._Si2 + ".phonon",
                 OutputWorkspace=self._wrk_name,
+                CacheDirectory=self._cache_directory,
             )
 
     def test_wrong_tosca_resolution_constant_A(self):
@@ -110,6 +115,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
             Abins,
             VibrationalOrPhononFile=self._Si2 + ".phonon",
             OutputWorkspace=self._wrk_name,
+            CacheDirectory=self._cache_directory,
         )
 
     def test_wrong_tosca_resolution_constant_B(self):
@@ -120,6 +126,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
             Abins,
             VibrationalOrPhononFile=self._Si2 + ".phonon",
             OutputWorkspace=self._wrk_name,
+            CacheDirectory=self._cache_directory,
         )
 
     def test_wrong_tosca_resolution_constant_C(self):
@@ -130,6 +137,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
             Abins,
             VibrationalOrPhononFile=self._Si2 + ".phonon",
             OutputWorkspace=self._wrk_name,
+            CacheDirectory=self._cache_directory,
         )
 
     # tests for folders
@@ -146,6 +154,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
                 Abins,
                 VibrationalOrPhononFile=self._Si2 + ".phonon",
                 OutputWorkspace=self._wrk_name,
+                CacheDirectory=self._cache_directory,
             )
 
     def test_wrong_powder_data_group(self):
@@ -161,6 +170,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
                 Abins,
                 VibrationalOrPhononFile=self._Si2 + ".phonon",
                 OutputWorkspace=self._wrk_name,
+                CacheDirectory=self._cache_directory,
             )
 
     def test_wrong_crystal_data_group(self):
@@ -176,6 +186,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
                 Abins,
                 VibrationalOrPhononFile=self._Si2 + ".phonon",
                 OutputWorkspace=self._wrk_name,
+                CacheDirectory=self._cache_directory,
             )
 
     def test_wrong_powder_s_data_group(self):
@@ -191,6 +202,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
                 Abins,
                 VibrationalOrPhononFile=self._Si2 + ".phonon",
                 OutputWorkspace=self._wrk_name,
+                CacheDirectory=self._cache_directory,
             )
 
     def test_doubled_name(self):
@@ -203,6 +215,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
             Abins,
             VibrationalOrPhononFile=self._Si2 + ".phonon",
             OutputWorkspace=self._wrk_name,
+            CacheDirectory=self._cache_directory,
         )
 
     def test_wrong_min_wavenumber(self):
@@ -218,6 +231,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
                 Abins,
                 VibrationalOrPhononFile=self._Si2 + ".phonon",
                 OutputWorkspace=self._wrk_name,
+                CacheDirectory=self._cache_directory,
             )
 
     def test_wrong_max_wavenumber(self):
@@ -233,6 +247,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
                 Abins,
                 VibrationalOrPhononFile=self._Si2 + ".phonon",
                 OutputWorkspace=self._wrk_name,
+                CacheDirectory=self._cache_directory,
             )
 
     def test_wrong_energy_window(self):
@@ -245,6 +260,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
             Abins,
             VibrationalOrPhononFile=self._Si2 + ".phonon",
             OutputWorkspace=self._wrk_name,
+            CacheDirectory=self._cache_directory,
         )
 
     def test_wrong_s_absolute_threshold(self):
@@ -258,6 +274,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
                 Abins,
                 VibrationalOrPhononFile=self._Si2 + ".phonon",
                 OutputWorkspace=self._wrk_name,
+                CacheDirectory=self._cache_directory,
             )
 
     def test_wrong_s_relative_threshold(self):
@@ -271,6 +288,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
                 Abins,
                 VibrationalOrPhononFile=self._Si2 + ".phonon",
                 OutputWorkspace=self._wrk_name,
+                CacheDirectory=self._cache_directory,
             )
 
     def test_wrong_optimal_size(self):
@@ -286,6 +304,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
                 Abins,
                 VibrationalOrPhononFile=self._Si2 + ".phonon",
                 OutputWorkspace=self._wrk_name,
+                CacheDirectory=self._cache_directory,
             )
 
     def test_wrong_threads(self):
@@ -297,11 +316,16 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
                 Abins,
                 VibrationalOrPhononFile=self._Si2 + ".phonon",
                 OutputWorkspace=self._wrk_name,
+                CacheDirectory=self._cache_directory,
             )
 
     def test_good_case(self):
         good_names = [self._wrk_name, self._wrk_name + "_Si", self._wrk_name + "_Si_total"]
-        Abins(VibrationalOrPhononFile=self._Si2 + ".phonon", OutputWorkspace=self._wrk_name)
+        Abins(
+            VibrationalOrPhononFile=self._Si2 + ".phonon",
+            OutputWorkspace=self._wrk_name,
+            CacheDirectory=self._cache_directory,
+        )
         names = mtd.getObjectNames()
 
         # Builtin cmp has been removed in Python 3

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
@@ -30,6 +30,10 @@ class AbinsBasicTest(unittest.TestCase):
     _workspace_name = "output_workspace"
     _tolerance = 0.0001
 
+    from mantid.kernel import ConfigService
+
+    _cache_directory = ConfigService.getString("defaultsave.directory")
+
     def tearDown(self):
         abins.test_helpers.remove_output_files(
             list_of_names=[
@@ -42,7 +46,8 @@ class AbinsBasicTest(unittest.TestCase):
                 "benzene_Abins",
                 "experimental",
                 "numbered",
-            ]
+            ],
+            directory=self._cache_directory,
         )
         mtd.clear()
 
@@ -56,6 +61,7 @@ class AbinsBasicTest(unittest.TestCase):
             Abins,
             VibrationalOrPhononFile="Si2-sc_wrong.phonon",
             OutputWorkspace=self._workspace_name,
+            CacheDirectory=self._cache_directory,
         )
 
         # wrong extension of phonon file in case of CASTEP
@@ -65,6 +71,7 @@ class AbinsBasicTest(unittest.TestCase):
             Abins,
             VibrationalOrPhononFile="Si2-sc.wrong_phonon",
             OutputWorkspace=self._workspace_name,
+            CacheDirectory=self._cache_directory,
         )
 
         # wrong extension of phonon file in case of CRYSTAL
@@ -75,6 +82,7 @@ class AbinsBasicTest(unittest.TestCase):
             AbInitioProgram="CRYSTAL",
             VibrationalOrPhononFile="MgO.wrong_out",
             OutputWorkspace=self._workspace_name,
+            CacheDirectory=self._cache_directory,
         )
 
         # no name for workspace
@@ -88,6 +96,7 @@ class AbinsBasicTest(unittest.TestCase):
             VibrationalOrPhononFile=self._si2 + ".phonon",
             TemperatureInKelvin=self._temperature,
             OutputWorkspace=self._workspace_name + "total",
+            CacheDirectory=self._cache_directory,
         )
 
         # negative temperature in K
@@ -98,6 +107,7 @@ class AbinsBasicTest(unittest.TestCase):
             VibrationalOrPhononFile=self._si2 + ".phonon",
             TemperatureInKelvin=-1.0,
             OutputWorkspace=self._workspace_name,
+            CacheDirectory=self._cache_directory,
         )
 
         # negative scale
@@ -108,6 +118,7 @@ class AbinsBasicTest(unittest.TestCase):
             VibrationalOrPhononFile=self._si2 + ".phonon",
             Scale=-0.2,
             OutputWorkspace=self._workspace_name,
+            CacheDirectory=self._cache_directory,
         )
 
         # unknown instrument
@@ -118,6 +129,7 @@ class AbinsBasicTest(unittest.TestCase):
             VibrationalOrPhononFile=self._si2 + ".phonon",
             Instrument="UnknownInstrument",
             OutputWorkspace=self._workspace_name,
+            CacheDirectory=self._cache_directory,
         )
 
     # test if intermediate results are consistent
@@ -132,6 +144,7 @@ class AbinsBasicTest(unittest.TestCase):
             VibrationalOrPhononFile=self._squaricn + ".phonon",
             Atoms="C,C,H",
             OutputWorkspace=self._workspace_name,
+            CacheDirectory=self._cache_directory,
         )
 
     def test_non_unique_atoms(self):
@@ -145,6 +158,7 @@ class AbinsBasicTest(unittest.TestCase):
             VibrationalOrPhononFile=self._squaricn + ".phonon",
             Atoms="atom_1,atom_2,atom1",
             OutputWorkspace=self._workspace_name,
+            CacheDirectory=self._cache_directory,
         )
 
     def test_non_existing_atoms(self):
@@ -159,6 +173,7 @@ class AbinsBasicTest(unittest.TestCase):
             VibrationalOrPhononFile=self._squaricn + ".phonon",
             Atoms="N",
             OutputWorkspace=self._workspace_name,
+            CacheDirectory=self._cache_directory,
         )
 
     def test_atom_index_limits(self):
@@ -172,6 +187,7 @@ class AbinsBasicTest(unittest.TestCase):
             VibrationalOrPhononFile=self._squaricn + ".phonon",
             Atoms=ATOM_PREFIX + "0",
             OutputWorkspace=self._workspace_name,
+            CacheDirectory=self._cache_directory,
         )
         self.assertRaisesRegex(
             RuntimeError,
@@ -180,6 +196,7 @@ class AbinsBasicTest(unittest.TestCase):
             VibrationalOrPhononFile=self._squaricn + ".phonon",
             Atoms=ATOM_PREFIX + "61",
             OutputWorkspace=self._workspace_name,
+            CacheDirectory=self._cache_directory,
         )
 
     def test_atom_index_invalid(self):
@@ -193,6 +210,7 @@ class AbinsBasicTest(unittest.TestCase):
             VibrationalOrPhononFile=self._squaricn + ".phonon",
             Atoms=ATOM_PREFIX + "-3",
             OutputWorkspace=self._workspace_name,
+            CacheDirectory=self._cache_directory,
         )
         self.assertRaisesRegex(
             RuntimeError,
@@ -201,6 +219,7 @@ class AbinsBasicTest(unittest.TestCase):
             VibrationalOrPhononFile=self._squaricn + ".phonon",
             Atoms=ATOM_PREFIX + "_#4",
             OutputWorkspace=self._workspace_name,
+            CacheDirectory=self._cache_directory,
         )
 
     def test_scale(self):
@@ -220,6 +239,7 @@ class AbinsBasicTest(unittest.TestCase):
             QuantumOrderEventsNumber=self._quantum_order_events_number,
             ScaleByCrossSection=self._cross_section_factor,
             OutputWorkspace=self._squaricn + "_ref",
+            CacheDirectory=self._cache_directory,
         )
 
         wrk = Abins(
@@ -234,6 +254,7 @@ class AbinsBasicTest(unittest.TestCase):
             Scale=10,
             ScaleByCrossSection=self._cross_section_factor,
             OutputWorkspace="squaricn_scale",
+            CacheDirectory=self._cache_directory,
         )
 
         ref = Scale(wrk_ref, Factor=10)
@@ -255,6 +276,7 @@ class AbinsBasicTest(unittest.TestCase):
             QuantumOrderEventsNumber=self._quantum_order_events_number,
             ScaleByCrossSection=self._cross_section_factor,
             OutputWorkspace="squaricn-lagrange",
+            CacheDirectory=self._cache_directory,
         )
 
     def test_exp(self):
@@ -275,6 +297,7 @@ class AbinsBasicTest(unittest.TestCase):
             QuantumOrderEventsNumber=self._quantum_order_events_number,
             ScaleByCrossSection=self._cross_section_factor,
             OutputWorkspace="benzene_exp",
+            CacheDirectory=self._cache_directory,
         )
 
         # load experimental data
@@ -303,6 +326,7 @@ class AbinsBasicTest(unittest.TestCase):
             QuantumOrderEventsNumber=self._quantum_order_events_number,
             ScaleByCrossSection=self._cross_section_factor,
             OutputWorkspace=self._squaricn + "_ref",
+            CacheDirectory=self._cache_directory,
         )
 
         wks_all_atoms_explicitly = Abins(
@@ -311,6 +335,7 @@ class AbinsBasicTest(unittest.TestCase):
             SumContributions=self._sum_contributions,
             QuantumOrderEventsNumber=self._quantum_order_events_number,
             OutputWorkspace="explicit",
+            CacheDirectory=self._cache_directory,
         )
 
         wks_all_atoms_default = Abins(
@@ -318,6 +343,7 @@ class AbinsBasicTest(unittest.TestCase):
             SumContributions=self._sum_contributions,
             QuantumOrderEventsNumber=self._quantum_order_events_number,
             OutputWorkspace="default",
+            CacheDirectory=self._cache_directory,
         )
 
         # Python 3 has no guarantee of dict order so the workspaces in the group may be in
@@ -348,6 +374,7 @@ class AbinsBasicTest(unittest.TestCase):
             QuantumOrderEventsNumber=self._quantum_order_events_number,
             ScaleByCrossSection=self._cross_section_factor,
             OutputWorkspace=self._squaricn + "_ref",
+            CacheDirectory=self._cache_directory,
         )
 
         numbered_workspace_name = "numbered"
@@ -359,6 +386,7 @@ class AbinsBasicTest(unittest.TestCase):
             QuantumOrderEventsNumber=self._quantum_order_events_number,
             ScaleByCrossSection=self._cross_section_factor,
             OutputWorkspace=numbered_workspace_name,
+            CacheDirectory=self._cache_directory,
         )
 
         wrk_ref_names = list(wrk_ref.getNames())

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
@@ -4,11 +4,12 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from tempfile import TemporaryDirectory
 import unittest
+
 from numpy.testing import assert_array_almost_equal
 
 from mantid.simpleapi import mtd, Abins, Scale, CompareWorkspaces, Load
-import abins
 from abins.constants import ATOM_PREFIX, FUNDAMENTALS
 
 
@@ -30,25 +31,12 @@ class AbinsBasicTest(unittest.TestCase):
     _workspace_name = "output_workspace"
     _tolerance = 0.0001
 
-    from mantid.kernel import ConfigService
-
-    _cache_directory = ConfigService.getString("defaultsave.directory")
+    def setUp(self):
+        self._tmpdir = TemporaryDirectory()
+        self._cache_directory = self._tmpdir.name
 
     def tearDown(self):
-        abins.test_helpers.remove_output_files(
-            list_of_names=[
-                "explicit",
-                "default",
-                "total",
-                "squaricn_sum_Abins",
-                "squaricn_scale",
-                "benzene_exp",
-                "benzene_Abins",
-                "experimental",
-                "numbered",
-            ],
-            directory=self._cache_directory,
-        )
+        self._tmpdir.cleanup()
         mtd.clear()
 
     def test_wrong_input(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
@@ -32,11 +32,11 @@ class AbinsBasicTest(unittest.TestCase):
     _tolerance = 0.0001
 
     def setUp(self):
-        self._tmpdir = TemporaryDirectory()
-        self._cache_directory = self._tmpdir.name
+        self.tempdir = TemporaryDirectory()
+        self._cache_directory = self.tempdir.name
 
     def tearDown(self):
-        self._tmpdir.cleanup()
+        self.tempdir.cleanup()
         mtd.clear()
 
     def test_wrong_input(self):

--- a/docs/source/algorithms/Abins-v1.rst
+++ b/docs/source/algorithms/Abins-v1.rst
@@ -58,6 +58,16 @@ Usage
 
 **Example - loading CASTEP phonon data:**
 
+.. testsetup:: AbinsCastepSimple
+
+    from tempfile import TemporaryDirectory
+    from mantid.kernel import ConfigService
+
+    test_dir = TemporaryDirectory()
+
+    initial_defaultsave = ConfigService.getString("defaultsave.directory")
+    ConfigService.setString("defaultsave.directory", test_dir.name)
+
 .. testcode:: AbinsCastepSimple
 
     benzene_wrk = Abins(AbInitioProgram="CASTEP", VibrationalOrPhononFile="benzene.phonon",
@@ -77,15 +87,20 @@ Output:
 
 .. testcleanup:: AbinsCastepSimple
 
-    import os
-    from mantid.kernel import ConfigService
-
-    savedir = ConfigService.getString("defaultsave.directory")
-
-    os.remove(os.path.join(savedir, "benzene.hdf5"))
-
+    ConfigService.setString("defaultsave.directory", initial_defaultsave)
+    test_dir.cleanup()
 
 **Example - loading CRYSTAL phonon data:**
+
+.. testsetup:: AbinsCrystalSimple
+
+    from tempfile import TemporaryDirectory
+    from mantid.kernel import ConfigService
+
+    test_dir = TemporaryDirectory()
+
+    initial_defaultsave = ConfigService.getString("defaultsave.directory")
+    ConfigService.setString("defaultsave.directory", test_dir.name)
 
 .. testcode:: AbinsCrystalSimple
 
@@ -111,12 +126,8 @@ Output:
 
 .. testcleanup:: AbinsCrystalSimple
 
-    import os
-    from mantid.kernel import ConfigService
-
-    savedir = ConfigService.getString("defaultsave.directory")
-
-    os.remove(os.path.join(savedir, "b3lyp.hdf5"))
+    test_dir.cleanup()
+    ConfigService.setString("defaultsave.directory", initial_defaultsave)
 
 **Example - calling AbINS with more arguments:**
 

--- a/docs/source/algorithms/Abins-v1.rst
+++ b/docs/source/algorithms/Abins-v1.rst
@@ -61,8 +61,7 @@ Usage
 .. testcode:: AbinsCastepSimple
 
     benzene_wrk = Abins(AbInitioProgram="CASTEP", VibrationalOrPhononFile="benzene.phonon",
-                        QuantumOrderEventsNumber="1", CacheDirectory="/tmp")
-
+                        QuantumOrderEventsNumber="1")
 
     for name in benzene_wrk.getNames():
         print(name)
@@ -79,13 +78,18 @@ Output:
 .. testcleanup:: AbinsCastepSimple
 
     import os
-    os.remove("/tmp/benzene.hdf5")
+    from mantid.kernel import ConfigService
+
+    savedir = ConfigService.getString("defaultsave.directory")
+
+    os.remove(os.path.join(savedir, "benzene.hdf5"))
+
 
 **Example - loading CRYSTAL phonon data:**
 
 .. testcode:: AbinsCrystalSimple
 
-    wrk=Abins(AbInitioProgram="CRYSTAL", VibrationalOrPhononFile="b3lyp.out", QuantumOrderEventsNumber="1", CacheDirectory="/tmp")
+    wrk=Abins(AbInitioProgram="CRYSTAL", VibrationalOrPhononFile="b3lyp.out", QuantumOrderEventsNumber="1")
 
     for name in wrk.getNames():
         print(name)
@@ -108,24 +112,34 @@ Output:
 .. testcleanup:: AbinsCrystalSimple
 
     import os
-    os.remove("/tmp/b3lyp.hdf5")
+    from mantid.kernel import ConfigService
+
+    savedir = ConfigService.getString("defaultsave.directory")
+
+    os.remove(os.path.join(savedir, "b3lyp.hdf5"))
 
 **Example - calling AbINS with more arguments:**
 
-.. testcode:: AbinsexplicitParameters
+Here the cache file is directed to a temporary directory and will be cleaned up automatically.
 
-    wrk_verbose=Abins(AbInitioProgram="CASTEP", VibrationalOrPhononFile="benzene.phonon",
-                      ExperimentalFile="benzene_experimental.dat",
-                      TemperatureInKelvin=10, BinWidthInWavenumber=1.0, SampleForm="Powder", Instrument="TOSCA",
-                      Atoms="H, atom1, atom2", SumContributions=True, QuantumOrderEventsNumber="1", ScaleByCrossSection="Incoherent",
-                      CacheDirectory="/tmp")
+.. testcode:: AbinsExplicitParameters
+
+    from tempfile import TemporaryDirectory
+
+    with TemporaryDirectory() as tmp_dir:
+
+        wrk_verbose=Abins(AbInitioProgram="CASTEP", VibrationalOrPhononFile="benzene.phonon",
+                          ExperimentalFile="benzene_experimental.dat",
+                          TemperatureInKelvin=10, BinWidthInWavenumber=1.0, SampleForm="Powder", Instrument="TOSCA",
+                          Atoms="H, atom1, atom2", SumContributions=True, QuantumOrderEventsNumber="1", ScaleByCrossSection="Incoherent",
+                          CacheDirectory=tmp_dir)
 
     for name in wrk_verbose.getNames():
         print(name)
 
 Output:
 
-.. testoutput:: AbinsexplicitParameters
+.. testoutput:: AbinsExplicitParameters
 
     experimental_wrk
     wrk_verbose_total
@@ -135,11 +149,6 @@ Output:
     wrk_verbose_atom_1
     wrk_verbose_atom_2_total
     wrk_verbose_atom_2
-
-.. testcleanup:: AbinsexplicitParameters
-
-    import os
-    os.remove("/tmp/benzene.hdf5")
 
 .. categories::
 

--- a/docs/source/algorithms/Abins-v1.rst
+++ b/docs/source/algorithms/Abins-v1.rst
@@ -61,7 +61,7 @@ Usage
 .. testcode:: AbinsCastepSimple
 
     benzene_wrk = Abins(AbInitioProgram="CASTEP", VibrationalOrPhononFile="benzene.phonon",
-                        QuantumOrderEventsNumber="1")
+                        QuantumOrderEventsNumber="1", CacheDirectory="/tmp")
 
 
     for name in benzene_wrk.getNames():
@@ -79,13 +79,13 @@ Output:
 .. testcleanup:: AbinsCastepSimple
 
     import os
-    os.remove("benzene.hdf5")
+    os.remove("/tmp/benzene.hdf5")
 
 **Example - loading CRYSTAL phonon data:**
 
 .. testcode:: AbinsCrystalSimple
 
-    wrk=Abins(AbInitioProgram="CRYSTAL", VibrationalOrPhononFile="b3lyp.out", QuantumOrderEventsNumber="1")
+    wrk=Abins(AbInitioProgram="CRYSTAL", VibrationalOrPhononFile="b3lyp.out", QuantumOrderEventsNumber="1", CacheDirectory="/tmp")
 
     for name in wrk.getNames():
         print(name)
@@ -108,7 +108,7 @@ Output:
 .. testcleanup:: AbinsCrystalSimple
 
     import os
-    os.remove("b3lyp.hdf5")
+    os.remove("/tmp/b3lyp.hdf5")
 
 **Example - calling AbINS with more arguments:**
 
@@ -117,7 +117,8 @@ Output:
     wrk_verbose=Abins(AbInitioProgram="CASTEP", VibrationalOrPhononFile="benzene.phonon",
                       ExperimentalFile="benzene_experimental.dat",
                       TemperatureInKelvin=10, BinWidthInWavenumber=1.0, SampleForm="Powder", Instrument="TOSCA",
-                      Atoms="H, atom1, atom2", SumContributions=True, QuantumOrderEventsNumber="1", ScaleByCrossSection="Incoherent")
+                      Atoms="H, atom1, atom2", SumContributions=True, QuantumOrderEventsNumber="1", ScaleByCrossSection="Incoherent",
+                      CacheDirectory="/tmp")
 
     for name in wrk_verbose.getNames():
         print(name)
@@ -138,7 +139,7 @@ Output:
 .. testcleanup:: AbinsexplicitParameters
 
     import os
-    os.remove("benzene.hdf5")
+    os.remove("/tmp/benzene.hdf5")
 
 .. categories::
 

--- a/docs/source/algorithms/Abins-v1.rst
+++ b/docs/source/algorithms/Abins-v1.rst
@@ -58,7 +58,11 @@ Usage
 
 **Example - loading CASTEP phonon data:**
 
-.. testsetup:: AbinsCastepSimple
+.. testsetup:: *
+
+    # On CI defaultsave.directory may be set to an inappropriate
+    # value, causing the input validator to raise an error.
+    # Set it somewhere that is guaranteed to be suitable.
 
     from tempfile import TemporaryDirectory
     from mantid.kernel import ConfigService
@@ -67,6 +71,14 @@ Usage
 
     initial_defaultsave = ConfigService.getString("defaultsave.directory")
     ConfigService.setString("defaultsave.directory", test_dir.name)
+
+.. testcleanup:: *
+
+    # Restore the original defaultsave.directory to avoid surprises
+    # when running doctests locally.
+
+    test_dir.cleanup()
+    ConfigService.setString("defaultsave.directory", initial_defaultsave)
 
 .. testcode:: AbinsCastepSimple
 
@@ -85,22 +97,7 @@ Output:
     benzene_wrk_H_total
     benzene_wrk_H
 
-.. testcleanup:: AbinsCastepSimple
-
-    ConfigService.setString("defaultsave.directory", initial_defaultsave)
-    test_dir.cleanup()
-
 **Example - loading CRYSTAL phonon data:**
-
-.. testsetup:: AbinsCrystalSimple
-
-    from tempfile import TemporaryDirectory
-    from mantid.kernel import ConfigService
-
-    test_dir = TemporaryDirectory()
-
-    initial_defaultsave = ConfigService.getString("defaultsave.directory")
-    ConfigService.setString("defaultsave.directory", test_dir.name)
 
 .. testcode:: AbinsCrystalSimple
 
@@ -123,11 +120,6 @@ Output:
     wrk_Na
     wrk_O_total
     wrk_O
-
-.. testcleanup:: AbinsCrystalSimple
-
-    test_dir.cleanup()
-    ConfigService.setString("defaultsave.directory", initial_defaultsave)
 
 **Example - calling AbINS with more arguments:**
 

--- a/docs/source/algorithms/Abins2D-v1.rst
+++ b/docs/source/algorithms/Abins2D-v1.rst
@@ -58,7 +58,7 @@ A minimal example, relying heavily on default parameters:
 
 .. testcode:: Abins2DCastepSimple
 
-    benzene_wrk = Abins2D(AbInitioProgram="CASTEP", VibrationalOrPhononFile="benzene.phonon")
+    benzene_wrk = Abins2D(AbInitioProgram="CASTEP", VibrationalOrPhononFile="benzene.phonon", CacheDirectory="/tmp/")
 
 
     for name in benzene_wrk.getNames():
@@ -76,7 +76,7 @@ Output: (note that only the fundamental excitations are included)
 .. testcleanup:: Abins2DCastepSimple
 
     import os
-    os.remove("benzene.hdf5")
+    os.remove("/tmp/benzene.hdf5")
 
 **Example - using more arguments:**
 
@@ -94,7 +94,7 @@ approximation may not be the appropriate tool.)
                         TemperatureInKelvin=10, Instrument="MAPS",
                         Atoms="H, atom1, atom2", SumContributions=True,
                         QuantumOrderEventsNumber="2", Autoconvolution=True,
-                        ScaleByCrossSection="Total")
+                        ScaleByCrossSection="Total", CacheDirectory="/tmp")
 
     print(f"Created {wrk_verbose.size()} workspaces")
     print(f"including {wrk_verbose[12].name()}")
@@ -109,7 +109,7 @@ Output:
 .. testcleanup:: Abins2DExplicitParameters
 
     import os
-    os.remove("benzene.hdf5")
+    os.remove("/tmp/benzene.hdf5")
 
 .. categories::
 

--- a/docs/source/algorithms/Abins2D-v1.rst
+++ b/docs/source/algorithms/Abins2D-v1.rst
@@ -56,6 +56,16 @@ Usage
 
 A minimal example, relying heavily on default parameters:
 
+.. testsetup:: Abins2DCastepSimple
+
+    from tempfile import TemporaryDirectory
+    from mantid.kernel import ConfigService
+
+    test_dir = TemporaryDirectory()
+
+    initial_defaultsave = ConfigService.getString("defaultsave.directory")
+    ConfigService.setString("defaultsave.directory", test_dir.name)
+
 .. testcode:: Abins2DCastepSimple
 
     benzene_wrk = Abins2D(AbInitioProgram="CASTEP", VibrationalOrPhononFile="benzene.phonon")
@@ -75,12 +85,8 @@ Output: (note that only the fundamental excitations are included)
 
 .. testcleanup:: Abins2DCastepSimple
 
-    import os
-    from mantid.kernel import ConfigService
-
-    savedir = ConfigService.getString("defaultsave.directory")
-
-    os.remove(os.path.join(savedir, "benzene.hdf5"))
+    test_dir.cleanup()
+    ConfigService.setString("defaultsave.directory", initial_defaultsave)
 
 **Example - using more arguments:**
 
@@ -91,6 +97,16 @@ Abins only (so far) calculates the incoherent contribution, coherent
 weights can be added for a slight improvement to the predicted
 spectrum.  (If the spectrum is dominated by coherent scattering, this
 approximation may not be the appropriate tool.)
+
+.. testsetup:: Abins2DExplicitParameters
+
+    from tempfile import TemporaryDirectory
+    from mantid.kernel import ConfigService
+
+    test_dir = TemporaryDirectory()
+
+    initial_defaultsave = ConfigService.getString("defaultsave.directory")
+    ConfigService.setString("defaultsave.directory", test_dir.name)
 
 .. testcode:: Abins2DExplicitParameters
 
@@ -112,12 +128,8 @@ Output:
 
 .. testcleanup:: Abins2DExplicitParameters
 
-    import os
-    from mantid.kernel import ConfigService
-
-    savedir = ConfigService.getString("defaultsave.directory")
-
-    os.remove(os.path.join(savedir, "benzene.hdf5"))
+    test_dir.cleanup()
+    ConfigService.setString("defaultsave.directory", initial_defaultsave)
 
 .. categories::
 

--- a/docs/source/algorithms/Abins2D-v1.rst
+++ b/docs/source/algorithms/Abins2D-v1.rst
@@ -56,7 +56,11 @@ Usage
 
 A minimal example, relying heavily on default parameters:
 
-.. testsetup:: Abins2DCastepSimple
+.. testsetup:: *
+
+    # On CI defaultsave.directory may be set to an inappropriate
+    # value, causing the input validator to raise an error.
+    # Set it somewhere that is guaranteed to be suitable.
 
     from tempfile import TemporaryDirectory
     from mantid.kernel import ConfigService
@@ -65,6 +69,15 @@ A minimal example, relying heavily on default parameters:
 
     initial_defaultsave = ConfigService.getString("defaultsave.directory")
     ConfigService.setString("defaultsave.directory", test_dir.name)
+
+.. testcleanup:: *
+
+    # Restore the original defaultsave.directory to avoid surprises
+    # when running doctests locally.
+
+    test_dir.cleanup()
+    ConfigService.setString("defaultsave.directory", initial_defaultsave)
+
 
 .. testcode:: Abins2DCastepSimple
 
@@ -83,11 +96,6 @@ Output: (note that only the fundamental excitations are included)
     benzene_wrk_H_total
     benzene_wrk_H
 
-.. testcleanup:: Abins2DCastepSimple
-
-    test_dir.cleanup()
-    ConfigService.setString("defaultsave.directory", initial_defaultsave)
-
 **Example - using more arguments:**
 
 In practice we would usually select an instrument, incident energy,
@@ -97,16 +105,6 @@ Abins only (so far) calculates the incoherent contribution, coherent
 weights can be added for a slight improvement to the predicted
 spectrum.  (If the spectrum is dominated by coherent scattering, this
 approximation may not be the appropriate tool.)
-
-.. testsetup:: Abins2DExplicitParameters
-
-    from tempfile import TemporaryDirectory
-    from mantid.kernel import ConfigService
-
-    test_dir = TemporaryDirectory()
-
-    initial_defaultsave = ConfigService.getString("defaultsave.directory")
-    ConfigService.setString("defaultsave.directory", test_dir.name)
 
 .. testcode:: Abins2DExplicitParameters
 
@@ -125,11 +123,6 @@ Output:
 
    Created 34 workspaces
    including wrk_verbose_atom_1_total
-
-.. testcleanup:: Abins2DExplicitParameters
-
-    test_dir.cleanup()
-    ConfigService.setString("defaultsave.directory", initial_defaultsave)
 
 .. categories::
 

--- a/docs/source/algorithms/Abins2D-v1.rst
+++ b/docs/source/algorithms/Abins2D-v1.rst
@@ -58,7 +58,7 @@ A minimal example, relying heavily on default parameters:
 
 .. testcode:: Abins2DCastepSimple
 
-    benzene_wrk = Abins2D(AbInitioProgram="CASTEP", VibrationalOrPhononFile="benzene.phonon", CacheDirectory="/tmp/")
+    benzene_wrk = Abins2D(AbInitioProgram="CASTEP", VibrationalOrPhononFile="benzene.phonon")
 
 
     for name in benzene_wrk.getNames():
@@ -76,7 +76,11 @@ Output: (note that only the fundamental excitations are included)
 .. testcleanup:: Abins2DCastepSimple
 
     import os
-    os.remove("/tmp/benzene.hdf5")
+    from mantid.kernel import ConfigService
+
+    savedir = ConfigService.getString("defaultsave.directory")
+
+    os.remove(os.path.join(savedir, "benzene.hdf5"))
 
 **Example - using more arguments:**
 
@@ -94,7 +98,7 @@ approximation may not be the appropriate tool.)
                         TemperatureInKelvin=10, Instrument="MAPS",
                         Atoms="H, atom1, atom2", SumContributions=True,
                         QuantumOrderEventsNumber="2", Autoconvolution=True,
-                        ScaleByCrossSection="Total", CacheDirectory="/tmp")
+                        ScaleByCrossSection="Total")
 
     print(f"Created {wrk_verbose.size()} workspaces")
     print(f"including {wrk_verbose[12].name()}")
@@ -109,7 +113,11 @@ Output:
 .. testcleanup:: Abins2DExplicitParameters
 
     import os
-    os.remove("/tmp/benzene.hdf5")
+    from mantid.kernel import ConfigService
+
+    savedir = ConfigService.getString("defaultsave.directory")
+
+    os.remove(os.path.join(savedir, "benzene.hdf5"))
 
 .. categories::
 

--- a/docs/source/release/v6.13.0/Indirect/Algorithms/New_features/38620.rst
+++ b/docs/source/release/v6.13.0/Indirect/Algorithms/New_features/38620.rst
@@ -1,0 +1,1 @@
+- A "CacheDirectory" parameter has been added to the Abins and Abins2D algorithms. This allows an explicit cache directory to be set independently for each calculation; the previous behaviour (to use the User Save Directory) remains available as the default value.

--- a/scripts/abins/abins2.py
+++ b/scripts/abins/abins2.py
@@ -127,6 +127,7 @@ class Abins(AbinsAlgorithm, PythonAlgorithm):
             instrument=self._instrument,
             quantum_order_num=quantum_order_num,
             autoconvolution_max=autoconvolution_max,
+            cache_directory=self._cache_directory,
         )
         s_calculator.progress_reporter = prog_reporter
         s_data = s_calculator.get_formatted_data()

--- a/scripts/abins/abins2.py
+++ b/scripts/abins/abins2.py
@@ -86,7 +86,9 @@ class Abins(AbinsAlgorithm, PythonAlgorithm):
         prog_reporter.report("Input data from the user has been collected.")
 
         # 2) read ab initio data
-        ab_initio_data = abins.AbinsData.from_calculation_data(self._vibrational_or_phonon_data_file, self._ab_initio_program)
+        ab_initio_data = abins.AbinsData.from_calculation_data(
+            self._vibrational_or_phonon_data_file, self._ab_initio_program, cache_directory=self._cache_directory
+        )
         prog_reporter.report("Vibrational/phonon data has been read.")
 
         # 3) calculate S

--- a/scripts/abins/abinsalgorithm.py
+++ b/scripts/abins/abinsalgorithm.py
@@ -51,7 +51,7 @@ class AbinsAlgorithm:
 
         self._energy_units = self.getProperty("EnergyUnits").value
 
-        self._cache_directory = self.getProperty("CacheDirectory").value
+        self._cache_directory = Path(self.getProperty("CacheDirectory").value)
 
         # conversion from str to int
         self._num_quantum_order_events = int(self.getProperty("QuantumOrderEventsNumber").value)

--- a/scripts/abins/abinsalgorithm.py
+++ b/scripts/abins/abinsalgorithm.py
@@ -35,29 +35,6 @@ import abins.parameters
 class AbinsAlgorithm:
     """Class providing shared utility for multiple inheritence by 1D, 2D implementations"""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)  # i.e. forward everything to PythonAlgorithm
-
-        # User input private properties
-        self._instrument_name = None
-
-        self._vibrational_or_phonon_data_file = None
-        self._ab_initio_program = None
-        self._out_ws_name = None
-        self._temperature = None
-        self._atoms = None
-        self._sum_contributions = None
-        self._save_ascii = None
-        self._scale_by_cross_section = None
-
-        self._num_quantum_order_events = None
-        self._autoconvolution = None
-        self._energy_units = None
-
-        # Interally-used private properties
-        self._max_event_order = None
-        self._bin_width = None
-
     def get_common_properties(self) -> None:
         """From user input, set properties common to Abins 1D and 2D versions"""
         self._ab_initio_program = self.getProperty("AbInitioProgram").value

--- a/scripts/abins/abinsdata.py
+++ b/scripts/abins/abinsdata.py
@@ -49,7 +49,7 @@ class AbinsData:
                     ab_initio_program.upper(), " ".join(all_loaders.keys())
                 )
             )
-        loader = all_loaders[ab_initio_program.upper()](input_ab_initio_filename=filename)
+        loader = all_loaders[ab_initio_program.upper()](input_ab_initio_filename=filename, cache_directory=cache_directory)
         data = loader.get_formatted_data()
         return data
 

--- a/scripts/abins/abinsdata.py
+++ b/scripts/abins/abinsdata.py
@@ -4,6 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from pathlib import Path
 from typing import Any, Dict, Type, TypedDict, TypeVar
 
 from pydantic import validate_call
@@ -32,12 +33,13 @@ class AbinsData:
         self._check_consistent_dimensions()
 
     @staticmethod
-    def from_calculation_data(filename: str, ab_initio_program: str) -> "AbinsData":
+    def from_calculation_data(filename: str, ab_initio_program: str, cache_directory: Path) -> "AbinsData":
         """
         Get AbinsData from ab initio calculation output file.
 
         :param filename: Path to vibration/phonon data file
         :param ab_initio_program: Program which generated data file; this should be a key in AbinsData.ab_initio_loaders
+        :param cache_directory: Location for cache files
         """
         from abins.input import all_loaders  # Defer import to avoid loops when abins.__init__ imports AbinsData
 

--- a/scripts/abins/input/abinitioloader.py
+++ b/scripts/abins/input/abinitioloader.py
@@ -30,7 +30,7 @@ class AbInitioLoader(metaclass=NamedAbstractClass):
     read_formatted_data() if necessary and caching the results.
     """
 
-    def __init__(self, input_ab_initio_filename: str = None):
+    def __init__(self, input_ab_initio_filename: str = None, cache_directory: Path | None = None):
         """An object for loading phonon data from ab initio output files"""
 
         if not isinstance(input_ab_initio_filename, str):
@@ -38,7 +38,11 @@ class AbInitioLoader(metaclass=NamedAbstractClass):
         elif not Path(input_ab_initio_filename).is_file():
             raise IOError(f"Ab initio file {input_ab_initio_filename} not found.")
 
-        self._clerk = abins.IO(input_filename=input_ab_initio_filename, group_name=abins.parameters.hdf_groups["ab_initio_data"])
+        self._clerk = abins.IO(
+            input_filename=input_ab_initio_filename,
+            group_name=abins.parameters.hdf_groups["ab_initio_data"],
+            cache_directory=cache_directory,
+        )
 
     @property
     @abstractmethod

--- a/scripts/abins/input/crystalloader.py
+++ b/scripts/abins/input/crystalloader.py
@@ -5,6 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import io
+from pathlib import Path
+
 import numpy as np
 
 from .textparser import TextParser
@@ -19,11 +21,11 @@ class CRYSTALLoader(AbInitioLoader):
     contributing to this module.
     """
 
-    def __init__(self, input_ab_initio_filename=None):
+    def __init__(self, input_ab_initio_filename=None, cache_directory: Path | None = None):
         """
         :param input_ab_initio_filename: name of a file with vibrational or phonon data (foo.out)
         """
-        super().__init__(input_ab_initio_filename=input_ab_initio_filename)
+        super().__init__(input_ab_initio_filename=input_ab_initio_filename, cache_directory=cache_directory)
 
         self._num_k = None
         self._num_modes = None

--- a/scripts/abins/input/dmol3loader.py
+++ b/scripts/abins/input/dmol3loader.py
@@ -37,13 +37,6 @@ class DMOL3Loader(AbInitioLoader):
     Class for loading DMOL3 ab initio vibrational data.
     """
 
-    def __init__(self, input_ab_initio_filename):
-        """
-        :param input_ab_initio_filename: name of file with vibrational data (foo.outmol)
-        """
-        super().__init__(input_ab_initio_filename=input_ab_initio_filename)
-        self._norm = 0
-
     @property
     def _ab_initio_program(self) -> str:
         return "DMOL3"

--- a/scripts/abins/input/gaussianloader.py
+++ b/scripts/abins/input/gaussianloader.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import io
 from io import BufferedReader
+from pathlib import Path
 import re
 from typing import Iterable, List
 
@@ -22,11 +23,11 @@ class GAUSSIANLoader(AbInitioLoader):
     Class for loading GAUSSIAN ab initio vibrational data.
     """
 
-    def __init__(self, input_ab_initio_filename) -> None:
+    def __init__(self, input_ab_initio_filename: str, cache_directory: Path | None = None) -> None:
         """
         :param input_ab_initio_filename: name of file with vibrational data (foo.log or foo.LOG)
         """
-        super().__init__(input_ab_initio_filename=input_ab_initio_filename)
+        super().__init__(input_ab_initio_filename=input_ab_initio_filename, cache_directory=cache_directory)
         self._active_atoms = None
         self._num_atoms = None
         self._num_read_freq = 0

--- a/scripts/abins/io.py
+++ b/scripts/abins/io.py
@@ -35,7 +35,7 @@ class IO(BaseModel):
     setting: str = ""
     autoconvolution: int = 10
     temperature: float = None
-    cache_directory: Path | None = None
+    cache_directory: Path
 
     @staticmethod
     def _dir_is_not_writeable(directory: str):

--- a/scripts/abins/io.py
+++ b/scripts/abins/io.py
@@ -86,8 +86,7 @@ class IO(BaseModel):
 
         if self._dir_is_not_writeable(str(self.cache_directory)):
             raise Exception(
-                f"Could not write a file to the cache directory {self.cache_directory}. "
-                "Please check this location is reasonable."
+                f"Could not write a file to the cache directory {self.cache_directory}. Please check this location is reasonable."
             )
         self._hdf_filename = str(self.cache_directory / f"{core_name}.hdf5")
 

--- a/scripts/abins/io.py
+++ b/scripts/abins/io.py
@@ -35,7 +35,7 @@ class IO(BaseModel):
     setting: str = ""
     autoconvolution: int = 10
     temperature: float = None
-    cache_directory: Path = None
+    cache_directory: Path | None = None
 
     @staticmethod
     def _dir_is_not_writeable(directory: str):

--- a/scripts/abins/io.py
+++ b/scripts/abins/io.py
@@ -60,6 +60,9 @@ class IO(BaseModel):
         if self.cache_directory:
             return self.cache_directory
 
+        else:
+            raise Exception("No directory")
+
         return Path(ConfigService.getString("defaultsave.directory"))
 
     def model_post_init(self, __context):

--- a/scripts/abins/powdercalculator.py
+++ b/scripts/abins/powdercalculator.py
@@ -4,8 +4,10 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-import numpy as np
+from pathlib import Path
 from typing import Dict, Tuple
+
+import numpy as np
 
 import abins
 from abins.constants import ACOUSTIC_PHONON_THRESHOLD, CONSTANT, CM1_2_HARTREE, K_2_HARTREE, NUM_ZERO
@@ -17,10 +19,11 @@ class PowderCalculator:
     Class for calculating powder data.
     """
 
-    def __init__(self, *, filename: str, abins_data: abins.AbinsData, temperature: float) -> None:
+    def __init__(self, *, filename: str, abins_data: abins.AbinsData, temperature: float, cache_directory: Path | None = None) -> None:
         """
         :param filename:  name of input DFT filename
         :param abins_data: object of type AbinsData with data from input DFT file
+        :param temperature: temperature in Kelvin (for Bose-Einstein occupation)
         """
         if not isinstance(abins_data, abins.AbinsData):
             raise ValueError("Object of AbinsData was expected.")
@@ -40,7 +43,10 @@ class PowderCalculator:
 
         self._masses = np.asarray([atoms_data[atom]["mass"] for atom in range(len(atoms_data))])
         self._clerk = abins.IO(
-            input_filename=filename, group_name=abins.parameters.hdf_groups["powder_data"], temperature=self._temperature
+            input_filename=filename,
+            group_name=abins.parameters.hdf_groups["powder_data"],
+            temperature=self._temperature,
+            cache_directory=cache_directory,
         )
 
     def _calculate_powder(self) -> abins.PowderData:

--- a/scripts/abins/powdercalculator.py
+++ b/scripts/abins/powdercalculator.py
@@ -19,7 +19,7 @@ class PowderCalculator:
     Class for calculating powder data.
     """
 
-    def __init__(self, *, filename: str, abins_data: abins.AbinsData, temperature: float, cache_directory: Path | None = None) -> None:
+    def __init__(self, *, filename: str, abins_data: abins.AbinsData, temperature: float, cache_directory: Path) -> None:
         """
         :param filename:  name of input DFT filename
         :param abins_data: object of type AbinsData with data from input DFT file

--- a/scripts/abins/scalculatorfactory.py
+++ b/scripts/abins/scalculatorfactory.py
@@ -4,6 +4,8 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from pathlib import Path
+
 import numpy as np
 
 import abins
@@ -28,6 +30,7 @@ class SCalculatorFactory(object):
         instrument: Instrument,
         quantum_order_num: int,
         autoconvolution_max: int = 0,
+        cache_directory: Path | None = None,
     ):
         """
         :param filename: name of input DFT file (CASTEP: foo.phonon)
@@ -37,6 +40,7 @@ class SCalculatorFactory(object):
         :param instrument: object of type Instrument for which simulation should be performed
         :param quantum_order_num: number of quantum order events taken into account during the simulation
         :param autoconvolution_max: Convolve results with fundamentals to obtain approximate spectra up to this order
+        :param cache_directory: Directory for .hdf5 cache files
         """
         if sample_form in ALL_SAMPLE_FORMS:
             if sample_form == "Powder":
@@ -47,6 +51,7 @@ class SCalculatorFactory(object):
                     instrument=instrument,
                     quantum_order_num=quantum_order_num,
                     autoconvolution_max=autoconvolution_max,
+                    cache_directory=cache_directory,
                 )
 
             else:

--- a/scripts/abins/scalculatorfactory.py
+++ b/scripts/abins/scalculatorfactory.py
@@ -30,7 +30,7 @@ class SCalculatorFactory(object):
         instrument: Instrument,
         quantum_order_num: int,
         autoconvolution_max: int = 0,
-        cache_directory: Path | None = None,
+        cache_directory: Path,
     ):
         """
         :param filename: name of input DFT file (CASTEP: foo.phonon)

--- a/scripts/abins/spowdersemiempiricalcalculator.py
+++ b/scripts/abins/spowdersemiempiricalcalculator.py
@@ -35,7 +35,7 @@ class SPowderSemiEmpiricalCalculator:
         instrument: Instrument,
         quantum_order_num: int = Field(ge=1, le=2),
         autoconvolution_max: int = 0,
-        cache_directory: Path | None = None,
+        cache_directory: Path,
     ) -> None:
         """
         :param filename: name of input DFT file (CASTEP: foo.phonon). This is only used for caching, the file will not be read.

--- a/scripts/abins/spowdersemiempiricalcalculator.py
+++ b/scripts/abins/spowdersemiempiricalcalculator.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 
+from pathlib import Path
 from typing import Optional, Union
 
 import numpy as np
@@ -34,6 +35,7 @@ class SPowderSemiEmpiricalCalculator:
         instrument: Instrument,
         quantum_order_num: int = Field(ge=1, le=2),
         autoconvolution_max: int = 0,
+        cache_directory: Path | None = None,
     ) -> None:
         """
         :param filename: name of input DFT file (CASTEP: foo.phonon). This is only used for caching, the file will not be read.
@@ -43,6 +45,7 @@ class SPowderSemiEmpiricalCalculator:
         :param quantum_order_num: number of quantum order events to simulate in semi-analytic approximation
         :param autoconvolution_max:
             approximate spectra up to this order using auto-convolution
+        :param cache_directory: location for .hdf5
         """
         from abins.constants import TWO_DIMENSIONAL_INSTRUMENTS
 
@@ -53,6 +56,7 @@ class SPowderSemiEmpiricalCalculator:
         self._quantum_order_num = quantum_order_num
         self._autoconvolution_max = autoconvolution_max
         self._instrument = instrument
+        self._cache_directory = cache_directory
 
         # This is only used as metadata for clerk, like filename
         self._sample_form = "Powder"
@@ -79,6 +83,7 @@ class SPowderSemiEmpiricalCalculator:
                 sample_form=self._sample_form,
                 temperature=self._temperature,
             ),
+            cache_directory=self._cache_directory,
         )
 
         # Set up two sampling grids: _bins for broadening/output
@@ -245,7 +250,7 @@ class SPowderSemiEmpiricalCalculator:
 
         # Compute tensors and traces, write to cache for access during atomic s calculations
         powder_calculator = abins.PowderCalculator(
-            filename=self._input_filename, abins_data=self._abins_data, temperature=self._temperature
+            filename=self._input_filename, abins_data=self._abins_data, temperature=self._temperature, cache_directory=self._cache_directory
         )
         self._powder_data = powder_calculator.get_formatted_data()
 

--- a/scripts/abins/test_helpers.py
+++ b/scripts/abins/test_helpers.py
@@ -4,14 +4,12 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-import os
 from pathlib import Path
-from typing import Any, Dict, List, Mapping
+from typing import Any, Dict, Mapping
 from unittest import TestCase
 
 import numpy as np
 from numpy.testing import assert_allclose
-from pydantic import validate_call
 
 from abins.atomsdata import _AtomData
 from abins.kpointsdata import KpointData
@@ -37,20 +35,6 @@ def find_file(filename: str, try_upcase_suffix: bool = True) -> str:
         return find_file(str(path.with_suffix(path.suffix.upper())), try_upcase_suffix=False)
     else:
         raise ValueError(f"Could not find file '{filename}'")
-
-
-@validate_call
-def remove_output_files(list_of_names: List[str], directory: Path) -> None:
-    """Removes output files created during a test."""
-    all_files = os.listdir(directory)
-
-    for filename in all_files:
-        for name in list_of_names:
-            if name in filename:
-                full_path = directory / filename
-                if full_path.exists():
-                    os.remove(full_path)
-                break
 
 
 def dict_arrays_to_lists(mydict: Mapping[str, Any]) -> Dict[str, Any]:

--- a/scripts/abins/test_helpers.py
+++ b/scripts/abins/test_helpers.py
@@ -15,7 +15,6 @@ from pydantic import validate_call
 
 from abins.atomsdata import _AtomData
 from abins.kpointsdata import KpointData
-import abins.io
 
 
 # Module with helper functions used to create tests.
@@ -41,26 +40,15 @@ def find_file(filename: str, try_upcase_suffix: bool = True) -> str:
 
 
 @validate_call
-def remove_output_files(list_of_names: List[str]) -> None:
+def remove_output_files(list_of_names: List[str], directory: Path) -> None:
     """Removes output files created during a test."""
-
-    # import ConfigService here to avoid:
-    # RuntimeError: Pickling of "mantid.kernel._kernel.ConfigServiceImpl"
-    # instances is not enabled (http://www.boost.org/libs/python/doc/v2/pickle.html)
-
-    from mantid.kernel import ConfigService
-
-    save_dir_path = ConfigService.getString("defaultsave.directory")
-    if save_dir_path != "":  # default save directory set
-        all_files = os.listdir(save_dir_path)
-    else:
-        all_files = os.listdir(os.getcwd())
+    all_files = os.listdir(directory)
 
     for filename in all_files:
         for name in list_of_names:
             if name in filename:
-                full_path = os.path.join(abins.io.IO.get_save_dir_path(), filename)
-                if os.path.isfile(full_path):
+                full_path = directory / filename
+                if full_path.exists():
                     os.remove(full_path)
                 break
 

--- a/scripts/test/Abins/AbinsCalculateSPowderTest.py
+++ b/scripts/test/Abins/AbinsCalculateSPowderTest.py
@@ -7,7 +7,9 @@
 from copy import deepcopy
 import functools
 import json
+from pathlib import Path
 import unittest
+from tempfile import TemporaryDirectory
 
 import numpy as np
 from numpy.testing import assert_almost_equal
@@ -32,14 +34,21 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
     _si2 = "Si2-sc_CalculateSPowder"
     _instruments_defaults = {}
 
-    default_calculator_kwargs = dict(
-        temperature=_temperature, instrument=_instrument, sample_form=_sample_form, quantum_order_num=_order_event, autoconvolution_max=0
-    )
-
     def setUp(self):
         self.default_threads = abins.parameters.performance["threads"]
         abins.parameters.performance["threads"] = 1
         self._instruments_defaults = deepcopy(abins.parameters.instruments)
+        self._temporary_directory = TemporaryDirectory()
+        self._cache_directory = Path(self._temporary_directory.name)
+
+        self.default_calculator_kwargs = dict(
+            temperature=self._temperature,
+            instrument=self._instrument,
+            sample_form=self._sample_form,
+            quantum_order_num=self._order_event,
+            autoconvolution_max=0,
+            cache_directory=self._cache_directory,
+        )
 
     def tearDown(self):
         from mantid.kernel import ConfigService
@@ -65,6 +74,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
                 abins_data=good_data,
                 instrument=self._instrument,
                 quantum_order_num=self._order_event,
+                cache_directory=self._cache_directory,
             )
 
         # invalid temperature
@@ -76,6 +86,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
                 abins_data=good_data,
                 instrument=self._instrument,
                 quantum_order_num=self._order_event,
+                cache_directory=self._cache_directory,
             )
 
         # invalid sample
@@ -87,6 +98,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
                 abins_data=good_data,
                 instrument=self._instrument,
                 quantum_order_num=self._order_event,
+                cache_directory=self._cache_directory,
             )
 
         # invalid abins data: content of abins data instead of object abins_data
@@ -98,6 +110,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
                 abins_data=good_data.extract(),
                 instrument=self._instrument,
                 quantum_order_num=self._order_event,
+                cache_directory=self._cache_directory,
             )
 
         # invalid instrument
@@ -109,6 +122,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
                 abins_data=good_data,
                 instrument="INSTRUMENT",
                 quantum_order_num=self._order_event,
+                cache_directory=self._cache_directory,
             )
 
     def test_1d_order1(self):

--- a/scripts/test/Abins/AbinsCalculateSPowderTest.py
+++ b/scripts/test/Abins/AbinsCalculateSPowderTest.py
@@ -42,7 +42,11 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
         self._instruments_defaults = deepcopy(abins.parameters.instruments)
 
     def tearDown(self):
-        abins.test_helpers.remove_output_files(list_of_names=["_CalculateSPowder"])
+        from mantid.kernel import ConfigService
+
+        abins.test_helpers.remove_output_files(
+            list_of_names=["_CalculateSPowder"], directory=ConfigService.getString("defaultsave.directory")
+        )
         abins.parameters.performance["threads"] = self.default_threads
         abins.parameters.instruments.update(self._instruments_defaults)
 

--- a/scripts/test/Abins/AbinsCalculateSPowderTest.py
+++ b/scripts/test/Abins/AbinsCalculateSPowderTest.py
@@ -39,7 +39,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
         abins.parameters.performance["threads"] = 1
         self._instruments_defaults = deepcopy(abins.parameters.instruments)
         self._temporary_directory = TemporaryDirectory()
-        self._cache_directory = Path(self._temporary_directory.name)
+        self.cache_directory = Path(self._temporary_directory.name)
 
         self.default_calculator_kwargs = dict(
             temperature=self._temperature,
@@ -47,7 +47,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
             sample_form=self._sample_form,
             quantum_order_num=self._order_event,
             autoconvolution_max=0,
-            cache_directory=self._cache_directory,
+            cache_directory=self.cache_directory,
         )
 
     def tearDown(self):
@@ -71,7 +71,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
                 abins_data=good_data,
                 instrument=self._instrument,
                 quantum_order_num=self._order_event,
-                cache_directory=self._cache_directory,
+                cache_directory=self.cache_directory,
             )
 
         # invalid temperature
@@ -83,7 +83,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
                 abins_data=good_data,
                 instrument=self._instrument,
                 quantum_order_num=self._order_event,
-                cache_directory=self._cache_directory,
+                cache_directory=self.cache_directory,
             )
 
         # invalid sample
@@ -95,7 +95,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
                 abins_data=good_data,
                 instrument=self._instrument,
                 quantum_order_num=self._order_event,
-                cache_directory=self._cache_directory,
+                cache_directory=self.cache_directory,
             )
 
         # invalid abins data: content of abins data instead of object abins_data
@@ -107,7 +107,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
                 abins_data=good_data.extract(),
                 instrument=self._instrument,
                 quantum_order_num=self._order_event,
-                cache_directory=self._cache_directory,
+                cache_directory=self.cache_directory,
             )
 
         # invalid instrument
@@ -119,7 +119,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
                 abins_data=good_data,
                 instrument="INSTRUMENT",
                 quantum_order_num=self._order_event,
-                cache_directory=self._cache_directory,
+                cache_directory=self.cache_directory,
             )
 
     def test_1d_order1(self):

--- a/scripts/test/Abins/AbinsCalculateSPowderTest.py
+++ b/scripts/test/Abins/AbinsCalculateSPowderTest.py
@@ -51,11 +51,8 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
         )
 
     def tearDown(self):
-        from mantid.kernel import ConfigService
+        self._temporary_directory.cleanup()
 
-        abins.test_helpers.remove_output_files(
-            list_of_names=["_CalculateSPowder"], directory=ConfigService.getString("defaultsave.directory")
-        )
         abins.parameters.performance["threads"] = self.default_threads
         abins.parameters.instruments.update(self._instruments_defaults)
 

--- a/scripts/test/Abins/AbinsDataTest.py
+++ b/scripts/test/Abins/AbinsDataTest.py
@@ -22,6 +22,10 @@ from abins.test_helpers import assert_kpoint_almost_equal
 
 class TestAbinsData(unittest.TestCase):
     def setUp(self):
+        from mantid.kernel import ConfigService
+
+        self.cache_directory = ConfigService.getString("defaultsave.directory")
+
         self.mock_ad = MagicMock(spec=abins.AtomsData)
         self.mock_kpd = MagicMock(spec=abins.KpointsData)
 
@@ -34,7 +38,9 @@ class TestAbinsData(unittest.TestCase):
     def test_init_noloader(self):
         with self.assertRaises(ValueError):
             AbinsData.from_calculation_data(
-                abins.test_helpers.find_file("squaricn_sum_LoadCASTEP.phonon"), ab_initio_program="fake_program"
+                abins.test_helpers.find_file("squaricn_sum_LoadCASTEP.phonon"),
+                ab_initio_program="fake_program",
+                cache_directory=self.cache_directory,
             )
 
     def test_data_content(self):
@@ -54,13 +60,17 @@ class DummyLoader:
 
 class TestAbinsDataFromCalculation(unittest.TestCase):
     def setUp(self):
+        from mantid.kernel import ConfigService
+
+        self.cache_directory = ConfigService.getString("defaultsave.directory")
+
         all_loaders["DUMMYLOADER"] = DummyLoader
 
     def tearDown(self):
         del all_loaders["DUMMYLOADER"]
 
     def test_with_dummy_loader(self):
-        data = AbinsData.from_calculation_data("dummy_file.ext", "DummyLoader")
+        data = AbinsData.from_calculation_data("dummy_file.ext", "DummyLoader", cache_directory=self.cache_directory)
         self.assertEqual(data, "FORMATTED DATA")
 
 

--- a/scripts/test/Abins/AbinsDataTest.py
+++ b/scripts/test/Abins/AbinsDataTest.py
@@ -51,8 +51,9 @@ class TestAbinsData(unittest.TestCase):
 
 
 class DummyLoader:
-    def __init__(self, *, input_ab_initio_filename):
+    def __init__(self, *, input_ab_initio_filename, cache_directory):
         self.filename = input_ab_initio_filename
+        self.cache_directory = cache_directory
 
     def get_formatted_data(self):
         return "FORMATTED DATA"

--- a/scripts/test/Abins/AbinsDataTest.py
+++ b/scripts/test/Abins/AbinsDataTest.py
@@ -22,12 +22,14 @@ from abins.test_helpers import assert_kpoint_almost_equal
 
 class TestAbinsData(unittest.TestCase):
     def setUp(self):
-        from mantid.kernel import ConfigService
-
-        self.cache_directory = ConfigService.getString("defaultsave.directory")
+        self._tempdir = TemporaryDirectory()
+        self.cache_directory = Path(self._tempdir.name)
 
         self.mock_ad = MagicMock(spec=abins.AtomsData)
         self.mock_kpd = MagicMock(spec=abins.KpointsData)
+
+    def tearDown(self):
+        self._tempdir.cleanup()
 
     def test_init_typeerror(self):
         with self.assertRaisesRegex(ValidationError, "Input should be an instance of KpointsData"):
@@ -61,13 +63,14 @@ class DummyLoader:
 
 class TestAbinsDataFromCalculation(unittest.TestCase):
     def setUp(self):
-        from mantid.kernel import ConfigService
-
-        self.cache_directory = ConfigService.getString("defaultsave.directory")
+        self._tempdir = TemporaryDirectory()
+        self.cache_directory = Path(self._tempdir.name)
 
         all_loaders["DUMMYLOADER"] = DummyLoader
 
     def tearDown(self):
+        self._tempdir.cleanup()
+
         del all_loaders["DUMMYLOADER"]
 
     def test_with_dummy_loader(self):

--- a/scripts/test/Abins/AbinsIOmoduleTest.py
+++ b/scripts/test/Abins/AbinsIOmoduleTest.py
@@ -15,11 +15,11 @@ from abins import IO
 
 class IOTest(unittest.TestCase):
     def setUp(self):
-        self._tmpdir = TemporaryDirectory()
-        self.cache_directory = Path(self._tmpdir.name)
+        self.tempdir = TemporaryDirectory()
+        self.cache_directory = Path(self.tempdir.name)
 
     def tearDown(self):
-        self._tmpdir.cleanup()
+        self.tempdir.cleanup()
 
     def _save_stuff(self):
         saver = IO(input_filename="Cars.foo", group_name="Volksvagen", cache_directory=self.cache_directory)

--- a/scripts/test/Abins/AbinsIOmoduleTest.py
+++ b/scripts/test/Abins/AbinsIOmoduleTest.py
@@ -13,7 +13,9 @@ from abins import IO, test_helpers
 
 class IOTest(unittest.TestCase):
     def tearDown(self):
-        test_helpers.remove_output_files(list_of_names=["Cars", "temphgfrt"])
+        from mantid.kernel import ConfigService
+
+        test_helpers.remove_output_files(list_of_names=["Cars", "temphgfrt"], directory=ConfigService.getString("defaultsave.directory"))
 
     @staticmethod
     def _save_stuff():

--- a/scripts/test/Abins/AbinsIOmoduleTest.py
+++ b/scripts/test/Abins/AbinsIOmoduleTest.py
@@ -4,6 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from pathlib import Path
 import unittest
 
 import numpy as np
@@ -12,14 +13,16 @@ from abins import IO, test_helpers
 
 
 class IOTest(unittest.TestCase):
-    def tearDown(self):
+    def setUp(self):
         from mantid.kernel import ConfigService
 
-        test_helpers.remove_output_files(list_of_names=["Cars", "temphgfrt"], directory=ConfigService.getString("defaultsave.directory"))
+        self._cache_directory = Path(ConfigService.getString("defaultsave.directory"))
 
-    @staticmethod
-    def _save_stuff():
-        saver = IO(input_filename="Cars.foo", group_name="Volksvagen")
+    def tearDown(self):
+        test_helpers.remove_output_files(list_of_names=["Cars", "temphgfrt"], directory=self._cache_directory)
+
+    def _save_stuff(self):
+        saver = IO(input_filename="Cars.foo", group_name="Volksvagen", cache_directory=self._cache_directory)
 
         # add some attributes
         saver.add_attribute("Fuel", 100)
@@ -45,13 +48,13 @@ class IOTest(unittest.TestCase):
         saver.save()
 
     def _add_wrong_attribute(self):
-        poor_saver = IO(input_filename="BadCars.foo", group_name="Volksvagen")
+        poor_saver = IO(input_filename="BadCars.foo", group_name="Volksvagen", cache_directory=self._cache_directory)
 
         with self.assertRaisesRegex(ValidationError, "Input should be an instance of int64"):
             poor_saver.add_attribute("BadPassengers", np.array([4, 5], dtype=np.int64))
 
     def _save_wrong_dataset(self):
-        poor_saver = IO(input_filename="BadCars.foo", group_name="Volksvagen")
+        poor_saver = IO(input_filename="BadCars.foo", group_name="Volksvagen", cache_directory=self._cache_directory)
         poor_saver.add_data("BadPassengers", 4)
         self.assertRaises(TypeError, poor_saver.save)
 
@@ -65,7 +68,7 @@ class IOTest(unittest.TestCase):
         self.assertRaises(ValueError, IO, input_filename="goodfile", group_name=1)
 
     def _wrong_file(self):
-        poor_loader = IO(input_filename="bumCars", group_name="nice_group")
+        poor_loader = IO(input_filename="bumCars", group_name="nice_group", cache_directory=self._cache_directory)
         self.assertRaises(IOError, poor_loader.load, list_of_attributes="one_attribute")
 
     def _loading_attributes(self):
@@ -116,7 +119,7 @@ class IOTest(unittest.TestCase):
         self._add_wrong_attribute()
         self._save_wrong_dataset()
 
-        self.loader = IO(input_filename="Cars.foo", group_name="Volksvagen")
+        self.loader = IO(input_filename="Cars.foo", group_name="Volksvagen", cache_directory=self._cache_directory)
 
         self._wrong_filename_type()
         self._empty_filename()

--- a/scripts/test/Abins/AbinsLoadCASTEPTest.py
+++ b/scripts/test/Abins/AbinsLoadCASTEPTest.py
@@ -48,11 +48,6 @@ class LoadCASTEPTest(unittest.TestCase, abins.input.Tester):
             # noinspection PyUnusedLocal
             CASTEPLoader(input_ab_initio_filename=1)
 
-    def tearDown(self):
-        from mantid.kernel import ConfigService
-
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadCASTEP"], directory=ConfigService.getString("defaultsave.directory"))
-
     #  *************************** USE CASES ********************************************
     # ===================================================================================
     # | Use case: Gamma point calculation and sum correction enabled during calculations|

--- a/scripts/test/Abins/AbinsLoadCASTEPTest.py
+++ b/scripts/test/Abins/AbinsLoadCASTEPTest.py
@@ -45,7 +45,9 @@ class LoadCASTEPTest(unittest.TestCase, abins.input.Tester):
             CASTEPLoader(input_ab_initio_filename=1)
 
     def tearDown(self):
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadCASTEP"])
+        from mantid.kernel import ConfigService
+
+        abins.test_helpers.remove_output_files(list_of_names=["_LoadCASTEP"], directory=ConfigService.getString("defaultsave.directory"))
 
     #  *************************** USE CASES ********************************************
     # ===================================================================================

--- a/scripts/test/Abins/AbinsLoadCASTEPTest.py
+++ b/scripts/test/Abins/AbinsLoadCASTEPTest.py
@@ -4,6 +4,8 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from pathlib import Path
+from tempfile import TemporaryDirectory
 import unittest
 from unittest.mock import patch, Mock
 
@@ -23,12 +25,14 @@ class LoadCastepUsingEuphonicTest(unittest.TestCase):
         # filename makes it to Euphonic CASTEP parser
 
         filename = abins.test_helpers.find_file("squaricn_sum_LoadCASTEP.phonon")
-        reader = CASTEPLoader(input_ab_initio_filename=filename)
 
-        try:
-            reader.read_vibrational_or_phonon_data()
-        except TypeError:
-            pass  # Clerk will freak out when passed mocked data to serialise
+        with TemporaryDirectory() as tmpdir:
+            reader = CASTEPLoader(input_ab_initio_filename=filename, cache_directory=Path(tmpdir))
+
+            try:
+                reader.read_vibrational_or_phonon_data()
+            except TypeError:
+                pass  # Clerk will freak out when passed mocked data to serialise
 
         from_castep.assert_called_with(filename, prefer_non_loto=True)
 

--- a/scripts/test/Abins/AbinsLoadCRYSTALTest.py
+++ b/scripts/test/Abins/AbinsLoadCRYSTALTest.py
@@ -11,11 +11,6 @@ from abins.input import CRYSTALLoader
 
 
 class AbinsLoadCRYSTALTest(unittest.TestCase, abins.input.Tester):
-    def tearDown(self):
-        from mantid.kernel import ConfigService
-
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadCRYSTAL"], directory=ConfigService.getString("defaultsave.directory"))
-
     # *************************** USE CASES *********************************************
     # ===================================================================================
     # | Use cases: Gamma point calculation for CRYSTAL                                  |

--- a/scripts/test/Abins/AbinsLoadCRYSTALTest.py
+++ b/scripts/test/Abins/AbinsLoadCRYSTALTest.py
@@ -12,7 +12,9 @@ from abins.input import CRYSTALLoader
 
 class AbinsLoadCRYSTALTest(unittest.TestCase, abins.input.Tester):
     def tearDown(self):
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadCRYSTAL"])
+        from mantid.kernel import ConfigService
+
+        abins.test_helpers.remove_output_files(list_of_names=["_LoadCRYSTAL"], directory=ConfigService.getString("defaultsave.directory"))
 
     # *************************** USE CASES *********************************************
     # ===================================================================================

--- a/scripts/test/Abins/AbinsLoadDMOL3Test.py
+++ b/scripts/test/Abins/AbinsLoadDMOL3Test.py
@@ -14,11 +14,6 @@ import abins.test_helpers
 class AbinsLoadDMOL3Test(unittest.TestCase, abins.input.Tester):
     """Check entire input files against expected outputs"""
 
-    def tearDown(self):
-        from mantid.kernel import ConfigService
-
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadDMOL3"], directory=ConfigService.getString("defaultsave.directory"))
-
     _gamma_dmol3 = "LTA_40_O2_LoadDMOL3"
     _gamma_no_h_dmol3 = "Na2SiF6_LoadDMOL3"
     _molecule_dmol3 = "methane_LoadDMOL3"

--- a/scripts/test/Abins/AbinsLoadDMOL3Test.py
+++ b/scripts/test/Abins/AbinsLoadDMOL3Test.py
@@ -15,7 +15,9 @@ class AbinsLoadDMOL3Test(unittest.TestCase, abins.input.Tester):
     """Check entire input files against expected outputs"""
 
     def tearDown(self):
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadDMOL3"])
+        from mantid.kernel import ConfigService
+
+        abins.test_helpers.remove_output_files(list_of_names=["_LoadDMOL3"], directory=ConfigService.getString("defaultsave.directory"))
 
     _gamma_dmol3 = "LTA_40_O2_LoadDMOL3"
     _gamma_no_h_dmol3 = "Na2SiF6_LoadDMOL3"

--- a/scripts/test/Abins/AbinsLoadGAUSSIANTest.py
+++ b/scripts/test/Abins/AbinsLoadGAUSSIANTest.py
@@ -12,7 +12,9 @@ import abins.test_helpers
 
 class AbinsLoadGAUSSIANTest(unittest.TestCase, abins.input.Tester):
     def tearDown(self):
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadGAUSSIAN"])
+        from mantid.kernel import ConfigService
+
+        abins.test_helpers.remove_output_files(list_of_names=["_LoadGAUSSIAN"], directory=ConfigService.getString("defaultsave.directory"))
 
         #  *************************** USE CASES ********************************************
 

--- a/scripts/test/Abins/AbinsLoadGAUSSIANTest.py
+++ b/scripts/test/Abins/AbinsLoadGAUSSIANTest.py
@@ -11,12 +11,7 @@ import abins.test_helpers
 
 
 class AbinsLoadGAUSSIANTest(unittest.TestCase, abins.input.Tester):
-    def tearDown(self):
-        from mantid.kernel import ConfigService
-
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadGAUSSIAN"], directory=ConfigService.getString("defaultsave.directory"))
-
-        #  *************************** USE CASES ********************************************
+    #  *************************** USE CASES ********************************************
 
     # ===================================================================================
     # | Use cases: molecular calculation for GAUSSIAN03 Hartree Fock, Unix              |

--- a/scripts/test/Abins/AbinsLoadJSONTest.py
+++ b/scripts/test/Abins/AbinsLoadJSONTest.py
@@ -17,7 +17,10 @@ class AbinsLoadJSONTest(unittest.TestCase, abins.input.Tester):
         abins.parameters.sampling["force_constants"]["qpt_cutoff"] = 4.0
 
     def tearDown(self):
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadJSON"])
+        from mantid.kernel import ConfigService
+
+        abins.test_helpers.remove_output_files(list_of_names=["_LoadJSON"], directory=ConfigService.getString("defaultsave.directory"))
+
         abins.parameters.sampling["force_constants"]["qpt_cutoff"] = self.default_cutoff
 
     def test_json_1(self):

--- a/scripts/test/Abins/AbinsLoadJSONTest.py
+++ b/scripts/test/Abins/AbinsLoadJSONTest.py
@@ -17,10 +17,6 @@ class AbinsLoadJSONTest(unittest.TestCase, abins.input.Tester):
         abins.parameters.sampling["force_constants"]["qpt_cutoff"] = 4.0
 
     def tearDown(self):
-        from mantid.kernel import ConfigService
-
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadJSON"], directory=ConfigService.getString("defaultsave.directory"))
-
         abins.parameters.sampling["force_constants"]["qpt_cutoff"] = self.default_cutoff
 
     def test_json_1(self):

--- a/scripts/test/Abins/AbinsLoadPhonopyTest.py
+++ b/scripts/test/Abins/AbinsLoadPhonopyTest.py
@@ -21,10 +21,6 @@ class AbinsLoadPhonopyTest(unittest.TestCase, abins.input.Tester):
         abins.parameters.sampling["force_constants"]["qpt_cutoff"] = 4.0
 
     def tearDown(self):
-        from mantid.kernel import ConfigService
-
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadPhonopy"], directory=ConfigService.getString("defaultsave.directory"))
-
         abins.parameters.sampling["force_constants"]["qpt_cutoff"] = self.default_cutoff
 
     def test_non_existing_file(self):

--- a/scripts/test/Abins/AbinsLoadPhonopyTest.py
+++ b/scripts/test/Abins/AbinsLoadPhonopyTest.py
@@ -21,7 +21,10 @@ class AbinsLoadPhonopyTest(unittest.TestCase, abins.input.Tester):
         abins.parameters.sampling["force_constants"]["qpt_cutoff"] = 4.0
 
     def tearDown(self):
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadPhonopy"])
+        from mantid.kernel import ConfigService
+
+        abins.test_helpers.remove_output_files(list_of_names=["_LoadPhonopy"], directory=ConfigService.getString("defaultsave.directory"))
+
         abins.parameters.sampling["force_constants"]["qpt_cutoff"] = self.default_cutoff
 
     def test_non_existing_file(self):

--- a/scripts/test/Abins/AbinsLoadVASPTest.py
+++ b/scripts/test/Abins/AbinsLoadVASPTest.py
@@ -12,8 +12,10 @@ from abins.input import VASPLoader
 
 class AbinsLoadVASPTest(unittest.TestCase, abins.input.Tester):
     def tearDown(self):
-        # Remove ref files from .check() calls
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadVASP"])
+        # Remove cache files
+        from mantid.kernel import ConfigService
+
+        abins.test_helpers.remove_output_files(list_of_names=["_LoadVASP"], directory=ConfigService.getString("defaultsave.directory"))
 
     def test_non_existing_file(self):
         with self.assertRaises(IOError):

--- a/scripts/test/Abins/AbinsLoadVASPTest.py
+++ b/scripts/test/Abins/AbinsLoadVASPTest.py
@@ -4,33 +4,40 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+from pathlib import Path
 import unittest
+from tempfile import TemporaryDirectory
 
 import abins
 from abins.input import VASPLoader
 
 
 class AbinsLoadVASPTest(unittest.TestCase, abins.input.Tester):
-    def tearDown(self):
-        # Remove cache files
-        from mantid.kernel import ConfigService
+    # def tearDown(self):
+    #     # Remove cache files
+    #     from mantid.kernel import ConfigService
 
-        abins.test_helpers.remove_output_files(list_of_names=["_LoadVASP"], directory=ConfigService.getString("defaultsave.directory"))
+    #     abins.test_helpers.remove_output_files(list_of_names=["_LoadVASP"], directory=ConfigService.getString("defaultsave.directory"))
 
     def test_non_existing_file(self):
-        with self.assertRaises(IOError):
-            bad_vasp_reader = VASPLoader(input_ab_initio_filename="NonExistingFile.txt")
-            bad_vasp_reader.read_vibrational_or_phonon_data()
+        with TemporaryDirectory() as tmpdir:
+            with self.assertRaises(IOError):
+                bad_vasp_reader = VASPLoader(input_ab_initio_filename="NonExistingFile.txt", cache_directory=Path(tmpdir))
+                bad_vasp_reader.read_vibrational_or_phonon_data()
 
-        with self.assertRaises(TypeError):
-            _ = VASPLoader(input_ab_initio_filename=1)
+            with self.assertRaises(TypeError):
+                _ = VASPLoader(input_ab_initio_filename=1, cache_directory=Path(tmpdir))
 
     # Not a real vibration calc; check the appropriate error is raised
     def test_singlepoint_input(self):
         filename = abins.test_helpers.find_file("ethane_singlepoint.xml")
-        bad_vasp_reader = VASPLoader(input_ab_initio_filename=filename)
-        with self.assertRaisesRegexp(ValueError, "Could not find a 'calculation' block containing a 'dynmat' block in VASP XML file\\."):
-            bad_vasp_reader.read_vibrational_or_phonon_data()
+
+        with TemporaryDirectory() as tmpdir:
+            bad_vasp_reader = VASPLoader(input_ab_initio_filename=filename, cache_directory=Path(tmpdir))
+            with self.assertRaisesRegexp(
+                ValueError, "Could not find a 'calculation' block containing a 'dynmat' block in VASP XML file\\."
+            ):
+                bad_vasp_reader.read_vibrational_or_phonon_data()
 
     # IBRION=8 from optimised structure
     def test_xml_dfpt(self):

--- a/scripts/test/Abins/AbinsLoadVASPTest.py
+++ b/scripts/test/Abins/AbinsLoadVASPTest.py
@@ -13,12 +13,6 @@ from abins.input import VASPLoader
 
 
 class AbinsLoadVASPTest(unittest.TestCase, abins.input.Tester):
-    # def tearDown(self):
-    #     # Remove cache files
-    #     from mantid.kernel import ConfigService
-
-    #     abins.test_helpers.remove_output_files(list_of_names=["_LoadVASP"], directory=ConfigService.getString("defaultsave.directory"))
-
     def test_non_existing_file(self):
         with TemporaryDirectory() as tmpdir:
             with self.assertRaises(IOError):

--- a/scripts/test/Abins/AbinsPowderCalculatorTest.py
+++ b/scripts/test/Abins/AbinsPowderCalculatorTest.py
@@ -27,7 +27,7 @@ class PowderCalculatorTest(unittest.TestCase):
     #     test input
     def setUp(self):
         self._tempdir = TemporaryDirectory()
-        self._cache_directory = Path(self._tempdir.name)
+        self.cache_directory = Path(self._tempdir.name)
 
     def tearDown(self):
         self._tempdir.cleanup()
@@ -59,7 +59,7 @@ class PowderCalculatorTest(unittest.TestCase):
         ref_data = self._get_ref_data(filename=abins_data_filename)
 
         good_tester = abins.PowderCalculator(
-            filename=abins_data_filename, abins_data=ref_data["DFT"], temperature=300.0, cache_directory=self._cache_directory
+            filename=abins_data_filename, abins_data=ref_data["DFT"], temperature=300.0, cache_directory=self.cache_directory
         )
         calculated_data = good_tester.calculate_data().extract()
 
@@ -73,7 +73,7 @@ class PowderCalculatorTest(unittest.TestCase):
 
         # check if loading powder data is correct
         new_tester = abins.PowderCalculator(
-            filename=abins_data_filename, abins_data=ref_data["DFT"], temperature=300.0, cache_directory=self._cache_directory
+            filename=abins_data_filename, abins_data=ref_data["DFT"], temperature=300.0, cache_directory=self.cache_directory
         )
 
         loaded_data = new_tester.load_formatted_data().extract()
@@ -101,7 +101,7 @@ class PowderCalculatorTest(unittest.TestCase):
             abins_data = AbinsData.from_dict(json.load(fp))
 
         powder = abins.PowderCalculator(
-            filename=abins_data_filename, abins_data=abins_data, temperature=300.0, cache_directory=self._cache_directory
+            filename=abins_data_filename, abins_data=abins_data, temperature=300.0, cache_directory=self.cache_directory
         ).calculate_data()
 
         powder_dict = abins.test_helpers.dict_arrays_to_lists(powder.extract())

--- a/scripts/test/Abins/AbinsPowderCalculatorTest.py
+++ b/scripts/test/Abins/AbinsPowderCalculatorTest.py
@@ -23,7 +23,11 @@ class PowderCalculatorTest(unittest.TestCase):
 
     #     test input
     def tearDown(self):
-        abins.test_helpers.remove_output_files(list_of_names=["CalculatePowder"])
+        from mantid.kernel import ConfigService
+
+        abins.test_helpers.remove_output_files(
+            list_of_names=["CalculatePowder"], directory=ConfigService.getString("defaultsave.directory")
+        )
 
     def test_wrong_input(self):
         full_path_filename = abins.test_helpers.find_file(filename=self._si2 + ".json")

--- a/scripts/test/Abins/AbinsPowderCalculatorTest.py
+++ b/scripts/test/Abins/AbinsPowderCalculatorTest.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import json
 from pathlib import Path
+from tempfile import TemporaryDirectory
 import unittest
 
 import numpy as np
@@ -25,12 +26,11 @@ class PowderCalculatorTest(unittest.TestCase):
 
     #     test input
     def setUp(self):
-        from mantid.kernel import ConfigService
-
-        self._cache_directory = Path(ConfigService.getString("defaultsave.directory"))
+        self._tempdir = TemporaryDirectory()
+        self._cache_directory = Path(self._tempdir.name)
 
     def tearDown(self):
-        abins.test_helpers.remove_output_files(list_of_names=["CalculatePowder"], directory=self._cache_directory)
+        self._tempdir.cleanup()
 
     def test_wrong_input(self):
         full_path_filename = abins.test_helpers.find_file(filename=self._si2 + ".json")

--- a/scripts/test/Abins/AbinsPowderCalculatorTest.py
+++ b/scripts/test/Abins/AbinsPowderCalculatorTest.py
@@ -38,14 +38,25 @@ class PowderCalculatorTest(unittest.TestCase):
             abins_data = AbinsData.from_dict(json.load(fp))
 
         # wrong filename
-        self.assertRaises(ValueError, PowderCalculator, filename=1, abins_data=abins_data, temperature=300.0)
+        self.assertRaises(
+            ValueError, PowderCalculator, filename=1, abins_data=abins_data, temperature=300.0, cache_directory=self.cache_directory
+        )
 
         # data from object of type AtomsData instead of object of type AbinsData
         wrong_type_data = abins_data.get_atoms_data()
-        self.assertRaises(ValueError, PowderCalculator, filename=full_path_filename, abins_data=wrong_type_data, temperature=300.0)
+        self.assertRaises(
+            ValueError,
+            PowderCalculator,
+            filename=full_path_filename,
+            abins_data=wrong_type_data,
+            temperature=300.0,
+            cache_directory=self.cache_directory,
+        )
 
         # Missing Temperature
-        self.assertRaises(TypeError, PowderCalculator, filename=full_path_filename, abins_data=abins_data)
+        self.assertRaises(
+            TypeError, PowderCalculator, filename=full_path_filename, abins_data=abins_data, cache_directory=self.cache_directory
+        )
 
     #       main test
     def test_good_case(self):


### PR DESCRIPTION
### Description of work
Fixes #38084 


#### Summary of work
- Add an input parameter to Abins/Abins2D which explicitly sets the cache file directory. The default value is the Default Save Directory so if the user does nothing files will continue to save in the same place. But they are more likely to notice it!
- Use temporary directories throughout test suite to avoid collisions and simplify cleanup
  - By refactoring this into the "check" function, some boilerplate is removed from loader tests.
- Remove existing (more verbose and spooky) cleanup mechanism from Abins tests

#### Purpose of work

Abins uses the Default Save Directory. This has a few drawbacks:
- Sometimes it is set to a bad location, and not easy to change (mostly addressed in #38606)
- Users may be unaware that they are creating cache files that are never cleaned up
- Parallel tests and workflows may have unintended interactions through a common cache file
- It is not obvious from the code which functions will interact with a cache


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
- Cache *directory* was chosen rather than cache *filename* to avoid a likely future API-break: I am considering migrating all the caching to use joblib (already a Mantid dependency) and this caches to multiple files in a directory structure.

### To test:
The changes are covered by unit tests and system tests.

For fun, you can try setting the Default Save Directory to somewhere unwriteable and running the tests. Abins tests used to fail in this scenario, but now will pass because they are all directed to temporary cache directories.


- [x] Add release note

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
