### PR TITLE
SNAPRed stylesheets

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/SNAPRed.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/SNAPRed.py
@@ -5,7 +5,9 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=invalid-name,unused-import
+from pathlib import Path
 import sys
+
 from mantidqt.gui_helper import get_qapplication
 
 try:
@@ -26,15 +28,18 @@ if SNAPRedGUI is not None:
     else:
         parent, flags = None, None
 
-    if not within_mantid:
-        # set the super-awesome color scheme
-        from snapred.meta.Config import Resource
+    # Recent versions of SNAPRed have required stylesheet settings, but it's important to apply these
+    #   only to the SNAPRed GUI and its children.
+    from snapred.meta.Config import Resource
 
-        with Resource.open("style.qss", "r") as styleSheet:
-            app.setStyleSheet(styleSheet.read())
-
-    # turn off tranlucent when running in mantid
+    # turn off translucent background when running in mantid
     s = SNAPRedGUI(parent, window_flags=flags, translucentBackground=(not within_mantid))
+
+    # "workbench_style.qss" may not exist in all versions of SNAPRed.
+    qssFilePath = Resource.getPath("workbench_style.qss" if within_mantid else "style.qss")
+    if Path(qssFilePath).exists():
+        with open(qssFilePath, "r") as styleSheet:
+            s.setStyleSheet(styleSheet.read())
     s.show()
 
     if not within_mantid:


### PR DESCRIPTION
### Description of work

Qt uses CSS-based stylesheets to specify widget properties.  Rather than having SNAPRed use NO stylesheet when it's launched under Mantid workbench.  The `SNAPRedGUI`will be assigned one of either "workbench_style.qss" or SNAPRed's normal "style.qss", depending on how the application is launched.

#### Summary of work
Changes to the `SNAPRed.py` qt-interface file.

#### Purpose of work
In order to centralize its widget property settings, the `SNAPRed` application now has _required_ stylesheet values.

[EWM task #9132](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9132)


#### Further detail of work
PR in support of SNAPRed's reduction live-data implementation: [EWM#7437](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=7437)

### To test:
**Although anyone is welcome to review this PR, it would be easiest for a SNAPRed developer to review it!**

1. Either build Mantid and install the SNAPRed developer's environment (_or_ move the single changed python file into its location in the `mantidworkbench` directory of your existing _recent_ "SNAPRed" environment).
2. Launch workbench, then  launch SNAPRed.  **No changes should be observed in comparison to launching SNAPRed in its most recent conda environment.**
3. Verify that the `workbench_style.qss` will be used if it exists:  copy `src/snapred/resources/style.qss` to `src/snapred/resources/workbench_style.qss` in the SNAPRed environment you are using (which may be the "developer's installation).
4. Again  launch workbench:  now the super awesome SNAPRed color scheme will be used for the SNAPRed application (, although that has nothing to do with this PR  :(  ).

*This does not require release notes* because it is in support of **SNAPRed internal** changes.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
