### PR TITLE
Display region selectors on Reflectometry GUI Preview Tab slice viewer plot on workspace load

### DIFF
--- a/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
+++ b/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
@@ -216,6 +216,7 @@ Preview tab
 #. Check that moving and vertically resizing regions triggers a re-run of the reduction (note that changing only the width of the rectangular selectors on the slice viewer plot will **not** trigger a new reduction).
 #. Check that you can delete one of the Background regions by selecting it and pressing the ``Delete`` key on your keyboard.
 #. Click the ``Apply`` button at the bottom right of the tab. The selected regions of interest should be populated in the lookup table on the Experiment Settings tab.
+#. Click the ``Load`` button to reload the same run. The slice viewer plot should display selectors for the regions of interest that you saved in the previous step. The instrument view plot currently does not do this so should not display any selectors. If you click ``Apply`` without making any changes then the ``ROI Detector IDs`` entry in the Experiment Settings lookup table should be unchanged (i.e. it shouldn't be cleared).
 #. Back on the Reduction Preview tab, click the export button above the top left of the 1D plot. This should export a workspace called ``preview_reduced_ws`` to the ADS.
 #. Right-click the workspace and select ``Show History``:
 

--- a/docs/source/release/v6.13.0/Reflectometry/New_features/36573.rst
+++ b/docs/source/release/v6.13.0/Reflectometry/New_features/36573.rst
@@ -1,0 +1,1 @@
+-  When a workspace is loaded on the ISIS Reflectometry GUI :ref:`Reduction Preview <refl_preview>` tab, region selectors are now added to the slice viewer plot to display any ROIs from matching experiment settings.

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
@@ -28,6 +28,10 @@ class RegionSelectorView(QWidget):
 
         self.setWindowTitle("Region Selector")
 
+    @property
+    def data_view(self):
+        return self._data_view
+
     def set_workspace(self, workspace):
         self._data_view.image_info_widget.setWorkspace(workspace)
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -401,4 +401,39 @@ bool BatchPresenter::hasROIDetectorIDsForPreviewRow() const {
   }
   return true;
 }
+
+std::map<ROIType, ProcessingInstructions> BatchPresenter::getMatchingProcessingInstructionsForPreviewRow() const {
+  std::map<ROIType, ProcessingInstructions> roiMap;
+
+  auto const &previewRow = m_previewPresenter->getPreviewRow();
+  try {
+    if (auto const lookupRow = m_model->findLookupRow(previewRow)) {
+      if (auto const signalROI = lookupRow->processingInstructions()) {
+        roiMap[ROIType::Signal] = signalROI.get();
+      }
+      if (auto const backgroundROI = lookupRow->backgroundProcessingInstructions()) {
+        roiMap[ROIType::Background] = backgroundROI.get();
+      }
+      if (auto const transmissionROI = lookupRow->transmissionProcessingInstructions()) {
+        roiMap[ROIType::Transmission] = transmissionROI.get();
+      }
+    }
+  } catch (MultipleRowsFoundException const &) {
+    // Do nothing, we will just return an empty map
+  }
+
+  return roiMap;
+}
+
+boost::optional<ProcessingInstructions> BatchPresenter::getMatchingROIDetectorIDsForPreviewRow() const {
+  auto const &previewRow = m_previewPresenter->getPreviewRow();
+  try {
+    if (auto const lookupRow = m_model->findLookupRow(previewRow)) {
+      return lookupRow->roiDetectorIDs();
+    }
+  } catch (MultipleRowsFoundException const &) {
+    // Do nothing
+  }
+  return boost::none;
+}
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -389,19 +389,6 @@ void BatchPresenter::notifyPreviewApplyRequested() {
   m_experimentPresenter->notifyPreviewApplyRequested(previewRow);
 }
 
