### PR TITLE
Fix crash on inelastic symmetrise interface

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -138,8 +138,8 @@ bool IUserInputValidator::checkWorkspaceType(QString const &workspaceName, QStri
       addErrorMessage("The " + inputType.toStdString() + " workspace is not a " + validType.toStdString() + ".",
                       silent);
       return false;
-    } else
-      return true;
+    }
+    return true;
   }
   return false;
 }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -133,15 +133,15 @@ private:
 template <typename T>
 bool IUserInputValidator::checkWorkspaceType(QString const &workspaceName, QString const &inputType,
                                              QString const &validType, bool silent) {
-  if (checkWorkspaceExists(workspaceName, silent)) {
-    if (!MantidWidgets::WorkspaceUtils::getADSWorkspace<T>(workspaceName.toStdString())) {
-      addErrorMessage("The " + inputType.toStdString() + " workspace is not a " + validType.toStdString() + ".",
-                      silent);
-      return false;
-    }
-    return true;
+  if (!checkWorkspaceExists(workspaceName, silent)) {
+    return false;
   }
-  return false;
+
+  if (!MantidWidgets::WorkspaceUtils::getADSWorkspace<T>(workspaceName.toStdString())) {
+    addErrorMessage("The " + inputType.toStdString() + " workspace is not a " + validType.toStdString() + ".", silent);
+    return false;
+  }
+  return true;
 }
 
 } // namespace CustomInterfaces

--- a/qt/widgets/common/src/UserInputValidator.cpp
+++ b/qt/widgets/common/src/UserInputValidator.cpp
@@ -293,11 +293,13 @@ bool UserInputValidator::checkNotEqual(const QString &name, double x, double y, 
  * @return True if the workspace is in the ADS
  */
 bool UserInputValidator::checkWorkspaceExists(QString const &workspaceName, bool silent) {
-  if (workspaceName.isEmpty())
+  if (workspaceName.isEmpty()) {
+    addErrorMessage("No workspace added.", silent);
     return false;
+  }
 
   if (!doesExistInADS(workspaceName.toStdString())) {
-    addErrorMessage(workspaceName.toStdString() + " could not be found.", silent);
+    addErrorMessage(workspaceName.toStdString() + " not found.", silent);
     return false;
   }
   return true;


### PR DESCRIPTION
### Description of work
Issue #38743. 
Crash was happening because validating function was not generating an error string when the workspace name is empty.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
I added an error string so that validating function behaves accordingly (read my commit message).

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38743 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
Follow the instructions on the original issue.
Additionally:
- Without adding any data, click `Run`. This should pop up the same warning (was previously causing the same crash)
- Browse to a data file to add data
- Delete worksapce in the ADS
- Change reflection type and you should see a different error about the workspace not found.


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
