### PR TITLE
Fix bug in FitParameter getConstraint

### DIFF
--- a/Framework/Geometry/src/Instrument/FitParameter.cpp
+++ b/Framework/Geometry/src/Instrument/FitParameter.cpp
@@ -49,7 +49,7 @@ std::string FitParameter::getConstraint() const {
       max = std::stod(m_constraintMax);
   }
 
-  if (!(m_constraintMin.empty() && m_constraintMax.empty())) {
+  if (!m_constraintMin.empty() && !m_constraintMax.empty()) {
     constraint << min << " < " << m_name << " < " << max;
   } else if (!m_constraintMin.empty()) {
     constraint << min << " < " << m_name;

--- a/Framework/Geometry/test/FitParameterTest.h
+++ b/Framework/Geometry/test/FitParameterTest.h
@@ -119,4 +119,26 @@ public:
     TS_ASSERT(fitP.getTie().compare("") == 0);
     TS_ASSERT(fitP.getConstraint().compare("3 < name < 8") == 0);
   }
+
+  void testConstraintMinEmptyandMaxNotEmpty() {
+    FitParameter fitP;
+
+    std::istringstream input("9.1 , function , name ,3 ,  , , , , ,    ");
+
+    input >> fitP;
+
+    auto foo = fitP.getConstraint();
+
+    TS_ASSERT(fitP.getConstraint().compare("3 < name") == 0);
+  }
+
+  void testConstraintMinNotEmptyandMaxEmpty() {
+    FitParameter fitP;
+
+    std::istringstream input("9.1 , function , name , ,8 , , , , ,    ");
+
+    input >> fitP;
+
+    TS_ASSERT(fitP.getConstraint().compare("name < 8") == 0);
+  }
 };

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -624,7 +624,6 @@ constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Instrument/CompA
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Instrument/CompAssembly.cpp:405
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Instrument/ComponentInfo.cpp:129
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Instrument/ComponentInfoBankHelpers.cpp:113
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Instrument/FitParameter.cpp:54
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp:593
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp:1552
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp:2330

--- a/docs/source/release/v6.13.0/Framework/Fit_Functions/Bugfixes/38745.rst
+++ b/docs/source/release/v6.13.0/Framework/Fit_Functions/Bugfixes/38745.rst
@@ -1,0 +1,1 @@
+- Fixed logic in FitParameter so that if only a Minimum constraint or only a Maximum constraint is available the string returned will not record a 0 for the unavailable constraint.


### PR DESCRIPTION
### Description of work
As part of fixing cppcheck suppressions (see #38731) a bug was found in getConstraint() in FitParameter.cpp where the loop was always true for the first if so never reached the other parts. This fixes that bug and adds tests to ensure this works as expected.

#### Summary of work
Logic fixed in loop for constraints. Tests added.

*There is no associated issue.*

### To test:

Code review, tests should pass

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
