### PR TITLE
Change windows macro for warnings into compiler flags - ornl-next

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/System.h
+++ b/Framework/Kernel/inc/MantidKernel/System.h
@@ -17,30 +17,14 @@
  *******************************************************************************/
 
 /*  A system-wide file to contain, e.g., useful system-dependent macros
-
-    @author Russell Taylor, Tessella Support Services plc
-    @date 26/10/2007
-*/
+ *
+ *  @author Russell Taylor, Tessella Support Services plc
+ */
 
 /**
  * Definitions of the DLLImport compiler directives for MSVC
  */
 #ifdef _WIN32
-// 'identifier' : class 'type' needs to have dll-interface to be used by clients
-// of class 'type2'
-// Things from the std library give these warnings and we can't do anything
-// about them.
-#pragma warning(disable : 4251)
-// Given that we are compiling everything with msvc under Windows and
-// linking all with the same runtime we can disable the warning about
-// inheriting from a non-exported interface, e.g. std::runtime_error */
-#pragma warning(disable : 4275)
-// Warning C4373: previous versions of the compiler did not override when
-// parameters only differed by const/volatile qualifiers
-// This is basically saying that it now follows the C++ standard and doesn't
-// seem useful
-#pragma warning(disable : 4373)
-
 // Export/Import declarations
 #define DLLExport __declspec(dllexport)
 #define DLLImport __declspec(dllimport)

--- a/buildconfig/CMake/GenerateMantidExportHeader.cmake
+++ b/buildconfig/CMake/GenerateMantidExportHeader.cmake
@@ -3,29 +3,6 @@ function(GENERATE_MANTID_EXPORT_HEADER TARGET_LIBRARY GENERATE_EXTERN)
   string(TOUPPER "${TARGET_LIBRARY}" TARGET_NAME)
   set(CUSTOM "\n")
 
-  if(MSVC)
-    set(CUSTOM
-        "${CUSTOM}\n\
-#ifdef _WIN32\n\
-    // 'identifier' : class 'type' needs to have dll-interface to be used by clients\n\
-    // of class 'type2'\n\
-    // Things from the std library give these warnings and we can't do anything\n\
-    // about them.\n\
-    #pragma warning(disable : 4251)\n\
-    // Given that we are compiling everything with msvc under Windows and\n\
-    // linking all with the same runtime we can disable the warning about\n\
-    // inheriting from a non-exported interface, e.g. std::runtime_error */\n\
-    #pragma warning(disable : 4275)\n\
-    // Warning C4373: previous versions of the compiler did not override when\n\
-    // parameters only differed by const/volatile qualifiers\n\
-    // This is basically saying that it now follows the C++ standard and doesn't\n\
-    // seem useful\n\
-    #pragma warning(disable : 4373)\n\
-#endif\n\n\
-"
-    )
-  endif(MSVC)
-
   set(CUSTOM
       "${CUSTOM}\
 #ifndef UNUSED_ARG\n\

--- a/buildconfig/CMake/GenerateMantidExportHeader.cmake
+++ b/buildconfig/CMake/GenerateMantidExportHeader.cmake
@@ -1,17 +1,11 @@
 include(GenerateExportHeader)
 function(GENERATE_MANTID_EXPORT_HEADER TARGET_LIBRARY GENERATE_EXTERN)
   string(TOUPPER "${TARGET_LIBRARY}" TARGET_NAME)
-  set(CUSTOM "\n")
-
   set(CUSTOM
-      "${CUSTOM}\
-#ifndef UNUSED_ARG\n\
-    #define UNUSED_ARG(x) (void) x;\n\
-#endif\n\n\
+      "\n\
 #ifndef ${TARGET_NAME}_DEPRECATED\n\
     #define ${TARGET_NAME}_DEPRECATED(func) MANTID_${TARGET_NAME}_DEPRECATED func\n\
-#endif\n\n\
-"
+#endif\n\n"
   )
 
   if(GENERATE_EXTERN)
@@ -26,9 +20,18 @@ function(GENERATE_MANTID_EXPORT_HEADER TARGET_LIBRARY GENERATE_EXTERN)
 // EXTERN_IMPORT is defined in MantidKernel/System.h\n
 #define EXTERN_MANTID_${TARGET_NAME} EXTERN_IMPORT\n\
 #endif /* ${TARGET_LIBRARY}_EXPORTS*/\n\n\
-#include <cstdint>
  "
     )
+  else()
+    # UNUSED_ARG is defined and cstdint is included in MantidKernel/System.h
+    set(CUSTOM
+        "${CUSTOM}\
+#ifndef UNUSED_ARG\n\
+    #define UNUSED_ARG(x) (void) x;\n\
+#endif\n\n\
+#include <cstdint>\n"
+    )
+
   endif(GENERATE_EXTERN)
 
   generate_export_header(

--- a/buildconfig/CMake/WindowsSetup.cmake
+++ b/buildconfig/CMake/WindowsSetup.cmake
@@ -30,8 +30,19 @@ add_definitions(-D_SILENCE_CXX17_SHARED_PTR_UNIQUE_DEPRECATION_WARNING)
 set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} \
   /MP /W3 /bigobj \
+  /wd4251 /wd4275 /wd4373 \
   /experimental:external /external:W0 "
 )
+# the warnings suppressed are:
+#
+# 4251 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2' Things from the
+# std library give these warnings and we can't do anything about them.
+#
+# 4275 Given that we are compiling everything with msvc under Windows and linking all with the same runtime we can
+# disable the warning about inheriting from a non-exported interface, e.g. std::runtime_error
+#
+# 4373 previous versions of the compiler did not override when parameters only differed by const/volatile qualifiers.
+# This is basically saying that it now follows the C++ standard and doesn't seem useful
 
 # Set PCH heap limit, the default does not work when running msbuild from the commandline for some reason Any other
 # value lower or higher seems to work but not the default. It is fine without this when compiling in the GUI though...


### PR DESCRIPTION
This is a version of #38611 into `ornl-next`