### PR TITLE
Bravo team cppcheck set 20

### DIFF
--- a/Framework/API/inc/MantidAPI/IFunctionMW.h
+++ b/Framework/API/inc/MantidAPI/IFunctionMW.h
@@ -41,7 +41,7 @@ protected:
   /// Keep a weak pointer to the workspace
   std::weak_ptr<const API::MatrixWorkspace> m_workspace;
   /// An index to a spectrum
-  size_t m_workspaceIndex;
+  size_t m_workspaceIndex = 0;
 };
 
 } // namespace API

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -161,7 +161,7 @@ void SaveLauenorm::exec() {
   double minD = EMPTY_DBL();
   for (int wi = 0; wi < ws->getNumberPeaks(); wi++) {
 
-    Peak const &p = peaks[wi];
+    const Peak &p = peaks[wi];
     double intensity = p.getIntensity();
     double sigI = p.getSigmaIntensity();
     if (intensity == 0.0 || !(std::isfinite(sigI)))

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -161,7 +161,7 @@ void SaveLauenorm::exec() {
   double minD = EMPTY_DBL();
   for (int wi = 0; wi < ws->getNumberPeaks(); wi++) {
 
-    Peak &p = peaks[wi];
+    Peak const &p = peaks[wi];
     double intensity = p.getIntensity();
     double sigI = p.getSigmaIntensity();
     if (intensity == 0.0 || !(std::isfinite(sigI)))
@@ -231,7 +231,7 @@ void SaveLauenorm::exec() {
   // Go through each peak at this run / bank
   for (int wi = 0; wi < ws->getNumberPeaks(); wi++) {
 
-    Peak &p = peaks[wi];
+    Peak const &p = peaks[wi];
     double intensity = p.getIntensity();
     double sigI = p.getSigmaIntensity();
     if (intensity == 0.0 || !(std::isfinite(sigI)))

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -231,7 +231,7 @@ void SaveLauenorm::exec() {
   // Go through each peak at this run / bank
   for (int wi = 0; wi < ws->getNumberPeaks(); wi++) {
 
-    Peak const &p = peaks[wi];
+    const Peak &p = peaks[wi];
     double intensity = p.getIntensity();
     double sigI = p.getSigmaIntensity();
     if (intensity == 0.0 || !(std::isfinite(sigI)))

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/Fit1D.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/Fit1D.h
@@ -58,7 +58,7 @@ public:
   virtual void functionDeriv(const double *in, API::Jacobian *out, const double *xValues, const size_t nData);
 
 protected:
-  ~Fit1D() = default;
+  ~Fit1D() override = default;
   // Overridden Algorithm methods
   void init() override;
   void exec() override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PawleyFit.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PawleyFit.h
@@ -49,7 +49,7 @@ protected:
 class MANTID_CURVEFITTING_DLL PawleyFit : public API::Algorithm {
 public:
   PawleyFit();
-  virtual ~PawleyFit() = default;
+  virtual ~PawleyFit() override = default;
   const std::string name() const override { return "PawleyFit"; }
   int version() const override { return 1; }
   const std::vector<std::string> seeAlso() const override { return {"PoldiPeakSearch"}; }

--- a/Framework/CurveFitting/inc/MantidCurveFitting/EigenVector.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/EigenVector.h
@@ -88,7 +88,7 @@ public:
   /// Sort this vector in order defined by an index array
   void sort(const std::vector<size_t> &indices);
   /// Copy the values to an std vector of doubles
-  std::vector<double> toStdVector() const;
+  const std::vector<double> toStdVector() const;
   /// Return a reference to m_data
   std::vector<double> &StdVectorRef();
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/EigenVector.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/EigenVector.h
@@ -88,7 +88,7 @@ public:
   /// Sort this vector in order defined by an index array
   void sort(const std::vector<size_t> &indices);
   /// Copy the values to an std vector of doubles
-  const std::vector<double> toStdVector() const;
+  const std::vector<double> &toStdVector() const;
   /// Return a reference to m_data
   std::vector<double> &StdVectorRef();
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BSpline.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BSpline.h
@@ -31,7 +31,6 @@ public:
   BSpline();
   /// overwrite IFunction base class methods
   std::string name() const override { return "BSpline"; }
-  const std::string category() const { return "Background"; }
   void function1D(double *out, const double *xValues, const size_t nData) const override;
   void derivative1D(double *out, const double *xValues, size_t nData, const size_t order) const override;
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BSpline.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BSpline.h
@@ -31,7 +31,7 @@ public:
   BSpline();
   /// overwrite IFunction base class methods
   std::string name() const override { return "BSpline"; }
-  const std::string category() const override { return "Background"; }
+  const std::string category() const { return "Background"; }
   void function1D(double *out, const double *xValues, const size_t nData) const override;
   void derivative1D(double *out, const double *xValues, size_t nData, const size_t order) const override;
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Chebyshev.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Chebyshev.h
@@ -34,7 +34,6 @@ public:
 
   /// overwrite IFunction base class methods
   std::string name() const override { return "Chebyshev"; }
-  const std::string category() const { return "Background"; }
   void function1D(double *out, const double *xValues, const size_t nData) const override;
   void functionDeriv1D(API::Jacobian *out, const double *xValues, const size_t nData) override;
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Chebyshev.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Chebyshev.h
@@ -34,7 +34,7 @@ public:
 
   /// overwrite IFunction base class methods
   std::string name() const override { return "Chebyshev"; }
-  const std::string category() const override { return "Background"; }
+  const std::string category() const { return "Background"; }
   void function1D(double *out, const double *xValues, const size_t nData) const override;
   void functionDeriv1D(API::Jacobian *out, const double *xValues, const size_t nData) override;
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Convolution.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Convolution.h
@@ -102,7 +102,6 @@ public:
 
   /// overwrite IFunction base class methods
   std::string name() const override { return "Convolution"; }
-  const std::string category() const { return "General"; }
   /// Function you want to fit to.
   void function(const API::FunctionDomain &domain, API::FunctionValues &values) const override;
   void functionFFTMode(const API::FunctionDomain &domain, API::FunctionValues &values) const;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Convolution.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Convolution.h
@@ -102,7 +102,7 @@ public:
 
   /// overwrite IFunction base class methods
   std::string name() const override { return "Convolution"; }
-  const std::string category() const override { return "General"; }
+  const std::string category() const { return "General"; }
   /// Function you want to fit to.
   void function(const API::FunctionDomain &domain, API::FunctionValues &values) const override;
   void functionFFTMode(const API::FunctionDomain &domain, API::FunctionValues &values) const;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h
@@ -23,7 +23,6 @@ class MANTID_CURVEFITTING_DLL CrystalFieldFunction : public API::IFunction {
 public:
   CrystalFieldFunction();
   std::string name() const override { return "CrystalFieldFunction"; }
-  const std::string category() const { return "General"; }
   size_t getNumberDomains() const override;
   std::vector<API::IFunction_sptr> createEquivalentFunctions() const override;
   /// Evaluate the function

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h
@@ -23,7 +23,7 @@ class MANTID_CURVEFITTING_DLL CrystalFieldFunction : public API::IFunction {
 public:
   CrystalFieldFunction();
   std::string name() const override { return "CrystalFieldFunction"; }
-  const std::string category() const override { return "General"; }
+  const std::string category() const { return "General"; }
   size_t getNumberDomains() const override;
   std::vector<API::IFunction_sptr> createEquivalentFunctions() const override;
   /// Evaluate the function

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMultiSpectrum.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMultiSpectrum.h
@@ -23,7 +23,6 @@ public:
 
   void init() override;
   std::string name() const override { return "CrystalFieldMultiSpectrum"; }
-  const std::string category() const { return "General"; }
   size_t getNumberDomains() const override;
   void setAttribute(const std::string &name, const Attribute &) override;
   std::vector<API::IFunction_sptr> createEquivalentFunctions() const override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMultiSpectrum.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMultiSpectrum.h
@@ -23,7 +23,7 @@ public:
 
   void init() override;
   std::string name() const override { return "CrystalFieldMultiSpectrum"; }
-  const std::string category() const override { return "General"; }
+  const std::string category() const { return "General"; }
   size_t getNumberDomains() const override;
   void setAttribute(const std::string &name, const Attribute &) override;
   std::vector<API::IFunction_sptr> createEquivalentFunctions() const override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
@@ -21,7 +21,7 @@ public:
 
   void init() override;
   std::string name() const override { return "CrystalFieldSpectrum"; }
-  const std::string category() const override { return "General"; }
+  const std::string category() const { return "General"; }
   void buildTargetFunction() const override;
 
 protected:

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
@@ -21,7 +21,6 @@ public:
 
   void init() override;
   std::string name() const override { return "CrystalFieldSpectrum"; }
-  const std::string category() const { return "General"; }
   void buildTargetFunction() const override;
 
 protected:

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CubicSpline.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CubicSpline.h
@@ -36,7 +36,7 @@ public:
 
   /// overwrite IFunction base class methods
   std::string name() const override { return "CubicSpline"; }
-  const std::string category() const override { return "Background"; }
+  const std::string category() const { return "Background"; }
   void function1D(double *out, const double *xValues, const size_t nData) const override;
   void derivative1D(double *out, const double *xValues, size_t nData, const size_t order) const override;
   void setParameter(size_t i, const double &value, bool explicitlySet = true) override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CubicSpline.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CubicSpline.h
@@ -36,7 +36,6 @@ public:
 
   /// overwrite IFunction base class methods
   std::string name() const override { return "CubicSpline"; }
-  const std::string category() const { return "Background"; }
   void function1D(double *out, const double *xValues, const size_t nData) const override;
   void derivative1D(double *out, const double *xValues, size_t nData, const size_t order) const override;
   void setParameter(size_t i, const double &value, bool explicitlySet = true) override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FullprofPolynomial.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FullprofPolynomial.h
@@ -22,7 +22,7 @@ public:
   /// Overwrite IFunction base class
   std::string name() const override { return "FullprofPolynomial"; }
 
-  const std::string category() const override { return "Background"; }
+  const std::string category() const { return "Background"; }
 
   void function1D(double *out, const double *xValues, const size_t nData) const override;
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FullprofPolynomial.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FullprofPolynomial.h
@@ -22,8 +22,6 @@ public:
   /// Overwrite IFunction base class
   std::string name() const override { return "FullprofPolynomial"; }
 
-  const std::string category() const { return "Background"; }
-
   void function1D(double *out, const double *xValues, const size_t nData) const override;
 
   void functionDeriv1D(API::Jacobian *out, const double *xValues, const size_t nData) override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PawleyFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PawleyFunction.h
@@ -49,7 +49,7 @@ public:
   std::string getProfileFunctionName() const { return getAttribute("ProfileFunction").asString(); }
 
   /// Returns the name of the stored function's center parameter
-  const std::string getProfileFunctionCenterParameterName() const { return m_profileFunctionCenterParameterName; }
+  const std::string &getProfileFunctionCenterParameterName() const { return m_profileFunctionCenterParameterName; }
 
   void function(const API::FunctionDomain &domain, API::FunctionValues &values) const override;
   void functionDeriv(const API::FunctionDomain &domain, API::Jacobian &jacobian) override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PawleyFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PawleyFunction.h
@@ -49,7 +49,7 @@ public:
   std::string getProfileFunctionName() const { return getAttribute("ProfileFunction").asString(); }
 
   /// Returns the name of the stored function's center parameter
-  std::string getProfileFunctionCenterParameterName() const { return m_profileFunctionCenterParameterName; }
+  const std::string getProfileFunctionCenterParameterName() const { return m_profileFunctionCenterParameterName; }
 
   void function(const API::FunctionDomain &domain, API::FunctionValues &values) const override;
   void functionDeriv(const API::FunctionDomain &domain, API::Jacobian &jacobian) override;

--- a/Framework/CurveFitting/src/EigenVector.cpp
+++ b/Framework/CurveFitting/src/EigenVector.cpp
@@ -273,7 +273,7 @@ void EigenVector::sort(const std::vector<size_t> &indices) {
 }
 
 /// Copy the values to an std vector of doubles
-std::vector<double> EigenVector::toStdVector() const { return m_data; }
+const std::vector<double> &EigenVector::toStdVector() const { return m_data; }
 
 /// return reference to m_data
 std::vector<double> &EigenVector::StdVectorRef() { return m_data; }

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -327,8 +327,6 @@ containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveHKL.cpp:607
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawPeaks.cpp:508
 constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawUB.cpp:49
 constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawUB.cpp:50
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveLauenorm.cpp:164
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveLauenorm.cpp:234
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SelectCellWithForm.cpp:134
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/Fit1D.h:61
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PawleyFit.h:52

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -328,7 +328,6 @@ passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawPeaks.cpp:508
 constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawUB.cpp:49
 constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawUB.cpp:50
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SelectCellWithForm.cpp:134
-returnByReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/EigenVector.h:91
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BSpline.h:34
 uninitDerivedMemberVar:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Bk2BkExpConvPV.h:28
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Chebyshev.h:37
@@ -338,7 +337,6 @@ uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFittin
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h:24
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CubicSpline.h:39
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FullprofPolynomial.h:25
-returnByReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PawleyFunction.h:52
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/UserFunction1D.h:64
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/EstimateFitParameters.cpp:214
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/EstimateFitParameters.cpp:260

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -328,7 +328,6 @@ passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawPeaks.cpp:508
 constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawUB.cpp:49
 constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawUB.cpp:50
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SelectCellWithForm.cpp:134
-uninitDerivedMemberVar:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Bk2BkExpConvPV.h:28
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/UserFunction1D.h:64
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/EstimateFitParameters.cpp:214
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/EstimateFitParameters.cpp:260

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -328,8 +328,6 @@ passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawPeaks.cpp:508
 constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawUB.cpp:49
 constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawUB.cpp:50
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SelectCellWithForm.cpp:134
-missingOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/Fit1D.h:61
-missingOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PawleyFit.h:52
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/EigenVector.h:91
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BSpline.h:34
 uninitDerivedMemberVar:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Bk2BkExpConvPV.h:28

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -328,15 +328,7 @@ passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawPeaks.cpp:508
 constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawUB.cpp:49
 constVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawUB.cpp:50
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SelectCellWithForm.cpp:134
-uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BSpline.h:34
 uninitDerivedMemberVar:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Bk2BkExpConvPV.h:28
-uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Chebyshev.h:37
-uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Convolution.h:105
-uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h:26
-uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMultiSpectrum.h:26
-uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h:24
-uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CubicSpline.h:39
-uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FullprofPolynomial.h:25
 uselessOverride:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/UserFunction1D.h:64
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/EstimateFitParameters.cpp:214
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/EstimateFitParameters.cpp:260


### PR DESCRIPTION
cppCheck suppression set 20 fixes


Issue | File | Line
-- | -- | --
constVariableReference | ${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveLauenorm.cpp | 234
constVariableReference | ${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SelectCellWithForm.cpp | 134
missingOverride | ${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/Fit1D.h | 61
missingOverride | ${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PawleyFit.h | 52
returnByReference | ${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/EigenVector.h | 91
uselessOverride | ${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BSpline.h | 34
uninitDerivedMemberVar | ${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Bk2BkExpConvPV.h | 28
uselessOverride | ${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Chebyshev.h | 37
uselessOverride | ${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Convolution.h | 105
uselessOverride | ${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h | 26
uselessOverride | ${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMultiSpectrum.h | 26
uselessOverride | ${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h | 24
uselessOverride | ${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CubicSpline.h | 39
uselessOverride | ${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FullprofPolynomial.h | 25
returnByReference | ${CMAKE_SOURCE_DIR}/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PawleyFunction.h | 52


---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
