### PR TITLE
Fixed typo in error message in SaveAscii2

### DIFF
--- a/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Framework/DataHandling/src/SaveAscii2.cpp
@@ -169,7 +169,7 @@ void SaveAscii2::exec() {
   }
 
   if (!m_ws) {
-    throw std::runtime_error("SaveAscii does not now how to save this workspace type, " + ws->getName());
+    throw std::runtime_error("SaveAscii does not know how to save this workspace type, " + ws->getName());
   }
 
   // Get the properties valid for matrix workspaces


### PR DESCRIPTION
### Description of work

There was an annoying typo in an error message in SaveAscii2. I couldn’t resist fixing it.

*There is no associated issue.*

### To test:

Check changed error message for typos.

*This does not require release notes* because **it is just a tiny fix for a typo.**

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
