### PR TITLE
Allow User-Configured Input Spin State Orders From The GUI & Parameter File

### DIFF
--- a/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/PolarizationEfficiencyCor.cpp
@@ -96,17 +96,9 @@ void PolarizationEfficiencyCor::init() {
       "histograms: P1, P2, F1 and F2 in the Wildes method and Pp, "
       "Ap, Rho and Alpha for Fredrikze.");
 
-  const std::string full = std::string(FlipperConfigurations::OFF_OFF) + ", " + FlipperConfigurations::OFF_ON + ", " +
-                           FlipperConfigurations::ON_OFF + ", " + FlipperConfigurations::ON_ON;
-  const std::string missing01 = std::string(FlipperConfigurations::OFF_OFF) + ", " + FlipperConfigurations::ON_OFF +
-                                ", " + FlipperConfigurations::ON_ON;
-  const std::string missing10 = std::string(FlipperConfigurations::OFF_OFF) + ", " + FlipperConfigurations::OFF_ON +
-                                ", " + FlipperConfigurations::ON_ON;
-  const std::string missing0110 = std::string(FlipperConfigurations::OFF_OFF) + ", " + FlipperConfigurations::ON_ON;
-  const std::string noAnalyzer = std::string(FlipperConfigurations::OFF) + ", " + FlipperConfigurations::ON;
-  const std::string directBeam = std::string(FlipperConfigurations::OFF);
-  const std::vector<std::string> setups{{"", full, missing01, missing10, missing0110, noAnalyzer, directBeam}};
-  declareProperty(Prop::FLIPPERS, "", std::make_shared<Kernel::ListValidator<std::string>>(setups),
+  const auto wildesFlipperValidator =
+      std::make_shared<SpinStateValidator>(std::unordered_set<int>{1, 2, 3, 4}, true, '0', '1', true);
+  declareProperty(Prop::FLIPPERS, "", wildesFlipperValidator,
                   "Flipper configurations of the input workspaces  (Wildes method only)");
 
   const auto spinStateValidator =

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -112,6 +112,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
             "CalibrationFile",
             "OutputWorkspace",
             "PolarizationEfficiencies",
+            "FredrikzePolarizationSpinStateOrder",
             "ROIDetectorIDs",
         ]
         self.copyProperties("ReflectometryISISLoadAndProcess", self._child_properties)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -278,6 +278,16 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
             "the Wildes or Fredrikze correction methods.",
             Direction.Input,
         )