-bool BatchPresenter::hasROIDetectorIDsForPreviewRow() const {
-  auto const &previewRow = m_previewPresenter->getPreviewRow();
-  try {
-    auto const lookupRow = m_model->findLookupRow(previewRow);
-    if (!lookupRow || !lookupRow->roiDetectorIDs().has_value()) {
-      return false;
-    }
-  } catch (MultipleRowsFoundException const &) {
-    return false;
-  }
-  return true;
-}
-
 std::map<ROIType, ProcessingInstructions> BatchPresenter::getMatchingProcessingInstructionsForPreviewRow() const {
   std::map<ROIType, ProcessingInstructions> roiMap;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -96,6 +96,8 @@ public:
   std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> rowProcessingProperties() const override;
   void notifyPreviewApplyRequested() override;
   bool hasROIDetectorIDsForPreviewRow() const override;
+  std::map<ROIType, ProcessingInstructions> getMatchingProcessingInstructionsForPreviewRow() const override;
+  boost::optional<ProcessingInstructions> getMatchingROIDetectorIDsForPreviewRow() const override;
 
   // WorkspaceObserver overrides
   void postDeleteHandle(const std::string &wsName) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -95,7 +95,6 @@ public:
   int percentComplete() const override;
   std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> rowProcessingProperties() const override;
   void notifyPreviewApplyRequested() override;
-  bool hasROIDetectorIDsForPreviewRow() const override;
   std::map<ROIType, ProcessingInstructions> getMatchingProcessingInstructionsForPreviewRow() const override;
   boost::optional<ProcessingInstructions> getMatchingROIDetectorIDsForPreviewRow() const override;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -75,7 +75,6 @@ public:
   virtual Mantid::Geometry::Instrument_const_sptr instrument() const = 0;
   virtual std::string instrumentName() const = 0;
 
-  virtual bool hasROIDetectorIDsForPreviewRow() const = 0;
   virtual std::map<ROIType, ProcessingInstructions> getMatchingProcessingInstructionsForPreviewRow() const = 0;
   virtual boost::optional<ProcessingInstructions> getMatchingROIDetectorIDsForPreviewRow() const = 0;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -7,9 +7,11 @@
 #pragma once
 
 #include "GUI/Batch/RowProcessingAlgorithm.h"
+#include "GUI/Preview/ROIType.h"
 #include "MantidAPI/IAlgorithmRuntimeProps.h"
 #include "MantidGeometry/Instrument_fwd.h"
 #include "Reduction/Group.h"
+#include "Reduction/ProcessingInstructions.h"
 
 #include <memory>
 #include <string>
@@ -74,6 +76,8 @@ public:
   virtual std::string instrumentName() const = 0;
 
   virtual bool hasROIDetectorIDsForPreviewRow() const = 0;
+  virtual std::map<ROIType, ProcessingInstructions> getMatchingProcessingInstructionsForPreviewRow() const = 0;
+  virtual boost::optional<ProcessingInstructions> getMatchingROIDetectorIDsForPreviewRow() const = 0;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -107,14 +107,16 @@ private:
   std::unique_ptr<MantidQt::Widgets::IRegionSelector> m_regionSelector;
   std::unique_ptr<MantidQt::MantidWidgets::PlotPresenter> m_plotPresenter;
   std::shared_ptr<StubRegionObserver> m_stubRegionObserver;
+  bool m_plotExistingROIs = false;
 
   void updateWidgetEnabledState();
   void updateSelectedRegionInModelFromView();
+  void updateRegionSelectorWorkspace();
 
   void plotInstView();
   void plotRegionSelector();
   void plotLinePlot();
-  void runSumBanks();
+  void runSumBanks(bool const addExistingROIsToPlot);
   void runReduction();
   void clearRegionSelector();
   void clearReductionPlot();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -548,32 +548,6 @@ public:
     presenter->notifyPreviewApplyRequested();
   }
 
