### PR TITLE
Fix stack overflow error due to invalid condition

### DIFF
--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -85,8 +85,10 @@ namespace { // anonymous namespace for some utility functions
 /// static Logger object
 Logger g_log("ConfigService");
 
+const std::string PATH_DELIMITERS = ";,";
+
 /**
- * Split the supplied string on semicolons.
+ * Split the supplied string on semicolons and commas.
  *
  * @param path The path to split.
  * @returns vector containing the split path.
@@ -94,11 +96,11 @@ Logger g_log("ConfigService");
 std::vector<std::string> splitPath(const std::string &path) {
   std::vector<std::string> splitted;
 
-  if (path.find(';') == std::string::npos) { // don't bother tokenizing
+  if (path.find_first_of(PATH_DELIMITERS) == std::string::npos) { // don't bother tokenizing
     splitted.emplace_back(path);
   } else {
     int options = Mantid::Kernel::StringTokenizer::TOK_TRIM + Mantid::Kernel::StringTokenizer::TOK_IGNORE_EMPTY;
-    Mantid::Kernel::StringTokenizer tokenizer(path, ";,", options);
+    Mantid::Kernel::StringTokenizer tokenizer(path, PATH_DELIMITERS, options);
     auto iend = tokenizer.end();
     for (auto itr = tokenizer.begin(); itr != iend; ++itr) {
       if (!itr->empty()) {
@@ -425,7 +427,7 @@ std::string ConfigServiceImpl::makeAbsolute(const std::string &dir, const std::s
   }
   std::string converted;
   // If we have a list, chop it up and convert each one
-  if (dir.find_first_of(";,") != std::string::npos) {
+  if (dir.find_first_of(PATH_DELIMITERS) != std::string::npos) {
     auto splitted = splitPath(dir);
     auto iend = splitted.cend();
     for (auto itr = splitted.begin(); itr != iend;) {
@@ -1695,7 +1697,7 @@ void ConfigServiceImpl::updateFacilities(const std::string &fName) {
 /// Empty the list of facilities, deleting the FacilityInfo objects in the
 /// process
 void ConfigServiceImpl::clearFacilities() {
-  for (auto &facility : m_facilities) {
+  for (const auto &facility : m_facilities) {
     delete facility;
   }
   m_facilities.clear();

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -659,6 +659,35 @@ public:
     }
   }
 
+  void testsetDataSearchDirs() {
+    std::string dirs;
+    std::string expected = "/test/a/;/test/b/;/test/c/";
+
+    // separated all by ;
+    dirs = "/test/a/;/test/b/;/test/c/";
+    ConfigService::Instance().setDataSearchDirs(dirs);
+    TS_ASSERT_EQUALS(ConfigService::Instance().getString("datasearch.directories"), dirs);
+    ConfigService::Instance().reset();
+
+    // separated all by ,
+    dirs = "/test/a/,/test/b/,/test/c/";
+    ConfigService::Instance().setDataSearchDirs(dirs);
+    TS_ASSERT_EQUALS(ConfigService::Instance().getString("datasearch.directories"), expected);
+    ConfigService::Instance().reset();
+
+    // separated all by , and ;
+    dirs = "/test/a/,/test/b/;/test/c/";
+    ConfigService::Instance().setDataSearchDirs(dirs);
+    TS_ASSERT_EQUALS(ConfigService::Instance().getString("datasearch.directories"), expected);
+    ConfigService::Instance().reset();
+
+    // one path
+    dirs = "/test/a/";
+    ConfigService::Instance().setDataSearchDirs(dirs);
+    TS_ASSERT_EQUALS(ConfigService::Instance().getString("datasearch.directories"), dirs);
+    ConfigService::Instance().reset();
+  }
+
 protected:
   bool m_valueChangedSent;
   std::string m_key;

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -498,7 +498,6 @@ missingOverride:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/GitHubApiH
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/InstrumentInfo.h:47
 returnByReference:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/UsageService.h:63
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/AttenuationProfile.cpp:28
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/ConfigService.cpp:1698
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/DateValidator.cpp:122
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/DiskBuffer.cpp:363
 constVariablePointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/EnabledWhenProperty.cpp:111

--- a/docs/source/release/v6.13.0/Framework/Python/Bugfixes/38821.rst
+++ b/docs/source/release/v6.13.0/Framework/Python/Bugfixes/38821.rst
@@ -1,0 +1,1 @@
+- :class:`ConfigService.setDataSearchDirs <mantid.kernel.ConfigServiceImpl.setDataSearchDirs>` will no longer crash when comma separated paths are used in the `datasearch.directories` setting of the `mantid.user.properties` file.


### PR DESCRIPTION
### Description of work
This PR fixes a stack overflow error in `ConfigService` due to an invalid condition causing infinite recursion in the function `makeAbsolute`. 

Fixes #38704

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
In the `splitPath` function, the previous condition was only checking for the ";" delimiter. This causes `makeAbsolute` to call itself infinitely when the string contains only "," delimiters. I have corrected the function to include the "," delimiter, similar to the condition in `make absolute`, to ensure consistency. 
### To test:
1- Run this line in the Python script area:
``ConfigService.setDataSearchDirs("/archive/NDXSANS2D/user/masks/,/archive/NDXSANS2D/user/Masks/")``
2- It should work well without a crash
3- Check the data search dirs in Manage directories to ensure the two paths have been added correctly
4- Try different paths with combinations of "," and ";"

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
