### PR TITLE
Refactor adding new batches in ISIS Reflectometry GUI

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -813,7 +813,6 @@ missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/G
 missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h:31
 missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h:66
 missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.h:32
-constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp:545
 missingOverride:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTableView.h:31
 constVariablePointer:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp:510
 constVariableReference:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp:749

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -72,8 +72,8 @@ BatchPresenter::BatchPresenter(
  */
 void BatchPresenter::acceptMainPresenter(IMainWindowPresenter *mainPresenter) { m_mainPresenter = mainPresenter; }
 
-void BatchPresenter::initInstrumentList(const std::string &selectedInstrument) {
-  m_runsPresenter->initInstrumentList(selectedInstrument);
+std::string BatchPresenter::initInstrumentList(const std::string &selectedInstrument) {
+  return m_runsPresenter->initInstrumentList(selectedInstrument);
 }
 
 bool BatchPresenter::requestClose() const { return true; }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -59,7 +59,7 @@ public:
 
   // IBatchPresenter overrides
   void acceptMainPresenter(IMainWindowPresenter *mainPresenter) override;
-  void initInstrumentList(const std::string &selectedInstrument = "") override;
+  std::string initInstrumentList(const std::string &selectedInstrument = "") override;
   void notifyPauseReductionRequested() override;
   void notifyResumeReductionRequested() override;
   void notifyResumeAutoreductionRequested() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -32,7 +32,7 @@ public:
   virtual ~IBatchPresenter() = default;
 
   virtual void acceptMainPresenter(IMainWindowPresenter *mainPresenter) = 0;
-  virtual void initInstrumentList(const std::string &selectedInstrument = "") = 0;
+  virtual std::string initInstrumentList(const std::string &selectedInstrument = "") = 0;
 
   virtual void notifyPauseReductionRequested() = 0;
   virtual void notifyResumeReductionRequested() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
@@ -112,6 +112,7 @@ private:
   void updateInstrument(const std::string &instrumentName);
   void setDefaultInstrument(const std::string &newInstrument);
   void onInstrumentChanged();
+  void processInstrumentSelection(std::string const &selectedInstrument, IBatchPresenter *batchPresenter = nullptr);
 
   void disableSaveAndLoadBatch();
   void enableSaveAndLoadBatch();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
@@ -24,7 +24,7 @@ class IRunsPresenter {
 public:
   virtual ~IRunsPresenter() = default;
   virtual void acceptMainPresenter(IBatchPresenter *mainPresenter) = 0;
-  virtual void initInstrumentList(const std::string &selectedInstrument = "") = 0;
+  virtual std::string initInstrumentList(const std::string &selectedInstrument = "") = 0;
   virtual RunsTable const &runsTable() const = 0;
   virtual RunsTable &mutableRunsTable() = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
@@ -13,6 +13,7 @@
 #include "MantidQtWidgets/Common/QtAlgorithmRunner.h"
 #include <QMenu>
 #include <QMessageBox>
+#include <QSignalBlocker>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 using namespace Mantid::API;
@@ -168,14 +169,12 @@ void QtRunsView::setInstrumentList(const std::vector<std::string> &instruments, 
   // We block signals while populating the list and setting the selected instrument because adding the first item
   // will trigger a currentIndexChanged signal. This causes existing batch settings to be overwritten when we're
   // initialising a new batch for an instrument that isn't the first in the list.
-  m_ui.comboSearchInstrument->blockSignals(true);
+  const QSignalBlocker blocker(m_ui.comboSearchInstrument);
+
   m_ui.comboSearchInstrument->clear();
   for (auto &&instrument : instruments)
     m_ui.comboSearchInstrument->addItem(QString::fromStdString(instrument));
   setSearchInstrument(selectedInstrument);
-  m_ui.comboSearchInstrument->blockSignals(false);
-  // Manually emit the signal once we've finished setting up the dropdown.
-  emit m_ui.comboSearchInstrument->currentIndexChanged(m_ui.comboSearchInstrument->currentIndex());
 }
 
 /**

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -547,7 +547,7 @@ IAlgorithm_sptr RunsPresenter::setupLiveDataMonitorAlgorithm() {
   auto errorMap = alg->validateInputs();
   if (!errorMap.empty()) {
     std::string errorString;
-    for (auto &kvp : errorMap)
+    for (auto const &kvp : errorMap)
       errorString.append(kvp.first + ":" + kvp.second);
     handleError(errorString);
     return nullptr;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -72,8 +72,13 @@ RunsPresenter::~RunsPresenter() {
  */
 void RunsPresenter::acceptMainPresenter(IBatchPresenter *mainPresenter) { m_mainPresenter = mainPresenter; }
 
-void RunsPresenter::initInstrumentList(const std::string &selectedInstrument) {
+/** Initialise the list of available instruments.
+ * @param selectedInstrument : Optional name of an instrument to try and select from the list.
+ * @returns The name of the instrument that is selected.
+ */
+std::string RunsPresenter::initInstrumentList(const std::string &selectedInstrument) {
   m_view->setInstrumentList(m_instruments, selectedInstrument);
+  return m_view->getSearchInstrument();
 }
 
 RunsTable const &RunsPresenter::runsTable() const { return tablePresenter()->runsTable(); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -67,7 +67,7 @@ public:
 
   // IRunsPresenter overrides
   void acceptMainPresenter(IBatchPresenter *mainPresenter) override;
-  void initInstrumentList(const std::string &selectedInstrument = "") override;
+  std::string initInstrumentList(const std::string &selectedInstrument = "") override;
   RunsTable const &runsTable() const override;
   RunsTable &mutableRunsTable() override;
   bool isProcessing() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -64,8 +64,9 @@ public:
 
   void testInitInstrumentListUpdatesRunsPresenter() {
     auto presenter = makePresenter(makeModel());
-    EXPECT_CALL(*m_runsPresenter, initInstrumentList(_)).Times(1);
-    presenter->initInstrumentList();
+    std::string const selectedInstrument = "INTER";
+    EXPECT_CALL(*m_runsPresenter, initInstrumentList(selectedInstrument)).Times(1).WillOnce(Return(selectedInstrument));
+    TS_ASSERT_EQUALS(presenter->initInstrumentList(selectedInstrument), selectedInstrument);
   }
 
   void testMainPresenterUpdatedWhenChangeInstrumentRequested() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -64,7 +64,7 @@ public:
 class MockBatchPresenter : public IBatchPresenter {
 public:
   MOCK_METHOD1(acceptMainPresenter, void(IMainWindowPresenter *));
-  MOCK_METHOD1(initInstrumentList, void(const std::string &));
+  MOCK_METHOD1(initInstrumentList, std::string(const std::string &));
   MOCK_METHOD0(notifyResumeReductionRequested, void());
   MOCK_METHOD0(notifyPauseReductionRequested, void());
   MOCK_METHOD0(notifyResumeAutoreductionRequested, void());
@@ -111,7 +111,7 @@ public:
 class MockRunsPresenter : public IRunsPresenter {
 public:
   MOCK_METHOD1(acceptMainPresenter, void(IBatchPresenter *));
-  MOCK_METHOD1(initInstrumentList, void(const std::string &));
+  MOCK_METHOD1(initInstrumentList, std::string(const std::string &));
   MOCK_CONST_METHOD0(runsTable, RunsTable const &());
   MOCK_METHOD0(mutableRunsTable, RunsTable &());
   MOCK_METHOD1(notifyChangeInstrumentRequested, bool(std::string const &));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -84,8 +84,15 @@ public:
 
   void testInitInstrumentListUpdatesView() {
     auto presenter = makePresenter();
-    EXPECT_CALL(m_view, setInstrumentList(m_instruments, _)).Times(1);
+    expectInstrumentListUpdated();
     presenter.initInstrumentList();
+  }
+
+  void testInitInstrumentListUpdatesViewWithSelectedValue() {
+    auto presenter = makePresenter();
+    std::string const &selectedInstrument = m_instruments[2];
+    expectInstrumentListUpdated(selectedInstrument);
+    TS_ASSERT_EQUALS(presenter.initInstrumentList(selectedInstrument), selectedInstrument);
   }
 
   void testCreatePresenterUpdatesView() {
@@ -883,6 +890,12 @@ private:
     props->setPropertyValue("InputWorkspace", "TOF_live");
     props->setPropertyValue("Instrument", instrument);
     return props;
+  }
+
+  void expectInstrumentListUpdated(std::string const &requestedInstrument = "") {
+    EXPECT_CALL(m_view, setInstrumentList(m_instruments, requestedInstrument)).Times(1);
+    std::string const &selectedInstrument = requestedInstrument.empty() ? m_instruments[0] : requestedInstrument;
+    EXPECT_CALL(m_view, getSearchInstrument()).Times(1).WillOnce(Return(selectedInstrument));
   }
 
   void expectRunsTableWithContent(RunsTable &runsTable) {


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Refactors the code for adding new batches in the Reflectometry GUI.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #34941. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

- When adding a new batch, we used to rely on the change instrument workflow being triggered from the signal that was emitted after populating the instrument list. Now we block this signal and instead call new method `onInstrumentSelected()` directly to start the workflow. Hopefully this will help to make it clearer to follow exactly what is happening in the code. It should also make it easier to spot that code is being shared between the change instrument and add new batch workflows.

- Tests have been updated for the new functionality. The refactor means that the `MainWindowPresenter` instances in `MainWindowPresenterTest` now automatically load an instrument, so I have been able to remove code that used to set the instrument manually. I also found that the expectations in `testConstructorAddsBatchPresenterForAllBatchViews` were being set before the variables had been initialised, so were not testing anything. I made some changes to resolve that.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Test adding batches (see [manual testing instructions](https://developer.mantidproject.org/Testing/ReflectometryGUI/ReflectometryGUITests.html#adding-and-deleting-batch-tabs)) and changing the default instrument (also see [manual testing instructions](https://developer.mantidproject.org/Testing/ReflectometryGUI/ReflectometryGUITests.html#changing-the-default-instrument)).

When the instrument is changed it should clear all settings on all batches.
When a new batch is added it should be blank/have default settings only. Any user-specified settings on existing batches should remain unchanged (i.e. check that this bug hasn't been re-introduced: https://github.com/mantidproject/mantid/issues/34845).

*This does not require release notes* because **it is only a refactor and should not change the existing functionality**.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
