### PR TITLE
Simplify NeXus logging

### DIFF
--- a/Framework/API/inc/MantidAPI/FrameworkManager.h
+++ b/Framework/API/inc/MantidAPI/FrameworkManager.h
@@ -76,8 +76,6 @@ private:
   void loadPluginsUsingKey(const std::string &locationKey, const std::string &excludeKey);
   /// Set up the global locale
   void setGlobalNumericLocaleToC();
-  /// Silence NeXus output
-  void disableNexusOutput();
   /// Starts asynchronous tasks that are done as part of Start-up
   void asynchronousStartupTasks();
   /// Setup Usage Reporting if enabled

--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -63,15 +63,6 @@ const char *PLUGINS_DIR_KEY = "framework.plugins.directory";
 const char *PLUGINS_EXCLUDE_KEY = "framework.plugins.exclude";
 } // namespace
 
-/** This is a function called every time NeXuS raises an error.
- * This swallows the errors and outputs nothing.
- */
-// Prevent clang-tidy trying to change the signature for ext. interface
-// NOLINTNEXTLINE(readability-non-const-parameter)
-void NexusErrorFunction(void *, const char *) {
-  // Do nothing.
-}
-
 #ifdef __linux__
 /**
  * Print current backtrace to the given stream

--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -16,7 +16,6 @@
 #include "MantidKernel/MultiThreaded.h"
 #include "MantidKernel/PropertyManagerDataService.h"
 #include "MantidKernel/UsageService.h"
-#include "MantidNexusCpp/NeXusFile.hpp"
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -133,7 +132,6 @@ FrameworkManagerImpl::FrameworkManagerImpl() {
   ConfigService::Instance();
   g_log.notice() << Mantid::welcomeMessage() << '\n';
   loadPlugins();
-  disableNexusOutput();
   setNumOMPThreadsToConfigValue();
 
   g_log.debug() << "FrameworkManager created.\n";
@@ -338,9 +336,6 @@ void FrameworkManagerImpl::setGlobalNumericLocaleToC() {
   // C as the locale.
   setlocale(LC_NUMERIC, "C");
 }
-
-/// Silence NeXus output
-void FrameworkManagerImpl::disableNexusOutput() { NXMSetError(nullptr, NexusErrorFunction); }
 
 /// Starts asynchronous tasks that are done as part of Start-up.
 void FrameworkManagerImpl::asynchronousStartupTasks() {

--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -204,8 +204,8 @@ void SaveNexusProcessed::getWSIndexList(std::vector<int> &indices, const MatrixW
 void SaveNexusProcessed::doExec(const Workspace_sptr &inputWorkspace,
                                 std::shared_ptr<Mantid::NeXus::NexusFileIO> &nexusFile, const bool keepFile,
                                 optional_size_t entryNumber) {
-  // TODO: Remove?
-  NXMEnableErrorReporting();
+  //
+  //
 
   // Retrieve the filename from the properties
   const std::string filename = getPropertyValue("Filename");

--- a/Framework/LegacyNexus/inc/MantidLegacyNexus/napi.h
+++ b/Framework/LegacyNexus/inc/MantidLegacyNexus/napi.h
@@ -771,12 +771,6 @@ MANTID_LEGACYNEXUS_DLL void NXMSetError(void *pData, ErrFunc newErr);
 MANTID_LEGACYNEXUS_DLL void NXMSetTError(void *pData, ErrFunc newErr);
 
 /**
- * Retrieve the current error display function
- * \return The current error display function.
- */
-MANTID_LEGACYNEXUS_DLL ErrFunc NXMGetError();
-
-/**
  * Suppress error reports from the NeXus-API
  */
 MANTID_LEGACYNEXUS_DLL void NXMDisableErrorReporting();

--- a/Framework/LegacyNexus/src/napi.cpp
+++ b/Framework/LegacyNexus/src/napi.cpp
@@ -238,18 +238,20 @@ NXstatus NXsetcache(long newVal) {
 }
 
 /*-------------------------------------------------------------------------*/
