### PR TITLE
Only log that an invalid monitor was seen once

### DIFF
--- a/Framework/LiveData/inc/MantidLiveData/SNSLiveEventDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/SNSLiveEventDataListener.h
@@ -16,6 +16,7 @@
 #include <Poco/Net/StreamSocket.h>
 #include <Poco/Runnable.h>
 #include <Poco/Timer.h>
+#include <set>
 
 namespace Mantid {
 namespace LiveData {
@@ -200,6 +201,9 @@ private:
   // from the previous state (which was probably NO_RUN).
   // This holds a copy of the RunStatusPkt until we can call setRunDetails().
   std::shared_ptr<ADARA::RunStatusPkt> m_deferredRunDetailsPkt;
+
+  /// list of monitors that were seen on the stream but are not in the IDF
+  std::set<detid_t> m_badMonitors;
 };
 
 } // namespace LiveData

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -851,8 +851,6 @@ shadowFunction:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/Kafka/KafkaTopicSubscr
 shadowFunction:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/Kafka/KafkaTopicSubscriber.cpp:452
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/LoadLiveData.cpp:49
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/LoadLiveData.cpp:58
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/SNSLiveEventDataListener.cpp:239
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/SNSLiveEventDataListener.cpp:246
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDEventsWSIndexing.h:166
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ImportMDHistoWorkspaceBase.h:27
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/inc/MantidMDAlgorithms/InvalidParameter.h:35

--- a/docs/source/release/v6.13.0/Framework/New_features/38803.rst
+++ b/docs/source/release/v6.13.0/Framework/New_features/38803.rst
@@ -1,0 +1,1 @@
+- ``SNSLiveEventDataListener`` was modified to only log invalid monitor ids once on each startup


### PR DESCRIPTION
Since it is events, the logger gets overwhelmed with messages from ill-configured monitor pixels. Rather than logging each one, log once and carry on.

Most of the edits are collapsing comments/strings into less lines since clang-format doesn't automatically rejoin them. This was only done in the functions modified rather than globally in the files.

#### Summary of work
At the moment SNAP has an additional monitor that was installed without updating the IDF. This generates a ton of log messages and locks up the mantid logger. This change reduces the volume of logs while still informing the user of the issue.

*There is no associated issue,* but this is associated with [EWM9484](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9484)

### To test:

Start live data listening on SNAP before they update the IDF. After this change there will be a lot less error messages.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
