### PR TITLE
Adding group inputs to SaveNXcanSAS algorithm 

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/NXcanSASHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/NXcanSASHelper.h
@@ -18,7 +18,7 @@ namespace NXcanSAS {
 enum class WorkspaceDimensionality;
 
 std::string MANTID_DATAHANDLING_DLL makeCanSASRelaxedName(const std::string &input);
-
+std::string MANTID_DATAHANDLING_DLL prepareFilename(std::string &baseFilename, int index, bool isGroup = false);
 void MANTID_DATAHANDLING_DLL addDetectors(H5::Group &group, const Mantid::API::MatrixWorkspace_sptr &workspace,
                                           const std::vector<std::string> &detectorNames);
 void MANTID_DATAHANDLING_DLL addInstrument(H5::Group &group, const Mantid::API::MatrixWorkspace_sptr &workspace,

--- a/Framework/DataHandling/inc/MantidDataHandling/NXcanSASHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/NXcanSASHelper.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
 #include <H5Cpp.h>
+#include <filesystem>
 
 namespace Mantid {
 namespace DataHandling {
@@ -18,7 +19,8 @@ namespace NXcanSAS {
 enum class WorkspaceDimensionality;
 
 std::string MANTID_DATAHANDLING_DLL makeCanSASRelaxedName(const std::string &input);
-std::string MANTID_DATAHANDLING_DLL prepareFilename(std::string &baseFilename, int index, bool isGroup = false);
+std::filesystem::path MANTID_DATAHANDLING_DLL prepareFilename(const std::string &baseFilename, int index,
+                                                              bool isGroup = false);
 void MANTID_DATAHANDLING_DLL addDetectors(H5::Group &group, const Mantid::API::MatrixWorkspace_sptr &workspace,
                                           const std::vector<std::string> &detectorNames);
 void MANTID_DATAHANDLING_DLL addInstrument(H5::Group &group, const Mantid::API::MatrixWorkspace_sptr &workspace,

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSAS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSAS.h
@@ -26,6 +26,8 @@ public:
   const std::string summary() const override {
     return "Save a MatrixWorkspace to a file in the NXcanSAS format (for both 1D and 2D data).";
   }
+  /// Override processGroups
+  bool processGroups() override;
 
   /// Algorithm's version
   int version() const override { return (1); }
@@ -40,6 +42,9 @@ private:
   void init() override;
   /// Execution code
   void exec() override;
+  void processAllWorkspaces();
+
+  std::vector<API::MatrixWorkspace_sptr> m_workspaces;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSASBase.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSASBase.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
 #include <H5Cpp.h>
+#include <filesystem>
 
 namespace Mantid {
 namespace DataHandling {
@@ -20,7 +21,7 @@ namespace DataHandling {
  */
 class MANTID_DATAHANDLING_DLL SaveNXcanSASBase : public API::Algorithm {
 protected:
-  void saveSingleWorkspaceFile(const API::MatrixWorkspace_sptr &workspace, const std::string &filename);
+  void saveSingleWorkspaceFile(const API::MatrixWorkspace_sptr &workspace, const std::filesystem::path &path);
   void addStandardMetadata(const Mantid::API::MatrixWorkspace_sptr &workspace, H5::Group &sasEntry);
   void addData(H5::Group &group, const Mantid::API::MatrixWorkspace_sptr &workspace);
   H5::Group addSasEntry(H5::H5File &file, const Mantid::API::MatrixWorkspace_sptr &workspace,

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSASBase.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNXcanSASBase.h
@@ -20,12 +20,15 @@ namespace DataHandling {
  */
 class MANTID_DATAHANDLING_DLL SaveNXcanSASBase : public API::Algorithm {
 protected:
+  void saveSingleWorkspaceFile(const API::MatrixWorkspace_sptr &workspace, const std::string &filename);
   void addStandardMetadata(const Mantid::API::MatrixWorkspace_sptr &workspace, H5::Group &sasEntry);
   void addData(H5::Group &group, const Mantid::API::MatrixWorkspace_sptr &workspace);
   H5::Group addSasEntry(H5::H5File &file, const Mantid::API::MatrixWorkspace_sptr &workspace,
                         const std::string &suffix);
   void initStandardProperties();
   std::map<std::string, std::string> validateStandardInputs();
+
+  std::unique_ptr<API::Progress> m_progress = nullptr;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/NXcanSASHelper.cpp
+++ b/Framework/DataHandling/src/NXcanSASHelper.cpp
@@ -30,7 +30,7 @@ using namespace Mantid::API;
 using namespace Mantid::DataHandling::NXcanSAS;
 
 namespace {
-
+constexpr std::string NX_CANSAS_EXTENSION = ".h5";
 //------- SASFileName
 
 bool isCanSASCompliant(bool isStrict, const std::string &input) {
@@ -253,6 +253,17 @@ public:
 } // namespace
 
 namespace Mantid::DataHandling::NXcanSAS {
+
+std::string prepareFilename(std::string &baseFilename, int index, bool isGroup) {
+  if (auto const &extPos = baseFilename.find(NX_CANSAS_EXTENSION); extPos != std::string::npos) {
+    baseFilename.resize(extPos);
+  }
+  auto const addDigit = [&](int index) {
+    return isGroup ? (index < 10 ? "0" + std::to_string(index) : std::to_string(index)) : "";
+  };
+  return baseFilename + addDigit(index) + ".h5";
+}
+
 /**
  * This makes out of an input a relaxed name, something conforming to
  * "[A-Za-z_][\w_]*"

--- a/Framework/DataHandling/src/NXcanSASHelper.cpp
+++ b/Framework/DataHandling/src/NXcanSASHelper.cpp
@@ -30,7 +30,6 @@ using namespace Mantid::API;
 using namespace Mantid::DataHandling::NXcanSAS;
 
 namespace {
-constexpr std::string_view NX_CANSAS_EXTENSION = ".h5";
 //------- SASFileName
 
 bool isCanSASCompliant(bool isStrict, const std::string &input) {
@@ -253,15 +252,22 @@ public:
 } // namespace
 
 namespace Mantid::DataHandling::NXcanSAS {
+constexpr std::string_view NX_CANSAS_EXTENSION = ".h5";
 
-std::string prepareFilename(std::string &baseFilename, int index, bool isGroup) {
-  if (auto const &extPos = baseFilename.find(NX_CANSAS_EXTENSION); extPos != std::string::npos) {
-    baseFilename.resize(extPos);
+std::filesystem::path prepareFilename(const std::string &baseFilename, int index, bool isGroup) {
+  auto path = std::filesystem::path(baseFilename);
+  if (!isGroup) {
+    // return early if it doesn't need to add digits
+    return path.replace_extension(NX_CANSAS_EXTENSION);
   }
-  auto const addDigit = [&](int index) {
-    return isGroup ? (index < 10 ? "0" + std::to_string(index) : std::to_string(index)) : "";
-  };
-  return baseFilename + addDigit(index) + ".h5";
+
+  auto const addDigit = [&](int index) { return index < 10 ? "0" + std::to_string(index) : std::to_string(index); };
+  // remove extension if it has any
+  path.replace_extension("");
+  // add digit for groups
+  path += addDigit(index);
+  // add correct extension and return path
+  return path.replace_extension(NX_CANSAS_EXTENSION);
 }
 
 /**

--- a/Framework/DataHandling/src/NXcanSASHelper.cpp
+++ b/Framework/DataHandling/src/NXcanSASHelper.cpp
@@ -30,7 +30,7 @@ using namespace Mantid::API;
 using namespace Mantid::DataHandling::NXcanSAS;
 
 namespace {
-constexpr std::string NX_CANSAS_EXTENSION = ".h5";
+constexpr std::string_view NX_CANSAS_EXTENSION = ".h5";
 //------- SASFileName
 
 bool isCanSASCompliant(bool isStrict, const std::string &input) {

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -10,8 +10,6 @@
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/WorkspaceGroup.h"
 
-#include <Poco/File.h>
-
 using namespace Mantid::API;
 
 namespace Mantid::DataHandling {

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidDataHandling/NXcanSASHelper.h"
 
 using namespace Mantid::API;
 
@@ -36,13 +37,10 @@ bool SaveNXcanSAS::processGroups() {
 
 void SaveNXcanSAS::processAllWorkspaces() {
   m_progress = std::make_unique<API::Progress>(this, 0.1, 1.0, 3 * m_workspaces.size());
-  auto const &&baseFilename = getPropertyValue("Filename");
-  auto const addDigit = [&](int index) {
-    return m_workspaces.size() > 1 ? (index < 10 ? "0" + std::to_string(index) : std::to_string(index)) : "";
-  };
-
+  auto baseFilename = getPropertyValue("Filename");
   for (auto wksIndex = 0; wksIndex < static_cast<int>(m_workspaces.size()); wksIndex++) {
-    saveSingleWorkspaceFile(m_workspaces.at(wksIndex), baseFilename + addDigit(wksIndex));
+    saveSingleWorkspaceFile(m_workspaces.at(wksIndex),
+                            NXcanSAS::prepareFilename(baseFilename, wksIndex, m_workspaces.size() > 1));
   }
 }
 

--- a/Framework/DataHandling/src/SaveNXcanSASBase.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSASBase.cpp
@@ -20,8 +20,8 @@
 #include "MantidKernel/Unit.h"
 #include "MantidNexus/H5Util.h"
 
-#include <Poco/File.h>
 #include <algorithm>
+#include <filesystem>
 
 using namespace Mantid::API;
 using namespace Mantid::DataHandling::NXcanSAS;
@@ -50,13 +50,13 @@ std::string validateGroupWithProperties(const Workspace_sptr &ws) {
     auto const &groupItems = std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(ws)->getAllItems();
     if (std::any_of(groupItems.cbegin(), groupItems.cend(),
                     [](auto const &childWs) { return !checkValidMatrixWorkspace(childWs); })) {
-      return "Workspace must have common bins or Momentum transfer units";
+      return "Workspace must have common bins and Momentum transfer units";
     }
     return "";
   }
 
   if (!checkValidMatrixWorkspace(ws)) {
-    return "Workspace must have common bins or Momentum transfer units";
+    return "Workspace must have common bins and Momentum transfer units";
   }
   return "";
 }
@@ -297,8 +297,8 @@ void SaveNXcanSASBase::addData(H5::Group &group, const Mantid::API::MatrixWorksp
 void SaveNXcanSASBase::saveSingleWorkspaceFile(const API::MatrixWorkspace_sptr &workspace,
                                                const std::string &filename) {
   // Prepare file
-  if (Poco::File(filename).exists()) {
-    Poco::File(filename).remove();
+  if (auto const &path = std::filesystem::path(filename); !path.empty()) {
+    std::filesystem::remove(path);
   }
   H5::H5File file(filename, H5F_ACC_EXCL);
 

--- a/Framework/DataHandling/src/SaveNXcanSASBase.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSASBase.cpp
@@ -29,13 +29,16 @@ using namespace Mantid::DataHandling::NXcanSAS;
 namespace {
 
 bool hasUnit(const std::string &unitToCompareWith, const MatrixWorkspace_sptr &ws) {
+  if (ws->axes() == 0) {
+    return false;
+  }
   auto const unit = ws->getAxis(0)->unit();
   return (unit && !unit->unitID().compare(unitToCompareWith));
 }
 
 bool checkValidMatrixWorkspace(const Workspace_sptr &ws) {
   auto const &ws_input = std::dynamic_pointer_cast<MatrixWorkspace>(ws);
-  return (hasUnit("MomentumTransfer", ws_input) && ws_input->isCommonBins());
+  return (ws_input && hasUnit("MomentumTransfer", ws_input) && ws_input->isCommonBins());
 }
 
 std::string validateGroupWithProperties(const Workspace_sptr &ws) {

--- a/Framework/DataHandling/src/SaveNXcanSASBase.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSASBase.cpp
@@ -21,7 +21,6 @@
 #include "MantidNexus/H5Util.h"
 
 #include <algorithm>
-#include <filesystem>
 
 using namespace Mantid::API;
 using namespace Mantid::DataHandling::NXcanSAS;
@@ -295,12 +294,12 @@ void SaveNXcanSASBase::addData(H5::Group &group, const Mantid::API::MatrixWorksp
 }
 
 void SaveNXcanSASBase::saveSingleWorkspaceFile(const API::MatrixWorkspace_sptr &workspace,
-                                               const std::string &filename) {
+                                               const std::filesystem::path &path) {
   // Prepare file
-  if (auto const &path = std::filesystem::path(filename); !path.empty()) {
+  if (!path.empty()) {
     std::filesystem::remove(path);
   }
-  H5::H5File file(filename, H5F_ACC_EXCL);
+  H5::H5File file(path.string(), H5F_ACC_EXCL);
 
   const std::string suffix("01");
   m_progress->report("Adding a new entry.");

--- a/Framework/DataHandling/src/SaveNXcanSASBase.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSASBase.cpp
@@ -6,28 +6,67 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidDataHandling/SaveNXcanSASBase.h"
-#include "MantidAPI/CommonBinsValidator.h"
+#include "MantidAPI//WorkspaceGroup.h"
+#include "MantidAPI/Axis.h"
 #include "MantidAPI/FileProperty.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataHandling/NXcanSASDefinitions.h"
 #include "MantidDataHandling/NXcanSASHelper.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/CompositeValidator.h"
+#include "MantidKernel/LambdaValidator.h"
 #include "MantidKernel/ListValidator.h"
+#include "MantidKernel/Unit.h"
 #include "MantidNexus/H5Util.h"
+
+#include <Poco/File.h>
+#include <algorithm>
 
 using namespace Mantid::API;
 using namespace Mantid::DataHandling::NXcanSAS;
+
+namespace {
+
+bool hasUnit(const std::string &unitToCompareWith, const MatrixWorkspace_sptr &ws) {
+  auto const unit = ws->getAxis(0)->unit();
+  return (unit && !unit->unitID().compare(unitToCompareWith));
+}
+
+bool checkValidMatrixWorkspace(const Workspace_sptr &ws) {
+  auto const &ws_input = std::dynamic_pointer_cast<MatrixWorkspace>(ws);
+  return (hasUnit("MomentumTransfer", ws_input) && ws_input->isCommonBins());
+}
+
+std::string validateGroupWithProperties(const Workspace_sptr &ws) {
+  if (!ws) {
+    return "Workspace has to be a valid workspace";
+  }
+
+  if (ws->isGroup()) {
+    auto const &groupItems = std::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(ws)->getAllItems();
+    if (std::any_of(groupItems.cbegin(), groupItems.cend(),
+                    [](auto const &childWs) { return !checkValidMatrixWorkspace(childWs); })) {
+      return "Workspace must have common bins or Momentum transfer units";
+    }
+    return "";
+  }
+
+  if (!checkValidMatrixWorkspace(ws)) {
+    return "Workspace must have common bins or Momentum transfer units";
+  }
+  return "";
+}
+
+} // namespace
 
 namespace Mantid::DataHandling {
 
 void SaveNXcanSASBase::initStandardProperties() {
   // Standard NXcanSAS properties
-  auto inputWSValidator = std::make_shared<Kernel::CompositeValidator>();
-  inputWSValidator->add<API::WorkspaceUnitValidator>("MomentumTransfer");
-  inputWSValidator->add<API::CommonBinsValidator>();
-  declareProperty(std::make_unique<Mantid::API::WorkspaceProperty<>>("InputWorkspace", "", Kernel::Direction::Input,
-                                                                     inputWSValidator),
+  auto groupValidator = std::make_shared<Kernel::LambdaValidator<Workspace_sptr>>(validateGroupWithProperties);
+  declareProperty(std::make_unique<Mantid::API::WorkspaceProperty<Workspace>>("InputWorkspace", "",
+                                                                              Kernel::Direction::Input, groupValidator),
                   "The input workspace, which must be in units of Q. Can be a 1D or a 2D workspace.");
   declareProperty(std::make_unique<Mantid::API::FileProperty>("Filename", "", API::FileProperty::Save, ".h5"),
                   "The name of the .h5 file to save");
@@ -87,11 +126,24 @@ void SaveNXcanSASBase::initStandardProperties() {
 }
 
 std::map<std::string, std::string> SaveNXcanSASBase::validateStandardInputs() {
-  // The input should be a Workspace2D
-  Mantid::API::MatrixWorkspace_sptr workspace = getProperty("InputWorkspace");
   std::map<std::string, std::string> result;
-  if (!workspace || !std::dynamic_pointer_cast<const Mantid::DataObjects::Workspace2D>(workspace)) {
-    result.emplace("InputWorkspace", "The InputWorkspace must be a Workspace2D.");
+
+  /* If input workspace is a group, check that each group members is a valid 2D Workspace,
+     otherwise check that the input is a valid 2D workspace.*/
+  Mantid::API::Workspace_sptr const workspace = getProperty("InputWorkspace");
+  auto valid2DWorkspace = [](const Workspace_sptr &ws) {
+    return ws && std::dynamic_pointer_cast<const Mantid::DataObjects::Workspace2D>(ws);
+  };
+  if (workspace->isGroup()) {
+    auto const &groupItems = std::dynamic_pointer_cast<WorkspaceGroup>(workspace)->getAllItems();
+    if (std::any_of(groupItems.cbegin(), groupItems.cend(),
+                    [&](auto const &childWs) { return !valid2DWorkspace(childWs); })) {
+      result.emplace("InputWorkspace", "All input workspaces in the input group must be a Workspace2D.");
+    }
+  } else {
+    if (!valid2DWorkspace(workspace)) {
+      result.emplace("InputWorkspace", "The InputWorkspace must be a Workspace2D.");
+    }
   }
 
   // Transmission data should be 1D
@@ -237,6 +289,28 @@ void SaveNXcanSASBase::addData(H5::Group &group, const Mantid::API::MatrixWorksp
     throw std::runtime_error("SaveNXcanSAS: The provided workspace "
                              "dimensionality is not 1D or 2D.");
   }
+}
+
+void SaveNXcanSASBase::saveSingleWorkspaceFile(const API::MatrixWorkspace_sptr &workspace,
+                                               const std::string &filename) {
+  // Prepare file
+  if (Poco::File(filename).exists()) {
+    Poco::File(filename).remove();
+  }
+  H5::H5File file(filename, H5F_ACC_EXCL);
+
+  const std::string suffix("01");
+  m_progress->report("Adding a new entry.");
+  auto sasEntry = addSasEntry(file, workspace, suffix);
+
+  // Add metadata for canSAS file: Instrument, Sample, Process
+  m_progress->report("Adding standard metadata");
+  addStandardMetadata(workspace, sasEntry);
+
+  m_progress->report("Adding data.");
+  addData(sasEntry, workspace);
+
+  file.close();
 }
 
 } // namespace Mantid::DataHandling

--- a/Framework/DataHandling/test/NXcanSASTestHelper.cpp
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/Sample.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataHandling/NXcanSASDefinitions.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidGeometry/Instrument.h"
@@ -158,6 +159,22 @@ Mantid::API::MatrixWorkspace_sptr getTransmissionWorkspace(NXcanSASTestTransmiss
   if (parameters.isHistogram)
     ws = toHistogram(ws);
   return ws;
+}
+
+Mantid::API::WorkspaceGroup_sptr provideGroupWorkspace(Mantid::API::AnalysisDataServiceImpl &ads,
+                                                       NXcanSASTestParameters &parameters) {
+  auto const &ws1 = provide1DWorkspace(parameters);
+  auto const &ws2 = provide1DWorkspace(parameters);
+  ads.add("ws1", ws1);
+  ads.add("ws2", ws2);
+  parameters.idf = getIDFfromWorkspace(ws1);
+
+  auto const groupAlg = Mantid::API::AlgorithmManager::Instance().createUnmanaged("GroupWorkspaces");
+  groupAlg->initialize();
+  groupAlg->setProperty("InputWorkspaces", "ws1,ws2");
+  groupAlg->setProperty("OutputWorkspace", "ws_group");
+  groupAlg->execute();
+  return ads.retrieveWS<Mantid::API::WorkspaceGroup>("ws_group");
 }
 
 Mantid::API::MatrixWorkspace_sptr provide2DWorkspace(NXcanSASTestParameters &parameters) {

--- a/Framework/DataHandling/test/NXcanSASTestHelper.cpp
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.cpp
@@ -17,7 +17,7 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/UnitFactory.h"
 
-#include <Poco/File.h>
+#include <filesystem>
 
 namespace {
 // Create a histogram from a workspace and return it
@@ -237,7 +237,8 @@ void set2DValues(const Mantid::API::MatrixWorkspace_sptr &ws) {
 }
 
 void removeFile(const std::string &filename) {
-  if (Poco::File(filename).exists())
-    Poco::File(filename).remove();
+  if (auto const &path = std::filesystem::path(filename); !path.empty()) {
+    std::filesystem::remove(path);
+  }
 }
 } // namespace NXcanSASTestHelper

--- a/Framework/DataHandling/test/NXcanSASTestHelper.h
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.h
@@ -6,7 +6,10 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
+
 #include <Poco/TemporaryFile.h>
 #include <string>
 #include <vector>
@@ -15,11 +18,13 @@ namespace NXcanSASTestHelper {
 struct NXcanSASTestParameters {
   NXcanSASTestParameters() {
     Poco::TemporaryFile tmpFile;
+
     tmpFile.keep();
     filename = tmpFile.path();
   }
 
   std::string filename;
+  std::vector<std::string> expectedGroupSuffices{"00", "01"};
   int size{10};
   double value{10.23};
   double error{3.45};
@@ -78,6 +83,9 @@ void set_logs(const Mantid::API::MatrixWorkspace_sptr &workspace, const std::str
               const std::string &userFile);
 
 void set_instrument(const Mantid::API::MatrixWorkspace_sptr &workspace, const std::string &instrumentName);
+
+Mantid::API::WorkspaceGroup_sptr provideGroupWorkspace(Mantid::API::AnalysisDataServiceImpl &ads,
+                                                       NXcanSASTestParameters &parameters);
 
 Mantid::API::MatrixWorkspace_sptr provide1DWorkspace(NXcanSASTestParameters &parameters);
 

--- a/Framework/DataHandling/test/NXcanSASTestHelper.h
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.h
@@ -10,7 +10,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 
-#include <Poco/TemporaryFile.h>
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -18,7 +18,7 @@ namespace NXcanSASTestHelper {
 struct NXcanSASTestParameters {
   NXcanSASTestParameters() {}
 
-  std::string filename{Poco::TemporaryFile::tempName() + ".h5"};
+  std::string filename{std::filesystem::temp_directory_path().string() + "testFile.h5"};
   std::vector<std::string> expectedGroupSuffices{"00", "01"};
   int size{10};
   double value{10.23};

--- a/Framework/DataHandling/test/NXcanSASTestHelper.h
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.h
@@ -16,9 +16,9 @@
 
 namespace NXcanSASTestHelper {
 struct NXcanSASTestParameters {
-  NXcanSASTestParameters() { filename = Poco::TemporaryFile::tempName() + ".h5"; }
+  NXcanSASTestParameters() {}
 
-  std::string filename;
+  std::string filename{Poco::TemporaryFile::tempName() + ".h5"};
   std::vector<std::string> expectedGroupSuffices{"00", "01"};
   int size{10};
   double value{10.23};

--- a/Framework/DataHandling/test/NXcanSASTestHelper.h
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.h
@@ -16,12 +16,7 @@
 
 namespace NXcanSASTestHelper {
 struct NXcanSASTestParameters {
-  NXcanSASTestParameters() {
-    Poco::TemporaryFile tmpFile;
-
-    tmpFile.keep();
-    filename = tmpFile.path();
-  }
+  NXcanSASTestParameters() { filename = Poco::TemporaryFile::tempName() + ".h5"; }
 
   std::string filename;
   std::vector<std::string> expectedGroupSuffices{"00", "01"};

--- a/Framework/DataHandling/test/NXcanSASTestHelper.h
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.h
@@ -18,7 +18,7 @@ namespace NXcanSASTestHelper {
 struct NXcanSASTestParameters {
   NXcanSASTestParameters() {}
 
-  std::string filename{std::filesystem::temp_directory_path().string() + "testFile.h5"};
+  std::string filename{(std::filesystem::temp_directory_path() / "testFile.h5").string()};
   std::vector<std::string> expectedGroupSuffices{"00", "01"};
   int size{10};
   double value{10.23};

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -23,7 +23,7 @@
 #include "NXcanSASTestHelper.h"
 
 #include <H5Cpp.h>
-#include <Poco/File.h>
+#include <filesystem>
 #include <sstream>
 
 namespace {
@@ -76,7 +76,6 @@ public:
 
   void test_that_sample_run_numbers_included_if_sample_transmission_property_is_set() {
     NXcanSASTestParameters parameters;
-    removeFile(parameters.filename);
 
     parameters.detectors.emplace_back("front-detector");
     parameters.detectors.emplace_back("rear-detector");
@@ -110,7 +109,6 @@ public:
 
   void test_that_can_run_numbers_included_if_can_transmission_property_is_set() {
     NXcanSASTestParameters parameters;
-    removeFile(parameters.filename);
 
     parameters.detectors.emplace_back("front-detector");
     parameters.detectors.emplace_back("rear-detector");
@@ -144,7 +142,6 @@ public:
 
   void test_that_can_and_sample_runs_included_if_both_transmission_properties_are_set() {
     NXcanSASTestParameters parameters;
-    removeFile(parameters.filename);
 
     parameters.detectors.emplace_back("front-detector");
     parameters.detectors.emplace_back("rear-detector");
@@ -187,7 +184,6 @@ public:
   void test_that_1D_workspace_without_transmissions_is_saved_correctly() {
     // Arrange
     NXcanSASTestParameters parameters;
-    removeFile(parameters.filename);
 
     parameters.detectors.emplace_back("front-detector");
     parameters.detectors.emplace_back("rear-detector");
@@ -210,7 +206,6 @@ public:
 
   void test_that_sample_bgsub_values_included_if_properties_are_set() {
     NXcanSASTestParameters parameters;
-    removeFile(parameters.filename);
 
     parameters.detectors.emplace_back("front-detector");
     parameters.detectors.emplace_back("rear-detector");
@@ -245,7 +240,6 @@ public:
   void test_that_unknown_detector_names_are_not_saved() {
     // Arrange
     NXcanSASTestParameters parameters;
-    removeFile(parameters.filename);
 
     parameters.detectors.emplace_back("wrong-detector1");
     parameters.detectors.emplace_back("wrong-detector2");
@@ -270,7 +264,6 @@ public:
   void test_that_1D_workspace_without_transmissions_and_without_xerror_is_saved_correctly() {
     // Arrange
     NXcanSASTestParameters parameters;
-    removeFile(parameters.filename);
 
     parameters.detectors.emplace_back("front-detector");
     parameters.detectors.emplace_back("rear-detector");
@@ -306,7 +299,6 @@ public:
   void run_test_1D_workspace_with_transmissions_is_saved_correctly(const bool isHistogram) {
     // Arrange
     NXcanSASTestParameters parameters;
-    removeFile(parameters.filename);
 
     parameters.detectors.emplace_back("front-detector");
     parameters.detectors.emplace_back("rear-detector");
@@ -343,7 +335,6 @@ public:
   void test_that_2D_workspace_is_saved_correctly() {
     // Arrange
     NXcanSASTestParameters parameters;
-    removeFile(parameters.filename);
 
     parameters.detectors.emplace_back("front-detector");
     parameters.detectors.emplace_back("rear-detector");
@@ -369,7 +360,6 @@ public:
   void test_that_group_workspaces_are_saved_correctly_in_individual_files() {
     // Arrange
     NXcanSASTestParameters parameters;
-    removeFile(parameters.filename);
 
     auto &ads = Mantid::API::AnalysisDataService::Instance();
     auto const ws_group = provideGroupWorkspace(ads, parameters);
@@ -379,9 +369,9 @@ public:
 
     for (auto const &suffix : parameters.expectedGroupSuffices) {
       // Assert
-      auto const tmpFilename = parameters.filename;
-      parameters.filename += suffix;
-      TS_ASSERT(Poco::File(parameters.filename).exists());
+      auto tmpFilename = parameters.filename;
+      parameters.filename.insert(tmpFilename.size() - 3, suffix);
+      TS_ASSERT(!std::filesystem::is_empty(parameters.filename));
       do_assert(parameters);
 
       // clean files

--- a/docs/source/algorithms/SaveNXcanSAS-v1.rst
+++ b/docs/source/algorithms/SaveNXcanSAS-v1.rst
@@ -17,6 +17,8 @@ Formats Working Group `schema <http://cansas-org.github.io/NXcanSAS/classes/cont
 If the input workspace is 2D then the vertical axis needs to be a numeric axis in momentum transfer units. The created
 file can be reloaded using the :ref:`algm-LoadNXcanSAS` algorithm.
 
+If the input workspace is a group, every compatible workspace member of the group will be saved in a separate file.
+
 In addition, it is possible to save the transmission workspaces obtained from a reduction.
 
 

--- a/docs/source/release/v6.13.0/Reflectometry/New_features/38504.rst
+++ b/docs/source/release/v6.13.0/Reflectometry/New_features/38504.rst
@@ -1,0 +1,1 @@
+- The :ref:`algm-SaveNXcanSAS` algorithm can also accept compatible Workspace Groups as input.


### PR DESCRIPTION
### Description of work
This PR refactors the **SaveNXcanSAS** algorithm to accept group workspaces as inputs. This prepares the ground for a future algorithm for saving polarized SANS data that will need the feature. More information on : #38504
#### Summary of work
To save groups there are three main changes to notice: 

 - The `InputWorkspace` property accepts a pointer to the base class `Workspace` that can be downcasted to a matrix workspace or group workspace. To be able to still filter appropiate compatible data and distinguish between group and matrix workspace I have added a custom `LambdaValidator` that does unit and compatible bins validation to each workspace in the selected input groups, that will filter appropiate groups. Additionally, it also filters compatible workspaces. 
 - To handle groups in the algorithms, I have overridden the `processGroups` methods from the `Algorithm` base class, so that it will call `exec` when it needs to process matrix workspaces and  `processGroups` for processing group workspaces. 
 - The default behaviour for groups (although this can be discussed further) is to save each workspace of the group in an individual file and add a digit at the end of the selected filename to distinguish between files. Although we could add another input property for the algorithm with a custom suffix for group inputs. 


<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38504. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

 - Code review. 
 - All tests are passing. 
 - Check doc changes are appropriate.
 - Run the script and check that data is saved as intended (This uses CLI to reduce data and the training course data set): 
 ```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from sans.command_interface.ISISCommandInterface import *

LOQ()
MaskFile('MaskFile.toml')
AssignSample('LOQ74044.nxs')
TransmissionSample('LOQ74024.nxs', 'LOQ74014.nxs')
AssignCan('LOQ74019.nxs')
TransmissionCan('LOQ74020.nxs', 'LOQ74014.nxs')
#Performs reduction
ws_out=WavRangeReduction(2.2, 10)

ws_group=GroupWorkspaces(ws_out)

# saved in default mantid save directory

# this ought to save two separate files with suffices 00 and 01 and name test_group
SaveNXcanSAS(ws_group, 'test_group')

#this saves individual file with name test_file
SaveNXcanSAS(ws_out[0], 'test_file')
```

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