-static void NXNXNXReportError(void *pData, const char *string) {
+static void NXNXNoReport(void *pData, const char *string) {
+  // do nothing but declare the variables unused
   UNUSED_ARG(pData);
-  fprintf(stderr, "%s \n", string);
+  UNUSED_ARG(string);
 }
 
 /*---------------------------------------------------------------------*/
 
 static void *NXEHpData = NULL;
-static void (*NXEHIReportError)(void *pData, const char *string) = NXNXNXReportError;
+// default to no logging
+static ErrFunc NXEHIReportError = NXNXNoReport;
 #ifdef HAVE_TLS
 static THREAD_LOCAL void *NXEHpTData = NULL;
-static THREAD_LOCAL void (*NXEHIReportTError)(void *pData, const char *string) = NULL;
+static THREAD_LOCAL ErrFunc NXEHIReportTError = NULL;
 #endif
 
 void NXIReportError(void *pData, const char *string) {
@@ -273,13 +275,13 @@ void NXReportError(const char *string) {
 }
 
 /*---------------------------------------------------------------------*/
-extern void NXMSetError(void *pData, void (*NewError)(void *pD, const char *text)) {
+extern void NXMSetError(void *pData, ErrFunc NewError) {
   NXEHpData = pData;
   NXEHIReportError = NewError;
 }
 
 /*----------------------------------------------------------------------*/
-extern void NXMSetTError(void *pData, void (*NewError)(void *pD, const char *text)) {
+extern void NXMSetTError(void *pData, ErrFunc NewError) {
 #ifdef HAVE_TLS
   NXEHpTData = pData;
   NXEHIReportTError = NewError;
@@ -289,25 +291,8 @@ extern void NXMSetTError(void *pData, void (*NewError)(void *pD, const char *tex
 }
 
 /*----------------------------------------------------------------------*/
-extern ErrFunc NXMGetError() {
-#ifdef HAVE_TLS
-  if (NXEHIReportTError) {
-    return NXEHIReportTError;
-  }
-#endif
-  return NXEHIReportError;
-}
 
-/*----------------------------------------------------------------------*/
-static void NXNXNoReport(void *pData, const char *string) {
-  // do nothing but declare the variables unused
-  (void)pData;
-  (void)string;
-}
-
-/*----------------------------------------------------------------------*/
-
-static ErrFunc last_global_errfunc = NXNXNXReportError;
+static ErrFunc last_global_errfunc = NXEHIReportError;
 #ifdef HAVE_TLS
 static THREAD_LOCAL ErrFunc last_thread_errfunc = NULL;
 #endif

--- a/Framework/NexusCpp/inc/MantidNexusCpp/napi.h
+++ b/Framework/NexusCpp/inc/MantidNexusCpp/napi.h
@@ -738,60 +738,11 @@ MANTID_NEXUSCPP_DLL NXstatus NXgetrawinfo(NXhandle handle, int *rank, int dimens
  */
 MANTID_NEXUSCPP_DLL NXstatus NXgetrawinfo64(NXhandle handle, int *rank, int64_t dimension[], NXnumtype *datatype);
 
-/** \typedef void (*ErrFunc)(void *data, const char *text)
- * All NeXus error reporting happens through this special function, the
- * ErrFunc. The NeXus-API allows this error reporting function to be replaced
- * through a user defined implementation. The default error function prints to stderr. User
- * defined ones may pop up dialog boxes or whatever.
- * \param data A pointer to some user defined data structure
- * \param text The text of the error message to display.
- */
-typedef void (*ErrFunc)(void *data, const char *text);
-
 /**
- * Set a global error function.
- * Not threadsafe.
- * \param pData A pointer to a user defined data structure which be passed to
- * the error display function.
- * \param newErr The new error display function.
- */
-MANTID_NEXUSCPP_DLL void NXMSetError(void *pData, ErrFunc newErr);
-
-/**
- * Set an error function for the current thread.
- * When used this overrides anything set in NXMSetError (for the current thread).
- * Use this method in threaded applications.
- * \param pData A pointer to a user defined data structure which be passed to
- * the error display function.
- * \param newErr The new error display function.
- */
-MANTID_NEXUSCPP_DLL void NXMSetTError(void *pData, ErrFunc newErr);
-
-/**
- * Retrieve the current error display function
- * \return The current error display function.
- */
-MANTID_NEXUSCPP_DLL ErrFunc NXMGetError();
-
-/**
- * Suppress error reports from the NeXus-API
- */
-MANTID_NEXUSCPP_DLL void NXMDisableErrorReporting();
-
-/**
- * Enable error reports from the NeXus-API
- */
-MANTID_NEXUSCPP_DLL void NXMEnableErrorReporting();
-
-/**
- * Dispatches the error message to the error function defined by NXMSetTError
+ * Dispatches the error message
  */
 MANTID_NEXUSCPP_DLL void NXReportError(const char *text);
 
-/**
- * Do not use, first parameter should be set by NXMSetTError
- */
-MANTID_NEXUSCPP_DLL void NXIReportError(void *pData, const char *text);
 /* extern void *NXpData; */
 MANTID_NEXUSCPP_DLL char *NXIformatNeXusTime();
 

--- a/Framework/NexusCpp/src/napi4.cpp
+++ b/Framework/NexusCpp/src/napi4.cpp
@@ -1096,13 +1096,11 @@ NXstatus NX4getdataID(NXhandle fid, NXlink *sRes) {
   } else {
     sRes->iTag = DFTAG_NDG;
     sRes->iRef = SDidtoref(pFile->iCurrentSDS);
-    NXMDisableErrorReporting();
     datalen = 1024;
     memset(&sRes->targetPath, 0, 1024);
     if (NX4getattr(fid, "target", &sRes->targetPath, &datalen, &type) != NXstatus::NX_OK) {
       NXIbuildPath(pFile, sRes->targetPath, 1024);
     }
-    NXMEnableErrorReporting();
     return NXstatus::NX_OK;
   }
   sRes->iTag = static_cast<int>(NXstatus::NX_ERROR);

--- a/Framework/NexusCpp/src/napi5.cpp
+++ b/Framework/NexusCpp/src/napi5.cpp
@@ -1204,13 +1204,11 @@ NXstatus NX5getdataID(NXhandle fid, NXlink *sRes) {
      this means: if the item is already linked: use the target attribute else,
      the path to the current node
    */
-  NXMDisableErrorReporting();
   datalen = 1024;
   memset(&sRes->targetPath, 0, static_cast<size_t>(datalen) * sizeof(char));
   if (NX5getattr(fid, "target", &sRes->targetPath, &datalen, &type) != NXstatus::NX_OK) {
     buildCurrentPath(pFile, sRes->targetPath, 1024);
   }
-  NXMEnableErrorReporting();
   sRes->linkType = 1;
   return NXstatus::NX_OK;
 }
@@ -2120,13 +2118,11 @@ NXstatus NX5getgroupID(NXhandle fileid, NXlink *sRes) {
        this means: if the item is already linked: use the target attribute, else
        the path to the current node
      */
-    NXMDisableErrorReporting();
     int datalen = 1024;
     memset(sRes->targetPath, 0, static_cast<size_t>(datalen) * sizeof(char));
     if (NX5getattr(fileid, "target", sRes->targetPath, &datalen, &type) != NXstatus::NX_OK) {
       buildCurrentPath(pFile, sRes->targetPath, datalen);
     }
-    NXMEnableErrorReporting();
     sRes->linkType = 0;
     return NXstatus::NX_OK;
   }


### PR DESCRIPTION
### Description of work

#### Summary of work

The Nexus logging is immediately turned off by the FrameworkManager.  However, there is a lot of functionality around turning it on and off and switching the channel within `napi`, that is never actually used.  As it was suspected this might be causing a null pointer reference causing errors in the Windows system tests, this was simplified.

#### Purpose of work

Related to Issue #38332 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

Windows System Tests:
1.  [![Build Status](https://builds.mantidproject.org/job/build_packages_from_branch/996/badge/icon)](https://builds.mantidproject.org/job/build_packages_from_branch/996/)
2. [![Build Status](https://builds.mantidproject.org/buildStatus/icon?job=build_packages_from_branch&build=999)](https://builds.mantidproject.org/job/build_packages_from_branch/999/)
---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