-  void testHasROIDetectorIDsForPreviewRow() {
-    auto const lookupRow = makeLookupRow(boost::none);
-    auto const maybeLookupRow = boost::optional<LookupRow>(lookupRow);
-    runHasROIDetectorIDsForPreviewRowTest(maybeLookupRow, true);
-  }
-
-  void testHasROIDetectorIDsForPreviewRowNoDetectorIdsInLookupRow() {
-    auto lookupRow = makeLookupRow(boost::none);
-    lookupRow.setRoiDetectorIDs(boost::none);
-    auto const maybeLookupRow = boost::optional<LookupRow>(lookupRow);
-    runHasROIDetectorIDsForPreviewRowTest(maybeLookupRow, false);
-  }
-
-  void testHasROIDetectorIDsForPreviewRowNoLookupRowFound() {
-    runHasROIDetectorIDsForPreviewRowTest(boost::none, false);
-  }
-
-  void testHasROIDetectorIDsForPreviewRowMultipleLookupRowsFound() {
-    auto mockModel = makeMockModel();
-    auto const previewRow = PreviewRow({"12345"});
-    EXPECT_CALL(*mockModel, findLookupPreviewRowProxy(_)).WillOnce(Throw(MultipleRowsFoundException("")));
-    auto presenter = makePresenter(std::move(mockModel));
-    EXPECT_CALL(*m_previewPresenter, getPreviewRow()).Times(1).WillOnce(ReturnRef(previewRow));
-    TS_ASSERT_EQUALS(presenter->hasROIDetectorIDsForPreviewRow(), false);
-  }
-
   void testGetMatchingProcessingInstructionsForPreviewRow() {
     auto const lookupRow = makeLookupRow(boost::none);
     auto const maybeLookupRow = boost::optional<LookupRow>(lookupRow);
@@ -695,12 +669,6 @@ private:
     auto const result = presenter->getMatchingProcessingInstructionsForPreviewRow();
     TS_ASSERT_EQUALS(result.size(), 2);
     return result;
-  }
-
-  void runHasROIDetectorIDsForPreviewRowTest(boost::optional<LookupRow> lookupRow, bool expectedResult) {
-    auto const previewRow = PreviewRow({"12345"});
-    auto const presenter = makePresenterWithPreviewRowLookup(lookupRow, previewRow);
-    TS_ASSERT_EQUALS(presenter->hasROIDetectorIDsForPreviewRow(), expectedResult);
   }
 
   void runGetMatchingROIDetectorIDsForPreviewRowTest(boost::optional<LookupRow> lookupRow,

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include "../../../ISISReflectometry/GUI/Batch/BatchPresenter.h"
+#include "../../../ISISReflectometry/GUI/Preview/ROIType.h"
+#include "../../../ISISReflectometry/Reduction/ProcessingInstructions.h"
 #include "../../../ISISReflectometry/Reduction/RowExceptions.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
 #include "../MainWindow/MockMainWindowPresenter.h"
@@ -572,6 +574,97 @@ public:
     TS_ASSERT_EQUALS(presenter->hasROIDetectorIDsForPreviewRow(), false);
   }
 