+        self.declareProperty(
+            "FredrikzePolarizationEfficienciesSpinStateOrder",
+            "",
+            "The spin state order of the workspaces in the workspace group to be passed to "
+            'PolarizationCorrectionsFredrikze. See the "Spin State Configurations" -> '
+            '"InputSpinStates" section of the PolarizationCorrectionsFredrikze v1 documentation for '
+            "more details. This is only applied to Fredrikze corrections. Wildes flipper "
+            "configurations are taken from the instrument's parameter file.",
+            Direction.Input,
+        )
 
     def _getInputWorkspaces(self, runs, isTrans):
         """Convert the given run numbers into real workspace names. Uses workspaces from

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -279,7 +279,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
             Direction.Input,
         )
         self.declareProperty(
-            "FredrikzePolarizationEfficienciesSpinStateOrder",
+            "FredrikzePolarizationSpinStateOrder",
             "",
             "The spin state order of the workspaces in the workspace group to be passed to "
             'PolarizationCorrectionsFredrikze. See the "Spin State Configurations" -> '
@@ -647,6 +647,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         efficiencies_ws = self._loadPolarizationCorrectionWorkspace()
         if efficiencies_ws:
             alg.setProperty("PolarizationEfficiencies", efficiencies_ws)
+        alg.setProperty("FredrikzePolarizationSpinStateOrder", self.getPropertyValue("FredrikzePolarizationSpinStateOrder"))
         alg.execute()
         return alg
 

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -88,8 +88,9 @@ private:
                                                const Mantid::Geometry::Instrument_const_sptr &instrument);
   std::string findPolarizationCorrectionMethod(const API::MatrixWorkspace_sptr &efficiencies);
   std::string findPolarizationCorrectionOption(const std::string &correctionMethod);
+  std::string getFredrikzeInputSpinStateOrder(const std::string &correctionMethod);
   /// Get a polarization efficiencies workspace.
-  std::tuple<API::MatrixWorkspace_sptr, std::string, std::string> getPolarizationEfficiencies();
+  std::tuple<API::MatrixWorkspace_sptr, std::string, std::string, std::string> getPolarizationEfficiencies();
   void applyPolarizationCorrection(const std::string &outputIvsLam);
   API::MatrixWorkspace_sptr getFloodWorkspace();
   void applyFloodCorrection(const API::MatrixWorkspace_sptr &flood, const std::string &propertyName);

--- a/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
@@ -1334,7 +1334,7 @@ public:
 
     TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::logic_error &e, std::string(e.what()),
                             "Invalid value for property Flippers (string) from string \"01,01,10\": When setting value "
-                            "of property \"Flippers\": The value \"01,01,10\" is not in the list of allowed values");
+                            "of property \"Flippers\": Each spin state must only appear once");
   }
 
   void test_error_occurs_when_set_spin_states_used_with_Wildes() {

--- a/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
@@ -1310,6 +1310,33 @@ public:
     TS_ASSERT_DELTA(outQGroup[3]->y(0)[0], 0.7544, 0.0001);
   }
 
+  void test_parameter_file_used_with_efficiency_workspace_Wildes() {
+    std::string const name = "input";
+    prepareInputGroup(name, "Wildes");
+    auto input_group = retrieveOutWS(name);
+    // We're setting this to an invalid value to catch it on purpose later.
+    input_group[0]->instrumentParameters().addString(input_group[0]->getInstrument()->getComponentID(),
+                                                     "WildesFlipperConfig", "01,01,10");
+    auto efficiencies = createPolarizationEfficienciesWorkspace("Wildes");
+    ReflectometryReductionOneAuto3 alg;
+    alg.initialize();
+    alg.setPropertyValue("InputWorkspace", name);
+    alg.setProperty("ThetaIn", 10.0);
+    alg.setProperty("WavelengthMin", 1.0);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("ProcessingInstructions", "2");
+    alg.setProperty("MomentumTransferStep", 0.04);
+    alg.setProperty("PolarizationAnalysis", true);
+    alg.setProperty("PolarizationEfficiencies", efficiencies);
+    alg.setPropertyValue("OutputWorkspace", "IvsQ");
+    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
+
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::logic_error &e, std::string(e.what()),
+                            "Invalid value for property Flippers (string) from string \"01,01,10\": When setting value "
+                            "of property \"Flippers\": The value \"01,01,10\" is not in the list of allowed values");
+  }
+
   void test_polarization_correction_with_efficiency_workspace_Wildes_no_analyser() {
 
     std::string const name = "input";

--- a/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
@@ -1337,6 +1337,78 @@ public:
                             "of property \"Flippers\": The value \"01,01,10\" is not in the list of allowed values");
   }
 
+  void test_error_occurs_when_set_spin_states_used_with_Wildes() {
+    std::string const name = "input";
+    prepareInputGroup(name, "Wildes");
+    auto input_group = retrieveOutWS(name);
+    // We're setting this to an invalid value to catch it on purpose later.
+    input_group[0]->instrumentParameters().addString(input_group[0]->getInstrument()->getComponentID(),
+                                                     "WildesFlipperConfig", "00,11,01,10");
+    auto efficiencies = createPolarizationEfficienciesWorkspace("Wildes");
+    ReflectometryReductionOneAuto3 alg;
+    alg.initialize();
+    alg.setPropertyValue("InputWorkspace", name);
+    alg.setProperty("ThetaIn", 10.0);
+    alg.setProperty("WavelengthMin", 1.0);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("ProcessingInstructions", "2");
+    alg.setProperty("MomentumTransferStep", 0.04);
+    alg.setProperty("PolarizationAnalysis", true);
+    alg.setProperty("PolarizationEfficiencies", efficiencies);
+    alg.setProperty("FredrikzePolarizationSpinStateOrder", "01,10,11,00");
+    alg.setPropertyValue("OutputWorkspace", "IvsQ");
+    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
+
+    TS_ASSERT_THROWS_EQUALS(
+        alg.execute(), const std::runtime_error &e, std::string(e.what()),
+        "A custom spin state order cannot be entered using the FredrikzePolarizationSpinStateOrder property when "
+        "performing a Wildes polarization correction. Check you don't have one assigned in the Experiment Settings. "
+        "Modify the parameter file for your instrument to change the spin state order.");
+  }
+
+  void test_polarization_correction_with_efficiency_workspace_Fredrikze_custom() {
+
+    std::string const name = "input";
+    prepareInputGroup(name, "Fredrikze", 2);
+    auto efficiencies = createPolarizationEfficienciesWorkspace("Fredrikze");
+
+    ReflectometryReductionOneAuto3 alg;
+    alg.initialize();
+    alg.setPropertyValue("InputWorkspace", name);
+    alg.setProperty("ThetaIn", 10.0);
+    alg.setProperty("WavelengthMin", 1.0);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("ProcessingInstructions", "2");
+    alg.setProperty("MomentumTransferStep", 0.04);
+    alg.setProperty("PolarizationAnalysis", true);
+    alg.setProperty("PolarizationEfficiencies", efficiencies);
+    alg.setProperty("FredrikzePolarizationSpinStateOrder", "a,p");
+    alg.setPropertyValue("OutputWorkspace", "IvsQ");
+    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
+    alg.execute();
+
+    auto outQGroup = retrieveOutWS("IvsQ");
+    auto outLamGroup = retrieveOutWS("IvsLam");
+
+    TS_ASSERT_EQUALS(outQGroup.size(), 2);
+    TS_ASSERT_EQUALS(outLamGroup.size(), 2);
+
+    TS_ASSERT_EQUALS(outLamGroup[0]->blocksize(), 9);
+    // X range in outLam
+    TS_ASSERT_DELTA(outLamGroup[0]->x(0).front(), 2.0729661466, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[0]->x(0).back(), 14.2963182408, 0.0001);
+
+    TS_ASSERT_DELTA(outLamGroup[0]->y(0)[0], 0.2938, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[1]->y(0)[0], 1.4186, 0.0001);
+
+    TS_ASSERT_EQUALS(outQGroup[0]->blocksize(), 9);
+
+    TS_ASSERT_DELTA(outQGroup[0]->y(0)[0], 0.2938, 0.0001);
+    TS_ASSERT_DELTA(outQGroup[1]->y(0)[0], 1.4186, 0.0001);
+  }
+
   void test_polarization_correction_with_efficiency_workspace_Wildes_no_analyser() {
 
     std::string const name = "input";

--- a/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
+++ b/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
@@ -90,15 +90,21 @@ Assuming the whole table is processed:
 Polarisation Corrections
 ------------------------
 
-Polarisation corrections settings are under the ``Experiment Settings`` tab in the interface. These should only work with ``CRISP``, ``POLREF`` or ``OFFSPEC``.
+Polarisation corrections settings are under the ``Experiment Settings`` tab in the interface. These should only work
+with ``CRISP``, ``POLREF`` or ``OFFSPEC``.
 
 #. In the Runs tab set the instrument to ``INTER``.
 #. On the ``Experiment Settings`` tab, the ``Polarisation Corrections`` combo box should be greyed out.
 #. Go back to the Runs tab and set the instrument to ``OFFSPEC``.
-#. Back on the ``Experiment Settings`` tab, the ``Polarisation Corrections`` combo box should now be enabled and the ``Polarization Efficiencies`` combo box should be disabled.
-#. Select ``Parameter File`` from the ``Polarisation Corrections`` combo box. The ``Polarization Efficiencies`` combo box should still be disabled.
-#. Switch to ``Workspace`` from the ``Polarisation Corrections`` combo box. The ``Polarization Efficiencies`` combo box should become enabled and show a list of all loaded workspaces.
-#. Switch to ``FilePath`` from the ``Polarisation Corrections`` combo box. ``Polarization Efficiencies`` should now appear as a line edit. It should appear red for invalid paths and white for valid paths on your system.
+#. Back on the ``Experiment Settings`` tab, the ``Polarisation Corrections`` combo box should now be enabled and the
+   ``Polarization Efficiencies`` combo box should be disabled.
+#. Select ``Parameter File`` from the ``Polarisation Corrections`` combo box. The ``Polarization Efficiencies`` combo
+   box should still be disabled.
+#. Switch to ``Workspace`` from the ``Polarisation Corrections`` combo box. The ``Fredrikze Input Spin State Order`` and
+   ``Polarization Efficiencies`` combo boxes should become enabled. The latter should show a list of all loaded
+   workspaces.
+#. Switch to ``FilePath`` from the ``Polarisation Corrections`` combo box. ``Polarization Efficiencies`` should now
+   appear as a line edit. It should appear red for invalid paths and white for valid paths on your system.
 #. Switch back to the ``ParameterFile`` setting from the ``Polarisation Corrections`` combo box.
 #. Back on the ``Runs`` tab, delete all rows in the table (this can be done by pressing ``Ctrl-A`` and then ``Delete``).
 #. Note that this will leave an empty row. In that row enter run number ``44956`` and angle ``0.4``.

--- a/docs/source/release/v6.13.0/Reflectometry/New_features/37617.rst
+++ b/docs/source/release/v6.13.0/Reflectometry/New_features/37617.rst
@@ -1,0 +1,7 @@
+- A new field, ``Fredrikze Input Spin State Order``, has been added to the :ref:`Experiment Settings Tab <refl_exp_instrument_settings>` on the
+  ISIS Reflectometry interface. This allows the spin state order of the input workspace group to be supplied when
+  the reduction performs a Fredrikze polarisation correction.
+- The flipper configuration for the input workspace group from the :ref:`interface-isis-refl`, when performing a Wildes
+  polarisation correction, can now be passed to the reduction by adding a parameter called ``WildesFlipperConfig`` to
+  your intrument's parameter file. Additionally, a default configuration of ``01,01,10,11`` has been added to POLREF's
+  parameter file.

--- a/instrument/POLREF_Parameters.xml
+++ b/instrument/POLREF_Parameters.xml
@@ -83,6 +83,10 @@
     <value val="0.972762,0.001828,-0.000261,0.0"/>
    </parameter>
 
+   <parameter name="WildesFlipperConfig" type="string">
+     <value val="00,01,10,11" />
+   </parameter>
+
 <!-- 1DStitchMany parameters-->
    <parameter name="StitchUseManualScaleFactors" type="string">
     <value val="True"/>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -109,6 +109,8 @@ void updatePolarizationCorrectionProperties(AlgorithmRuntimeProps &properties,
   // Use the supplied workspace.
   if (corrections.correctionType() == PolarizationCorrectionType::Workspace) {
     AlgorithmProperties::update("PolarizationEfficiencies", corrections.workspace(), properties);
+    AlgorithmProperties::update("FredrikzePolarizationSpinStateOrder", corrections.fredrikzeSpinStateOrder(),
+                                properties);
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -104,6 +104,7 @@ void Decoder::decodeExperiment(QtExperimentView *gui, const QMap<QString, QVaria
   decodePolarizationCorrectionsComboBox(gui->m_ui.polCorrComboBox, map);
   gui->m_polCorrEfficienciesWsSelector->setCurrentText(map[QString("polCorrEfficienciesWsSelector")].toString());
   gui->m_polCorrEfficienciesLineEdit->setText(map[QString("polCorrEfficienciesLineEdit")].toString());
+  gui->m_ui.polCorrFredrikzeSpinStateEdit->setText(map[QString("polCorrFredrikzeSpinStateEdit")].toString());
   gui->m_ui.floodCorComboBox->setCurrentIndex(map[QString("floodCorComboBox")].toInt());
   gui->m_floodCorrWsSelector->setCurrentText(map[QString("floodWorkspaceWsSelector")].toString());
   gui->m_floodCorrLineEdit->setText(map[QString("floodWorkspaceLineEdit")].toString());

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
@@ -286,6 +286,8 @@ QMap<QString, QVariant> Encoder::encodeExperiment(const QtExperimentView *gui) {
   experimentMap.insert(QString("polCorrEfficienciesWsSelector"),
                        QVariant(gui->m_polCorrEfficienciesWsSelector->currentText()));
   experimentMap.insert(QString("polCorrEfficienciesLineEdit"), QVariant(gui->m_polCorrEfficienciesLineEdit->text()));
+  experimentMap.insert(QString("polCorrFredrikzeSpinStateEdit"),
+                       QVariant(gui->m_ui.polCorrFredrikzeSpinStateEdit->text()));
   experimentMap.insert(QString("floodCorComboBox"), QVariant(gui->m_ui.floodCorComboBox->currentIndex()));
   experimentMap.insert(QString("floodWorkspaceWsSelector"), QVariant(gui->m_floodCorrWsSelector->currentText()));
   experimentMap.insert(QString("floodWorkspaceLineEdit"), QVariant(gui->m_floodCorrLineEdit->text()));

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -174,12 +174,13 @@ PolarizationCorrections ExperimentPresenter::polarizationCorrectionsFromView() {
   if (polCorrType == PolarizationCorrectionType::None || polCorrType == PolarizationCorrectionType::ParameterFile) {
     return PolarizationCorrections(polCorrType);
   }
+  auto const &fredrikzeSpinStateOrder = m_view->getFredrikzeSpinStateOrder();
   if (polCorrOptionString == "FilePath") {
     auto const &polCorrFilePath = m_view->getPolarizationEfficienciesFilePath();
     showPolCorrFilePathValidity(polCorrFilePath);
-    return PolarizationCorrections(polCorrType, polCorrFilePath);
+    return PolarizationCorrections(polCorrType, polCorrFilePath, fredrikzeSpinStateOrder);
   }
-  return PolarizationCorrections(polCorrType, m_view->getPolarizationEfficienciesWorkspace());
+  return PolarizationCorrections(polCorrType, m_view->getPolarizationEfficienciesWorkspace(), fredrikzeSpinStateOrder);
 }
 
 void ExperimentPresenter::showPolCorrFilePathValidity(std::string const &filePath) {
@@ -443,6 +444,7 @@ void ExperimentPresenter::updateViewFromModel() {
   m_view->setPolarizationEfficienciesFilePath("");
   if (m_model.polarizationCorrections().workspace())
     m_view->setPolarizationEfficienciesWorkspace(m_model.polarizationCorrections().workspace().get());
+  m_view->setFredrikzeSpinStateOrder(m_model.polarizationCorrections().fredrikzeSpinStateOrder());
   m_view->setFloodCorrectionType(floodCorrectionTypeToString(m_model.floodCorrections().correctionType()));
   if (m_model.floodCorrections().workspace())
     m_view->setFloodWorkspace(m_model.floodCorrections().workspace().value());

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -443,7 +443,7 @@ void ExperimentPresenter::updateViewFromModel() {
       polarizationCorrectionTypeToString(m_model.polarizationCorrections().correctionType()));
   m_view->setPolarizationEfficienciesFilePath("");
   if (m_model.polarizationCorrections().workspace())
-    m_view->setPolarizationEfficienciesWorkspace(m_model.polarizationCorrections().workspace().get());
+    m_view->setPolarizationEfficienciesWorkspace(m_model.polarizationCorrections().workspace().value());
   m_view->setFredrikzeSpinStateOrder(m_model.polarizationCorrections().fredrikzeSpinStateOrder());
   m_view->setFloodCorrectionType(floodCorrectionTypeToString(m_model.floodCorrections().correctionType()));
   if (m_model.floodCorrections().workspace())

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -251,11 +251,13 @@ void ExperimentPresenter::updatePolarizationCorrectionEnabledState() {
   }
   if (polCorrOption == "Workspace") {
     m_view->enablePolarizationEfficiencies();
+    m_view->enableFredrikzeSpinStateOrder();
     m_view->setPolarizationEfficienciesWorkspaceMode();
     return;
   }
   if (polCorrOption == "FilePath") {
     m_view->enablePolarizationEfficiencies();
+    m_view->enableFredrikzeSpinStateOrder();
     m_view->setPolarizationEfficienciesFilePathMode();
     return;
   }
@@ -264,6 +266,7 @@ void ExperimentPresenter::updatePolarizationCorrectionEnabledState() {
 void ExperimentPresenter::disablePolarizationEfficiencies() {
   m_view->setPolarizationEfficienciesWorkspaceMode();
   m_view->disablePolarizationEfficiencies();
+  m_view->disableFredrikzeSpinStateOrder();
 }
 
 void ExperimentPresenter::updateFloodCorrectionEnabledState() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
@@ -698,7 +698,7 @@
       </widget>
      </item>
      <item row="13" column="2">
-      <widget class="QLabel" name="fredrikzeSpinStateLabel">
+      <widget class="QLabel" name="polCorrFredrikzeSpinStateLabel">
        <property name="minimumSize">
         <size>
          <width>117</width>
@@ -708,31 +708,15 @@
        <property name="text">
         <string>Fredrikze Input SpinState Order</string>
        </property>
-       <property name="toolTip">
-        <string>
-         The spin state order of the workspaces in the workspace group to be passed to PolarizationCorrectionsFredrikze.
-         See the "Spin State Configurations" -> "InputSpinStates" section of the PolarizationCorrectionsFredrikze v1
-         documentation for more details. This is only applied to Fredrikze corrections. Wildes flipper configurations
-         are taken from the instrument's parameter file.
-        </string>
-       </property>
       </widget>
      </item>
      <item row="13" column="3">
-      <widget class="QLineEdit" name="fredrikzeSpinStateEdit">
+      <widget class="QLineEdit" name="polCorrFredrikzeSpinStateEdit">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
-       </property>
-       <property name="toolTip">
-        <string>
-         The spin state order of the workspaces in the workspace group to be passed to PolarizationCorrectionsFredrikze.
-         See the "Spin State Configurations" -> "InputSpinStates" section of the PolarizationCorrectionsFredrikze v1
-         documentation for more details. This is only applied to Fredrikze corrections. Wildes flipper configurations
-         are taken from the instrument's parameter file.
-        </string>
        </property>
       </widget>
      </item>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
@@ -697,6 +697,45 @@
        </item>
       </widget>
      </item>
+     <item row="13" column="2">
+      <widget class="QLabel" name="fredrikzeSpinStateLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Fredrikze Input SpinState Order</string>
+       </property>
+       <property name="toolTip">
+        <string>
+         The spin state order of the workspaces in the workspace group to be passed to PolarizationCorrectionsFredrikze.
+         See the "Spin State Configurations" -> "InputSpinStates" section of the PolarizationCorrectionsFredrikze v1
+         documentation for more details. This is only applied to Fredrikze corrections. Wildes flipper configurations
+         are taken from the instrument's parameter file.
+        </string>
+       </property>
+      </widget>
+     </item>
+     <item row="13" column="3">
+      <widget class="QLineEdit" name="fredrikzeSpinStateEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>
+         The spin state order of the workspaces in the workspace group to be passed to PolarizationCorrectionsFredrikze.
+         See the "Spin State Configurations" -> "InputSpinStates" section of the PolarizationCorrectionsFredrikze v1
+         documentation for more details. This is only applied to Fredrikze corrections. Wildes flipper configurations
+         are taken from the instrument's parameter file.
+        </string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -93,6 +93,8 @@ public:
   virtual void disablePolarizationCorrections() = 0;
   virtual void enablePolarizationEfficiencies() = 0;
   virtual void disablePolarizationEfficiencies() = 0;
+  virtual void enableFredrikzeSpinStateOrder() = 0;
+  virtual void disableFredrikzeSpinStateOrder() = 0;
   virtual void enableFloodCorrectionInputs() = 0;
   virtual void disableFloodCorrectionInputs() = 0;
 
@@ -117,6 +119,8 @@ public:
   virtual std::string getPolarizationEfficienciesFilePath() const = 0;
   virtual void setPolarizationEfficienciesWorkspace(std::string const &workspace) = 0;
   virtual void setPolarizationEfficienciesFilePath(std::string const &filePath) = 0;
+  virtual std::string getFredrikzeSpinStateOrder() const = 0;
+  virtual void setFredrikzeSpinStateOrder(std::string const &spinStates) = 0;
 
   virtual std::string getFloodCorrectionType() const = 0;
   virtual void setFloodCorrectionType(std::string const &correction) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -584,12 +584,12 @@ void QtExperimentView::disablePolarizationEfficiencies() {
 
 void QtExperimentView::enableFredrikzeSpinStateOrder() {
   m_ui.polCorrFredrikzeSpinStateLabel->setEnabled(true);
-  m_ui.polCorrFredrikzeSpinStateLabel->setEnabled(true);
+  m_ui.polCorrFredrikzeSpinStateEdit->setEnabled(true);
 }
 
 void QtExperimentView::disableFredrikzeSpinStateOrder() {
   m_ui.polCorrFredrikzeSpinStateLabel->setEnabled(false);
-  m_ui.polCorrFredrikzeSpinStateLabel->setEnabled(false);
+  m_ui.polCorrFredrikzeSpinStateEdit->setEnabled(false);
 }
 
 void QtExperimentView::disableFloodCorrectionInputs() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -297,6 +297,7 @@ void QtExperimentView::setEnabledStateForAllWidgets(bool enabled) {
   m_ui.transScaleRHSCheckBox->setEnabled(enabled);
   m_polCorrEfficienciesWsSelector->setEnabled(enabled);
   m_polCorrEfficienciesLineEdit->setEnabled(enabled);
+  m_ui.polCorrFredrikzeSpinStateEdit->setEnabled(enabled);
   stitchOptionsLineEdit().setEnabled(enabled);
   m_ui.reductionTypeComboBox->setEnabled(enabled);
   m_ui.summationTypeComboBox->setEnabled(enabled);
@@ -330,6 +331,7 @@ void QtExperimentView::registerExperimentSettingsWidgets(const Mantid::API::IAlg
   registerSettingWidget(*m_ui.polCorrComboBox, "PolarizationAnalysis", alg);
   registerSettingWidget(*m_polCorrEfficienciesWsSelector, "PolarizationEfficiencies", alg);
   registerSettingWidget(*m_polCorrEfficienciesLineEdit, "PolarizationEfficiencies", alg);
+  registerSettingWidget(*m_ui.polCorrFredrikzeSpinStateEdit, "FredrikzePolarizationEfficienciesSpinStateOrder", alg);
   registerSettingWidget(*m_ui.reductionTypeComboBox, "ReductionType", alg);
   registerSettingWidget(*m_ui.summationTypeComboBox, "SummationType", alg);
   registerSettingWidget(*m_ui.includePartialBinsCheckBox, "IncludePartialBins", alg);
@@ -359,6 +361,7 @@ void QtExperimentView::connectExperimentSettingsWidgets() {
   connectSettingsChange(*m_ui.polCorrComboBox);
   connectSettingsChange(*m_polCorrEfficienciesWsSelector);
   connectSettingsChange(*m_polCorrEfficienciesLineEdit);
+  connectSettingsChange(*m_ui.polCorrFredrikzeSpinStateEdit);
   connectSettingsChange(stitchOptionsLineEdit());
   connectSettingsChange(*m_ui.reductionTypeComboBox);
   connectSettingsChange(*m_ui.includePartialBinsCheckBox);
@@ -383,6 +386,7 @@ void QtExperimentView::disconnectExperimentSettingsWidgets() {
   disconnectSettingsChange(*m_ui.polCorrComboBox);
   disconnectSettingsChange(*m_polCorrEfficienciesWsSelector);
   disconnectSettingsChange(*m_polCorrEfficienciesLineEdit);
+  disconnectSettingsChange(*m_ui.polCorrFredrikzeSpinStateEdit);
   disconnectSettingsChange(stitchOptionsLineEdit());
   disconnectSettingsChange(*m_ui.reductionTypeComboBox);
   disconnectSettingsChange(*m_ui.includePartialBinsCheckBox);
@@ -576,6 +580,16 @@ void QtExperimentView::disablePolarizationEfficiencies() {
   m_polCorrEfficienciesWsSelector->setEnabled(false);
   m_polCorrEfficienciesLineEdit->setEnabled(false);
   m_ui.polCorrEfficienciesLabel->setEnabled(false);
+}
+
+void QtExperimentView::enableFredrikzeSpinStateOrder() {
+  m_ui.polCorrFredrikzeSpinStateLabel->setEnabled(true);
+  m_ui.polCorrFredrikzeSpinStateLabel->setEnabled(true);
+}
+
+void QtExperimentView::disableFredrikzeSpinStateOrder() {
+  m_ui.polCorrFredrikzeSpinStateLabel->setEnabled(false);
+  m_ui.polCorrFredrikzeSpinStateLabel->setEnabled(false);
 }
 
 void QtExperimentView::disableFloodCorrectionInputs() {
@@ -825,6 +839,14 @@ void QtExperimentView::setPolarizationEfficienciesWorkspace(std::string const &w
 
 void QtExperimentView::setPolarizationEfficienciesFilePath(std::string const &filePath) {
   setText(*m_polCorrEfficienciesLineEdit, filePath);
+}
+
+std::string QtExperimentView::getFredrikzeSpinStateOrder() const {
+  return getText(*m_ui.polCorrFredrikzeSpinStateEdit);
+}
+
+void QtExperimentView::setFredrikzeSpinStateOrder(std::string const &spinStates) {
+  setText(*m_ui.polCorrFredrikzeSpinStateEdit, spinStates);
 }
 
 std::string QtExperimentView::getStitchOptions() const { return getText(stitchOptionsLineEdit()); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -331,7 +331,7 @@ void QtExperimentView::registerExperimentSettingsWidgets(const Mantid::API::IAlg
   registerSettingWidget(*m_ui.polCorrComboBox, "PolarizationAnalysis", alg);
   registerSettingWidget(*m_polCorrEfficienciesWsSelector, "PolarizationEfficiencies", alg);
   registerSettingWidget(*m_polCorrEfficienciesLineEdit, "PolarizationEfficiencies", alg);
-  registerSettingWidget(*m_ui.polCorrFredrikzeSpinStateEdit, "FredrikzePolarizationEfficienciesSpinStateOrder", alg);
+  registerSettingWidget(*m_ui.polCorrFredrikzeSpinStateEdit, "FredrikzePolarizationSpinStateOrder", alg);
   registerSettingWidget(*m_ui.reductionTypeComboBox, "ReductionType", alg);
   registerSettingWidget(*m_ui.summationTypeComboBox, "SummationType", alg);
   registerSettingWidget(*m_ui.includePartialBinsCheckBox, "IncludePartialBins", alg);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -83,6 +83,8 @@ public:
   std::string getPolarizationEfficienciesFilePath() const override;
   void setPolarizationEfficienciesWorkspace(std::string const &workspace) override;
   void setPolarizationEfficienciesFilePath(std::string const &filePath) override;
+  std::string getFredrikzeSpinStateOrder() const override;
+  void setFredrikzeSpinStateOrder(std::string const &spinStates) override;
 
   std::string getFloodCorrectionType() const override;
   void setFloodCorrectionType(std::string const &correction) override;
@@ -123,6 +125,8 @@ public:
   void disablePolarizationCorrections() override;
   void enablePolarizationEfficiencies() override;
   void disablePolarizationEfficiencies() override;
+  void enableFredrikzeSpinStateOrder() override;
+  void disableFredrikzeSpinStateOrder() override;
 
   void enableFloodCorrectionInputs() override;
   void disableFloodCorrectionInputs() override;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.cpp
@@ -8,16 +8,20 @@
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 PolarizationCorrections::PolarizationCorrections(PolarizationCorrectionType correctionType,
-                                                 boost::optional<std::string> workspace)
-    : m_correctionType(correctionType), m_workspace(workspace) {}
+                                                 boost::optional<std::string> workspace,
+                                                 std::string const &fredrikzeSpinStateOrder)
+    : m_correctionType(correctionType), m_workspace(workspace), m_fredrikzeSpinStateOrder(fredrikzeSpinStateOrder) {}
 
 PolarizationCorrectionType PolarizationCorrections::correctionType() const { return m_correctionType; }
 
 boost::optional<std::string> PolarizationCorrections::workspace() const { return m_workspace; }
 
+std::string const &PolarizationCorrections::fredrikzeSpinStateOrder() const { return m_fredrikzeSpinStateOrder; }
+
 bool operator!=(PolarizationCorrections const &lhs, PolarizationCorrections const &rhs) { return !(lhs == rhs); }
 
 bool operator==(PolarizationCorrections const &lhs, PolarizationCorrections const &rhs) {
-  return lhs.correctionType() == rhs.correctionType() && lhs.workspace() == rhs.workspace();
+  return lhs.correctionType() == rhs.correctionType() && lhs.workspace() == rhs.workspace() &&
+         lhs.fredrikzeSpinStateOrder() == rhs.fredrikzeSpinStateOrder();
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.cpp
@@ -8,13 +8,13 @@
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 PolarizationCorrections::PolarizationCorrections(PolarizationCorrectionType correctionType,
-                                                 boost::optional<std::string> workspace,
+                                                 std::optional<std::string> workspace,
                                                  std::string const &fredrikzeSpinStateOrder)
     : m_correctionType(correctionType), m_workspace(workspace), m_fredrikzeSpinStateOrder(fredrikzeSpinStateOrder) {}
 
 PolarizationCorrectionType PolarizationCorrections::correctionType() const { return m_correctionType; }
 
-boost::optional<std::string> PolarizationCorrections::workspace() const { return m_workspace; }
+std::optional<std::string> PolarizationCorrections::workspace() const { return m_workspace; }
 
 std::string const &PolarizationCorrections::fredrikzeSpinStateOrder() const { return m_fredrikzeSpinStateOrder; }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.h
@@ -47,14 +47,17 @@ inline std::string polarizationCorrectionTypeToString(PolarizationCorrectionType
 class MANTIDQT_ISISREFLECTOMETRY_DLL PolarizationCorrections {
 public:
   explicit PolarizationCorrections(PolarizationCorrectionType correctionType,
-                                   boost::optional<std::string> workspace = boost::none);
+                                   boost::optional<std::string> workspace = boost::none,
+                                   std::string const &fredrikzeSpinStateOrder = "");
 
   PolarizationCorrectionType correctionType() const;
   boost::optional<std::string> workspace() const;
+  std::string const &fredrikzeSpinStateOrder() const;
 
 private:
   PolarizationCorrectionType m_correctionType;
   boost::optional<std::string> m_workspace;
+  std::string m_fredrikzeSpinStateOrder;
 };
 
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(PolarizationCorrections const &lhs, PolarizationCorrections const &rhs);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include "Common/DllConfig.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <stdexcept>
 #include <string>
 namespace MantidQt {
@@ -47,16 +47,16 @@ inline std::string polarizationCorrectionTypeToString(PolarizationCorrectionType
 class MANTIDQT_ISISREFLECTOMETRY_DLL PolarizationCorrections {
 public:
   explicit PolarizationCorrections(PolarizationCorrectionType correctionType,
-                                   boost::optional<std::string> workspace = boost::none,
+                                   std::optional<std::string> workspace = std::nullopt,
                                    std::string const &fredrikzeSpinStateOrder = "");
 
   PolarizationCorrectionType correctionType() const;
-  boost::optional<std::string> workspace() const;
+  std::optional<std::string> workspace() const;
   std::string const &fredrikzeSpinStateOrder() const;
 
 private:
   PolarizationCorrectionType m_correctionType;
-  boost::optional<std::string> m_workspace;
+  std::optional<std::string> m_workspace;
   std::string m_fredrikzeSpinStateOrder;
 };
 

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -406,7 +406,7 @@ PolarizationCorrections makePolarizationCorrections() {
 
 PolarizationCorrections makeWorkspacePolarizationCorrections() {
   return PolarizationCorrections(PolarizationCorrectionType::Workspace,
-                                 boost::optional<std::string>("test_eff_workspace"));
+                                 std::optional<std::string>("test_eff_workspace"));
 }
 
 PolarizationCorrections makeEmptyPolarizationCorrections() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
@@ -82,6 +82,8 @@ private:
     TS_ASSERT_EQUALS(gui->m_polCorrEfficienciesWsSelector->currentText(),
                      map[QString("polCorrEfficienciesWsSelector")].toString())
     TS_ASSERT_EQUALS(gui->m_polCorrEfficienciesLineEdit->text(), map[QString("polCorrEfficienciesLineEdit")].toString())
+    TS_ASSERT_EQUALS(gui->m_ui.polCorrFredrikzeSpinStateEdit->text(),
+                     map[QString("polCorrFredrikzeSpinStateEdit")].toString());
     TS_ASSERT_EQUALS(gui->m_ui.floodCorComboBox->currentIndex(), map[QString("floodCorComboBox")].toInt())
     TS_ASSERT_EQUALS(gui->m_floodCorrWsSelector->currentText(), map[QString("floodWorkspaceWsSelector")].toString())
     TS_ASSERT_EQUALS(gui->m_floodCorrLineEdit->text(), map[QString("floodWorkspaceFilePath")].toString())
@@ -326,6 +328,7 @@ public:
     declareProperty("ScaleRHSWorkspace", "");
     declareProperty("PolarizationAnalysis", "");
     declareProperty("PolarizationEfficiencies", "");
+    declareProperty("FredrikzePolarizationSpinStateOrder", "");
     declareProperty("ReductionType", "");
     declareProperty("SummationType", "");
     declareProperty("IncludePartialBins", "");

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -1021,6 +1021,10 @@ private:
                      PolarizationCorrectionType::Workspace);
   }
 
+  void assertFredrikzeSpinStateOrder(ExperimentPresenter const &presenter, std::string const &expected = "") {
+    TS_ASSERT_EQUALS(presenter.experiment().polarizationCorrections().fredrikzeSpinStateOrder(), expected);
+  }
+
   void assertFloodCorrectionUsesParameterFile(ExperimentPresenter const &presenter) {
     TS_ASSERT_EQUALS(presenter.experiment().floodCorrections().correctionType(), FloodCorrectionType::ParameterFile);
   }
@@ -1068,11 +1072,13 @@ private:
 
     EXPECT_CALL(m_view, getPolarizationCorrectionOption()).Times(2).WillRepeatedly(Return("ParameterFile"));
     EXPECT_CALL(m_view, getPolarizationEfficienciesWorkspace()).Times(0);
+    EXPECT_CALL(m_view, getFredrikzeSpinStateOrder()).Times(0);
     EXPECT_CALL(m_view, disablePolarizationEfficiencies()).Times(1);
 
     presenter.notifySettingsChanged();
 
     assertPolarizationAnalysisParameterFile(presenter);
+    assertFredrikzeSpinStateOrder(presenter, "");
   }
 
   void runTestThatPolarizationCorrectionsUsesWorkspace() {
@@ -1080,12 +1086,14 @@ private:
 
     EXPECT_CALL(m_view, getPolarizationCorrectionOption()).Times(2).WillRepeatedly(Return("Workspace"));
     EXPECT_CALL(m_view, getPolarizationEfficienciesWorkspace()).Times(1).WillOnce(Return("test_ws"));
+    EXPECT_CALL(m_view, getFredrikzeSpinStateOrder()).Times(1).WillOnce(Return("aa,pp,pa,ap"));
     EXPECT_CALL(m_view, setPolarizationEfficienciesWorkspaceMode()).Times(1);
     EXPECT_CALL(m_view, enablePolarizationEfficiencies()).Times(1);
 
     presenter.notifySettingsChanged();
 
     assertPolarizationAnalysisWorkspace(presenter);
+    assertFredrikzeSpinStateOrder(presenter, "aa,pp,pa,ap");
   }
 
   void runTestThatPolarizationCorrectionsUsesFilePath() {
@@ -1093,12 +1101,14 @@ private:
 
     EXPECT_CALL(m_view, getPolarizationCorrectionOption()).Times(2).WillRepeatedly(Return("FilePath"));
     EXPECT_CALL(m_view, getPolarizationEfficienciesFilePath()).Times(1).WillOnce(Return("path/to/test_ws.nxs"));
+    EXPECT_CALL(m_view, getFredrikzeSpinStateOrder()).Times(1).WillOnce(Return("pp,aa,ap,pa"));
     EXPECT_CALL(m_view, setPolarizationEfficienciesFilePathMode()).Times(1);
     EXPECT_CALL(m_view, enablePolarizationEfficiencies()).Times(1);
 
     presenter.notifySettingsChanged();
 
     assertPolarizationAnalysisWorkspace(presenter);
+    assertFredrikzeSpinStateOrder(presenter, "pp,aa,ap,pa");
   }
 
   void runWithFloodCorrectionInputsDisabled(std::string const &type) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/MockExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/MockExperimentView.h
@@ -76,6 +76,8 @@ public:
   MOCK_METHOD0(disablePolarizationCorrections, void());
   MOCK_METHOD0(enablePolarizationEfficiencies, void());
   MOCK_METHOD0(disablePolarizationEfficiencies, void());
+  MOCK_METHOD(void, enableFredrikzeSpinStateOrder, (), (override));
+  MOCK_METHOD(void, disableFredrikzeSpinStateOrder, (), (override));
   MOCK_METHOD0(enableFloodCorrectionInputs, void());
   MOCK_METHOD0(disableFloodCorrectionInputs, void());
   MOCK_CONST_METHOD0(getTransmissionStartOverlap, double());
@@ -98,6 +100,8 @@ public:
   MOCK_CONST_METHOD0(getPolarizationEfficienciesFilePath, std::string());
   MOCK_METHOD1(setPolarizationEfficienciesWorkspace, void(std::string const &));
   MOCK_METHOD1(setPolarizationEfficienciesFilePath, void(std::string const &));
+  MOCK_METHOD(std::string, getFredrikzeSpinStateOrder, (), (const, override));
+  MOCK_METHOD(void, setFredrikzeSpinStateOrder, (std::string const &), (override));
   MOCK_CONST_METHOD0(getFloodCorrectionType, std::string());
   MOCK_METHOD1(setFloodCorrectionType, void(std::string const &));
   MOCK_METHOD0(setFloodCorrectionWorkspaceMode, void());


### PR DESCRIPTION
### Description of work

#### Summary of work
Adds two adjacent features to support the polarised reduction through the reflectometry interface. 
##### Wildes
- Allows the Flipper configuration (order of the spin states in the input workspace) to be given via the instrument parameter file. A default has been defined for POLREF. 
##### Fredrikze
- A rarer polarisation correction that would have different spin state orders on an experiment-to-experiment basis. 
- To facilitate this a new field has been added to the Experiment Settings tab of the ISIS Reflectometry Interface. 
- This field is then passed to the Fredrikze polarisation correction algorithm. 
- The reduction algorithm throws an error if the reduction expected to perform a Wildes correction but a value was entered for the Fredrikze order. 

Fixes #37617 

### To test:
1. Open the ISIS Reflectometry Interface
2. Switch the Instrument to POLREF
3. Enter a run of 37125 and an angle of 2.3 on the runs tab.
4. Run this script:
```python
eWs = CreateSampleWorkspace('Histogram', Function='User Defined', UserDefinedFunction='name=UserFunction,Formula=(1 + tanh(0.0733 * 12 * x * 0.2))/2',XUnit='Wavelength', xMin='1',XMax='8', BinWidth='1', NumBanks='1', BankPixelWidth='1')
# Wildes  {"P1", "P2", "F1", "F2"}
eff_wildes = JoinISISPolarizationEfficiencies(P1=eWs, P2=eWs, F1=eWs, F2=eWs )

# Fredrikze {"Pp", "Ap", "Rho", "Alpha"}
eff_fredrikze = JoinISISPolarizationEfficiencies(Pp=eWs, Ap=eWs, Rho=eWs, Alpha=eWs )
```
5. Swap to the experiment settings tab
6. Set the Polarization Corrections to workspace.

#### Wildes
1. Select the `eff_wildes` workspace from the Polarization Efficiencies dropdown
2. Run the reduction on the Runs tab. Given this run is a 2 workspace group, and the setting in the parameter file is for 4 workspaces, we expect this to fail. Change the WildesFlipperConfig in the POLREF_Parameter file from `00,01,10,11` to `0,1` to see it succeed. 

#### Fredrikze
1. Select the `eff_fredrikze` workspace from the polarization efficiencies dropdown
2. Enter a fredrikze spin state order into the text entry box and run the reduction. 
3. It should fail when four entries are given E.g `pa,ap,pp,aa`
4. It should succeed when two entries are given `p, a`

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
