### PR TITLE
Cppcheck suppression team delta - set 86

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -1420,16 +1420,3 @@ constParameterPointer:${CMAKE_SOURCE_DIR}/qt/widgets/mplcpp/src/RangeMarker.cpp:
 constParameterPointer:${CMAKE_SOURCE_DIR}/qt/widgets/mplcpp/src/SingleMarker.cpp:20
 unknownMacro:${CMAKE_SOURCE_DIR}/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PeakPicker.h:40
 unknownMacro:${CMAKE_SOURCE_DIR}/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/RangeSelector.h:44
-unknownMacro:${CMAKE_SOURCE_DIR}/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/SingleSelector.h:50
-unsafeClassCanLeak:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h:185
-unsafeClassCanLeak:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h:186
-returnByReference:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/SampleShapeHelpers.h:133
-constVariablePointer:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp:202
-constVariablePointer:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp:413
-constVariablePointer:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/LoadRawDialog.cpp:123
-constVariablePointer:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/LoadRawDialog.cpp:140
-constVariablePointer:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/LoadRawDialog.cpp:149
-constVariableReference:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/SortTableWorkspaceDialog.cpp:115
-unreadVariable:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp:143
-constVariableReference:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp:398
-returnTempReference:${CMAKE_SOURCE_DIR}/qt/widgets/spectroscopy/src/FitData.cpp:127

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/SingleSelector.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/SingleSelector.h
@@ -47,6 +47,8 @@ signals:
   void resetScientificBounds();
   void valueChanged(double position);
 
+  // C++ does not recognise QT macros
+  // cppcheck-suppress unknownMacro
 private slots:
   void handleMouseDown(const QPoint &point);
   void handleMouseMove(const QPoint &point);

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h
@@ -180,7 +180,7 @@ public:
   /// Set all workspace properties
   void setProperties() override;
 
-protected:
+private:
   QSpinBox *m_workspaceIndex;
   QLineEdit *m_startX;
   QLineEdit *m_endX;
@@ -198,7 +198,7 @@ public:
   /// Set all workspace properties
   void setProperties() override;
 
-protected:
+private:
   QSpinBox *m_maxSize;
 };
 } // namespace CustomDialogs

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h
@@ -175,12 +175,13 @@ protected:
 class MWPropertiesWidget : public DynamicPropertiesWidget {
 public:
   MWPropertiesWidget(InputWorkspaceWidget *parent);
+  ~MWPropertiesWidget();
   /// Initialize the child widgets with stored and allowed values
   void init() override;
   /// Set all workspace properties
   void setProperties() override;
 
-private:
+protected:
   QSpinBox *m_workspaceIndex;
   QLineEdit *m_startX;
   QLineEdit *m_endX;
@@ -198,7 +199,7 @@ public:
   /// Set all workspace properties
   void setProperties() override;
 
-private:
+protected:
   QSpinBox *m_maxSize;
 };
 } // namespace CustomDialogs

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h
@@ -175,15 +175,17 @@ protected:
 class MWPropertiesWidget : public DynamicPropertiesWidget {
 public:
   MWPropertiesWidget(InputWorkspaceWidget *parent);
-  ~MWPropertiesWidget();
   /// Initialize the child widgets with stored and allowed values
   void init() override;
   /// Set all workspace properties
   void setProperties() override;
 
-protected:
+private:
   QSpinBox *m_workspaceIndex;
+  // both unsafeClassCanLeak below seem to be incorrectly detected as QT manages the clean up
+  // cppcheck-suppress unsafeClassCanLeak
   QLineEdit *m_startX;
+  // cppcheck-suppress unsafeClassCanLeak
   QLineEdit *m_endX;
   QSpinBox *m_maxSize;
 };
@@ -199,7 +201,7 @@ public:
   /// Set all workspace properties
   void setProperties() override;
 
-protected:
+private:
   QSpinBox *m_maxSize;
 };
 } // namespace CustomDialogs

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/SampleShapeHelpers.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/SampleShapeHelpers.h
@@ -129,9 +129,7 @@ public:
   /// Write out the XML definition for this shape
   virtual QString writeXML() const = 0;
 
