### PR TITLE
Add C++ Standards for Handling CppCheck Suppressions

### DIFF
--- a/dev-docs/source/Standards/CPPModernization.rst
+++ b/dev-docs/source/Standards/CPPModernization.rst
@@ -1,4 +1,4 @@
-.. _CppMordernization:
+.. _CppModernization:
 
 =================================
 C++ Code Modernization Guidelines

--- a/dev-docs/source/Standards/CPPStandards.rst
+++ b/dev-docs/source/Standards/CPPStandards.rst
@@ -413,6 +413,12 @@ In order to allow the suppressions file to function as a to-do list of fixes and
 to reduce developer time spent looking for solutions that have already been
 considered, false positives should be suppressed inline.
 
+Inline suppressions must be accompanied by a comment explaining why the problem
+was suppressed rather than fixed. This comment also allows future developers to
+determine if the suppressions can be removed when the code around them changes.
+
+Reviewers and gatekeepers should give these comments additional attention.
+
 .. attention::
 
    Inline suppressions are a last resort. You should be sure that a suppression

--- a/dev-docs/source/Standards/CPPStandards.rst
+++ b/dev-docs/source/Standards/CPPStandards.rst
@@ -375,3 +375,71 @@ of the following should take into account the use of the code.
    -  No further action is required.
    -  Check the XYZ input data and then repeat the process.
    -  Contact the system administrator.
+
+Cppcheck
+^^^^^^^^
+
+Cppcheck analyses all C++ code in the project to locate undefined behavior
+and poor coding practices. Updates to Cppcheck result in such a large number of
+these potential problems being found that it is impractical to solve them all
+in the Pull Request where the update takes place.
+
+Suppressions File
+-----------------
+
+When Cppcheck is updated, a suppressions file will be created using the
+suppressions file generator script, ``generate_cppcheck_suppressions_list.py``.
+
+This file, ``CppCheck_Suppressions.txt.in``, contains a list of all the problems
+that Cppcheck found in the codebase. It has two functions:
+
+- Suppress all errors for problems that are known to be entirely or
+  almost-entirely false positives.
+- Act as a to-do list for any remaining problems that should be fixed when found
+  during normal development.
+
+When modifying a ``.cpp`` file, it is likely that changes in line numbers will
+cause once-suppressed errors to trigger again. Similar to the rules in
+:ref:`CppModernization`, these issues should be fixed as part of the same unit
+of work that revealed them.
+
+Suppressing False Positives
+---------------------------
+
+Occasionally Cppcheck will incorrectly identify problems that cannot or should
+not be fixed.
+
+In order to allow the suppressions file to function as a to-do list of fixes and
+to reduce developer time spent looking for solutions that have already been
+considered, false positives should be suppressed inline.
+
+.. attention::
+
+   Inline suppressions are a last resort. You should be sure that a suppression
+   cannot be fixed by modifying the code before suppressing it using the
+   techniques below.
+
+**Suppressing a single line of code:**
+
+.. code-block:: c++
+
+   // cppcheck-suppress arrayIndexOutOfBounds
+   sizeFourArray[5] = 0;
+
+
+**Suppressing multiple errors on a single line:**
+
+.. code-block:: c++
+
+   // cppcheck-suppress [arrayIndexOutOfBounds,zeroDiv]
+   sizeFourArray[5] = 1 / 0;
+
+
+**Suppressing multiple lines:**
+
+.. code-block:: c++
+
+   // cppcheck-suppress-begin arrayIndexOutOfBounds
+   sizeFourArray[5] = 0;
+   sizeFiveArray[5] = 1;
+   // cppcheck-suppress-end arrayIndexOutOfBounds


### PR DESCRIPTION
### Description of work

#### Summary of work
Adds standards for the handling of the `CppCheck_Suppressions` file and how to suppress any CppCheck warnings that are valid. 

#### Purpose of work
The CppCheck suppressions file should be a to-do list, being whittled down as issues become un-suppressed during normal development. This means that if false-positives are left in the file, the work to identify them is repeated by every subsequent developer that modifies the file containing the problem. 

This standard aims to ameliorate that by guiding developers to suppress CppCheck warnings inline, identifying them clearly as false-positive problems. 


*There is no associated issue.*

### To test:
1. Build the `dev-docs-html` target. 
2. Open the C++ Standards page in a browser and check the formatting of the new section.  

*This does not require release notes* because **it only affects developer documentation.*


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