+  void testGetMatchingProcessingInstructionsForPreviewRow() {
+    auto const lookupRow = makeLookupRow(boost::none);
+    auto const maybeLookupRow = boost::optional<LookupRow>(lookupRow);
+    auto const previewRow = PreviewRow({"12345"});
+    auto const presenter = makePresenterWithPreviewRowLookup(maybeLookupRow, previewRow);
+    auto const result = presenter->getMatchingProcessingInstructionsForPreviewRow();
+    TS_ASSERT_EQUALS(result.size(), 3);
+    TS_ASSERT_EQUALS(result.at(ROIType::Signal), lookupRow.processingInstructions())
+    TS_ASSERT_EQUALS(result.at(ROIType::Background), lookupRow.backgroundProcessingInstructions())
+    TS_ASSERT_EQUALS(result.at(ROIType::Transmission), lookupRow.transmissionProcessingInstructions())
+  }
+
+  void testGetMatchingProcessingInstructionsForPreviewRowLookupRowHasNoInstructions() {
+    auto lookupRow = makeLookupRow(boost::none);
+    lookupRow.setProcessingInstructions(ROIType::Signal, boost::none);
+    lookupRow.setProcessingInstructions(ROIType::Background, boost::none);
+    lookupRow.setProcessingInstructions(ROIType::Transmission, boost::none);
+    auto const maybeLookupRow = boost::optional<LookupRow>(lookupRow);
+    auto const previewRow = PreviewRow({"12345"});
+    auto const presenter = makePresenterWithPreviewRowLookup(maybeLookupRow, previewRow);
+    auto const result = presenter->getMatchingProcessingInstructionsForPreviewRow();
+    TS_ASSERT(result.empty());
+  }
+
+  void testGetMatchingProcessingInstructionsForPreviewRowLookupRowHasNoSignalInstructions() {
+    auto lookupRow = makeLookupRow(boost::none);
+    auto const result =
+        runGetMatchingProcessingInstructionsForPreviewRowWithMissingInstruction(lookupRow, ROIType::Signal);
+    TS_ASSERT_EQUALS(result.at(ROIType::Background), lookupRow.backgroundProcessingInstructions());
+    TS_ASSERT_EQUALS(result.at(ROIType::Transmission), lookupRow.transmissionProcessingInstructions());
+  }
+
+  void testGetMatchingProcessingInstructionsForPreviewRowLookupRowHasNoBackgroundInstructions() {
+    auto lookupRow = makeLookupRow(boost::none);
+    auto const result =
+        runGetMatchingProcessingInstructionsForPreviewRowWithMissingInstruction(lookupRow, ROIType::Background);
+    TS_ASSERT_EQUALS(result.at(ROIType::Signal), lookupRow.processingInstructions());
+    TS_ASSERT_EQUALS(result.at(ROIType::Transmission), lookupRow.transmissionProcessingInstructions());
+  }
+
+  void testGetMatchingProcessingInstructionsForPreviewRowLookupRowHasNoTransmissionInstructions() {
+    auto lookupRow = makeLookupRow(boost::none);
+    auto const result =
+        runGetMatchingProcessingInstructionsForPreviewRowWithMissingInstruction(lookupRow, ROIType::Transmission);
+    TS_ASSERT_EQUALS(result.at(ROIType::Signal), lookupRow.processingInstructions());
+    TS_ASSERT_EQUALS(result.at(ROIType::Background), lookupRow.backgroundProcessingInstructions());
+  }
+
+  void testGetMatchingProcessingInstructionsForPreviewRowNoLookupRowFound() {
+    auto const previewRow = PreviewRow({"12345"});
+    auto const presenter = makePresenterWithPreviewRowLookup(boost::none, previewRow);
+    auto const result = presenter->getMatchingProcessingInstructionsForPreviewRow();
+    TS_ASSERT(result.empty());
+  }
+
+  void testGetMatchingProcessingInstructionsForPreviewRowMultipleLookupRowsFound() {
+    auto mockModel = makeMockModel();
+    auto const previewRow = PreviewRow({"12345"});
+    EXPECT_CALL(*mockModel, findLookupPreviewRowProxy(_)).WillOnce(Throw(MultipleRowsFoundException("")));
+    auto presenter = makePresenter(std::move(mockModel));
+    EXPECT_CALL(*m_previewPresenter, getPreviewRow()).Times(1).WillOnce(ReturnRef(previewRow));
+    auto const result = presenter->getMatchingProcessingInstructionsForPreviewRow();
+    TS_ASSERT(result.empty());
+  }
+
+  void testGetMatchingROIDetectorIDsForPreviewRow() {
+    auto const lookupRow = makeLookupRow(boost::none);
+    auto const maybeLookupRow = boost::optional<LookupRow>(lookupRow);
+    runGetMatchingROIDetectorIDsForPreviewRowTest(maybeLookupRow, lookupRow.roiDetectorIDs());
+  }
+
+  void testGetMatchingROIDetectorIDsForPreviewRowNoDetectorIdsInLookupRow() {
+    auto lookupRow = makeLookupRow(boost::none);
+    lookupRow.setRoiDetectorIDs(boost::none);
+    auto const maybeLookupRow = boost::optional<LookupRow>(lookupRow);
+    runGetMatchingROIDetectorIDsForPreviewRowTest(maybeLookupRow, boost::none);
+  }
+
+  void testGetMatchingROIDetectorIDsForPreviewRowNoLookupRowFound() {
+    runGetMatchingROIDetectorIDsForPreviewRowTest(boost::none, boost::none);
+  }
+
+  void testGetMatchingROIDetectorIDsForPreviewRowMultipleLookupRowsFound() {
+    auto mockModel = makeMockModel();
+    auto const previewRow = PreviewRow({"12345"});
+    EXPECT_CALL(*mockModel, findLookupPreviewRowProxy(_)).WillOnce(Throw(MultipleRowsFoundException("")));
+    auto presenter = makePresenter(std::move(mockModel));
+    EXPECT_CALL(*m_previewPresenter, getPreviewRow()).Times(1).WillOnce(ReturnRef(previewRow));
+    TS_ASSERT_EQUALS(presenter->getMatchingROIDetectorIDsForPreviewRow(), boost::none);
+  }
+
 private:
   NiceMock<MockBatchView> m_view;
   NiceMock<MockBatchJobManager> *m_jobManager;
