### PR TITLE
Reimplement #38486 to avoid project recovery error

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -7,7 +7,6 @@
 #  This file is part of the mantid package
 from collections.abc import Iterable
 import copy
-from enum import IntEnum
 from functools import wraps
 
 import numpy as np
@@ -42,9 +41,6 @@ WATERFALL_XOFFSET_DEFAULT, WATERFALL_YOFFSET_DEFAULT = 10, 20
 # -----------------------------------------------------------------------------
 # Decorators
 # -----------------------------------------------------------------------------
-class AxisArgType(IntEnum):
-    WORKSPACE = 0
-    LINE = 1
 
 
 def plot_decorator(func):
@@ -55,7 +51,6 @@ def plot_decorator(func):
         # Saves saving it on array objects
         if datafunctions.validate_args(*args, **kwargs):
             # Fill out kwargs with the values of args
-            kwargs["argType"] = AxisArgType.WORKSPACE
 
             kwargs["workspaces"] = args[0].name()
             kwargs["function"] = func_name
@@ -65,9 +60,8 @@ def plot_decorator(func):
             if "cmap" in kwargs and isinstance(kwargs["cmap"], Colormap):
                 kwargs["cmap"] = kwargs["cmap"].name
             self.creation_args.append(kwargs)
-        elif func_name in ["axhline", "axvline"]:
-            new_creation_args = {"function": func_name, "args": args, "kwargs": kwargs, "argType": AxisArgType.LINE}
-            self.creation_args.append(new_creation_args)
+        elif func_name == "axhline" or func_name == "axvline":
+            self.creation_args.append({"function": func_name, "args": args, "kwargs": kwargs})
 
         return func_value
 
@@ -488,9 +482,9 @@ class MantidAxes(Axes):
         """
 
         for cargs in self.creation_args:
-            argType = cargs["argType"]
-            # for workspace creation args, since lines dont have "workspaces"
-            if argType == AxisArgType.WORKSPACE and cargs["workspaces"] == old_name:
+            # If a workspace plot is overplotted with a line (e.g ax.axvline), the second set of creation args
+            # will not have a "workspaces" key
+            if cargs.get("workspaces") == old_name:
                 cargs["workspaces"] = new_name
         for ws_name, ws_artist_list in list(self.tracked_workspaces.items()):
             for ws_artist in ws_artist_list:

--- a/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
@@ -784,6 +784,14 @@ class MantidAxesTest(unittest.TestCase):
         self.ax.rename_workspace(new_name="new_name", old_name="ws")
         self.assertEqual("new_name", self.ax.creation_args[0]["workspaces"])
 
+    def test_rename_workspace_works_with_additional_line_plot(self):
+        ws = CreateSampleWorkspace()
+        self.ax.plot(ws, specNum=2)
+        self.ax.axvline(x=1, label="label", color="red")
+        self.assertIsNone(self.ax.creation_args[1].get("workspaces"))
+        # Line plot has no workspaces creation arg, test there is no exception
+        self.ax.rename_workspace(new_name="new_name", old_name="ws")
+
     def _run_check_axes_distribution_consistency(self, normalization_states):
         mock_tracked_workspaces = {
             "ws": [Mock(is_normalized=normalization_states[0]), Mock(is_normalized=normalization_states[1])],

--- a/docs/source/release/v6.12.0/Framework/Python/Bugfixes/38486.rst
+++ b/docs/source/release/v6.12.0/Framework/Python/Bugfixes/38486.rst
@@ -1,1 +1,0 @@
-:class:`~mantid.plots.MantidAxes` accounts for plotting both workspaces and lines on the same axis in the rename case

--- a/docs/source/release/v6.12.0/Framework/Python/Bugfixes/38650.rst
+++ b/docs/source/release/v6.12.0/Framework/Python/Bugfixes/38650.rst
@@ -1,0 +1,1 @@
+Fix for bug in ``mantid.plots.MantidAxes`` where an exception would occur when a workspace plot, which also had data not tied to a workspace on the same axes, had its workspace renamed.

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -885,7 +885,7 @@ class FigureInteraction(object):
                         raise RuntimeError("No spectrum number associated with plot of workspace '{}'".format(workspace.name()))
 
                 arg_set_copy = copy(arg_set)
-                for key in ["function", "workspaces", "autoscale_on_update", "norm", "argType"]:
+                for key in ["function", "workspaces", "autoscale_on_update", "norm"]:
                     try:
                         del arg_set_copy[key]
                     except KeyError:


### PR DESCRIPTION
### Description of work

The pr #38486 introduced a problem with project recovery (#38650) by adding a creation arg to all plots. These creating args eventually find themselves passed to an mpl plotting function when being recovered. This causes an error.

The original problem is that when you have a plot that has workspace data (plotted with a workspace name argument) **and** non-workspace data, renaming the plotted workspace threw and exception because the code assumed all sets of plotting arguments would have a workspace name.

I think instead of keeping track of a new creation arg, the original bug (key error) can be avoided by using `get()` on the creation arg dictionary to check for workspace names safely.

Added a test for the original bug. Haven't added one for project recovery because I think it was working correctly (feeding back the mpl error and not crashing).

Fixes #38650 
Fixes #38486

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Test the script from the original issue #38486 causes no problems.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
