### PR TITLE
cppcheck suppression set 42 Team Bravo

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
@@ -86,9 +86,7 @@ public:
   /// Return whether this object has a valid shape
   bool hasValidShape() const override;
   int setObject(const int objName, const std::string &lineStr);
-  int procString(const std::string &lineStr);
-  int complementaryObject(const int cellNum,
-                          std::string &lineStr); ///< Process a complementary object
+  void procString(const std::string &lineStr);
   int hasComplement() const;
 
   int populate(const std::map<int, std::shared_ptr<Surface>> &);

--- a/Framework/Geometry/src/Objects/CSGObject.cpp
+++ b/Framework/Geometry/src/Objects/CSGObject.cpp
@@ -560,7 +560,9 @@ int CSGObject::complementaryObject(const int cellNum, std::string &lineStr) {
   std::string Part = lineStr.substr(posA, posB - (posA + 1));
 
   m_objNum = cellNum;
+  // cppcheck-suppress knownConditionTrueFalse
   if (procString(Part)) {
+    // this validates if Part is a valid procString, a variable specific to this file
     m_surList.clear();
     lineStr.erase(posA - 1, posB + 1); // Delete brackets ( Part ) .
     std::ostringstream CompCell;
@@ -699,7 +701,7 @@ std::unique_ptr<CompGrp> CSGObject::procComp(std::unique_ptr<Rule> ruleItem) con
     return std::make_unique<CompGrp>();
 
   Rule *Pptr = ruleItem->getParent();
-  Rule *RItemptr = ruleItem.get();
+  const Rule *RItemptr = ruleItem.get();
   auto CG = std::make_unique<CompGrp>(Pptr, std::move(ruleItem));
   if (Pptr) {
     const int Ln = Pptr->findLeaf(RItemptr);
@@ -902,11 +904,11 @@ void CSGObject::print() const {
   Rule *TA, *TB; // Temp. for storage
 
   while (!rst.empty()) {
-    Rule *T1 = rst.front();
+    const Rule *T1 = rst.front();
     rst.pop_front();
     if (T1) {
       Rcount++;
-      auto *surface = dynamic_cast<SurfPoint *>(T1);
+      const auto *surface = dynamic_cast<const SurfPoint *>(T1);
       if (surface)
         Cells.emplace_back(surface->getKeyN());
       else {

--- a/Framework/Geometry/src/Objects/CSGObject.cpp
+++ b/Framework/Geometry/src/Objects/CSGObject.cpp
@@ -470,15 +470,10 @@ int CSGObject::setObject(const int objName, const std::string &lineStr) {
   if (Mantid::Kernel::Strings::StrLook(lineStr, letters))
     return 0;
 
-  if (procString(lineStr)) // this currently does not fail:
-  {
-    m_surList.clear();
-    m_objNum = objName;
-    return 1;
-  }
-
-  // failure
-  return 0;
+  procString(lineStr);
+  m_surList.clear();
+  m_objNum = objName;
+  return 1;
 }
 
 /**
@@ -523,55 +518,6 @@ std::string CSGObject::cellStr(const std::map<int, CSGObject> &MList) const {
   }
   cx << TopStr;
   return cx.str();
-}
-
-/*
- * Calculate if there are any complementary components in
- * the object. That is lines with #(....)
- * @throw ColErr::ExBase :: Error with processing
- * @param lineStr :: Input string must:  ID Mat {Density}  {rules}
- * @param cellNum :: Number for cell since we don't have one
- * @retval 0 on no work to do
- * @retval 1 :: A (maybe there are many) #(...) object found
- */
-int CSGObject::complementaryObject(const int cellNum, std::string &lineStr) {
-  std::string::size_type posA = lineStr.find("#(");
-  // No work to do ?
-  if (posA == std::string::npos)
-    return 0;
-  posA += 2;
-
-  // First get the area to be removed
-  int numBrackets;
-  std::string::size_type posB;
-  posB = lineStr.find_first_of("()", posA);
-  if (posB == std::string::npos)
-    throw std::runtime_error("Object::complement :: " + lineStr);
-
-  numBrackets = (lineStr[posB] == '(') ? 1 : 0;
-  while (posB != std::string::npos && numBrackets) {
-    posB = lineStr.find_first_of("()", posB);
-    if (posB == std::string::npos)
-      break;
-    numBrackets += (lineStr[posB] == '(') ? 1 : -1;
-    posB++;
-  }
-
-  std::string Part = lineStr.substr(posA, posB - (posA + 1));
-
-  m_objNum = cellNum;
-  // cppcheck-suppress knownConditionTrueFalse
-  if (procString(Part)) {
-    // this validates if Part is a valid procString, a variable specific to this file
-    m_surList.clear();
-    lineStr.erase(posA - 1, posB + 1); // Delete brackets ( Part ) .
-    std::ostringstream CompCell;
-    CompCell << cellNum << " ";
-    lineStr.insert(posA - 1, CompCell.str());
-    return 1;
-  }
-
-  throw std::runtime_error("Object::complement :: " + Part);
 }
 
 /**
@@ -990,9 +936,8 @@ void CSGObject::write(std::ostream &outStream) const {
  * Processes the cell string. This is an internal function
  * to process a string with - String type has #( and ( )
  * @param lineStr :: String value
- * @returns 1 on success
  */
-int CSGObject::procString(const std::string &lineStr) {
+void CSGObject::procString(const std::string &lineStr) {
   m_topRule = nullptr;
   std::map<int, std::unique_ptr<Rule>> RuleList; // List for the rules
   int Ridx = 0;                                  // Current index (not necessary size of RuleList
@@ -1066,7 +1011,6 @@ int CSGObject::procString(const std::string &lineStr) {
                            "surface rules found. Expected=1, found=" +
                            std::to_string(RuleList.size()));
   }
-  return 1;
 }
 
 /**

--- a/Framework/Geometry/src/Objects/RuleItems.cpp
+++ b/Framework/Geometry/src/Objects/RuleItems.cpp
@@ -699,7 +699,7 @@ void SurfPoint::setLeaf(std::unique_ptr<Rule> nR, const int /*unused*/)
 {
   // std::cerr<<"Calling SurfPoint setLeaf"<<'\n';
 
-  auto *newX = dynamic_cast<SurfPoint *>(nR.get());
+  const auto *newX = dynamic_cast<const SurfPoint *>(nR.get());
   if (newX)
     *this = *newX;
 }
@@ -712,7 +712,7 @@ void SurfPoint::setLeaves(std::unique_ptr<Rule> aR, std::unique_ptr<Rule> /*unus
 */
 {
   // std::cerr<<"Calling SurfPoint setLeaf"<<'\n';
-  auto *newX = dynamic_cast<SurfPoint *>(aR.get());
+  const auto *newX = dynamic_cast<const SurfPoint *>(aR.get());
   if (newX)
     *this = *newX;
 }
@@ -979,7 +979,7 @@ void CompObj::setLeaf(std::unique_ptr<Rule> aR, const int /*unused*/)
   @param :: Null side point
 */
 {
-  auto *newX = dynamic_cast<CompObj *>(aR.get());
+  const auto *newX = dynamic_cast<const CompObj *>(aR.get());
   // Make a copy
   if (newX)
     *this = *newX;
@@ -995,7 +995,7 @@ void CompObj::setLeaves(std::unique_ptr<Rule> aR, std::unique_ptr<Rule> oR)
 {
   (void)oR; // Avoid compiler warning
 
-  auto *newX = dynamic_cast<CompObj *>(aR.get());
+  const auto *newX = dynamic_cast<const CompObj *>(aR.get());
   if (newX)
     *this = *newX;
 }
@@ -1227,7 +1227,7 @@ void BoolValue::setLeaf(std::unique_ptr<Rule> aR, const int /*unused*/)
 */
 {
   // std::cerr<<"Calling BoolValue setLeaf"<<'\n';
-  auto *newX = dynamic_cast<BoolValue *>(aR.get());
+  const auto *newX = dynamic_cast<const BoolValue *>(aR.get());
   if (newX)
     *this = *newX;
 }
@@ -1242,7 +1242,7 @@ void BoolValue::setLeaves(std::unique_ptr<Rule> aR, std::unique_ptr<Rule> oR)
 {
   (void)oR; // Avoid compiler warning
   // std::cerr<<"Calling BoolValue setLeaves"<<'\n';
-  auto *newX = dynamic_cast<BoolValue *>(aR.get());
+  const auto *newX = dynamic_cast<const BoolValue *>(aR.get());
   if (newX)
     *this = *newX;
 }

--- a/Framework/Geometry/src/Objects/Rules.cpp
+++ b/Framework/Geometry/src/Objects/Rules.cpp
@@ -392,7 +392,7 @@ int Rule::removeItem(std::unique_ptr<Rule> &TRule, const int SurfN)
     if (LevelTwo) /// Not the top level
     {
       // Decide which of the pairs is to be copied
-      Rule *PObj = (LevelOne->leaf(0) != Ptr) ? LevelOne->leaf(0) : LevelOne->leaf(1);
+      const Rule *PObj = (LevelOne->leaf(0) != Ptr) ? LevelOne->leaf(0) : LevelOne->leaf(1);
       //
       const int side = (LevelTwo->leaf(0) != LevelOne) ? 1 : 0;
       LevelTwo->setLeaf(PObj->clone(), side);
@@ -443,6 +443,7 @@ Rule::Rule(Rule *A)
 */
 {}
 
+// cppcheck-suppress operatorEqVarError
 Rule &Rule::operator=(const Rule & /*unused*/)
 /**
   Assignment operator=
@@ -666,8 +667,7 @@ int Rule::Eliminate()
           Base[baseKeys[ic]] = baseVal[ic];
       }
     }
-    if (keyChange < 0) // Success !!!!!
-      deadKeys.emplace_back(targetKey);
+    deadKeys.emplace_back(targetKey);
   }
   return static_cast<int>(deadKeys.size());
 }

--- a/Framework/Geometry/src/Rasterize.cpp
+++ b/Framework/Geometry/src/Rasterize.cpp
@@ -27,24 +27,6 @@ constexpr static V3D X_AXIS{1, 0, 0};
 constexpr static V3D Y_AXIS{0, 1, 0};
 constexpr static V3D Z_AXIS{0, 0, 1};
 
-struct CylinderParameters {
-  // cppcheck-suppress-begin unusedStructMember
-  double radius;
-  double height;
-  // cppcheck-suppress-end unusedStructMember
-  V3D centerBottomBase;
-  V3D symmetryaxis;
-};
-
-struct HollowCylinderParameters {
-  // cppcheck-suppress-begin unusedStructMember
-  double radius;
-  double innerRadius;
-  double height;
-  // cppcheck-suppress-end unusedStructMember
-  V3D centerBottomBase;
-  V3D symmetryaxis;
-};
 
 // since cylinders are symmetric around the main axis, choose a random
 // perpendicular to have as the second axis

--- a/Framework/Geometry/src/Rasterize.cpp
+++ b/Framework/Geometry/src/Rasterize.cpp
@@ -28,16 +28,20 @@ constexpr static V3D Y_AXIS{0, 1, 0};
 constexpr static V3D Z_AXIS{0, 0, 1};
 
 struct CylinderParameters {
+  // cppcheck-suppress-begin unusedStructMember
   double radius;
   double height;
+  // cppcheck-suppress-end unusedStructMember
   V3D centerBottomBase;
   V3D symmetryaxis;
 };
 
 struct HollowCylinderParameters {
+  // cppcheck-suppress-begin unusedStructMember
   double radius;
   double innerRadius;
   double height;
+  // cppcheck-suppress-end unusedStructMember
   V3D centerBottomBase;
   V3D symmetryaxis;
 };

--- a/Framework/Geometry/src/Rasterize.cpp
+++ b/Framework/Geometry/src/Rasterize.cpp
@@ -27,7 +27,6 @@ constexpr static V3D X_AXIS{1, 0, 0};
 constexpr static V3D Y_AXIS{0, 1, 0};
 constexpr static V3D Z_AXIS{0, 0, 1};
 
-
 // since cylinders are symmetric around the main axis, choose a random
 // perpendicular to have as the second axis
 V3D createPerpendicular(const V3D &symmetryAxis) {

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -718,7 +718,6 @@ knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Math/Acomp.cp
 invalidContainer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Math/Acomp.cpp:495
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:143
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:320
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:473
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/RenderingHelpersOpenGL.cpp:204
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/vtkGeometryCacheReader.cpp:64
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/vtkGeometryCacheWriter.cpp:83

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -719,11 +719,6 @@ invalidContainer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Math/Acomp.cpp:495
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:143
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:320
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:473
-unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rasterize.cpp:31
-unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rasterize.cpp:32
-unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rasterize.cpp:38
-unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rasterize.cpp:39
-unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rasterize.cpp:40
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/RenderingHelpersOpenGL.cpp:204
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/vtkGeometryCacheReader.cpp:64
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rendering/vtkGeometryCacheWriter.cpp:83

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -719,9 +719,6 @@ invalidContainer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Math/Acomp.cpp:495
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:143
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:320
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:473
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/Rules.cpp:395
-operatorEqVarError:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/Rules.cpp:446
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/Rules.cpp:669
 unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rasterize.cpp:31
 unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rasterize.cpp:32
 unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rasterize.cpp:38

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -719,9 +719,6 @@ invalidContainer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Math/Acomp.cpp:495
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:143
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:320
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:473
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:563
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:702
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:909
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp:702
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp:715
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp:982

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -719,12 +719,6 @@ invalidContainer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Math/Acomp.cpp:495
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:143
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:320
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp:473
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp:702
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp:715
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp:982
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp:998
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp:1230
-constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp:1245
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/Rules.cpp:395
 operatorEqVarError:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/Rules.cpp:446
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/Rules.cpp:669


### PR DESCRIPTION
### Description of work

#### Summary of work
cppcheck suppression fixes as part of the cppcheck hackathon January 2025

#### Purpose of work
Fix set 50 which is as follows

Issue | File | Line
-- | -- | --
knownConditionTrueFalse | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp | 563
constVariablePointer | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp | 702
constVariablePointer | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/CSGObject.cpp | 909
constVariablePointer | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp | 702
constVariablePointer | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp | 715
constVariablePointer | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp | 982
constVariablePointer | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp | 998
constVariablePointer | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp | 1230
constVariablePointer | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/RuleItems.cpp | 1245
constVariablePointer | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/Rules.cpp | 395
operatorEqVarError | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/Rules.cpp | 446
knownConditionTrueFalse | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Objects/Rules.cpp | 669
unusedStructMember | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rasterize.cpp | 31
unusedStructMember | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rasterize.cpp | 32
unusedStructMember | ${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Rasterize.cpp | 38


*There is no associated issue.*

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Code review, and cppcheck passes


*This does not require release notes* because **it fixes cppcheck suppressions**


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