@@ -592,13 +685,29 @@ private:
   Slicing m_slicing;
   std::deque<IConfiguredAlgorithm_sptr> m_mockAlgorithmsList;
 
-  void runHasROIDetectorIDsForPreviewRowTest(boost::optional<LookupRow> lookupRow, bool expectedResult) {
-    auto mockModel = makeMockModel();
+  std::map<ROIType, ProcessingInstructions>
+  runGetMatchingProcessingInstructionsForPreviewRowWithMissingInstruction(LookupRow &lookupRow,
+                                                                          ROIType instructionToOmit) {
+    lookupRow.setProcessingInstructions(instructionToOmit, boost::none);
+    auto const maybeLookupRow = boost::optional<LookupRow>(lookupRow);
     auto const previewRow = PreviewRow({"12345"});
-    EXPECT_CALL(*mockModel, findLookupPreviewRowProxy(_)).Times(1).WillOnce(Return(lookupRow));
-    auto presenter = makePresenter(std::move(mockModel));
-    EXPECT_CALL(*m_previewPresenter, getPreviewRow()).Times(1).WillOnce(ReturnRef(previewRow));
+    auto const presenter = makePresenterWithPreviewRowLookup(maybeLookupRow, previewRow);
+    auto const result = presenter->getMatchingProcessingInstructionsForPreviewRow();
+    TS_ASSERT_EQUALS(result.size(), 2);
+    return result;
+  }
+
+  void runHasROIDetectorIDsForPreviewRowTest(boost::optional<LookupRow> lookupRow, bool expectedResult) {
+    auto const previewRow = PreviewRow({"12345"});
+    auto const presenter = makePresenterWithPreviewRowLookup(lookupRow, previewRow);
     TS_ASSERT_EQUALS(presenter->hasROIDetectorIDsForPreviewRow(), expectedResult);
+  }
+
+  void runGetMatchingROIDetectorIDsForPreviewRowTest(boost::optional<LookupRow> lookupRow,
+                                                     boost::optional<ProcessingInstructions> expectedResult) {
+    auto const previewRow = PreviewRow({"12345"});
+    auto const presenter = makePresenterWithPreviewRowLookup(lookupRow, previewRow);
+    TS_ASSERT_EQUALS(presenter->getMatchingROIDetectorIDsForPreviewRow(), expectedResult);
   }
 
   class BatchPresenterFriend : public BatchPresenter {
@@ -660,6 +769,15 @@ private:
     // is resumed
     ON_CALL(*m_runsPresenter, resumeAutoreduction()).WillByDefault(Return(true));
     ON_CALL(*m_experimentPresenter, hasValidSettings()).WillByDefault(Return(true));
+    return presenter;
+  }
+
+  std::unique_ptr<BatchPresenterFriend> makePresenterWithPreviewRowLookup(boost::optional<LookupRow> lookupRow,
+                                                                          PreviewRow const &previewRow) {
+    auto mockModel = makeMockModel();
+    EXPECT_CALL(*mockModel, findLookupPreviewRowProxy(_)).Times(1).WillOnce(Return(lookupRow));
+    auto presenter = makePresenter(std::move(mockModel));
+    EXPECT_CALL(*m_previewPresenter, getPreviewRow()).Times(1).WillOnce(ReturnRef(previewRow));
     return presenter;
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -107,7 +107,6 @@ public:
   MOCK_METHOD0(setBatchUnsaved, void());
   MOCK_METHOD0(notifyChangesSaved, void());
   MOCK_METHOD0(notifyPreviewApplyRequested, void());
-  MOCK_CONST_METHOD0(hasROIDetectorIDsForPreviewRow, bool());
   MOCK_CONST_METHOD0(getMatchingProcessingInstructionsForPreviewRow, std::map<ROIType, ProcessingInstructions>());
   MOCK_CONST_METHOD0(getMatchingROIDetectorIDsForPreviewRow, boost::optional<ProcessingInstructions>());
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -23,6 +23,7 @@
 #include "GUI/Instrument/InstrumentOptionDefaults.h"
 #include "GUI/MainWindow/IMainWindowPresenter.h"
 #include "GUI/MainWindow/IMainWindowView.h"
+#include "GUI/Preview/ROIType.h"
 #include "GUI/Runs/IRunNotifier.h"
 #include "GUI/Runs/IRunsPresenter.h"
 #include "GUI/Runs/ISearchModel.h"
@@ -40,6 +41,7 @@
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "MantidQtWidgets/Common/Hint.h"
 #include "Reduction/PreviewRow.h"
+#include "Reduction/ProcessingInstructions.h"
 
 #include <QMap>
 #include <QString>
@@ -106,6 +108,8 @@ public:
   MOCK_METHOD0(notifyChangesSaved, void());
   MOCK_METHOD0(notifyPreviewApplyRequested, void());
   MOCK_CONST_METHOD0(hasROIDetectorIDsForPreviewRow, bool());
+  MOCK_CONST_METHOD0(getMatchingProcessingInstructionsForPreviewRow, std::map<ROIType, ProcessingInstructions>());
+  MOCK_CONST_METHOD0(getMatchingROIDetectorIDsForPreviewRow, boost::optional<ProcessingInstructions>());
 };
 
 class MockRunsPresenter : public IRunsPresenter {

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
@@ -27,5 +27,7 @@ public:
   virtual void deselectAllSelectors() = 0;
   virtual Selection getRegion(const std::string &regionType) = 0;
   virtual void cancelDrawingRegion() = 0;
+  virtual void displayRectangularRegion(const std::string &regionType, const std::string &color,
+                                        const std::string &hatch, const size_t y1, const size_t y2) = 0;
 };
 } // namespace MantidQt::Widgets

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
@@ -32,6 +32,8 @@ public:
   void deselectAllSelectors() override;
   Selection getRegion(const std::string &regionType) override;
   void cancelDrawingRegion() override;
