### PR TITLE
Only log that an invalid monitor was seen once - ornl-next

### DIFF
--- a/Framework/LiveData/inc/MantidLiveData/SNSLiveEventDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/SNSLiveEventDataListener.h
@@ -16,6 +16,7 @@
 #include <Poco/Net/StreamSocket.h>
 #include <Poco/Runnable.h>
 #include <Poco/Timer.h>
+#include <set>
 
 namespace Mantid {
 namespace LiveData {
@@ -200,6 +201,9 @@ private:
   // from the previous state (which was probably NO_RUN).
   // This holds a copy of the RunStatusPkt until we can call setRunDetails().
   std::shared_ptr<ADARA::RunStatusPkt> m_deferredRunDetailsPkt;
+
+  /// list of monitors that were seen on the stream but are not in the IDF
+  std::set<detid_t> m_badMonitors;
 };
 
 } // namespace LiveData

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -851,8 +851,6 @@ shadowFunction:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/Kafka/KafkaTopicSubscr
 shadowFunction:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/Kafka/KafkaTopicSubscriber.cpp:452
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/LoadLiveData.cpp:49
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/LoadLiveData.cpp:58
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/SNSLiveEventDataListener.cpp:239
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/SNSLiveEventDataListener.cpp:246
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvToMDEventsWSIndexing.h:166
 missingOverride:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ImportMDHistoWorkspaceBase.h:27
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/inc/MantidMDAlgorithms/InvalidParameter.h:35

--- a/docs/source/release/v6.13.0/Framework/New_features/38803.rst
+++ b/docs/source/release/v6.13.0/Framework/New_features/38803.rst
@@ -1,0 +1,1 @@
+- ``SNSLiveEventDataListener`` was modified to only log invalid monitor ids once on each startup


### PR DESCRIPTION
This is a version of #38803 into `ornl-next`