### PR TITLE
Road to removing qtassistant for workbench documentation --> Python based HelpWindow Implementation Design using pyqtwebengine

### DIFF
--- a/conda/recipes/mantid-developer/meta.yaml
+++ b/conda/recipes/mantid-developer/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - pycifrw
     - pydantic
     - pyqt {{ pyqt }}
+    - pyqtwebengine
     - python-dateutil {{ python_dateutil }}
     - python {{ python }}
     - python.app # [osx]

--- a/conda/recipes/mantidqt/meta.yaml
+++ b/conda/recipes/mantidqt/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - setuptools                             # [build_platform != target_platform]
     - numpy {{ numpy }}                      # [build_platform != target_platform]
     - pyqt {{ pyqt }}                        # [build_platform != target_platform]
+    - pyqtwebengine                          #[build_platform != target_platform]
     - qt-main {{ qt_main }}                  # [build_platform != target_platform]
     - sip {{ sip }}                          # [build_platform != target_platform]
     - {{ cdt('mesa-libgl-devel') }}  # [linux]

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -105,6 +105,7 @@ set(PYTHON_WIDGET_QT5_ONLY_TESTS
     mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogpresenter.py
     mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogview.py
     mantidqt/widgets/fitpropertybrowser/test/test_interactive_tool.py
+    mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_io.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_presenter.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_view.py

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/__init__.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
@@ -1,36 +1,71 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import argparse
 import os
+import sys
 from mantidqt.widgets.helpwindow.helpwindowpresenter import HelpWindowPresenter
 from qtpy.QtCore import QUrl
+from qtpy.QtWidgets import QApplication
 
 _presenter = None
 
-online_base_url = "https://docs.mantidproject.org/"
-# NOTE: Once you build the html docs using the command ninja docs-html, you will need to
-#      use the command export MANTID_LOCAL_DOCS_BASE="/path/to/build/docs/html".
-#      If this it not set, this will default to the online docs.
-local_docs_base = os.environ.get("MANTID_LOCAL_DOCS_BASE")  # e.g. /path/to/build/docs/html
+# online_base_url = "https://docs.mantidproject.org/"
+# # NOTE: Once you build the html docs using the command ninja docs-html, you will need to
+# #      use the command export MANTID_LOCAL_DOCS_BASE="/path/to/build/docs/html".
+# #      If this it not set, this will default to the online docs.
+# local_docs_base = os.environ.get("MANTID_LOCAL_DOCS_BASE")  # e.g. /path/to/build/docs/html
 
 
-def show_help_page(relative_url):
+def show_help_page(relative_url, local_docs=None, online_base_url="https://docs.mantidproject.org/"):
     """
-    Show the help window at the given relative URL path, e.g. "algorithms/Load-v1.html".
+    Show the help window at the given relative URL path
     """
     global _presenter
     if _presenter is None:
         _presenter = HelpWindowPresenter()
 
-    # Default to index.html if no specific file given
     if not relative_url or not relative_url.endswith(".html"):
         relative_url = "index.html"
 
-    if local_docs_base and os.path.isdir(local_docs_base):
+    if local_docs and os.path.isdir(local_docs):
         # Use local docs
-        full_path = os.path.join(local_docs_base, relative_url)
+        full_path = os.path.join(local_docs, relative_url)
         file_url = QUrl.fromLocalFile(full_path)
         _presenter.view.browser.setUrl(file_url)
     else:
         # Use online docs
-        full_url = online_base_url + relative_url
+        full_url = online_base_url.rstrip("/") + "/" + relative_url
         _presenter.view.browser.setUrl(QUrl(full_url))
 
     _presenter.show_help_window()
+
+
+def main():
+    """
+    Run this script standalone to test the Python-based Help Window.
+    """
+    parser = argparse.ArgumentParser(description="Standalone test of the Python-based Mantid Help Window.")
+    parser.add_argument(
+        "relative_url", nargs="?", default="", help="Relative doc path (like 'algorithms/Load-v1.html'), defaults to 'index.html' if empty."
+    )
+    parser.add_argument("--local-docs", default=None, help="Path to local Mantid HTML docs. If valid, the viewer will load docs from here.")
+    parser.add_argument(
+        "--online-base-url", default="https://docs.mantidproject.org/", help="Online docs base URL if local docs are not set or invalid."
+    )
+    args = parser.parse_args()
+    if args.local_docs is None:
+        # e.g. MANTID_LOCAL_DOCS_BASE is /path/to/build/docs/html
+        args.local_docs = os.environ.get("MANTID_LOCAL_DOCS_BASE", None)
+    app = QApplication(sys.argv)
+
+    show_help_page(relative_url=args.relative_url, local_docs=args.local_docs, online_base_url=args.online_base_url)
+
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
@@ -6,8 +6,9 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
 import sys
-from mantidqt.widgets.helpwindow.helpwindowpresenter import HelpWindowPresenter
+
 from qtpy.QtWidgets import QApplication
+from mantidqt.widgets.helpwindow.helpwindowpresenter import HelpWindowPresenter
 
 _presenter = None
 
@@ -28,10 +29,6 @@ def show_help_page(relative_url, local_docs=None, online_base_url="https://docs.
 def main(cmdargs=None):
     """
     Run this script standalone to test the Python-based Help Window.
-
-    Example:
-      python helpwindowbridge.py algorithms/Load-v1.html \
-          --local-docs /path/to/build/docs/html
     """
     import argparse
 

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
@@ -7,58 +7,53 @@
 import os
 import sys
 from mantidqt.widgets.helpwindow.helpwindowpresenter import HelpWindowPresenter
-from qtpy.QtCore import QUrl
 from qtpy.QtWidgets import QApplication
-
 
 _presenter = None
 
 
 def show_help_page(relative_url, local_docs=None, online_base_url="https://docs.mantidproject.org/"):
     """
-    Show the help window at the given relative URL path
+    Show the help window at the given relative URL path.
     """
     global _presenter
     if _presenter is None:
-        _presenter = HelpWindowPresenter()
+        # Create a Presenter once. Re-use it on subsequent calls.
+        _presenter = HelpWindowPresenter(local_docs=local_docs, online_base_url=online_base_url)
 
-    if not relative_url or not relative_url.endswith(".html"):
-        relative_url = "index.html"
-
-    if local_docs and os.path.isdir(local_docs):
-        # Use local docs
-        full_path = os.path.join(local_docs, relative_url)
-        file_url = QUrl.fromLocalFile(full_path)
-        _presenter.view.browser.setUrl(file_url)
-    else:
-        # Use online docs
-        full_url = online_base_url.rstrip("/") + "/" + relative_url
-        _presenter.view.browser.setUrl(QUrl(full_url))
-
-    _presenter.show_help_window()
+    # Ask the Presenter to load the requested page
+    _presenter.showHelpPage(relative_url)
 
 
 def main(cmdargs=None):
     """
     Run this script standalone to test the Python-based Help Window.
+
+    Example:
+      python helpwindowbridge.py algorithms/Load-v1.html \
+          --local-docs /path/to/build/docs/html
     """
     import argparse
 
     parser = argparse.ArgumentParser(description="Standalone test of the Python-based Mantid Help Window.")
     parser.add_argument(
-        "relative_url", nargs="?", default="", help="Relative doc path (like 'algorithms/Load-v1.html'), defaults to 'index.html' if empty."
+        "relative_url", nargs="?", default="", help="Relative doc path (e.g. 'algorithms/Load-v1.html'), defaults to 'index.html' if empty."
     )
-    parser.add_argument("--local-docs", default=None, help="Path to local Mantid HTML docs. If valid, the viewer will load docs from here.")
+    parser.add_argument("--local-docs", default=None, help="Path to local Mantid HTML docs. Overrides environment if set.")
     parser.add_argument(
-        "--online-base-url", default="https://docs.mantidproject.org/", help="Online docs base URL if local docs are not set or invalid."
+        "--online-base-url",
+        default="https://docs.mantidproject.org/",
+        help="Base URL for online docs if local docs are not set or invalid.",
     )
     args = parser.parse_args(cmdargs or sys.argv[1:])
 
+    # If user gave no --local-docs, fall back to environment
     if args.local_docs is None:
-        # e.g. MANTID_LOCAL_DOCS_BASE is /path/to/build/docs/html
         args.local_docs = os.environ.get("MANTID_LOCAL_DOCS_BASE", None)
 
     app = QApplication(sys.argv)
+
+    # Show the requested help page
     show_help_page(relative_url=args.relative_url, local_docs=args.local_docs, online_base_url=args.online_base_url)
 
     sys.exit(app.exec_())

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
@@ -1,0 +1,36 @@
+import os
+from mantidqt.widgets.helpwindow.helpwindowpresenter import HelpWindowPresenter
+from qtpy.QtCore import QUrl
+
+_presenter = None
+
+online_base_url = "https://docs.mantidproject.org/"
+# NOTE: Once you build the html docs using the command ninja docs-html, you will need to
+#      use the command export MANTID_LOCAL_DOCS_BASE="/path/to/build/docs/html".
+#      If this it not set, this will default to the online docs.
+local_docs_base = os.environ.get("MANTID_LOCAL_DOCS_BASE")  # e.g. /path/to/build/docs/html
+
+
+def show_help_page(relative_url):
+    """
+    Show the help window at the given relative URL path, e.g. "algorithms/Load-v1.html".
+    """
+    global _presenter
+    if _presenter is None:
+        _presenter = HelpWindowPresenter()
+
+    # Default to index.html if no specific file given
+    if not relative_url or not relative_url.endswith(".html"):
+        relative_url = "index.html"
+
+    if local_docs_base and os.path.isdir(local_docs_base):
+        # Use local docs
+        full_path = os.path.join(local_docs_base, relative_url)
+        file_url = QUrl.fromLocalFile(full_path)
+        _presenter.view.browser.setUrl(file_url)
+    else:
+        # Use online docs
+        full_url = online_base_url + relative_url
+        _presenter.view.browser.setUrl(QUrl(full_url))
+
+    _presenter.show_help_window()

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
@@ -4,20 +4,14 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-import argparse
 import os
 import sys
 from mantidqt.widgets.helpwindow.helpwindowpresenter import HelpWindowPresenter
 from qtpy.QtCore import QUrl
 from qtpy.QtWidgets import QApplication
 
-_presenter = None
 
-# online_base_url = "https://docs.mantidproject.org/"
-# # NOTE: Once you build the html docs using the command ninja docs-html, you will need to
-# #      use the command export MANTID_LOCAL_DOCS_BASE="/path/to/build/docs/html".
-# #      If this it not set, this will default to the online docs.
-# local_docs_base = os.environ.get("MANTID_LOCAL_DOCS_BASE")  # e.g. /path/to/build/docs/html
+_presenter = None
 
 
 def show_help_page(relative_url, local_docs=None, online_base_url="https://docs.mantidproject.org/"):
@@ -44,10 +38,12 @@ def show_help_page(relative_url, local_docs=None, online_base_url="https://docs.
     _presenter.show_help_window()
 
 
-def main():
+def main(cmdargs=None):
     """
     Run this script standalone to test the Python-based Help Window.
     """
+    import argparse
+
     parser = argparse.ArgumentParser(description="Standalone test of the Python-based Mantid Help Window.")
     parser.add_argument(
         "relative_url", nargs="?", default="", help="Relative doc path (like 'algorithms/Load-v1.html'), defaults to 'index.html' if empty."
@@ -56,12 +52,13 @@ def main():
     parser.add_argument(
         "--online-base-url", default="https://docs.mantidproject.org/", help="Online docs base URL if local docs are not set or invalid."
     )
-    args = parser.parse_args()
+    args = parser.parse_args(cmdargs or sys.argv[1:])
+
     if args.local_docs is None:
         # e.g. MANTID_LOCAL_DOCS_BASE is /path/to/build/docs/html
         args.local_docs = os.environ.get("MANTID_LOCAL_DOCS_BASE", None)
-    app = QApplication(sys.argv)
 
+    app = QApplication(sys.argv)
     show_help_page(relative_url=args.relative_url, local_docs=args.local_docs, online_base_url=args.online_base_url)
 
     sys.exit(app.exec_())

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
@@ -4,10 +4,44 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-class HelpWindowModel:
-    def __init__(self):
-        self.help_url = "https://docs.mantidproject.org/"
+import os
+from qtpy.QtCore import QUrl
 
-    def get_help_url(self):
-        """Get the help documentation URL."""
-        return self.help_url
+
+class HelpWindowModel:
+    def __init__(self, local_docs_base=None, online_base="https://docs.mantidproject.org/"):
+        self.local_docs_base = local_docs_base
+        self.online_base = online_base.rstrip("/")
+
+    def build_help_url(self, relative_url):
+        """
+        Returns a QUrl pointing to either local or online docs for the given relative URL.
+        """
+        if not relative_url or not relative_url.endswith(".html"):
+            relative_url = "index.html"
+
+        if self.local_docs_base and os.path.isdir(self.local_docs_base):
+            full_path = os.path.join(self.local_docs_base, relative_url)
+            return QUrl.fromLocalFile(full_path)
+        else:
+            return QUrl(self.online_base + "/" + relative_url)
+
+    def is_local_docs_enabled(self):
+        """
+        :return: True if local_docs_base is set and is a valid directory
+        """
+        return bool(self.local_docs_base and os.path.isdir(self.local_docs_base))
+
+    def get_home_url(self):
+        """
+        Return the 'home' page URL:
+          - Local 'index.html' if local docs are enabled
+          - Online docs homepage otherwise
+        """
+        if self.is_local_docs_enabled():
+            # local docs base + 'index.html'
+            full_path = os.path.join(self.local_docs_base, "index.html")
+            return QUrl.fromLocalFile(full_path)
+        else:
+            # online base
+            return QUrl(self.online_base + "/index.html")

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
@@ -1,0 +1,7 @@
+class HelpWindowModel:
+    def __init__(self):
+        self.help_url = "https://docs.mantidproject.org/"
+
+    def get_help_url(self):
+        """Get the help documentation URL."""
+        return self.help_url

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
@@ -32,6 +32,8 @@ class LocalRequestInterceptor(QWebEngineUrlRequestInterceptor):
 
 class HelpWindowModel:
     def __init__(self, local_docs_base=None, online_base="https://docs.mantidproject.org/"):
+        if local_docs_base and not os.path.isdir(local_docs_base):
+            raise ValueError(f"Local docs directory '{local_docs_base}' does not exist or is invalid.")
         self.local_docs_base = local_docs_base
         self.online_base = online_base.rstrip("/")
 

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
@@ -1,3 +1,9 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
 class HelpWindowModel:
     def __init__(self):
         self.help_url = "https://docs.mantidproject.org/"

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowmodel.py
@@ -6,12 +6,40 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
 from qtpy.QtCore import QUrl
+from qtpy.QtWebEngineCore import QWebEngineUrlRequestInterceptor, QWebEngineUrlRequestInfo
+
+
+class NoOpRequestInterceptor(QWebEngineUrlRequestInterceptor):
+    """
+    A no-op interceptor that does nothing. Used if we're not loading local docs.
+    """
+
+    def interceptRequest(self, info: QWebEngineUrlRequestInfo):
+        pass
+
+
+class LocalRequestInterceptor(QWebEngineUrlRequestInterceptor):
+    """
+    Intercepts requests so we can relax the CORS policy for loading MathJax fonts
+    from cdn.jsdelivr.net when using local docs.
+    """
+
+    def interceptRequest(self, info: QWebEngineUrlRequestInfo):
+        url = info.requestUrl()
+        if url.host() == "cdn.jsdelivr.net":
+            info.setHttpHeader(b"Access-Control-Allow-Origin", b"*")
 
 
 class HelpWindowModel:
     def __init__(self, local_docs_base=None, online_base="https://docs.mantidproject.org/"):
         self.local_docs_base = local_docs_base
         self.online_base = online_base.rstrip("/")
+
+    def is_local_docs_enabled(self):
+        """
+        :return: True if local_docs_base is set and is a valid directory
+        """
+        return bool(self.local_docs_base and os.path.isdir(self.local_docs_base))
 
     def build_help_url(self, relative_url):
         """
@@ -20,28 +48,31 @@ class HelpWindowModel:
         if not relative_url or not relative_url.endswith(".html"):
             relative_url = "index.html"
 
-        if self.local_docs_base and os.path.isdir(self.local_docs_base):
+        if self.is_local_docs_enabled():
             full_path = os.path.join(self.local_docs_base, relative_url)
             return QUrl.fromLocalFile(full_path)
         else:
             return QUrl(self.online_base + "/" + relative_url)
 
-    def is_local_docs_enabled(self):
-        """
-        :return: True if local_docs_base is set and is a valid directory
-        """
-        return bool(self.local_docs_base and os.path.isdir(self.local_docs_base))
-
     def get_home_url(self):
         """
         Return the 'home' page URL:
-          - Local 'index.html' if local docs are enabled
-          - Online docs homepage otherwise
+          - local 'index.html' if local docs are enabled
+          - online docs homepage otherwise
         """
         if self.is_local_docs_enabled():
-            # local docs base + 'index.html'
             full_path = os.path.join(self.local_docs_base, "index.html")
             return QUrl.fromLocalFile(full_path)
         else:
-            # online base
             return QUrl(self.online_base + "/index.html")
+
+    def create_request_interceptor(self):
+        """
+        Return an appropriate request interceptor:
+          - LocalRequestInterceptor if local docs are used (for mathjax CORS)
+          - NoOpRequestInterceptor otherwise
+        """
+        if self.is_local_docs_enabled():
+            return LocalRequestInterceptor()
+        else:
+            return NoOpRequestInterceptor()

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
@@ -1,0 +1,35 @@
+from .helpwindowview import HelpWindowView
+from .helpwindowmodel import HelpWindowModel
+
+
+class HelpWindowPresenter:
+    def __init__(self, parent_app=None):
+        """
+        Initialize the presenter for the Help Window.
+        :param parent_app: Optional parent application to tie the lifecycle of this presenter.
+        """
+        self.model = HelpWindowModel()
+        self.view = HelpWindowView(self)
+        self.parent_app = parent_app
+        self._window_open = False
+
+        if self.parent_app:
+            self.parent_app.aboutToQuit.connect(self.cleanup)
+
+    def show_help_window(self):
+        """Show the help window."""
+        if not self._window_open:
+            self._window_open = True
+            self.view.display()
+
+    def on_close(self):
+        """Handle actions when the window is closed."""
+        print("Help window closed.")
+        self.cleanup()
+
+    def cleanup(self):
+        """Ensure proper cleanup of resources."""
+        if self._window_open:
+            self._window_open = False
+            print("Cleaning up Help Window resources.")
+            self.view.close()

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
@@ -1,3 +1,9 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
 from .helpwindowview import HelpWindowView
 from .helpwindowmodel import HelpWindowModel
 

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
@@ -4,38 +4,54 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from .helpwindowview import HelpWindowView
 from .helpwindowmodel import HelpWindowModel
+from .helpwindowview import HelpWindowView
 
 
 class HelpWindowPresenter:
-    def __init__(self, parent_app=None):
-        """
-        Initialize the presenter for the Help Window.
-        :param parent_app: Optional parent application to tie the lifecycle of this presenter.
-        """
-        self.model = HelpWindowModel()
-        self.view = HelpWindowView(self)
+    def __init__(self, parent_app=None, local_docs=None, online_base_url="https://docs.mantidproject.org/"):
+        self.model = HelpWindowModel(local_docs_base=local_docs, online_base=online_base_url)
+
+        # The View is told whether local docs are in use so it can set up the request interceptor
+        use_local = self.model.is_local_docs_enabled()
+        self.view = HelpWindowView(self, using_local_docs=use_local)
+
         self.parent_app = parent_app
         self._window_open = False
 
         if self.parent_app:
             self.parent_app.aboutToQuit.connect(self.cleanup)
 
+    def showHelpPage(self, relative_url):
+        """
+        Build the doc URL from the Model and tell the View to load it.
+        """
+        doc_url = self.model.build_help_url(relative_url)
+        self.view.set_page_url(doc_url)
+        self.show_help_window()
+
     def show_help_window(self):
-        """Show the help window."""
         if not self._window_open:
             self._window_open = True
             self.view.display()
 
     def on_close(self):
-        """Handle actions when the window is closed."""
+        """Called by the View when the window closes."""
         print("Help window closed.")
         self.cleanup()
 
     def cleanup(self):
-        """Ensure proper cleanup of resources."""
+        """Cleanup resources, close the View if open."""
         if self._window_open:
             self._window_open = False
             print("Cleaning up Help Window resources.")
             self.view.close()
+
+    def show_home_page(self):
+        """
+        Presenter logic to load the 'Home' page, which might be local or online.
+        The View calls this when the user hits the Home button.
+        """
+        home_url = self.model.get_home_url()
+        self.view.set_page_url(home_url)
+        self.show_help_window()

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowview.py
@@ -12,7 +12,7 @@ from qtpy.QtGui import QIcon
 from qtpy.QtWebEngineCore import QWebEngineUrlRequestInterceptor, QWebEngineUrlRequestInfo
 
 
-class MyRequestInterceptor(QWebEngineUrlRequestInterceptor):
+class LocalRequestInterceptor(QWebEngineUrlRequestInterceptor):
     """
     Intercepts requests in QWebEngineView so we can relax the CORS policy
     for loading MathJax fonts from cdn.jsdelivr.net when local docs are in use.
@@ -38,7 +38,7 @@ class HelpWindowView(QMainWindow):
         # Determine initial URL
         local_docs_base = os.environ.get("MANTID_LOCAL_DOCS_BASE")
         if local_docs_base and os.path.isdir(local_docs_base):
-            interceptor = MyRequestInterceptor()
+            interceptor = LocalRequestInterceptor()
             profile = self.browser.page().profile()
             profile.setUrlRequestInterceptor(interceptor)
 

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowview.py
@@ -1,3 +1,9 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
 import os
 from qtpy.QtWidgets import QMainWindow, QVBoxLayout, QToolBar, QPushButton, QWidget
 from qtpy.QtWebEngineWidgets import QWebEngineView

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowview.py
@@ -8,23 +8,10 @@ from qtpy.QtWidgets import QMainWindow, QVBoxLayout, QToolBar, QPushButton, QWid
 from qtpy.QtWebEngineWidgets import QWebEngineView, QWebEngineSettings
 from qtpy.QtCore import QUrl
 from qtpy.QtGui import QIcon
-from qtpy.QtWebEngineCore import QWebEngineUrlRequestInterceptor, QWebEngineUrlRequestInfo
-
-
-class LocalRequestInterceptor(QWebEngineUrlRequestInterceptor):
-    """
-    Intercepts requests so we can relax the CORS policy
-    for loading MathJax fonts from cdn.jsdelivr.net if local docs are used.
-    """
-
-    def interceptRequest(self, info: QWebEngineUrlRequestInfo):
-        url = info.requestUrl()
-        if url.host() == "cdn.jsdelivr.net":
-            info.setHttpHeader(b"Access-Control-Allow-Origin", b"*")
 
 
 class HelpWindowView(QMainWindow):
-    def __init__(self, presenter, using_local_docs=False):
+    def __init__(self, presenter, interceptor=None):
         super().__init__()
         self.presenter = presenter
         self.setWindowTitle("Python Help Window")
@@ -36,9 +23,8 @@ class HelpWindowView(QMainWindow):
         # Allow local file:// docs to load remote resources (fonts, scripts, etc.)
         QWebEngineSettings.globalSettings().setAttribute(QWebEngineSettings.LocalContentCanAccessRemoteUrls, True)
 
-        # If local docs are used, set up request interceptor
-        if using_local_docs:
-            interceptor = LocalRequestInterceptor()
+        # If the interceptor is not None, apply it to the current profile
+        if interceptor is not None:
             profile = self.browser.page().profile()
             profile.setUrlRequestInterceptor(interceptor)
 

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowview.py
@@ -1,0 +1,77 @@
+import os
+from qtpy.QtWidgets import QMainWindow, QVBoxLayout, QToolBar, QPushButton, QWidget
+from qtpy.QtWebEngineWidgets import QWebEngineView
+from qtpy.QtCore import QUrl
+from qtpy.QtGui import QIcon
+
+
+class HelpWindowView(QMainWindow):
+    def __init__(self, presenter):
+        super().__init__()
+        self.presenter = presenter
+        self.setWindowTitle("Python Help Window")
+        self.resize(800, 600)
+
+        # Web browser widget
+        self.browser = QWebEngineView()
+
+        # Determine initial URL
+        local_docs_base = os.environ.get("MANTID_LOCAL_DOCS_BASE")
+        if local_docs_base and os.path.isdir(local_docs_base):
+            index_path = os.path.join(local_docs_base, "index.html")
+            self.browser.setUrl(QUrl.fromLocalFile(index_path))
+        else:
+            self.browser.setUrl(QUrl("https://docs.mantidproject.org/"))
+
+        # Toolbar with navigation buttons
+        self.toolbar = QToolBar("Navigation")
+        self.addToolBar(self.toolbar)
+
+        # Back button
+        back_button = QPushButton()
+        back_button.setIcon(QIcon.fromTheme("go-previous"))
+        back_button.setToolTip("Go Back")
+        back_button.clicked.connect(self.browser.back)
+        self.toolbar.addWidget(back_button)
+
+        # Forward button
+        forward_button = QPushButton()
+        forward_button.setIcon(QIcon.fromTheme("go-next"))
+        forward_button.setToolTip("Go Forward")
+        forward_button.clicked.connect(self.browser.forward)
+        self.toolbar.addWidget(forward_button)
+
+        # Home button
+        home_button = QPushButton()
+        home_button.setIcon(QIcon.fromTheme("go-home"))
+        home_button.setToolTip("Go Home")
+        home_button.clicked.connect(self.go_home)
+        self.toolbar.addWidget(home_button)
+
+        # Reload button
+        reload_button = QPushButton()
+        reload_button.setIcon(QIcon.fromTheme("view-refresh"))
+        reload_button.setToolTip("Reload")
+        reload_button.clicked.connect(self.browser.reload)
+        self.toolbar.addWidget(reload_button)
+
+        # Layout
+        layout = QVBoxLayout()
+        layout.addWidget(self.browser)
+
+        container = QWidget()
+        container.setLayout(layout)
+        self.setCentralWidget(container)
+
+    def go_home(self):
+        """Navigate to the home page."""
+        self.browser.setUrl(QUrl("https://docs.mantidproject.org/"))
+
+    def display(self):
+        """Show the help window."""
+        self.show()
+
+    def closeEvent(self, event):
+        """Handle the close event and notify the presenter."""
+        self.presenter.on_close()
+        super().closeEvent(event)

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/__init__.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
@@ -1,0 +1,63 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+import os
+import tempfile
+import shutil
+import unittest
+
+from mantidqt.widgets.helpwindow.helpwindowmodel import HelpWindowModel
+
+
+class TestHelpWindowModel(unittest.TestCase):
+    def setUp(self):
+        # We can create a temporary directory to simulate "local_docs_base" that actually exists
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        # Clean up any temporary directories
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_init_with_local_docs_configures_for_local(self):
+        model = HelpWindowModel(local_docs_base=self.temp_dir, online_base="https://example.org")
+
+        # The model should see this as local
+        self.assertTrue(model.is_local_docs_enabled(), "Expected is_local_docs_enabled() to be True for a valid folder")
+
+        # build_help_url should produce a file:// URL
+        test_url = model.build_help_url("algorithms/MyAlgorithm-v1.html")
+        self.assertTrue(test_url.isLocalFile(), "Expected a local file:// URL")
+
+        # home url also should be local
+        home_url = model.get_home_url()
+        self.assertTrue(home_url.isLocalFile(), "Expected a local file:// for home URL")
+
+    def test_init_with_no_local_docs_uses_online(self):
+        model = HelpWindowModel(local_docs_base=None, online_base="https://example.org")
+
+        # The model should see this as NOT local
+        self.assertFalse(model.is_local_docs_enabled(), "Expected is_local_docs_enabled() to be False")
+
+        # build_help_url should produce an https://example.org/ URL
+        test_url = model.build_help_url("algorithms/MyAlgorithm-v1.html")
+        self.assertTrue(test_url.toString().startswith("https://example.org/algorithms/"), "Expected an online docs URL")
+
+        # home url also should be online
+        home_url = model.get_home_url()
+        self.assertTrue("example.org/index.html" in home_url.toString(), "Expected an online docs home URL")
+
+    def test_init_with_bad_local_raises_exception(self):
+        # Create a path we know doesn't exist anymore
+        invalid_path = os.path.join(self.temp_dir, "non_existent")
+        # We do NOT create that subfolder
+
+        with self.assertRaises(ValueError):
+            HelpWindowModel(local_docs_base=invalid_path, online_base="https://example.org")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description of work
This pull request introduces the Python-based HelpWindow implementation design for Mantid Workbench. It complements the earlier C++ changes and provides a Python-centric system for managing and displaying help documentation using modern tools such as PyQt and QtWebEngine.
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
- **New Python HelpWindow Implementation**:
  - Introduced a new Python-based HelpWindow that leverages `QtWebEngine` for rendering help documentation.
  - Added navigation and resource management capabilities via a Model-View-Presenter (MVP) pattern for maintainability and clarity.

- **Integration with Environment Variables**:
  - Utilized the `MANTID_LOCAL_DOCS_BASE` environment variable to prioritize local documentation if available.
  - Defaulted to online documentation hosted at `https://docs.mantidproject.org/` when local documentation is unavailable.

- **Dependencies Updated**:
  - Updated `conda/recipes` to include `pyqtwebengine` for enabling the embedded web browser functionality.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Ref #37248  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->
**NOTE:** This current implementation of the Python Help Window is a standalone implementation. Meaning it is not implemented into MantidWorkbench within this PR. The subsequent PR's will enable this feature to be tested in fully deployed way within Workbench.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
Here are the testing instructions to test this feature:

1. Clone workbench repo
2. (from within mantidrepo/) `cmake --preset=linux`
3. `cd build/`
4. `ninja docs-html` (to build html docs)
5. (from mantidrepo/) `MANTID_LOCAL_DOCS_BASE="/path/to/mantid/build/docs/html"   python qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py   algorithms/ConvertDiffCal-v1.html`
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
