### PR TITLE
 Add a new revision to LoadMuonNexus to reenable alg selection

### DIFF
--- a/Framework/Muon/CMakeLists.txt
+++ b/Framework/Muon/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SRC_FILES
     src/LoadMuonNexus.cpp
     src/LoadMuonNexus1.cpp
     src/LoadMuonNexus2.cpp
+    src/LoadMuonNexus3.cpp
     src/MuonAlgorithmHelper.cpp
     src/MuonAsymmetryHelper.cpp
     src/MuonGroupDetectors.cpp
@@ -41,6 +42,7 @@ set(INC_FILES
     inc/MantidMuon/LoadMuonNexus.h
     inc/MantidMuon/LoadMuonNexus1.h
     inc/MantidMuon/LoadMuonNexus2.h
+    inc/MantidMuon/LoadMuonNexus3.h
     inc/MantidMuon/EstimateMuonAsymmetryFromCounts.h
     inc/MantidMuon/MuonAlgorithmHelper.h
     inc/MantidMuon/MuonAsymmetryHelper.h
@@ -112,7 +114,7 @@ set_property(TARGET Muon PROPERTY FOLDER "MantidFramework")
 target_link_libraries(
   Muon
   PUBLIC Mantid::API Mantid::Kernel Mantid::Geometry
-  PRIVATE Mantid::DataObjects Mantid::Indexing Mantid::Nexus
+  PRIVATE Mantid::DataObjects Mantid::Indexing Mantid::Nexus Mantid::DataHandling
 )
 # Add the unit tests directory
 add_subdirectory(test)

--- a/Framework/Muon/CMakeLists.txt
+++ b/Framework/Muon/CMakeLists.txt
@@ -71,6 +71,7 @@ set(TEST_FILES
     LoadAndApplyMuonDetectorGroupingTest.h
     LoadMuonNexus1Test.h
     LoadMuonNexus2Test.h
+    LoadMuonNexus3Test.h
     MuonAlgorithmHelperTest.h
     EstimateMuonAsymmetryFromCountsTest.h
     MuonGroupDetectorsTest.h

--- a/Framework/Muon/CMakeLists.txt
+++ b/Framework/Muon/CMakeLists.txt
@@ -115,7 +115,7 @@ set_property(TARGET Muon PROPERTY FOLDER "MantidFramework")
 target_link_libraries(
   Muon
   PUBLIC Mantid::API Mantid::Kernel Mantid::Geometry
-  PRIVATE Mantid::DataObjects Mantid::Indexing Mantid::Nexus Mantid::DataHandling
+  PRIVATE Mantid::DataObjects Mantid::Indexing Mantid::Nexus
 )
 # Add the unit tests directory
 add_subdirectory(test)

--- a/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
+++ b/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
@@ -58,8 +58,6 @@ public:
 
   int version() const override { return 3; }
   const std::vector<std::string> seeAlso() const override { return {"LoadNexus", "LoadMuonNexusV2"}; }
-  std::string m_algName;
-  int m_version;
 
   // Returns 0, as this wrapper version of the algorithm is never to be selected via load.
   int confidence(Kernel::NexusDescriptor &) const override { return 0; };
@@ -69,6 +67,8 @@ public:
 
 private:
   const std::map<const std::shared_ptr<API::Algorithm>, ConfFuncPtr> m_loadAlgs;
+  std::string m_algName;
+  int m_version;
 
   void exec() override;
   void runSelectedAlg();

--- a/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
+++ b/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
@@ -49,7 +49,7 @@ together based on the groupings in the NeXus file. </LI>
 */
 class MANTID_MUON_DLL LoadMuonNexus3 : public LoadMuonNexus {
 public:
-  LoadMuonNexus3();
+  LoadMuonNexus3() : m_version(0), LoadMuonNexus() {}
 
   const std::string summary() const override {
     return "The LoadMuonNexus algorithm will read the given NeXus Muon data "
@@ -60,15 +60,20 @@ public:
 
   int version() const override { return 3; }
   const std::vector<std::string> seeAlso() const override { return {"LoadNexus", "LoadMuonNexusV2"}; }
+  std::string m_algName;
+  int m_version;
 
-  /// Returns 0, as this version of the algorithm is never to be selected via load.
+  // Returns 0, as this version of the algorithm is never to be selected via load.
   int confidence(Kernel::NexusDescriptor &descriptor) const override { return 0; };
+  // Methods to enable testing.
+  const std::string &getSelectedAlg() const { return m_algName; }
+  int getSelectedVersion() const { return m_version; }
 
 private:
   std::map<std::shared_ptr<API::Algorithm>, ConfFuncPtr> m_loadAlgs;
 
   void exec() override;
-  void runSelectedAlg(const std::string &algName, const int version);
+  void runSelectedAlg();
 };
 
 } // namespace Algorithms

--- a/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
+++ b/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
@@ -12,13 +12,12 @@
 #include "MantidMuon/DllConfig.h"
 #include "MantidMuon/LoadMuonNexus.h"
 
-#include <map>
+#include <vector>
 
 namespace {
 using ConfFuncPtr = int (*)(const std::string &, const std::shared_ptr<Mantid::API::Algorithm> &);
 
 struct AlgDetail {
-  AlgDetail() : m_version(0), m_confFunc(nullptr), m_alg(nullptr) {};
   AlgDetail(const std::string &name, const int version, const ConfFuncPtr &loader,
             const Mantid::API::Algorithm_sptr &alg)
       : m_name(name), m_version(version), m_confFunc(loader), m_alg(alg) {}

--- a/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
+++ b/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
@@ -62,7 +62,7 @@ public:
   int m_version;
 
   // Returns 0, as this wrapper version of the algorithm is never to be selected via load.
-  int confidence(Kernel::NexusDescriptor &descriptor) const override { return 0; };
+  int confidence(Kernel::NexusDescriptor &) const override { return 0; };
   // Methods to enable testing.
   const std::string &getSelectedAlg() const { return m_algName; }
   int getSelectedVersion() const { return m_version; }

--- a/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
+++ b/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
@@ -1,0 +1,75 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2007 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include "MantidMuon/DllConfig.h"
+#include "MantidMuon/LoadMuonNexus.h"
+
+#include <map>
+
+namespace Mantid {
+
+namespace Algorithms {
+
+using ConfFuncPtr = int (*)(const std::string &, const std::shared_ptr<API::Algorithm> &);
+
+/**
+Loads an file in NeXus Muon format version 1 and 2 and stores it in a 2D
+workspace
+(Workspace2D class). LoadMuonNexus is an algorithm and as such inherits
+from the Algorithm class, via DataHandlingCommand, and overrides
+the init() & exec() methods.
+
+Required Properties:
+<UL>
+<LI> Filename - The name of and path to the input NeXus file </LI>
+<LI> OutputWorkspace - The name of the workspace in which to store the imported
+data
+(a multiperiod file will store higher periods in workspaces called
+OutputWorkspace_PeriodNo)
+[ not yet implemented for NeXus ]</LI>
+</UL>
+
+Optional Properties: (note that these options are not available if reading a
+multiperiod file)
+<UL>
+<LI> spectrum_min  - The spectrum to start loading from</LI>
+<LI> spectrum_max  - The spectrum to load to</LI>
+<LI> spectrum_list - An ArrayProperty of spectra to load</LI>
+<LI> auto_group - Determines whether the spectra are automatically grouped
+together based on the groupings in the NeXus file. </LI>
+</UL>
+*/
+class MANTID_MUON_DLL LoadMuonNexus3 : public LoadMuonNexus {
+public:
+  LoadMuonNexus3();
+
+  const std::string summary() const override {
+    return "The LoadMuonNexus algorithm will read the given NeXus Muon data "
+           "file Version 1 or 2 and use the results to populate the named "
+           "workspace. LoadMuonNexus may be invoked by LoadNexus if it is "
+           "given a NeXus file of this type.";
+  }
+
+  int version() const override { return 3; }
+  const std::vector<std::string> seeAlso() const override { return {"LoadNexus", "LoadMuonNexusV2"}; }
+
+  /// Returns 0, as this version of the algorithm is never to be selected via load.
+  int confidence(Kernel::NexusDescriptor &descriptor) const override { return 0; };
+
+private:
+  std::map<std::shared_ptr<API::Algorithm>, ConfFuncPtr> m_loadAlgs;
+
+  void exec() override;
+  void runSelectedAlg(const std::string &algName, const int version);
+};
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
+++ b/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2007 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
@@ -14,9 +14,7 @@
 
 #include <map>
 
-namespace Mantid {
-
-namespace Algorithms {
+namespace Mantid::Algorithms {
 
 using ConfFuncPtr = int (*)(const std::string &, const std::shared_ptr<API::Algorithm> &);
 
@@ -49,7 +47,7 @@ together based on the groupings in the NeXus file. </LI>
 */
 class MANTID_MUON_DLL LoadMuonNexus3 : public LoadMuonNexus {
 public:
-  LoadMuonNexus3() : m_version(0), LoadMuonNexus() {}
+  LoadMuonNexus3();
 
   const std::string summary() const override {
     return "The LoadMuonNexus algorithm will read the given NeXus Muon data "
@@ -63,18 +61,17 @@ public:
   std::string m_algName;
   int m_version;
 
-  // Returns 0, as this version of the algorithm is never to be selected via load.
+  // Returns 0, as this wrapper version of the algorithm is never to be selected via load.
   int confidence(Kernel::NexusDescriptor &descriptor) const override { return 0; };
   // Methods to enable testing.
   const std::string &getSelectedAlg() const { return m_algName; }
-  int getSelectedVersion() const { return m_version; }
+  const int getSelectedVersion() const { return m_version; }
 
 private:
-  std::map<std::shared_ptr<API::Algorithm>, ConfFuncPtr> m_loadAlgs;
+  const std::map<const std::shared_ptr<API::Algorithm>, ConfFuncPtr> m_loadAlgs;
 
   void exec() override;
   void runSelectedAlg();
 };
 
-} // namespace Algorithms
-} // namespace Mantid
+} // namespace Mantid::Algorithms

--- a/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
+++ b/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
@@ -65,7 +65,7 @@ public:
   int confidence(Kernel::NexusDescriptor &descriptor) const override { return 0; };
   // Methods to enable testing.
   const std::string &getSelectedAlg() const { return m_algName; }
-  const int getSelectedVersion() const { return m_version; }
+  int getSelectedVersion() const { return m_version; }
 
 private:
   const std::map<const std::shared_ptr<API::Algorithm>, ConfFuncPtr> m_loadAlgs;

--- a/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
+++ b/Framework/Muon/inc/MantidMuon/LoadMuonNexus3.h
@@ -14,7 +14,8 @@
 
 #include <vector>
 
-namespace {
+namespace Mantid::Algorithms {
+
 using ConfFuncPtr = int (*)(const std::string &, const std::shared_ptr<Mantid::API::Algorithm> &);
 
 struct AlgDetail {
@@ -27,9 +28,6 @@ struct AlgDetail {
   const ConfFuncPtr m_confFunc;
   const Mantid::API::Algorithm_sptr m_alg;
 };
-} // namespace
-
-namespace Mantid::Algorithms {
 
 /**
 Loads an file in NeXus Muon format version 1 and 2 and stores it in a 2D
@@ -80,7 +78,7 @@ public:
 
 private:
   std::vector<AlgDetail> m_loadAlgs;
-  int m_selectedIndex;
+  size_t m_selectedIndex;
 
   void exec() override;
   void runSelectedAlg();

--- a/Framework/Muon/src/LoadMuonNexus3.cpp
+++ b/Framework/Muon/src/LoadMuonNexus3.cpp
@@ -54,10 +54,10 @@ DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadMuonNexus3)
  */
 
 LoadMuonNexus3::LoadMuonNexus3()
-    : m_version(0), m_loadAlgs{{std::make_shared<Mantid::DataHandling::LoadMuonNexusV2>(), &calculateConfidenceHDF5},
-                               {std::make_shared<LoadMuonNexus1>(), &calculateConfidence},
-                               {std::make_shared<LoadMuonNexus2>(), &calculateConfidence}},
-      LoadMuonNexus() {};
+    : LoadMuonNexus(), m_loadAlgs{{std::make_shared<Mantid::DataHandling::LoadMuonNexusV2>(), &calculateConfidenceHDF5},
+                                  {std::make_shared<LoadMuonNexus1>(), &calculateConfidence},
+                                  {std::make_shared<LoadMuonNexus2>(), &calculateConfidence}},
+      m_version(0) {};
 
 void LoadMuonNexus3::exec() {
   const std::string filePath = getPropertyValue("Filename");

--- a/Framework/Muon/src/LoadMuonNexus3.cpp
+++ b/Framework/Muon/src/LoadMuonNexus3.cpp
@@ -59,17 +59,17 @@ void LoadMuonNexus3::exec() {
   m_loadAlgs.emplace(std::make_shared<LoadMuonNexus1>(), &calculateConfidence);
   m_loadAlgs.emplace(std::make_shared<LoadMuonNexus2>(), &calculateConfidence);
 
-  int maxConfidence{0};
+  int maxConfidenceRes{0};
   for (const auto &alg : m_loadAlgs) {
-    int confidence = alg.second(filePath, alg.first);
-    if (confidence > maxConfidence) {
-      maxConfidence = confidence;
+    int confidenceRes = alg.second(filePath, alg.first);
+    if (confidenceRes > maxConfidenceRes) {
+      maxConfidenceRes = confidenceRes;
       m_algName = alg.first->name();
       m_version = alg.first->version();
     }
   }
 
-  if (!maxConfidence) {
+  if (!maxConfidenceRes) {
     throw Kernel::Exception::FileError("Cannot open the file ", filePath);
   }
 

--- a/Framework/Muon/src/LoadMuonNexus3.cpp
+++ b/Framework/Muon/src/LoadMuonNexus3.cpp
@@ -47,8 +47,6 @@ namespace Mantid::Algorithms {
 // Register the algorithm into the algorithm factory
 DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadMuonNexus3)
 
-LoadMuonNexus3::LoadMuonNexus3() : LoadMuonNexus() {}
-
 /** Executes the right version of the Muon nexus loader
  *  @throw Exception::FileError If the Nexus file cannot be found/opened
  *  @throw std::invalid_argument If the optional properties are set to invalid
@@ -62,15 +60,12 @@ void LoadMuonNexus3::exec() {
   m_loadAlgs.emplace(std::make_shared<LoadMuonNexus2>(), &calculateConfidence);
 
   int maxConfidence{0};
-  int confidence{0};
-  int version{0};
-  std::string algName;
   for (const auto &alg : m_loadAlgs) {
-    confidence = alg.second(filePath, alg.first);
+    int confidence = alg.second(filePath, alg.first);
     if (confidence > maxConfidence) {
       maxConfidence = confidence;
-      algName = alg.first->name();
-      version = alg.first->version();
+      m_algName = alg.first->name();
+      m_version = alg.first->version();
     }
   }
 
@@ -78,11 +73,11 @@ void LoadMuonNexus3::exec() {
     throw Kernel::Exception::FileError("Cannot open the file ", filePath);
   }
 
-  runSelectedAlg(algName, version);
+  runSelectedAlg();
 }
 
-void LoadMuonNexus3::runSelectedAlg(const std::string &algName, const int version) {
-  auto childAlg = createChildAlgorithm(algName, 0, 1, true, version);
+void LoadMuonNexus3::runSelectedAlg() {
+  auto childAlg = createChildAlgorithm(m_algName, 0, 1, true, m_version);
   auto loader = std::dynamic_pointer_cast<API::Algorithm>(childAlg);
   loader->copyPropertiesFrom(*this);
   loader->executeAsChildAlg();

--- a/Framework/Muon/src/LoadMuonNexus3.cpp
+++ b/Framework/Muon/src/LoadMuonNexus3.cpp
@@ -1,0 +1,93 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidMuon/LoadMuonNexus3.h"
+
+#include "MantidAPI/NexusFileLoader.h"
+#include "MantidAPI/Progress.h"
+#include "MantidAPI/RegisterFileLoader.h"
+#include "MantidDataHandling/LoadMuonNexusV2.h"
+#include "MantidKernel/Logger.h"
+#include "MantidMuon/LoadMuonNexus1.h"
+#include "MantidMuon/LoadMuonNexus2.h"
+#include "MantidNexus/NexusClasses.h"
+#include <H5Cpp.h>
+#include <string>
+
+namespace {
+const int CONFIDENCE_THRESHOLD{80};
+
+int calculateConfidenceHDF5(const std::string &filePath, const std::shared_ptr<Mantid::API::Algorithm> &alg) {
+  auto nexusLoader = std::dynamic_pointer_cast<Mantid::API::NexusFileLoader>(alg);
+  int confidence{0};
+  if (H5::H5File::isHdf5(filePath)) {
+    try {
+      Mantid::Kernel::NexusHDF5Descriptor descriptorHDF5(filePath);
+      confidence = nexusLoader->confidence(descriptorHDF5);
+    } catch (std::exception const &e) {
+      Mantid::Kernel::Logger("LoadMuonNexus3").debug()
+          << "Error in calculating confidence for: " << nexusLoader->name() << " " << e.what() << '\n';
+    }
+  }
+  return (confidence >= CONFIDENCE_THRESHOLD) ? confidence : 0;
+}
+
+int calculateConfidence(const std::string &filePath, const std::shared_ptr<Mantid::API::Algorithm> &alg) {
+  auto fileLoader = std::dynamic_pointer_cast<Mantid::API::IFileLoader<Mantid::Kernel::NexusDescriptor>>(alg);
+  Mantid::Kernel::NexusDescriptor descriptor(filePath);
+  const int confidence = fileLoader->confidence(descriptor);
+  return (confidence >= CONFIDENCE_THRESHOLD) ? confidence : 0;
+}
+} // namespace
+
+namespace Mantid::Algorithms {
+// Register the algorithm into the algorithm factory
+DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadMuonNexus3)
+
+LoadMuonNexus3::LoadMuonNexus3() : LoadMuonNexus() {}
+
+/** Executes the right version of the Muon nexus loader
+ *  @throw Exception::FileError If the Nexus file cannot be found/opened
+ *  @throw std::invalid_argument If the optional properties are set to invalid
+ *values
+ */
+
+void LoadMuonNexus3::exec() {
+  std::string filePath = getPropertyValue("Filename");
+  m_loadAlgs.emplace(std::make_shared<Mantid::DataHandling::LoadMuonNexusV2>(), &calculateConfidenceHDF5);
+  m_loadAlgs.emplace(std::make_shared<LoadMuonNexus1>(), &calculateConfidence);
+  m_loadAlgs.emplace(std::make_shared<LoadMuonNexus2>(), &calculateConfidence);
+
+  int maxConfidence{0};
+  int confidence{0};
+  int version{0};
+  std::string algName;
+  for (const auto &alg : m_loadAlgs) {
+    confidence = alg.second(filePath, alg.first);
+    if (confidence > maxConfidence) {
+      maxConfidence = confidence;
+      algName = alg.first->name();
+      version = alg.first->version();
+    }
+  }
+
+  if (!maxConfidence) {
+    throw Kernel::Exception::FileError("Cannot open the file ", filePath);
+  }
+
+  runSelectedAlg(algName, version);
+}
+
+void LoadMuonNexus3::runSelectedAlg(const std::string &algName, const int version) {
+  auto childAlg = createChildAlgorithm(algName, 0, 1, true, version);
+  auto loader = std::dynamic_pointer_cast<API::Algorithm>(childAlg);
+  loader->copyPropertiesFrom(*this);
+  loader->executeAsChildAlg();
+  this->copyPropertiesFrom(*loader);
+  API::Workspace_sptr outWS = loader->getProperty("OutputWorkspace");
+  setProperty("OutputWorkspace", outWS);
+}
+} // namespace Mantid::Algorithms

--- a/Framework/Muon/src/LoadMuonNexus3.cpp
+++ b/Framework/Muon/src/LoadMuonNexus3.cpp
@@ -84,8 +84,13 @@ void LoadMuonNexus3::runSelectedAlg() {
 }
 
 void LoadMuonNexus3::addAlgToVec(const std::string &name, const int version, const ConfFuncPtr &loader) {
-  const auto &factory = API::AlgorithmFactory::Instance();
-  const auto alg = factory.create(name, version);
-  m_loadAlgs.push_back(AlgDetail(name, version, loader, alg));
+  auto &factory = API::AlgorithmFactory::Instance();
+  if (factory.exists(name, version)) {
+    const auto alg = factory.create(name, version);
+    m_loadAlgs.push_back(AlgDetail(name, version, loader, alg));
+  } else {
+    Mantid::Kernel::Logger("LoadMuonNexus3").debug()
+        << "Cannot add algorithm: " << name << " v" << version << ". The algorithm is not registered." << '\n';
+  }
 }
 } // namespace Mantid::Algorithms

--- a/Framework/Muon/src/LoadMuonNexus3.cpp
+++ b/Framework/Muon/src/LoadMuonNexus3.cpp
@@ -60,7 +60,7 @@ void LoadMuonNexus3::exec() {
   const std::string filePath = getPropertyValue("Filename");
 
   int maxConfidenceRes{0};
-  for (int i = 0; i < m_loadAlgs.size(); i++) {
+  for (size_t i = 0; i < m_loadAlgs.size(); i++) {
     const int confidenceRes = m_loadAlgs[i].m_confFunc(filePath, m_loadAlgs[i].m_alg);
     if (confidenceRes > maxConfidenceRes) {
       maxConfidenceRes = confidenceRes;

--- a/Framework/Muon/src/LoadMuonNexus3.cpp
+++ b/Framework/Muon/src/LoadMuonNexus3.cpp
@@ -50,7 +50,6 @@ DECLARE_NEXUS_FILELOADER_ALGORITHM(LoadMuonNexus3)
  *  @throw std::invalid_argument If the optional properties are set to invalid
  *values
  */
-
 LoadMuonNexus3::LoadMuonNexus3() : LoadMuonNexus() {
   addAlgToVec("LoadMuonNexusV2", 1, &calculateConfidenceHDF5);
   addAlgToVec("LoadMuonNexus", 1, &calculateConfidence);

--- a/Framework/Muon/test/LoadMuonNexus3Test.h
+++ b/Framework/Muon/test/LoadMuonNexus3Test.h
@@ -9,16 +9,29 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/NexusFileLoader.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidMuon/LoadMuonNexus1.h"
+#include "MantidMuon/LoadMuonNexus2.h"
 #include "MantidMuon/LoadMuonNexus3.h"
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
 using namespace Mantid::Algorithms;
 using namespace Mantid::DataObjects;
-using Mantid::detid_t;
-using Mantid::Types::Core::DateAndTime;
+
+namespace {
+// Mock class for LoadMuonNexusV2 which is in the DataHandling Library
+class LoadMuonNexusV2 : public NexusFileLoader {
+  const std::string name() const override { return "LoadMuonNexusV2"; }
+  int version() const override { return 1; }
+  int confidence(NexusHDF5Descriptor &descriptor) const override { return 100; }
+  void execLoader() override {}
+  const std::string summary() const override { return "mock class"; }
+  void init() override {}
+};
+} // namespace
 
 class LoadMuonNexus3Test : public CxxTest::TestSuite {
 public:
@@ -103,15 +116,6 @@ public:
     // Test execute to read file and populate workspace
     TS_ASSERT_THROWS_NOTHING(nxLoad.execute());
     TS_ASSERT(nxLoad.isExecuted());
-
-    // Check output workspace group
-    MatrixWorkspace_sptr output;
-    output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outputSpace);
-    Workspace2D_sptr output2D = std::dynamic_pointer_cast<Workspace2D>(output);
-
-    // Perform limited tests on the outwork workspace as this is essentially just a wrapper algorithm.
-    // subset of tests performed in LoadMuonNexus2Test
-    check_spectra_and_detectors(output);
 
     TS_ASSERT(nxLoad.getSelectedAlg() == "LoadMuonNexusV2");
     TS_ASSERT(nxLoad.getSelectedVersion() == 1);

--- a/Framework/Muon/test/LoadMuonNexus3Test.h
+++ b/Framework/Muon/test/LoadMuonNexus3Test.h
@@ -26,7 +26,7 @@ namespace {
 class LoadMuonNexusV2 : public NexusFileLoader {
   const std::string name() const override { return "LoadMuonNexusV2"; }
   int version() const override { return 1; }
-  int confidence(NexusHDF5Descriptor &descriptor) const override { return 100; }
+  int confidence(NexusHDF5Descriptor &) const override { return 100; }
   void execLoader() override {}
   const std::string summary() const override { return "mock class"; }
   void init() override {}

--- a/Framework/Muon/test/LoadMuonNexus3Test.h
+++ b/Framework/Muon/test/LoadMuonNexus3Test.h
@@ -1,0 +1,119 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidMuon/LoadMuonNexus3.h"
+
+using namespace Mantid::API;
+using namespace Mantid::Kernel;
+using namespace Mantid::Algorithms;
+using namespace Mantid::DataObjects;
+using Mantid::detid_t;
+using Mantid::Types::Core::DateAndTime;
+
+class LoadMuonNexus3Test : public CxxTest::TestSuite {
+public:
+  void check_spectra_and_detectors(const MatrixWorkspace_sptr &output) {
+
+    //----------------------------------------------------------------------
+    // Tests to check that spectra-detector mapping is done correctly
+    //----------------------------------------------------------------------
+    // Check the total number of elements in the map for HET
+    TS_ASSERT_EQUALS(output->getNumberHistograms(), 192);
+
+    // Test one to one mapping, for example spectra 6 has only 1 pixel
+    TS_ASSERT_EQUALS(output->getSpectrum(6).getDetectorIDs().size(), 1);
+
+    auto detectorgroup = output->getSpectrum(99).getDetectorIDs();
+    TS_ASSERT_EQUALS(detectorgroup.size(), 1);
+    TS_ASSERT_EQUALS(*detectorgroup.begin(), 100);
+  }
+
+  void testExecLoadMuonNexus2() {
+    LoadMuonNexus3 nxLoad;
+    nxLoad.initialize();
+
+    // Now set required filename and output workspace name
+    std::string inputFile = "argus0026287.nxs";
+    nxLoad.setPropertyValue("FileName", inputFile);
+
+    std::string outputSpace = "outer";
+    nxLoad.setPropertyValue("OutputWorkspace", outputSpace);
+
+    // Test execute to read file and populate workspace
+    TS_ASSERT_THROWS_NOTHING(nxLoad.execute());
+    TS_ASSERT(nxLoad.isExecuted());
+
+    // Check output workspace
+    MatrixWorkspace_sptr output;
+    output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outputSpace);
+    Workspace2D_sptr output2D = std::dynamic_pointer_cast<Workspace2D>(output);
+
+    // Perform limited tests on the outwork workspace as this is essentially just a wrapper algorithm.
+    // subset of tests performed in LoadMuonNexus2Test
+    check_spectra_and_detectors(output);
+
+    TS_ASSERT(nxLoad.getSelectedAlg() == "LoadMuonNexus");
+    TS_ASSERT(nxLoad.getSelectedVersion() == 2);
+  }
+
+  void testExecLoadMuonNexus1() {
+    LoadMuonNexus3 nxLoad;
+    nxLoad.initialize();
+
+    // Now set required filename and output workspace name
+    std::string inputFile = "emu00006475.nxs";
+    nxLoad.setPropertyValue("FileName", inputFile);
+
+    std::string outputSpace = "outer";
+    nxLoad.setPropertyValue("OutputWorkspace", outputSpace);
+
+    // Test execute to read file and populate workspace
+    TS_ASSERT_THROWS_NOTHING(nxLoad.execute());
+    TS_ASSERT(nxLoad.isExecuted());
+
+    // Check output workspace group
+    Mantid::API::WorkspaceGroup_sptr output = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(outputSpace);
+    TS_ASSERT(output->size() == 4);
+
+    TS_ASSERT(nxLoad.getSelectedAlg() == "LoadMuonNexus");
+    TS_ASSERT(nxLoad.getSelectedVersion() == 1);
+  }
+
+  void testExecLoadMuonNexusV2() {
+    LoadMuonNexus3 nxLoad;
+    nxLoad.initialize();
+
+    // Now set required filename and output workspace name
+    std::string inputFile = "ARGUS00073601.nxs";
+    nxLoad.setPropertyValue("FileName", inputFile);
+
+    std::string outputSpace = "outer";
+    nxLoad.setPropertyValue("OutputWorkspace", outputSpace);
+
+    // Test execute to read file and populate workspace
+    TS_ASSERT_THROWS_NOTHING(nxLoad.execute());
+    TS_ASSERT(nxLoad.isExecuted());
+
+    // Check output workspace group
+    MatrixWorkspace_sptr output;
+    output = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outputSpace);
+    Workspace2D_sptr output2D = std::dynamic_pointer_cast<Workspace2D>(output);
+
+    // Perform limited tests on the outwork workspace as this is essentially just a wrapper algorithm.
+    // subset of tests performed in LoadMuonNexus2Test
+    check_spectra_and_detectors(output);
+
+    TS_ASSERT(nxLoad.getSelectedAlg() == "LoadMuonNexusV2");
+    TS_ASSERT(nxLoad.getSelectedVersion() == 1);
+  }
+};

--- a/docs/source/algorithms/LoadMuonNexus-v3.rst
+++ b/docs/source/algorithms/LoadMuonNexus-v3.rst
@@ -1,0 +1,85 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+The algorithm LoadMuonNexus will read a Muon Nexus data file and place
+the data into the named workspace. The file name can be an absolute or
+relative path and should have the extension .nxs or .NXS.
+
+v3 of this algoirthm acts as an algorithm selector. Given the input filename,
+the confidence of the following loaders will be assessed and the loader with the
+highest confidence selected:
+- :ref:`algm-LoadMuonNexus-v1`
+- :ref:`algm-LoadMuonNexus-v2`
+- :ref:`algm-LoadMuonNexusV2-v1`
+
+This algorithm has the same input properties as :ref:`algm-LoadMuonNexus-v2`, some
+algorithm properties only apply to :ref:`algm-LoadMuonNexus-v1`.
+
+Please refer to the documentation for the individual algorithms for implementation detail.
+
+Usage
+-----
+
+.. include:: ../usagedata-note.txt
+
+**Example - Load ISIS muon MUSR dataset:**
+
+.. testcode:: LoadMuonNexusOnePeriod
+
+   # Load MUSR dataset
+   ws = Load(Filename="MUSR00015189.nxs",EntryNumber=1)
+   print("Workspace has  {}  spectra".format(ws[0].getNumberHistograms()))
+
+Output:
+
+.. testoutput:: LoadMuonNexusOnePeriod
+
+   Workspace has  64  spectra
+
+**Example - Load event nexus file with time filtering:**
+
+.. testcode:: ExLoadMuonNexusSomeSpectra
+
+   # Load some spectra
+   ws = Load(Filename="MUSR00015189.nxs",SpectrumMin=5,SpectrumMax=10,EntryNumber=1)
+   print("Workspace has  {}  spectra".format(ws[0].getNumberHistograms()))
+
+Output:
+
+.. testoutput:: ExLoadMuonNexusSomeSpectra
+
+   Workspace has  6  spectra
+
+**Example - Load dead times into table:**
+
+.. testcode:: ExLoadDeadTimeTable
+
+   # Load some spectra
+   ws = Load(Filename="emu00006473.nxs",SpectrumMin=5,SpectrumMax=10,DeadTimeTable="deadTimeTable")
+   tab = mtd['deadTimeTable']
+   for i in range(0,tab.rowCount()):
+       print("{} {:.12f}".format(tab.cell(i,0), tab.cell(i,1)))
+
+Output:
+
+.. testoutput:: ExLoadDeadTimeTable
+
+   5 0.001611122512
+   6 0.002150168177
+   7 0.010217159986
+   8 0.004316862207
+   9 0.007436056621
+   10 0.004211476538
+
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/LoadMuonNexus-v3.rst
+++ b/docs/source/algorithms/LoadMuonNexus-v3.rst
@@ -16,6 +16,7 @@ relative path and should have the extension .nxs or .NXS.
 v3 of this algoirthm acts as an algorithm selector. Given the input filename,
 the confidence of the following loaders will be assessed and the loader with the
 highest confidence selected:
+
 - :ref:`algm-LoadMuonNexus-v1`
 - :ref:`algm-LoadMuonNexus-v2`
 - :ref:`algm-LoadMuonNexusV2-v1`
@@ -35,7 +36,7 @@ Usage
 .. testcode:: LoadMuonNexusOnePeriod
 
    # Load MUSR dataset
-   ws = Load(Filename="MUSR00015189.nxs",EntryNumber=1)
+   ws = LoadMuonNexus(Filename="MUSR00015189.nxs",EntryNumber=1)
    print("Workspace has  {}  spectra".format(ws[0].getNumberHistograms()))
 
 Output:
@@ -49,7 +50,7 @@ Output:
 .. testcode:: ExLoadMuonNexusSomeSpectra
 
    # Load some spectra
-   ws = Load(Filename="MUSR00015189.nxs",SpectrumMin=5,SpectrumMax=10,EntryNumber=1)
+   ws = LoadMuonNexus(Filename="MUSR00015189.nxs",SpectrumMin=5,SpectrumMax=10,EntryNumber=1)
    print("Workspace has  {}  spectra".format(ws[0].getNumberHistograms()))
 
 Output:
@@ -63,7 +64,7 @@ Output:
 .. testcode:: ExLoadDeadTimeTable
 
    # Load some spectra
-   ws = Load(Filename="emu00006473.nxs",SpectrumMin=5,SpectrumMax=10,DeadTimeTable="deadTimeTable")
+   ws = LoadMuonNexus(Filename="emu00006473.nxs",SpectrumMin=5,SpectrumMax=10,DeadTimeTable="deadTimeTable")
    tab = mtd['deadTimeTable']
    for i in range(0,tab.rowCount()):
        print("{} {:.12f}".format(tab.cell(i,0), tab.cell(i,1)))

--- a/docs/source/release/v6.12.0/muon.rst
+++ b/docs/source/release/v6.12.0/muon.rst
@@ -33,8 +33,9 @@ New features
 Algorithms
 ----------
 
-Bugfixes
+New features
 ############
-- The :ref:`LoadMuonNexus v2<algm-LoadMuonNexus-v2>` algorithm no longer chooses a different Muon loader if appropriate. Users should call the :ref:`Load <algm-Load>` algorithm directly if they want the appropriate loader to be chosen for them.
+- The :ref:`LoadMuonNexus v2<algm-LoadMuonNexus-v2>` algorithm no longer chooses a different Muon loader if appropriate. This functionality has been moved to a new algorithm version, :ref:`LoadMuonNexus v3<algm-LoadMuonNexus-v3>`.
+- Users can also call the :ref:`Load <algm-Load>` algorithm directly which will also select the appropriate loader for them.
 
 :ref:`Release 6.12.0 <v6.12.0>`


### PR DESCRIPTION
### Description of work

Fixes #38826

This PR introduces a new revision of `LoadMuonNexus`.

This new revision acts as an algorithm selector, selecting either the `LoadMuonNexus1`, `LoadMuonNexus2`, or `LoadMuonNexusV2` loaders. This is functionality that was previously baked into `LoadMuonNexus2` but was removed.

The loader itself returns a confidence of 0, as if a user is using the generic `Load` algorithm they may as well use the logic there as a selector so this algorithm is irrelevant.

### To test:

Load a variety of Muon data using the `LoadMuonNexus` algorithm.

There is a selection available in the unit test data with filenames `ARGUS`, `EMU`, `MUSR` etc.

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
