### PR TITLE
Replace some uses of Poco::Path with std::filesystem::path

### DIFF
--- a/Framework/API/inc/MantidAPI/InstrumentFileFinder.h
+++ b/Framework/API/inc/MantidAPI/InstrumentFileFinder.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/DllConfig.h"
 
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -25,14 +26,14 @@ public:
   /// Utility to retrieve a resource file (IDF, Parameters, ..)
   static std::vector<std::string> getResourceFilenames(const std::string &prefix,
                                                        const std::vector<std::string> &fileFormats,
-                                                       const std::vector<std::string> &directoryNames,
+                                                       const std::vector<std::filesystem::path> &directoryNames,
                                                        const std::string &date);
 
   /// Utility to retrieve the validity dates for the given IDF
   static void getValidFromTo(const std::string &IDFfilename, std::string &outValidFrom, std::string &outValidTo);
 
 private:
-  static std::string lookupIPF(const std::string &dir, std::string filename);
+  static std::string lookupIPF(const std::filesystem::path &dir, std::string filename);
 };
 
 } // Namespace Mantid::API

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -773,7 +773,7 @@ const API::Result<std::string> FileFinderImpl::getPath(const std::vector<IArchiv
   // Remove wild cards.
   extensions.erase(std::remove_if(extensions.begin(), extensions.end(), containsWildCard), extensions.end());
 
-  const std::vector<std::string> &searchPaths = Kernel::ConfigService::Instance().getDataSearchDirs();
+  const auto &searchPaths = Kernel::ConfigService::Instance().getDataSearchDirs();
 
   // Before we try any globbing, make sure we exhaust all reasonable attempts at
   // constructing the possible filename.
@@ -785,7 +785,7 @@ const API::Result<std::string> FileFinderImpl::getPath(const std::vector<IArchiv
     for (const auto &filename : filenames) {
       for (const auto &searchPath : searchPaths) {
         try {
-          const Poco::Path filePath(searchPath, filename + extension);
+          const Poco::Path filePath(searchPath.string(), filename + extension);
           const Poco::File file(filePath);
           if (file.exists())
             return API::Result<std::string>(filePath.toString());

--- a/Framework/API/src/FileProperty.cpp
+++ b/Framework/API/src/FileProperty.cpp
@@ -121,7 +121,7 @@ std::string createDirectory(const std::filesystem::path &path) {
   }
 
   if (!stempath.string().empty()) {
-    Poco::File stem(stempath);
+    Poco::File stem(stempath.string());
     if (!stem.exists()) {
       try {
         stem.createDirectories();

--- a/Framework/API/src/FileProperty.cpp
+++ b/Framework/API/src/FileProperty.cpp
@@ -114,7 +114,7 @@ std::string expandUser(const std::string &filepath) {
  */
 std::string createDirectory(const std::filesystem::path &path) {
   std::filesystem::path stempath(path);
-  if (stempath.has_extension()) {
+  if (stempath.has_filename()) {
     stempath = stempath.parent_path();
   }
 

--- a/Framework/API/src/FileProperty.cpp
+++ b/Framework/API/src/FileProperty.cpp
@@ -114,13 +114,11 @@ std::string expandUser(const std::string &filepath) {
  */
 std::string createDirectory(const std::filesystem::path &path) {
   std::filesystem::path stempath(path);
-  // If the path exists and it's a directory, then use that, otherwise we're pointing to
-  // a file and need the parent path
-  if (!(std::filesystem::exists(stempath) && std::filesystem::is_directory(stempath))) {
+  if (stempath.has_extension()) {
     stempath = stempath.parent_path();
   }
 
-  if (!stempath.string().empty()) {
+  if (!stempath.empty()) {
     Poco::File stem(stempath.string());
     if (!stem.exists()) {
       try {
@@ -385,7 +383,7 @@ std::string FileProperty::setSaveProperty(const std::string &propValue) {
   }
   errorMsg = createDirectory(save_dir);
   if (errorMsg.empty()) {
-    std::filesystem::path fullpath = std::filesystem::absolute(save_dir / propValue);
+    std::filesystem::path fullpath = save_dir / propValue;
     errorMsg = PropertyWithValue<std::string>::setValue(fullpath.string());
   }
   return errorMsg;

--- a/Framework/API/src/GroupingLoader.cpp
+++ b/Framework/API/src/GroupingLoader.cpp
@@ -15,6 +15,7 @@
 #include <Poco/DOM/DOMParser.h>
 #include <Poco/DOM/Document.h>
 #include <Poco/DOM/NodeList.h>
+#include <filesystem>
 #include <memory>
 #include <utility>
 
@@ -59,9 +60,9 @@ std::shared_ptr<Grouping> GroupingLoader::getGroupingFromIDF() const {
     const std::string groupingFile = groupingFiles[0];
 
     // Get search directory for XML instrument definition files (IDFs)
-    std::string directoryName = Kernel::ConfigService::Instance().getInstrumentDirectory().string();
+    const auto directoryName = Kernel::ConfigService::Instance().getInstrumentDirectory();
 
-    loadGroupingFromXML(directoryName + groupingFile, *loadedGrouping);
+    loadGroupingFromXML((directoryName / groupingFile).string(), *loadedGrouping);
   } else {
     throw std::runtime_error("Multiple groupings specified for the instrument");
   }

--- a/Framework/API/src/GroupingLoader.cpp
+++ b/Framework/API/src/GroupingLoader.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<Grouping> GroupingLoader::getGroupingFromIDF() const {
     const std::string groupingFile = groupingFiles[0];
 
     // Get search directory for XML instrument definition files (IDFs)
-    std::string directoryName = Kernel::ConfigService::Instance().getInstrumentDirectory();
+    std::string directoryName = Kernel::ConfigService::Instance().getInstrumentDirectory().string();
 
     loadGroupingFromXML(directoryName + groupingFile, *loadedGrouping);
   } else {

--- a/Framework/API/src/InstrumentFileFinder.cpp
+++ b/Framework/API/src/InstrumentFileFinder.cpp
@@ -154,7 +154,7 @@ std::string InstrumentFileFinder::lookupIPF(const std::filesystem::path &dir, st
     prefix = filename;
   }
 
-  Poco::Path directoryPath(dir);
+  Poco::Path directoryPath(dir.string());
   directoryPath.makeDirectory();
 
   // Assemble parameter file name
@@ -227,7 +227,7 @@ InstrumentFileFinder::getResourceFilenames(const std::string &prefix, const std:
   for (const auto &directoryName : directoryNames) {
     // Iterate over the directories from user ->etc ->install, and find the
     // first beat file
-    for (Poco::DirectoryIterator dir_itr(directoryName); dir_itr != end_iter; ++dir_itr) {
+    for (Poco::DirectoryIterator dir_itr(directoryName.string()); dir_itr != end_iter; ++dir_itr) {
 
       const auto &filePath = dir_itr.path();
       if (!filePath.isFile())

--- a/Framework/API/src/InstrumentFileFinder.cpp
+++ b/Framework/API/src/InstrumentFileFinder.cpp
@@ -87,7 +87,8 @@ std::string InstrumentFileFinder::getInstrumentFilename(const std::string &instr
   const std::string instrument(Kernel::ConfigService::Instance().getInstrument(instrumentName).name());
 
   // Get the instrument directories for instrument file search
-  const std::vector<std::string> &directoryNames = Kernel::ConfigService::Instance().getInstrumentDirectories();
+  const std::vector<std::filesystem::path> &directoryNames =
+      Kernel::ConfigService::Instance().getInstrumentDirectories();
 
   // matching files sorted with newest files coming first
   const std::vector<std::string> matchingFiles =
@@ -120,7 +121,7 @@ std::string InstrumentFileFinder::getParameterPath(const std::string &instName, 
   }
 
   const Kernel::ConfigServiceImpl &configService = Kernel::ConfigService::Instance();
-  const std::vector<std::string> directoryNames = configService.getInstrumentDirectories();
+  const std::vector<std::filesystem::path> directoryNames = configService.getInstrumentDirectories();
 
   for (const auto &dirName : directoryNames) {
     // This will iterate around the directories from user ->etc ->install, and
@@ -136,7 +137,7 @@ std::string InstrumentFileFinder::getParameterPath(const std::string &instName, 
   return "";
 }
 
-std::string InstrumentFileFinder::lookupIPF(const std::string &dir, std::string filename) {
+std::string InstrumentFileFinder::lookupIPF(const std::filesystem::path &dir, std::string filename) {
   const std::string ext = ".xml";
   // Remove .xml for example if abc.xml was passed
   boost::algorithm::ierase_all(filename, ext);
@@ -186,10 +187,10 @@ std::string InstrumentFileFinder::lookupIPF(const std::string &dir, std::string 
  * this date
  * @return list of absolute paths for each valid file
  */
-std::vector<std::string> InstrumentFileFinder::getResourceFilenames(const std::string &prefix,
-                                                                    const std::vector<std::string> &fileFormats,
-                                                                    const std::vector<std::string> &directoryNames,
-                                                                    const std::string &date) {
+std::vector<std::string>
+InstrumentFileFinder::getResourceFilenames(const std::string &prefix, const std::vector<std::string> &fileFormats,
+                                           const std::vector<std::filesystem::path> &directoryNames,
+                                           const std::string &date) {
 
   if (date.empty()) {
     // Just use the current date

--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -105,7 +105,7 @@ public:
     ConfigService::Instance().updateFacilities(m_facFile.path());
     ConfigService::Instance().setString("datacachesearch.directory", "");
     // Update entire config to set search data directories
-    const std::string propfile = ConfigService::Instance().getDirectoryOfExecutable() + "Mantid.properties";
+    const std::filesystem::path propfile = ConfigService::Instance().getDirectoryOfExecutable() / "Mantid.properties";
     ConfigService::Instance().updateConfig(propfile);
   }
 

--- a/Framework/API/test/FilePropertyTest.h
+++ b/Framework/API/test/FilePropertyTest.h
@@ -176,14 +176,14 @@ public:
 
   void testDirectoryPasses() {
     std::filesystem::path TestDir(ConfigService::Instance().getDirectoryOfExecutable() / "MyTestFolder");
-    Poco::File dir(TestDir);
+    Poco::File dir(TestDir.string());
     dir.createDirectory();
 
     FileProperty fp("SavePath", "", FileProperty::Directory);
     TS_ASSERT_EQUALS(fp.isDirectoryProperty(), true);
 
     // The directory exists, so no failure
-    std::string msg = fp.setValue(TestDir);
+    std::string msg = fp.setValue(TestDir.string());
     TS_ASSERT_EQUALS(msg, "");
 
     dir.remove(); // clean up your folder

--- a/Framework/API/test/FilePropertyTest.h
+++ b/Framework/API/test/FilePropertyTest.h
@@ -13,6 +13,7 @@
 #include "MantidKernel/ConfigService.h"
 #include <Poco/File.h>
 #include <cstdlib>
+#include <filesystem>
 #include <fstream>
 
 using Mantid::API::FileFinder;
@@ -174,7 +175,7 @@ public:
   }
 
   void testDirectoryPasses() {
-    std::string TestDir(ConfigService::Instance().getDirectoryOfExecutable() + "MyTestFolder");
+    std::filesystem::path TestDir(ConfigService::Instance().getDirectoryOfExecutable() / "MyTestFolder");
     Poco::File dir(TestDir);
     dir.createDirectory();
 

--- a/Framework/API/test/GroupingLoaderTest.h
+++ b/Framework/API/test/GroupingLoaderTest.h
@@ -10,7 +10,6 @@
 #include "MantidAPI/GroupingLoader.h"
 #include "MantidKernel/ConfigService.h"
 #include <Poco/File.h>
-#include <Poco/Path.h>
 #include <cxxtest/TestSuite.h>
 
 using Mantid::API::Grouping;
@@ -27,13 +26,11 @@ public:
   GroupingLoaderTest() {
     using Mantid::Kernel::ConfigService;
 
-    auto dataPaths = ConfigService::Instance().getDataSearchDirs();
+    const auto &dataPaths = ConfigService::Instance().getDataSearchDirs();
 
     // Find the path of AutoTestData
-    for (auto &dataPath : dataPaths) {
-      Poco::Path path(dataPath);
-
-      if (path.directory(path.depth() - 1) == "UnitTest") {
+    for (const auto &dataPath : dataPaths) {
+      if (dataPath.filename() == "UnitTest") {
         m_testDataDir = dataPath;
         break;
       }
@@ -50,7 +47,7 @@ public:
   void test_loadGroupingFromXML() {
     Grouping g;
 
-    TS_ASSERT_THROWS_NOTHING(GroupingLoader::loadGroupingFromXML(m_testDataDir + "MUSRGrouping.xml", g));
+    TS_ASSERT_THROWS_NOTHING(GroupingLoader::loadGroupingFromXML(m_testDataDir / "MUSRGrouping.xml", g));
 
     TS_ASSERT_EQUALS(g.groupNames.size(), 2);
     TS_ASSERT_EQUALS(g.groupNames[0], "fwd");
@@ -75,6 +72,6 @@ public:
   }
 
 private:
-  std::string m_testDataDir;
-  std::string m_tmpDir;
+  std::filesystem::path m_testDataDir;
+  std::filesystem::path m_tmpDir;
 };

--- a/Framework/API/test/GroupingLoaderTest.h
+++ b/Framework/API/test/GroupingLoaderTest.h
@@ -47,7 +47,7 @@ public:
   void test_loadGroupingFromXML() {
     Grouping g;
 
-    TS_ASSERT_THROWS_NOTHING(GroupingLoader::loadGroupingFromXML(m_testDataDir / "MUSRGrouping.xml", g));
+    TS_ASSERT_THROWS_NOTHING(GroupingLoader::loadGroupingFromXML((m_testDataDir / "MUSRGrouping.xml").string(), g));
 
     TS_ASSERT_EQUALS(g.groupNames.size(), 2);
     TS_ASSERT_EQUALS(g.groupNames[0], "fwd");

--- a/Framework/API/test/InstrumentFileFinderTest.h
+++ b/Framework/API/test/InstrumentFileFinderTest.h
@@ -157,9 +157,9 @@ public:
   }
 
   void testHelper_ValidDateOverlap() {
-    const std::string instDir = ConfigService::Instance().getInstrumentDirectory();
-    const std::string testDir = instDir + "unit_testing";
-    ConfigService::Instance().setString("instrumentDefinition.directory", testDir);
+    const std::filesystem::path instDir = ConfigService::Instance().getInstrumentDirectory();
+    const std::filesystem::path testDir = instDir / "unit_testing";
+    ConfigService::Instance().setString("instrumentDefinition.directory", testDir.string());
     InstrumentFileFinder helper;
     std::string boevs = helper.getInstrumentFilename("ARGUS", "1909-01-31 22:59:59");
     TS_ASSERT_DIFFERS(boevs.find("TEST1_ValidDateOverlap"), std::string::npos);
@@ -167,10 +167,10 @@ public:
     TS_ASSERT_DIFFERS(boevs.find("TEST2_ValidDateOverlap"), std::string::npos);
     boevs = helper.getInstrumentFilename("ARGUS", "1909-05-31 22:59:59");
     TS_ASSERT_DIFFERS(boevs.find("TEST1_ValidDateOverlap"), std::string::npos);
-    ConfigService::Instance().setString("instrumentDefinition.directory", instDir);
+    ConfigService::Instance().setString("instrumentDefinition.directory", instDir.string());
 
     std::vector<std::string> formats = {"xml"};
-    std::vector<std::string> dirs;
+    std::vector<std::filesystem::path> dirs;
     dirs.emplace_back(testDir);
     std::vector<std::string> fnames = helper.getResourceFilenames("ARGUS", formats, dirs, "1909-01-31 22:59:59");
     TS_ASSERT_DIFFERS(fnames[0].find("TEST1_ValidDateOverlap"), std::string::npos);

--- a/Framework/API/test/LiveListenerFactoryTest.h
+++ b/Framework/API/test/LiveListenerFactoryTest.h
@@ -11,7 +11,6 @@
 #include "MantidAPI/LiveListenerFactory.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Instantiator.h"
-#include <Poco/Path.h>
 #include <cxxtest/TestSuite.h>
 
 #include <utility>
@@ -59,9 +58,10 @@ public:
 
   void setUp() override {
     auto &config = Kernel::ConfigService::Instance();
-    Poco::Path testFile = Poco::Path(config.getInstrumentDirectory()).resolve("unit_testing/UnitTestFacilities.xml");
+    std::filesystem::path testFile =
+        std::filesystem::absolute(config.getInstrumentDirectory() / "unit_testing/UnitTestFacilities.xml");
     // Load the test facilities file
-    config.updateFacilities(testFile.toString());
+    config.updateFacilities(testFile.string());
   }
 
   void tearDown() override {

--- a/Framework/API/test/MultipleFilePropertyTest.h
+++ b/Framework/API/test/MultipleFilePropertyTest.h
@@ -15,7 +15,6 @@
 #include <cxxtest/TestSuite.h>
 
 #include <Poco/File.h>
-#include <Poco/Path.h>
 
 #include <boost/algorithm/string/join.hpp>
 #include <unordered_set>
@@ -37,12 +36,10 @@ namespace // anonymous
  *
  * @returns the absolute path to the directory.
  */
-std::string createAbsoluteDirectory(const std::string &dirPath) {
+std::filesystem::path createAbsoluteDirectory(const std::string &dirPath) {
   Poco::File dir(dirPath);
   dir.createDirectories();
-  Poco::Path path(dir.path());
-  path = path.makeAbsolute();
-  return path.toString();
+  return std::filesystem::absolute(dir.path());
 }
 
 /**
@@ -52,9 +49,9 @@ std::string createAbsoluteDirectory(const std::string &dirPath) {
  * @param filenames :: the names of the files to create.
  * @param dirPath   :: the directory in which to create the files.
  */
-void createFilesInDirectory(const std::unordered_set<std::string> &filenames, const std::string &dirPath) {
+void createFilesInDirectory(const std::unordered_set<std::string> &filenames, const std::filesystem::path &dirPath) {
   for (const auto &filename : filenames) {
-    Poco::File file(dirPath + "/" + filename);
+    Poco::File file((dirPath / filename).string());
     file.createFile();
   }
 }
@@ -74,9 +71,9 @@ private:
   std::string m_oldDataSearchDirectories;
   std::string m_oldDefaultFacility;
   std::string m_oldDefaultInstrument;
-  std::string m_dummyFilesDir;
-  std::string m_dirWithWhitespace;
-  std::unordered_set<std::string> m_tempDirs;
+  std::filesystem::path m_dummyFilesDir;
+  std::filesystem::path m_dirWithWhitespace;
+  std::vector<std::filesystem::path> m_tempDirs;
   std::vector<std::string> m_exts;
   std::string m_oldArchiveSearchSetting;
 
@@ -102,8 +99,8 @@ public:
     m_dummyFilesDir = createAbsoluteDirectory("_MultipleFilePropertyTestDummyFiles");
     m_dirWithWhitespace = createAbsoluteDirectory("_MultipleFilePropertyTest Folder With Whitespace");
 
-    m_tempDirs.insert(m_dummyFilesDir);
-    m_tempDirs.insert(m_dirWithWhitespace);
+    m_tempDirs.push_back(m_dummyFilesDir);
+    m_tempDirs.push_back(m_dirWithWhitespace);
 
     std::unordered_set<std::string> dummyFilenames = {
         // Standard raw file runs.
@@ -143,7 +140,7 @@ public:
   ~MultipleFilePropertyTest() override {
     // Remove temp dirs.
     for (const auto &tempDir : m_tempDirs) {
-      Poco::File dir(tempDir);
+      Poco::File dir(tempDir.string());
       dir.remove(true);
     }
   }
@@ -154,7 +151,7 @@ public:
     m_oldDefaultInstrument = g_config.getString("default.instrument");
     m_oldArchiveSearchSetting = g_config.getString("datasearch.searcharchive");
 
-    g_config.setString("datasearch.directories", m_dummyFilesDir + ";" + m_dirWithWhitespace + ";");
+    g_config.setString("datasearch.directories", m_dummyFilesDir.string() + ";" + m_dirWithWhitespace.string() + ";");
     g_config.setString("default.facility", "ISIS");
     g_config.setString("default.instrument", "TOSCA");
     g_config.setString("datasearch.searcharchive", "Off");
@@ -184,7 +181,7 @@ public:
     p.setValue(dummyFile("TSC1.raw"));
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
   }
 
   void test_singeFile_noInst() {
@@ -192,7 +189,7 @@ public:
     p.setValue(dummyFile("1.raw"));
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
   }
 
   void test_singeFile_noExt() {
@@ -200,7 +197,7 @@ public:
     p.setValue(dummyFile("TSC1"));
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
   }
 
   void test_singeFile_noInstNoExt() {
@@ -208,7 +205,7 @@ public:
     p.setValue(dummyFile("1"));
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
   }
 
   void test_singeFile_noDir() {
@@ -216,7 +213,7 @@ public:
     p.setValue("TSC1.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
   }
 
   void test_singeFile_noDirNoInst() {
@@ -224,7 +221,7 @@ public:
     p.setValue("1.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
   }
 
   void test_singeFile_noDirNoExt() {
@@ -232,7 +229,7 @@ public:
     p.setValue("TSC1");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
   }
 
   void test_singeFile_noDirNoInstNoExt() {
@@ -240,7 +237,7 @@ public:
     p.setValue("1");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
   }
 
   void test_singleFile_shortZeroPadding() {
@@ -248,7 +245,7 @@ public:
     p.setValue("TSC001.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
   }
 
   void test_singleFile_longZeroPadding() {
@@ -256,7 +253,7 @@ public:
     p.setValue("TSC000000000001.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
   }
 
   void test_singleFile_fileWithIncorrectZeroPaddingStillFound() {
@@ -264,7 +261,7 @@ public:
     p.setValue("TSC9999999.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC9999999.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC9999999.raw"));
   }
 
   void test_singleFile_longForm_singleFileLooksLikeARangeWithSuffix() {
@@ -289,7 +286,7 @@ public:
     p.setValue("IRS10001-10005_graphite002_info.nxs");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("IRS10001-10005_graphite002_info.nxs"));
+    compareFilename(fileNames[0][0], dummyFile("IRS10001-10005_graphite002_info.nxs"));
   }
 
   void test_singleFile_fileThatHasNoExtension() {
@@ -297,7 +294,7 @@ public:
     p.setValue("bl6_flux_at_sample");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("bl6_flux_at_sample"));
+    compareFilename(fileNames[0][0], dummyFile("bl6_flux_at_sample"));
   }
 
   void test_multipleFiles_shortForm_commaList() {
@@ -305,11 +302,11 @@ public:
     p.setValue("TSC1,2,3,4,5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[2][0], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[3][0], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[4][0], dummyFile("TSC00005.raw"));
   }
 
   void test_multipleFiles_shortForm_plusList() {
@@ -317,11 +314,11 @@ public:
     p.setValue("TSC1+2+3+4+5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][3], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][4], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][1], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[0][2], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[0][3], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[0][4], dummyFile("TSC00005.raw"));
   }
 
   void test_multipleFiles_shortForm_range() {
@@ -329,11 +326,11 @@ public:
     p.setValue("TSC1:5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[2][0], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[3][0], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[4][0], dummyFile("TSC00005.raw"));
   }
 
   void test_multipleFiles_shortForm_addedRange() {
@@ -341,11 +338,11 @@ public:
     p.setValue("TSC1-5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][3], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][4], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][1], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[0][2], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[0][3], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[0][4], dummyFile("TSC00005.raw"));
   }
 
   void test_multipleFiles_shortForm_steppedRange() {
@@ -353,9 +350,9 @@ public:
     p.setValue("TSC1:5:2.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[2][0], dummyFile("TSC00005.raw"));
   }
 
   void test_multipleFiles_shortForm_steppedAddedRange() {
@@ -363,9 +360,9 @@ public:
     p.setValue("TSC1-5:2.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][1], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[0][2], dummyFile("TSC00005.raw"));
   }
 
   void test_multipleFiles_shortForm_complex() {
@@ -373,17 +370,17 @@ public:
     p.setValue("TSC1,2:5,1+2+3,2-4.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.raw"));
-    TS_ASSERT_EQUALS(fileNames[5][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[5][1], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[5][2], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[6][0], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[6][1], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[6][2], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[2][0], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[3][0], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[4][0], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[5][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[5][1], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[5][2], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[6][0], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[6][1], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[6][2], dummyFile("TSC00004.raw"));
   }
 
   void test_multipleFiles_shortForm_addRanges() {
@@ -391,10 +388,10 @@ public:
     p.setValue("TSC1-2+4-5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][3], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][1], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[0][2], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[0][3], dummyFile("TSC00005.raw"));
   }
 
   void test_multipleFiles_shortForm_addSingleToRange() {
@@ -402,9 +399,9 @@ public:
     p.setValue("TSC2+4-5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[0][1], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[0][2], dummyFile("TSC00005.raw"));
   }
 
   void test_multipleFiles_shortForm_rangeToSingle() {
@@ -412,9 +409,9 @@ public:
     p.setValue("TSC1-2+5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][1], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[0][2], dummyFile("TSC00005.raw"));
   }
 
   void test_multipleFiles_longForm_commaList() {
@@ -422,11 +419,11 @@ public:
     p.setValue("TSC1.raw,TSC2.raw,TSC3.raw,TSC4.raw,TSC5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[2][0], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[3][0], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[4][0], dummyFile("TSC00005.raw"));
   }
 
   void test_multipleFiles_longForm_plusList() {
@@ -434,11 +431,11 @@ public:
     p.setValue("TSC1.raw+TSC2.raw+TSC3.raw+TSC4.raw+TSC5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][3], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][4], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][1], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[0][2], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[0][3], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[0][4], dummyFile("TSC00005.raw"));
   }
 
   void test_multipleFiles_longForm_nonRunFiles() {
@@ -447,9 +444,9 @@ public:
                "IRS10003_graphite002_info.nxs");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("IRS10001_graphite002_info.nxs"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("IRS10002_graphite002_info.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("IRS10003_graphite002_info.nxs"));
+    compareFilename(fileNames[0][0], dummyFile("IRS10001_graphite002_info.nxs"));
+    compareFilename(fileNames[0][1], dummyFile("IRS10002_graphite002_info.nxs"));
+    compareFilename(fileNames[1][0], dummyFile("IRS10003_graphite002_info.nxs"));
   }
 
   void test_multipleFiles_mixedForm_1() {
@@ -457,11 +454,11 @@ public:
     p.setValue("TSC1,2.raw,TSC3,4,5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[2][0], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[3][0], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[4][0], dummyFile("TSC00005.raw"));
   }
 
   void test_multipleFiles_mixedForm_2() {
@@ -469,11 +466,11 @@ public:
     p.setValue("TSC1,2.raw,TSC3:5.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[2][0], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[3][0], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[4][0], dummyFile("TSC00005.raw"));
   }
 
   void test_multipleFiles_mixedForm_mixedInstAndExt() {
@@ -485,16 +482,16 @@ public:
     p.setValue("TSC1-5:1.raw,IRS1-5:1.nxs");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][3], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][4], dummyFile("TSC00005.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("IRS00001.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][1], dummyFile("IRS00002.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][2], dummyFile("IRS00003.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][3], dummyFile("IRS00004.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][4], dummyFile("IRS00005.nxs"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][1], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[0][2], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[0][3], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[0][4], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[1][0], dummyFile("IRS00001.nxs"));
+    compareFilename(fileNames[1][1], dummyFile("IRS00002.nxs"));
+    compareFilename(fileNames[1][2], dummyFile("IRS00003.nxs"));
+    compareFilename(fileNames[1][3], dummyFile("IRS00004.nxs"));
+    compareFilename(fileNames[1][4], dummyFile("IRS00005.nxs"));
   }
 
   void test_multipleFiles_mixedForm_missingExtensionsMeansFirstDefaultExtIsUsed() {
@@ -503,16 +500,16 @@ public:
     p.setValue("TSC1-5:1,IRS1-5:1");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][3], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][4], dummyFile("TSC00005.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("IRS00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][1], dummyFile("IRS00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][2], dummyFile("IRS00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][3], dummyFile("IRS00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][4], dummyFile("IRS00005.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][1], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[0][2], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[0][3], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[0][4], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[1][0], dummyFile("IRS00001.raw"));
+    compareFilename(fileNames[1][1], dummyFile("IRS00002.raw"));
+    compareFilename(fileNames[1][2], dummyFile("IRS00003.raw"));
+    compareFilename(fileNames[1][3], dummyFile("IRS00004.raw"));
+    compareFilename(fileNames[1][4], dummyFile("IRS00005.raw"));
   }
 
   void test_multipleFiles_mixedForm_someMissingExtensionsMeansFirstSpecifiedIsUsed() {
@@ -520,16 +517,16 @@ public:
     p.setValue("IRS1-5:1,TSC1-5:1.nxs");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("IRS00001.nxs"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("IRS00002.nxs"));
-    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("IRS00003.nxs"));
-    TS_ASSERT_EQUALS(fileNames[0][3], dummyFile("IRS00004.nxs"));
-    TS_ASSERT_EQUALS(fileNames[0][4], dummyFile("IRS00005.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00001.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][1], dummyFile("TSC00002.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][2], dummyFile("TSC00003.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][3], dummyFile("TSC00004.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][4], dummyFile("TSC00005.nxs"));
+    compareFilename(fileNames[0][0], dummyFile("IRS00001.nxs"));
+    compareFilename(fileNames[0][1], dummyFile("IRS00002.nxs"));
+    compareFilename(fileNames[0][2], dummyFile("IRS00003.nxs"));
+    compareFilename(fileNames[0][3], dummyFile("IRS00004.nxs"));
+    compareFilename(fileNames[0][4], dummyFile("IRS00005.nxs"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00001.nxs"));
+    compareFilename(fileNames[1][1], dummyFile("TSC00002.nxs"));
+    compareFilename(fileNames[1][2], dummyFile("TSC00003.nxs"));
+    compareFilename(fileNames[1][3], dummyFile("TSC00004.nxs"));
+    compareFilename(fileNames[1][4], dummyFile("TSC00005.nxs"));
   }
 
   void test_multipleFiles_mixedForm_complex() {
@@ -537,17 +534,17 @@ public:
     p.setValue("TSC1,2:5.raw,TSC1+2+3,2-4.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.raw"));
-    TS_ASSERT_EQUALS(fileNames[5][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[5][1], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[5][2], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[6][0], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[6][1], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[6][2], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[2][0], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[3][0], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[4][0], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[5][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[5][1], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[5][2], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[6][0], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[6][1], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[6][2], dummyFile("TSC00004.raw"));
   }
 
   void test_multipleFiles_mixedForm_complexAndNonRunFile() {
@@ -555,18 +552,18 @@ public:
     p.setValue("TSC1,2:5.raw,IRS10001_graphite002_info.nxs,TSC1+2+3,2-4.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.raw"));
-    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.raw"));
-    TS_ASSERT_EQUALS(fileNames[5][0], dummyFile("IRS10001_graphite002_info.nxs"));
-    TS_ASSERT_EQUALS(fileNames[6][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[6][1], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[6][2], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[7][0], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[7][1], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[7][2], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[2][0], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[3][0], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[4][0], dummyFile("TSC00005.raw"));
+    compareFilename(fileNames[5][0], dummyFile("IRS10001_graphite002_info.nxs"));
+    compareFilename(fileNames[6][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[6][1], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[6][2], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[7][0], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[7][1], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[7][2], dummyFile("TSC00004.raw"));
   }
 
   void test_multipleFiles_mixedForm_addingTwoLists_FAILS() {
@@ -582,10 +579,10 @@ public:
     p.setValue("TSC1+2.raw+TSC3+4.raw");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00002.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00003.raw"));
-    TS_ASSERT_EQUALS(fileNames[0][3], dummyFile("TSC00004.raw"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.raw"));
+    compareFilename(fileNames[0][1], dummyFile("TSC00002.raw"));
+    compareFilename(fileNames[0][2], dummyFile("TSC00003.raw"));
+    compareFilename(fileNames[0][3], dummyFile("TSC00004.raw"));
   }
 
   void test_allowEmptyTokenOptionalLoad() {
@@ -595,9 +592,9 @@ public:
     p.setValue("111213,0,171819");
     std::vector<std::vector<std::string>> fileNames = p();
     TS_ASSERT_EQUALS(fileNames.size(), 3);
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("111213.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][0], "000000");
-    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("171819.nxs"));
+    compareFilename(fileNames[0][0], dummyFile("111213.nxs"));
+    compareFilename(fileNames[1][0], "000000");
+    compareFilename(fileNames[2][0], dummyFile("171819.nxs"));
     g_config.setString("default.facility", "ISIS");
     g_config.setString("default.instrument", "TOSCA");
   }
@@ -619,11 +616,11 @@ public:
 
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.nxs"));
-    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.nxs"));
-    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.nxs"));
-    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.nxs"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.nxs"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00002.nxs"));
+    compareFilename(fileNames[2][0], dummyFile("TSC00003.nxs"));
+    compareFilename(fileNames[3][0], dummyFile("TSC00004.nxs"));
+    compareFilename(fileNames[4][0], dummyFile("TSC00005.nxs"));
   }
 
   void test_multipleFiles_inconsistent_spaces() {
@@ -632,11 +629,11 @@ public:
 
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.nxs"));
-    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.nxs"));
-    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.nxs"));
-    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.nxs"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.nxs"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00002.nxs"));
+    compareFilename(fileNames[2][0], dummyFile("TSC00003.nxs"));
+    compareFilename(fileNames[3][0], dummyFile("TSC00004.nxs"));
+    compareFilename(fileNames[4][0], dummyFile("TSC00005.nxs"));
   }
 
   void test_multipleFiles_space_after_first() {
@@ -645,11 +642,11 @@ public:
 
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.nxs"));
-    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.nxs"));
-    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.nxs"));
-    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.nxs"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.nxs"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00002.nxs"));
+    compareFilename(fileNames[2][0], dummyFile("TSC00003.nxs"));
+    compareFilename(fileNames[3][0], dummyFile("TSC00004.nxs"));
+    compareFilename(fileNames[4][0], dummyFile("TSC00005.nxs"));
   }
 
   void test_multipleFiles_ranges_with_spaces() {
@@ -657,13 +654,13 @@ public:
     p.setValue("1-5, 3-4");
     std::vector<std::vector<std::string>> fileNames = p();
 
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.nxs"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00002.nxs"));
-    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00003.nxs"));
-    TS_ASSERT_EQUALS(fileNames[0][3], dummyFile("TSC00004.nxs"));
-    TS_ASSERT_EQUALS(fileNames[0][4], dummyFile("TSC00005.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00003.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][1], dummyFile("TSC00004.nxs"));
+    compareFilename(fileNames[0][0], dummyFile("TSC00001.nxs"));
+    compareFilename(fileNames[0][1], dummyFile("TSC00002.nxs"));
+    compareFilename(fileNames[0][2], dummyFile("TSC00003.nxs"));
+    compareFilename(fileNames[0][3], dummyFile("TSC00004.nxs"));
+    compareFilename(fileNames[0][4], dummyFile("TSC00005.nxs"));
+    compareFilename(fileNames[1][0], dummyFile("TSC00003.nxs"));
+    compareFilename(fileNames[1][1], dummyFile("TSC00004.nxs"));
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////
@@ -730,5 +727,12 @@ private:
   //////////////////////////////////////////////////////////////////////////////////////////////
   // Private helper functions.
   //////////////////////////////////////////////////////////////////////////////////////////////
-  std::string dummyFile(const std::string &filename) { return m_dummyFilesDir + Poco::Path::separator() + filename; }
+  std::string dummyFile(const std::string &filename) { return (m_dummyFilesDir / filename).string(); }
+
+  void compareFilename(const std::string &filename, const std::string &expected) {
+    std::filesystem::path filenamePath(filename);
+    std::filesystem::path expectedPath(expected);
+    // Using std::filesystem::equivalent requires the path to exist
+    TS_ASSERT(std::filesystem::weakly_canonical(filenamePath) == std::filesystem::weakly_canonical(expectedPath));
+  }
 };

--- a/Framework/Algorithms/src/ClearCache.cpp
+++ b/Framework/Algorithms/src/ClearCache.cpp
@@ -73,7 +73,7 @@ void ClearCache::exec() {
 
   // get the instrument directories
   auto instrumentDirs = Mantid::Kernel::ConfigService::Instance().getInstrumentDirectories();
-  Poco::Path localPath(instrumentDirs[0]);
+  Poco::Path localPath(instrumentDirs[0].string());
   localPath.makeDirectory();
 
   if (clearAlgCache) {

--- a/Framework/Algorithms/test/ClearCacheTest.h
+++ b/Framework/Algorithms/test/ClearCacheTest.h
@@ -16,6 +16,8 @@
 #include <Poco/File.h>
 #include <Poco/Path.h>
 
+#include <filesystem>
+
 using Mantid::Algorithms::ClearCache;
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
@@ -163,7 +165,7 @@ public:
     TS_ASSERT_EQUALS(filesRemoved, 0);
   }
 
-  std::string m_localInstDir;
-  std::vector<std::string> m_originalInstDir;
+  std::filesystem::path m_localInstDir;
+  std::vector<std::filesystem::path> m_originalInstDir;
   std::vector<Poco::File> m_directoriesToRemove;
 };

--- a/Framework/Algorithms/test/ClearCacheTest.h
+++ b/Framework/Algorithms/test/ClearCacheTest.h
@@ -47,7 +47,7 @@ public:
   }
 
   void createDirectory(const std::filesystem::path &path) {
-    Poco::File file(path);
+    Poco::File file(path.string());
     if (file.createDirectory()) {
       m_directoriesToRemove.emplace_back(file);
     }
@@ -114,7 +114,7 @@ public:
       localPath = localPath.parent_path();
     }
     // create a file in the directory
-    Poco::File testFile(localPath / "test_exec_DownloadInstrument_Cache.xml");
+    Poco::File testFile((localPath / "test_exec_DownloadInstrument_Cache.xml").string());
     testFile.createFile();
 
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
@@ -138,7 +138,7 @@ public:
     }
 
     // create a file in the directory
-    Poco::File testFile(localPath / "geometryCache" / "test_exec_Geometry_Cache.vtp");
+    Poco::File testFile((localPath / "geometryCache" / "test_exec_Geometry_Cache.vtp").string());
     testFile.createFile();
 
     TS_ASSERT_THROWS_NOTHING(alg.initialize())

--- a/Framework/Algorithms/test/ConvertUnitsTest.h
+++ b/Framework/Algorithms/test/ConvertUnitsTest.h
@@ -72,7 +72,7 @@ void setup_WS(std::string &inputSpace) {
   loader.initialize();
   // Path to test input file assumes Test directory checked out from SVN
   const std::filesystem::path inputFile = ConfigService::Instance().getInstrumentDirectory() / "HET_Definition_old.xml";
-  loader.setPropertyValue("Filename", inputFile);
+  loader.setPropertyValue("Filename", inputFile.string());
   loader.setPropertyValue("Workspace", inputSpace);
   loader.setProperty("RewriteSpectraMap", Mantid::Kernel::OptionalBool(false));
   loader.execute();
@@ -106,7 +106,7 @@ void setup_Points_WS(std::string &inputSpace) {
   loader.initialize();
   // Path to test input file assumes Test directory checked out from SVN
   const std::filesystem::path inputFile = ConfigService::Instance().getInstrumentDirectory() / "HET_Definition_old.xml";
-  loader.setPropertyValue("Filename", inputFile);
+  loader.setPropertyValue("Filename", inputFile.string());
   loader.setPropertyValue("Workspace", inputSpace);
   loader.setProperty("RewriteSpectraMap", Mantid::Kernel::OptionalBool(false));
   loader.execute();

--- a/Framework/Algorithms/test/ConvertUnitsTest.h
+++ b/Framework/Algorithms/test/ConvertUnitsTest.h
@@ -25,6 +25,8 @@
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/UnitFactory.h"
 
+#include <filesystem>
+
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::Algorithms;
@@ -69,7 +71,7 @@ void setup_WS(std::string &inputSpace) {
   Mantid::DataHandling::LoadInstrument loader;
   loader.initialize();
   // Path to test input file assumes Test directory checked out from SVN
-  const std::string inputFile = ConfigService::Instance().getInstrumentDirectory() + "HET_Definition_old.xml";
+  const std::filesystem::path inputFile = ConfigService::Instance().getInstrumentDirectory() / "HET_Definition_old.xml";
   loader.setPropertyValue("Filename", inputFile);
   loader.setPropertyValue("Workspace", inputSpace);
   loader.setProperty("RewriteSpectraMap", Mantid::Kernel::OptionalBool(false));
@@ -103,7 +105,7 @@ void setup_Points_WS(std::string &inputSpace) {
   Mantid::DataHandling::LoadInstrument loader;
   loader.initialize();
   // Path to test input file assumes Test directory checked out from SVN
-  const std::string inputFile = ConfigService::Instance().getInstrumentDirectory() + "HET_Definition_old.xml";
+  const std::filesystem::path inputFile = ConfigService::Instance().getInstrumentDirectory() / "HET_Definition_old.xml";
   loader.setPropertyValue("Filename", inputFile);
   loader.setPropertyValue("Workspace", inputSpace);
   loader.setProperty("RewriteSpectraMap", Mantid::Kernel::OptionalBool(false));

--- a/Framework/Crystal/test/CentroidPeaksTest.h
+++ b/Framework/Crystal/test/CentroidPeaksTest.h
@@ -17,6 +17,7 @@
 #include "MantidFrameworkTestHelpers/FacilityHelper.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidHistogramData/LinearGenerator.h"
+#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/Timer.h"
 #include <cmath>

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -29,11 +29,11 @@
 #include "MantidNexus/NeXusException.hpp"
 #include "MantidNexus/NeXusFile.hpp"
 
-#include <Poco/Path.h>
 #include <algorithm>
 #include <boost/lexical_cast.hpp>
 #include <boost/scoped_array.hpp>
 #include <cstdint>
+#include <filesystem>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -532,10 +532,10 @@ bool LoadEventNexus::runLoadInstrument(const std::string &nexusfilename, T local
           API::InstrumentFileFinder::getInstrumentFilename(instrument, localWorkspace->getWorkspaceStartDate());
     } catch (Kernel::Exception::NotFoundError &) {
       if (instFilename.empty()) {
-        Poco::Path directory(Kernel::ConfigService::Instance().getInstrumentDirectory().string());
-        Poco::Path file(instrument + "_Definition.xml");
-        Poco::Path fullPath(directory, file);
-        instFilename = fullPath.toString();
+        const auto directory = Kernel::ConfigService::Instance().getInstrumentDirectory();
+        const auto filename = instrument + "_Definition.xml";
+        const auto fullPath = directory / filename;
+        instFilename = fullPath.string();
       }
     }
   }

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -532,7 +532,7 @@ bool LoadEventNexus::runLoadInstrument(const std::string &nexusfilename, T local
           API::InstrumentFileFinder::getInstrumentFilename(instrument, localWorkspace->getWorkspaceStartDate());
     } catch (Kernel::Exception::NotFoundError &) {
       if (instFilename.empty()) {
-        Poco::Path directory(Kernel::ConfigService::Instance().getInstrumentDirectory());
+        Poco::Path directory(Kernel::ConfigService::Instance().getInstrumentDirectory().string());
         Poco::Path file(instrument + "_Definition.xml");
         Poco::Path fullPath(directory, file);
         instFilename = fullPath.toString();

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
@@ -19,15 +19,12 @@
 #include "MantidTypes/SpectrumDefinition.h"
 
 #include <climits>
+#include <filesystem>
 #include <list>
 #include <memory>
 
 class ISISRAW;
 class ISISRAW2;
-
-namespace Poco {
-class Path;
-}
 
 namespace Mantid {
 namespace API {
@@ -60,7 +57,7 @@ public:
   int confidence(Kernel::FileDescriptor &descriptor) const override;
 
   /// Search for the log files in the workspace, and output their names as a list.
-  static std::list<std::string> searchForLogFiles(const Poco::Path &pathToRawFile);
+  static std::list<std::string> searchForLogFiles(const std::filesystem::path &pathToRawFile);
   /// returns true if the Exclude Monitor option(property) selected
   static bool isExcludeMonitors(const std::string &monitorOption);
   /// returns true if the Separate Monitor Option  selected

--- a/Framework/DataHandling/inc/MantidDataHandling/SampleEnvironmentFactory.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SampleEnvironmentFactory.h
@@ -8,6 +8,7 @@
 
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataHandling/SampleEnvironmentSpec.h"
+#include <filesystem>
 
 namespace Mantid {
 namespace DataHandling {
@@ -57,7 +58,7 @@ private:
  */
 class MANTID_DATAHANDLING_DLL SampleEnvironmentSpecFileFinder final : public ISampleEnvironmentSpecFinder {
 public:
-  SampleEnvironmentSpecFileFinder(std::vector<std::string> directories);
+  SampleEnvironmentSpecFileFinder(std::vector<std::filesystem::path> directories);
 
   SampleEnvironmentSpec_uptr find(const std::string &facility, const std::string &instrument,
                                   const std::string &name) const override;
@@ -65,7 +66,7 @@ public:
 
 private:
   const std::string m_fileext = ".xml";
-  const std::vector<std::string> m_rootDirs;
+  const std::vector<std::filesystem::path> m_rootDirs;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/DownloadInstrument.cpp
+++ b/Framework/DataHandling/src/DownloadInstrument.cpp
@@ -154,7 +154,7 @@ DownloadInstrument::StringToStringMap DownloadInstrument::processRepository() {
 
   // get the date of the local github.json file if it exists
   std::filesystem::path gitHubJson(localPath / "github.json");
-  Poco::File gitHubJsonFile(gitHubJson);
+  Poco::File gitHubJsonFile(gitHubJson.string());
   Poco::DateTime gitHubJsonDate(1900, 1, 1);
   bool forceUpdate = this->getProperty("ForceUpdate");
   if ((!forceUpdate) && gitHubJsonFile.exists() && gitHubJsonFile.isFile()) {

--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include <cmath>
 #include <cstdio>
+#include <filesystem>
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Axis.h"
@@ -429,10 +430,11 @@ void LoadBBY::loadInstrumentParameters(const NeXus::NXEntry &entry, std::map<std
                                        std::map<std::string, std::string> &logStrings,
                                        std::map<std::string, std::string> &allParams) {
   using namespace Poco::XML;
-  std::string idfDirectory = Mantid::Kernel::ConfigService::Instance().getString("instrumentDefinition.directory");
+  std::filesystem::path idfDirectory(
+      Mantid::Kernel::ConfigService::Instance().getString("instrumentDefinition.directory"));
 
   try {
-    std::string parameterFilename = idfDirectory + "BILBY_Parameters.xml";
+    std::string parameterFilename = (idfDirectory / "BILBY_Parameters.xml").string();
     // Set up the DOM parser and parse xml file
     DOMParser pParser;
     Poco::AutoPtr<Poco::XML::Document> pDoc;

--- a/Framework/DataHandling/src/LoadFITS.cpp
+++ b/Framework/DataHandling/src/LoadFITS.cpp
@@ -443,7 +443,7 @@ void LoadFITS::doLoadFiles(const std::vector<std::string> &paths, const std::str
     // files
     try {
       auto loadInst = createChildAlgorithm("LoadInstrument");
-      std::string directoryName = Kernel::ConfigService::Instance().getInstrumentDirectory();
+      std::string directoryName = Kernel::ConfigService::Instance().getInstrumentDirectory().string();
       directoryName = directoryName + "/IMAT_Definition.xml";
       loadInst->setPropertyValue("Filename", directoryName);
       loadInst->setProperty<MatrixWorkspace_sptr>("Workspace", std::dynamic_pointer_cast<MatrixWorkspace>(imgWS));

--- a/Framework/DataHandling/src/LoadIDFFromNexus.cpp
+++ b/Framework/DataHandling/src/LoadIDFFromNexus.cpp
@@ -139,16 +139,15 @@ void LoadIDFFromNexus::exec() {
  */
 std::string LoadIDFFromNexus::getParameterCorrectionFile(const std::string &instName) {
 
-  std::vector<std::string> directoryNames = ConfigService::Instance().getInstrumentDirectories();
+  std::vector<std::filesystem::path> directoryNames = ConfigService::Instance().getInstrumentDirectories();
   for (auto &directoryName : directoryNames) {
     // This will iterate around the directories from user ->etc ->install, and
     // find the first appropriate file
-    Poco::Path iPath(directoryName,
-                     "embedded_instrument_corrections"); // Go to correction file subfolder
+    std::filesystem::path iPath(directoryName / "embedded_instrument_corrections"); // Go to correction file subfolder
     // First see if the directory exists
     Poco::File ipDir(iPath);
     if (ipDir.exists() && ipDir.isDirectory()) {
-      iPath.append(instName + "_Parameter_Corrections.xml"); // Append file name to pathname
+      iPath /= instName + "_Parameter_Corrections.xml"; // Append file name to pathname
       Poco::File ipFile(iPath);
       if (ipFile.exists() && ipFile.isFile()) {
         return ipFile.path(); // Return first found
@@ -256,16 +255,16 @@ void LoadIDFFromNexus::LoadParameters(::NeXus::File *nxfile, const MatrixWorkspa
   if (parameterString.empty()) {
     // No parameters have been found in Nexus file, so we look for them in a
     // parameter file.
-    std::vector<std::string> directoryNames = ConfigService::Instance().getInstrumentDirectories();
+    std::vector<std::filesystem::path> directoryNames = ConfigService::Instance().getInstrumentDirectories();
     const std::string instrumentName = localWorkspace->getInstrument()->getName();
     for (const auto &directoryName : directoryNames) {
       // This will iterate around the directories from user ->etc ->install, and
       // find the first appropriate file
-      const std::string paramFile = directoryName + instrumentName + "_Parameters.xml";
+      const std::filesystem::path paramFile = directoryName / instrumentName / "_Parameters.xml";
 
       // Attempt to load specified file, if successful, use file and stop
       // search.
-      if (loadParameterFile(paramFile, localWorkspace))
+      if (loadParameterFile(paramFile.string(), localWorkspace))
         break;
     }
   } else { // We do have parameters from the Nexus file

--- a/Framework/DataHandling/src/LoadIDFFromNexus.cpp
+++ b/Framework/DataHandling/src/LoadIDFFromNexus.cpp
@@ -140,7 +140,7 @@ void LoadIDFFromNexus::exec() {
 std::string LoadIDFFromNexus::getParameterCorrectionFile(const std::string &instName) {
 
   std::vector<std::filesystem::path> directoryNames = ConfigService::Instance().getInstrumentDirectories();
-  for (auto &directoryName : directoryNames) {
+  for (const auto &directoryName : directoryNames) {
     // This will iterate around the directories from user ->etc ->install, and
     // find the first appropriate file
     std::filesystem::path iPath(directoryName / "embedded_instrument_corrections"); // Go to correction file subfolder

--- a/Framework/DataHandling/src/LoadIDFFromNexus.cpp
+++ b/Framework/DataHandling/src/LoadIDFFromNexus.cpp
@@ -145,10 +145,10 @@ std::string LoadIDFFromNexus::getParameterCorrectionFile(const std::string &inst
     // find the first appropriate file
     std::filesystem::path iPath(directoryName / "embedded_instrument_corrections"); // Go to correction file subfolder
     // First see if the directory exists
-    Poco::File ipDir(iPath);
+    Poco::File ipDir(iPath.string());
     if (ipDir.exists() && ipDir.isDirectory()) {
       iPath /= instName + "_Parameter_Corrections.xml"; // Append file name to pathname
-      Poco::File ipFile(iPath);
+      Poco::File ipFile(iPath.string());
       if (ipFile.exists() && ipFile.isFile()) {
         return ipFile.path(); // Return first found
       }

--- a/Framework/DataHandling/src/LoadIDFFromNexus.cpp
+++ b/Framework/DataHandling/src/LoadIDFFromNexus.cpp
@@ -260,7 +260,7 @@ void LoadIDFFromNexus::LoadParameters(::NeXus::File *nxfile, const MatrixWorkspa
     for (const auto &directoryName : directoryNames) {
       // This will iterate around the directories from user ->etc ->install, and
       // find the first appropriate file
-      const std::filesystem::path paramFile = directoryName / instrumentName / "_Parameters.xml";
+      const std::filesystem::path paramFile = directoryName / (instrumentName + "_Parameters.xml");
 
       // Attempt to load specified file, if successful, use file and stop
       // search.

--- a/Framework/DataHandling/src/LoadILLDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLDiffraction.cpp
@@ -736,7 +736,7 @@ void LoadILLDiffraction::moveTwoThetaZero(double twoTheta0Read) {
  */
 std::string LoadILLDiffraction::getInstrumentFilePath(const std::string &instName) const {
 
-  Poco::Path directory(ConfigService::Instance().getInstrumentDirectory());
+  Poco::Path directory(ConfigService::Instance().getInstrumentDirectory().string());
   Poco::Path file(instName + "_Definition.xml");
   Poco::Path fullPath(directory, file);
   return fullPath.toString();

--- a/Framework/DataHandling/src/LoadILLSANS.cpp
+++ b/Framework/DataHandling/src/LoadILLSANS.cpp
@@ -782,7 +782,7 @@ void LoadILLSANS::createEmptyWorkspace(const size_t numberOfHistograms, const si
  */
 std::string LoadILLSANS::getInstrumentFilePath(const std::string &instName) const {
 
-  Poco::Path directory(ConfigService::Instance().getInstrumentDirectory());
+  Poco::Path directory(ConfigService::Instance().getInstrumentDirectory().string());
   Poco::Path file(instName + "_Definition.xml");
   Poco::Path fullPath(directory, file);
   return fullPath.toString();

--- a/Framework/DataHandling/src/LoadNXcanSAS.cpp
+++ b/Framework/DataHandling/src/LoadNXcanSAS.cpp
@@ -18,6 +18,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataHandling/NXcanSASDefinitions.h"
+#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Logger.h"
 #include "MantidNexus/H5Util.h"
 #include "MantidNexus/NeXusFile.hpp"

--- a/Framework/DataHandling/src/LoadParameterFile.cpp
+++ b/Framework/DataHandling/src/LoadParameterFile.cpp
@@ -101,11 +101,8 @@ void LoadParameterFile::exec() {
       // First see if the file exists
       Poco::File ipfFile(filename);
       if (!ipfFile.exists()) {
-        Poco::Path filePath(filename);
-        filename = Poco::Path(Kernel::ConfigService::Instance().getInstrumentDirectory())
-                       .makeDirectory()
-                       .setFileName(filePath.getFileName())
-                       .toString();
+        std::filesystem::path filePath(filename);
+        filename = (Kernel::ConfigService::Instance().getInstrumentDirectory() / filePath.filename()).string();
       }
       g_log.information() << "Parsing from XML file: " << filename << '\n';
       pDoc = pParser.parse(filename);

--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -83,7 +83,7 @@ std::set<std::string> logFilesFromAlternateDataStream(const std::filesystem::pat
       std::filesystem::path logFilePath(dirOfFile);
       logFilePath.append(line.substr(asteriskPos + 1));
       if (std::filesystem::exists(logFilePath)) {
-        logfilesList.insert(logFilePath.string());
+        logfilesList.insert(logFilePath.generic_string());
       }
     }
   }
@@ -1139,9 +1139,9 @@ std::list<std::string> LoadRawHelper::searchForLogFiles(const std::filesystem::p
   // potentialLogFiles
   // have we been given what looks like a log file
   const auto fileExt = pathToRawFile.extension().string();
-  if (boost::algorithm::iequals(fileExt, "log") || boost::algorithm::iequals(fileExt, "txt")) {
+  if (boost::algorithm::iequals(fileExt, ".log") || boost::algorithm::iequals(fileExt, ".txt")) {
     // then we will assume that the file is an ISIS log file
-    potentialLogFiles.insert(pathToRawFile.string());
+    potentialLogFiles.insert(pathToRawFile.generic_string());
   } else {
     // then we will assume that the file is an ISIS raw file. The file validator
     // will have warned the user if the extension is not one of the suggested
@@ -1162,7 +1162,7 @@ std::list<std::string> LoadRawHelper::searchForLogFiles(const std::filesystem::p
       combinedLogPath.replace_extension("log");
       if (std::filesystem::exists(combinedLogPath)) {
         // Push three column filename to end of list.
-        potentialLogFilesList.insert(potentialLogFilesList.end(), combinedLogPath.string());
+        potentialLogFilesList.insert(potentialLogFilesList.end(), combinedLogPath.generic_string());
       }
     }
 

--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -20,17 +20,18 @@
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/UnitFactory.h"
-#include <Poco/File.h>
-#include <Poco/Path.h>
 #include <boost/algorithm/string/predicate.hpp>
 #include <cstdio>
+#include <filesystem>
 
 namespace {
 /**
  * Return the path to the alternate data stream for the given path
  * @param filePath The full path to the main data path
  */
-inline std::string alternateDataStream(const Poco::Path &filePath) { return filePath.toString() + ":checksum"; }
+inline std::string alternateDataStream(const std::filesystem::path &filePath) {
+  return filePath.string() + ":checksum";
+}
 
 /**
  * This method looks for ADS with name checksum exists
@@ -38,7 +39,7 @@ inline std::string alternateDataStream(const Poco::Path &filePath) { return file
  * @return True if ADS stream checksum exists
  */
 #ifdef _WIN32
-inline bool hasAlternateDataStream(const Poco::Path &pathToFile) {
+inline bool hasAlternateDataStream(const std::filesystem::path &pathToFile) {
   std::ifstream adsStream(alternateDataStream(pathToFile));
   if (!adsStream) {
     return false;
@@ -47,7 +48,7 @@ inline bool hasAlternateDataStream(const Poco::Path &pathToFile) {
   return true;
 }
 #else
-inline bool hasAlternateDataStream([[maybe_unused]] const Poco::Path &pathToFile) { return false; }
+inline bool hasAlternateDataStream([[maybe_unused]] const std::filesystem::path &pathToFile) { return false; }
 #endif
 
 /**
@@ -57,7 +58,7 @@ inline bool hasAlternateDataStream([[maybe_unused]] const Poco::Path &pathToFile
  * @param pathToRawFile The path and name of the raw file.
  * @return set of logfile names.
  */
-std::set<std::string> logFilesFromAlternateDataStream(const Poco::Path &pathToRawFile) {
+std::set<std::string> logFilesFromAlternateDataStream(const std::filesystem::path &pathToRawFile) {
   std::set<std::string> logfilesList;
   std::ifstream adsStream(alternateDataStream(pathToRawFile));
   if (!adsStream) {
@@ -72,17 +73,17 @@ std::set<std::string> logFilesFromAlternateDataStream(const Poco::Path &pathToRa
   // e200aa65186b61e487175d5263b315aa *IRIS00055132_ICPevent.txt
   // 91be40aa4f54d050a9eb4abea394720e *IRIS00055132_ICPstatus.txt
   // 50aa2872110a9b862b01c6c83f8ce9a8 *IRIS00055132_Status.txt
-  Poco::Path dirOfFile(pathToRawFile.parent());
+  std::filesystem::path dirOfFile(pathToRawFile.parent_path());
   std::string line;
   while (Mantid::Kernel::Strings::extractToEOL(adsStream, line)) {
     if (boost::algorithm::iends_with(line, ".txt") || boost::algorithm::iends_with(line, ".log")) {
       const size_t asteriskPos = line.find('*');
       if (asteriskPos == std::string::npos)
         continue;
-      Poco::Path logFilePath(dirOfFile);
+      std::filesystem::path logFilePath(dirOfFile);
       logFilePath.append(line.substr(asteriskPos + 1));
-      if (Poco::File(logFilePath).exists()) {
-        logfilesList.insert(logFilePath.toString());
+      if (std::filesystem::exists(logFilePath)) {
+        logfilesList.insert(logFilePath.string());
       }
     }
   }
@@ -670,7 +671,7 @@ void LoadRawHelper::runLoadMappingTable(const std::string &fileName,
 void LoadRawHelper::runLoadLog(const std::string &fileName, const DataObjects::Workspace2D_sptr &localWorkspace,
                                double progStart, double progEnd) {
   // search for the log file to load, and save their names in a list.
-  std::list<std::string> logFiles = searchForLogFiles(Poco::Path(fileName));
+  std::list<std::string> logFiles = searchForLogFiles(std::filesystem::path(fileName));
 
   g_log.debug("Loading the log files...");
   if (progStart < progEnd) {
@@ -750,7 +751,7 @@ void LoadRawHelper::runLoadLog(const std::string &fileName, const DataObjects::W
  */
 std::string LoadRawHelper::extractLogName(const std::string &path) {
   // The log file's name, including workspace (e.g. CSP78173_ICPevent)
-  std::string fileName = Poco::Path(Poco::Path(path).getFileName()).getBaseName();
+  std::string fileName = std::filesystem::path(std::filesystem::path(path).filename()).stem().string();
   // Return only the log name (excluding workspace, e.g. ICPevent)
   return (fileName.substr(fileName.find('_') + 1));
 }
@@ -1115,7 +1116,7 @@ int LoadRawHelper::confidence(Kernel::FileDescriptor &descriptor) const {
  * @param pathToRawFile The path and name of the raw file.
  * @returns A set containing paths to log files related to RAW file used.
  */
-std::list<std::string> LoadRawHelper::searchForLogFiles(const Poco::Path &pathToRawFile) {
+std::list<std::string> LoadRawHelper::searchForLogFiles(const std::filesystem::path &pathToRawFile) {
   // If pathToRawFile is the filename of a raw datafile then search for
   // potential log files
   // in the directory of this raw datafile. Otherwise check if it is a potential
@@ -1130,17 +1131,17 @@ std::list<std::string> LoadRawHelper::searchForLogFiles(const Poco::Path &pathTo
 
   // File property checks whether the given path exists, just check that is
   // actually a file
-  if (Poco::File(pathToRawFile).isDirectory()) {
-    throw Exception::FileError("Filename is a directory:", pathToRawFile.toString());
+  if (std::filesystem::is_directory(pathToRawFile)) {
+    throw Exception::FileError("Filename is a directory:", pathToRawFile.string());
   }
 
   // start the process or populating potential log files into the container:
   // potentialLogFiles
   // have we been given what looks like a log file
-  const auto fileExt = pathToRawFile.getExtension();
+  const auto fileExt = pathToRawFile.extension().string();
   if (boost::algorithm::iequals(fileExt, "log") || boost::algorithm::iequals(fileExt, "txt")) {
     // then we will assume that the file is an ISIS log file
-    potentialLogFiles.insert(pathToRawFile.toString());
+    potentialLogFiles.insert(pathToRawFile.string());
   } else {
     // then we will assume that the file is an ISIS raw file. The file validator
     // will have warned the user if the extension is not one of the suggested
@@ -1150,17 +1151,18 @@ std::list<std::string> LoadRawHelper::searchForLogFiles(const Poco::Path &pathTo
       potentialLogFiles = logFilesFromAlternateDataStream(pathToRawFile);
     } else {
       // look for log files in the directory of the raw datafile
-      Poco::Path pattern = pathToRawFile;
-      pattern.setFileName(pathToRawFile.getBaseName() + "_*.txt");
+      auto pattern = pathToRawFile;
+      pattern.replace_filename(pathToRawFile.stem().string() + "_*.txt");
       try {
         Kernel::Glob::glob(pattern, potentialLogFiles);
       } catch (std::exception &) {
       }
       // Check for .log
-      const Poco::File combinedLogPath(Poco::Path(pathToRawFile).setExtension("log"));
-      if (combinedLogPath.exists()) {
+      std::filesystem::path combinedLogPath(pathToRawFile);
+      combinedLogPath.replace_extension("log");
+      if (std::filesystem::exists(combinedLogPath)) {
         // Push three column filename to end of list.
-        potentialLogFilesList.insert(potentialLogFilesList.end(), combinedLogPath.path());
+        potentialLogFilesList.insert(potentialLogFilesList.end(), combinedLogPath.string());
       }
     }
 

--- a/Framework/DataHandling/src/SampleEnvironmentFactory.cpp
+++ b/Framework/DataHandling/src/SampleEnvironmentFactory.cpp
@@ -124,7 +124,7 @@ SampleEnvironmentSpec_uptr SampleEnvironmentFactory::parseSpec(const std::string
  * then forms the path to find the named spec
  * @throws std::invalid_argument if the list is empty
  */
-SampleEnvironmentSpecFileFinder::SampleEnvironmentSpecFileFinder(std::vector<std::string> directories)
+SampleEnvironmentSpecFileFinder::SampleEnvironmentSpecFileFinder(std::vector<std::filesystem::path> directories)
     : m_rootDirs(std::move(directories)) {
   if (m_rootDirs.empty()) {
     throw std::invalid_argument("SampleEnvironmentSpecFileFinder() - Empty directory search list.");

--- a/Framework/DataHandling/src/SampleEnvironmentFactory.cpp
+++ b/Framework/DataHandling/src/SampleEnvironmentFactory.cpp
@@ -153,7 +153,7 @@ SampleEnvironmentSpec_uptr SampleEnvironmentSpecFileFinder::find(const std::stri
   // check for the instrument environment, then facility environment
   for (const auto &rel_path : {relpath_instr, relpath_facil}) {
     for (const auto &prefixStr : m_rootDirs) {
-      Path prefix(prefixStr);
+      Path prefix(prefixStr.string());
       // Ensure the path is a directory (note that this does not create it!)
       prefix.makeDirectory();
       File fullpath(Poco::Path(prefix, rel_path));

--- a/Framework/DataHandling/src/SetSample.cpp
+++ b/Framework/DataHandling/src/SetSample.cpp
@@ -597,7 +597,7 @@ SetSample::setSampleEnvironmentFromFile(API::ExperimentInfo &exptInfo, const Ker
   }
 
   const auto &instDirs = config.getInstrumentDirectories();
-  std::vector<std::string> environDirs(instDirs);
+  std::vector<std::filesystem::path> environDirs(instDirs);
   for (auto &direc : environDirs) {
     direc = Poco::Path(direc).append("sampleenvironments").toString();
   }

--- a/Framework/DataHandling/src/SetSample.cpp
+++ b/Framework/DataHandling/src/SetSample.cpp
@@ -599,7 +599,7 @@ SetSample::setSampleEnvironmentFromFile(API::ExperimentInfo &exptInfo, const Ker
   const auto &instDirs = config.getInstrumentDirectories();
   std::vector<std::filesystem::path> environDirs(instDirs);
   for (auto &direc : environDirs) {
-    direc = Poco::Path(direc).append("sampleenvironments").toString();
+    direc = Poco::Path(direc.string()).append("sampleenvironments").toString();
   }
   auto finder = std::make_unique<SampleEnvironmentSpecFileFinder>(environDirs);
   SampleEnvironmentFactory factory(std::move(finder));

--- a/Framework/DataHandling/test/DownloadInstrumentTest.h
+++ b/Framework/DataHandling/test/DownloadInstrumentTest.h
@@ -162,7 +162,6 @@ public:
   void test_execOrphanedFile() {
     // add an orphaned file
     std::filesystem::path orphanedFilePath(m_localInstDir);
-    std::filesystem::create_directory(orphanedFilePath);
     orphanedFilePath.replace_filename("Orphaned_Should_not_be_here.xml");
 
     std::ofstream file;

--- a/Framework/DataHandling/test/DownloadInstrumentTest.h
+++ b/Framework/DataHandling/test/DownloadInstrumentTest.h
@@ -98,7 +98,7 @@ public:
   static void destroySuite(DownloadInstrumentTest *suite) { delete suite; }
 
   void createDirectory(const std::filesystem::path &path) {
-    Poco::File file(path);
+    Poco::File file(path.string());
     if (file.createDirectory()) {
       m_directoriesToRemove.emplace_back(file);
     }
@@ -169,7 +169,7 @@ public:
 
     TSM_ASSERT_EQUALS("The expected number of files downloaded was wrong.", runDownloadInstrument(), 2);
 
-    Poco::File orphanedFile(orphanedFilePath);
+    Poco::File orphanedFile(orphanedFilePath.string());
     TSM_ASSERT("The orphaned file was not deleted", orphanedFile.exists() == false);
   }
 

--- a/Framework/DataHandling/test/DownloadInstrumentTest.h
+++ b/Framework/DataHandling/test/DownloadInstrumentTest.h
@@ -161,8 +161,7 @@ public:
 
   void test_execOrphanedFile() {
     // add an orphaned file
-    std::filesystem::path orphanedFilePath(m_localInstDir);
-    orphanedFilePath.replace_filename("Orphaned_Should_not_be_here.xml");
+    std::filesystem::path orphanedFilePath(m_localInstDir / "Orphaned_Should_not_be_here.xml");
 
     std::ofstream file;
     file.open(orphanedFilePath.string().c_str());

--- a/Framework/DataHandling/test/GenerateGroupingPowder2Test.h
+++ b/Framework/DataHandling/test/GenerateGroupingPowder2Test.h
@@ -24,10 +24,10 @@
 #include <Poco/DOM/DOMParser.h>
 #include <Poco/DOM/NodeFilter.h>
 #include <Poco/DOM/NodeIterator.h>
-#include <Poco/File.h>
 #include <Poco/SAX/InputSource.h>
 #include <cxxtest/TestSuite.h>
 #include <exception>
+#include <filesystem>
 #include <fstream>
 
 using namespace Mantid;
@@ -544,8 +544,5 @@ private:
 
   MatrixWorkspace_sptr m_emptyInstrument;
 
-  bool fileExists(const std::string &filename) {
-    Poco::File handle{filename};
-    return handle.exists();
-  }
+  bool fileExists(const std::string &filename) { return std::filesystem::exists(filename); }
 };

--- a/Framework/DataHandling/test/GenerateGroupingPowderTest.h
+++ b/Framework/DataHandling/test/GenerateGroupingPowderTest.h
@@ -24,10 +24,10 @@
 #include <Poco/DOM/DOMParser.h>
 #include <Poco/DOM/NodeFilter.h>
 #include <Poco/DOM/NodeIterator.h>
-#include <Poco/File.h>
 #include <Poco/SAX/InputSource.h>
 #include <cxxtest/TestSuite.h>
 #include <exception>
+#include <filesystem>
 #include <fstream>
 
 using namespace Mantid;
@@ -549,8 +549,5 @@ private:
 
   MatrixWorkspace_sptr m_emptyInstrument;
 
-  bool fileExists(const std::string &filename) {
-    Poco::File handle{filename};
-    return handle.exists();
-  }
+  bool fileExists(const std::string &filename) { return std::filesystem::exists(filename); }
 };

--- a/Framework/DataHandling/test/LoadAsciiTest.h
+++ b/Framework/DataHandling/test/LoadAsciiTest.h
@@ -15,8 +15,7 @@
 #include "MantidAPI/Run.h"
 #include "MantidKernel/Unit.h"
 
-#include <Poco/File.h>
-
+#include <filesystem>
 #include <fstream>
 
 class LoadAsciiTest : public CxxTest::TestSuite {
@@ -25,28 +24,28 @@ public:
     const std::string filename("LoadAsciiTest_test_No_Header_3.txt");
     writeThreeColumnTestFile(filename, false);
     runTest(filename, "CSV", true);
-    Poco::File(filename).remove();
+    std::filesystem::remove(filename);
   }
 
   void test_Three_Column_With_Header_Info() {
     const std::string filename("LoadAsciiTest_test_With_Header_3.txt");
     writeThreeColumnTestFile(filename, true);
     runTest(filename, "CSV", true);
-    Poco::File(filename).remove();
+    std::filesystem::remove(filename);
   }
 
   void test_Two_Column_Example_With_No_Header() {
     const std::string filename("LoadAsciiTest_test_No_Header_2.txt");
     writeTwoColumnTestFile(filename, false);
     runTest(filename, "Space", false);
-    Poco::File(filename).remove();
+    std::filesystem::remove(filename);
   }
 
   void test_Two_Column_With_Header_Info() {
     const std::string filename("LoadAsciiTest_test_With_Header_2.txt");
     writeTwoColumnTestFile(filename, true);
     runTest(filename, "Space", false);
-    Poco::File(filename).remove();
+    std::filesystem::remove(filename);
   }
 
   void test_Four_Column_Example_With_No_Header() {
@@ -56,7 +55,7 @@ public:
     TS_ASSERT_EQUALS(outputWS->dx(0)[0], 0.1);
     TS_ASSERT_EQUALS(outputWS->dx(0)[18], 1.9);
     TS_ASSERT_EQUALS(outputWS->dx(0)[29], 0.8);
-    Poco::File(filename).remove();
+    std::filesystem::remove(filename);
   }
 
   void test_Spacing_Around_Separators() {
@@ -79,7 +78,7 @@ public:
     TS_ASSERT_EQUALS(outputWS->blocksize(), 9);
 
     Mantid::API::AnalysisDataService::Instance().remove(outputWS->getName());
-    Poco::File(filename).remove();
+    std::filesystem::remove(filename);
   }
 
 private:

--- a/Framework/DataHandling/test/LoadDetectorInfoTest.h
+++ b/Framework/DataHandling/test/LoadDetectorInfoTest.h
@@ -22,8 +22,8 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidNexus/NeXusFile.hpp"
 
-#include <Poco/File.h>
 #include <boost/lexical_cast.hpp>
+#include <filesystem>
 #include <vector>
 
 using namespace Mantid::DataHandling;
@@ -247,8 +247,8 @@ public:
   }
 
   ~LoadDetectorInfoTest() override {
-    Poco::File(m_DatFile).remove();
-    Poco::File(m_NXSFile).remove();
+    std::filesystem::remove(m_DatFile);
+    std::filesystem::remove(m_NXSFile);
   }
 
   void testLoadDat() { loadDatFileTestHelper(m_DatFile); }
@@ -416,7 +416,7 @@ public:
   }
 
   void tearDown() override {
-    Poco::File(m_testfile).remove();
+    std::filesystem::remove(m_testfile);
     AnalysisDataService::Instance().remove(m_wsName);
   }
 

--- a/Framework/DataHandling/test/LoadDetectorsGroupingFileTest.h
+++ b/Framework/DataHandling/test/LoadDetectorsGroupingFileTest.h
@@ -17,6 +17,7 @@
 #include "Poco/File.h"
 
 #include <cxxtest/TestSuite.h>
+#include <filesystem>
 #include <fstream>
 
 using namespace Mantid;
@@ -81,7 +82,9 @@ public:
     TS_ASSERT_DELTA(gws->y(3696)[0], 2.0, 1.0E-5);
     TS_ASSERT_DELTA(gws->y(7000)[0], 0.0, 1.0E-5);
     // Check if filename is saved
-    TS_ASSERT_EQUALS(load.getPropertyValue("InputFile"), gws->run().getProperty("Filename")->value());
+    std::filesystem::path loadInputFile(load.getPropertyValue("InputFile"));
+    std::filesystem::path gwsInputFile(gws->run().getProperty("Filename")->value());
+    TS_ASSERT(std::filesystem::equivalent(loadInputFile, gwsInputFile))
 
     // Clean-up
     API::AnalysisDataService::Instance().remove(ws);

--- a/Framework/DataHandling/test/LoadDiffCalTest.h
+++ b/Framework/DataHandling/test/LoadDiffCalTest.h
@@ -16,7 +16,7 @@
 #include "MantidDataHandling/SaveDetectorsGrouping.h"
 #include "SaveDiffCalTest.h"
 
-#include <Poco/File.h>
+#include <filesystem>
 
 using Mantid::DataHandling::LoadDiffCal;
 using Mantid::DataHandling::SaveDiffCal;
@@ -80,9 +80,7 @@ public:
       AnalysisDataService::Instance().remove(outWSName + "_cal");
     }
 
-    // cleanup
-    if (Poco::File(filename).exists())
-      Poco::File(filename).remove();
+    removeFileIfItExists(filename);
   }
 
   // Override a grouping definition specified by LoadDiffCal "Filename" property.
@@ -163,11 +161,8 @@ public:
       AnalysisDataService::Instance().remove(outWSName + "_group");
     }
 
-    // cleanup
-    if (Poco::File(filename).exists())
-      Poco::File(filename).remove();
-    if (Poco::File(groupingfile).exists())
-      Poco::File(groupingfile).remove();
+    removeFileIfItExists(filename);
+    removeFileIfItExists(groupingfile);
   }
 
   // Create a zero calibration workspace consistent with an input grouping workspace.
@@ -281,10 +276,14 @@ public:
       AnalysisDataService::Instance().remove(outWSName + "_group");
     }
 
-    // cleanup
-    if (Poco::File(filename).exists())
-      Poco::File(filename).remove();
-    if (Poco::File(groupingfile).exists())
-      Poco::File(groupingfile).remove();
+    removeFileIfItExists(filename);
+    removeFileIfItExists(groupingfile);
+  }
+
+private:
+  void removeFileIfItExists(const std::string &filename) {
+    if (std::filesystem::exists(filename)) {
+      std::filesystem::remove(filename);
+    }
   }
 };

--- a/Framework/DataHandling/test/LoadEmptyInstrumentTest.h
+++ b/Framework/DataHandling/test/LoadEmptyInstrumentTest.h
@@ -53,7 +53,7 @@ public:
 
   // Helper method to create the IDF File.
   ScopedFile createIDFFileObject(const std::string &idf_filename, const std::string &idf_file_contents) {
-    const std::filesystem::path instrument_dir = ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/";
+    const std::filesystem::path instrument_dir = ConfigService::Instance().getInstrumentDirectory() / "unit_testing/";
 
     return ScopedFile(idf_file_contents, idf_filename, instrument_dir.string());
   }

--- a/Framework/DataHandling/test/LoadEmptyInstrumentTest.h
+++ b/Framework/DataHandling/test/LoadEmptyInstrumentTest.h
@@ -21,6 +21,7 @@
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Logger.h"
 
+#include <filesystem>
 #include <vector>
 
 using namespace Mantid::API;
@@ -52,9 +53,9 @@ public:
 
   // Helper method to create the IDF File.
   ScopedFile createIDFFileObject(const std::string &idf_filename, const std::string &idf_file_contents) {
-    const std::string instrument_dir = ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/";
+    const std::filesystem::path instrument_dir = ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/";
 
-    return ScopedFile(idf_file_contents, idf_filename, instrument_dir);
+    return ScopedFile(idf_file_contents, idf_filename, instrument_dir.string());
   }
 
   void testExecSLS() {

--- a/Framework/DataHandling/test/LoadFullprofResolutionTest.h
+++ b/Framework/DataHandling/test/LoadFullprofResolutionTest.h
@@ -19,7 +19,7 @@
 #include "MantidGeometry/Instrument/Component.h"
 #include "MantidGeometry/Instrument/FitParameter.h"
 #include "MantidKernel/OptionalBool.h"
-#include <Poco/File.h>
+#include <filesystem>
 #include <fstream>
 
 using Mantid::DataHandling::LoadFullprofResolution;
@@ -79,8 +79,7 @@ public:
 
     // 4. Clean
     AnalysisDataService::Instance().remove("TestBank1Table");
-    Poco::File("Test1Bank.irf").remove();
-
+    std::filesystem::remove("Test1Bank.irf");
     return;
   }
 
@@ -123,8 +122,7 @@ public:
 
     // 4. Clean
     AnalysisDataService::Instance().remove("TestBank3Table");
-    Poco::File("Test2Bank.irf").remove();
-
+    std::filesystem::remove("Test2Bank.irf");
     return;
   }
 
@@ -221,8 +219,7 @@ public:
     AnalysisDataService::Instance().remove("TestBank4Table");
     AnalysisDataService::Instance().remove("TestBank4TableFalse");
     AnalysisDataService::Instance().remove("TestBank4TableTrue");
-    Poco::File("Test2Bank.irf").remove();
-
+    std::filesystem::remove("Test2Bank.irf");
     return;
   }
 
@@ -265,8 +262,7 @@ public:
 
     // Clean
     AnalysisDataService::Instance().remove("TestBank5Table");
-    Poco::File("Test3Bank.irf").remove();
-
+    std::filesystem::remove("Test3Bank.irf");
     return;
   }
 
@@ -314,8 +310,7 @@ public:
 
     // 4. Clean
     AnalysisDataService::Instance().remove("TestAGSTable");
-    Poco::File("TestAGS.irf").remove();
-
+    std::filesystem::remove("TestAGS.irf");
     return;
   }
 
@@ -402,8 +397,7 @@ public:
       TS_ASSERT_DELTA(formulaValueCantreAt10, 0.0, 0.0000001);
     }
 
-    // Clean
-    Poco::File(filename).remove();
+    std::filesystem::remove(filename);
   }
 
   //----------------------------------------------------------------------------------------------
@@ -514,8 +508,7 @@ public:
       TS_ASSERT_DELTA(boost::lexical_cast<double>(fitParam.getFormula()), 6.251096, 0.0000001);
     }
 
-    // Clean
-    Poco::File("TestMultiWorskpace.irf").remove();
+    std::filesystem::remove("TestMultiWorskpace.irf");
   }
 
   //----------------------------------------------------------------------------------------------
@@ -589,8 +582,7 @@ public:
       TS_ASSERT_DELTA(formulaValueCantreAt2, 0.0251, 0.0001);
     }
 
-    // Clean
-    Poco::File("TestWorskpaceBBX.irf").remove();
+    std::filesystem::remove("TestWorskpaceBBX.irf");
   }
 
   //----------------------------------------------------------------------------------------------
@@ -614,8 +606,7 @@ public:
     alg.execute();
     TS_ASSERT(!alg.isExecuted());
 
-    // Clean
-    Poco::File("TestNoOutput.irf").remove();
+    std::filesystem::remove("TestNoOutput.irf");
   }
 
   //----------------------------------------------------------------------------------------------
@@ -656,7 +647,7 @@ public:
 
     // Clean
     AnalysisDataService::Instance().remove("TestNPROFTable");
-    Poco::File("TestNPROF.irf").remove();
+    std::filesystem::remove("TestNPROF.irf");
   }
 
   //----------------------------------------------------------------------------------------------
@@ -681,8 +672,7 @@ public:
     TS_ASSERT(!alg.isExecuted());
 
     // 4. Clean
-    Poco::File("Test2Bank.irf").remove();
-
+    std::filesystem::remove("Test2Bank.irf");
     return;
   }
 

--- a/Framework/DataHandling/test/LoadGSASInstrumentFileTest.h
+++ b/Framework/DataHandling/test/LoadGSASInstrumentFileTest.h
@@ -18,7 +18,7 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/Component.h"
 #include "MantidGeometry/Instrument/FitParameter.h"
-#include <Poco/File.h>
+#include <filesystem>
 #include <fstream>
 
 using Mantid::DataHandling::LoadGSASInstrumentFile;
@@ -77,8 +77,7 @@ public:
 
     // 4. Clean
     AnalysisDataService::Instance().remove("Test1BankTable");
-    Poco::File("Test1Bank.prm").remove();
-
+    std::filesystem::remove("Test1Bank.prm");
     return;
   }
 
@@ -130,8 +129,7 @@ public:
 
     // 4. Clean
     AnalysisDataService::Instance().remove("Test2BankTable");
-    Poco::File("Test2Bank.prm").remove();
-
+    std::filesystem::remove("Test2Bank.prm");
     return;
   }
 
@@ -178,8 +176,7 @@ public:
 
     // 4. Clean
     AnalysisDataService::Instance().remove("TestAGSTable");
-    Poco::File("TestAGS.prm").remove();
-
+    std::filesystem::remove("TestAGS.prm");
     return;
   }
 
@@ -202,8 +199,7 @@ public:
     TS_ASSERT(!alg.isExecuted());
 
     // 3. Clean
-    Poco::File("TestBadHistogramType.prm").remove();
-
+    std::filesystem::remove("TestBadHistogramType.prm");
     return;
   }
 
@@ -308,7 +304,7 @@ public:
     TS_ASSERT_EQUALS(fitParam.getValue(0.0), 0.0);
 
     // Clean
-    Poco::File(filename).remove();
+    std::filesystem::remove(filename);
     AnalysisDataService::Instance().remove("loadGSASInstrumentFileWorkspace");
   }
 

--- a/Framework/DataHandling/test/LoadIDFFromNexusTest.h
+++ b/Framework/DataHandling/test/LoadIDFFromNexusTest.h
@@ -19,7 +19,8 @@
 #include "MantidGeometry/Instrument/Detector.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/Exception.h"
-#include <Poco/Path.h>
+
+#include <filesystem>
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
@@ -248,9 +249,9 @@ public:
 
     // First we check that both scoped files are in the same directory,
     // because the rest of the test relies on this.
-    Poco::Path cPath(cFullFilename);
-    Poco::Path pPath(pFullFilename);
-    TS_ASSERT_EQUALS(cPath.parent().toString(), pPath.parent().toString());
+    std::filesystem::path cPath(cFullFilename);
+    std::filesystem::path pPath(pFullFilename);
+    TS_ASSERT(std::filesystem::equivalent(cPath.parent_path(), pPath.parent_path()));
 
     // Set properties
     loader.setPropertyValue("Workspace", wsName);
@@ -330,9 +331,9 @@ public:
 
     // First we check that both scoped files are in the same directory,
     // because the rest of the test relies on this.
-    Poco::Path cPath(cFullFilename);
-    Poco::Path pPath(pFullFilename);
-    TS_ASSERT_EQUALS(cPath.parent().toString(), pPath.parent().toString());
+    std::filesystem::path cPath(cFullFilename);
+    std::filesystem::path pPath(pFullFilename);
+    TS_ASSERT_EQUALS(cPath.parent_path().string(), pPath.parent_path().string());
 
     // Set properties
     loader.setPropertyValue("Workspace", wsName);
@@ -369,11 +370,10 @@ public:
 
     // LET parameter correction file exists
     std::string testpath1 = loader.getParameterCorrectionFile("LET");
-    Poco::Path iPath(true);                                                             // Absolute path
-    TS_ASSERT(iPath.tryParse(testpath1));                                               // Result has correct syntax
-    TS_ASSERT(iPath.isFile());                                                          // Result is a file
-    TS_ASSERT(iPath.getFileName() == "LET_Parameter_Corrections.xml");                  // Correct filename
-    TS_ASSERT(iPath.directory(iPath.depth() - 1) == "embedded_instrument_corrections"); // Correct folder
+    std::filesystem::path iPath(testpath1);                                         // Absolute path
+    TS_ASSERT(std::filesystem::is_regular_file(iPath));                             // Result is a file
+    TS_ASSERT(iPath.filename() == "LET_Parameter_Corrections.xml");                 // Correct filename
+    TS_ASSERT(iPath.parent_path().filename() == "embedded_instrument_corrections"); // Correct folder
 
     // TEST0 parameter correction file does not exist
     std::string testpath0 = loader.getParameterCorrectionFile("TEST0");

--- a/Framework/DataHandling/test/LoadInstrumentTest.h
+++ b/Framework/DataHandling/test/LoadInstrumentTest.h
@@ -96,7 +96,7 @@ public:
     auto runAlg = [&generateFiles, &loader, &ws2D](const std::string &name, const std::string &expected) {
       auto filePath = generateFiles(name);
 
-      loader.setPropertyValue("Filename", filePath);
+      loader.setPropertyValue("Filename", filePath.string());
       loader.setProperty("RewriteSpectraMap", OptionalBool(true));
       loader.setProperty("Workspace", ws2D);
 

--- a/Framework/DataHandling/test/LoadIsawDetCalTest.h
+++ b/Framework/DataHandling/test/LoadIsawDetCalTest.h
@@ -21,8 +21,8 @@
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Exception.h"
-#include <Poco/File.h>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <vector>
 
@@ -100,7 +100,7 @@ public:
     checkRotation(det, 0.707146, -8.47033e-22, -0.707068, -7.53079e-13);
 
     // remove file created by this algorithm
-    Poco::File(inputFile).remove();
+    std::filesystem::remove(inputFile);
     // Remove workspace
     AnalysisDataService::Instance().remove(wsName);
   }

--- a/Framework/DataHandling/test/LoadRaw3Test.h
+++ b/Framework/DataHandling/test/LoadRaw3Test.h
@@ -84,11 +84,11 @@ public:
 
     // One .log and four .txt files are listed in the alternate data stream.
     TS_ASSERT_EQUALS(5, logFiles.size());
-    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), "fakeRawFile.log") != logFiles.end());
-    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), "fakeRawFile_ICPdebug.txt") != logFiles.end());
-    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), "fakeRawFile_ICPevent.txt") != logFiles.end());
-    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), "fakeRawFile_ICPstatus.txt") != logFiles.end());
-    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), "fakeRawFile_Status.txt") != logFiles.end());
+    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), logFilePath.generic_string()) != logFiles.end());
+    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), icpDebugFilePath.generic_string()) != logFiles.end());
+    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), icpEventFilePath.generic_string()) != logFiles.end());
+    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), icpStatusFilePath.generic_string()) != logFiles.end());
+    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), statusFilePath.generic_string()) != logFiles.end());
 
     std::filesystem::remove(rawFilePath);
     std::filesystem::remove(logFilePath);

--- a/Framework/DataHandling/test/LoadRaw3Test.h
+++ b/Framework/DataHandling/test/LoadRaw3Test.h
@@ -54,7 +54,7 @@ public:
     std::ofstream file(rawFilePath);
     file << "data goes here";
 
-    std::string adsFileName = rawFilePath + ":checksum";
+    std::string adsFileName = rawFilePath.string() + ":checksum";
     std::ofstream adsFile(adsFileName);
     adsFile << "ad0bc56c4c556fa368565000f01e77f7 *fakeRawFile.log" << std::endl;
     adsFile << "d5ace6dc7ac6c4365d48ee1f2906c6f4 *fakeRawFile.nxs" << std::endl;

--- a/Framework/DataHandling/test/LoadTest.h
+++ b/Framework/DataHandling/test/LoadTest.h
@@ -23,7 +23,7 @@ using namespace Mantid::Kernel;
 class LoadTest : public CxxTest::TestSuite {
 
 private:
-  std::vector<std::string> m_dataSearchDirs;
+  std::vector<std::filesystem::path> m_dataSearchDirs;
   std::string m_instName;
 
 public:

--- a/Framework/DataHandling/test/SampleEnvironmentSpecFileFinderTest.h
+++ b/Framework/DataHandling/test/SampleEnvironmentSpecFileFinderTest.h
@@ -58,12 +58,12 @@ public:
                             "  </containers>"
                             " </components>"
                             "</environmentspec>";
-    Poco::File envFile(testDirec / (m_envName + ".xml"));
+    Poco::File envFile((testDirec / (m_envName + ".xml")).string());
     std::ofstream goodStream(envFile.path(), std::ios_base::out);
     goodStream << xml;
     goodStream.close();
     // Bad file
-    envFile = testDirec / (m_badName + ".xml");
+    envFile = (testDirec / (m_badName + ".xml")).string();
     std::ofstream badStream(envFile.path(), std::ios_base::out);
     const std::string wrongContent = "<garbage>";
     badStream << wrongContent;
@@ -72,7 +72,7 @@ public:
 
   ~SampleEnvironmentSpecFileFinderTest() {
     try {
-      Poco::File(m_testRoot).remove(true);
+      Poco::File(m_testRoot.string()).remove(true);
     } catch (...) {
     }
   }

--- a/Framework/DataHandling/test/SampleEnvironmentSpecFileFinderTest.h
+++ b/Framework/DataHandling/test/SampleEnvironmentSpecFileFinderTest.h
@@ -28,11 +28,11 @@ public:
   SampleEnvironmentSpecFileFinderTest() {
     // Setup a temporary directory structure for testing
     std::filesystem::path testDirec = std::filesystem::temp_directory_path() / "SampleEnvironmentSpecFileFinderTest";
-    std::filesystem::create_directory(testDirec);
+    testDirec.remove_filename();
     m_testRoot = testDirec;
     testDirec /= m_facilityName;
     testDirec /= m_instName;
-    std::filesystem::create_directory(testDirec);
+    std::filesystem::create_directories(testDirec);
 
     // Write test files
     const std::string xml = "<environmentspec>"

--- a/Framework/DataHandling/test/SetScalingPSDTest.h
+++ b/Framework/DataHandling/test/SetScalingPSDTest.h
@@ -13,7 +13,6 @@
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidKernel/ConfigService.h"
 #include <Poco/File.h>
-#include <Poco/Path.h>
 #include <cmath>
 #include <cxxtest/TestSuite.h>
 #include <fstream>
@@ -152,11 +151,10 @@ private:
   }
 
   Workspace2D_sptr loadEmptyMARI() {
-    Poco::Path mariIDF(ConfigService::Instance().getInstrumentDirectory());
-    mariIDF.resolve("MARI_Definition.xml");
+    std::filesystem::path mariIDF(ConfigService::Instance().getInstrumentDirectory() / "MARI_Definition.xml");
     LoadEmptyInstrument loader;
     loader.initialize();
-    loader.setPropertyValue("Filename", mariIDF.toString());
+    loader.setPropertyValue("Filename", mariIDF.string());
     const std::string outputName("test-emptyMARI");
     loader.setPropertyValue("OutputWorkspace", outputName);
     loader.execute();

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/IDFObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/IDFObject.h
@@ -11,7 +11,7 @@
 #include <memory>
 #endif
 #include <Poco/File.h>
-#include <Poco/Path.h>
+#include <filesystem>
 #include <stdexcept>
 
 namespace Mantid {
@@ -32,8 +32,8 @@ class MANTID_GEOMETRY_DLL AbstractIDFObject {
 public:
   AbstractIDFObject() = default;
   static const std::string expectedExtension();
-  virtual const Poco::Path getParentDirectory() const = 0;
-  virtual const Poco::Path &getFileFullPath() const = 0;
+  virtual const std::filesystem::path getParentDirectory() const = 0;
+  virtual const std::filesystem::path &getFileFullPath() const = 0;
   virtual const std::string &getFileFullPathStr() const = 0;
   virtual std::string getFileNameOnly() const = 0;
   virtual std::string getExtension() const = 0;
@@ -52,8 +52,8 @@ private:
 class MANTID_GEOMETRY_DLL IDFObject : public AbstractIDFObject {
 public:
   IDFObject(const std::string &fileName);
-  const Poco::Path getParentDirectory() const override;
-  const Poco::Path &getFileFullPath() const override;
+  const std::filesystem::path getParentDirectory() const override;
+  const std::filesystem::path &getFileFullPath() const override;
   const std::string &getFileFullPathStr() const override;
   std::string getFileNameOnly() const override;
   std::string getExtension() const override;
@@ -65,8 +65,8 @@ private:
   IDFObject &operator=(const IDFObject &);
   const Poco::File m_defFile;
   const bool m_hasFileName;
-  const Poco::Path m_cachePath;
-  const Poco::Path m_cacheParentDirectory;
+  const std::filesystem::path m_cachePath;
+  const std::filesystem::path m_cacheParentDirectory;
   const std::string m_cachePathStr;
 };
 
@@ -79,8 +79,12 @@ private:
 
 public:
   NullIDFObject() : m_emptyResponse("") {}
-  const Poco::Path getParentDirectory() const override { throw std::runtime_error("Not implemented on NullIDFObject"); }
-  const Poco::Path &getFileFullPath() const override { throw std::runtime_error("Not implemented on NullIDFObject"); }
+  const std::filesystem::path getParentDirectory() const override {
+    throw std::runtime_error("Not implemented on NullIDFObject");
+  }
+  const std::filesystem::path &getFileFullPath() const override {
+    throw std::runtime_error("Not implemented on NullIDFObject");
+  }
   const std::string &getFileFullPathStr() const override { return m_emptyResponse; }
   std::string getFileNameOnly() const override { return m_emptyResponse; }
   std::string getExtension() const override { return m_emptyResponse; }

--- a/Framework/Geometry/src/Instrument/IDFObject.cpp
+++ b/Framework/Geometry/src/Instrument/IDFObject.cpp
@@ -22,7 +22,7 @@ const std::string AbstractIDFObject::expectedExtension() { return ".xml"; }
  */
 IDFObject::IDFObject(const std::string &fileName)
     : m_defFile(fileName), m_hasFileName(!fileName.empty()), m_cachePath(m_defFile.path()),
-      m_cacheParentDirectory(m_cachePath.parent()), m_cachePathStr(m_cachePath.toString())
+      m_cacheParentDirectory(m_cachePath.parent_path()), m_cachePathStr(m_cachePath.string())
 
 {}
 
@@ -30,13 +30,13 @@ IDFObject::IDFObject(const std::string &fileName)
 Gets the parent directory of the file.
 @return Parent directory path.
 */
-const Poco::Path IDFObject::getParentDirectory() const { return m_cacheParentDirectory; }
+const std::filesystem::path IDFObject::getParentDirectory() const { return m_cacheParentDirectory; }
 
 /**
 Getter for the full file path.
 @return Full file path.
 */
-const Poco::Path &IDFObject::getFileFullPath() const { return m_cachePath; }
+const std::filesystem::path &IDFObject::getFileFullPath() const { return m_cachePath; }
 
 const std::string &IDFObject::getFileFullPathStr() const { return m_cachePathStr; }
 
@@ -44,19 +44,13 @@ const std::string &IDFObject::getFileFullPathStr() const { return m_cachePathStr
 Gets the filename for the FileObject.
 @return filename only.
 */
-std::string IDFObject::getFileNameOnly() const { return m_cachePath.getFileName(); }
+std::string IDFObject::getFileNameOnly() const { return m_cachePath.filename().string(); }
 
 /**
  * Gets the extension of this IDF file, including the leading period
  * @return A string containing the extension for this file
  */
-std::string IDFObject::getExtension() const {
-  std::string ext = m_cachePath.getExtension();
-  if (ext.empty())
-    return ext;
-  else
-    return "." + ext;
-}
+std::string IDFObject::getExtension() const { return m_cachePath.extension().string(); }
 
 /**
 Gets the idf file as a mangled name.

--- a/Framework/Geometry/src/Instrument/IDFObject.cpp
+++ b/Framework/Geometry/src/Instrument/IDFObject.cpp
@@ -22,7 +22,8 @@ const std::string AbstractIDFObject::expectedExtension() { return ".xml"; }
  */
 IDFObject::IDFObject(const std::string &fileName)
     : m_defFile(fileName), m_hasFileName(!fileName.empty()), m_cachePath(m_defFile.path()),
-      m_cacheParentDirectory(m_cachePath.parent_path()), m_cachePathStr(m_cachePath.string())
+      m_cacheParentDirectory(m_cachePath.empty() ? std::filesystem::path("../") : m_cachePath.parent_path()),
+      m_cachePathStr(m_cachePath.string())
 
 {}
 

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -2554,7 +2554,7 @@ InstrumentDefinitionParser::CachingOption InstrumentDefinitionParser::setupGeome
   // temporary
   // directory.
   IDFObject_const_sptr fallBackCache = std::make_shared<const IDFObject>(
-      Poco::Path(ConfigService::Instance().getTempDir()).append(this->getMangledName() + ".vtp").toString());
+      Poco::Path(ConfigService::Instance().getTempDir().string()).append(this->getMangledName() + ".vtp").toString());
   CachingOption cachingOption = NoneApplied;
   if (m_cacheFile->exists()) {
     applyCache(m_cacheFile);
@@ -2964,7 +2964,7 @@ const std::string InstrumentDefinitionParser::createVTPFileName() {
   std::string retVal;
   std::string filename = getMangledName();
   if (!filename.empty()) {
-    Poco::Path path(ConfigService::Instance().getVTPFileDirectory());
+    Poco::Path path(ConfigService::Instance().getVTPFileDirectory().string());
     path.makeDirectory();
     path.append(filename + ".vtp");
     retVal = path.toString();

--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -2516,8 +2516,10 @@ InstrumentDefinitionParser::writeAndApplyCache(IDFObject_const_sptr firstChoiceC
 
   g_log.notice("Geometry cache is not available");
   try {
-    Poco::File dir = usedCache->getParentDirectory();
-    if (dir.path().empty() || !dir.exists() || !dir.canWrite()) {
+    const auto dir = usedCache->getParentDirectory();
+    if (dir.empty() || !std::filesystem::exists(dir) ||
+        (std::filesystem::status(dir).permissions() & std::filesystem::perms::owner_write) ==
+            std::filesystem::perms::none) {
       usedCache = std::move(fallBackCache);
       cachingOption = WroteCacheTemp;
       g_log.information() << "Geometrycache directory is read only, writing cache "

--- a/Framework/Geometry/test/IDFObjectTest.h
+++ b/Framework/Geometry/test/IDFObjectTest.h
@@ -11,7 +11,6 @@
 #include "MantidKernel/ConfigService.h"
 #include <Poco/DateTimeFormatter.h>
 #include <Poco/DigestStream.h>
-#include <Poco/Path.h>
 #include <Poco/SHA1Engine.h>
 #include <Poco/String.h>
 #include <Poco/Thread.h>
@@ -32,8 +31,8 @@ public:
   void testExpectedExtensionIsXML() { TS_ASSERT_EQUALS(".xml", IDFObject::expectedExtension()); }
 
   void testExists() {
-    const std::string filename =
-        ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/IDF_for_UNIT_TESTING.xml";
+    const std::filesystem::path filename =
+        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING.xml";
     IDFObject obj(filename);
     TS_ASSERT(obj.exists());
   }
@@ -50,38 +49,39 @@ public:
   }
 
   void testGetParentDirectory() {
-    const Poco::Path expectedDir = Poco::Path(ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/");
-    std::string filename = expectedDir.toString() + "IDF_for_UNIT_TESTING.xml";
+    const std::filesystem::path expectedDir = ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/";
+    std::string filename = expectedDir.string() + "IDF_for_UNIT_TESTING.xml";
     IDFObject obj(filename);
-    TS_ASSERT_EQUALS(expectedDir.toString(), obj.getParentDirectory().toString());
+    TS_ASSERT_EQUALS(expectedDir.string(), obj.getParentDirectory().toString());
   }
 
   void testGetFullPath() {
-    const std::string filename =
-        ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/IDF_for_UNIT_TESTING.xml";
+    const std::filesystem::path filename =
+        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING.xml";
     IDFObject obj(filename);
-    TS_ASSERT_EQUALS(Poco::Path(filename).toString(), obj.getFileFullPath().toString());
+    TS_ASSERT_EQUALS(filename.string(), obj.getFileFullPath().toString());
   }
 
   void testGetExtension() {
-    const std::string filename =
-        ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/IDF_for_UNIT_TESTING.xml";
+    const std::filesystem::path filename =
+        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING.xml";
     IDFObject obj(filename);
     TS_ASSERT_EQUALS(".xml", obj.getExtension());
   }
 
   void testGetFileNameOnly() {
     const std::string filenameonly = "IDF_for_UNIT_TESTING.xml";
-    const std::string filename = ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/" + filenameonly;
+    const std::filesystem::path filename =
+        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/" / filenameonly;
     IDFObject obj(filename);
     TS_ASSERT_EQUALS(filenameonly, obj.getFileNameOnly());
   }
 
   void testGetMangledName() {
     const std::string filename =
-        ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/IDF_for_UNIT_TESTING.xml";
+        ConfigService::Instance().getInstrumentDirectory().string() + "/unit_testing/IDF_for_UNIT_TESTING.xml";
 
-    Poco::Path path(filename);
+    std::filesystem::path path(filename);
 
     using Poco::DigestEngine;
     using Poco::DigestOutputStream;
@@ -112,7 +112,7 @@ public:
     outstr << contents;
     outstr.flush(); // to pass everything to the digest engine
 
-    auto head = path.getFileName();
+    auto head = path.filename().string();
     auto tail = DigestEngine::digestToHex(sha1.digest());
 
     IDFObject obj(filename);
@@ -121,9 +121,9 @@ public:
   }
 
   void testGetFileFullPathStr() {
-    const std::string filename =
-        ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/IDF_for_UNIT_TESTING.xml";
-    IDFObject obj(filename);
-    TS_ASSERT_EQUALS(Poco::Path(filename).toString(), obj.getFileFullPathStr());
+    const std::filesystem::path filename =
+        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING.xml";
+    IDFObject obj(filename.string());
+    TS_ASSERT_EQUALS(filename.string(), obj.getFileFullPathStr());
   }
 };

--- a/Framework/Geometry/test/IDFObjectTest.h
+++ b/Framework/Geometry/test/IDFObjectTest.h
@@ -33,7 +33,7 @@ public:
   void testExists() {
     const std::filesystem::path filename =
         ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING.xml";
-    IDFObject obj(filename);
+    IDFObject obj(filename.string());
     TS_ASSERT(obj.exists());
   }
 
@@ -59,14 +59,14 @@ public:
   void testGetFullPath() {
     const std::filesystem::path filename =
         ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING.xml";
-    IDFObject obj(filename);
+    IDFObject obj(filename.string());
     TS_ASSERT_EQUALS(filename.string(), obj.getFileFullPath().toString());
   }
 
   void testGetExtension() {
     const std::filesystem::path filename =
         ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING.xml";
-    IDFObject obj(filename);
+    IDFObject obj(filename.string());
     TS_ASSERT_EQUALS(".xml", obj.getExtension());
   }
 
@@ -74,7 +74,7 @@ public:
     const std::string filenameonly = "IDF_for_UNIT_TESTING.xml";
     const std::filesystem::path filename =
         ConfigService::Instance().getInstrumentDirectory() / "unit_testing" / filenameonly;
-    IDFObject obj(filename);
+    IDFObject obj(filename.string());
     TS_ASSERT_EQUALS(filenameonly, obj.getFileNameOnly());
   }
 

--- a/Framework/Geometry/test/IDFObjectTest.h
+++ b/Framework/Geometry/test/IDFObjectTest.h
@@ -52,7 +52,7 @@ public:
     const std::filesystem::path expectedDir = ConfigService::Instance().getInstrumentDirectory() / "unit_testing";
     const std::string filename = (expectedDir / "IDF_for_UNIT_TESTING.xml").string();
     IDFObject obj(filename);
-    const std::filesystem::path parentDirectory(obj.getParentDirectory().toString());
+    const std::filesystem::path parentDirectory = obj.getParentDirectory();
     TS_ASSERT(std::filesystem::equivalent(expectedDir, parentDirectory));
   }
 
@@ -60,7 +60,7 @@ public:
     const std::filesystem::path filename =
         ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING.xml";
     IDFObject obj(filename.string());
-    TS_ASSERT_EQUALS(filename.string(), obj.getFileFullPath().toString());
+    TS_ASSERT_EQUALS(filename.string(), obj.getFileFullPath().string());
   }
 
   void testGetExtension() {

--- a/Framework/Geometry/test/IDFObjectTest.h
+++ b/Framework/Geometry/test/IDFObjectTest.h
@@ -32,7 +32,7 @@ public:
 
   void testExists() {
     const std::filesystem::path filename =
-        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING.xml";
+        ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING.xml";
     IDFObject obj(filename);
     TS_ASSERT(obj.exists());
   }
@@ -49,22 +49,23 @@ public:
   }
 
   void testGetParentDirectory() {
-    const std::filesystem::path expectedDir = ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/";
-    std::string filename = expectedDir.string() + "IDF_for_UNIT_TESTING.xml";
+    const std::filesystem::path expectedDir = ConfigService::Instance().getInstrumentDirectory() / "unit_testing";
+    const std::string filename = (expectedDir / "IDF_for_UNIT_TESTING.xml").string();
     IDFObject obj(filename);
-    TS_ASSERT_EQUALS(expectedDir.string(), obj.getParentDirectory().toString());
+    const std::filesystem::path parentDirectory(obj.getParentDirectory().toString());
+    TS_ASSERT(std::filesystem::equivalent(expectedDir, parentDirectory));
   }
 
   void testGetFullPath() {
     const std::filesystem::path filename =
-        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING.xml";
+        ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING.xml";
     IDFObject obj(filename);
     TS_ASSERT_EQUALS(filename.string(), obj.getFileFullPath().toString());
   }
 
   void testGetExtension() {
     const std::filesystem::path filename =
-        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING.xml";
+        ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING.xml";
     IDFObject obj(filename);
     TS_ASSERT_EQUALS(".xml", obj.getExtension());
   }
@@ -72,16 +73,15 @@ public:
   void testGetFileNameOnly() {
     const std::string filenameonly = "IDF_for_UNIT_TESTING.xml";
     const std::filesystem::path filename =
-        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/" / filenameonly;
+        ConfigService::Instance().getInstrumentDirectory() / "unit_testing" / filenameonly;
     IDFObject obj(filename);
     TS_ASSERT_EQUALS(filenameonly, obj.getFileNameOnly());
   }
 
   void testGetMangledName() {
-    const std::string filename =
-        ConfigService::Instance().getInstrumentDirectory().string() + "/unit_testing/IDF_for_UNIT_TESTING.xml";
-
-    std::filesystem::path path(filename);
+    std::filesystem::path path(ConfigService::Instance().getInstrumentDirectory() /
+                               "unit_testing/IDF_for_UNIT_TESTING.xml");
+    const std::string filename = path.string();
 
     using Poco::DigestEngine;
     using Poco::DigestOutputStream;
@@ -122,7 +122,7 @@ public:
 
   void testGetFileFullPathStr() {
     const std::filesystem::path filename =
-        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING.xml";
+        ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING.xml";
     IDFObject obj(filename.string());
     TS_ASSERT_EQUALS(filename.string(), obj.getFileFullPathStr());
   }

--- a/Framework/Geometry/test/InstrumentDefinitionParserTest.h
+++ b/Framework/Geometry/test/InstrumentDefinitionParserTest.h
@@ -670,7 +670,6 @@ public:
   void RemoveFallbackVTPFile(InstrumentDefinitionParser &parser) {
     std::filesystem::path vtpPath(parser.createVTPFileName());
     std::filesystem::path fallbackPath(ConfigService::Instance().getTempDir());
-    std::filesystem::create_directory(fallbackPath);
     fallbackPath.replace_filename(vtpPath.filename().string());
     std::string fp = fallbackPath.string();
     Poco::File fallbackFile(fallbackPath.string());

--- a/Framework/Geometry/test/InstrumentDefinitionParserTest.h
+++ b/Framework/Geometry/test/InstrumentDefinitionParserTest.h
@@ -43,7 +43,7 @@ private:
   public:
     MockIDFObjectWithParentDirectory(const std::string &fileName) : Mantid::Geometry::IDFObject(fileName) {}
     MOCK_CONST_METHOD0(exists, bool());
-    MOCK_CONST_METHOD0(getParentDirectory, const Poco::Path());
+    MOCK_CONST_METHOD0(getParentDirectory, const std::filesystem::path());
   };
   GNU_DIAG_ON_SUGGEST_OVERRIDE
   /**
@@ -731,7 +731,7 @@ public:
     EXPECT_CALL(*mockCache, exists()).WillRepeatedly(Return(false)); // Mock expectation set such that Cache
                                                                      // file does not exist, and location is
                                                                      // inaccessible.
-    EXPECT_CALL(*mockCache, getParentDirectory()).WillRepeatedly(Return(Poco::Path("this does not exist")));
+    EXPECT_CALL(*mockCache, getParentDirectory()).WillRepeatedly(Return(std::filesystem::path("this does not exist")));
 
     IDFObject_const_sptr idf(mockIDF);
     IDFObject_const_sptr cache(mockCache);

--- a/Framework/Geometry/test/InstrumentDefinitionParserTest.h
+++ b/Framework/Geometry/test/InstrumentDefinitionParserTest.h
@@ -95,7 +95,7 @@ private:
     const std::string vtp_file_contents = "<VTKFile byte_order=\"LittleEndian\" type=\"PolyData\" "
                                           "version=\"1.0\"><PolyData/></VTKFile>";
 
-    const std::filesystem::path instrument_dir = ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/";
+    const std::filesystem::path instrument_dir = ConfigService::Instance().getInstrumentDirectory() / "unit_testing/";
     std::filesystem::path vtp_dir = ConfigService::Instance().getVTPFileDirectory();
     if (!put_vtp_next_to_IDF) {
       vtp_dir = std::filesystem::path(ConfigService::Instance().getTempDir());
@@ -108,7 +108,7 @@ private:
 
   // Helper method to create the IDF File.
   ScopedFile createIDFFileObject(const std::string &idf_filename, const std::string &idf_file_contents) {
-    const std::filesystem::path instrument_dir = ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/";
+    const std::filesystem::path instrument_dir = ConfigService::Instance().getInstrumentDirectory() / "unit_testing/";
 
     return ScopedFile(idf_file_contents, idf_filename, instrument_dir);
   }
@@ -121,7 +121,7 @@ public:
 
   void test_extract_ref_info() {
     std::filesystem::path filename =
-        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING.xml";
+        ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING.xml";
     std::string xmlText = Strings::loadFile(filename);
     std::shared_ptr<const Instrument> i;
 
@@ -142,7 +142,7 @@ public:
 
   void test_extract_ref_info_theta_sign() {
     std::filesystem::path filename =
-        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING6.xml";
+        ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING6.xml";
     std::string xmlText = Strings::loadFile(filename);
     std::shared_ptr<const Instrument> i;
 
@@ -161,7 +161,7 @@ public:
   void test_parse_IDF_for_unit_testing() // IDF stands for Instrument Definition File
   {
     std::filesystem::path filenameNoExt =
-        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING";
+        ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING";
     std::string filename = filenameNoExt.string() + ".xml";
     std::string xmlText = Strings::loadFile(filename);
     std::shared_ptr<const Instrument> i;
@@ -447,7 +447,7 @@ public:
                                           // Definition File
   {
     std::filesystem::path filename =
-        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING2.xml";
+        ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING2.xml";
     std::string xmlText = Strings::loadFile(filename.string());
     std::shared_ptr<const Instrument> i;
 
@@ -491,7 +491,7 @@ public:
 
   void test_parse_RectangularDetector() {
     std::filesystem::path filename =
-        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_RECTANGULAR_UNIT_TESTING.xml";
+        ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_RECTANGULAR_UNIT_TESTING.xml";
     std::string xmlText = Strings::loadFile(filename.string());
     std::shared_ptr<const Instrument> i;
 
@@ -543,7 +543,7 @@ public:
   // testing through Loading IDF_for_UNIT_TESTING5.xml method adjust()
   void testAdjust() {
     std::filesystem::path filename =
-        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING5.xml";
+        ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING5.xml";
     std::string xmlText = Strings::loadFile(filename.string());
     std::shared_ptr<const Instrument> i;
 
@@ -801,7 +801,7 @@ public:
 
   Instrument_sptr loadInstrLocations(const std::string &locations, detid_t numDetectors, bool rethrow = false) {
     std::filesystem::path filename =
-        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_locations_test.xml";
+        ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_locations_test.xml";
 
     std::string contents = Strings::loadFile(filename.string());
 
@@ -994,7 +994,7 @@ public:
       : m_instrumentDirectoryPath(ConfigService::Instance().getInstrumentDirectory()) {}
 
   void testLoadingAndParsing() {
-    const std::filesystem::path filename = m_instrumentDirectoryPath / "/unit_testing/IDF_for_UNIT_TESTING.xml";
+    const std::filesystem::path filename = m_instrumentDirectoryPath / "unit_testing/IDF_for_UNIT_TESTING.xml";
     const std::string xmlText = Strings::loadFile(filename);
 
     std::shared_ptr<const Instrument> instrument;
@@ -1009,7 +1009,7 @@ public:
   }
 
   void test_load_wish() {
-    const auto definition = m_instrumentDirectoryPath / "/WISH_Definition_10Panels.xml";
+    const auto definition = m_instrumentDirectoryPath / "WISH_Definition_10Panels.xml";
     std::string contents = Strings::loadFile(definition.string());
     InstrumentDefinitionParser parser(definition, "dummy", contents);
     auto wishInstrument = parser.parseXML(nullptr);
@@ -1018,7 +1018,7 @@ public:
   }
 
   void test_load_sans2d() {
-    const auto definition = m_instrumentDirectoryPath / "/SANS2D_Definition_Tubes.xml";
+    const auto definition = m_instrumentDirectoryPath / "SANS2D_Definition_Tubes.xml";
     std::string contents = Strings::loadFile(definition.string());
     InstrumentDefinitionParser parser(definition, "dummy", contents);
     auto sansInstrument = parser.parseXML(nullptr);

--- a/Framework/Geometry/test/InstrumentDefinitionParserTest.h
+++ b/Framework/Geometry/test/InstrumentDefinitionParserTest.h
@@ -100,8 +100,8 @@ private:
     if (!put_vtp_next_to_IDF) {
       vtp_dir = std::filesystem::path(ConfigService::Instance().getTempDir());
     }
-    ScopedFile idf(idf_file_contents, idf_filename, instrument_dir);
-    ScopedFile vtp(vtp_file_contents, vtp_filename, vtp_dir);
+    ScopedFile idf(idf_file_contents, idf_filename, instrument_dir.string());
+    ScopedFile vtp(vtp_file_contents, vtp_filename, vtp_dir.string());
 
     return IDFEnvironment(idf, vtp, idf_file_contents, instrument_name);
   }
@@ -110,7 +110,7 @@ private:
   ScopedFile createIDFFileObject(const std::string &idf_filename, const std::string &idf_file_contents) {
     const std::filesystem::path instrument_dir = ConfigService::Instance().getInstrumentDirectory() / "unit_testing/";
 
-    return ScopedFile(idf_file_contents, idf_filename, instrument_dir);
+    return ScopedFile(idf_file_contents, idf_filename, instrument_dir.string());
   }
 
 public:
@@ -122,11 +122,11 @@ public:
   void test_extract_ref_info() {
     std::filesystem::path filename =
         ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING.xml";
-    std::string xmlText = Strings::loadFile(filename);
+    std::string xmlText = Strings::loadFile(filename.string());
     std::shared_ptr<const Instrument> i;
 
     // Parse the XML
-    InstrumentDefinitionParser parser(filename, "For Unit Testing", xmlText);
+    InstrumentDefinitionParser parser(filename.string(), "For Unit Testing", xmlText);
     TS_ASSERT_THROWS_NOTHING(i = parser.parseXML(nullptr););
 
     // Extract the reference frame object
@@ -143,11 +143,11 @@ public:
   void test_extract_ref_info_theta_sign() {
     std::filesystem::path filename =
         ConfigService::Instance().getInstrumentDirectory() / "unit_testing/IDF_for_UNIT_TESTING6.xml";
-    std::string xmlText = Strings::loadFile(filename);
+    std::string xmlText = Strings::loadFile(filename.string());
     std::shared_ptr<const Instrument> i;
 
     // Parse the XML
-    InstrumentDefinitionParser parser(filename, "For Unit Testing", xmlText);
+    InstrumentDefinitionParser parser(filename.string(), "For Unit Testing", xmlText);
     TS_ASSERT_THROWS_NOTHING(i = parser.parseXML(nullptr););
 
     // Extract the reference frame object
@@ -452,7 +452,7 @@ public:
     std::shared_ptr<const Instrument> i;
 
     // Parse the XML
-    InstrumentDefinitionParser parser(filename, "For Unit Testing2", xmlText);
+    InstrumentDefinitionParser parser(filename.string(), "For Unit Testing2", xmlText);
     TS_ASSERT_THROWS_NOTHING(i = parser.parseXML(nullptr););
 
     std::shared_ptr<const IDetector> ptrDetShape = i->getDetector(1100);
@@ -496,7 +496,7 @@ public:
     std::shared_ptr<const Instrument> i;
 
     // Parse the XML
-    InstrumentDefinitionParser parser(filename, "RectangularUnitTest", xmlText);
+    InstrumentDefinitionParser parser(filename.string(), "RectangularUnitTest", xmlText);
     TS_ASSERT_THROWS_NOTHING(i = parser.parseXML(nullptr););
 
     // Now the XY detector in bank1
@@ -548,7 +548,7 @@ public:
     std::shared_ptr<const Instrument> i;
 
     // Parse the XML
-    InstrumentDefinitionParser parser(filename, "AdjustTest", xmlText);
+    InstrumentDefinitionParser parser(filename.string(), "AdjustTest", xmlText);
     TS_ASSERT_THROWS_NOTHING(i = parser.parseXML(nullptr););
 
     // None rotated cuboid
@@ -808,7 +808,7 @@ public:
     boost::replace_first(contents, "%LOCATIONS%", locations);
     boost::replace_first(contents, "%NUM_DETECTORS%", boost::lexical_cast<std::string>(numDetectors));
 
-    InstrumentDefinitionParser parser(filename, "LocationsTestInstrument", contents);
+    InstrumentDefinitionParser parser(filename.string(), "LocationsTestInstrument", contents);
 
     Instrument_sptr instr;
 
@@ -995,10 +995,10 @@ public:
 
   void testLoadingAndParsing() {
     const std::filesystem::path filename = m_instrumentDirectoryPath / "unit_testing/IDF_for_UNIT_TESTING.xml";
-    const std::string xmlText = Strings::loadFile(filename);
+    const std::string xmlText = Strings::loadFile(filename.string());
 
     std::shared_ptr<const Instrument> instrument;
-    InstrumentDefinitionParser parser(filename, "For Unit Testing", xmlText);
+    InstrumentDefinitionParser parser(filename.string(), "For Unit Testing", xmlText);
     TS_ASSERT_THROWS_NOTHING(instrument = parser.parseXML(nullptr));
 
     // Clean up VTP file
@@ -1011,7 +1011,7 @@ public:
   void test_load_wish() {
     const auto definition = m_instrumentDirectoryPath / "WISH_Definition_10Panels.xml";
     std::string contents = Strings::loadFile(definition.string());
-    InstrumentDefinitionParser parser(definition, "dummy", contents);
+    InstrumentDefinitionParser parser(definition.string(), "dummy", contents);
     auto wishInstrument = parser.parseXML(nullptr);
     TS_ASSERT_EQUALS(extractDetectorInfo(*wishInstrument)->size(),
                      778245); // Sanity check
@@ -1020,7 +1020,7 @@ public:
   void test_load_sans2d() {
     const auto definition = m_instrumentDirectoryPath / "SANS2D_Definition_Tubes.xml";
     std::string contents = Strings::loadFile(definition.string());
-    InstrumentDefinitionParser parser(definition, "dummy", contents);
+    InstrumentDefinitionParser parser(definition.string(), "dummy", contents);
     auto sansInstrument = parser.parseXML(nullptr);
     TS_ASSERT_EQUALS(extractDetectorInfo(*sansInstrument)->size(),
                      122888); // Sanity check

--- a/Framework/Geometry/test/InstrumentDefinitionParserTest.h
+++ b/Framework/Geometry/test/InstrumentDefinitionParserTest.h
@@ -95,10 +95,10 @@ private:
     const std::string vtp_file_contents = "<VTKFile byte_order=\"LittleEndian\" type=\"PolyData\" "
                                           "version=\"1.0\"><PolyData/></VTKFile>";
 
-    const std::string instrument_dir = ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/";
-    std::string vtp_dir = ConfigService::Instance().getVTPFileDirectory();
+    const std::filesystem::path instrument_dir = ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/";
+    std::filesystem::path vtp_dir = ConfigService::Instance().getVTPFileDirectory();
     if (!put_vtp_next_to_IDF) {
-      vtp_dir = ConfigService::Instance().getTempDir();
+      vtp_dir = std::filesystem::path(ConfigService::Instance().getTempDir());
     }
     ScopedFile idf(idf_file_contents, idf_filename, instrument_dir);
     ScopedFile vtp(vtp_file_contents, vtp_filename, vtp_dir);
@@ -108,7 +108,7 @@ private:
 
   // Helper method to create the IDF File.
   ScopedFile createIDFFileObject(const std::string &idf_filename, const std::string &idf_file_contents) {
-    const std::string instrument_dir = ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/";
+    const std::filesystem::path instrument_dir = ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/";
 
     return ScopedFile(idf_file_contents, idf_filename, instrument_dir);
   }
@@ -120,8 +120,8 @@ public:
   static void destroySuite(InstrumentDefinitionParserTest *suite) { delete suite; }
 
   void test_extract_ref_info() {
-    std::string filename =
-        ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/IDF_for_UNIT_TESTING.xml";
+    std::filesystem::path filename =
+        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING.xml";
     std::string xmlText = Strings::loadFile(filename);
     std::shared_ptr<const Instrument> i;
 
@@ -141,8 +141,8 @@ public:
   }
 
   void test_extract_ref_info_theta_sign() {
-    std::string filename =
-        ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/IDF_for_UNIT_TESTING6.xml";
+    std::filesystem::path filename =
+        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING6.xml";
     std::string xmlText = Strings::loadFile(filename);
     std::shared_ptr<const Instrument> i;
 
@@ -160,9 +160,9 @@ public:
 
   void test_parse_IDF_for_unit_testing() // IDF stands for Instrument Definition File
   {
-    std::string filenameNoExt =
-        ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/IDF_for_UNIT_TESTING";
-    std::string filename = filenameNoExt + ".xml";
+    std::filesystem::path filenameNoExt =
+        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING";
+    std::string filename = filenameNoExt.string() + ".xml";
     std::string xmlText = Strings::loadFile(filename);
     std::shared_ptr<const Instrument> i;
 
@@ -446,9 +446,9 @@ public:
   void test_prase_IDF_for_unit_testing2() // IDF stands for Instrument
                                           // Definition File
   {
-    std::string filename =
-        ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/IDF_for_UNIT_TESTING2.xml";
-    std::string xmlText = Strings::loadFile(filename);
+    std::filesystem::path filename =
+        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING2.xml";
+    std::string xmlText = Strings::loadFile(filename.string());
     std::shared_ptr<const Instrument> i;
 
     // Parse the XML
@@ -490,9 +490,9 @@ public:
   }
 
   void test_parse_RectangularDetector() {
-    std::string filename =
-        ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/IDF_for_RECTANGULAR_UNIT_TESTING.xml";
-    std::string xmlText = Strings::loadFile(filename);
+    std::filesystem::path filename =
+        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_RECTANGULAR_UNIT_TESTING.xml";
+    std::string xmlText = Strings::loadFile(filename.string());
     std::shared_ptr<const Instrument> i;
 
     // Parse the XML
@@ -542,9 +542,9 @@ public:
 
   // testing through Loading IDF_for_UNIT_TESTING5.xml method adjust()
   void testAdjust() {
-    std::string filename =
-        ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/IDF_for_UNIT_TESTING5.xml";
-    std::string xmlText = Strings::loadFile(filename);
+    std::filesystem::path filename =
+        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_UNIT_TESTING5.xml";
+    std::string xmlText = Strings::loadFile(filename.string());
     std::shared_ptr<const Instrument> i;
 
     // Parse the XML
@@ -668,12 +668,12 @@ public:
   }
 
   void RemoveFallbackVTPFile(InstrumentDefinitionParser &parser) {
-    Poco::Path vtpPath(parser.createVTPFileName());
-    Poco::Path fallbackPath(ConfigService::Instance().getTempDir());
-    fallbackPath.makeDirectory();
-    fallbackPath.setFileName(vtpPath.getFileName());
-    std::string fp = fallbackPath.toString();
-    Poco::File fallbackFile(fallbackPath.toString());
+    std::filesystem::path vtpPath(parser.createVTPFileName());
+    std::filesystem::path fallbackPath(ConfigService::Instance().getTempDir());
+    std::filesystem::create_directory(fallbackPath);
+    fallbackPath.replace_filename(vtpPath.filename().string());
+    std::string fp = fallbackPath.string();
+    Poco::File fallbackFile(fallbackPath.string());
     if (fallbackFile.exists()) {
       fallbackFile.remove();
     }
@@ -801,10 +801,10 @@ public:
   }
 
   Instrument_sptr loadInstrLocations(const std::string &locations, detid_t numDetectors, bool rethrow = false) {
-    std::string filename =
-        ConfigService::Instance().getInstrumentDirectory() + "/unit_testing/IDF_for_locations_test.xml";
+    std::filesystem::path filename =
+        ConfigService::Instance().getInstrumentDirectory() / "/unit_testing/IDF_for_locations_test.xml";
 
-    std::string contents = Strings::loadFile(filename);
+    std::string contents = Strings::loadFile(filename.string());
 
     boost::replace_first(contents, "%LOCATIONS%", locations);
     boost::replace_first(contents, "%NUM_DETECTORS%", boost::lexical_cast<std::string>(numDetectors));
@@ -995,7 +995,7 @@ public:
       : m_instrumentDirectoryPath(ConfigService::Instance().getInstrumentDirectory()) {}
 
   void testLoadingAndParsing() {
-    const std::string filename = m_instrumentDirectoryPath + "/unit_testing/IDF_for_UNIT_TESTING.xml";
+    const std::filesystem::path filename = m_instrumentDirectoryPath / "/unit_testing/IDF_for_UNIT_TESTING.xml";
     const std::string xmlText = Strings::loadFile(filename);
 
     std::shared_ptr<const Instrument> instrument;
@@ -1010,8 +1010,8 @@ public:
   }
 
   void test_load_wish() {
-    const auto definition = m_instrumentDirectoryPath + "/WISH_Definition_10Panels.xml";
-    std::string contents = Strings::loadFile(definition);
+    const auto definition = m_instrumentDirectoryPath / "/WISH_Definition_10Panels.xml";
+    std::string contents = Strings::loadFile(definition.string());
     InstrumentDefinitionParser parser(definition, "dummy", contents);
     auto wishInstrument = parser.parseXML(nullptr);
     TS_ASSERT_EQUALS(extractDetectorInfo(*wishInstrument)->size(),
@@ -1019,8 +1019,8 @@ public:
   }
 
   void test_load_sans2d() {
-    const auto definition = m_instrumentDirectoryPath + "/SANS2D_Definition_Tubes.xml";
-    std::string contents = Strings::loadFile(definition);
+    const auto definition = m_instrumentDirectoryPath / "/SANS2D_Definition_Tubes.xml";
+    std::string contents = Strings::loadFile(definition.string());
     InstrumentDefinitionParser parser(definition, "dummy", contents);
     auto sansInstrument = parser.parseXML(nullptr);
     TS_ASSERT_EQUALS(extractDetectorInfo(*sansInstrument)->size(),
@@ -1028,7 +1028,7 @@ public:
   }
 
 private:
-  const std::string m_instrumentDirectoryPath;
+  const std::filesystem::path m_instrumentDirectoryPath;
 
   std::unique_ptr<Geometry::DetectorInfo> extractDetectorInfo(const Mantid::Geometry::Instrument &instrument) {
     Geometry::ParameterMap pmap;

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -14,6 +14,7 @@
 #include "MantidKernel/SingletonHolder.h"
 #include <optional>
 
+#include <filesystem>
 #include <map>
 #include <set>
 #include <string>
@@ -105,7 +106,7 @@ public:
   /// Reset to "factory" settings. Removes current user properties
   void reset();
   /// Wipe out the current configuration and load a new one
-  void updateConfig(const std::string &filename, const bool append = false, const bool update_caches = true);
+  void updateConfig(const std::filesystem::path &filename, const bool append = false, const bool update_caches = true);
   /// Save the configuration to the user file
   void saveConfig(const std::string &filename) const;
   /// Searches for a configuration property
@@ -164,7 +165,7 @@ public:
   //@}
 
   /// Returns the directory where the Mantid.properties file is found.
-  std::string getPropertiesDir() const;
+  const std::filesystem::path &getPropertiesDir() const;
   /// Returns a directory to use to write out Mantid information. Needs to be
   /// writable
   std::string getUserPropertiesDir() const;
@@ -182,13 +183,13 @@ public:
   /// Appends subdirectory to each of the specified data search directories
   void appendDataSearchSubDir(const std::string &subdir);
   /// Sets instrument directories
-  void setInstrumentDirectories(const std::vector<std::string> &directories);
+  void setInstrumentDirectories(const std::vector<std::filesystem::path> &directories);
   /// Get instrument search directories
-  const std::vector<std::string> &getInstrumentDirectories() const;
+  const std::vector<std::filesystem::path> &getInstrumentDirectories() const;
   /// Get instrument search directory
-  const std::string getInstrumentDirectory() const;
+  const std::filesystem::path getInstrumentDirectory() const;
   /// get the vtp file directory
-  const std::string getVTPFileDirectory();
+  const std::filesystem::path getVTPFileDirectory();
   //@}
 
   /// Load facility information from instrumentDir/Facilities.xml file
@@ -261,7 +262,8 @@ private:
   const std::vector<std::string> getFacilityFilenames(const std::string &fName);
   /// Verifies the directory exists and add it to the back of the directory list
   /// if valid
-  bool addDirectoryifExists(const std::string &directoryName, std::vector<std::string> &directoryList);
+  bool addDirectoryifExists(const std::filesystem::path &directoryName,
+                            std::vector<std::filesystem::path> &directoryList);
   /// Returns a list of all keys under a given root key
   void getKeysRecursive(const std::string &root, std::vector<std::string> &allKeys) const;
 
@@ -274,7 +276,7 @@ private:
   mutable std::set<std::string> m_changed_keys;
 
   /// The directory that is considered to be the base directory
-  std::string m_strBaseDir;
+  std::filesystem::path m_strBaseDir;
   /// The configuration properties in string format
   std::string m_propertyString;
   /// The filename of the Mantid properties file
@@ -284,7 +286,7 @@ private:
   /// Store a list of data search paths
   std::vector<std::string> m_dataSearchDirs;
   /// Store a list of instrument directory paths
-  std::vector<std::string> m_instrumentDirs;
+  std::vector<std::filesystem::path> m_instrumentDirs;
 
   /// The list of available facilities
   std::vector<FacilityInfo *> m_facilities;

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -189,7 +189,7 @@ public:
   /// Get instrument search directories
   const std::vector<std::filesystem::path> &getInstrumentDirectories() const;
   /// Get instrument search directory
-  const std::filesystem::path getInstrumentDirectory() const;
+  const std::filesystem::path &getInstrumentDirectory() const;
   /// get the vtp file directory
   const std::filesystem::path getVTPFileDirectory();
   //@}

--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -149,17 +149,17 @@ public:
   /// Returns the username
   std::string getUsername();
   /// Returns the current directory
-  std::string getCurrentDir();
+  std::filesystem::path getCurrentDir();
   /// Returns the current directory
-  std::string getCurrentDir() const;
+  std::filesystem::path getCurrentDir() const;
   /// Returns the system's temp directory
-  std::string getTempDir();
+  std::filesystem::path getTempDir();
   /// Returns the system's appdata directory
-  std::string getAppDataDir();
+  std::filesystem::path getAppDataDir() const;
   // Return the executable path
-  std::string getDirectoryOfExecutable() const;
+  std::filesystem::path getDirectoryOfExecutable() const;
   // Return the full path to the executable
-  std::string getPathToExecutable() const;
+  std::filesystem::path getPathToExecutable() const;
   // Check if the path is on a network drive
   bool isNetworkDrive([[maybe_unused]] const std::string &path);
   //@}
@@ -168,14 +168,16 @@ public:
   const std::filesystem::path &getPropertiesDir() const;
   /// Returns a directory to use to write out Mantid information. Needs to be
   /// writable
-  std::string getUserPropertiesDir() const;
+  std::filesystem::path getUserPropertiesDir() const;
 
   /** @name Search paths handling */
   //@{
   /// Get the list of search paths
-  const std::vector<std::string> &getDataSearchDirs() const;
-  /// Set a list of search paths via a vector
+  const std::vector<std::filesystem::path> &getDataSearchDirs() const;
+  /// Set a list of search paths via a vector of strings
   void setDataSearchDirs(const std::vector<std::string> &searchDirs);
+  /// Set a list of search paths via a vector of paths
+  void setDataSearchDirs(const std::vector<std::filesystem::path> &searchDirs);
   /// Set a list of search paths via a string
   void setDataSearchDirs(const std::string &searchDirs);
   /// Adds the passed path to the end of the list of data search paths
@@ -254,7 +256,7 @@ private:
   /// Create the storage of the instrument directories
   void cacheInstrumentPaths();
   /// Returns true if the path is in the data search list
-  bool isInDataSearchList(const std::string &path) const;
+  bool isInDataSearchList(const std::filesystem::path &path) const;
   /// Empty the list of facilities, deleting the FacilityInfo objects in the
   /// process
   void clearFacilities();
@@ -266,6 +268,8 @@ private:
                             std::vector<std::filesystem::path> &directoryList);
   /// Returns a list of all keys under a given root key
   void getKeysRecursive(const std::string &root, std::vector<std::string> &allKeys) const;
+
+  std::vector<std::string> pathVectorAsStrings(const std::vector<std::filesystem::path> &paths) const;
 
   /// the POCO file config object
   Poco::AutoPtr<Poco::Util::PropertyFileConfiguration> m_pConf;
@@ -284,7 +288,7 @@ private:
   /// The filename of the Mantid user properties file
   const std::string m_user_properties_file_name;
   /// Store a list of data search paths
-  std::vector<std::string> m_dataSearchDirs;
+  std::vector<std::filesystem::path> m_dataSearchDirs;
   /// Store a list of instrument directory paths
   std::vector<std::filesystem::path> m_instrumentDirs;
 

--- a/Framework/Kernel/inc/MantidKernel/Glob.h
+++ b/Framework/Kernel/inc/MantidKernel/Glob.h
@@ -11,8 +11,8 @@
 //----------------------------------------------------------------------
 #include "MantidKernel/DllConfig.h"
 #include <Poco/Glob.h>
-#include <Poco/Path.h>
 
+#include <filesystem>
 #include <set>
 #include <string>
 
@@ -28,7 +28,7 @@ namespace Kernel {
 class MANTID_KERNEL_DLL Glob : public Poco::Glob {
 public:
   /// Creates a set of files that match the given pathPattern.
-  static void glob(const Poco::Path &pathPattern, std::set<std::string> &files, int options = 0);
+  static void glob(const std::filesystem::path &pathPattern, std::set<std::string> &files, int options = 0);
 };
 
 } // namespace Kernel

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -452,7 +452,7 @@ std::string ConfigServiceImpl::makeAbsolute(const std::string &dir, const std::s
   }
   if (is_relative) {
     const std::filesystem::path propFileDir(getPropertiesDir());
-    converted = std::filesystem::absolute(propFileDir / dir).string();
+    converted = (propFileDir / dir).string();
   } else {
     converted = dir;
   }

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1441,7 +1441,8 @@ void ConfigServiceImpl::appendDataSearchSubDir(const std::string &subdir) {
     return;
   }
 
-  if (!std::filesystem::is_directory(subDirPath) || !subDirPath.is_relative()) {
+  if ((std::filesystem::exists(subDirPath) && !std::filesystem::is_directory(subDirPath)) ||
+      !subDirPath.is_relative()) {
     return;
   }
 

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -465,10 +465,9 @@ std::string ConfigServiceImpl::makeAbsolute(const std::string &dir, const std::s
   } else {
     converted = dir;
   }
+
   converted = std::filesystem::path(converted).string();
-  if (std::filesystem::path(converted).extension() == "") {
-    std::filesystem::create_directory(converted);
-  }
+
   // Backward slashes cannot be allowed to go into our properties file
   // Note this is a temporary fix for ticket #2445.
   // Ticket #2460 prompts a review of our path handling in the config service.
@@ -1234,7 +1233,6 @@ std::string ConfigServiceImpl::getAppDataDir() {
   std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
   std::string appdata = converter.to_bytes(w_appdata);
   std::filesystem::path path(appdata);
-  std::filesystem::create_directory(path);
   path /= vendorName;
   path /= applicationName;
   return path.string();
@@ -1388,7 +1386,7 @@ std::string ConfigServiceImpl::getUserPropertiesDir() const {
   std::filesystem::path datadir(m_pSysConfig->getString("system.homeDir"));
   datadir.append(".mantid");
   // Create the directory if it doesn't already exist
-  std::filesystem::create_directory(datadir);
+  std::filesystem::create_directories(datadir);
   return datadir.string() + "/";
 #endif
 }
@@ -1466,7 +1464,9 @@ void ConfigServiceImpl::appendDataSearchDir(const std::string &path) {
   std::filesystem::path dirPath;
   try {
     dirPath = std::filesystem::path(path);
-    std::filesystem::create_directory(dirPath);
+    if (!std::filesystem::is_directory(path)) {
+      dirPath.remove_filename();
+    }
   } catch (std::filesystem::filesystem_error &) {
     return;
   }
@@ -1510,7 +1510,6 @@ const std::filesystem::path ConfigServiceImpl::getVTPFileDirectory() {
   }
 
   std::filesystem::path path(getAppDataDir());
-  std::filesystem::create_directory(path);
   path /= "instrument";
   path /= "geometryCache";
   return path;
@@ -1529,7 +1528,6 @@ void ConfigServiceImpl::cacheInstrumentPaths() {
   m_instrumentDirs.clear();
 
   std::filesystem::path path(getAppDataDir());
-  std::filesystem::create_directory(path);
   path /= "instrument";
   addDirectoryifExists(path, m_instrumentDirs);
 

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -185,7 +185,7 @@ ConfigServiceImpl::ConfigServiceImpl()
   // Assert that the appdata and the instrument subdirectory exists
   std::filesystem::path path(getAppDataDir());
   path /= "instrument";
-  Poco::File file(path);
+  Poco::File file(path.string());
   // createDirectories will fail gracefully if it is already present - but will
   // throw an error if it cannot create the directory
   try {
@@ -195,7 +195,7 @@ ConfigServiceImpl::ConfigServiceImpl()
                   << "]. Mantid will not be able to update instrument definitions.\n"
                   << fe.what() << '\n';
   }
-  Poco::File vtpDir(getVTPFileDirectory());
+  Poco::File vtpDir(getVTPFileDirectory().string());
   try {
     vtpDir.createDirectories();
   } catch (Poco::FileException &fe) {
@@ -241,14 +241,14 @@ void ConfigServiceImpl::setBaseDirectory() {
 
   // First directory: the current working
   m_strBaseDir = std::filesystem::current_path();
-  f = Poco::File(m_strBaseDir / m_properties_file_name);
+  f = Poco::File((m_strBaseDir / m_properties_file_name).string());
   if (f.exists())
     return;
 
   // Check the executable directory to see if it includes a mantid.properties
   // file
   m_strBaseDir = getDirectoryOfExecutable();
-  f = Poco::File(m_strBaseDir / m_properties_file_name);
+  f = Poco::File((m_strBaseDir / m_properties_file_name).string());
   if (f.exists())
     return;
 
@@ -265,7 +265,7 @@ void ConfigServiceImpl::setBaseDirectory() {
 #else
     m_strBaseDir = Poco::Environment::get("MANTIDPATH") + "/";
 #endif
-    f = Poco::File(m_strBaseDir / m_properties_file_name);
+    f = Poco::File((m_strBaseDir / m_properties_file_name).string());
     if (f.exists())
       return;
   }
@@ -274,7 +274,7 @@ void ConfigServiceImpl::setBaseDirectory() {
   // Finally, on OSX check if we're in the package directory and the .properties
   // file just happens to be two directories up
   auto path = std::filesystem::path(getDirectoryOfExecutable());
-  m_strBaseDir = path.parent().parent().parent().string();
+  m_strBaseDir = path.parent_path().parent_path().parent_path().string();
 #endif
 }
 
@@ -430,7 +430,7 @@ std::string ConfigServiceImpl::makeAbsolute(const std::string &dir, const std::s
     auto splitted = splitPath(dir);
     auto iend = splitted.cend();
     for (auto itr = splitted.begin(); itr != iend;) {
-      std::string absolute = makeAbsolute(*itr, key);
+      std::string absolute = makeAbsolute((*itr).string(), key);
       if (absolute.empty()) {
         ++itr;
       } else {
@@ -1908,7 +1908,7 @@ std::string ConfigServiceImpl::getFullPath(const std::string &filename, const bo
       }
 #ifdef _WIN32
     } else {
-      std::filesystem::path path(searchPath, fName);
+      std::filesystem::path path(searchPath / fName);
       if (std::filesystem::exists(path) && !(ignoreDirs && std::filesystem::is_directory(path))) {
         return path.string();
       }

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1516,7 +1516,7 @@ const std::vector<std::filesystem::path> &ConfigServiceImpl::getInstrumentDirect
  * Return the base search directories for XML instrument definition files (IDFs)
  * @returns a last entry of getInstrumentDirectories
  */
-const std::filesystem::path ConfigServiceImpl::getInstrumentDirectory() const { return m_instrumentDirs.back(); }
+const std::filesystem::path &ConfigServiceImpl::getInstrumentDirectory() const { return m_instrumentDirs.back(); }
 /**
  * Return the search directory for vtp files
  * @returns a path

--- a/Framework/Kernel/src/Glob.cpp
+++ b/Framework/Kernel/src/Glob.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/Glob.h"
+#include "Poco/Path.h"
 
 namespace Mantid::Kernel {
 
@@ -30,7 +31,7 @@ namespace Mantid::Kernel {
  *    @param files :: The names of the files that match the pattern
  *    @param options :: Options
  */
-void Glob::glob(const Poco::Path &pathPattern, std::set<std::string> &files, int options) {
+void Glob::glob(const std::filesystem::path &pathPattern, std::set<std::string> &files, int options) {
 #ifdef _WIN32
   // There appears to be a bug in the glob for windows.
   // Putting case sensitive on then with reference to test
@@ -40,9 +41,9 @@ void Glob::glob(const Poco::Path &pathPattern, std::set<std::string> &files, int
   // the case is wrong, but for some strange reason it then cannot find
   // IDF_for_UNiT_TESTiNG.xMl!!!!
   // Hence the reason to circumvent this by this #ifdef
-  Poco::Glob::glob(Poco::Path(pathPattern.toString()), files, Poco::Glob::GLOB_CASELESS);
+  Poco::Glob::glob(Poco::Path(pathPattern.string()), files, Poco::Glob::GLOB_CASELESS);
 #else
-  Poco::Glob::glob(Poco::Path(pathPattern.toString()), files, options);
+  Poco::Glob::glob(Poco::Path(pathPattern.string()), files, options);
 #endif
 }
 

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -218,13 +218,15 @@ public:
     TS_ASSERT_LESS_THAN(0, username.length());
     TS_ASSERT_LESS_THAN(0, ConfigService::Instance().getOSVersion().length()); // check that the string is not empty
     TS_ASSERT_LESS_THAN(0, ConfigService::Instance().getOSVersionReadable().length());
-    TS_ASSERT_LESS_THAN(0, ConfigService::Instance().getCurrentDir().length()); // check that the string is not empty
+    TS_ASSERT_LESS_THAN(
+        0, ConfigService::Instance().getCurrentDir().string().length()); // check that the string is not empty
     //        TS_ASSERT_LESS_THAN(0,
     //        ConfigService::Instance().getHomeDir().length()); //check that the
     //        string is not empty
-    TS_ASSERT_LESS_THAN(0, ConfigService::Instance().getTempDir().length()); // check that the string is not empty
+    TS_ASSERT_LESS_THAN(0,
+                        ConfigService::Instance().getTempDir().string().length()); // check that the string is not empty
 
-    std::string appdataDir = ConfigService::Instance().getAppDataDir();
+    std::string appdataDir = ConfigService::Instance().getAppDataDir().string();
     TS_ASSERT_LESS_THAN(0, appdataDir.length());
 #ifdef _WIN32
     std::string::size_type index = appdataDir.find("\\AppData\\Roaming\\mantidproject\\mantid");
@@ -336,7 +338,8 @@ public:
   }
 
   void testSaveConfigCleanFile() {
-    const std::string propfile = ConfigService::Instance().getDirectoryOfExecutable() + "MantidTest.properties";
+    const std::string propfile =
+        (ConfigService::Instance().getDirectoryOfExecutable() / "MantidTest.properties").string();
     ConfigService::Instance().updateConfig(propfile);
 
     const std::string filename("user.settings");
@@ -384,7 +387,8 @@ public:
     writer << "mantid.legs = " << value << "\n";
     writer.close();
 
-    const std::string propfile = ConfigService::Instance().getDirectoryOfExecutable() + "MantidTest.properties";
+    const std::string propfile =
+        (ConfigService::Instance().getDirectoryOfExecutable() / "MantidTest.properties").string();
     ConfigService::Instance().updateConfig(propfile);
     ConfigService::Instance().setString("mantid.legs", value);
     ConfigService::Instance().updateConfig(propfile, false, false);
@@ -407,7 +411,8 @@ public:
     } catch (Poco::Exception &) {
     }
 
-    const std::string propfile = ConfigService::Instance().getDirectoryOfExecutable() + "MantidTest.properties";
+    const std::string propfile =
+        (ConfigService::Instance().getDirectoryOfExecutable() / "MantidTest.properties").string();
     settings.updateConfig(propfile);
     settings.setString("mantid.legs", "15");
 
@@ -592,7 +597,8 @@ public:
   }
 
   void testGetKeysWithValidInput() {
-    const std::string propfile = ConfigService::Instance().getDirectoryOfExecutable() + "MantidTest.properties";
+    const std::string propfile =
+        (ConfigService::Instance().getDirectoryOfExecutable() / "MantidTest.properties").string();
     ConfigService::Instance().updateConfig(propfile);
 
     // Returns all subkeys with the given root key
@@ -605,7 +611,8 @@ public:
   }
 
   void testGetKeysWithZeroSubKeys() {
-    const std::string propfile = ConfigService::Instance().getDirectoryOfExecutable() + "MantidTest.properties";
+    const std::string propfile =
+        (ConfigService::Instance().getDirectoryOfExecutable() / "MantidTest.properties").string();
     ConfigService::Instance().updateConfig(propfile);
 
     std::vector<std::string> keyVector = ConfigService::Instance().getKeys("mantid.legs");
@@ -615,7 +622,8 @@ public:
   }
 
   void testGetKeysWithEmptyPrefix() {
-    const std::string propfile = ConfigService::Instance().getDirectoryOfExecutable() + "MantidTest.properties";
+    const std::string propfile =
+        (ConfigService::Instance().getDirectoryOfExecutable() / "MantidTest.properties").string();
     ConfigService::Instance().updateConfig(propfile);
 
     // Returns all *root* keys, i.e. unique keys left of the first period
@@ -634,7 +642,8 @@ public:
   }
 
   void testRemovingProperty() {
-    const std::string propfile = ConfigService::Instance().getDirectoryOfExecutable() + "MantidTest.properties";
+    const std::string propfile =
+        (ConfigService::Instance().getDirectoryOfExecutable() / "MantidTest.properties").string();
     ConfigService::Instance().updateConfig(propfile);
 
     std::string rootName = "mantid.legs";

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -310,9 +310,9 @@ public:
   void testAppendProperties() {
 
     // This should clear out all old properties
-    const std::string propfilePath = ConfigService::Instance().getDirectoryOfExecutable();
-    const std::string propfile = propfilePath + "MantidTest.properties";
-    ConfigService::Instance().updateConfig(propfile);
+    const std::filesystem::path propfilePath = ConfigService::Instance().getDirectoryOfExecutable();
+    const std::filesystem::path propfile = propfilePath / "MantidTest.properties";
+    ConfigService::Instance().updateConfig(propfile.string());
     // this should return an empty string
     TS_ASSERT_EQUALS(ConfigService::Instance().getString("mantid.noses"), "");
     // this should pass
@@ -320,7 +320,7 @@ public:
     TS_ASSERT_EQUALS(ConfigService::Instance().getString("mantid.thorax"), "1");
 
     // This should append a new properties file properties
-    ConfigService::Instance().updateConfig(propfilePath + "MantidTest.user.properties", true);
+    ConfigService::Instance().updateConfig((propfilePath / "MantidTest.user.properties").string(), true);
     // this should now be valid
     TS_ASSERT_EQUALS(ConfigService::Instance().getString("mantid.noses"), "5");
     // this should have been overridden
@@ -632,9 +632,9 @@ public:
   }
 
   void testGetAllKeys() {
-    const std::string propfilePath = ConfigService::Instance().getDirectoryOfExecutable();
-    const std::string propfile = propfilePath + "MantidTest.properties";
-    ConfigService::Instance().updateConfig(propfile);
+    const std::filesystem::path propfilePath = ConfigService::Instance().getDirectoryOfExecutable();
+    const std::filesystem::path propfile = propfilePath / "MantidTest.properties";
+    ConfigService::Instance().updateConfig(propfile.string());
 
     std::vector<std::string> keys = ConfigService::Instance().keys();
 

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -243,7 +243,7 @@ public:
     TS_ASSERT_LESS_THAN(1, directories.size());
     // the first entry should be the AppDataDir + instrument
     TSM_ASSERT_LESS_THAN("Could not find the appData directory in getInstrumentDirectories()[0]",
-                         directories[0].string().find(ConfigService::Instance().getAppDataDir()),
+                         directories[0].string().find(ConfigService::Instance().getAppDataDir().string()),
                          directories[0].string().size());
     TSM_ASSERT_LESS_THAN("Could not find the 'instrument' directory in "
                          "getInstrumentDirectories()[0]",
@@ -261,7 +261,7 @@ public:
 
     // check all of the directory entries actually exist
     for (auto &directoryPath : directories) {
-      Poco::File directory(directoryPath);
+      Poco::File directory(directoryPath.string());
       TSM_ASSERT(directoryPath.string() + " does not exist", directory.exists());
     }
   }

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -241,16 +241,17 @@ public:
     TS_ASSERT_LESS_THAN(1, directories.size());
     // the first entry should be the AppDataDir + instrument
     TSM_ASSERT_LESS_THAN("Could not find the appData directory in getInstrumentDirectories()[0]",
-                         directories[0].find(ConfigService::Instance().getAppDataDir()), directories[0].size());
+                         directories[0].string().find(ConfigService::Instance().getAppDataDir()),
+                         directories[0].string().size());
     TSM_ASSERT_LESS_THAN("Could not find the 'instrument' directory in "
                          "getInstrumentDirectories()[0]",
-                         directories[0].find("instrument"), directories[0].size());
+                         directories[0].string().find("instrument"), directories[0].string().size());
 
     if (directories.size() == 3) {
       // The middle entry should be /etc/mantid/instrument
       TSM_ASSERT_LESS_THAN("Could not find /etc/mantid/instrument path in "
                            "getInstrumentDirectories()[1]",
-                           directories[1].find("etc/mantid/instrument"), directories[1].size());
+                           directories[1].string().find("etc/mantid/instrument"), directories[1].string().size());
     }
     // Check that the last directory matches that returned by
     // getInstrumentDirectory
@@ -259,14 +260,14 @@ public:
     // check all of the directory entries actually exist
     for (auto &directoryPath : directories) {
       Poco::File directory(directoryPath);
-      TSM_ASSERT(directoryPath + " does not exist", directory.exists());
+      TSM_ASSERT(directoryPath.string() + " does not exist", directory.exists());
     }
   }
 
   void testSetInstrumentDirectory() {
 
     auto originalDirectories = ConfigService::Instance().getInstrumentDirectories();
-    std::vector<std::string> testDirectories;
+    std::vector<std::filesystem::path> testDirectories;
     testDirectories.emplace_back("Test Directory 1");
     testDirectories.emplace_back("Test Directory 2");
     ConfigService::Instance().setInstrumentDirectories(testDirectories);

--- a/Framework/Kernel/test/GlobTest.h
+++ b/Framework/Kernel/test/GlobTest.h
@@ -32,7 +32,7 @@ public:
   }
 
   void test_Glob() {
-    std::string pattern = base.string() + "Framework/*/CMakeLists.*t";
+    const auto pattern = base / "Framework/*/CMakeLists.*t";
 
     std::set<std::string> files;
     Glob::glob(pattern, files);
@@ -41,7 +41,7 @@ public:
     size_t matches = 0;
     for (const auto &file : files) {
       std::filesystem::path path(file);
-      std::string project = path.filename().string();
+      std::string project = path.parent_path().filename().string();
       if (project == "API")
         ++matches;
       if (project == "Algorithms")
@@ -58,7 +58,7 @@ public:
   }
 
   void test_no_match() {
-    std::string pattern = base.string() + "Doesnotexist/*/CMakeLists.*t";
+    const auto pattern = base / "Doesnotexist/*/CMakeLists.*t";
 
     std::set<std::string> files;
     Glob::glob(pattern, files);
@@ -100,7 +100,7 @@ public:
   }
 
   void test_double_dots_in_pattern() {
-    std::string pattern = base.string() + "Framework/*/CMakeLists.*t";
+    const auto pattern = base / "Framework/*/CMakeLists.*t";
 
     std::set<std::string> files;
     Glob::glob(pattern, files);
@@ -109,7 +109,7 @@ public:
     size_t matches = 0;
     for (const auto &file : files) {
       std::filesystem::path path(file);
-      std::string project = path.filename().string();
+      std::string project = path.parent_path().filename().string();
       if (project == "API")
         ++matches;
       if (project == "Algorithms")

--- a/Framework/Kernel/test/GlobTest.h
+++ b/Framework/Kernel/test/GlobTest.h
@@ -11,14 +11,13 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Glob.h"
 
-#include <Poco/Path.h>
 #include <filesystem>
 #include <fstream>
 
 using namespace Mantid::Kernel;
 
 class GlobTest : public CxxTest::TestSuite {
-  Poco::Path base;
+  std::filesystem::path base;
 
 public:
   // This pair of boilerplate methods prevent the suite being created statically
@@ -28,12 +27,12 @@ public:
 
   GlobTest() {
     base.assign(ConfigService::Instance().getInstrumentDirectory());
-    base.makeParent();
-    base.assign(base.toString());
+    base = base.parent_path();
+    base.assign(base.string());
   }
 
   void test_Glob() {
-    std::string pattern = base.toString() + "Framework/*/CMakeLists.*t";
+    std::string pattern = base.string() + "Framework/*/CMakeLists.*t";
 
     std::set<std::string> files;
     Glob::glob(pattern, files);
@@ -41,8 +40,8 @@ public:
 
     size_t matches = 0;
     for (const auto &file : files) {
-      Poco::Path path = file;
-      std::string project = path[path.depth() - 1];
+      std::filesystem::path path(file);
+      std::string project = path.filename().string();
       if (project == "API")
         ++matches;
       if (project == "Algorithms")
@@ -53,13 +52,13 @@ public:
         ++matches;
       if (project == "DataObjects")
         ++matches;
-      TS_ASSERT_EQUALS(path.getFileName(), "CMakeLists.txt");
+      TS_ASSERT_EQUALS(path.filename().string(), "CMakeLists.txt");
     }
     TS_ASSERT_EQUALS(matches, 5);
   }
 
   void test_no_match() {
-    std::string pattern = base.toString() + "Doesnotexist/*/CMakeLists.*t";
+    std::string pattern = base.string() + "Doesnotexist/*/CMakeLists.*t";
 
     std::set<std::string> files;
     Glob::glob(pattern, files);
@@ -101,7 +100,7 @@ public:
   }
 
   void test_double_dots_in_pattern() {
-    std::string pattern = base.toString() + "Framework/*/CMakeLists.*t";
+    std::string pattern = base.string() + "Framework/*/CMakeLists.*t";
 
     std::set<std::string> files;
     Glob::glob(pattern, files);
@@ -109,8 +108,8 @@ public:
 
     size_t matches = 0;
     for (const auto &file : files) {
-      Poco::Path path = file;
-      std::string project = path[path.depth() - 1];
+      std::filesystem::path path(file);
+      std::string project = path.filename().string();
       if (project == "API")
         ++matches;
       if (project == "Algorithms")
@@ -121,13 +120,15 @@ public:
         ++matches;
       if (project == "DataObjects")
         ++matches;
-      TS_ASSERT_EQUALS(path.getFileName(), "CMakeLists.txt");
+      TS_ASSERT_EQUALS(path.filename().string(), "CMakeLists.txt");
     }
     TS_ASSERT_EQUALS(matches, 5);
   }
 
   void test_filename_contains_directory() {
-    Poco::Path pattern(base.toString() + "instrument", "unit_testing/DUM_Definition.xml");
+    std::filesystem::path pattern(base);
+    pattern /= "instrument";
+    pattern /= "unit_testing/DUM_Definition.xml";
 
     std::set<std::string> files;
     Glob::glob(pattern, files);
@@ -135,7 +136,9 @@ public:
   }
 
   void test_caseless() {
-    Poco::Path pattern(base.toString() + "instrument", "unit_TESTING/dum_Definition.xml");
+    std::filesystem::path pattern(base);
+    pattern /= "instrument";
+    pattern /= "unit_TESTING/dum_Definition.xml";
 
     std::set<std::string> files;
     Glob::glob(pattern, files, Poco::Glob::GLOB_CASELESS);

--- a/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
+++ b/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
@@ -37,7 +37,7 @@ public:
     config.updateFacilities(testFile.string());
     config.setFacility("TEST");
     // Update instrument search directory
-    config.setString("instrumentDefinition.directory", baseInstDir / "unit_testing");
+    config.setString("instrumentDefinition.directory", (baseInstDir / "unit_testing").string());
   }
 
   void tearDown() override {

--- a/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
+++ b/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
@@ -17,9 +17,9 @@
 
 #include "MantidLiveData/Kafka/KafkaEventStreamDecoder.h"
 
-#include <Poco/Path.h>
 #include <condition_variable>
 #include <cxxtest/TestSuite.h>
+#include <filesystem>
 #include <iostream>
 #include <thread>
 
@@ -32,12 +32,12 @@ public:
     using Mantid::Kernel::ConfigService;
     auto &config = ConfigService::Instance();
     auto baseInstDir = config.getInstrumentDirectory();
-    Poco::Path testFile = Poco::Path(baseInstDir).resolve("unit_testing/UnitTestFacilities.xml");
+    std::filesystem::path testFile = std::filesystem::absolute(baseInstDir / "unit_testing/UnitTestFacilities.xml");
     // Load the test facilities file
-    config.updateFacilities(testFile.toString());
+    config.updateFacilities(testFile.string());
     config.setFacility("TEST");
     // Update instrument search directory
-    config.setString("instrumentDefinition.directory", baseInstDir + "/unit_testing");
+    config.setString("instrumentDefinition.directory", baseInstDir / "/unit_testing");
   }
 
   void tearDown() override {

--- a/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
+++ b/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
@@ -37,7 +37,7 @@ public:
     config.updateFacilities(testFile.string());
     config.setFacility("TEST");
     // Update instrument search directory
-    config.setString("instrumentDefinition.directory", baseInstDir / "/unit_testing");
+    config.setString("instrumentDefinition.directory", baseInstDir / "unit_testing");
   }
 
   void tearDown() override {

--- a/Framework/LiveData/test/KafkaHistoStreamDecoderTest.h
+++ b/Framework/LiveData/test/KafkaHistoStreamDecoderTest.h
@@ -35,7 +35,7 @@ public:
     config.updateFacilities(testFile.string());
     config.setFacility("TEST");
     // Update instrument search directory
-    config.setString("instrumentDefinition.directory", baseInstDir / "unit_testing");
+    config.setString("instrumentDefinition.directory", (baseInstDir / "unit_testing").string());
   }
 
   void tearDown() override {

--- a/Framework/LiveData/test/KafkaHistoStreamDecoderTest.h
+++ b/Framework/LiveData/test/KafkaHistoStreamDecoderTest.h
@@ -35,7 +35,7 @@ public:
     config.updateFacilities(testFile.string());
     config.setFacility("TEST");
     // Update instrument search directory
-    config.setString("instrumentDefinition.directory", baseInstDir / "/unit_testing");
+    config.setString("instrumentDefinition.directory", baseInstDir / "unit_testing");
   }
 
   void tearDown() override {

--- a/Framework/LiveData/test/KafkaHistoStreamDecoderTest.h
+++ b/Framework/LiveData/test/KafkaHistoStreamDecoderTest.h
@@ -16,10 +16,8 @@
 #include "MantidHistogramData/HistogramY.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/TimeSeriesProperty.h"
-
 #include "MantidLiveData/Kafka/KafkaHistoStreamDecoder.h"
 
-#include <Poco/Path.h>
 #include <cxxtest/TestSuite.h>
 
 using Mantid::LiveData::KafkaHistoStreamDecoder;
@@ -32,12 +30,12 @@ public:
     using Mantid::Kernel::ConfigService;
     auto &config = ConfigService::Instance();
     auto baseInstDir = config.getInstrumentDirectory();
-    Poco::Path testFile = Poco::Path(baseInstDir).resolve("unit_testing/UnitTestFacilities.xml");
+    std::filesystem::path testFile = std::filesystem::absolute(baseInstDir / "unit_testing/UnitTestFacilities.xml");
     // Load the test facilities file
-    config.updateFacilities(testFile.toString());
+    config.updateFacilities(testFile.string());
     config.setFacility("TEST");
     // Update instrument search directory
-    config.setString("instrumentDefinition.directory", baseInstDir + "/unit_testing");
+    config.setString("instrumentDefinition.directory", baseInstDir / "/unit_testing");
   }
 
   void tearDown() override {

--- a/Framework/MDAlgorithms/test/AccumulateMDTest.h
+++ b/Framework/MDAlgorithms/test/AccumulateMDTest.h
@@ -13,7 +13,6 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidMDAlgorithms/AccumulateMD.h"
 #include <Poco/File.h>
-#include <Poco/Path.h>
 #include <cxxtest/TestSuite.h>
 
 using Mantid::MDAlgorithms::AccumulateMD;
@@ -62,11 +61,11 @@ public:
     std::vector<double> efix(1, 0.0);
 
     // Add absolute path to a file which doesn't exist
-    Poco::Path filepath =
-        Poco::Path(Mantid::Kernel::ConfigService::Instance().getTempDir(), "ACCUMULATEMDTEST_NONEXISTENTFILE");
+    std::filesystem::path filepath =
+        Mantid::Kernel::ConfigService::Instance().getTempDir() / "ACCUMULATEMDTEST_NONEXISTENTFILE";
 
     // Create vector of data_sources to filter
-    std::vector<std::string> data_sources{filepath.toString()};
+    std::vector<std::string> data_sources{filepath.string()};
 
     Mantid::MDAlgorithms::filterToExistingSources(data_sources, psi, gl, gs, efix);
 
@@ -123,12 +122,12 @@ public:
     std::vector<double> efix(1, 0.0);
 
     // Create a temporary file to find
-    Poco::Path filepath =
-        Poco::Path(Mantid::Kernel::ConfigService::Instance().getTempDir(), "ACCUMULATEMDTEST_EXISTENTFILE");
+    std::filesystem::path filepath =
+        Mantid::Kernel::ConfigService::Instance().getTempDir() / "ACCUMULATEMDTEST_EXISTENTFILE";
     Poco::File existent_file(filepath);
     existent_file.createFile();
     // Create vector of data_sources to filter
-    std::vector<std::string> data_sources{filepath.toString()};
+    std::vector<std::string> data_sources{filepath.string()};
 
     Mantid::MDAlgorithms::filterToExistingSources(data_sources, psi, gl, gs, efix);
 

--- a/Framework/MDAlgorithms/test/AccumulateMDTest.h
+++ b/Framework/MDAlgorithms/test/AccumulateMDTest.h
@@ -124,7 +124,7 @@ public:
     // Create a temporary file to find
     std::filesystem::path filepath =
         Mantid::Kernel::ConfigService::Instance().getTempDir() / "ACCUMULATEMDTEST_EXISTENTFILE";
-    Poco::File existent_file(filepath);
+    Poco::File existent_file(filepath.string());
     existent_file.createFile();
     // Create vector of data_sources to filter
     std::vector<std::string> data_sources{filepath.string()};

--- a/Framework/Parallel/src/IO/EventLoader.cpp
+++ b/Framework/Parallel/src/IO/EventLoader.cpp
@@ -48,7 +48,8 @@ void load(const std::string &filename, const std::string &groupname, const std::
   auto concurencyNumber = PARALLEL_GET_MAX_THREADS;
   auto numThreads = std::max<int>(concurencyNumber / 2, 1);
   auto numProceses = std::max<int>(concurencyNumber / 2, 1);
-  std::string executableName = Kernel::ConfigService::Instance().getPropertiesDir() / "MantidNexusParallelLoader";
+  std::string executableName =
+      (Kernel::ConfigService::Instance().getPropertiesDir() / "MantidNexusParallelLoader").string();
 
   MultiProcessEventLoader loader(static_cast<unsigned>(eventLists.size()), numProceses, numThreads, executableName,
                                  precalcEvents);

--- a/Framework/Parallel/src/IO/EventLoader.cpp
+++ b/Framework/Parallel/src/IO/EventLoader.cpp
@@ -48,7 +48,7 @@ void load(const std::string &filename, const std::string &groupname, const std::
   auto concurencyNumber = PARALLEL_GET_MAX_THREADS;
   auto numThreads = std::max<int>(concurencyNumber / 2, 1);
   auto numProceses = std::max<int>(concurencyNumber / 2, 1);
-  std::string executableName = Kernel::ConfigService::Instance().getPropertiesDir() + "MantidNexusParallelLoader";
+  std::string executableName = Kernel::ConfigService::Instance().getPropertiesDir() / "MantidNexusParallelLoader";
 
   MultiProcessEventLoader loader(static_cast<unsigned>(eventLists.size()), numProceses, numThreads, executableName,
                                  precalcEvents);

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Testing/PythonInterpreterGlobalFixture.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Testing/PythonInterpreterGlobalFixture.h
@@ -29,7 +29,7 @@ public:
     // Insert the directory of the properties file as a sitedir
     // to ensure the built copy of mantid gets picked up
     const py::object siteModule{py::handle<>(PyImport_ImportModule("site"))};
-    siteModule.attr("addsitedir")(ConfigService::Instance().getPropertiesDir());
+    siteModule.attr("addsitedir")(ConfigService::Instance().getPropertiesDir().string());
 
     // Use Agg backend for matplotlib
     py::object mpl{py::handle<>(PyImport_ImportModule("matplotlib"))};

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -38,9 +38,9 @@ GET_POINTER_SPECIALIZATION(ExperimentInfo)
 // user
 list getResourceFilenames(const std::string &prefix, const list &fileFormats, const list &directoryNames,
                           const std::string &date) {
-  return Converters::ToPyList<std::string>()(
-      InstrumentFileFinder::getResourceFilenames(prefix, Converters::PySequenceToVector<std::string>(fileFormats)(),
-                                                 Converters::PySequenceToVector<std::string>(directoryNames)(), date));
+  return Converters::ToPyList<std::string>()(InstrumentFileFinder::getResourceFilenames(
+      prefix, Converters::PySequenceToVector<std::string>(fileFormats)(),
+      Converters::PySequenceToVector<std::filesystem::path>(directoryNames)(), date));
 }
 
 std::string getInstrumentFilenameWarn(const std::string &instName, const std::string &date = "") {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -72,6 +72,7 @@ GNU_DIAG_OFF("unused-local-typedef")
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
 // Overload generator for getInstrument
+// Cppcheck doesn't understand Boost macros
 // cppcheck-suppress unknownMacro
 BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrument_Overload, getInstrument, 1, 2)
 // Overload generator for getString

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -65,6 +65,8 @@ std::string getStringUsingCacheElseDefault(ConfigServiceImpl const *const self, 
     return defaultValue;
 }
 
+std::string getPropertiesDir(ConfigServiceImpl const *const self) { return self->getPropertiesDir().string(); }
+
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -93,7 +95,7 @@ void export_ConfigService() {
            "Returns the path to the system wide properties file.")
       .def("getUserFilename", &ConfigServiceImpl::getUserFilename, arg("self"),
            "Returns the path to the user properties file")
-      .def("getPropertiesDir", &ConfigServiceImpl::getPropertiesDir, arg("self"),
+      .def("getPropertiesDir", &getPropertiesDir, arg("self"),
            "Returns the directory containing the Mantid.properties file.")
       .def("getUserPropertiesDir", &ConfigServiceImpl::getUserPropertiesDir, arg("self"),
            "Returns the directory to use to write out Mantid information")

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -65,7 +65,19 @@ std::string getStringUsingCacheElseDefault(ConfigServiceImpl const *const self, 
     return defaultValue;
 }
 
+std::string getInstrumentDirectory(ConfigServiceImpl const *const self) {
+  return self->getInstrumentDirectory().string();
+}
+
 std::string getPropertiesDir(ConfigServiceImpl const *const self) { return self->getPropertiesDir().string(); }
+
+std::vector<std::string> getInstrumentDirectories(ConfigServiceImpl const *const self) {
+  const auto &instrumentDirectories = self->getInstrumentDirectories();
+  std::vector<std::string> instrumentDirectoryStrings(instrumentDirectories.size());
+  std::transform(instrumentDirectories.cbegin(), instrumentDirectories.cend(), instrumentDirectoryStrings.begin(),
+                 [](const auto &p) { return p.string(); });
+  return instrumentDirectoryStrings;
+}
 
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
@@ -100,10 +112,9 @@ void export_ConfigService() {
            "Returns the directory containing the Mantid.properties file.")
       .def("getUserPropertiesDir", &ConfigServiceImpl::getUserPropertiesDir, arg("self"),
            "Returns the directory to use to write out Mantid information")
-      .def("getInstrumentDirectory", &ConfigServiceImpl::getInstrumentDirectory, arg("self"),
+      .def("getInstrumentDirectory", &getInstrumentDirectory, arg("self"),
            "Returns the directory used for the instrument definitions")
-      .def("getInstrumentDirectories", &ConfigServiceImpl::getInstrumentDirectories, arg("self"),
-           return_value_policy<reference_existing_object>(),
+      .def("getInstrumentDirectories", &getInstrumentDirectories, arg("self"),
            "Returns the list of directories searched for the instrument "
            "definitions")
       .def("getFacilityNames", &ConfigServiceImpl::getFacilityNames, arg("self"), "Returns the default facility")

--- a/Framework/PythonInterface/test/python/mantid/utils/pathTest.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/pathTest.py
@@ -23,7 +23,8 @@ class PathTest(unittest.TestCase):
         config["datasearch.directories"] = f"{data_dir};{old}"
         expected = Path(data_dir) / "SNAP_45874.nxs.h5"
         expected.touch()  # create empty file
-        self.assertEqual(path.run_file(45874, instrument="SNAP", oncat=False), str(expected))
+        file = Path(path.run_file(45874, instrument="SNAP", oncat=False))
+        self.assertEqual(file, expected)
         config["datasearch.directories"] = old  # restore the original list of data search directories
 
 

--- a/Framework/Reflectometry/test/SpecularReflectionAlgorithmTest.h
+++ b/Framework/Reflectometry/test/SpecularReflectionAlgorithmTest.h
@@ -91,24 +91,22 @@ public:
 
     FrameworkManager::Instance();
 
-    const std::string instDir = ConfigService::Instance().getInstrumentDirectory();
-    Poco::Path path(instDir);
-    path.append("INTER_Definition.xml");
+    const std::filesystem::path &instDir = ConfigService::Instance().getInstrumentDirectory();
+    std::filesystem::path path(instDir / "INTER_Definition.xml");
 
     auto loadAlg = AlgorithmManager::Instance().create("LoadEmptyInstrument");
     loadAlg->initialize();
     loadAlg->setChild(true);
-    loadAlg->setProperty("Filename", path.toString());
+    loadAlg->setProperty("Filename", path.string());
     loadAlg->setPropertyValue("OutputWorkspace", "demo");
     loadAlg->execute();
     pointDetectorWS = loadAlg->getProperty("OutputWorkspace");
 
-    path = Poco::Path(instDir);
-    path.append("POLREF_Definition.xml");
+    path = instDir / "POLREF_Definition.xml";
     loadAlg = AlgorithmManager::Instance().create("LoadEmptyInstrument");
     loadAlg->initialize();
     loadAlg->setChild(true);
-    loadAlg->setProperty("Filename", path.toString());
+    loadAlg->setProperty("Filename", path.string());
     loadAlg->setPropertyValue("OutputWorkspace", "demo");
     loadAlg->execute();
     linearDetectorWS = loadAlg->getProperty("OutputWorkspace");

--- a/Framework/Reflectometry/test/SpecularReflectionCalculateTheta2Test.h
+++ b/Framework/Reflectometry/test/SpecularReflectionCalculateTheta2Test.h
@@ -9,6 +9,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidKernel/ConfigService.h"
 #include "SpecularReflectionAlgorithmTest.h"
 
 #include "MantidReflectometry/SpecularReflectionCalculateTheta2.h"

--- a/Framework/Reflectometry/test/SpecularReflectionCalculateThetaTest.h
+++ b/Framework/Reflectometry/test/SpecularReflectionCalculateThetaTest.h
@@ -9,6 +9,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidKernel/ConfigService.h"
 #include "SpecularReflectionAlgorithmTest.h"
 
 #include "MantidReflectometry/SpecularReflectionCalculateTheta.h"

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FacilityHelper.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/FacilityHelper.h
@@ -14,7 +14,6 @@
 
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/FacilityInfo.h"
-#include <Poco/Path.h>
 
 namespace FacilityHelper {
 
@@ -31,9 +30,9 @@ struct ScopedFacilities {
   ScopedFacilities(const std::string &filename, const std::string &defFacility) {
     auto &config = Mantid::Kernel::ConfigService::Instance();
     defFacilityOnStart = config.getFacility().name();
-    Poco::Path testFile = Poco::Path(config.getInstrumentDirectory()).resolve(filename);
+    const std::filesystem::path testFile = std::filesystem::absolute(config.getInstrumentDirectory() / filename);
     // Load the test facilities file
-    config.updateFacilities(testFile.toString());
+    config.updateFacilities(testFile.string());
     config.setFacility(defFacility);
   }
 

--- a/Framework/TestHelpers/src/FileResource.cpp
+++ b/Framework/TestHelpers/src/FileResource.cpp
@@ -22,7 +22,7 @@ FileResource::FileResource(const std::string &fileName, bool debugMode) : m_debu
     m_full_path = temp_full_path;
 
   } else {
-    throw std::invalid_argument("failed to load temp directory: " + temp_dir.generic_string());
+    throw std::invalid_argument("failed to load temp directory: " + temp_dir.string());
   }
 
   // if the file already exists and was not cleaned up, remove it
@@ -40,7 +40,7 @@ bool FileResource::exists() {
 }
 
 void FileResource::setDebugMode(bool mode) { m_debugMode = mode; }
-std::string FileResource::fullPath() const { return m_full_path.generic_string(); }
+std::string FileResource::fullPath() const { return m_full_path.string(); }
 
 FileResource::~FileResource() {
 

--- a/Framework/TestHelpers/src/IndirectFitDataCreationHelper.cpp
+++ b/Framework/TestHelpers/src/IndirectFitDataCreationHelper.cpp
@@ -7,6 +7,8 @@
 #include "MantidFrameworkTestHelpers/IndirectFitDataCreationHelper.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 
+#include <filesystem>
+
 namespace Mantid::IndirectFitDataCreationHelper {
 using namespace Mantid::API;
 
@@ -112,9 +114,10 @@ MatrixWorkspace_sptr createWorkspaceWithInelasticInstrument(int const &yLength) 
 MatrixWorkspace_sptr createWorkspaceWithIndirectInstrumentAndParameters(std::string const &analyser) {
 
   auto testWorkspace = createWorkspace(1, 5);
-  std::string idfdirectory = Mantid::Kernel::ConfigService::Instance().getString("instrumentDefinition.directory");
+  std::filesystem::path idfdirectory =
+      Mantid::Kernel::ConfigService::Instance().getString("instrumentDefinition.directory");
   // IRIS instrument with graphite detector.
-  auto const ipfFilename = idfdirectory + "IRIS" + "_" + analyser + "_" + "002" + "_Parameters.xml";
+  auto const ipfFilename = idfdirectory / std::filesystem::path("IRIS_" + analyser + "_002_Parameters.xml");
 
   auto loadInst = AlgorithmManager::Instance().create("LoadInstrument");
   loadInst->setLogging(true);
@@ -129,7 +132,7 @@ MatrixWorkspace_sptr createWorkspaceWithIndirectInstrumentAndParameters(std::str
   loadParams->setLogging(true);
   loadParams->initialize();
   loadParams->setProperty("Workspace", testWorkspace);
-  loadParams->setProperty("Filename", ipfFilename);
+  loadParams->setProperty("Filename", ipfFilename.string());
   loadParams->execute();
 
   return testWorkspace;

--- a/Framework/TestHelpers/src/ScopedFileHelper.cpp
+++ b/Framework/TestHelpers/src/ScopedFileHelper.cpp
@@ -19,7 +19,7 @@ namespace ScopedFileHelper {
 Constructor generates the file. Sets location to be the temp directory
 */
 ScopedFile::ScopedFile(const std::string &fileContents, const std::string &fileName) {
-  Poco::Path path(Mantid::Kernel::ConfigService::Instance().getTempDir().c_str());
+  Poco::Path path(Mantid::Kernel::ConfigService::Instance().getTempDir().string());
   path.append(fileName);
   doCreateFile(fileContents, path);
 }

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -132,8 +132,8 @@ std::string EQSANSLoad::findConfigFile(const int &run) {
   static boost::regex re1("eqsans_configuration\\.([0-9]+)$");
   boost::smatch matches;
   for (const auto &searchPath : searchPaths) {
-    if (Poco::File(searchPath).exists()) {
-      Poco::DirectoryIterator file_it(searchPath);
+    if (Poco::File(searchPath.string()).exists()) {
+      Poco::DirectoryIterator file_it(searchPath.string());
       Poco::DirectoryIterator end;
       for (; file_it != end; ++file_it) {
         if (boost::regex_search(file_it.name(), matches, re1)) {

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -125,7 +125,7 @@ std::string EQSANSLoad::findConfigFile(const int &run) {
   if (Poco::File(sns_folder).exists())
     Kernel::ConfigService::Instance().appendDataSearchDir(sns_folder);
 
-  const std::vector<std::string> &searchPaths = Kernel::ConfigService::Instance().getDataSearchDirs();
+  const auto &searchPaths = Kernel::ConfigService::Instance().getDataSearchDirs();
 
   int max_run_number = 0;
   std::string config_file;

--- a/qt/scientific_interfaces/Muon/test/ALCLatestFileFinderTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCLatestFileFinderTest.h
@@ -27,7 +27,7 @@ class ScopedDirectory final {
 public:
   /// Constructor: create directory in temp folder
   ScopedDirectory(const std::string &dirName) : m_dirName(dirName) {
-    Poco::Path tmpPath(Mantid::Kernel::ConfigService::Instance().getTempDir());
+    Poco::Path tmpPath(Mantid::Kernel::ConfigService::Instance().getTempDir().string());
     tmpPath.pushDirectory(m_dirName);
     m_directory = Poco::File(tmpPath);
     m_directory.createDirectories();

--- a/qt/widgets/common/src/MantidHelpWindow.cpp
+++ b/qt/widgets/common/src/MantidHelpWindow.cpp
@@ -375,7 +375,7 @@ void MantidHelpWindow::findCollectionFile(const std::string &binDir) {
  */
 void MantidHelpWindow::determineFileLocs() {
   // determine collection file location
-  string binDir = Mantid::Kernel::ConfigService::Instance().getPropertiesDir();
+  string binDir = Mantid::Kernel::ConfigService::Instance().getPropertiesDir().string();
 
   this->findCollectionFile(binDir);
   g_log.debug() << "Using collection file \"" << m_collectionFile << "\"\n";

--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -134,12 +134,12 @@ bool SequentialFitDialog::addWorkspaces(const QStringList &wsNames) {
 void SequentialFitDialog::addFile() {
   QFileDialog dlg(this);
   dlg.setFileMode(QFileDialog::ExistingFiles);
-  const std::vector<std::string> &searchDirs = Mantid::Kernel::ConfigService::Instance().getDataSearchDirs();
+  const auto &searchDirs = Mantid::Kernel::ConfigService::Instance().getDataSearchDirs();
   QString dir;
   if (searchDirs.empty()) {
     dir = "";
   } else {
-    dir = QString::fromStdString(searchDirs.front());
+    dir = QString::fromStdString(searchDirs.front().string());
   }
   dlg.setDirectory(dir);
   if (dlg.exec()) {

--- a/qt/widgets/common/src/UserFunctionDialog.cpp
+++ b/qt/widgets/common/src/UserFunctionDialog.cpp
@@ -86,7 +86,7 @@ void UserFunctionDialog::loadFunctions() {
   setFunction("Base", "erfc", "erfc(x)", "Complementary error function erfc(x) = 1 - erf(x)");
   setFunction("Built-in", "Gauss", "h*exp(-s*(x-c)^2)");
   setFunction("Built-in", "ExpDecay", "h*exp(-x/t)");
-  QFile funFile(QString::fromStdString(Mantid::Kernel::ConfigService::Instance().getUserPropertiesDir()) +
+  QFile funFile(QString::fromStdString(Mantid::Kernel::ConfigService::Instance().getUserPropertiesDir().string()) +
                 "Mantid.user.functions");
   if (funFile.exists() && funFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
     QTextStream in(&funFile);
@@ -354,7 +354,7 @@ void UserFunctionDialog::saveFunction() {
 }
 
 void UserFunctionDialog::saveToFile() {
-  QFile funFile(QString::fromStdString(Mantid::Kernel::ConfigService::Instance().getUserPropertiesDir()) +
+  QFile funFile(QString::fromStdString(Mantid::Kernel::ConfigService::Instance().getUserPropertiesDir().string()) +
                 "Mantid.user.functions");
   if (funFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
     QMap<QString, QString>::const_iterator it = m_funs.begin();

--- a/qt/widgets/common/test/Python/SipTest.h
+++ b/qt/widgets/common/test/Python/SipTest.h
@@ -24,7 +24,7 @@ public:
     // to ensure the built copy of mantid gets picked up
     const MantidQt::Widgets::Common::Python::Object siteModule{
         MantidQt::Widgets::Common::Python::NewRef(PyImport_ImportModule("site"))};
-    siteModule.attr("addsitedir")(Mantid::Kernel::ConfigService::Instance().getPropertiesDir());
+    siteModule.attr("addsitedir")(Mantid::Kernel::ConfigService::Instance().getPropertiesDir().string());
     TS_ASSERT(Py_IsInitialized());
   }
 


### PR DESCRIPTION
I've replaced some usages of `Poco::Path` with `std::filesystem::path`, and in some places where strings were being used to represent paths I switched to `std::filesystem::path`. I made changes to `ConfigService` so would be good to give this a thorough check. See #37868 for further details on this migration.

Note: `Poco::Path::expand` does not have an equivalent in the standard library, it expands all environment variables in the path.

One gotcha I found, if you thought that `Poco::Path::makeDirectory` would make a directory, then you'd be wrong, it removes the filename from the `Poco::Path` object.

`Poco::Path` objects know if they represent a file or a directory (they have some internal flag), but there's no way to tell if a `std::filesystem::path` is supposed to point at a file or a directory. The only way I could think of was to check if the path has an extension or not, but `Poco::TemporaryFile` returns a file with no extension, and that's used in a number of tests.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Refs #37868. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **this is an internal refactor, API should stay the same.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
