### PR TITLE
move NexusFile to DataHandling as a helper for SaveNexusProcessed

### DIFF
--- a/Framework/API/src/WorkspaceHistory.cpp
+++ b/Framework/API/src/WorkspaceHistory.cpp
@@ -173,7 +173,7 @@ void WorkspaceHistory::printSelf(std::ostream &os, const int indent) const {
 //------------------------------------------------------------------------------------------------
 /** Saves all of the workspace history to a "process" field
  * in an open NXS file.
- * Code taken from NexusFileIO.cpp on May 14, 2012.
+ * Code taken from SaveNexusProcessedHelper.cpp on May 14, 2012.
  *
  * @param file :: previously opened NXS file.
  */

--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -190,6 +190,7 @@ set(SRC_FILES
     src/SaveNexusESS.cpp
     src/SaveNexusGeometry.cpp
     src/SaveNexusProcessed.cpp
+    src/SaveNexusProcessedHelper.cpp
     src/SaveOpenGenieAscii.cpp
     src/SavePAR.cpp
     src/SavePDFGui.cpp
@@ -409,6 +410,7 @@ set(INC_FILES
     inc/MantidDataHandling/SaveNexusESS.h
     inc/MantidDataHandling/SaveNexusGeometry.h
     inc/MantidDataHandling/SaveNexusProcessed.h
+    inc/MantidDataHandling/SaveNexusProcessedHelper.h
     inc/MantidDataHandling/SaveOpenGenieAscii.h
     inc/MantidDataHandling/SavePAR.h
     inc/MantidDataHandling/SavePDFGui.h

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNexusProcessedHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNexusProcessedHelper.h
@@ -76,8 +76,9 @@ public:
   int writeNexusProcessedDataEvent(const DataObjects::EventWorkspace_const_sptr &ws);
 
   int writeNexusProcessedDataEventCombined(const DataObjects::EventWorkspace_const_sptr &ws,
-                                           std::vector<int64_t> const &indices, double *tofs, float *weights,
-                                           float *errorSquareds, int64_t *pulsetimes, bool compress) const;
+                                           std::vector<int64_t> const &indices, double const *tofs,
+                                           float const *weights, float const *errorSquareds, int64_t const *pulsetimes,
+                                           bool compress) const;
 
   int writeEventList(const DataObjects::EventList &el, const std::string &group_name) const;
 

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNexusProcessedHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNexusProcessedHelper.h
@@ -10,11 +10,11 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/Run.h"
+#include "MantidDataHandling/DllConfig.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace_fwd.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/cow_ptr.h"
-#include "MantidNexus/DllConfig.h"
 #include "MantidNexusCpp/NeXusFile.hpp"
 
 #include <boost/date_time/c_local_time_adjustor.hpp>
@@ -28,10 +28,10 @@
 
 namespace Mantid {
 namespace NeXus {
-MANTID_NEXUS_DLL int getNexusEntryTypes(const std::string &fileName, std::vector<std::string> &entryName,
-                                        std::vector<std::string> &definition);
+MANTID_DATAHANDLING_DLL int getNexusEntryTypes(const std::string &fileName, std::vector<std::string> &entryName,
+                                               std::vector<std::string> &definition);
 
-/** @class NexusFileIO NexusFileIO.h NeXus/NexusFileIO.h
+/** @class NexusFileIO SaveNexusProcessedHelper.h NeXus/SaveNexusProcessedHelper.h
 
 Utility method for saving NeXus format of Mantid Workspace
 This class interfaces to the C Nexus API. This is written for use by
@@ -39,7 +39,7 @@ Save and Load NexusProcessed classes, though it could be extended to
 other Nexus formats. It might be replaced in future by methods using
 the new Nexus C++ API.
 */
-class MANTID_NEXUS_DLL NexusFileIO {
+class MANTID_DATAHANDLING_DLL NexusFileIO {
 
 public:
   // Helper typedef
@@ -76,7 +76,7 @@ public:
   int writeNexusProcessedDataEvent(const DataObjects::EventWorkspace_const_sptr &ws);
 
   int writeNexusProcessedDataEventCombined(const DataObjects::EventWorkspace_const_sptr &ws,
-                                           std::vector<int64_t> &indices, double *tofs, float *weights,
+                                           std::vector<int64_t> const &indices, double *tofs, float *weights,
                                            float *errorSquareds, int64_t *pulsetimes, bool compress) const;
 
   int writeEventList(const DataObjects::EventList &el, const std::string &group_name) const;
@@ -84,7 +84,8 @@ public:
   template <class T>
   void writeEventListData(std::vector<T> events, bool writeTOF, bool writePulsetime, bool writeWeight,
                           bool writeError) const;
-  void NXwritedata(const char *name, int datatype, int rank, int *dims_array, void *data, bool compress = false) const;
+  void NXwritedata(const char *name, int datatype, int rank, int *dims_array, void const *data,
+                   bool compress = false) const;
 
   /// find size of open entry data section
   int getWorkspaceSize(int &numberOfSpectra, int &numberOfChannels, int &numberOfXpoints, bool &uniformBounds,

--- a/Framework/DataHandling/src/LoadNexus.cpp
+++ b/Framework/DataHandling/src/LoadNexus.cpp
@@ -15,11 +15,11 @@
 #include "MantidDataHandling/LoadNexus.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidDataHandling/SaveNexusProcessedHelper.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidNexus/NexusClasses.h"
-#include "MantidNexus/NexusFileIO.h"
 
 #include <cmath>
 #include <memory>

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -17,6 +17,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAPI/WorkspaceHistory.h"
+#include "MantidDataHandling/SaveNexusProcessedHelper.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/LeanElasticPeaksWorkspace.h"
 #include "MantidDataObjects/Peak.h"
@@ -35,7 +36,6 @@
 #include "MantidKernel/StringTokenizer.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidNexus/NexusClasses.h"
-#include "MantidNexus/NexusFileIO.h"
 #include "MantidNexusCpp/NeXusException.hpp"
 
 #include <boost/algorithm/string/trim.hpp>

--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -12,6 +12,7 @@
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidAPI/WorkspaceHistory.h"
+#include "MantidDataHandling/SaveNexusProcessedHelper.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidDataObjects/MaskWorkspace.h"
@@ -20,7 +21,6 @@
 #include "MantidGeometry/Crystal/AngleUnits.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
-#include "MantidNexus/NexusFileIO.h"
 #include <memory>
 #include <utility>
 

--- a/Framework/DataHandling/src/SaveNexusProcessedHelper.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessedHelper.cpp
@@ -722,8 +722,9 @@ int NexusFileIO::writeNexusTableWorkspace(const API::ITableWorkspace_const_sptr 
  * @param compress :: if true, compress the entry
  */
 int NexusFileIO::writeNexusProcessedDataEventCombined(const DataObjects::EventWorkspace_const_sptr &ws,
-                                                      std::vector<int64_t> const &indices, double *tofs, float *weights,
-                                                      float *errorSquareds, int64_t *pulsetimes, bool compress) const {
+                                                      std::vector<int64_t> const &indices, double const *tofs,
+                                                      float const *weights, float const *errorSquareds,
+                                                      int64_t const *pulsetimes, bool compress) const {
   NXopengroup(fileID, "event_workspace", "NXdata");
 
   // The array of indices for each event list #

--- a/Framework/DataHandling/src/SaveNexusProcessedHelper.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessedHelper.cpp
@@ -16,6 +16,7 @@
 #define NAME_MAX 260
 #endif /* _WIN32 */
 #include "MantidAPI/NumericAxis.h"
+#include "MantidDataHandling/SaveNexusProcessedHelper.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidDataObjects/RebinnedOutput.h"
@@ -27,7 +28,6 @@
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/VectorHelper.h"
-#include "MantidNexus/NexusFileIO.h"
 
 #include <Poco/File.h>
 #include <Poco/Path.h>
@@ -722,7 +722,7 @@ int NexusFileIO::writeNexusTableWorkspace(const API::ITableWorkspace_const_sptr 
  * @param compress :: if true, compress the entry
  */
 int NexusFileIO::writeNexusProcessedDataEventCombined(const DataObjects::EventWorkspace_const_sptr &ws,
-                                                      std::vector<int64_t> &indices, double *tofs, float *weights,
+                                                      std::vector<int64_t> const &indices, double *tofs, float *weights,
                                                       float *errorSquareds, int64_t *pulsetimes, bool compress) const {
   NXopengroup(fileID, "event_workspace", "NXdata");
 
@@ -781,7 +781,7 @@ int NexusFileIO::writeNexusProcessedDataEvent(const DataObjects::EventWorkspace_
 
 //-------------------------------------------------------------------------------------
 /** Write out an array to the open file. */
-void NexusFileIO::NXwritedata(const char *name, int datatype, int rank, int *dims_array, void *data,
+void NexusFileIO::NXwritedata(const char *name, int datatype, int rank, int *dims_array, void const *data,
                               bool compress) const {
   if (compress) {
     // We'll use the same slab/buffer size as the size of the array

--- a/Framework/DataHandling/src/StartAndEndTimeFromNexusFileExtractor.cpp
+++ b/Framework/DataHandling/src/StartAndEndTimeFromNexusFileExtractor.cpp
@@ -7,10 +7,10 @@
 #include "MantidDataHandling/StartAndEndTimeFromNexusFileExtractor.h"
 #include "MantidAPI/FileFinder.h"
 #include "MantidDataHandling/LoadNexus.h"
+#include "MantidDataHandling/SaveNexusProcessedHelper.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Logger.h"
 #include "MantidNexus/NexusClasses.h"
-#include "MantidNexus/NexusFileIO.h"
 
 #include <vector>
 

--- a/Framework/DataObjects/src/VectorColumn.cpp
+++ b/Framework/DataObjects/src/VectorColumn.cpp
@@ -15,7 +15,7 @@ namespace Mantid::DataObjects {
 // places as well:
 //   - ARRAY_TYPES in ITableWorkspace.cpp, so that column is exported to Python
 //   properly
-//   - IF_VECTOR_COLUMN in NexusFileIO.cpp, so that column is save to Nexus file
+//   - IF_VECTOR_COLUMN in SaveNexusProcessedHelper.cpp, so that column is save to Nexus file
 //   properly
 //   - IF_VECTOR_COLUMN in LoadNexusProcessed.cpp, so that column can be loaded
 //   from Nexus file

--- a/Framework/Nexus/CMakeLists.txt
+++ b/Framework/Nexus/CMakeLists.txt
@@ -1,7 +1,7 @@
-set(SRC_FILES src/H5Util.cpp src/MuonNexusReader.cpp src/NexusClasses.cpp src/NexusFileIO.cpp)
+set(SRC_FILES src/H5Util.cpp src/MuonNexusReader.cpp src/NexusClasses.cpp)
 
 set(INC_FILES inc/MantidNexus/H5Util.h inc/MantidNexus/MuonNexusReader.h inc/MantidNexus/NexusClasses.h
-              inc/MantidNexus/NexusFileIO.h inc/MantidNexus/NexusIOHelper.h
+              inc/MantidNexus/NexusIOHelper.h
 )
 
 set(TEST_FILES H5UtilTest.h NexusIOHelperTest.h)

--- a/Framework/Nexus/src/MuonNexusReader.cpp
+++ b/Framework/Nexus/src/MuonNexusReader.cpp
@@ -70,7 +70,7 @@ void MuonNexusReader::openFirstNXentry(NeXus::File &handle) {
 // which does not use namespace.
 // This reader is only used by LoadMuonNexus - the NexusProcessed files are
 // dealt with by
-// NexusFileIO.cpp
+// SaveNexusProcessedHelper.cpp
 //
 // Expected content of Nexus file is:
 //     Entry: "run" (first entry opened, whatever name is)

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -909,8 +909,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Muon/src/PlotAsymmetryByLog
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Muon/src/PlotAsymmetryByLogValue.cpp:507
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Muon/src/PlotAsymmetryByLogValue.cpp:868
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Nexus/inc/MantidNexus/NexusClasses.h:150
-constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/NexusFileIO.cpp:725
-constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Nexus/src/NexusFileIO.cpp:784
 argumentSize:${CMAKE_SOURCE_DIR}/Framework/NexusCpp/src/NeXusFile.cpp:900
 argumentSize:${CMAKE_SOURCE_DIR}/Framework/NexusCpp/src/NeXusFile.cpp:964
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/NexusCpp/src/napi.cpp:194


### PR DESCRIPTION
### Description of work

#### Summary of work
Moves the `NexusFileIO` files closer to the `SaveNexusProcessed` files, and renames is as a helper.

Methods defined in this class are no longer used outside of the `DataHandling` target.

One method inside `SANSSensitivityCorrection` was edited to no longer rely on methods inside `NexusFileIO`.

#### Further detail of work

Had to update CMakes files, and CxxTest suppressions.

Mostly name changes.

The one major change is to `SANSSensitivityCorrection`, which was refactored to no longer rely on the method inside `NexusFileIO`.  This enables isolating `SaveNexusProcessedHelper` inside the `DataHandling` target, and not having to include it as a dependency for workflow algorithms.

Refs #38332

This work is described in ORNL in [EWM 8452](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=8452):
> [Framework/Nexus/NexusFileIO](https://github.com/mantidproject/mantid/blob/fc0059ccd0ea26cef605008b8fb0c721bcb1701c/Framework/Nexus/inc/MantidNexus/NexusFileIO.h)  is only used by [Framework/DataHandling/SaveNexusProcessed](https://github.com/mantidproject/mantid/blob/fc0059ccd0ea26cef605008b8fb0c721bcb1701c/Framework/DataHandling/inc/MantidDataHandling/SaveNexusProcessed.h)  and will be moved to be closer to where it is used.
> The files (.h and .cpp) move to Framework/DataHandling and should be renamed to SaveNexusProcessedHelper. The namespace should be updated and the DLLExport macros can probably be removed.

### To test:

This should be fine if all tests pass.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