-  /// Get the id string - returning by values is safer than by reference here
-  // cppcheck-suppress returnByReference
-  QString getShapeID() const { return m_idvalue; }
+  const QString &getShapeID() const { return m_idvalue; }
 
   /// Create a new length units box
   static QComboBox *createLengthUnitsCombo();

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/SampleShapeHelpers.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/SampleShapeHelpers.h
@@ -129,7 +129,8 @@ public:
   /// Write out the XML definition for this shape
   virtual QString writeXML() const = 0;
 
-  /// Get the id string
+  /// Get the id string - returning by values is safer than by reference here
+  // cppcheck-suppress returnByReference
   QString getShapeID() const { return m_idvalue; }
 
   /// Create a new length units box

--- a/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
@@ -199,7 +199,7 @@ MWPropertiesWidget::MWPropertiesWidget(InputWorkspaceWidget *parent) : DynamicPr
   if (wsName.isEmpty())
     return;
   try {
-    const auto ws = dynamic_cast<Mantid::API::MatrixWorkspace *>(
+    const auto *ws = dynamic_cast<Mantid::API::MatrixWorkspace *>(
         Mantid::API::AnalysisDataService::Instance().retrieve(wsName.toStdString()).get());
     if (ws) {
       m_workspaceIndex->setRange(0, static_cast<int>(ws->getNumberHistograms()));
@@ -211,6 +211,14 @@ MWPropertiesWidget::MWPropertiesWidget(InputWorkspaceWidget *parent) : DynamicPr
     }
   } catch (...) {
   }
+}
+
+/**
+ * Destructor.
+ */
+MWPropertiesWidget::~MWPropertiesWidget() {
+  delete m_startX;
+  delete m_endX;
 }
 
 /**
@@ -410,7 +418,7 @@ void FitDialog::createInputWorkspaceWidgets() {
   m_form.tabWidget->clear();
   QStringList wsNames;
   foreach (QWidget *t, m_tabs) {
-    const auto tab = dynamic_cast<InputWorkspaceWidget *>(t);
+    const auto *tab = dynamic_cast<InputWorkspaceWidget *>(t);
     if (tab) {
       wsNames << tab->getWorkspaceName();
     } else {

--- a/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
@@ -199,7 +199,7 @@ MWPropertiesWidget::MWPropertiesWidget(InputWorkspaceWidget *parent) : DynamicPr
   if (wsName.isEmpty())
     return;
   try {
-    auto ws = dynamic_cast<Mantid::API::MatrixWorkspace *>(
+    const auto ws = dynamic_cast<Mantid::API::MatrixWorkspace *>(
         Mantid::API::AnalysisDataService::Instance().retrieve(wsName.toStdString()).get());
     if (ws) {
       m_workspaceIndex->setRange(0, static_cast<int>(ws->getNumberHistograms()));
@@ -410,7 +410,7 @@ void FitDialog::createInputWorkspaceWidgets() {
   m_form.tabWidget->clear();
   QStringList wsNames;
   foreach (QWidget *t, m_tabs) {
-    auto tab = dynamic_cast<InputWorkspaceWidget *>(t);
+    const auto tab = dynamic_cast<InputWorkspaceWidget *>(t);
     if (tab) {
       wsNames << tab->getWorkspaceName();
     } else {

--- a/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
@@ -214,14 +214,6 @@ MWPropertiesWidget::MWPropertiesWidget(InputWorkspaceWidget *parent) : DynamicPr
 }
 
 /**
- * Destructor.
- */
-MWPropertiesWidget::~MWPropertiesWidget() {
-  delete m_startX;
-  delete m_endX;
-}
-
-/**
  * Initialize the child widgets with stored and allowed values
  */
 void MWPropertiesWidget::init() {}

