### PR TITLE
36018 system tests for multi ws focus

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS_PowderGemTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderGemTest.py
@@ -176,8 +176,7 @@ def run_vanadium_calibration():
     return splined_ws
 
 
-def run_focus(absorb_corrections):
-    run_number = 83605
+def run_focus(absorb_corrections, run_number="83605", focus_mode="Individual"):
     sample_empty = 83608  # Use the vanadium empty again to make it obvious
     sample_empty_scale = 0.5  # Set it to 50% scale
 
@@ -195,7 +194,7 @@ def run_focus(absorb_corrections):
 
     return inst_object.focus(
         run_number=run_number,
-        input_mode="Individual",
+        input_mode=focus_mode,
         vanadium_normalisation=True,
         do_absorb_corrections=absorb_corrections,
         multiple_scattering=False,

--- a/Testing/SystemTests/tests/framework/ISIS_PowderGemTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderGemTest.py
@@ -91,10 +91,10 @@ class FocusTestMixin(object):
             self.assert_output_file_exists(output_dat_dir, f"GEM{ws_num}-b_{bankno}-TOF.dat")
             self.assert_output_file_exists(output_dat_dir, f"GEM{ws_num}-b_{bankno}-d.dat")
 
-    def doTest(self, absorb_corrections):
+    def doTest(self, absorb_corrections, run_number="83605", focus_mode="Individual"):
         # Gen vanadium calibration first
         setup_mantid_paths()
-        self.focus_results = run_focus(absorb_corrections)
+        self.focus_results = run_focus(absorb_corrections, run_number, focus_mode)
 
     def cleanup(self):
         try:
@@ -121,6 +121,23 @@ class FocusTestWithAbsCorr(systemtesting.MantidSystemTest, FocusTestMixin):
 
     def validate(self):
         return self.focus_results.name(), "ISIS_Powder-GEM83605_FocusSempty_abscorr.nxs"
+
+
+class FocusTestMultipleWSIndividual(systemtesting.MantidSystemTest, FocusTestMixin):
+    def runTest(self):
+        self.doTest(absorb_corrections=False, run_number="83605,83607", focus_mode="Individual")
+
+    def validate(self):
+        self.validate_focus_files_exist("83605")
+        self.validate_focus_files_exist("83607")
+
+
+class FocusTestMultipleWSSummed(systemtesting.MantidSystemTest, FocusTestMixin):
+    def runTest(self):
+        self.doTest(absorb_corrections=False, run_number="83605,83607", focus_mode="Summed")
+
+    def validate(self):
+        self.validate_focus_files_exist("83605,83607")
 
 
 class CreateCalTest(systemtesting.MantidSystemTest):

--- a/Testing/SystemTests/tests/framework/ISIS_PowderGemTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderGemTest.py
@@ -91,10 +91,10 @@ class FocusTestMixin(object):
             self.assert_output_file_exists(output_dat_dir, f"GEM{ws_num}-b_{bankno}-TOF.dat")
             self.assert_output_file_exists(output_dat_dir, f"GEM{ws_num}-b_{bankno}-d.dat")
 
-    def doTest(self, absorb_corrections, run_number="83605", focus_mode="Individual"):
+    def doTest(self, absorb_corrections, run_number="83605", input_mode="Individual"):
         # Gen vanadium calibration first
         setup_mantid_paths()
-        self.focus_results = run_focus(absorb_corrections, run_number, focus_mode)
+        self.focus_results = run_focus(absorb_corrections, run_number, input_mode)
 
     def cleanup(self):
         try:
@@ -125,7 +125,7 @@ class FocusTestWithAbsCorr(systemtesting.MantidSystemTest, FocusTestMixin):
 
 class FocusTestMultipleWSIndividual(systemtesting.MantidSystemTest, FocusTestMixin):
     def runTest(self):
-        self.doTest(absorb_corrections=False, run_number="83605,83607", focus_mode="Individual")
+        self.doTest(absorb_corrections=False, run_number="83605,83607", input_mode="Individual")
 
     def validate(self):
         self.validate_focus_files_exist("83605")
@@ -134,7 +134,7 @@ class FocusTestMultipleWSIndividual(systemtesting.MantidSystemTest, FocusTestMix
 
 class FocusTestMultipleWSSummed(systemtesting.MantidSystemTest, FocusTestMixin):
     def runTest(self):
-        self.doTest(absorb_corrections=False, run_number="83605,83607", focus_mode="Summed")
+        self.doTest(absorb_corrections=False, run_number="83605,83607", input_mode="Summed")
 
     def validate(self):
         self.validate_focus_files_exist("83605,83607")
@@ -193,7 +193,7 @@ def run_vanadium_calibration():
     return splined_ws
 
 
-def run_focus(absorb_corrections, run_number="83605", focus_mode="Individual"):
+def run_focus(absorb_corrections, run_number="83605", input_mode="Individual"):
     sample_empty = 83608  # Use the vanadium empty again to make it obvious
     sample_empty_scale = 0.5  # Set it to 50% scale
 
@@ -211,7 +211,7 @@ def run_focus(absorb_corrections, run_number="83605", focus_mode="Individual"):
 
     return inst_object.focus(
         run_number=run_number,
-        input_mode=focus_mode,
+        input_mode=input_mode,
         vanadium_normalisation=True,
         do_absorb_corrections=absorb_corrections,
         multiple_scattering=False,

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -8,6 +8,7 @@ import numpy as np
 import os
 import systemtesting
 import shutil
+from abc import abstractmethod
 
 import mantid.simpleapi as mantid
 from mantid import config
@@ -50,36 +51,40 @@ total_scattering_input_file = os.path.join(input_dir, "ISIS_Powder-POLARIS98533_
 total_scattering_input_file_per_det = os.path.join(input_dir, "ISIS_Powder-POLARIS98533_TotalScatteringInputPerDetector.nxs")
 
 
-def generate_helper_class():
-    # perform inheritance like this to prevent base class appearing as a test
-    class HelperClass(systemtesting.MantidSystemTest):
-        tolerance_is_rel_err = True
-        tolerance = 1e-6
+class HelperClass:
+    tolerance_is_rel_err = True
+    tolerance = 1e-6
 
-        def requiredFiles(self):
-            return _gen_required_files()
+    @abstractmethod
+    def assertTrue(self, *args, **kwargs):
+        pass
 
-        # check output files as expected
-        def generate_error_message(self, expected_file, output_dir):
-            return f"Unable to find {expected_file} in {output_dir}.\nContents={os.listdir(output_dir)}"
+    @abstractmethod
+    def assertEqual(self, *args, **kwargs):
+        pass
 
-        def assert_output_file_exists(self, directory, filename):
-            self.assertTrue(os.path.isfile(os.path.join(directory, filename)), msg=self.generate_error_message(filename, directory))
+    def requiredFiles(self):
+        return _gen_required_files()
 
-        def validate_focus_files_exist(self, ws_num):
-            user_output = os.path.join(output_dir, "17_1", "Test")
-            self.assert_output_file_exists(user_output, f"POLARIS{ws_num}.nxs")
-            self.assert_output_file_exists(user_output, f"POLARIS{ws_num}.gsas")
-            output_dat_dir = os.path.join(user_output, "dat_files")
-            for bankno in range(1, 6):
-                self.assert_output_file_exists(output_dat_dir, f"POL{ws_num}-b_{bankno}-TOF.dat")
-                self.assert_output_file_exists(output_dat_dir, f"POL{ws_num}-b_{bankno}-d.dat")
+    # check output files as expected
+    def generate_error_message(self, expected_file, output_dir):
+        return f"Unable to find {expected_file} in {output_dir}.\nContents={os.listdir(output_dir)}"
 
-        def validate_focus_material(self, focus_results):
-            for ws in focus_results:
-                self.assertEqual(ws.sample().getMaterial().name(), "Si Si")
+    def assert_output_file_exists(self, directory, filename):
+        self.assertTrue(os.path.isfile(os.path.join(directory, filename)), msg=self.generate_error_message(filename, directory))
 
-    return HelperClass
+    def validate_focus_files_exist(self, ws_num):
+        user_output = os.path.join(output_dir, "17_1", "Test")
+        self.assert_output_file_exists(user_output, f"POLARIS{ws_num}.nxs")
+        self.assert_output_file_exists(user_output, f"POLARIS{ws_num}.gsas")
+        output_dat_dir = os.path.join(user_output, "dat_files")
+        for bankno in range(1, 6):
+            self.assert_output_file_exists(output_dat_dir, f"POL{ws_num}-b_{bankno}-TOF.dat")
+            self.assert_output_file_exists(output_dat_dir, f"POL{ws_num}-b_{bankno}-d.dat")
+
+    def validate_focus_material(self, focus_results):
+        for ws in focus_results:
+            self.assertEqual(ws.sample().getMaterial().name(), "Si Si")
 
 
 class CreateVanadiumTest(systemtesting.MantidSystemTest):
@@ -148,7 +153,7 @@ class CreateVanadiumPerDetectorTest(systemtesting.MantidSystemTest):
             config["datasearch.directories"] = self.existing_config
 
 
-class FocusTestNoAbsorptionWithRelativeNormalisation(generate_helper_class()):
+class FocusTestNoAbsorptionWithRelativeNormalisation(systemtesting.MantidSystemTest, HelperClass):
     focus_results = None
     existing_config = config["datasearch.directories"]
 
@@ -171,7 +176,7 @@ class FocusTestNoAbsorptionWithRelativeNormalisation(generate_helper_class()):
             config["datasearch.directories"] = self.existing_config
 
 
-class FocusTestNoAbsorptionWithAbsoluteNormalisation(generate_helper_class()):
+class FocusTestNoAbsorptionWithAbsoluteNormalisation(systemtesting.MantidSystemTest, HelperClass):
     focus_results = None
     existing_config = config["datasearch.directories"]
 
@@ -194,7 +199,7 @@ class FocusTestNoAbsorptionWithAbsoluteNormalisation(generate_helper_class()):
             config["datasearch.directories"] = self.existing_config
 
 
-class TestFocusNoAbsorptionIndividual(generate_helper_class()):
+class TestFocusNoAbsorptionIndividual(systemtesting.MantidSystemTest, HelperClass):
     focus_results = None
     existing_config = config["datasearch.directories"]
 
@@ -220,7 +225,7 @@ class TestFocusNoAbsorptionIndividual(generate_helper_class()):
             config["datasearch.directories"] = self.existing_config
 
 
-class TestFocusNoAbsorptionSummed(generate_helper_class()):
+class TestFocusNoAbsorptionSummed(systemtesting.MantidSystemTest, HelperClass):
     focus_results = None
     existing_config = config["datasearch.directories"]
 
@@ -245,7 +250,7 @@ class TestFocusNoAbsorptionSummed(generate_helper_class()):
             config["datasearch.directories"] = self.existing_config
 
 
-class FocusTestAbsorptionPaalmanPings(generate_helper_class()):
+class FocusTestAbsorptionPaalmanPings(systemtesting.MantidSystemTest, HelperClass):
     focus_results = None
     existing_config = config["datasearch.directories"]
 
@@ -270,7 +275,7 @@ class FocusTestAbsorptionPaalmanPings(generate_helper_class()):
             config["datasearch.directories"] = self.existing_config
 
 
-class FocusTestAbsorptionMayers(generate_helper_class()):
+class FocusTestAbsorptionMayers(systemtesting.MantidSystemTest, HelperClass):
     focus_results = None
     existing_config = config["datasearch.directories"]
 
@@ -355,7 +360,7 @@ class FocusTestRunTwice(systemtesting.MantidSystemTest):
             config["datasearch.directories"] = self.existing_config
 
 
-class FocusTestPerDetector(generate_helper_class()):
+class FocusTestPerDetector(systemtesting.MantidSystemTest, HelperClass):
     focus_results = None
     existing_config = config["datasearch.directories"]
 

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -549,7 +549,7 @@ def run_vanadium_calibration(per_detector):
     return splined_ws, unsplined_ws
 
 
-def run_focus_no_absorption(per_detector=False, mode="PDF"):
+def run_focus_no_absorption(per_detector=False, mode="PDF", focus_mode="Individual"):
     if mode == "PDF_NORM":
         run_number = 98534
     elif mode == "PDF":
@@ -571,7 +571,7 @@ def run_focus_no_absorption(per_detector=False, mode="PDF"):
     inst_object = setup_inst_object(mode=mode)
     return inst_object.focus(
         run_number=run_number,
-        input_mode="Individual",
+        input_mode=focus_mode,
         do_van_normalisation=True,
         do_absorb_corrections=False,
         sample_empty=sample_empty,
@@ -601,7 +601,7 @@ def run_focus_no_chopper(run_number):
     )
 
 
-def run_focus_absorption(run_number, paalman_pings=False):
+def run_focus_absorption(run_number, paalman_pings=False, focus_mode="Summed"):
     sample_empty = 98532  # Use the vanadium empty again to make it obvious
     sample_empty_scale = 0.5  # ignored if paalman_pings True
 
@@ -621,7 +621,7 @@ def run_focus_absorption(run_number, paalman_pings=False):
 
     return inst_object.focus(
         run_number=run_number,
-        input_mode="Summed",
+        input_mode=focus_mode,
         do_van_normalisation=True,
         do_absorb_corrections=True,
         sample_empty=sample_empty,

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -200,7 +200,7 @@ class TestFocusNoAbsorptionIndividual(systemtesting.MantidSystemTest, HelperClas
     def runTest(self):
         # Gen vanadium calibration first
         setup_mantid_paths()
-        self.focus_results = run_focus_no_absorption("98533, 98534", mode="PDF", focus_mode="Individual")
+        self.focus_results = run_focus_no_absorption("98533, 98534", mode="PDF", input_mode="Individual")
 
     def validate(self):
         # Just check the files exists as functionality of the focussing tested elsewhere
@@ -226,7 +226,7 @@ class TestFocusNoAbsorptionSummed(systemtesting.MantidSystemTest, HelperClass):
     def runTest(self):
         # Gen vanadium calibration first
         setup_mantid_paths()
-        self.focus_results = run_focus_no_absorption("98533,98534", mode="PDF", focus_mode="Summed")
+        self.focus_results = run_focus_no_absorption("98533,98534", mode="PDF", input_mode="Summed")
 
     def validate(self):
         # Just check the files exists as functionality of the focussing tested elsewhere
@@ -596,7 +596,7 @@ def run_vanadium_calibration(per_detector):
     return splined_ws, unsplined_ws
 
 
-def run_focus_no_absorption(run_number, per_detector=False, mode="PDF", focus_mode="Individual"):
+def run_focus_no_absorption(run_number, per_detector=False, mode="PDF", input_mode="Individual"):
     sample_empty = "98532"  # Use the vanadium empty again to make it obvious
     sample_empty_scale = 0.5  # Set it to 50% scale
 
@@ -612,7 +612,7 @@ def run_focus_no_absorption(run_number, per_detector=False, mode="PDF", focus_mo
     inst_object = setup_inst_object(mode=mode)
     return inst_object.focus(
         run_number=run_number,
-        input_mode=focus_mode,
+        input_mode=input_mode,
         do_van_normalisation=True,
         do_absorb_corrections=False,
         sample_empty=sample_empty,
@@ -642,7 +642,7 @@ def run_focus_no_chopper(run_number):
     )
 
 
-def run_focus_absorption(run_number, paalman_pings=False, focus_mode="Summed"):
+def run_focus_absorption(run_number, paalman_pings=False, input_mode="Summed"):
     sample_empty = 98532  # Use the vanadium empty again to make it obvious
     sample_empty_scale = 0.5  # ignored if paalman_pings True
 
@@ -662,7 +662,7 @@ def run_focus_absorption(run_number, paalman_pings=False, focus_mode="Summed"):
 
     return inst_object.focus(
         run_number=run_number,
-        input_mode=focus_mode,
+        input_mode=input_mode,
         do_van_normalisation=True,
         do_absorb_corrections=True,
         sample_empty=sample_empty,

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -8,7 +8,6 @@ import numpy as np
 import os
 import systemtesting
 import shutil
-from abc import abstractmethod
 
 import mantid.simpleapi as mantid
 from mantid import config
@@ -54,14 +53,6 @@ total_scattering_input_file_per_det = os.path.join(input_dir, "ISIS_Powder-POLAR
 class HelperClass:
     tolerance_is_rel_err = True
     tolerance = 1e-6
-
-    @abstractmethod
-    def assertTrue(self, *args, **kwargs):
-        pass
-
-    @abstractmethod
-    def assertEqual(self, *args, **kwargs):
-        pass
 
     def requiredFiles(self):
         return _gen_required_files()

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -50,6 +50,38 @@ total_scattering_input_file = os.path.join(input_dir, "ISIS_Powder-POLARIS98533_
 total_scattering_input_file_per_det = os.path.join(input_dir, "ISIS_Powder-POLARIS98533_TotalScatteringInputPerDetector.nxs")
 
 
+def generate_helper_class():
+    # perform inheritance like this to prevent base class appearing as a test
+    class HelperClass(systemtesting.MantidSystemTest):
+        tolerance_is_rel_err = True
+        tolerance = 1e-6
+
+        def requiredFiles(self):
+            return _gen_required_files()
+
+        # check output files as expected
+        def generate_error_message(self, expected_file, output_dir):
+            return f"Unable to find {expected_file} in {output_dir}.\nContents={os.listdir(output_dir)}"
+
+        def assert_output_file_exists(self, directory, filename):
+            self.assertTrue(os.path.isfile(os.path.join(directory, filename)), msg=self.generate_error_message(filename, directory))
+
+        def validate_focus_files_exist(self, ws_num):
+            user_output = os.path.join(output_dir, "17_1", "Test")
+            self.assert_output_file_exists(user_output, f"POLARIS{ws_num}.nxs")
+            self.assert_output_file_exists(user_output, f"POLARIS{ws_num}.gsas")
+            output_dat_dir = os.path.join(user_output, "dat_files")
+            for bankno in range(1, 6):
+                self.assert_output_file_exists(output_dat_dir, f"POL{ws_num}-b_{bankno}-TOF.dat")
+                self.assert_output_file_exists(output_dat_dir, f"POL{ws_num}-b_{bankno}-d.dat")
+
+        def validate_focus_material(self, focus_results):
+            for ws in focus_results:
+                self.assertEqual(ws.sample().getMaterial().name(), "Si Si")
+
+    return HelperClass
+
+
 class CreateVanadiumTest(systemtesting.MantidSystemTest):
     calibration_results = None
     existing_config = config["datasearch.directories"]
@@ -116,12 +148,9 @@ class CreateVanadiumPerDetectorTest(systemtesting.MantidSystemTest):
             config["datasearch.directories"] = self.existing_config
 
 
-class FocusTestNoAbsorptionWithRelativeNormalisation(systemtesting.MantidSystemTest):
+class FocusTestNoAbsorptionWithRelativeNormalisation(generate_helper_class()):
     focus_results = None
     existing_config = config["datasearch.directories"]
-
-    def requiredFiles(self):
-        return _gen_required_files()
 
     def runTest(self):
         # Gen vanadium calibration first
@@ -129,7 +158,9 @@ class FocusTestNoAbsorptionWithRelativeNormalisation(systemtesting.MantidSystemT
         self.focus_results = run_focus_no_absorption(mode="PDF")
 
     def validate(self):
-        return validate_normalisation_focus_tests(self, "98533")
+        self.validate_focus_files_exist("98533")
+        self.validate_focus_material(self.focus_results)
+        return self.focus_results.name(), "ISIS_Powder-POLARIS98533_FocusSempty.nxs"
 
     def cleanup(self):
         try:
@@ -140,12 +171,9 @@ class FocusTestNoAbsorptionWithRelativeNormalisation(systemtesting.MantidSystemT
             config["datasearch.directories"] = self.existing_config
 
 
-class FocusTestNoAbsorptionWithAbsoluteNormalisation(systemtesting.MantidSystemTest):
+class FocusTestNoAbsorptionWithAbsoluteNormalisation(generate_helper_class()):
     focus_results = None
     existing_config = config["datasearch.directories"]
-
-    def requiredFiles(self):
-        return _gen_required_files()
 
     def runTest(self):
         # Gen vanadium calibration first
@@ -153,7 +181,9 @@ class FocusTestNoAbsorptionWithAbsoluteNormalisation(systemtesting.MantidSystemT
         self.focus_results = run_focus_no_absorption(mode="PDF_NORM")
 
     def validate(self):
-        return validate_normalisation_focus_tests(self, "98534")
+        self.validate_focus_files_exist("98534")
+        self.validate_focus_material(self.focus_results)
+        return self.focus_results.name(), "ISIS_Powder-POLARIS98534_FocusSempty.nxs"
 
     def cleanup(self):
         try:
@@ -164,12 +194,9 @@ class FocusTestNoAbsorptionWithAbsoluteNormalisation(systemtesting.MantidSystemT
             config["datasearch.directories"] = self.existing_config
 
 
-class FocusTestAbsorptionPaalmanPings(systemtesting.MantidSystemTest):
+class FocusTestAbsorptionPaalmanPings(generate_helper_class()):
     focus_results = None
     existing_config = config["datasearch.directories"]
-
-    def requiredFiles(self):
-        return _gen_required_files()
 
     def runTest(self):
         # Gen vanadium calibration first
@@ -179,25 +206,8 @@ class FocusTestAbsorptionPaalmanPings(systemtesting.MantidSystemTest):
     def validate(self):
         self.disableChecking.append("Uncertainty")
 
-        # check output files as expected
-        def generate_error_message(expected_file, output_dir):
-            return "Unable to find {} in {}.\nContents={}".format(expected_file, output_dir, os.listdir(output_dir))
-
-        def assert_output_file_exists(directory, filename):
-            self.assertTrue(os.path.isfile(os.path.join(directory, filename)), msg=generate_error_message(filename, directory))
-
-        user_output = os.path.join(output_dir, "17_1", "Test")
-        assert_output_file_exists(user_output, "POLARIS98533.nxs")
-        assert_output_file_exists(user_output, "POLARIS98533.gsas")
-        output_dat_dir = os.path.join(user_output, "dat_files")
-        for bankno in range(1, 6):
-            assert_output_file_exists(output_dat_dir, "POL98533-b_{}-TOF.dat".format(bankno))
-            assert_output_file_exists(output_dat_dir, "POL98533-b_{}-d.dat".format(bankno))
-
-        for ws in self.focus_results:
-            self.assertEqual(ws.sample().getMaterial().name(), "Si Si")
-        self.tolerance_is_rel_err = True
-        self.tolerance = 1e-6
+        self.validate_focus_files_exist("98533")
+        self.validate_focus_material(self.focus_results)
         return self.focus_results.name(), "ISIS_Powder-POLARIS98533_FocusPaalmanPings.nxs"
 
     def cleanup(self):
@@ -209,7 +219,7 @@ class FocusTestAbsorptionPaalmanPings(systemtesting.MantidSystemTest):
             config["datasearch.directories"] = self.existing_config
 
 
-class FocusTestAbsorptionMayers(systemtesting.MantidSystemTest):
+class FocusTestAbsorptionMayers(generate_helper_class()):
     focus_results = None
     existing_config = config["datasearch.directories"]
 
@@ -222,24 +232,8 @@ class FocusTestAbsorptionMayers(systemtesting.MantidSystemTest):
         self.focus_results = run_focus_absorption("98533", paalman_pings=False)
 
     def validate(self):
-        # check output files as expected
-        def generate_error_message(expected_file, output_dir):
-            return "Unable to find {} in {}.\nContents={}".format(expected_file, output_dir, os.listdir(output_dir))
-
-        def assert_output_file_exists(directory, filename):
-            self.assertTrue(os.path.isfile(os.path.join(directory, filename)), msg=generate_error_message(filename, directory))
-
-        user_output = os.path.join(output_dir, "17_1", "Test")
-        assert_output_file_exists(user_output, "POLARIS98533.nxs")
-        assert_output_file_exists(user_output, "POLARIS98533.gsas")
-        output_dat_dir = os.path.join(user_output, "dat_files")
-        for bankno in range(1, 6):
-            assert_output_file_exists(output_dat_dir, "POL98533-b_{}-TOF.dat".format(bankno))
-            assert_output_file_exists(output_dat_dir, "POL98533-b_{}-d.dat".format(bankno))
-
-        for ws in self.focus_results:
-            self.assertEqual(ws.sample().getMaterial().name(), "Si Si")
-        self.tolerance_is_rel_err = True
+        self.validate_focus_files_exist("98533")
+        self.validate_focus_material(self.focus_results)
         self.tolerance = 1e-5
         # MayersSampleCorrection involves a fit that may give slightly different results on different OS
         return self.focus_results.name(), "ISIS_Powder-POLARIS98533_FocusMayers.nxs"
@@ -310,7 +304,7 @@ class FocusTestRunTwice(systemtesting.MantidSystemTest):
             config["datasearch.directories"] = self.existing_config
 
 
-class FocusTestPerDetector(systemtesting.MantidSystemTest):
+class FocusTestPerDetector(generate_helper_class()):
     focus_results = None
     existing_config = config["datasearch.directories"]
 
@@ -323,24 +317,8 @@ class FocusTestPerDetector(systemtesting.MantidSystemTest):
         self.focus_results = run_focus_no_absorption(per_detector=True)
 
     def validate(self):
-        # check output files as expected
-        def generate_error_message(expected_file, output_dir):
-            return "Unable to find {} in {}.\nContents={}".format(expected_file, output_dir, os.listdir(output_dir))
-
-        def assert_output_file_exists(directory, filename):
-            self.assertTrue(os.path.isfile(os.path.join(directory, filename)), msg=generate_error_message(filename, directory))
-
-        user_output = os.path.join(output_dir, "17_1", "Test")
-        assert_output_file_exists(user_output, "POLARIS98533.nxs")
-        assert_output_file_exists(user_output, "POLARIS98533.gsas")
-        output_dat_dir = os.path.join(user_output, "dat_files")
-        for bankno in range(1, 6):
-            assert_output_file_exists(output_dat_dir, "POL98533-b_{}-TOF.dat".format(bankno))
-            assert_output_file_exists(output_dat_dir, "POL98533-b_{}-d.dat".format(bankno))
-
-        for ws in self.focus_results:
-            self.assertEqual(ws.sample().getMaterial().name(), "Si Si")
-        self.tolerance_is_rel_err = True
+        self.validate_focus_files_exist("98533")
+        self.validate_focus_material(self.focus_results)
         self.tolerance = 1e-5
         return self.focus_results.name(), "ISIS_Powder-POLARIS98533_FocusPerDet.nxs"
 
@@ -702,26 +680,3 @@ def get_bin_number_at_given_r(r_data, r):
     diffs = [abs(i - r) for i in r_centres]
     idx = diffs.index(min(diffs))
     return idx
-
-
-def validate_normalisation_focus_tests(test, ws_num):
-    # check output files as expected
-    def generate_error_message(expected_file, output_dir):
-        return f"Unable to find {expected_file} in {output_dir}.\nContents={os.listdir(output_dir)}"
-
-    def assert_output_file_exists(directory, filename):
-        test.assertTrue(os.path.isfile(os.path.join(directory, filename)), msg=generate_error_message(filename, directory))
-
-    user_output = os.path.join(output_dir, "17_1", "Test")
-    assert_output_file_exists(user_output, f"POLARIS{ws_num}.nxs")
-    assert_output_file_exists(user_output, f"POLARIS{ws_num}.gsas")
-    output_dat_dir = os.path.join(user_output, "dat_files")
-    for bankno in range(1, 6):
-        assert_output_file_exists(output_dat_dir, f"POL{ws_num}-b_{bankno}-TOF.dat")
-        assert_output_file_exists(output_dat_dir, f"POL{ws_num}-b_{bankno}-d.dat")
-
-    for ws in test.focus_results:
-        test.assertEqual(ws.sample().getMaterial().name(), "Si Si")
-    test.tolerance_is_rel_err = True
-    test.tolerance = 1e-6
-    return test.focus_results.name(), f"ISIS_Powder-POLARIS{ws_num}_FocusSempty.nxs"


### PR DESCRIPTION
### Description of work

Added System Test for focussing of Polaris and GEM, checking that when multiple ws are passed they are dealt with correctly by `input_mode = "Individual"/"Summed"`

Additionally reformatted code to avoid repetition 

#### Summary of work

Tests now exist which take `run_number="xxxxx,yyyyy"` rather than previously where all tests only ever operated on a single run workspace.

The tests simply check for the correct output workspaces i.e. for `"Individual"` : `xxxxx.gsas`, `xxxxx.nxs`, `yyyyy.gsas`, and `yyyyy.nxs` should all be produced. For `"Summed"` only  `xxxxx,yyyyy.gsas` and `xxxxx,yyyyy.nxs` should be produced.

Fixes #36018. 

#### Further detail of work
Refactoring of code chosen to do Multiple class inheritance but leave the Base Class without comprehensive implementation. Bogging it down with abstractmethod decorators for the not yet instantiated assert methods that need to be inherited from the Testing Class was deemed to be unnecessary for code that is not user-facing.

### To test:

Run ISIS_PowderPolarisTest.py and ISIS_PowderGemTest.py

*This does not require release notes* because **no change to any user-facing code**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
