### PR TITLE
Clang format for east-const, and only format diffed files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,4 +4,5 @@ BasedOnStyle: LLVM
 ---
 Language: Cpp
 ColumnLimit: 120
+QualifierAlignment: Right
 ...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
     rev: v19.1.7
     hooks:
     - id: clang-format
+      files: $(git diff --name-only main HEAD)
       exclude: Testing/Tools/cxxtest|tools|qt/icons/resources/
 
   - repo: https://github.com/mantidproject/pre-commit-hooks.git
@@ -65,4 +66,5 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
+        files: $(git diff --name-only main HEAD)
         exclude: scripts/templates/reference/|Testing/Tools/cxxtest

--- a/Framework/DataHandling/src/LoadDiffCal.cpp
+++ b/Framework/DataHandling/src/LoadDiffCal.cpp
@@ -48,21 +48,21 @@ using namespace NeXus;
 
 namespace {
 enum class CalibFilenameExtensionEnum { H5, HD5, HDF, CAL, enum_count };
-const std::vector<std::string> calibFilenameExtensions{".h5", ".hd5", ".hdf", ".cal"};
+std::vector<std::string> const calibFilenameExtensions{".h5", ".hd5", ".hdf", ".cal"};
 typedef EnumeratedString<CalibFilenameExtensionEnum, &calibFilenameExtensions, &compareStringsCaseInsensitive>
     CalibFilenameExtension;
 
 enum class GroupingFilenameExtensionEnum { XML, H5, HD5, HDF, CAL, enum_count };
-const std::vector<std::string> groupingFilenameExtensions{".xml", ".h5", ".hd5", ".hdf", ".cal"};
+std::vector<std::string> const groupingFilenameExtensions{".xml", ".h5", ".hd5", ".hdf", ".cal"};
 typedef EnumeratedString<GroupingFilenameExtensionEnum, &groupingFilenameExtensions, &compareStringsCaseInsensitive>
     GroupingFilenameExtension;
 
 namespace PropertyNames {
-const std::string CAL_FILE("Filename");
-const std::string GROUP_FILE("GroupFilename");
-const std::string MAKE_CAL("MakeCalWorkspace");
-const std::string MAKE_GRP("MakeGroupingWorkspace");
-const std::string MAKE_MSK("MakeMaskWorkspace");
+std::string const CAL_FILE("Filename");
+std::string const GROUP_FILE("GroupFilename");
+std::string const MAKE_CAL("MakeCalWorkspace");
+std::string const MAKE_GRP("MakeGroupingWorkspace");
+std::string const MAKE_MSK("MakeMaskWorkspace");
 } // namespace PropertyNames
 } // namespace
 
@@ -70,16 +70,16 @@ const std::string MAKE_MSK("MakeMaskWorkspace");
 DECLARE_ALGORITHM(LoadDiffCal)
 
 /// Algorithms name for identification. @see Algorithm::name
-const std::string LoadDiffCal::name() const { return "LoadDiffCal"; }
+std::string const LoadDiffCal::name() const { return "LoadDiffCal"; }
 
 /// Algorithm's version for identification. @see Algorithm::version
 int LoadDiffCal::version() const { return 1; }
 
 /// Algorithm's category for identification. @see Algorithm::category
-const std::string LoadDiffCal::category() const { return "DataHandling\\Instrument;Diffraction\\DataHandling"; }
+std::string const LoadDiffCal::category() const { return "DataHandling\\Instrument;Diffraction\\DataHandling"; }
 
 /// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
-const std::string LoadDiffCal::summary() const { return "Loads a calibration file for powder diffraction"; }
+std::string const LoadDiffCal::summary() const { return "Loads a calibration file for powder diffraction"; }
 
 /** Initialize the algorithm's properties.
  */
