### PR TITLE
Fix a performance issue in SumSpectra with EventWorkspace

### DIFF
--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -568,6 +568,24 @@ void SumSpectra::execEvent(const MatrixWorkspace_sptr &outputWorkspace, Progress
   outputEL.clearDetectorIDs();
 
   const auto &spectrumInfo = inputWorkspace->spectrumInfo();
+
+  // count number of events for the output
+  std::size_t numOutputEvents{0};
+  for (const auto i : m_indices) {
+    if (spectrumInfo.hasDetectors(i)) {
+      // Skip monitors, if the property is set to do so
+      if (!m_keepMonitors && spectrumInfo.isMonitor(i))
+        continue;
+      // Skip masked detectors
+      if (spectrumInfo.isMasked(i)) {
+        continue;
+      }
+    }
+    numOutputEvents += inputWorkspace->getSpectrum(i).getNumberEvents();
+  }
+
+  outputEL.reserve(numOutputEvents);
+
   // Loop over spectra
   for (const auto i : m_indices) {
     if (spectrumInfo.hasDetectors(i)) {


### PR DESCRIPTION
Since `SumSpectra` was using `EventList::operator+=()`, the memory was reserved as each additional EventList was added in. This calculates the full number of events to be added and reserves that. Then the individual `std::vector::reserve()` inside of EventList are effectively no-op.

The result of this change is that `SumSpectra` in the script below went from ~30m to <1s.

*There is no associated issue.*

**Report to:** @AndreiSavici 

### To test:

The original script that this was discovered in is
```py
from mantid.simpleapi import *
w=LoadEventNexus('/SNS/ARCS/IPTS-33648/nexus/ARCS_295790.nxs.h5')
s=SumSpectra(w)
```
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->


*This does not require release notes* because it is an internal change.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
