### PR TITLE
Enable nightly standalone packages to install mslice nightly versions

### DIFF
--- a/installers/conda/linux/create_tarball.sh
+++ b/installers/conda/linux/create_tarball.sh
@@ -132,9 +132,17 @@ mkdir -p "$bundle_contents"
 # Create conda environment internally. --copy ensures no symlinks are used
 bundle_conda_prefix="$bundle_contents"
 
+# The mantid channel is required as the source for installing mslice
+mantid_channel=mantid
+# If it's a Nightly or Unstable package, use the mantid/label/nightly label so it picks up
+# the nightly version of mslice
+if [[ "$suffix" == "Unstable" ]] || [[ "$suffix" == "Nightly" ]]; then
+  mantid_channel=mantid/label/nightly
+fi
+
 echo "Creating Conda environment in '$bundle_conda_prefix'"
 "$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --copy \
-  --channel "$conda_channel" --channel conda-forge --channel mantid --yes \
+  --channel "$conda_channel" --channel conda-forge --channel $mantid_channel --yes \
   mantidworkbench \
   jq  # used for processing the version string
 echo

--- a/installers/conda/osx/create_bundle.sh
+++ b/installers/conda/osx/create_bundle.sh
@@ -201,9 +201,17 @@ mkdir -p "$bundle_contents"/{Resources,MacOS}
 # --platform osx-64 is required to allow ARM-based systems to install the osx-64 mantid packages.
 bundle_conda_prefix="$bundle_contents"/Resources
 
+# The mantid channel is required as the source for installing mslice
+mantid_channel=mantid
+# If it's a Nightly or Unstable package, use the mantid/label/nightly label so it picks up
+# the nightly version of mslice
+if [[ "$suffix" == "Unstable" ]] || [[ "$suffix" == "Nightly" ]]; then
+  mantid_channel=mantid/label/nightly
+fi
+
 echo "Creating Conda environment in '$bundle_conda_prefix'"
 "$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --copy --platform osx-64 \
-  --channel "$conda_channel" --channel conda-forge --channel mantid --yes \
+  --channel "$conda_channel" --channel conda-forge --channel $mantid_channel --yes \
   mantidworkbench \
   jq  # used for processing the version string
 echo

--- a/installers/conda/win/create_package.sh
+++ b/installers/conda/win/create_package.sh
@@ -72,9 +72,17 @@ rm -rf $CONDA_ENV_PATH
 
 mkdir $COPY_DIR
 
+# The mantid channel is required as the source for installing mslice
+MANTID_CHANNEL=mantid
+# If it's a Nightly or Unstable package, use the mantid/label/nightly label so it picks up
+# the nightly version of mslice
+if [[ "$SUFFIX" == "Unstable" ]] || [[ "$SUFFIX" == "Nightly" ]]; then
+  MANTID_CHANNEL=mantid/label/nightly
+fi
+
 echo "Creating conda env from mantidworkbench and jq"
 "$CONDA_EXE" create --prefix $CONDA_ENV_PATH \
-  --copy --channel $CONDA_CHANNEL --channel conda-forge --channel mantid -y \
+  --copy --channel $CONDA_CHANNEL --channel conda-forge --channel $MANTID_CHANNEL -y \
   mantidworkbench \
   m2w64-jq
 echo "Conda env created"


### PR DESCRIPTION
### Description of work
The standalone installer scripts install `mantidworkbench` into a conda environment before bundling up all the files into an installable package. [Recently](https://github.com/mantidproject/mantid/pull/38299), the `mantid` anaconda channel was added as a source to facilitate the installation of `mslice` as a conda package via the dependencies of `mantidworkbench`. Here the channel `mantid/label/nightly` is also added so that nightly versions of the standalone pacakages are able to install nightly versions of `mslice` that are not on the `main` label. The `nightly` label is only added when the package suffix is either `Nightly` or `Unstable`, which means release versions of the standalone packages will only pick up the released versions of `mslice`.


Fixes #38628 
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->



### To test:
On each OS:
1. Download and install the standalone package from [this build](https://builds.mantidproject.org/job/build_packages_from_branch/979/)
3. Open the application
4. Enter the following in the Python console, it should return `'2.10.1.dev25+uncommitted'`:
  ```
  import mslice
  mslice.__version__
  ```

*This does not require release notes* because **this is attempting to reproduce the old behaviour when we used the SHA to keep mslice up to date**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
