### PR TITLE
Increase sleep in test algorithm

### DIFF
--- a/Framework/API/test/AsynchronousTest.h
+++ b/Framework/API/test/AsynchronousTest.h
@@ -58,7 +58,7 @@ public:
       for (int i = 0; i < NO_OF_LOOPS; i++) {
         result = i;
         if (thr)
-          thr->sleep(1);
+          thr->sleep(10);
         progress(double(i) / NO_OF_LOOPS); // send progress notification
         interruption_point();              // check for a termination request
         if (throw_exception && i == NO_OF_LOOPS / 2)


### PR DESCRIPTION
This test fails intermittently, but I can't reproduce it, even when building with the CI cmake configuration and running the test 100 times. My best guess is that when the test asserts that the algorithm hasn't finished yet, e.g. [here](https://github.com/mantidproject/mantid/blob/77501cbee17678a70413a00853a977097f9d60fc/Framework/API/test/AsynchronousTest.h#L101), it was so quick that it has finished, so I've increased the sleep in the test algorithm from 1 ms to 10 ms to make it take longer (but still not long).

If the test continues to fail randomly after this then we can go back to #37760 

Fixes #37760. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