--- a/qt/widgets/plugins/algorithm_dialogs/src/LoadRawDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/LoadRawDialog.cpp
@@ -120,7 +120,7 @@ void LoadRawDialog::initLayout() {
   //------------- Cache option , log files options and Monitors Options
   //---------------------
 
-  Mantid::Kernel::Property *cacheProp = getAlgorithmProperty("Cache");
+  const Mantid::Kernel::Property *cacheProp = getAlgorithmProperty("Cache");
   if (cacheProp) {
     auto *cacheBox = new QComboBox;
     std::vector<std::string> items = cacheProp->allowedValues();
@@ -137,7 +137,7 @@ void LoadRawDialog::initLayout() {
   prop_line->addStretch();
   // If the algorithm version supports the LoadLog property add a check box for
   // it
-  Mantid::Kernel::Property *loadlogs = getAlgorithmProperty("LoadLogFiles");
+  const Mantid::Kernel::Property *loadlogs = getAlgorithmProperty("LoadLogFiles");
   if (loadlogs) {
     QCheckBox *checkbox = new QCheckBox("Load Log Files", this);
     prop_line->addWidget(checkbox);
@@ -146,7 +146,7 @@ void LoadRawDialog::initLayout() {
   prop_line->addStretch();
   //------------- If the algorithm version supports the LoadMonitors property
   // add a check box for it ----
-  Mantid::Kernel::Property *loadMonitors = getAlgorithmProperty("LoadMonitors");
+  const Mantid::Kernel::Property *loadMonitors = getAlgorithmProperty("LoadMonitors");
   if (loadMonitors) {
     auto *monitorsBox = new QComboBox;
     std::vector<std::string> monitoritems = loadMonitors->allowedValues();

--- a/qt/widgets/plugins/algorithm_dialogs/src/SortTableWorkspaceDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/SortTableWorkspaceDialog.cpp
@@ -112,7 +112,7 @@ void SortTableWorkspaceDialog::workspaceChanged(const QString &wsName) {
     m_columnNames.clear();
     // get and cache the column names from the workspace
     auto columnNames = ws->getColumnNames();
-    for (auto &columnName : columnNames) {
+    for (const auto &columnName : columnNames) {
       m_columnNames << QString::fromStdString(columnName);
     }
     m_form.cbColumnName->addItems(m_columnNames);

--- a/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
@@ -140,7 +140,6 @@ void StartLiveDataDialog::initLayout() {
     if (post)
       prefix = "PostProcessing";
     QString algo = AlgorithmInputHistory::Instance().previousInput("StartLiveData", prefix + "Algorithm");
-    QString algoProps = AlgorithmInputHistory::Instance().previousInput("StartLiveData", prefix + "Properties");
     QString script = AlgorithmInputHistory::Instance().previousInput("StartLiveData", prefix + "Script");
 
     if (!post) {
@@ -395,7 +394,7 @@ void StartLiveDataDialog::accept() {
 void StartLiveDataDialog::initListenerPropLayout(const QString &listener) {
   // remove previous listener's properties
   auto props = m_algorithm->getPropertiesInGroup("ListenerProperties");
-  for (auto &prop : props) {
+  for (const auto &prop : props) {
     QString propName = QString::fromStdString((*prop).name());
     if (m_algProperties.contains(propName)) {
       m_algProperties.removeAll(propName);

--- a/qt/widgets/spectroscopy/src/FitData.cpp
+++ b/qt/widgets/spectroscopy/src/FitData.cpp
@@ -128,10 +128,10 @@ std::unique_ptr<boost::basic_format<char>> tryPassFormatArgument(boost::basic_fo
   try {
     tmpString = formatString % arg;
   } catch (const boost::io::too_many_args &) {
-    return std::unique_ptr<boost::basic_format<char>>(&tmpString);
+    return std::unique_ptr<boost::basic_format<char>>(new boost::basic_format<char>(tmpString));
   }
 
-  return std::unique_ptr<boost::basic_format<char>>(&tmpString);
+  return std::unique_ptr<boost::basic_format<char>>(new boost::basic_format<char>(tmpString));
 }
 
 std::pair<double, double> getBinRange(const MatrixWorkspace_sptr &workspace) {

--- a/qt/widgets/spectroscopy/src/FitData.cpp
+++ b/qt/widgets/spectroscopy/src/FitData.cpp
@@ -122,18 +122,11 @@ std::string cutLastOf(const std::string &str, const std::string &delimiter) {
   return str;
 }
 
-// formatString cannot be const to allow the bitwise and operation in the try block
-// cppcheck-suppress constParameterReference
-std::unique_ptr<boost::basic_format<char>> tryPassFormatArgument(boost::basic_format<char> &formatString,
-                                                                 const std::string &arg) {
-  auto tmpString = formatString;
+void tryPassFormatArgument(boost::basic_format<char> &formatString, const std::string &arg) {
   try {
-    tmpString = formatString % arg;
+    formatString = formatString % arg;
   } catch (const boost::io::too_many_args &) {
-    return std::unique_ptr<boost::basic_format<char>>(new boost::basic_format<char>(tmpString));
   }
-
-  return std::unique_ptr<boost::basic_format<char>>(new boost::basic_format<char>(tmpString));
 }
 
 std::pair<double, double> getBinRange(const MatrixWorkspace_sptr &workspace) {
@@ -191,8 +184,8 @@ std::string FitData::displayName(const std::string &formatString, const std::str
   const auto spectraString = m_spectra.getString();
 
   auto formatted = boost::format(formatString);
-  formatted = *tryPassFormatArgument(formatted, workspaceName);
-  formatted = *tryPassFormatArgument(formatted, spectraString);
+  tryPassFormatArgument(formatted, workspaceName);
+  tryPassFormatArgument(formatted, spectraString);
 
   auto name = formatted.str();
   std::replace(name.begin(), name.end(), ',', '+');
@@ -203,8 +196,8 @@ std::string FitData::displayName(const std::string &formatString, WorkspaceIndex
   const auto workspaceName = getBasename();
 
   auto formatted = boost::format(formatString);
-  formatted = *tryPassFormatArgument(formatted, workspaceName);
-  formatted = *tryPassFormatArgument(formatted, std::to_string(spectrum.value));
+  tryPassFormatArgument(formatted, workspaceName);
+  tryPassFormatArgument(formatted, std::to_string(spectrum.value));
   return formatted.str();
 }
 

--- a/qt/widgets/spectroscopy/src/FitData.cpp
+++ b/qt/widgets/spectroscopy/src/FitData.cpp
@@ -124,7 +124,8 @@ std::string cutLastOf(const std::string &str, const std::string &delimiter) {
 
 boost::basic_format<char> &tryPassFormatArgument(boost::basic_format<char> &formatString, const std::string &arg) {
   try {
-    return formatString % arg;
+    auto tmpString = formatString % arg;
+    return tmpString;
   } catch (const boost::io::too_many_args &) {
     return formatString;
   }

--- a/qt/widgets/spectroscopy/src/FitData.cpp
+++ b/qt/widgets/spectroscopy/src/FitData.cpp
@@ -122,6 +122,8 @@ std::string cutLastOf(const std::string &str, const std::string &delimiter) {
   return str;
 }
 
+// formatString cannot be const to allow the bitwise and operation in the try block
+// cppcheck-suppress constParameterReference
 std::unique_ptr<boost::basic_format<char>> tryPassFormatArgument(boost::basic_format<char> &formatString,
                                                                  const std::string &arg) {
   auto tmpString = formatString;

--- a/qt/widgets/spectroscopy/src/FitData.cpp
+++ b/qt/widgets/spectroscopy/src/FitData.cpp
@@ -124,7 +124,7 @@ std::string cutLastOf(const std::string &str, const std::string &delimiter) {
 
 boost::basic_format<char> &tryPassFormatArgument(boost::basic_format<char> &formatString, const std::string &arg) {
   try {
-    auto tmpString = formatString % arg;
+    auto &tmpString = formatString % arg;
     return tmpString;
   } catch (const boost::io::too_many_args &) {
     return formatString;


### PR DESCRIPTION
### Description of work

cppcheck suppression fixes for set 86:


- unknownMacro | ${CMAKE_SOURCE_DIR}/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/SingleSelector.h | 50
- unsafeClassCanLeak | ${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h | 185
- unsafeClassCanLeak | ${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h | 186
- returnByReference | ${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/SampleShapeHelpers.h | 133
- constVariablePointer | ${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp | 202
- constVariablePointer | ${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp | 413
- constVariablePointer | ${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/LoadRawDialog.cpp | 123
- constVariablePointer | ${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/LoadRawDialog.cpp | 140
- constVariablePointer | ${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/LoadRawDialog.cpp | 149
- constVariableReference | ${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/SortTableWorkspaceDialog.cpp | 115
- unreadVariable | ${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp | 143
- constVariableReference | ${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp | 398
- returnTempReference | ${CMAKE_SOURCE_DIR}/qt/widgets/spectroscopy/src/FitData.cpp | 127



### To test:

Code review, and cppcheck passes


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
