### PR TITLE
Fix LoadErrorEventsNexus/PulseIndexer when there are zero events

### DIFF
--- a/Framework/DataHandling/src/LoadErrorEventsNexus.cpp
+++ b/Framework/DataHandling/src/LoadErrorEventsNexus.cpp
@@ -134,6 +134,8 @@ void LoadErrorEventsNexus::exec() {
 
   if (min_tof < max_tof)
     eventWS->setAllX(HistogramData::BinEdges{min_tof, max_tof});
+  else
+    eventWS->setAllX(HistogramData::BinEdges{0, 16666.7});
 
   outWS->getAxis(0)->setUnit("TOF");
   outWS->setYUnit("Counts");

--- a/Framework/DataHandling/src/LoadErrorEventsNexus.cpp
+++ b/Framework/DataHandling/src/LoadErrorEventsNexus.cpp
@@ -132,7 +132,8 @@ void LoadErrorEventsNexus::exec() {
   g_log.information() << "Loaded " << numEvents << " events with TOF min = " << min_tof << ", max = " << max_tof
                       << "\n";
 
-  eventWS->setAllX(HistogramData::BinEdges{min_tof, max_tof});
+  if (min_tof < max_tof)
+    eventWS->setAllX(HistogramData::BinEdges{min_tof, max_tof});
 
   outWS->getAxis(0)->setUnit("TOF");
   outWS->setYUnit("Counts");

--- a/Framework/DataHandling/src/PulseIndexer.cpp
+++ b/Framework/DataHandling/src/PulseIndexer.cpp
@@ -46,7 +46,7 @@ PulseIndexer::PulseIndexer(std::shared_ptr<std::vector<uint64_t>> event_index, c
   // determine if should trim the front end to remove empty pulses
   auto firstPulseIndex = m_roi.front();
   auto eventRange = this->getEventIndexRange(firstPulseIndex);
-  while (eventRange.first == eventRange.second) {
+  while (eventRange.first == eventRange.second && eventRange.first < m_numEvents) {
     ++firstPulseIndex;
     eventRange = this->getEventIndexRange(firstPulseIndex);
   }
@@ -54,7 +54,7 @@ PulseIndexer::PulseIndexer(std::shared_ptr<std::vector<uint64_t>> event_index, c
   // determine if should trim the back end to remove empty pulses
   auto lastPulseIndex = m_roi.back();
   eventRange = this->getEventIndexRange(lastPulseIndex - 1);
-  while (eventRange.first == eventRange.second) {
+  while (eventRange.first == eventRange.second && eventRange.second > 0) {
     --lastPulseIndex;
     eventRange = this->getEventIndexRange(lastPulseIndex - 1);
   }
@@ -146,7 +146,7 @@ size_t PulseIndexer::getLastPulseIndex() const { return m_roi.back(); }
 std::pair<size_t, size_t> PulseIndexer::getEventIndexRange(const size_t pulseIndex) const {
   const auto start = this->getStartEventIndex(pulseIndex);
   // return early if the start is too big
-  if (start > m_numEvents)
+  if (start >= m_numEvents)
     return std::make_pair(start, m_numEvents);
 
   // get the end index

--- a/Framework/DataHandling/test/LoadErrorEventsNexusTest.h
+++ b/Framework/DataHandling/test/LoadErrorEventsNexusTest.h
@@ -74,6 +74,26 @@ public:
     TS_ASSERT_EQUALS(events[0].pulseTime(), Mantid::Types::Core::DateAndTime("2021-10-06T14:25:29.962441733-04:00"))
   }
 
+  void test_CG3_zeroEvents() {
+    // This file contains no events in bank_error_events so should create an EventWorkspace with 0 events
+    LoadErrorEventsNexus alg;
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "unused"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "CG3_960.nxs.h5"))
+    TS_ASSERT(alg.execute());
+
+    Mantid::DataObjects::EventWorkspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);
+
+    TS_ASSERT_EQUALS(outputWS->blocksize(), 1)
+    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1)
+    TS_ASSERT_EQUALS(outputWS->getNumberEvents(), 0)
+    TS_ASSERT_EQUALS(outputWS->readX(0)[0], 0)
+    TS_ASSERT_EQUALS(outputWS->readX(0)[1], std::numeric_limits<double>::min())
+  }
+
   void test_HYSA() {
     // this should fail to load as bank_error_events does not exist in this file
 

--- a/Framework/DataHandling/test/LoadErrorEventsNexusTest.h
+++ b/Framework/DataHandling/test/LoadErrorEventsNexusTest.h
@@ -91,7 +91,7 @@ public:
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1)
     TS_ASSERT_EQUALS(outputWS->getNumberEvents(), 0)
     TS_ASSERT_EQUALS(outputWS->readX(0)[0], 0)
-    TS_ASSERT_EQUALS(outputWS->readX(0)[1], std::numeric_limits<double>::min())
+    TS_ASSERT_DELTA(outputWS->readX(0)[1], 16666.7, 1e-9)
   }
 
   void test_HYSA() {

--- a/Framework/DataHandling/test/PulseIndexerTest.h
+++ b/Framework/DataHandling/test/PulseIndexerTest.h
@@ -169,6 +169,19 @@ public:
     run_test(eventIndices, start_event_index, total_events, first_pulse_index);
   }
 
+  void test_zerosEvents() {
+    // test that the pulse indexer can handle no events
+    auto eventIndices = std::make_shared<std::vector<uint64_t>>();
+    eventIndices->push_back(0);
+    eventIndices->push_back(0);
+
+    constexpr size_t start_event_index{0};
+    constexpr size_t total_events{0};
+    constexpr size_t first_pulse_index{1};
+
+    run_test(eventIndices, start_event_index, total_events, first_pulse_index);
+  }
+
   void test_invalidPulseROI() {
     auto eventIndices = generate_nonConstant();
 

--- a/docs/source/release/v6.12.0/Framework/Algorithms/Bugfixes/38738.rst
+++ b/docs/source/release/v6.12.0/Framework/Algorithms/Bugfixes/38738.rst
@@ -1,0 +1,1 @@
+- Fixed a bug in :ref:`LoadErrorEventsNexus <algm-LoadErrorEventsNexus>` that would cause it to hang when the error bank had zero events.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38696

[9176: [mantid] LoadErrorEventsNexus hangs if the file has no events](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/9176)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Running the following should create an EventWorkspace with zero events, file is in UnitTest data. Before this fix it would get stuck in an infinite loop.

```python
ws=LoadErrorEventsNexus("CG3_960.nxs.h5")
```

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