+  void displayRectangularRegion(const std::string &regionType, const std::string &color, const std::string &hatch,
+                                const size_t y1, const size_t y2) override;
 
 private:
   Common::Python::Object getView() const;

--- a/qt/widgets/regionselector/src/RegionSelector.cpp
+++ b/qt/widgets/regionselector/src/RegionSelector.cpp
@@ -119,4 +119,10 @@ auto RegionSelector::getRegion(const std::string &regionType) -> Selection {
   }
   return result;
 }
+
+void RegionSelector::displayRectangularRegion(const std::string &regionType, const std::string &color,
+                                              const std::string &hatch, const size_t y1, const size_t y2) {
+  GlobalInterpreterLock lock;
+  pyobj().attr("display_rectangular_region")(regionType, color, hatch, y1, y2);
+}
 } // namespace MantidQt::Widgets

--- a/qt/widgets/regionselector/test/MockRegionSelector.h
+++ b/qt/widgets/regionselector/test/MockRegionSelector.h
@@ -20,5 +20,9 @@ public:
   MOCK_METHOD(void, deselectAllSelectors, (), (override));
   MOCK_METHOD(Selection, getRegion, (const std::string &regionType), (override));
   MOCK_METHOD(void, cancelDrawingRegion, (), (override));
+  MOCK_METHOD(void, displayRectangularRegion,
+              (std::string const &regionType, std::string const &color, std::string const &hatch, size_t const y1,
+               size_t const y2),
+              (override));
 };
 } // namespace MantidQt::Widgets


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
When a workspace is loaded, or the angle is updated, on the Reflectometry GUI preview tab then we now check the experiment settings look-up table to see if there are matching signal, background or transmission regions. If there are then we clear the slice viewer plot and add region selectors to display the experiment settings ROIs.