@@ -123,21 +123,21 @@ void LoadDiffCal::init() {
 
 namespace { // anonymous
 
-void setGroupWSProperty(API::Algorithm *alg, const std::string &prefix, const GroupingWorkspace_sptr &wksp) {
+void setGroupWSProperty(API::Algorithm *alg, std::string const &prefix, GroupingWorkspace_sptr const &wksp) {
   alg->declareProperty(std::make_unique<WorkspaceProperty<DataObjects::GroupingWorkspace>>(
                            "OutputGroupingWorkspace", prefix + "_group", Direction::Output),
                        "Set the output GroupingWorkspace, if any.");
   alg->setProperty("OutputGroupingWorkspace", wksp);
 }
 
-void setMaskWSProperty(API::Algorithm *alg, const std::string &prefix, const MaskWorkspace_sptr &wksp) {
+void setMaskWSProperty(API::Algorithm *alg, std::string const &prefix, MaskWorkspace_sptr const &wksp) {
   alg->declareProperty(std::make_unique<WorkspaceProperty<DataObjects::MaskWorkspace>>(
                            "OutputMaskWorkspace", prefix + "_mask", Direction::Output),
                        "Set the output MaskWorkspace, if any.");
   alg->setProperty("OutputMaskWorkspace", wksp);
 }
 
-void setCalWSProperty(API::Algorithm *alg, const std::string &prefix, const ITableWorkspace_sptr &wksp) {
+void setCalWSProperty(API::Algorithm *alg, std::string const &prefix, ITableWorkspace_sptr const &wksp) {
   alg->declareProperty(
       std::make_unique<WorkspaceProperty<ITableWorkspace>>("OutputCalWorkspace", prefix + "_cal", Direction::Output),
       "Set the output Diffraction Calibration workspace, if any.");
@@ -182,7 +182,7 @@ void LoadDiffCal::getInstrument(H5File &file) {
                       << m_instrument->getFilename() << "\"\n";
 }
 
-void LoadDiffCal::makeGroupingWorkspace(const std::vector<int32_t> &detids, const std::vector<int32_t> &groups) {
+void LoadDiffCal::makeGroupingWorkspace(std::vector<int32_t> const &detids, std::vector<int32_t> const &groups) {
   bool makeWS = getProperty(PropertyNames::MAKE_GRP);
   if (!makeWS) {
     g_log.information("Not loading GroupingWorkspace from the calibration file");
@@ -211,7 +211,7 @@ void LoadDiffCal::makeGroupingWorkspace(const std::vector<int32_t> &detids, cons
   setGroupWSProperty(this, m_workspaceName, wksp);
 }
 
-void LoadDiffCal::makeMaskWorkspace(const std::vector<int32_t> &detids, const std::vector<int32_t> &use) {
+void LoadDiffCal::makeMaskWorkspace(std::vector<int32_t> const &detids, std::vector<int32_t> const &use) {
   bool makeWS = getProperty(PropertyNames::MAKE_MSK);
   if (!makeWS) {
     g_log.information("Not making a MaskWorkspace");
@@ -238,10 +238,10 @@ void LoadDiffCal::makeMaskWorkspace(const std::vector<int32_t> &detids, const st
   setMaskWSProperty(this, m_workspaceName, wksp);
 }
 
-void LoadDiffCal::makeCalWorkspace(const std::vector<int32_t> &detids, const std::vector<double> &difc,
-                                   const std::vector<double> &difa, const std::vector<double> &tzero,
-                                   const std::vector<int32_t> &dasids, const std::vector<double> &offsets,
-                                   const std::vector<int32_t> &use) {
+void LoadDiffCal::makeCalWorkspace(std::vector<int32_t> const &detids, std::vector<double> const &difc,
+                                   std::vector<double> const &difa, std::vector<double> const &tzero,
+                                   std::vector<int32_t> const &dasids, std::vector<double> const &offsets,
+                                   std::vector<int32_t> const &use) {
   bool makeWS = getProperty(PropertyNames::MAKE_CAL);
   if (!makeWS) {
     g_log.information("Not making a calibration workspace");
@@ -290,14 +290,14 @@ void LoadDiffCal::makeCalWorkspace(const std::vector<int32_t> &detids, const std
 
     // calculate tof range for information
     Kernel::Units::dSpacing dspacingUnit;
-    const double tofMinRow = dspacingUnit.calcTofMin(difc[i], difa[i], tzero[i], tofMin);
+    double const tofMinRow = dspacingUnit.calcTofMin(difc[i], difa[i], tzero[i], tofMin);
     std::stringstream msg;
     if (tofMinRow != tofMin) {
       msg << "TofMin shifted from " << tofMin << " to " << tofMinRow << " ";
     }
     newrow << tofMinRow;
     if (useTofMax) {
-      const double tofMaxRow = dspacingUnit.calcTofMax(difc[i], difa[i], tzero[i], tofMax);
+      double const tofMaxRow = dspacingUnit.calcTofMax(difc[i], difa[i], tzero[i], tofMax);
       newrow << tofMaxRow;
 
       if (tofMaxRow != tofMax) {


### PR DESCRIPTION
### Description of work

#### Summary of work

Added the east-`const` option to the clang-format, and set pre-commit to only run on touched files.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work

The east-`const` standard is more consistent, and easier to parse.  The type of a variable is read right-to-left.  For instance
- `int const x` is a constant integer
- `int const * x` is a pointer to a constant integer
- `int * const x` is a constant pointer to an integer
- `int const * const x` is a constant pointer to a constant integer

Changing this in an inconsistent way (i.e. differences within a file, or even within a single method) is non-ideal.

This updates clang-format to enforce this change over an entire file.

The also changes the pre-commit hook so that it only updates files which are changed within a PR.  This avoids monster PRs updating the entire codebase when a clang-format option is changed.  In this way, all clang-format changes will be **gradually** introduced into the codebase as files are updated.

*There is no associated issue.*

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
