### PR TITLE
Remove napi from NexusClasses

### DIFF
--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -340,7 +340,7 @@ void FrameworkManagerImpl::setGlobalNumericLocaleToC() {
 }
 
 /// Silence NeXus output
-void FrameworkManagerImpl::disableNexusOutput() { NXMSetError(nullptr, NexusErrorFunction); }
+void FrameworkManagerImpl::disableNexusOutput() { ::NeXus::setError(nullptr, NexusErrorFunction); }
 
 /// Starts asynchronous tasks that are done as part of Start-up.
 void FrameworkManagerImpl::asynchronousStartupTasks() {

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -60,9 +60,6 @@ using namespace DataObjects;
 using Types::Core::DateAndTime;
 
 namespace {
-// detnotes the end of iteration for NeXus::getNextEntry
-const std::string NULL_STR("NULL");
-
 const std::vector<std::string> binningModeNames{"Default", "Linear", "Logarithmic"};
 enum class BinningMode { DEFAULT, LINEAR, LOGARITHMIC, enum_count };
 typedef Mantid::Kernel::EnumeratedString<BinningMode, &binningModeNames> BINMODE;
@@ -348,7 +345,7 @@ void LoadEventNexus::setTopEntryName() {
           m_top_entry_name = entry.first;
           break;
         }
-      } else if (entry.first == NULL_STR && entry.second == NULL_STR) {
+      } else if (entry == ::NeXus::EOD_ENTRY) {
         g_log.error() << "Unable to determine name of top level NXentry - assuming "
                          "\"entry\".\n";
         m_top_entry_name = "entry";

--- a/Framework/DataHandling/src/LoadHelper.cpp
+++ b/Framework/DataHandling/src/LoadHelper.cpp
@@ -497,7 +497,7 @@ void LoadHelper::fillMovingWorkspace(const API::MatrixWorkspace_sptr &ws, const 
   const auto useCustomSpectraMap = customDetectorIDs.size() != 0;
   const auto useAcceptedDetectorIDs = acceptedDetectorIDs.size() != 0;
 
-  std::array dims = {data.dim0(), data.dim1(), data.dim2()};
+  std::array<int, 3U> dims = {data.dim0(), data.dim1(), data.dim2()};
   const auto nTubes = dims[std::get<0>(axisOrder)];
   const auto nPixels = dims[std::get<1>(axisOrder)];
   const auto nScans = dims[std::get<2>(axisOrder)];

--- a/Framework/DataHandling/src/LoadNexus.cpp
+++ b/Framework/DataHandling/src/LoadNexus.cpp
@@ -37,10 +37,6 @@ using namespace Kernel;
 using namespace API;
 using namespace DataObjects;
 
-namespace {
-const std::string NULL_STR("NULL");
-}
-
 /// Empty default constructor
 LoadNexus::LoadNexus() : Algorithm(), m_filename() {}
 
@@ -297,7 +293,7 @@ int LoadNexus::getNexusEntryTypes(const std::string &fileName, std::vector<std::
   std::pair<std::string, std::string> entry;
   while (true) {
     entry = fileH->getNextEntry();
-    if (entry.first == NULL_STR && entry.second == NULL_STR)
+    if (entry == ::NeXus::EOD_ENTRY)
       break;
 
     if (entry.second == "NXentry")
@@ -312,7 +308,7 @@ int LoadNexus::getNexusEntryTypes(const std::string &fileName, std::vector<std::
     // loop through field names in this entry
     while (true) {
       entry = fileH->getNextEntry();
-      if (entry.first == NULL_STR && entry.second == NULL_STR)
+      if (entry == ::NeXus::EOD_ENTRY)
         break;
       // if a data field
       if (entry.second == "SDS") {

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -846,10 +846,10 @@ API::Workspace_sptr LoadNexusProcessed::loadTableEntry(const NXEntry &entry) {
         std::string columnTitle = data.attributes("name");
         if (!columnTitle.empty()) {
           workspace->addColumn("str", columnTitle);
-          int nRows = info.dims[0];
+          NeXus::DimSize nRows = info.dims[0];
           workspace->setRowCount(nRows);
 
-          const int maxStr = info.dims[1];
+          NeXus::DimSize const maxStr = info.dims[1];
           data.load();
           for (int iR = 0; iR < nRows; ++iR) {
             auto &cellContents = workspace->cell<std::string>(iR, columnNumber - 1);
@@ -1176,7 +1176,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXInfo info = nx_tw.getDataSetInfo(str);
       NXChar data = nx_tw.openNXChar(str);
 
-      const int maxShapeJSONLength = info.dims[1];
+      const int maxShapeJSONLength = static_cast<int>(info.dims[1]);
       data.load();
       for (int i = 0; i < numberPeaks; ++i) {
 
@@ -1470,7 +1470,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXInfo info = nx_tw.getDataSetInfo(str);
       NXChar data = nx_tw.openNXChar(str);
 
-      const int maxShapeJSONLength = info.dims[1];
+      NeXus::DimSize const maxShapeJSONLength = info.dims[1];
       data.load();
       for (int i = 0; i < numberPeaks; ++i) {
 

--- a/Framework/DataHandling/src/LoadTOFRawNexus.cpp
+++ b/Framework/DataHandling/src/LoadTOFRawNexus.cpp
@@ -187,7 +187,7 @@ void LoadTOFRawNexus::countPixels(const std::string &nexusfilename, const std::s
 
           // Count how many pixels in the bank
           file.openData("pixel_id");
-          std::vector<int64_t> dims = file.getInfo().dims;
+          std::vector<int64_t> const dims = file.getInfo().dims;
           file.closeData();
 
           if (!dims.empty()) {
@@ -200,11 +200,11 @@ void LoadTOFRawNexus::countPixels(const std::string &nexusfilename, const std::s
 
           // Get the number of pixels from the offsets arrays
           file.openData("x_pixel_offset");
-          std::vector<int64_t> xdim = file.getInfo().dims;
+          std::vector<int64_t> const xdim = file.getInfo().dims;
           file.closeData();
 
           file.openData("y_pixel_offset");
-          std::vector<int64_t> ydim = file.getInfo().dims;
+          std::vector<int64_t> const ydim = file.getInfo().dims;
           file.closeData();
 
           if (!xdim.empty() && !ydim.empty()) {
@@ -215,7 +215,7 @@ void LoadTOFRawNexus::countPixels(const std::string &nexusfilename, const std::s
         if (bankEntries.find(m_axisField) != bankEntries.end()) {
           // Get the size of the X vector
           file.openData(m_axisField);
-          std::vector<int64_t> dims = file.getInfo().dims;
+          std::vector<int64_t> const dims = file.getInfo().dims;
           // Find the units, if available
           if (file.hasAttr("units"))
             file.getAttr("units", m_xUnits);

--- a/Framework/DataHandling/src/NexusTester.cpp
+++ b/Framework/DataHandling/src/NexusTester.cpp
@@ -146,7 +146,7 @@ void NexusTester::exec() {
   if (!LoadFilename.empty()) {
     ::NeXus::File file(LoadFilename, NXACC_READ);
     int HDFCacheSize = getProperty("HDFCacheSize");
-    NXsetcache(HDFCacheSize);
+    ::NeXus::setCache(HDFCacheSize);
     file.openGroup("FakeDataGroup", "NXdata");
     Progress prog(this, 0.0, 1.0, NumChunks);
     CPUTimer tim;

--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -205,7 +205,7 @@ void SaveNexusProcessed::doExec(const Workspace_sptr &inputWorkspace,
                                 std::shared_ptr<Mantid::NeXus::NexusFileIO> &nexusFile, const bool keepFile,
                                 optional_size_t entryNumber) {
   // TODO: Remove?
-  NXMEnableErrorReporting();
+  ::NeXus::EnableErrorReporting();
 
   // Retrieve the filename from the properties
   const std::string filename = getPropertyValue("Filename");

--- a/Framework/LegacyNexus/src/napi4.cpp
+++ b/Framework/LegacyNexus/src/napi4.cpp
@@ -60,7 +60,7 @@ typedef struct __NexusFile {
   int iNXID;
   int iStackPtr;
   char iAccess[2];
-} NexusFile, *pNexusFile;
+} NexusFile, *pLgcyNexusFile;
 
 /*-------------------------------------------------------------------*/
 
@@ -81,16 +81,16 @@ static int nxToHDF4Type(NXnumtype type) {
 
 /*-------------------------------------------------------------------*/
 
-static pNexusFile NXIassert(NXhandle fid) {
-  pNexusFile pRes;
+static pLgcyNexusFile NXIassert(NXhandle fid) {
+  pLgcyNexusFile pRes;
 
   assert(fid != NULL);
-  pRes = static_cast<pNexusFile>(fid);
+  pRes = static_cast<pLgcyNexusFile>(fid);
   assert(pRes->iNXID == NXSIGNATURE);
   return pRes;
 }
 /*----------------------------------------------------------------------*/
-static int findNapiClass(pNexusFile pFile, int groupRef, NXname nxclass) {
+static int findNapiClass(pLgcyNexusFile pFile, int groupRef, NXname nxclass) {
   NXname classText;
   int32 tags[2], attID, linkID, groupID;
 
@@ -123,7 +123,7 @@ static int findNapiClass(pNexusFile pFile, int groupRef, NXname nxclass) {
 }
 /* --------------------------------------------------------------------- */
 
-static int32 NXIFindVgroup(pNexusFile pFile, CONSTCHAR *name, CONSTCHAR *nxclass) {
+static int32 NXIFindVgroup(pLgcyNexusFile pFile, CONSTCHAR *name, CONSTCHAR *nxclass) {
   int const NX_EOD = static_cast<int>(NXstatus::NX_EOD);
   int32 iNew, iRef, iTag;
   int iN, i;
@@ -188,7 +188,7 @@ static int32 NXIFindVgroup(pNexusFile pFile, CONSTCHAR *name, CONSTCHAR *nxclass
 
 static int32 NXIFindSDS(NXhandle fid, CONSTCHAR *name) {
   int const NX_EOD = static_cast<int>(NXstatus::NX_EOD);
-  pNexusFile self;
+  pLgcyNexusFile self;
   int32 iNew, iRet, iTag, iRef;
   int32 i, iN, iA, iD1, iD2;
   NXname pNam;
@@ -241,7 +241,7 @@ static int32 NXIFindSDS(NXhandle fid, CONSTCHAR *name) {
 
 /*----------------------------------------------------------------------*/
 
-static NXstatus NXIInitDir(pNexusFile self) {
+static NXstatus NXIInitDir(pLgcyNexusFile self) {
   int32 iTag, iRef;
   int iStackPtr;
 
@@ -283,7 +283,7 @@ static NXstatus NXIInitDir(pNexusFile self) {
 
 /*----------------------------------------------------------------------*/
 
-static void NXIKillDir(pNexusFile self) {
+static void NXIKillDir(pLgcyNexusFile self) {
   if (self->iStack[self->iStackPtr].iRefDir) {
     free(self->iStack[self->iStackPtr].iRefDir);
     self->iStack[self->iStackPtr].iRefDir = NULL;
@@ -298,7 +298,7 @@ static void NXIKillDir(pNexusFile self) {
 
 /*-------------------------------------------------------------------------*/
 
-static NXstatus NXIInitAttDir(pNexusFile pFile) {
+static NXstatus NXIInitAttDir(pLgcyNexusFile pFile) {
   int iRet;
   int32 iData, iAtt, iRank, iType;
   int32 iDim[H4_MAX_VAR_DIMS];
@@ -328,7 +328,7 @@ static NXstatus NXIInitAttDir(pNexusFile pFile) {
 
 /* --------------------------------------------------------------------- */
 
-static void NXIKillAttDir(pNexusFile self) {
+static void NXIKillAttDir(pLgcyNexusFile self) {
   if (self->iAtt.iRefDir) {
     free(self->iAtt.iRefDir);
     self->iAtt.iRefDir = NULL;
@@ -341,7 +341,7 @@ static void NXIKillAttDir(pNexusFile self) {
   self->iAtt.iNDir = 0;
 }
 /*------------------------------------------------------------------*/
-static void NXIbuildPath(pNexusFile pFile, char *buffer, int bufLen) {
+static void NXIbuildPath(pLgcyNexusFile pFile, char *buffer, int bufLen) {
   int i;
   int32 groupID, iA, iD1, iD2, iDim[H4_MAX_VAR_DIMS];
   NXname pText;
@@ -377,7 +377,7 @@ static void NXIbuildPath(pNexusFile pFile, char *buffer, int bufLen) {
  ---------------------------------------------------------------------*/
 
 NXstatus NX4open(CONSTCHAR *filename, NXaccess am, NXhandle *pHandle) {
-  pNexusFile pNew = NULL;
+  pLgcyNexusFile pNew = NULL;
   char pBuffer[512];
   char *time_puffer = NULL;
   char HDF_VERSION[64];
@@ -399,7 +399,7 @@ NXstatus NX4open(CONSTCHAR *filename, NXaccess am, NXhandle *pHandle) {
     am1 = DFACC_RDWR;
   }
   /* get memory */
-  pNew = static_cast<pNexusFile>(malloc(sizeof(NexusFile)));
+  pNew = static_cast<pLgcyNexusFile>(malloc(sizeof(NexusFile)));
   if (!pNew) {
     NXReportError("ERROR: no memory to create File datastructure");
     return NXstatus::NX_ERROR;
@@ -526,7 +526,7 @@ NXstatus NX4open(CONSTCHAR *filename, NXaccess am, NXhandle *pHandle) {
 /*-----------------------------------------------------------------------*/
 
 NXstatus NX4close(NXhandle *fid) {
-  pNexusFile pFile = NULL;
+  pLgcyNexusFile pFile = NULL;
   int iRet;
 
   pFile = NXIassert(*fid);
@@ -561,7 +561,7 @@ NXstatus NX4close(NXhandle *fid) {
 /*-----------------------------------------------------------------------*/
 
 NXstatus NX4makegroup(NXhandle fid, CONSTCHAR *name, CONSTCHAR *nxclass) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int32 iNew, iRet;
   char pBuffer[256];
 
@@ -601,7 +601,7 @@ NXstatus NX4makegroup(NXhandle fid, CONSTCHAR *name, CONSTCHAR *nxclass) {
 
 /*------------------------------------------------------------------------*/
 NXstatus NX4opengroup(NXhandle fid, CONSTCHAR *name, CONSTCHAR *nxclass) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int32 iRef;
 
   pFile = NXIassert(fid);
@@ -630,7 +630,7 @@ NXstatus NX4opengroup(NXhandle fid, CONSTCHAR *name, CONSTCHAR *nxclass) {
 /* ------------------------------------------------------------------- */
 
 NXstatus NX4closegroup(NXhandle fid) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
 
   pFile = NXIassert(fid);
 
@@ -659,7 +659,7 @@ NXstatus NX4closegroup(NXhandle fid) {
 /* --------------------------------------------------------------------- */
 
 NXstatus NX4makedata64(NXhandle fid, CONSTCHAR *name, NXnumtype datatype, int rank, int64_t dimensions[]) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int32 iNew;
   char pBuffer[256];
   int i, iRet, type;
@@ -740,7 +740,7 @@ NXstatus NX4makedata64(NXhandle fid, CONSTCHAR *name, NXnumtype datatype, int ra
 NXstatus NX4compmakedata64(NXhandle fid, CONSTCHAR *name, NXnumtype datatype, int rank, int64_t dimensions[],
                            int compress_type, int64_t const chunk_size[]) {
   UNUSED_ARG(chunk_size);
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int32 iNew, iRet, type;
   char pBuffer[256];
   int i, compress_level;
@@ -855,7 +855,7 @@ NXstatus NX4compmakedata64(NXhandle fid, CONSTCHAR *name, NXnumtype datatype, in
 /* --------------------------------------------------------------------- */
 
 NXstatus NX4compress(NXhandle fid, int compress_type) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int32 iRank, iAtt, iType;
   int32 iSize[H4_MAX_VAR_DIMS];
   comp_coder_t compress_typei = COMP_CODE_NONE;
@@ -911,7 +911,7 @@ NXstatus NX4compress(NXhandle fid, int compress_type) {
 /* --------------------------------------------------------------------- */
 
 NXstatus NX4opendata(NXhandle fid, CONSTCHAR *name) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int32 iNew, attID, tags[2];
   pFile = NXIassert(fid);
 
@@ -957,7 +957,7 @@ NXstatus NX4opendata(NXhandle fid, CONSTCHAR *name) {
 /* ----------------------------------------------------------------- */
 
 NXstatus NX4closedata(NXhandle fid) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   pFile = NXIassert(fid);
 
   if (pFile->iCurrentSDS != 0) {
@@ -978,7 +978,7 @@ NXstatus NX4closedata(NXhandle fid) {
 /* ------------------------------------------------------------------- */
 
 NXstatus NX4putdata(NXhandle fid, const void *data) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int32 iStart[H4_MAX_VAR_DIMS], iSize[H4_MAX_VAR_DIMS], iStride[H4_MAX_VAR_DIMS];
   NXname pBuffer;
   int32 iRank, iAtt, iType;
@@ -1015,7 +1015,7 @@ NXstatus NX4putdata(NXhandle fid, const void *data) {
 /* ------------------------------------------------------------------- */
 
 NXstatus NX4putattr(NXhandle fid, CONSTCHAR *name, const void *data, int datalen, NXnumtype iType) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int iRet, type;
 
   pFile = NXIassert(fid);
@@ -1046,7 +1046,7 @@ NXstatus NX4putattr(NXhandle fid, CONSTCHAR *name, const void *data, int datalen
 /* ------------------------------------------------------------------- */
 
 NXstatus NX4putslab64(NXhandle fid, const void *data, const int64_t iStart[], const int64_t iSize[]) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int iRet;
   int32 iStride[H4_MAX_VAR_DIMS];
   int32 myStart[H4_MAX_VAR_DIMS], mySize[H4_MAX_VAR_DIMS];
@@ -1084,7 +1084,7 @@ NXstatus NX4putslab64(NXhandle fid, const void *data, const int64_t iStart[], co
 /* ------------------------------------------------------------------- */
 
 NXstatus NX4getdataID(NXhandle fid, NXlink *sRes) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int datalen;
   NXnumtype type = NXnumtype::CHAR;
 
@@ -1112,7 +1112,7 @@ NXstatus NX4getdataID(NXhandle fid, NXlink *sRes) {
 /* ------------------------------------------------------------------- */
 
 NXstatus NX4makelink(NXhandle fid, NXlink *sLink) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int32 dataID, type = DFNT_CHAR8;
   char name[] = "target";
 
@@ -1138,7 +1138,7 @@ NXstatus NX4makelink(NXhandle fid, NXlink *sLink) {
 /* ------------------------------------------------------------------- */
 
 NXstatus NX4makenamedlink(NXhandle fid, CONSTCHAR *newname, NXlink *sLink) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int32 dataID, type = DFNT_CHAR8, rank = 1;
   NXnumtype dataType = NXnumtype::CHAR, attType = NXnumtype::INT32;
   char name[] = "target";
@@ -1190,7 +1190,7 @@ NXstatus NX4flush(NXhandle *pHandle) {
   char *pFileName, *pCopy = NULL;
   int access, dummy, i, iStack;
   NXstatus iRet;
-  pNexusFile pFile = NULL;
+  pLgcyNexusFile pFile = NULL;
   NXaccess ac;
   int *iRefs = NULL;
 
@@ -1263,7 +1263,7 @@ NXstatus NX4flush(NXhandle *pHandle) {
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX4getnextentry(NXhandle fid, NXname name, NXname nxclass, NXnumtype *datatype) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int iStackPtr, iCurDir;
   int32 iTemp, iD1, iD2, iA;
   int32 iDim[H4_MAX_VAR_DIMS];
@@ -1340,7 +1340,7 @@ NXstatus NX4getnextentry(NXhandle fid, NXname name, NXname nxclass, NXnumtype *d
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX4getdata(NXhandle fid, void *data) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int32 iStart[H4_MAX_VAR_DIMS], iSize[H4_MAX_VAR_DIMS];
   NXname pBuffer;
   int32 iRank, iAtt, iType;
@@ -1363,7 +1363,7 @@ NXstatus NX4getdata(NXhandle fid, void *data) {
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX4getinfo64(NXhandle fid, int *rank, int64_t dimension[], NXnumtype *iType) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   NXname pBuffer;
   int32 iAtt, myDim[H4_MAX_VAR_DIMS], i, iRank, mType;
 
@@ -1389,7 +1389,7 @@ NXstatus NX4getinfo64(NXhandle fid, int *rank, int64_t dimension[], NXnumtype *i
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX4getslab64(NXhandle fid, void *data, const int64_t iStart[], const int64_t iSize[]) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int32 myStart[H4_MAX_VAR_DIMS], mySize[H4_MAX_VAR_DIMS];
   int32 i, iRank, iType, iAtt;
   NXname pBuffer;
@@ -1415,7 +1415,7 @@ NXstatus NX4getslab64(NXhandle fid, void *data, const int64_t iStart[], const in
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX4getnextattr(NXhandle fileid, NXname pName, int *iLength, NXnumtype *iType) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   NXstatus iRet;
   int32 iPType, iCount, count;
 
@@ -1458,7 +1458,7 @@ NXstatus NX4getnextattr(NXhandle fileid, NXname pName, int *iLength, NXnumtype *
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX4getattr(NXhandle fid, const char *name, void *data, int *datalen, NXnumtype *iType) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int32 iNew, iType32, count;
   void *pData = NULL;
   int32 iLen, iRet;
@@ -1545,7 +1545,7 @@ NXstatus NX4getattr(NXhandle fid, const char *name, void *data, int *datalen, NX
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX4getattrinfo(NXhandle fid, int *iN) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   int iRet;
   int32 iData, iAtt, iRank, iType;
   int32 iDim[H4_MAX_VAR_DIMS];
@@ -1575,7 +1575,7 @@ NXstatus NX4getattrinfo(NXhandle fid, int *iN) {
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX4getgroupID(NXhandle fileid, NXlink *sRes) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
 
   pFile = NXIassert(fileid);
 
@@ -1596,7 +1596,7 @@ NXstatus NX4getgroupID(NXhandle fileid, NXlink *sRes) {
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX4getgroupinfo(NXhandle fid, int *iN, NXname pName, NXname pClass) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
 
   pFile = NXIassert(fid);
   /* check if there is a group open */
@@ -1626,7 +1626,7 @@ NXstatus NX4sameID(NXhandle fileid, NXlink const *pFirstID, NXlink const *pSecon
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX4initattrdir(NXhandle fid) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   NXstatus iRet;
 
   pFile = NXIassert(fid);
@@ -1640,7 +1640,7 @@ NXstatus NX4initattrdir(NXhandle fid) {
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX4initgroupdir(NXhandle fid) {
-  pNexusFile pFile;
+  pLgcyNexusFile pFile;
   NXstatus iRet;
 
   pFile = NXIassert(fid);

--- a/Framework/LegacyNexus/src/napi4.cpp
+++ b/Framework/LegacyNexus/src/napi4.cpp
@@ -43,7 +43,7 @@
 
 extern void *NXpData;
 
-typedef struct __NexusFile {
+typedef struct __LgcyNexusFile {
   struct iStack {
     int32 *iRefDir;
     int32 *iTagDir;
@@ -60,7 +60,7 @@ typedef struct __NexusFile {
   int iNXID;
   int iStackPtr;
   char iAccess[2];
-} NexusFile, *pLgcyNexusFile;
+} LgcyNexusFile, *pLgcyNexusFile;
 
 /*-------------------------------------------------------------------*/
 
@@ -399,12 +399,12 @@ NXstatus NX4open(CONSTCHAR *filename, NXaccess am, NXhandle *pHandle) {
     am1 = DFACC_RDWR;
   }
   /* get memory */
-  pNew = static_cast<pLgcyNexusFile>(malloc(sizeof(NexusFile)));
+  pNew = static_cast<pLgcyNexusFile>(malloc(sizeof(LgcyNexusFile)));
   if (!pNew) {
     NXReportError("ERROR: no memory to create File datastructure");
     return NXstatus::NX_ERROR;
   }
-  memset(pNew, 0, sizeof(NexusFile));
+  memset(pNew, 0, sizeof(LgcyNexusFile));
 
 #if WRITE_OLD_IDENT /* not used at moment */
                     /*

--- a/Framework/LegacyNexus/src/napi5.cpp
+++ b/Framework/LegacyNexus/src/napi5.cpp
@@ -80,7 +80,7 @@ typedef struct __NexusFile5 {
   char name_ref[1024];
   char name_tmp[1024];
   char iAccess[2];
-} NexusFile5, *pNexusFile5;
+} LgcyNexusFile5, *pLgcyNexusFile5;
 
 /* forward declaration of NX5closegroup in order to get rid of a nasty warning */
 
@@ -88,18 +88,18 @@ NXstatus NX5closegroup(NXhandle fid);
 
 /*-------------------------------------------------------------------*/
 
-static pNexusFile5 NXI5assert(NXhandle fid) {
-  pNexusFile5 pRes;
+static pLgcyNexusFile5 NXI5assert(NXhandle fid) {
+  pLgcyNexusFile5 pRes;
 
   assert(fid != NULL);
-  pRes = static_cast<pNexusFile5>(fid);
+  pRes = static_cast<pLgcyNexusFile5>(fid);
   assert(pRes->iNXID == NX5SIGNATURE);
   return pRes;
 }
 
 /*--------------------------------------------------------------------*/
 
-static void NXI5KillDir(pNexusFile5 self) { self->iStack5[self->iStackPtr].iCurrentIDX = 0; }
+static void NXI5KillDir(pLgcyNexusFile5 self) { self->iStack5[self->iStackPtr].iCurrentIDX = 0; }
 
 static herr_t readStringAttribute(hid_t attr, char **data) {
   herr_t iRet = 0;
@@ -185,10 +185,10 @@ static herr_t readStringAttributeN(hid_t attr, char *data, int maxlen) {
 
 /*--------------------------------------------------------------------*/
 
-static void NXI5KillAttDir(pNexusFile5 self) { self->iAtt5.iCurrentIDX = 0; }
+static void NXI5KillAttDir(pLgcyNexusFile5 self) { self->iAtt5.iCurrentIDX = 0; }
 
 /*---------------------------------------------------------------------*/
-static void buildCurrentPath(pNexusFile5 self, char *pathBuffer, // cppcheck-suppress constParameterPointer
+static void buildCurrentPath(pLgcyNexusFile5 self, char *pathBuffer, // cppcheck-suppress constParameterPointer
                              int pathBufferLen) {
 
   memset(pathBuffer, 0, static_cast<size_t>(pathBufferLen));
@@ -213,15 +213,15 @@ static void buildCurrentPath(pNexusFile5 self, char *pathBuffer, // cppcheck-sup
    --------------------------------------------------------------------- */
 
 NXstatus NX5reopen(NXhandle pOrigHandle, NXhandle *pNewHandle) {
-  pNexusFile5 pNew = NULL, pOrig = NULL;
+  pLgcyNexusFile5 pNew = NULL, pOrig = NULL;
   *pNewHandle = NULL;
-  pOrig = static_cast<pNexusFile5>(pOrigHandle);
-  pNew = static_cast<pNexusFile5>(malloc(sizeof(NexusFile5)));
+  pOrig = static_cast<pLgcyNexusFile5>(pOrigHandle);
+  pNew = static_cast<pLgcyNexusFile5>(malloc(sizeof(LgcyNexusFile5)));
   if (!pNew) {
     NXReportError("ERROR: no memory to create File datastructure");
     return NXstatus::NX_ERROR;
   }
-  memset(pNew, 0, sizeof(NexusFile5));
+  memset(pNew, 0, sizeof(LgcyNexusFile5));
   pNew->iFID = H5Freopen(pOrig->iFID);
   if (pNew->iFID <= 0) {
     NXReportError("cannot clone file");
@@ -239,12 +239,12 @@ NXstatus NX5reopen(NXhandle pOrigHandle, NXhandle *pNewHandle) {
  * private functions used in NX5open
  */
 
-pNexusFile5 create_file_struct() {
-  pNexusFile5 pNew = static_cast<pNexusFile5>(malloc(sizeof(NexusFile5)));
+pLgcyNexusFile5 create_file_struct() {
+  pLgcyNexusFile5 pNew = static_cast<pLgcyNexusFile5>(malloc(sizeof(LgcyNexusFile5)));
   if (!pNew) {
     NXReportError("ERROR: not enough memory to create file structure");
   } else {
-    memset(pNew, 0, sizeof(NexusFile5));
+    memset(pNew, 0, sizeof(LgcyNexusFile5));
   }
 
   return pNew;
@@ -339,7 +339,7 @@ herr_t set_str_attribute(hid_t parent_id, CONSTCHAR *name, CONSTCHAR *buffer) {
 
 NXstatus NX5open(CONSTCHAR *filename, NXaccess am, NXhandle *pHandle) {
   hid_t root_id;
-  pNexusFile5 pNew = NULL;
+  pLgcyNexusFile5 pNew = NULL;
   char pBuffer[512];
   char *time_buffer = NULL;
   char version_nr[10];
@@ -473,7 +473,7 @@ NXstatus NX5open(CONSTCHAR *filename, NXaccess am, NXhandle *pHandle) {
 /* ------------------------------------------------------------------------- */
 
 NXstatus NX5close(NXhandle *fid) {
-  pNexusFile5 pFile = NULL;
+  pLgcyNexusFile5 pFile = NULL;
   herr_t iRet;
 
   pFile = NXI5assert(*fid);
@@ -519,7 +519,7 @@ NXstatus NX5close(NXhandle *fid) {
 /*-----------------------------------------------------------------------*/
 
 NXstatus NX5makegroup(NXhandle fid, CONSTCHAR *name, CONSTCHAR *nxclass) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   hid_t iVID;
   hid_t attr1, aid1, aid2;
   std::string pBuffer;
@@ -574,7 +574,7 @@ herr_t attr_check(hid_t loc_id, const char *member_name, const H5A_info_t *unuse
 
 NXstatus NX5opengroup(NXhandle fid, CONSTCHAR *name, CONSTCHAR *nxclass) {
 
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   hid_t attr1, atype, iVID;
   herr_t iRet;
   char pBuffer[NX_MAXPATHLEN + 12]; // no idea what the 12 is about
@@ -648,7 +648,7 @@ NXstatus NX5opengroup(NXhandle fid, CONSTCHAR *name, CONSTCHAR *nxclass) {
 /* ------------------------------------------------------------------- */
 
 NXstatus NX5closegroup(NXhandle fid) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
 
   pFile = NXI5assert(fid);
   /* first catch the trivial case: we are at root and cannot get
@@ -727,7 +727,7 @@ NXstatus NX5compmakedata64(NXhandle fid, CONSTCHAR *name, NXnumtype datatype, in
                            int compress_type, int64_t const chunk_size[]) {
   hid_t datatype1, dataspace, iNew;
   hid_t type, cparms = -1;
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   char pBuffer[256];
   size_t byte_zahl = 0;
   hsize_t chunkdims[H5S_MAX_RANK];
@@ -917,7 +917,7 @@ NXstatus NX5compress(NXhandle fid, int compress_type) {
 /* --------------------------------------------------------------------- */
 
 NXstatus NX5opendata(NXhandle fid, CONSTCHAR *name) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
 
   pFile = NXI5assert(fid);
   /* clear pending attribute directories first */
@@ -956,7 +956,7 @@ NXstatus NX5opendata(NXhandle fid, CONSTCHAR *name) {
 /* ----------------------------------------------------------------- */
 
 NXstatus NX5closedata(NXhandle fid) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   herr_t iRet;
 
   pFile = NXI5assert(fid);
@@ -974,7 +974,7 @@ NXstatus NX5closedata(NXhandle fid) {
 /* ------------------------------------------------------------------- */
 
 NXstatus NX5putdata(NXhandle fid, const void *data) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   herr_t iRet;
   int64_t myStart[H5S_MAX_RANK];
   int64_t mySize[H5S_MAX_RANK];
@@ -1017,7 +1017,7 @@ NXstatus NX5putdata(NXhandle fid, const void *data) {
 }
 
 /*------------------------------------------------------------------*/
-static hid_t getAttVID(pNexusFile5 pFile) {
+static hid_t getAttVID(pLgcyNexusFile5 pFile) {
   hid_t vid;
   if (pFile->iCurrentG == 0 && pFile->iCurrentD == 0) {
     /* global attribute */
@@ -1033,7 +1033,7 @@ static hid_t getAttVID(pNexusFile5 pFile) {
 }
 
 /*---------------------------------------------------------------*/
-static void killAttVID(const pNexusFile5 pFile, hid_t vid) {
+static void killAttVID(const pLgcyNexusFile5 pFile, hid_t vid) {
   if (pFile->iCurrentG == 0 && pFile->iCurrentD == 0) {
     H5Gclose(vid);
   }
@@ -1042,7 +1042,7 @@ static void killAttVID(const pNexusFile5 pFile, hid_t vid) {
 /* ------------------------------------------------------------------- */
 
 NXstatus NX5putattr(NXhandle fid, CONSTCHAR *name, const void *data, int datalen, NXnumtype iType) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   hid_t attr1, aid1, aid2;
   hid_t type;
   herr_t iRet = 0;
@@ -1093,7 +1093,7 @@ NXstatus NX5putattr(NXhandle fid, CONSTCHAR *name, const void *data, int datalen
 /* ------------------------------------------------------------------- */
 
 NXstatus NX5putslab64(NXhandle fid, const void *data, const int64_t iStart[], const int64_t iSize[]) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   int iRet, rank;
   hsize_t myStart[H5S_MAX_RANK];
   hsize_t mySize[H5S_MAX_RANK];
@@ -1190,7 +1190,7 @@ NXstatus NX5putslab64(NXhandle fid, const void *data, const int64_t iStart[], co
 /* ------------------------------------------------------------------- */
 
 NXstatus NX5getdataID(NXhandle fid, NXlink *sRes) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   int datalen;
   NXnumtype type = NXnumtype::CHAR;
 

--- a/Framework/LegacyNexus/src/napi5.cpp
+++ b/Framework/LegacyNexus/src/napi5.cpp
@@ -59,7 +59,7 @@
 
 extern void *NXpData;
 
-typedef struct __NexusFile5 {
+typedef struct __LgcyNexusFile5 {
   struct iStack5 {
     char irefn[1024];
     hid_t iVref;
@@ -1225,7 +1225,7 @@ NXstatus NX5printlink(NXhandle fid, NXlink const *sLink) {
 }
 
 /*--------------------------------------------------------------------*/
-static NXstatus NX5settargetattribute(pNexusFile5 pFile, NXlink *sLink) {
+static NXstatus NX5settargetattribute(pLgcyNexusFile5 pFile, NXlink *sLink) {
   hid_t dataID, aid2, aid1, attID;
   char name[] = "target";
 
@@ -1271,7 +1271,7 @@ static NXstatus NX5settargetattribute(pNexusFile5 pFile, NXlink *sLink) {
 /*---------------------------------------------------------------------*/
 
 NXstatus NX5makenamedlink(NXhandle fid, CONSTCHAR *name, NXlink *sLink) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   char linkTarget[NX_MAXPATHLEN];
 
   pFile = NXI5assert(fid);
@@ -1301,7 +1301,7 @@ NXstatus NX5makenamedlink(NXhandle fid, CONSTCHAR *name, NXlink *sLink) {
 /* ------------------------------------------------------------------- */
 
 NXstatus NX5makelink(NXhandle fid, NXlink *sLink) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   char linkTarget[NX_MAXPATHLEN];
   char *itemName = NULL;
 
@@ -1342,7 +1342,7 @@ NXstatus NX5makelink(NXhandle fid, NXlink *sLink) {
 /*----------------------------------------------------------------------*/
 
 NXstatus NX5flush(NXhandle *pHandle) {
-  pNexusFile5 pFile = NULL;
+  pLgcyNexusFile5 pFile = NULL;
   herr_t iRet;
 
   pFile = NXI5assert(*pHandle);
@@ -1415,7 +1415,7 @@ herr_t group_info(hid_t loc_id, const char *name, const H5L_info_t *statbuf, voi
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX5getgroupinfo_recurse(NXhandle fid, int *iN, NXname pName, NXname pClass) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   hid_t atype, attr_id, grp;
 
   pFile = NXI5assert(fid);
@@ -1469,7 +1469,7 @@ static int countObjectsInGroup(hid_t loc_id) {
 
 /*----------------------------------------------------------------------------*/
 NXstatus NX5getgroupinfo(NXhandle fid, int *iN, NXname pName, NXname pClass) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   hid_t atype, attr_id, gid;
 
   pFile = NXI5assert(fid);
@@ -1617,7 +1617,7 @@ static hid_t h5MemType(hid_t atype) {
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX5getnextentry(NXhandle fid, NXname name, NXname nxclass, NXnumtype *datatype) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   hid_t grp, attr1, type, atype;
   herr_t iRet;
   hsize_t idx;
@@ -1754,7 +1754,7 @@ NXstatus NX5getnextentry(NXhandle fid, NXname name, NXname nxclass, NXnumtype *d
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX5getdata(NXhandle fid, void *data) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   int iStart[H5S_MAX_RANK], status;
   hid_t memtype_id;
   H5T_class_t tclass;
@@ -1839,7 +1839,7 @@ NXstatus NX5getdata(NXhandle fid, void *data) {
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX5getinfo64(NXhandle fid, int *rank, int64_t dimension[], NXnumtype *iType) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   int i, iRank, mType;
   hsize_t myDim[H5S_MAX_RANK];
   H5T_class_t tclass;
@@ -1895,7 +1895,7 @@ NXstatus NX5getinfo64(NXhandle fid, int *rank, int64_t dimension[], NXnumtype *i
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX5getslab64(NXhandle fid, void *data, const int64_t iStart[], const int64_t iSize[]) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   hsize_t myStart[H5S_MAX_RANK];
   hsize_t mySize[H5S_MAX_RANK];
   hsize_t mStart[H5S_MAX_RANK];
@@ -2025,7 +2025,7 @@ NXstatus NX5getnextattr(NXhandle fileid, NXname pName, int *iLength, NXnumtype *
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX5getattr(NXhandle fid, const char *name, void *data, int *datalen, NXnumtype *iType) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   hid_t vid, iNew;
   hsize_t dims[H5S_MAX_RANK], totalsize;
   herr_t iRet;
@@ -2081,7 +2081,7 @@ NXstatus NX5getattr(NXhandle fid, const char *name, void *data, int *datalen, NX
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX5getattrinfo(NXhandle fid, int *iN) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   int idx;
   hid_t vid;
   H5O_info1_t oinfo;
@@ -2110,7 +2110,7 @@ NXstatus NX5getattrinfo(NXhandle fid, int *iN) {
 
 /*-------------------------------------------------------------------------*/
 NXstatus NX5getgroupID(NXhandle fileid, NXlink *sRes) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   NXnumtype type = NXnumtype::CHAR;
 
   pFile = NXI5assert(fileid);
@@ -2140,7 +2140,7 @@ NXstatus NX5getgroupID(NXhandle fileid, NXlink *sRes) {
 NXstatus NX5nativeexternallink(NXhandle fileid, const char *name, const char *externalfile, const char *remotetarget) {
   hid_t openwhere;
 
-  const pNexusFile5 pFile = NXI5assert(fileid);
+  const pLgcyNexusFile5 pFile = NXI5assert(fileid);
 
   if (pFile->iCurrentG <= 0) {
     openwhere = pFile->iFID;
@@ -2161,7 +2161,7 @@ NXstatus NX5nativeexternallink(NXhandle fileid, const char *name, const char *ex
 NXstatus NX5nativeinquirefile(NXhandle fileid, char *externalfile, const int filenamelen) {
   hid_t openthing;
 
-  const pNexusFile5 pFile = NXI5assert(fileid);
+  const pLgcyNexusFile5 pFile = NXI5assert(fileid);
   if (pFile->iCurrentD > 0) {
     openthing = pFile->iCurrentD;
   } else if (pFile->iCurrentG > 0) {
@@ -2181,7 +2181,7 @@ NXstatus NX5nativeinquirefile(NXhandle fileid, char *externalfile, const int fil
 /* ------------------------------------------------------------------- */
 
 NXstatus NX5nativeisexternallink(NXhandle fileid, const char *name, char *url, const int urllen) {
-  pNexusFile5 pFile; // cppcheck-suppress constVariablePointer
+  pLgcyNexusFile5 pFile; // cppcheck-suppress constVariablePointer
   herr_t ret;
   H5L_info_t link_buff;
   char linkval_buff[NX_MAXPATHLEN];
@@ -2239,7 +2239,7 @@ NXstatus NX5sameID(NXhandle fileid, NXlink const *pFirstID, NXlink const *pSecon
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX5initattrdir(NXhandle fid) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
 
   pFile = NXI5assert(fid);
   NXI5KillAttDir(pFile);
@@ -2249,7 +2249,7 @@ NXstatus NX5initattrdir(NXhandle fid) {
 /*-------------------------------------------------------------------------*/
 
 NXstatus NX5initgroupdir(NXhandle fid) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
 
   pFile = NXI5assert(fid);
   NXI5KillDir(pFile);
@@ -2261,7 +2261,7 @@ NXstatus NX5putattra(NXhandle handle, CONSTCHAR *name, const void *data, const i
                      const NXnumtype iType) {
   hid_t datatype1, dataspace;
   hid_t type;
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   int i;
   hid_t vid, iATT;
   herr_t iRet;
@@ -2333,7 +2333,7 @@ NXstatus NX5putattra(NXhandle handle, CONSTCHAR *name, const void *data, const i
 
 /*------------------------------------------------------------------------*/
 NXstatus NX5getnextattra(NXhandle handle, NXname pName, int *rank, int dim[], NXnumtype *iType) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   herr_t iRet;
   char *iname = NULL;
   hid_t vid;
@@ -2390,7 +2390,7 @@ NXstatus NX5getnextattra(NXhandle handle, NXname pName, int *rank, int dim[], NX
 }
 /*------------------------------------------------------------------------*/
 NXstatus NX5getattra(NXhandle handle, const char *name, void *data) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   int iStart[H5S_MAX_RANK], status;
   hid_t vid;
   hid_t memtype_id, filespace, datatype;
@@ -2479,7 +2479,7 @@ NXstatus NX5getattra(NXhandle handle, const char *name, void *data) {
 }
 /*------------------------------------------------------------------------*/
 NXstatus NX5getattrainfo(NXhandle handle, NXname name, int *rank, int dim[], NXnumtype *iType) {
-  pNexusFile5 pFile;
+  pLgcyNexusFile5 pFile;
   int iRet, mType;
   hid_t vid;
   hid_t filespace, attrt, memtype;

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -175,11 +175,11 @@ public:
    */
   virtual void load(int const blocksize, int const i, int const j, int const k, int const l) {
     // we need the var names for docs build, need below void casts to stop compiler warnings
-    (void)blocksize;
-    (void)i;
-    (void)j;
-    (void)k;
-    (void)l;
+    UNUSED_ARG(blocksize);
+    UNUSED_ARG(i);
+    UNUSED_ARG(j);
+    UNUSED_ARG(k);
+    UNUSED_ARG(l);
   };
 
 protected:
@@ -498,10 +498,6 @@ public:
   NXClass(NXClass const &parent, std::string const &name);
   /// The NX class identifier
   std::string NX_class() const override { return "NXClass"; }
-  /**  Returns the class information about the next entry (class or dataset) in
-   * this class.
-   */
-  NXClassInfo getNextEntry();
   /// Creates a new object in the NeXus file at path path.
   // virtual void make(const std::string& path) = 0;
   /// Resets the current position for getNextEntry() to the beginning

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -10,8 +10,8 @@
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidNexus/DllConfig.h"
 #include "MantidNexusCpp/NeXusFile_fwd.h"
-#include "MantidNexusCpp/napi.h"
 
+#include <array>
 #include <boost/container/vector.hpp>
 #include <map>
 #include <memory>
@@ -27,14 +27,18 @@ namespace NeXus {
 @date 28/05/2009
 */
 
+typedef ::NeXus::DimSize DimSize;
+typedef std::array<DimSize, 4> NXDimArray;
+
 /** Structure for keeping information about a Nexus data set,
  *  such as the dimensions and the type
  */
 struct NXInfo {
   NXInfo() : nxname(), rank(0), dims(), type(NXnumtype::BAD), stat(NXstatus::NX_ERROR) {}
+  NXInfo(::NeXus::Info const &info, std::string const &name);
   std::string nxname; ///< name of the object
-  int rank;           ///< number of dimensions of the data
-  int dims[4];        ///< sizes along each dimension
+  std::size_t rank;   ///< number of dimensions of the data
+  NXDimArray dims;    ///< sizes along each dimension
   NXnumtype type;     ///< type of the data, e.g. NX_CHAR, NXnumtype::FLOAT32, see napi.h
   NXstatus stat;      ///< return status
   operator bool() { return stat == NXstatus::NX_OK; } ///< returns success of an operation
@@ -43,6 +47,7 @@ struct NXInfo {
 /**  Information about a Nexus class
  */
 struct NXClassInfo {
+  NXClassInfo(::NeXus::Entry e) : nxname(e.first), nxclass(e.second), datatype(NXnumtype::BAD), stat(NXstatus::NX_OK) {}
   NXClassInfo() : nxname(), nxclass(), datatype(NXnumtype::BAD), stat(NXstatus::NX_ERROR) {}
   std::string nxname;  ///< name of the object
   std::string nxclass; ///< NX class of the object or "SDS" if a dataset
@@ -64,14 +69,12 @@ const int g_processed_blocksize = 8;
  */
 class MANTID_NEXUS_DLL NXAttributes {
 public:
-  int n() const { return int(m_values.size()); }         ///< number of attributes
-  std::vector<std::string> names() const;                ///< Returns the list of attribute names
-  std::vector<std::string> values() const;               ///< Returns the list of attribute values
-  std::string operator()(const std::string &name) const; ///< returns the value of attribute with name name
-  void set(const std::string &name,
-           const std::string &value); ///< set the attribute's value
-  void set(const std::string &name,
-           double value); ///< set the attribute's value as a double
+  std::size_t n() const { return m_values.size(); }                 ///< number of attributes
+  std::vector<std::string> names() const;                           ///< Returns the list of attribute names
+  std::vector<std::string> values() const;                          ///< Returns the list of attribute values
+  std::string operator()(const std::string &name) const;            ///< returns the value of attribute with name name
+  void set(const std::string &name, const std::string &value);      ///< set the attribute's value
+  template <typename T> void set(const std::string &name, T value); ///< set the attribute's value from type
 private:
   std::map<std::string, std::string> m_values; ///< the list of attributes
 };
@@ -88,7 +91,7 @@ class MANTID_NEXUS_DLL NXObject {
   friend class NXRoot;    ///< a friend class declaration
 public:
   // Constructor
-  NXObject(const NXhandle fileID, const NXClass *parent, const std::string &name);
+  NXObject(::NeXus::File *fileID, NXClass const *parent, std::string const &name);
   virtual ~NXObject() = default;
   /// Return the NX class name for a class (HDF group) or "SDS" for a data set;
   virtual std::string NX_class() const = 0;
@@ -102,13 +105,13 @@ public:
   /// Attributes
   NXAttributes attributes;
   /// Nexus file id
-  NXhandle m_fileID;
+  ::NeXus::File *m_fileID;
 
 protected:
   std::string m_path; ///< Keeps the absolute path to the object
   bool m_open;        ///< Set to true if the object has been open
 private:
-  NXObject() : m_fileID(), m_open(false) {} ///< Private default constructor
+  NXObject(); ///< Private default constructor
   void getAttributes();
 };
 
@@ -127,7 +130,7 @@ private:
 class MANTID_NEXUS_DLL NXDataSet : public NXObject {
 public:
   // Constructor
-  NXDataSet(const NXClass &parent, const std::string &name);
+  NXDataSet(NXClass const &parent, std::string const &name);
   /// NX class name. Returns "SDS"
   std::string NX_class() const override { return "SDS"; }
   /// Opens the data set. Does not read in any data. Call load(...) to load the
@@ -136,9 +139,10 @@ public:
   /// Opens datasets faster but the parent group must be already open
   void openLocal();
   /// Returns the rank (number of dimensions) of the data. The maximum is 4
-  int rank() const { return m_info.rank; }
+  std::size_t rank() const { return m_info.rank; }
   /// Returns the number of elements along i-th dimension
-  int dims(int i) const { return i < 4 ? m_info.dims[i] : 0; }
+  DimSize dims(std::size_t i) const { return i < 4 ? m_info.dims[i] : 0; }
+  // TODO these need to return DimSize -- but inteferes with some other code
   /// Returns the number of elements along the first dimension
   int dim0() const;
   /// Returns the number of elements along the second dimension
@@ -169,8 +173,8 @@ public:
    * rank()-4. i,j,k and l are its indices.
    *            The rank of the data must be 4
    */
-  virtual void load(const int blocksize = 1, int i = -1, int j = -1, int k = -1, int l = -1) {
-    // Avoid compiler warnings
+  virtual void load(int const blocksize, int const i, int const j, int const k, int const l) {
+    // we need the var names for docs build, need below void casts to stop compiler warnings
     (void)blocksize;
     (void)i;
     (void)j;
@@ -180,7 +184,7 @@ public:
 
 protected:
   void getData(void *data);
-  void getSlab(void *data, int start[], int size[]);
+  void getSlab(void *data, NXDimArray const &start, NXDimArray const &size);
 
 private:
   NXInfo m_info; ///< Holds the data info
@@ -200,7 +204,7 @@ public:
    * containing the dataset.
    *   @param name :: The name of the dataset relative to its parent
    */
-  NXDataSetTyped(const NXClass &parent, const std::string &name) : NXDataSet(parent, name), m_n(0) {}
+  NXDataSetTyped(const NXClass &parent, const std::string &name) : NXDataSet(parent, name), m_n(0UL) {}
   /** Returns a pointer to the internal data buffer.
    *  @throw runtime_error exception if the data have not been loaded /
    * initialized.
@@ -224,15 +228,15 @@ public:
    *  @throw range_error if the index is greater than the buffer size.
    *  @return A reference to the value
    */
-  const T &operator[](int i) const {
+  const T &operator[](std::size_t i) const {
     if (m_data.empty())
       throw std::runtime_error("Attempt to read uninitialized data from " + path());
-    if (i < 0 || i >= m_n)
+    if (i >= m_n)
       rangeError();
     return m_data[i];
   }
 
-  T &operator[](int i) { return const_cast<T &>(static_cast<const NXDataSetTyped &>(*this)[i]); }
+  T &operator[](std::size_t i) { return const_cast<T &>(static_cast<const NXDataSetTyped &>(*this)[i]); }
   /** Returns a value assuming the data is a two-dimensional array
    *  @param i :: The index along dim0()
    *  @param j :: The index along dim1()
@@ -240,8 +244,10 @@ public:
    *  @throw range_error if the indeces point outside the buffer.
    *  @return A reference to the value
    */
-  const T &operator()(int i, int j) const { return this->operator[](i * dim1() + j); }
-  T &operator()(int i, int j) { return const_cast<T &>(static_cast<const NXDataSetTyped &>(*this)(i, j)); }
+  const T &operator()(std::size_t i, std::size_t j) const { return this->operator[](i * dim1() + j); }
+  T &operator()(std::size_t i, std::size_t j) {
+    return const_cast<T &>(static_cast<const NXDataSetTyped &>(*this)(i, j));
+  }
   /** Returns a value assuming the data is a tree-dimensional array
    *  @param i :: The index along dim0()
    *  @param j :: The index along dim1()
@@ -250,13 +256,17 @@ public:
    *  @throw range_error if the indeces point outside the buffer.
    *  @return A reference to the value
    */
-  const T &operator()(int i, int j, int k) const { return this->operator[]((i * dim1() + j) * dim2() + k); }
-  T &operator()(int i, int j, int k) { return const_cast<T &>(static_cast<const NXDataSetTyped &>(*this)(i, j, k)); }
+  const T &operator()(std::size_t i, std::size_t j, std::size_t k) const {
+    return this->operator[]((i * dim1() + j) * dim2() + k);
+  }
+  T &operator()(std::size_t i, std::size_t j, std::size_t k) {
+    return const_cast<T &>(static_cast<const NXDataSetTyped &>(*this)(i, j, k));
+  }
 
   /// Returns a the internal buffer
   container_T<T> &vecBuffer() { return m_data; }
   /// Returns the size of the data buffer
-  int size() const { return m_n; }
+  std::size_t size() const { return m_n; }
   /**  Implementation of the virtual NXDataSet::load(...) method. Internally the
    * data are stored as a 1d array.
    *   If the data are loaded in chunks the newly read in data replace the old
@@ -278,21 +288,21 @@ public:
    * rank()-4. i,j,k and l are its indeces.
    *            The rank of the data must be 4
    */
-  void load(const int blocksize = 1, int i = -1, int j = -1, int k = -1, int l = -1) override {
+  void load(const int blocksize = 1, int const i = -1, int const j = -1, int const k = -1, int const l = -1) override {
     if (rank() > 4) {
       throw std::runtime_error("Cannot load dataset of rank greater than 4");
     }
-    int n = 0;
-    int start[4];
+    DimSize n = 0, id(i), jd(j), kd(l), ld(l);
+    NXDimArray start;
     if (rank() == 4) {
       if (i < 0) // load all data
       {
         n = dim0() * dim1() * dim2() * dim3();
-        alloc(n);
+        alloc(static_cast<std::size_t>(n));
         getData(m_data.data());
         return;
       } else if (j < 0) {
-        if (i >= dim0())
+        if (id >= dim0())
           rangeError();
         n = dim1() * dim2() * dim3();
         start[0] = i;
@@ -304,7 +314,7 @@ public:
         start[3] = 0;
         m_size[3] = dim2();
       } else if (k < 0) {
-        if (i >= dim0() || j >= dim1())
+        if (id >= dim0() || jd >= dim1())
           rangeError();
         n = dim2() * dim3();
         start[0] = i;
@@ -316,7 +326,7 @@ public:
         start[3] = 0;
         m_size[3] = dim2();
       } else if (l < 0) {
-        if (i >= dim0() || j >= dim1() || k >= dim2())
+        if (id >= dim0() || jd >= dim1() || kd >= dim2())
           rangeError();
         n = dim3();
         start[0] = i;
@@ -328,7 +338,7 @@ public:
         start[3] = 0;
         m_size[3] = dim2();
       } else {
-        if (i >= dim0() || j >= dim1() || k >= dim2() || l >= dim3())
+        if (id >= dim0() || jd >= dim1() || kd >= dim2() || ld >= dim3())
           rangeError();
         n = dim3();
         start[0] = i;
@@ -343,11 +353,11 @@ public:
     } else if (rank() == 3) {
       if (i < 0) {
         n = dim0() * dim1() * dim2();
-        alloc(n);
+        alloc(static_cast<std::size_t>(n));
         getData(m_data.data());
         return;
       } else if (j < 0) {
-        if (i >= dim0())
+        if (id >= dim0())
           rangeError();
         n = dim1() * dim2();
         start[0] = i;
@@ -357,11 +367,11 @@ public:
         start[2] = 0;
         m_size[2] = dim2();
       } else if (k < 0) {
-        if (i >= dim0() || j >= dim1())
+        if (id >= dim0() || jd >= dim1())
           rangeError();
-        int m = blocksize;
-        if (j + m > dim1())
-          m = dim1() - j;
+        DimSize m = blocksize;
+        if (jd + m > dim1())
+          m = dim1() - jd;
         n = dim2() * m;
         start[0] = i;
         m_size[0] = 1;
@@ -370,7 +380,7 @@ public:
         start[2] = 0;
         m_size[2] = dim2();
       } else {
-        if (i >= dim0() || j >= dim1() || k >= dim2())
+        if (id >= dim0() || jd >= dim1() || kd >= dim2())
           rangeError();
         n = 1;
         start[0] = i;
@@ -383,22 +393,22 @@ public:
     } else if (rank() == 2) {
       if (i < 0) {
         n = dim0() * dim1();
-        alloc(n);
+        alloc(static_cast<std::size_t>(n));
         getData(m_data.data());
         return;
       } else if (j < 0) {
-        if (i >= dim0())
+        if (id >= dim0())
           rangeError();
-        int m = blocksize;
-        if (i + m > dim0())
-          m = dim0() - i;
+        DimSize m = blocksize;
+        if (id + m > dim0())
+          m = dim0() - id;
         n = dim1() * m;
         start[0] = i;
         m_size[0] = m;
         start[1] = 0;
         m_size[1] = dim1();
       } else {
-        if (i >= dim0() || j >= dim1())
+        if (id >= dim0() || jd >= dim1())
           rangeError();
         n = 1;
         start[0] = i;
@@ -409,18 +419,18 @@ public:
     } else if (rank() == 1) {
       if (i < 0) {
         n = dim0();
-        alloc(n);
+        alloc(static_cast<std::size_t>(n));
         getData(m_data.data());
         return;
       } else {
-        if (i >= dim0())
+        if (id >= dim0())
           rangeError();
         n = 1 * blocksize;
         start[0] = i;
         m_size[0] = blocksize;
       }
     }
-    alloc(n);
+    alloc(static_cast<size_t>(n));
     getSlab(m_data.data(), start, m_size);
   }
 
@@ -428,8 +438,8 @@ private:
   /** Allocates memory for the data buffer
    *  @param n :: The number of elements to allocate.
    */
-  void alloc(int n) {
-    if (n <= 0) {
+  void alloc(std::size_t n) {
+    if (n == 0) {
       throw std::runtime_error("Attempt to load from an empty dataset " + path());
     }
     try {
@@ -447,8 +457,8 @@ private:
   void rangeError() const { throw std::range_error("Nexus dataset range error"); }
   // We cannot use an STL vector due to the dreaded std::vector<bool>
   container_T<T> m_data; ///< The data buffer
-  int m_size[4];         ///< The sizes of the loaded data
-  int m_n;               ///< The buffer size
+  NXDimArray m_size;     ///< The sizes of the loaded data
+  std::size_t m_n;       ///< The buffer size
 };
 
 /// The integer dataset type
@@ -485,7 +495,7 @@ public:
    * containing the NXClass.
    *   @param name :: The name of the NXClass relative to its parent
    */
-  NXClass(const NXClass &parent, const std::string &name);
+  NXClass(NXClass const &parent, std::string const &name);
   /// The NX class identifier
   std::string NX_class() const override { return "NXClass"; }
   /**  Returns the class information about the next entry (class or dataset) in
@@ -656,9 +666,9 @@ private:
       NXChar value(*this, "value");
       value.openLocal();
       value.load();
-      for (int i = 0; i < value.dim0(); i++) {
+      for (int64_t i = 0; i < value.dim0(); i++) {
         auto t = start_t + boost::posix_time::seconds(int(times[i]));
-        for (int j = 0; j < value.dim1(); j++) {
+        for (int64_t j = 0; j < value.dim1(); j++) {
           char *c = &value(i, j);
           if (!isprint(*c))
             *c = ' ';
@@ -672,7 +682,7 @@ private:
         NXDouble value(*this, "value");
         value.openLocal();
         value.load();
-        for (int i = 0; i < value.dim0(); i++) {
+        for (int64_t i = 0; i < value.dim0(); i++) {
           auto t = start_t + boost::posix_time::seconds(int(times[i]));
           logv->addValue(t, (value[i] == 0 ? false : true));
         }
@@ -702,7 +712,7 @@ private:
     value.openLocal();
     auto logv = new Kernel::TimeSeriesProperty<double>(logName);
     value.load();
-    for (int i = 0; i < value.dim0(); i++) {
+    for (int64_t i = 0; i < value.dim0(); i++) {
       if (i == 0 || value[i] != value[i - 1] || times[i] != times[i - 1]) {
         auto t = start_t + boost::posix_time::seconds(int(times[i]));
         logv->addValue(t, value[i]);
@@ -710,52 +720,6 @@ private:
     }
     return logv;
   }
-};
-
-/**  Implements NXnote Nexus class.
- */
-class MANTID_NEXUS_DLL NXNote : public NXClass {
-public:
-  /**  Constructor.
-   *   @param parent :: The parent Nexus class. In terms of HDF it is the group
-   * containing the NXClass.
-   *   @param name :: The name of the NXClass relative to its parent
-   */
-  NXNote(const NXClass &parent, const std::string &name)
-      : NXClass(parent, name), m_author_ok(), m_data_ok(), m_description_ok() {}
-  /// Nexus class id
-  std::string NX_class() const override { return "NXnote"; }
-  /// Returns the note's author
-  std::string author();
-  /// Returns the note's content
-  std::vector<std::string> &data();
-  /// Returns the description string
-  std::string description();
-
-protected:
-  std::string m_author;            ///< author
-  std::vector<std::string> m_data; ///< content
-  std::string m_description;       ///< description
-  bool m_author_ok;                ///< author loaded indicator
-  bool m_data_ok;                  ///< data loaded indicator
-  bool m_description_ok;           ///< description loaded indicator
-};
-
-/**  Implements NXnote Nexus class with binary data.
- */
-class MANTID_NEXUS_DLL NXBinary : public NXNote {
-public:
-  /**  Constructor.
-   *   @param parent :: The parent Nexus class. In terms of HDF it is the group
-   * containing the NXClass.
-   *   @param name :: The name of the NXClass relative to its parent
-   */
-  NXBinary(const NXClass &parent, const std::string &name) : NXNote(parent, name) {}
-  /// Return the binary data associated with the note
-  std::vector<char> &binary();
-
-private:
-  std::vector<char> m_binary; ///< content
 };
 
 //-------------------- main classes -------------------------------//
@@ -779,7 +743,6 @@ public:
    *   @param name :: The name of the NXNote
    *   @return The note
    */
-  NXNote openNXNote(const std::string &name) { return openNXClass<NXNote>(name); }
 };
 
 /**  Implements NXdata Nexus class.
@@ -844,22 +807,6 @@ public:
   NXFloat openPolarAngle() { return openNXFloat("polar_angle"); }
 };
 
-/**  Implements NXdisk_chopper Nexus class.
- */
-class MANTID_NEXUS_DLL NXDiskChopper : public NXMainClass {
-public:
-  /**  Constructor.
-   *   @param parent :: The parent Nexus class. In terms of HDF it is the group
-   * containing the NXClass.
-   *   @param name :: The name of the NXClass relative to its parent
-   */
-  NXDiskChopper(const NXClass &parent, const std::string &name) : NXMainClass(parent, name) {}
-  /// Nexus class id
-  std::string NX_class() const override { return "NXdisk_chopper"; }
-  /// Opens the dataset containing pixel distances
-  NXFloat openRotationSpeed() { return openNXFloat("rotation_speed"); }
-};
-
 /**  Implements NXinstrument Nexus class.
  */
 class MANTID_NEXUS_DLL NXInstrument : public NXMainClass {
@@ -877,12 +824,6 @@ public:
    *   @return The detector
    */
   NXDetector openNXDetector(const std::string &name) { return openNXClass<NXDetector>(name); }
-
-  /**  Opens a NXDetector
-   *   @param name :: The name of the class
-   *   @return The detector
-   */
-  NXDiskChopper openNXDiskChopper(const std::string &name) { return openNXClass<NXDiskChopper>(name); }
 };
 
 /**  Implements NXentry Nexus class.

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -133,19 +133,6 @@ void NXObject::getAttributes() {
 
 NXClass::NXClass(const NXClass &parent, const std::string &name) : NXObject(parent.m_fileID, &parent, name) { clear(); }
 
-NXClassInfo NXClass::getNextEntry() {
-  NXClassInfo res;
-  try {
-    auto entry = m_fileID->getNextEntry();
-    res.stat = NXstatus::NX_OK;
-    res.nxname = entry.first;
-    res.nxclass = entry.second;
-  } catch (::NeXus::Exception const &e) {
-    res.stat = e.status();
-  }
-  return res;
-}
-
 void NXClass::readAllInfo() {
   clear();
   for (auto const &entry : m_fileID->getEntries()) {

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -166,7 +166,7 @@ bool NXClass::isValid(const std::string &path) const {
     m_fileID->openGroupPath(path);
     m_fileID->closeGroup();
     return true;
-  } catch (::NeXus::Exception const &e) {
+  } catch (::NeXus::Exception const &) {
     return false;
   }
 }
@@ -202,7 +202,7 @@ bool NXClass::openLocal(const std::string &nxclass) {
 void NXClass::close() {
   try {
     m_fileID->closeGroup();
-  } catch (::NeXus::Exception const &e) {
+  } catch (::NeXus::Exception const &) {
     throw std::runtime_error("Cannot close group " + name() + " of class " + NX_class() + " (trying to close path " +
                              m_path + ")");
   }

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -5,14 +5,23 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidNexus/NexusClasses.h"
-
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/PropertyWithValue.h"
+#include "MantidNexusCpp/NeXusException.hpp"
+#include "MantidNexusCpp/NeXusFile.hpp"
 
 #include <memory>
 #include <utility>
 
 namespace Mantid::NeXus {
+
+static NXDimArray dimArray(::NeXus::DimVector xd) {
+  return NXDimArray({static_cast<DimSize>(xd[0]), static_cast<DimSize>(xd[1]), static_cast<DimSize>(xd[2]),
+                     static_cast<DimSize>(xd[3])});
+}
+
+NXInfo::NXInfo(::NeXus::Info const &info, std::string const &name)
+    : nxname(name), rank(info.dims.size()), dims(dimArray(info.dims)), type(info.type), stat(NXstatus::NX_OK) {}
 
 std::vector<std::string> NXAttributes::names() const {
   std::vector<std::string> out;
@@ -48,11 +57,11 @@ std::string NXAttributes::operator()(const std::string &name) const {
  */
 void NXAttributes::set(const std::string &name, const std::string &value) { m_values[name] = value; }
 
-/**  Sets the value of the attribute as a double.
+/**  Sets the value of the attribute from typed value.
  *   @param name :: The name of the attribute
  *   @param value :: The new value of the attribute
  */
-void NXAttributes::set(const std::string &name, double value) {
+template <typename T> void NXAttributes::set(const std::string &name, T value) {
   std::ostringstream ostr;
   ostr << value;
   m_values[name] = ostr.str();
@@ -62,13 +71,17 @@ void NXAttributes::set(const std::string &name, double value) {
 //          NXObject methods
 //---------------------------------------------------------
 
+/**  NXObject private default constructor
+ */
+NXObject::NXObject() : m_fileID(nullptr), m_open(false) {}
+
 /**  NXObject constructor.
  *   @param fileID :: The Nexus file id
  *   @param parent :: The parent Nexus class. In terms of HDF it is the group
  * containing the object.
  *   @param name :: The name of the object relative to its parent
  */
-NXObject::NXObject(const NXhandle fileID, const NXClass *parent, const std::string &name)
+NXObject::NXObject(::NeXus::File *fileID, NXClass const *parent, const std::string &name)
     : m_fileID(fileID), m_open(false) {
   if (parent && !name.empty()) {
     m_path = parent->path() + "/" + name;
@@ -86,51 +99,27 @@ std::string NXObject::name() const {
 /**  Reads in attributes
  */
 void NXObject::getAttributes() {
-  NXname pName;
-  NXnumtype iType;
-  int iLength;
-  int rank;
-  int dims[4];
   std::vector<char> buff(128);
-
-  while (NXgetnextattra(m_fileID, pName, &rank, dims, &iType) != NXstatus::NX_EOD) {
-    if (rank > 1) { // mantid only supports single value attributes
-      throw std::runtime_error("Encountered attribute with multi-dimensional array value");
-    }
-    iLength = dims[0]; // to clarify things
-    if (iType != NXnumtype::CHAR && iLength != 1) {
+  for (::NeXus::AttrInfo const &ainfo : m_fileID->getAttrInfos()) {
+    if (ainfo.type != NXnumtype::CHAR && ainfo.length != 1) {
       throw std::runtime_error("Encountered attribute with array value");
     }
 
-    switch (iType) {
+    switch (ainfo.type) {
     case NXnumtype::CHAR: {
-      if (iLength >= 0 && (unsigned)iLength > buff.size()) {
-        buff.resize(iLength);
-      }
-      int nz = iLength + 1;
-      NXgetattr(m_fileID, pName, buff.data(), &nz, &iType);
-      attributes.set(pName, buff.data());
+      attributes.set(ainfo.name, m_fileID->getStrAttr(ainfo));
       break;
     }
     case NXnumtype::INT16: {
-      short int value;
-      NXgetattr(m_fileID, pName, &value, &iLength, &iType);
-      sprintf(buff.data(), "%i", value);
-      attributes.set(pName, buff.data());
+      attributes.set(ainfo.name, m_fileID->getAttr<short int>(ainfo));
       break;
     }
     case NXnumtype::INT32: {
-      int value;
-      NXgetattr(m_fileID, pName, &value, &iLength, &iType);
-      sprintf(buff.data(), "%i", value);
-      attributes.set(pName, buff.data());
+      attributes.set(ainfo.name, m_fileID->getAttr<int>(ainfo));
       break;
     }
     case NXnumtype::UINT16: {
-      short unsigned int value;
-      NXgetattr(m_fileID, pName, &value, &iLength, &iType);
-      sprintf(buff.data(), "%u", value);
-      attributes.set(pName, buff.data());
+      attributes.set(ainfo.name, m_fileID->getAttr<short unsigned int>(ainfo));
       break;
     }
     default:
@@ -146,50 +135,44 @@ NXClass::NXClass(const NXClass &parent, const std::string &name) : NXObject(pare
 
 NXClassInfo NXClass::getNextEntry() {
   NXClassInfo res;
-  char nxname[NX_MAXNAMELEN], nxclass[NX_MAXNAMELEN];
-  // cppcheck-suppress argumentSize
-  res.stat = NXgetnextentry(m_fileID, nxname, nxclass, &res.datatype);
-  if (res) // Check if previous call was successful
-  {
-    res.nxname = nxname;
-    res.nxclass = nxclass;
+  try {
+    auto entry = m_fileID->getNextEntry();
+    res.stat = NXstatus::NX_OK;
+    res.nxname = entry.first;
+    res.nxclass = entry.second;
+  } catch (::NeXus::Exception const &e) {
+    res.stat = e.status();
   }
   return res;
 }
 
 void NXClass::readAllInfo() {
   clear();
-  NXClassInfo info;
-  while ((info = getNextEntry())) {
-    if (info.nxclass == "SDS") {
-      NXInfo data_info;
-      NXopendata(m_fileID, info.nxname.c_str());
-      data_info.stat = NXgetinfo(m_fileID, &data_info.rank, data_info.dims, &data_info.type);
-      NXclosedata(m_fileID);
-      data_info.nxname = info.nxname;
-      m_datasets->emplace_back(data_info);
-    } else if (info.nxclass.substr(0, 2) == "NX" || info.nxclass.substr(0, 2) == "IX") {
-      m_groups->emplace_back(info);
+  for (auto const &entry : m_fileID->getEntries()) {
+    if (entry.second == "SDS") {
+      m_fileID->openData(entry.first);
+      NXInfo info(m_fileID->getInfo(), entry.first);
+      m_fileID->closeData();
+      m_datasets->emplace_back(info);
+    } else if (entry.second.substr(0, 2) == "NX" || entry.second.substr(0, 2) == "IX") {
+      m_groups->emplace_back(NXClassInfo(entry));
     }
   }
   reset();
 }
 
 bool NXClass::isValid(const std::string &path) const {
-  if (NXopengrouppath(m_fileID, path.c_str()) == NXstatus::NX_OK) {
-    NXclosegroup(m_fileID);
+  try {
+    m_fileID->openGroupPath(path);
+    m_fileID->closeGroup();
     return true;
-  } else
+  } catch (::NeXus::Exception const &e) {
     return false;
+  }
 }
 
 void NXClass::open() {
-  if (NXopengrouppath(m_fileID, m_path.c_str()) == NXstatus::NX_ERROR) {
-
-    throw std::runtime_error("Cannot open group " + name() + " of class " + NX_class() + " (trying to open path " +
-                             m_path + ")");
-  }
-  //}
+  m_fileID->openGroupPath(m_path);
   m_open = true;
   readAllInfo();
 }
@@ -206,13 +189,9 @@ void NXClass::open() {
  */
 bool NXClass::openLocal(const std::string &nxclass) {
   std::string className = nxclass.empty() ? NX_class() : nxclass;
-  if (NXopengroup(m_fileID, name().c_str(), className.c_str()) == NXstatus::NX_ERROR) {
-    // It would be nice if this worked
-    // if (NXstatus::NX_ERROR == NXopengrouppath(m_fileID,m_path.c_str()))
-    //{
-    //  throw std::runtime_error("Cannot open group "+m_path+" of class
-    //  "+NX_class());
-    //}
+  try {
+    m_fileID->openGroup(name(), className);
+  } catch (::NeXus::Exception const &) {
     return false;
   }
   m_open = true;
@@ -221,14 +200,16 @@ bool NXClass::openLocal(const std::string &nxclass) {
 }
 
 void NXClass::close() {
-  if (NXclosegroup(m_fileID) == NXstatus::NX_ERROR) {
+  try {
+    m_fileID->closeGroup();
+  } catch (::NeXus::Exception const &e) {
     throw std::runtime_error("Cannot close group " + name() + " of class " + NX_class() + " (trying to close path " +
                              m_path + ")");
   }
   m_open = false;
 }
 
-void NXClass::reset() { NXinitgroupdir(m_fileID); }
+void NXClass::reset() { m_fileID->initGroupDir(); }
 
 void NXClass::clear() {
   m_groups.reset(new std::vector<NXClassInfo>);
@@ -296,75 +277,6 @@ bool NXClass::containsDataSet(const std::string &query) const {
 }
 
 //---------------------------------------------------------
-//          NXNote methods
-//---------------------------------------------------------
-
-std::string NXNote::author() {
-  if (!m_author_ok) {
-    NXChar aut = openNXChar("author");
-    aut.load();
-    m_author = std::string(aut(), aut.dim0());
-    m_author_ok = true;
-  }
-  return m_author;
-}
-
-std::vector<std::string> &NXNote::data() {
-  if (!m_data_ok) {
-    int rank;
-    int dims[4];
-    NXnumtype type;
-    NXopendata(m_fileID, "data");
-    NXgetinfo(m_fileID, &rank, dims, &type);
-    int n = dims[0];
-    auto buffer = new char[n];
-    NXstatus stat = NXgetdata(m_fileID, buffer);
-    NXclosedata(m_fileID);
-    m_data.clear();
-    if (stat == NXstatus::NX_ERROR) {
-      delete[] buffer;
-      return m_data;
-    }
-    std::istringstream istr(std::string(buffer, n));
-    delete[] buffer;
-
-    std::string line;
-    while (getline(istr, line)) {
-      m_data.emplace_back(line);
-    }
-
-    m_data_ok = true;
-  }
-  return m_data;
-}
-
-std::string NXNote::description() {
-  if (!m_description_ok) {
-    NXChar str = openNXChar("description");
-    str.load();
-    m_description = std::string(str(), str.dim0());
-    m_description_ok = true;
-  }
-  return m_description;
-}
-
-std::vector<char> &NXBinary::binary() {
-  if (!m_data_ok) {
-    int rank;
-    int dims[4];
-    NXnumtype type;
-    NXopendata(m_fileID, "data");
-    NXgetinfo(m_fileID, &rank, dims, &type);
-    int n = dims[0];
-    m_binary.resize(n);
-    NXstatus stat = NXgetdata(m_fileID, &m_binary[0]);
-    (void)stat; // Avoid unused variable compiler warning
-    NXclosedata(m_fileID);
-  }
-  return m_binary;
-}
-
-//---------------------------------------------------------
 //          NXRoot methods
 //---------------------------------------------------------
 
@@ -373,9 +285,10 @@ std::vector<char> &NXBinary::binary() {
  */
 NXRoot::NXRoot(std::string fname) : m_filename(std::move(fname)) {
   // Open NeXus file
-  NXstatus stat = NXopen(m_filename.c_str(), NXACC_READ, &m_fileID);
-  if (stat == NXstatus::NX_ERROR) {
-    std::cout << "NXRoot: Error loading " << m_filename;
+  try {
+    m_fileID = new ::NeXus::File(m_filename, NXACC_READ);
+  } catch (::NeXus::Exception const &e) {
+    std::cout << "NXRoot: Error loading " << m_filename << "\" in read mode: " << e.what() << "\n";
     throw Kernel::Exception::FileError("Unable to open File:", m_filename);
   }
   readAllInfo();
@@ -386,16 +299,16 @@ NXRoot::NXRoot(std::string fname) : m_filename(std::move(fname)) {
  *   @param fname :: The file name to create
  *   @param entry :: The name of the first entry in the new file
  */
-NXRoot::NXRoot(std::string fname, const std::string &entry) : m_filename(std::move(fname)) {
-  (void)entry;
+NXRoot::NXRoot(std::string fname, const std::string &) : m_filename(std::move(fname)) {
   // Open NeXus file
-  NXstatus stat = NXopen(m_filename.c_str(), NXACC_CREATE5, &m_fileID);
-  if (stat == NXstatus::NX_ERROR) {
+  try {
+    m_fileID = new ::NeXus::File(m_filename, NXACC_CREATE5);
+  } catch (::NeXus::Exception const &) {
     throw Kernel::Exception::FileError("Unable to open File:", m_filename);
   }
 }
 
-NXRoot::~NXRoot() { NXclose(&m_fileID); }
+NXRoot::~NXRoot() { m_fileID->close(); }
 
 bool NXRoot::isStandard() const { return true; }
 
@@ -440,30 +353,18 @@ void NXDataSet::open() {
   if (i == std::string::npos || i == 0)
     return; // we are in the root group, assume it is open
   std::string group_path = m_path.substr(0, i);
-  if (NXopenpath(m_fileID, group_path.c_str()) == NXstatus::NX_ERROR) {
-    throw std::runtime_error("Cannot open dataset " + m_path);
-  }
-  if (NXopendata(m_fileID, name().c_str()) != NXstatus::NX_OK) {
-    throw std::runtime_error("Error opening data in group \"" + name() + "\"");
-  }
-
-  if (NXgetinfo(m_fileID, &m_info.rank, m_info.dims, &m_info.type) != NXstatus::NX_OK) {
-    throw std::runtime_error("Error retrieving information for " + name() + " group");
-  }
-
+  m_fileID->openPath(group_path);
+  m_fileID->openData(name());
+  m_info = NXInfo(m_fileID->getInfo(), name());
   getAttributes();
-  NXclosedata(m_fileID);
+  m_fileID->closeData();
 }
 
 void NXDataSet::openLocal() {
-  if (NXopendata(m_fileID, name().c_str()) != NXstatus::NX_OK) {
-    throw std::runtime_error("Error opening data in group \"" + name() + "\"");
-  }
-  if (NXgetinfo(m_fileID, &m_info.rank, m_info.dims, &m_info.type) != NXstatus::NX_OK) {
-    throw std::runtime_error("Error retrieving information for " + name() + " group");
-  }
+  m_fileID->openData(name());
+  m_info = NXInfo(m_fileID->getInfo(), name());
   getAttributes();
-  NXclosedata(m_fileID);
+  m_fileID->closeData();
 }
 
 /**
@@ -472,10 +373,10 @@ void NXDataSet::openLocal() {
  * @throws out_of_range error if requested on an object of rank 0
  */
 int NXDataSet::dim0() const {
-  if (m_info.rank == 0) {
+  if (m_info.rank == 0UL) {
     throw std::out_of_range("NXDataSet::dim0() - Requested dimension greater than rank.");
   }
-  return m_info.dims[0];
+  return static_cast<int>(m_info.dims[0]);
 }
 
 /**
@@ -484,10 +385,10 @@ int NXDataSet::dim0() const {
  * @throws out_of_range error if requested on an object of rank < 2
  */
 int NXDataSet::dim1() const {
-  if (m_info.rank < 2) {
+  if (m_info.rank < 2UL) {
     throw std::out_of_range("NXDataSet::dim1() - Requested dimension greater than rank.");
   }
-  return m_info.dims[1];
+  return static_cast<int>(m_info.dims[1]);
 }
 
 /**
@@ -496,10 +397,10 @@ int NXDataSet::dim1() const {
  * @throws out_of_range error if requested on an object of rank < 3
  */
 int NXDataSet::dim2() const {
-  if (m_info.rank < 3) {
+  if (m_info.rank < 3UL) {
     throw std::out_of_range("NXDataSet::dim2() - Requested dimension greater than rank.");
   }
-  return m_info.dims[2];
+  return static_cast<int>(m_info.dims[2]);
 }
 
 /**
@@ -508,10 +409,10 @@ int NXDataSet::dim2() const {
  * @throws out_of_range error if requested on an object of rank < 4
  */
 int NXDataSet::dim3() const {
-  if (m_info.rank < 4) {
+  if (m_info.rank < 4UL) {
     throw std::out_of_range("NXDataSet::dim3() - Requested dimension greater than rank.");
   }
-  return m_info.dims[3];
+  return static_cast<int>(m_info.dims[3]);
 }
 
 /**  Wrapper to the NXgetdata.
@@ -519,10 +420,9 @@ int NXDataSet::dim3() const {
  *   @throw runtime_error if the operation fails.
  */
 void NXDataSet::getData(void *data) {
-  NXopendata(m_fileID, name().c_str());
-  if (NXgetdata(m_fileID, data) != NXstatus::NX_OK)
-    throw std::runtime_error("Cannot read data from NeXus file");
-  NXclosedata(m_fileID);
+  m_fileID->openData(name());
+  m_fileID->getData(data);
+  m_fileID->closeData();
 }
 
 /**  Wrapper to the NXgetslab.
@@ -536,11 +436,12 @@ void NXDataSet::getData(void *data) {
  * the rank of the data.
  *   @throw runtime_error if the operation fails.
  */
-void NXDataSet::getSlab(void *data, int start[], int size[]) {
-  NXopendata(m_fileID, name().c_str());
-  if (NXgetslab(m_fileID, data, start, size) != NXstatus::NX_OK)
-    throw std::runtime_error("Cannot read data slab from NeXus file");
-  NXclosedata(m_fileID);
+void NXDataSet::getSlab(void *data, NXDimArray const &start, NXDimArray const &size) {
+  std::vector<::NeXus::DimSize> vstart(start.cbegin(), start.cend());
+  std::vector<::NeXus::DimSize> vsize(size.cbegin(), size.cend());
+  m_fileID->openData(name());
+  m_fileID->getSlab(data, vstart, vsize);
+  m_fileID->closeData();
 }
 
 //---------------------------------------------------------

--- a/Framework/NexusCpp/inc/MantidNexusCpp/NeXusException.hpp
+++ b/Framework/NexusCpp/inc/MantidNexusCpp/NeXusException.hpp
@@ -38,7 +38,7 @@ public:
    *
    * \return the status value associated with the exception
    */
-  NXstatus status() throw();
+  NXstatus status() const throw();
   /** Destructor for exception */
   virtual ~Exception() throw();
 

--- a/Framework/NexusCpp/inc/MantidNexusCpp/NeXusFile.hpp
+++ b/Framework/NexusCpp/inc/MantidNexusCpp/NeXusFile.hpp
@@ -2,11 +2,14 @@
 
 #include "MantidNexusCpp/DllConfig.h"
 #include "MantidNexusCpp/NeXusFile_fwd.h"
-#include "MantidNexusCpp/napi.h"
 #include <map>
 #include <string>
 #include <utility>
 #include <vector>
+
+namespace {
+static const std::string NULL_STR("NULL");
+}
 
 /**
  * \file NeXusFile.hpp Definition of the NeXus C++ API.
@@ -18,48 +21,13 @@
 namespace NeXus {
 
 /**
- * The available compression types. These are all ignored in xml files.
- * \li NONE no compression
- * \li LZW Lossless Lempel Ziv Welch compression (recommended)
- * \li RLE Run length encoding (only HDF-4)
- * \li HUF Huffmann encoding (only HDF-4)
- * \ingroup cpp_types
- */
-enum NXcompression { CHUNK = NX_CHUNK, NONE = NX_COMP_NONE, LZW = NX_COMP_LZW, RLE = NX_COMP_RLE, HUF = NX_COMP_HUF };
-
-/**
- * Type definition for a type-keyed multimap
- */
-typedef std::multimap<std::string, std::string> TypeMap;
-
-/**
- * This structure holds the type and dimensions of a primative field/array.
- */
-struct Info {
-  /** The primative type for the field. */
-  NXnumtype type;
-  /** The dimensions of the file. */
-  std::vector<int64_t> dims;
-};
-
-/** Information about an attribute. */
-struct AttrInfo {
-  /** The primative type for the attribute. */
-  NXnumtype type;
-  /** The length of the attribute. */
-  unsigned length;
-  /** The name of the attribute. */
-  std::string name;
-  /** The dimensions of the attribute. */
-  std::vector<int> dims;
-};
-
-/**
  * The Object that allows access to the information in the file.
  * \ingroup cpp_core
  */
 class MANTID_NEXUSCPP_DLL File {
 private:
+  std::string m_filename;
+  NXaccess m_access;
   /** The handle for the C-API. */
   NXhandle m_file_id;
   /** should be close handle on exit */
@@ -69,18 +37,18 @@ public:
   /**
    * \return A pair of the next entry available in a listing.
    */
-  std::pair<std::string, std::string> getNextEntry();
+  Entry getNextEntry();
   /**
    * \return Information about the next attribute.
    */
   AttrInfo getNextAttr();
 
-private:
   /**
    * Initialize the pending group search to start again.
    */
   void initGroupDir();
 
+private:
   /**
    * Initialize the pending attribute search to start again.
    */
@@ -111,12 +79,25 @@ public:
   File(const char *filename, const NXaccess access = NXACC_READ);
 
   /**
-   * Use an existing handle returned from NXopen()
+   * Copy constructor
    *
-   * \param handle Handle to connect to
-   * \param close_handle Should the handle be closed on destruction
+   * \param f File to copy over, to complete rule of three
    */
-  File(NXhandle handle, bool close_handle = false);
+  File(File const &f);
+
+  /**
+   * Copy constructor from pointer
+   *
+   * \param pf Pointer to file to copy over
+   */
+  File(File const *const pf);
+
+  /**
+   * Assignment operator, to complete the rule of three
+   *
+   * \param f File to assign
+   */
+  File &operator=(File const &f);
 
   /** Destructor. This does close the file. */
   ~File();
@@ -155,6 +136,15 @@ public:
   void openPath(const std::string &path);
 
   /**
+   * Open the group in which the NeXus object with the specified path exists.
+   *
+   * \param path A unix like path string to a group or field. The path
+   * string is a list of group names and SDS names separated with a slash,
+   * '/' (i.e. "/entry/sample/name").
+   */
+  void openGroupPath(const std::string &path);
+
+  /**
    * Get the path into the current file
    * \return A unix like path string pointing to the current
    *         position in the file
@@ -168,7 +158,7 @@ public:
 
   /**
    * \copydoc NeXus::File::makeData(const std::string&, NXnumtype,
-   *                              const std::vector<int64_t>&, bool);
+   *                              const DimVector&, bool);
    */
   void makeData(const std::string &name, NXnumtype type, const std::vector<int> &dims, bool open_data = false);
 
@@ -180,7 +170,7 @@ public:
    * \param dims The dimensions of the field.
    * \param open_data Whether or not to open the data after creating it.
    */
-  void makeData(const std::string &name, NXnumtype type, const std::vector<int64_t> &dims, bool open_data = false);
+  void makeData(const std::string &name, NXnumtype type, const DimVector &dims, bool open_data = false);
 
   /**
    * Create a 1D data field with the specified information.
@@ -247,7 +237,7 @@ public:
    * \tparam NumT numeric data type of \a value
    */
   template <typename NumT>
-  void writeData(const std::string &name, const std::vector<NumT> &value, const std::vector<int64_t> &dims);
+  void writeData(const std::string &name, const std::vector<NumT> &value, const DimVector &dims);
 
   /** Create a 1D data field with an unlimited dimension, insert the data, and close the data.
    *
@@ -265,7 +255,7 @@ public:
    * \param chunkSize :: chunk size to use when writing
    */
   template <typename NumT>
-  void writeExtendibleData(const std::string &name, std::vector<NumT> &value, const int64_t chunk);
+  void writeExtendibleData(const std::string &name, std::vector<NumT> &value, const DimSize chunk);
 
   /** Create a 1D data field with an unlimited dimension, insert the data, and close the data.
    *
@@ -276,8 +266,7 @@ public:
    * \param chunk :: chunk size to use when writing
    */
   template <typename NumT>
-  void writeExtendibleData(const std::string &name, std::vector<NumT> &value, std::vector<int64_t> &dims,
-                           std::vector<int64_t> &chunk);
+  void writeExtendibleData(const std::string &name, std::vector<NumT> &value, DimVector &dims, DimSizeVector &chunk);
 
   /** Updates the data written into an already-created
    * data vector. If the data was created as extendible, it will be resized.
@@ -296,13 +285,12 @@ public:
    * \param value :: The vector to put into the file.
    * \param dims :: The dimensions of the data.
    */
-  template <typename NumT>
-  void writeUpdatedData(const std::string &name, std::vector<NumT> &value, std::vector<int64_t> &dims);
+  template <typename NumT> void writeUpdatedData(const std::string &name, std::vector<NumT> &value, DimVector &dims);
 
   /**
    * \copydoc makeCompData(const std::string&, const NXnumtype,
-   *                       const std::vector<int64_t>&, const NXcompression,
-   *                       const std::vector<int64_t>&, bool)
+   *                       const DimVector&, const NXcompression,
+   *                       const DimSizeVector&, bool)
    */
   void makeCompData(const std::string &name, const NXnumtype type, const std::vector<int> &dims,
                     const NXcompression comp, const std::vector<int> &bufsize, bool open_data = false);
@@ -317,14 +305,14 @@ public:
    * \param bufsize The size of the compression buffer to use.
    * \param open_data Whether or not to open the data after creating it.
    */
-  void makeCompData(const std::string &name, const NXnumtype type, const std::vector<int64_t> &dims,
-                    const NXcompression comp, const std::vector<int64_t> &bufsize, bool open_data = false);
+  void makeCompData(const std::string &name, const NXnumtype type, const DimVector &dims, const NXcompression comp,
+                    const DimSizeVector &bufsize, bool open_data = false);
 
   /**
    * \copydoc writeCompData(const std::string & name,
    *                        const std::vector<NumT> & value,
-   *                        const std::vector<int64_t> & dims, const NXcompression comp,
-   *                        const std::vector<int64_t> & bufsize)
+   *                        const DimVector & dims, const NXcompression comp,
+   *                        const DimSizeVector & bufsize)
    */
   template <typename NumT>
   void writeCompData(const std::string &name, const std::vector<NumT> &value, const std::vector<int> &dims,
@@ -341,8 +329,8 @@ public:
    * \tparam NumT numeric data type of \a value
    */
   template <typename NumT>
-  void writeCompData(const std::string &name, const std::vector<NumT> &value, const std::vector<int64_t> &dims,
-                     const NXcompression comp, const std::vector<int64_t> &bufsize);
+  void writeCompData(const std::string &name, const std::vector<NumT> &value, const DimVector &dims,
+                     const NXcompression comp, const DimSizeVector &bufsize);
 
   /**
    * \param name The name of the data to open.
@@ -399,8 +387,8 @@ public:
   void putAttr(const std::string &name, const std::string &value, const bool empty_add_space = true);
 
   /**
-   * \copydoc NeXus::File::putSlab(void* data, std::vector<int64_t>& start,
-   *                                std::vector<int64_t>& size)
+   * \copydoc NeXus::File::putSlab(void* data, DimSizeVector& start,
+   *                                DimSizeVector& size)
    */
   void putSlab(const void *data, const std::vector<int> &start, const std::vector<int> &size);
 
@@ -411,11 +399,11 @@ public:
    * \param start The starting index to insert the data.
    * \param size The size of the array to put in the file.
    */
-  void putSlab(const void *data, const std::vector<int64_t> &start, const std::vector<int64_t> &size);
+  void putSlab(const void *data, const DimSizeVector &start, const DimSizeVector &size);
 
   /**
-   * \copydoc NeXus::File::putSlab(std::vector<NumT>& data, std::vector<int64_t>&,
-   *                               std::vector<int64_t>&)
+   * \copydoc NeXus::File::putSlab(std::vector<NumT>& data, DimSizeVector&,
+   *                               DimSizeVector&)
    */
   template <typename NumT>
   void putSlab(const std::vector<NumT> &data, const std::vector<int> &start, const std::vector<int> &size);
@@ -429,7 +417,7 @@ public:
    * \tparam NumT numeric data type of \a data
    */
   template <typename NumT>
-  void putSlab(const std::vector<NumT> &data, const std::vector<int64_t> &start, const std::vector<int64_t> &size);
+  void putSlab(const std::vector<NumT> &data, const DimSizeVector &start, const DimSizeVector &size);
 
   /**
    * \copydoc NeXus::File::putSlab(std::vector<NumT>&, int64_t, int64_t)
@@ -444,7 +432,7 @@ public:
    * \param size The size of the array to put in the file.
    * \tparam NumT numeric data type of \a data
    */
-  template <typename NumT> void putSlab(const std::vector<NumT> &data, int64_t start, int64_t size);
+  template <typename NumT> void putSlab(const std::vector<NumT> &data, DimSize start, DimSize size);
 
   /**
    * \return The id of the data used for linking.
@@ -541,18 +529,18 @@ public:
   /**
    * Return the entries available in the current place in the file.
    */
-  std::map<std::string, std::string> getEntries();
+  Entries getEntries();
 
   /** Return the entries available in the current place in the file,
    * but avoids the map copy of getEntries().
    *
    * \param result The map that will be filled with the entries
    */
-  void getEntries(std::map<std::string, std::string> &result);
+  void getEntries(Entries &result);
 
   /**
-   * \copydoc NeXus::File::getSlab(void*, const std::vector<int64_t>&,
-   *                               const std::vector<int64_t>&)
+   * \copydoc NeXus::File::getSlab(void*, const DimSizeVector&,
+   *                               const DimSizeVector&)
    */
   void getSlab(void *data, const std::vector<int> &start, const std::vector<int> &size);
 
@@ -564,7 +552,7 @@ public:
    * from.
    * \param size The size of the block to read from the file.
    */
-  void getSlab(void *data, const std::vector<int64_t> &start, const std::vector<int64_t> &size);
+  void getSlab(void *data, const DimSizeVector &start, const DimSizeVector &size);
 
   /**
    * \return Information about all attributes on the data that is
@@ -633,5 +621,18 @@ public:
  * \tparam NumT numeric data type of \a number to check
  */
 template <typename NumT> MANTID_NEXUSCPP_DLL NXnumtype getType(NumT const number = NumT());
+
+MANTID_NEXUSCPP_DLL void EnableErrorReporting();
+
+MANTID_NEXUSCPP_DLL NXstatus setCache(long newVal);
+
+/**
+ * Set a global error function.
+ * Not threadsafe.
+ * \param pData A pointer to a user defined data structure which be passed to
+ * the error display function.
+ * \param newErr The new error display function.
+ */
+MANTID_NEXUSCPP_DLL void setError(void *pData, void (*newErr)(void *, const char *));
 
 }; // namespace NeXus

--- a/Framework/NexusCpp/inc/MantidNexusCpp/NeXusFile.hpp
+++ b/Framework/NexusCpp/inc/MantidNexusCpp/NeXusFile.hpp
@@ -20,6 +20,8 @@ static const std::string NULL_STR("NULL");
 
 namespace NeXus {
 
+static Entry const EOD_ENTRY(NULL_STR, NULL_STR);
+
 /**
  * The Object that allows access to the information in the file.
  * \ingroup cpp_core

--- a/Framework/NexusCpp/inc/MantidNexusCpp/napi.h
+++ b/Framework/NexusCpp/inc/MantidNexusCpp/napi.h
@@ -54,34 +54,6 @@
 /* NeXus HDF45 */
 #define NEXUS_VERSION "4.4.3" /* major.minor.patch */
 
-/*
- * Any new NXaccess_mode options should be numbered in 2^n format
- * (8, 16, 32, etc) so that they can be bit masked and tested easily.
- *
- * To test older non bit masked options (values below 8) use e.g.
- *
- *       if ( (mode & NXACCMASK_REMOVEFLAGS) == NXACC_CREATE )
- *
- * To test new (>=8) options just use normal bit masking e.g.
- *
- *       if ( mode & NXACC_NOSTRIP )
- *
- */
-#define NXACCMASK_REMOVEFLAGS (0x7) /* bit mask to remove higher flag options */
-
-#define NX_UNLIMITED -1
-
-#define NX_MAXRANK 32
-#define NX_MAXNAMELEN 64
-#define NX_MAXPATHLEN 1024
-
-/* Map NeXus compression methods to HDF compression methods */
-#define NX_CHUNK 0
-#define NX_COMP_NONE 100
-#define NX_COMP_LZW 200
-#define NX_COMP_RLE 300
-#define NX_COMP_HUF 400
-
 /* levels for deflate - to test for these we use ((value / 100) == NX_COMP_LZW) */
 #define NX_COMP_LZW_LVL0 (100 * NX_COMP_LZW + 0)
 #define NX_COMP_LZW_LVL1 (100 * NX_COMP_LZW + 1)
@@ -93,8 +65,6 @@
 #define NX_COMP_LZW_LVL7 (100 * NX_COMP_LZW + 7)
 #define NX_COMP_LZW_LVL8 (100 * NX_COMP_LZW + 8)
 #define NX_COMP_LZW_LVL9 (100 * NX_COMP_LZW + 9)
-
-#define NXMAXSTACK 50
 
 // name mangling macro
 #define CONCAT(__a, __b) __a##__b /* token concatenation */

--- a/Framework/NexusCpp/src/NeXusException.cpp
+++ b/Framework/NexusCpp/src/NeXusException.cpp
@@ -16,7 +16,7 @@ Exception::Exception(const std::string &msg, const NXstatus status) : std::runti
 
 const char *Exception::what() const throw() { return this->m_what.c_str(); }
 
-NXstatus Exception::status() throw() { return this->m_status; }
+NXstatus Exception::status() const throw() { return this->m_status; }
 
 Exception::~Exception() throw() {}
 

--- a/Framework/NexusCpp/src/NeXusFile.cpp
+++ b/Framework/NexusCpp/src/NeXusFile.cpp
@@ -752,7 +752,7 @@ pair<string, string> File::getNextEntry() {
     string str_class(class_name);
     return pair<string, string>(str_name, str_class);
   } else if (status == NXstatus::NX_EOD) {
-    return pair<string, string>(NULL_STR, NULL_STR); // TODO return the correct thing
+    return EOD_ENTRY;
   } else {
     throw Exception("NXgetnextentry failed", status);
   }
@@ -770,7 +770,7 @@ void File::getEntries(Entries &result) {
   Entry temp;
   while (true) {
     temp = this->getNextEntry();
-    if (temp.first == NULL_STR && temp.second == NULL_STR) { // TODO this needs to be changed when getNextEntry is fixed
+    if (temp == EOD_ENTRY) {
       break;
     } else {
       result.insert(temp);

--- a/Framework/NexusCpp/src/NeXusFile.cpp
+++ b/Framework/NexusCpp/src/NeXusFile.cpp
@@ -104,14 +104,10 @@ File::File(const char *filename, const NXaccess access) : m_filename(filename), 
 }
 
 File::File(File const &f)
-    : m_filename(f.m_filename), m_access(f.m_access), m_file_id(f.m_file_id), m_close_handle(f.m_close_handle) {
-  this->initOpenFile(m_filename, m_access);
-}
+    : m_filename(f.m_filename), m_access(f.m_access), m_file_id(f.m_file_id), m_close_handle(false) {}
 
 File::File(File const *const pf)
-    : m_filename(pf->m_filename), m_access(pf->m_access), m_file_id(pf->m_file_id), m_close_handle(pf->m_close_handle) {
-  this->initOpenFile(m_filename, m_access);
-}
+    : m_filename(pf->m_filename), m_access(pf->m_access), m_file_id(pf->m_file_id), m_close_handle(false) {}
 
 File &File::operator=(File const &f) {
   if (this == &f) {

--- a/Framework/NexusGeometry/src/NexusGeometryParser.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometryParser.cpp
@@ -799,7 +799,9 @@ public:
 
 std::unique_ptr<const Mantid::Geometry::Instrument>
 NexusGeometryParser::createInstrument(const std::string &fileName, std::unique_ptr<AbstractLogger> logger) {
-  const H5File file(fileName, H5F_ACC_RDONLY);
+  H5::FileAccPropList access_plist;
+  access_plist.setFcloseDegree(H5F_CLOSE_STRONG);
+  const H5File file(fileName, H5F_ACC_RDONLY, access_plist);
   auto rootGroup = file.openGroup("/");
   auto parentGroup = utilities::findGroupOrThrow(rootGroup, NX_ENTRY);
 
@@ -810,8 +812,9 @@ NexusGeometryParser::createInstrument(const std::string &fileName, std::unique_p
 std::unique_ptr<const Geometry::Instrument>
 NexusGeometryParser::createInstrument(const std::string &fileName, const std::string &parentGroupName,
                                       std::unique_ptr<AbstractLogger> logger) {
-
-  const H5File file(fileName, H5F_ACC_RDONLY);
+  H5::FileAccPropList access_plist;
+  access_plist.setFcloseDegree(H5F_CLOSE_STRONG);
+  const H5File file(fileName, H5F_ACC_RDONLY, access_plist);
   auto parentGroup = file.openGroup(std::string("/") + parentGroupName);
 
   Parser parser(std::move(logger));


### PR DESCRIPTION
### Description of work

#### Summary of work
This removes the last remaining `napi.h` dependence.  From now on, only `NeXus::File` will call the `napi` layer directoy.

Moving `napi.h` out of `NeXusFile.hpp` and into `NeXusFile.cpp` exposed some areas relying on `napi` through the `File` header.  I fixed these by just exposing an endpoint to `napi` through `::NeXus`.

The exception is `SaveISISNexus`, which relies heavily on `napi` functionality.  We are still debating if this needs to be edited, or if it can be entirely deleted.  For the moment, to get it to compile, I added the `napi.h` header to it.

It would be desirable at some point in the future to settle on the proper working of the `dims` array held in several of the classes.   It has a known, fixed size, and so should be a `std::array` object.  It also holds values representing sizes, so should be typed as `size_t` and not `int64_t` (and definitely not `int`).  However, that is way outside the scope of this work.  For the moment, instances involving these considerations were set to typedefs, which could hopefully be easily changed in the future.

Refs #38332

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Code review and make sure tests pass.  No behavior should be changed.

Most changes were minor, except for these five files:
- NexusClasses.h
- NexusClasses.cpp
- NeXusFile_fwd.h
- NeXusFile.hpp
- NeXusFile.cpp

Please review especially the updates in `NexusClasses.cpp`, to ensure the `NeXusFile` api is being called correctly.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