This refs rather than fixes the issue as the request was to add region selectors for both the instrument view and the slice viewer plots. See [this comment](https://github.com/mantidproject/mantid/issues/36573#issuecomment-2647363712) on the linked issue that explains why this first PR is limited to only implementing this on the slice viewer plot.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Refs #36573. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
- This PR adds method `display_rectangular_region` to the `RegionSelector` presenter and I originally wrote it to raise a `ValueError` if the location requested for the region was outside the y axis bounds. However, on the C++ side throwing this error seemed to mean that the `RegionSelector` python object lost all it's attributes, meaning you couldn't call another method from it afterwards. Unfortunately I don't have time to investigate the underlying cause of this, and I don't think that failing to throw the exception is significant from a user-facing perspective (I'm not sure if we would actually want to do anything in response to the exception), but it could be investigated further in future if desired.

- Without the changes in this PR, if you don't have any regions selected on either plot and you hit the `Apply` button then it will clear any matching settings in the experiment settings table. Now that we are displaying regions on the slice viewer plot on load but are not doing this on the instrument view plot, I felt it increased the risk of users forgetting to re-add their detector regions when making changes and then mistakenly clearing existing detector ROIs. To avoid this, I have made changes so that when we have displayed regions on the slice viewer plot on load then we won't overwrite any detector IDs in the look-up table when we click `Apply`, unless changes have been made by using a region selector on the instrument view plot.

- The workflow for the angle update function took a little bit of thought. My understanding is that this functionality is not really used at the moment - we have in the past considered removing it as a former NR Group instrument scientist wasn't sure there was a use case for it. My understanding is that each measurement is associated with a single angle, so the only circumstances where I would expect the angle update feature to be used would be if the angle value that we pick up automatically from the run was somehow incorrect. I have therefore made the assumption that updating the angle is conceptually very similar to re-loading the data, so updating the angle will trigger a check for matching experiment settings. If matching settings are found then these will replace any regions that have been selected by the user on the slice viewer plot. If there are no matching experiment settings than any user-selected regions will be retained (to allow for a scenario where the user has started selecting regions, only to realise afterwards that the angle is not correct). For the instrument view plot, because we do not add region selectors to this plot yet I have chosen to keep any regions that the user has added, regardless of whether or not there are matching experiment settings. However if no regions are selected then we automatically retain the detector IDs from any matching experiment settings in the model to ensure that they will not be overwritten unintentionally, in the same way as I described above.

Some decisions in this PR rely on assumptions about how the features in the tab are used. There are three paths that run through the code that has been changed - loading a workspace, updating an angle and adding/removing/changing a region on the instrument view plot. There are also many different sequences of steps that users could go through when working in the tab. I've done my best to try and make sure this new feature behaves sensibly across the various circumstances I could think of, however it would obviously be good for our scientists to test these changes carefully to ensure that the behaviour is optimal for their workflows.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Read through the [Reflectometry GUI Preview Tab manual testing instructions](https://developer.mantidproject.org/Testing/ReflectometryGUI/ReflectometryGUITests.html#preview-tab) steps 1-12 to become familiar with loading data, adding regions to the plots and using the `Apply` button to save the results to the `Experiment Settings` tab. Note that the dataset in these instructions is a test dataset that does not pick up an angle automatically when loaded. I have been testing with run number `INTER74872` as an example of a real dataset that populates the angle automatically.

For context to help with testing, the lookup table on the Experiment Settings tab has angle and title columns that are used for matching. If you enter an angle for a row then the settings in that row will be applied to all runs with that angle. The look-up table by default contains a wildcard row which has a blank angle and title. Any settings in the wildcard row act as a default that will be applied to all runs if a closer matching row has not been found.

Now check the following:

1) When you load a run where the angle matches a row in the experiment settings look-up table then region selectors should be added to the slice viewer plot corresponding to the entries in the `ROI`, `Background` and `Trans Spectra` columns.
      - Changing the selector locations and then clicking `Apply` should update the matching row without changing anything in the `ROI Detector IDs` column.
      - If you add a region selector to the instrument view plot and then click `Apply` it should update the detector ID selection in the matching row.

2) Use the `Update` button to change the angle to a value that matches a different row in the experiment settings table. Check that any existing region selectors are cleared from the slice viewer plot and it instead displays selectors corresponding to the entries in the `ROI`, `Background` and `Trans Spectra` columns.
      - Changing the selector locations and then clicking `Apply` should update the matching row without changing anything in the `ROI Detector IDs` column.
      - If you add a region selector to the instrument view plot and then click `Apply` it should update the detector ID selection in the matching row.
      - Have a couple of rows in the experiment settings table corresponding to different angles and check that switching between them using the `Update` button displays the correct regions on the slice viewer plot. Note that if you update to a row that does not have any regions entered at all (or if you don't have a wildcard row and then update to an angle value that doesn't match any row) the slice viewer plot will retain the region selectors that are already on the plot.

3) Try several different sequences of steps of adding regions, applying the changes, re-loading data and updating angles, etc. and check that the behaviour seems sensible in each case.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
