### PR TITLE
Revert napi lookup of HDF types from NX types

### DIFF
--- a/Framework/NexusCpp/src/napi4.cpp
+++ b/Framework/NexusCpp/src/napi4.cpp
@@ -64,19 +64,51 @@ typedef struct __NexusFile {
 
 /*-------------------------------------------------------------------*/
 
-std::map<NXnumtype, int> const nxToHDF4Map{
-    {NXnumtype::CHAR, DFNT_CHAR8},    {NXnumtype::INT8, DFNT_INT8},       {NXnumtype::UINT8, DFNT_UINT8},
-    {NXnumtype::INT16, DFNT_INT16},   {NXnumtype::UINT16, DFNT_UINT16},   {NXnumtype::INT32, DFNT_INT32},
-    {NXnumtype::UINT32, DFNT_UINT32}, {NXnumtype::FLOAT32, DFNT_FLOAT32}, {NXnumtype::FLOAT64, DFNT_FLOAT64}};
-
-static int nxToHDF4Type(NXnumtype type) {
-  auto const iter = nxToHDF4Map.find(type);
-  if (iter != nxToHDF4Map.cend()) {
-    return iter->second;
-  } else {
-    NXReportError("ERROR: nxToHDF4Type: unknown type");
-    return -1;
+static int nxToHDF4Type(NXnumtype datatype) {
+  int type;
+  switch (datatype) {
+  case NXnumtype::CHAR: {
+    type = DFNT_CHAR8;
+    break;
   }
+  case NXnumtype::INT8: {
+    type = DFNT_INT8;
+    break;
+  }
+  case NXnumtype::UINT8: {
+    type = DFNT_UINT8;
+    break;
+  }
+  case NXnumtype::INT16: {
+    type = DFNT_INT16;
+    break;
+  }
+  case NXnumtype::UINT16: {
+    type = DFNT_UINT16;
+    break;
+  }
+  case NXnumtype::INT32: {
+    type = DFNT_INT32;
+    break;
+  }
+  case NXnumtype::UINT32: {
+    type = DFNT_UINT8;
+    break;
+  }
+  case NXnumtype::FLOAT32: {
+    type = DFNT_FLOAT32;
+    break;
+  }
+  case NXnumtype::FLOAT64: {
+    type = DFNT_FLOAT64;
+    break;
+  }
+  default: {
+    NXReportError("ERROR: nxToHDF4Type: unknown type");
+    type = -1;
+  }
+  }
+  return type;
 }
 
 /*-------------------------------------------------------------------*/

--- a/Framework/NexusCpp/src/napi4.cpp
+++ b/Framework/NexusCpp/src/napi4.cpp
@@ -710,6 +710,10 @@ NXstatus NX4makedata64(NXhandle fid, CONSTCHAR *name, NXnumtype datatype, int ra
   }
 
   type = nxToHDF4Type(datatype);
+  if (type == -1) {
+    NXReportError("ERROR: invalid type in NX4makedata");
+    return NXstatus::NX_ERROR;
+  }
 
   if (rank <= 0) {
     sprintf(pBuffer, "ERROR: invalid rank specified for SDS %s", name);
@@ -792,6 +796,10 @@ NXstatus NX4compmakedata64(NXhandle fid, CONSTCHAR *name, NXnumtype datatype, in
   }
 
   type = nxToHDF4Type(datatype);
+  if (type == -1) {
+    NXReportError("ERROR: invalid datatype in NX4compmakedata");
+    return NXstatus::NX_ERROR;
+  }
 
   if (rank <= 0) {
     sprintf(pBuffer, "ERROR: invalid rank specified for SDS %s", name);
@@ -1052,6 +1060,10 @@ NXstatus NX4putattr(NXhandle fid, CONSTCHAR *name, const void *data, int datalen
 
   pFile = NXIassert(fid);
   type = nxToHDF4Type(iType);
+  if (type == -1) {
+    NXReportError("ERROR: Invalid data type for HDF attribute");
+    return NXstatus::NX_ERROR;
+  }
   if (pFile->iCurrentSDS != 0) {
     /* SDS attribute */
     iRet = SDsetattr(pFile->iCurrentSDS, static_cast<const char *>(name), static_cast<int32>(type),

--- a/Framework/NexusCpp/src/napi5.cpp
+++ b/Framework/NexusCpp/src/napi5.cpp
@@ -698,26 +698,59 @@ NXstatus NX5closegroup(NXhandle fid) {
 }
 
 /*-----------------------------------------------------------------------*/
-std::map<NXnumtype, hid_t> const nxToHDF5Map{{NXnumtype::CHAR, H5T_C_S1},
-                                             {NXnumtype::INT8, H5T_NATIVE_CHAR},
-                                             {NXnumtype::UINT8, H5T_NATIVE_UCHAR},
-                                             {NXnumtype::INT16, H5T_NATIVE_SHORT},
-                                             {NXnumtype::UINT16, H5T_NATIVE_USHORT},
-                                             {NXnumtype::INT32, H5T_NATIVE_INT},
-                                             {NXnumtype::UINT32, H5T_NATIVE_UINT},
-                                             {NXnumtype::INT64, H5T_NATIVE_INT64},
-                                             {NXnumtype::UINT64, H5T_NATIVE_UINT64},
-                                             {NXnumtype::FLOAT32, H5T_NATIVE_FLOAT},
-                                             {NXnumtype::FLOAT64, H5T_NATIVE_DOUBLE}};
-
-static hid_t nxToHDF5Type(NXnumtype type) {
-  auto const iter = nxToHDF5Map.find(type);
-  if (iter != nxToHDF5Map.cend()) {
-    return iter->second;
-  } else {
-    NXReportError("ERROR: nxToHDF5Type: unknown type");
-    return -1;
+static hid_t nxToHDF5Type(NXnumtype datatype) {
+  hid_t type;
+  switch (datatype) {
+  case NXnumtype::CHAR: {
+    type = H5T_C_S1;
+    break;
   }
+  case NXnumtype::INT8: {
+    type = H5T_NATIVE_CHAR;
+    break;
+  }
+  case NXnumtype::UINT8: {
+    type = H5T_NATIVE_UCHAR;
+    break;
+  }
+  case NXnumtype::INT16: {
+    type = H5T_NATIVE_SHORT;
+    break;
+  }
+  case NXnumtype::UINT16: {
+    type = H5T_NATIVE_USHORT;
+    break;
+  }
+  case NXnumtype::INT32: {
+    type = H5T_NATIVE_INT;
+    break;
+  }
+  case NXnumtype::UINT32: {
+    type = H5T_NATIVE_UINT;
+    break;
+  }
+  case NXnumtype::INT64: {
+    type = H5T_NATIVE_INT64;
+    break;
+  }
+  case NXnumtype::UINT64: {
+    type = H5T_NATIVE_UINT64;
+    break;
+  }
+  case NXnumtype::FLOAT32: {
+    type = H5T_NATIVE_FLOAT;
+    break;
+  }
+  case NXnumtype::FLOAT64: {
+    type = H5T_NATIVE_DOUBLE;
+    break;
+  }
+  default: {
+    NXReportError("ERROR: nxToHDF5Type: unknown type");
+    type = -1;
+  }
+  }
+  return type;
 }
 
 /* --------------------------------------------------------------------- */
@@ -1508,50 +1541,50 @@ NXstatus NX5getgroupinfo(NXhandle fid, int *iN, NXname pName, NXname pClass) {
  *
  *-------------------------------------------------------------------------
  */
-static int hdf5ToNXType(H5T_class_t tclass, hid_t atype) {
-  int iPtype = -1;
+static NXnumtype hdf5ToNXType(H5T_class_t tclass, hid_t atype) {
+  NXnumtype iPtype = NXnumtype::BAD;
   size_t size;
   H5T_sign_t sign;
 
   if (tclass == H5T_STRING) {
-    iPtype = NX_CHAR;
+    iPtype = NXnumtype::CHAR;
   } else if (tclass == H5T_INTEGER) {
     size = H5Tget_size(atype);
     sign = H5Tget_sign(atype);
     if (size == 1) {
       if (sign == H5T_SGN_2) {
-        iPtype = NX_INT8;
+        iPtype = NXnumtype::INT8;
       } else {
-        iPtype = NX_UINT8;
+        iPtype = NXnumtype::UINT8;
       }
     } else if (size == 2) {
       if (sign == H5T_SGN_2) {
-        iPtype = NX_INT16;
+        iPtype = NXnumtype::INT16;
       } else {
-        iPtype = NX_UINT16;
+        iPtype = NXnumtype::UINT16;
       }
     } else if (size == 4) {
       if (sign == H5T_SGN_2) {
-        iPtype = NX_INT32;
+        iPtype = NXnumtype::INT32;
       } else {
-        iPtype = NX_UINT32;
+        iPtype = NXnumtype::UINT32;
       }
     } else if (size == 8) {
       if (sign == H5T_SGN_2) {
-        iPtype = NX_INT64;
+        iPtype = NXnumtype::INT64;
       } else {
-        iPtype = NX_UINT64;
+        iPtype = NXnumtype::UINT64;
       }
     }
   } else if (tclass == H5T_FLOAT) {
     size = H5Tget_size(atype);
     if (size == 4) {
-      iPtype = NX_FLOAT32;
+      iPtype = NXnumtype::FLOAT32;
     } else if (size == 8) {
-      iPtype = NX_FLOAT64;
+      iPtype = NXnumtype::FLOAT64;
     }
   }
-  if (iPtype == -1) {
+  if (iPtype == NXnumtype::BAD) {
     char message[80];
     snprintf(message, 79, "ERROR: hdf5ToNXtype: invalid type (%d)", tclass);
     NXReportError(message);
@@ -1720,8 +1753,8 @@ NXstatus NX5getnextentry(NXhandle fid, NXname name, NXname nxclass, NXnumtype *d
       type = H5Dget_type(grp);
       atype = H5Tcopy(type);
       tclass = H5Tget_class(atype);
-      int iPtype = hdf5ToNXType(tclass, atype);
-      *datatype = static_cast<NXnumtype>(iPtype);
+      NXnumtype iPtype = hdf5ToNXType(tclass, atype);
+      *datatype = iPtype;
       strcpy(nxclass, "SDS");
       H5Tclose(atype);
       H5Tclose(type);
@@ -1837,7 +1870,8 @@ NXstatus NX5getdata(NXhandle fid, void *data) {
 
 NXstatus NX5getinfo64(NXhandle fid, int *rank, int64_t dimension[], NXnumtype *iType) {
   pNexusFile5 pFile;
-  int i, iRank, mType;
+  int i, iRank;
+  NXnumtype mType;
   hsize_t myDim[H5S_MAX_RANK];
   H5T_class_t tclass;
   hid_t memType;
@@ -1866,7 +1900,7 @@ NXstatus NX5getinfo64(NXhandle fid, int *rank, int64_t dimension[], NXnumtype *i
     UNUSED_ARG(total_dims_size);
   }
   /* conversion to proper ints for the platform */
-  *iType = static_cast<NXnumtype>(mType);
+  *iType = mType;
   if (tclass == H5T_STRING && myDim[iRank - 1] == 1) {
     if (H5Tis_variable_str(pFile->iCurrentT)) {
       /* this will not work for arrays of strings */
@@ -2475,7 +2509,8 @@ NXstatus NX5getattra(NXhandle handle, const char *name, void *data) {
 /*------------------------------------------------------------------------*/
 NXstatus NX5getattrainfo(NXhandle handle, NXname name, int *rank, int dim[], NXnumtype *iType) {
   pNexusFile5 pFile;
-  int iRet, mType;
+  int iRet;
+  NXnumtype mType;
   hid_t vid;
   hid_t filespace, attrt, memtype;
   hsize_t myDim[H5S_MAX_RANK];
@@ -2506,7 +2541,7 @@ NXstatus NX5getattrainfo(NXhandle handle, NXname name, int *rank, int dim[], NXn
   mType = hdf5ToNXType(tclass, attrt);
 
   /* conversion to proper ints for the platform */
-  *iType = static_cast<NXnumtype>(mType);
+  *iType = mType;
 
   if (tclass == H5T_STRING) {
     myrank++;


### PR DESCRIPTION
### Description of work

#### Summary of work

Previous PR #38708 had had some refactors to the `napi` package. The majority of those were simply changing a type name from `int` to `NXstatus` or `NXnumtype`.  However, in `napi4.cpp` and `napi5.cpp`, there were two larger refactors.

In `napi5.cpp`, the function `nxToHDF5Type()` was rewritten to rely on a static dictionary lookup instead of the if/else it was using.  Also, `napi4.cpp` was rewritten to use a similar function for HDF4 types.

This restores the original lookup form, using a `switch` in both cases.

Also, in `napi4.cpp`, there was an error condition that has been restored.

#### Purpose of work

Builds have been failing following Nexus refactor work in #38332 .

This is one step in figuring out what happened and trying to fix it.

#### Further detail of work

It's possible the old dictionary method was returning some invalid integer, or was not properly handling an error.  This should make sure that was not the source of problems.

### To test:

OSX System Tests:
-  [![Build Status](https://builds.mantidproject.org/buildStatus/icon?job=build_packages_from_branch&build=1010)](https://builds.mantidproject.org/job/build_packages_from_branch/1010/)
- [![Build Status](https://builds.mantidproject.org/buildStatus/icon?job=build_packages_from_branch&build=1013)](https://builds.mantidproject.org/job/build_packages_from_branch/1013/)

Windows System Tests:
- [![Build Status](https://builds.mantidproject.org/buildStatus/icon?job=build_packages_from_branch&build=1012)](https://builds.mantidproject.org/job/build_packages_from_branch/1012/)
- [![Build Status](https://builds.mantidproject.org/buildStatus/icon?job=build_packages_from_branch&build=1014)](https://builds.mantidproject.org/job/build_packages_from_branch/1014/)

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
