### PR TITLE
Change `NexusClasses` integer types

### DIFF
--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -846,10 +846,10 @@ API::Workspace_sptr LoadNexusProcessed::loadTableEntry(const NXEntry &entry) {
         std::string columnTitle = data.attributes("name");
         if (!columnTitle.empty()) {
           workspace->addColumn("str", columnTitle);
-          int nRows = info.dims[0];
+          nxdimsize_t nRows = info.dims[0];
           workspace->setRowCount(nRows);
 
-          const int maxStr = info.dims[1];
+          nxdimsize_t const maxStr = info.dims[1];
           data.load();
           for (int iR = 0; iR < nRows; ++iR) {
             auto &cellContents = workspace->cell<std::string>(iR, columnNumber - 1);
@@ -1176,7 +1176,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXInfo info = nx_tw.getDataSetInfo(str);
       NXChar data = nx_tw.openNXChar(str);
 
-      const int maxShapeJSONLength = info.dims[1];
+      nxdimsize_t const maxShapeJSONLength = info.dims[1];
       data.load();
       for (int i = 0; i < numberPeaks; ++i) {
 
@@ -1470,7 +1470,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXInfo info = nx_tw.getDataSetInfo(str);
       NXChar data = nx_tw.openNXChar(str);
 
-      const int maxShapeJSONLength = info.dims[1];
+      nxdimsize_t const maxShapeJSONLength = info.dims[1];
       data.load();
       for (int i = 0; i < numberPeaks; ++i) {
 

--- a/Framework/DataHandling/src/LoadTOFRawNexus.cpp
+++ b/Framework/DataHandling/src/LoadTOFRawNexus.cpp
@@ -187,7 +187,7 @@ void LoadTOFRawNexus::countPixels(const std::string &nexusfilename, const std::s
 
           // Count how many pixels in the bank
           file.openData("pixel_id");
-          std::vector<int64_t> dims = file.getInfo().dims;
+          ::NeXus::DimVector const dims = file.getInfo().dims;
           file.closeData();
 
           if (!dims.empty()) {
@@ -200,11 +200,11 @@ void LoadTOFRawNexus::countPixels(const std::string &nexusfilename, const std::s
 
           // Get the number of pixels from the offsets arrays
           file.openData("x_pixel_offset");
-          std::vector<int64_t> xdim = file.getInfo().dims;
+          ::NeXus::DimVector const xdim = file.getInfo().dims;
           file.closeData();
 
           file.openData("y_pixel_offset");
-          std::vector<int64_t> ydim = file.getInfo().dims;
+          ::NeXus::DimVector const ydim = file.getInfo().dims;
           file.closeData();
 
           if (!xdim.empty() && !ydim.empty()) {
@@ -215,7 +215,7 @@ void LoadTOFRawNexus::countPixels(const std::string &nexusfilename, const std::s
         if (bankEntries.find(m_axisField) != bankEntries.end()) {
           // Get the size of the X vector
           file.openData(m_axisField);
-          std::vector<int64_t> dims = file.getInfo().dims;
+          ::NeXus::DimVector const dims = file.getInfo().dims;
           // Find the units, if available
           if (file.hasAttr("units"))
             file.getAttr("units", m_xUnits);

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -290,7 +290,7 @@ public:
     if (rank() > 4) {
       throw std::runtime_error("Cannot load dataset of rank greater than 4");
     }
-    nxdimsize_t n = 0, id(i), jd(j), kd(l), ld(l);
+    nxdimsize_t n = 0, id(i), jd(j), kd(l), ld(l); // cppcheck-suppress variableScope
     NXDimArray start;
     if (rank() == 4) {
       if (i < 0) // load all data

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -434,7 +434,7 @@ public:
 
 private:
   /** Allocates memory for the data buffer
-   *  @param n :: The number of elements to allocate.
+   *  @param new_size :: The number of elements to allocate.
    */
   void alloc(nxdimsize_t new_size) {
     if (new_size <= 0) {

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -8,8 +8,6 @@
 
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/PropertyWithValue.h"
-#include "MantidNexusCpp/NeXusException.hpp"
-#include "MantidNexusCpp/NeXusFile.hpp"
 #include "MantidNexusCpp/napi.h"
 
 #include <memory>

--- a/Framework/NexusCpp/inc/MantidNexusCpp/NeXusFile.hpp
+++ b/Framework/NexusCpp/inc/MantidNexusCpp/NeXusFile.hpp
@@ -43,12 +43,12 @@ public:
    */
   AttrInfo getNextAttr();
 
-private:
   /**
    * Initialize the pending group search to start again.
    */
   void initGroupDir();
 
+private:
   /**
    * Initialize the pending attribute search to start again.
    */
@@ -145,7 +145,7 @@ public:
 
   /**
    * \copydoc NeXus::File::makeData(const std::string&, NXnumtype,
-   *                              const std::vector<int64_t>&, bool);
+   *                              const DimVector&, bool);
    */
   void makeData(const std::string &name, NXnumtype type, const std::vector<int> &dims, bool open_data = false);
 
@@ -157,7 +157,7 @@ public:
    * \param dims The dimensions of the field.
    * \param open_data Whether or not to open the data after creating it.
    */
-  void makeData(const std::string &name, NXnumtype type, const std::vector<int64_t> &dims, bool open_data = false);
+  void makeData(const std::string &name, NXnumtype type, const DimVector &dims, bool open_data = false);
 
   /**
    * Create a 1D data field with the specified information.
@@ -224,7 +224,7 @@ public:
    * \tparam NumT numeric data type of \a value
    */
   template <typename NumT>
-  void writeData(const std::string &name, const std::vector<NumT> &value, const std::vector<int64_t> &dims);
+  void writeData(const std::string &name, const std::vector<NumT> &value, const DimVector &dims);
 
   /** Create a 1D data field with an unlimited dimension, insert the data, and close the data.
    *
@@ -242,7 +242,7 @@ public:
    * \param chunkSize :: chunk size to use when writing
    */
   template <typename NumT>
-  void writeExtendibleData(const std::string &name, std::vector<NumT> &value, const int64_t chunk);
+  void writeExtendibleData(const std::string &name, std::vector<NumT> &value, const dimsize_t chunk);
 
   /** Create a 1D data field with an unlimited dimension, insert the data, and close the data.
    *
@@ -253,8 +253,7 @@ public:
    * \param chunk :: chunk size to use when writing
    */
   template <typename NumT>
-  void writeExtendibleData(const std::string &name, std::vector<NumT> &value, std::vector<int64_t> &dims,
-                           std::vector<int64_t> &chunk);
+  void writeExtendibleData(const std::string &name, std::vector<NumT> &value, DimVector &dims, DimSizeVector &chunk);
 
   /** Updates the data written into an already-created
    * data vector. If the data was created as extendible, it will be resized.
@@ -273,13 +272,12 @@ public:
    * \param value :: The vector to put into the file.
    * \param dims :: The dimensions of the data.
    */
-  template <typename NumT>
-  void writeUpdatedData(const std::string &name, std::vector<NumT> &value, std::vector<int64_t> &dims);
+  template <typename NumT> void writeUpdatedData(const std::string &name, std::vector<NumT> &value, DimVector &dims);
 
   /**
    * \copydoc makeCompData(const std::string&, const NXnumtype,
-   *                       const std::vector<int64_t>&, const NXcompression,
-   *                       const std::vector<int64_t>&, bool)
+   *                       const DimVector&, const NXcompression,
+   *                       const DimSizeVector&, bool)
    */
   void makeCompData(const std::string &name, const NXnumtype type, const std::vector<int> &dims,
                     const NXcompression comp, const std::vector<int> &bufsize, bool open_data = false);
@@ -294,14 +292,14 @@ public:
    * \param bufsize The size of the compression buffer to use.
    * \param open_data Whether or not to open the data after creating it.
    */
-  void makeCompData(const std::string &name, const NXnumtype type, const std::vector<int64_t> &dims,
-                    const NXcompression comp, const std::vector<int64_t> &bufsize, bool open_data = false);
+  void makeCompData(const std::string &name, const NXnumtype type, const DimVector &dims, const NXcompression comp,
+                    const DimSizeVector &bufsize, bool open_data = false);
 
   /**
    * \copydoc writeCompData(const std::string & name,
    *                        const std::vector<NumT> & value,
-   *                        const std::vector<int64_t> & dims, const NXcompression comp,
-   *                        const std::vector<int64_t> & bufsize)
+   *                        const DimVector & dims, const NXcompression comp,
+   *                        const DimSizeVector & bufsize)
    */
   template <typename NumT>
   void writeCompData(const std::string &name, const std::vector<NumT> &value, const std::vector<int> &dims,
@@ -318,8 +316,8 @@ public:
    * \tparam NumT numeric data type of \a value
    */
   template <typename NumT>
-  void writeCompData(const std::string &name, const std::vector<NumT> &value, const std::vector<int64_t> &dims,
-                     const NXcompression comp, const std::vector<int64_t> &bufsize);
+  void writeCompData(const std::string &name, const std::vector<NumT> &value, const DimVector &dims,
+                     const NXcompression comp, const DimSizeVector &bufsize);
 
   /**
    * \param name The name of the data to open.
@@ -376,8 +374,8 @@ public:
   void putAttr(const std::string &name, const std::string &value, const bool empty_add_space = true);
 
   /**
-   * \copydoc NeXus::File::putSlab(void* data, std::vector<int64_t>& start,
-   *                                std::vector<int64_t>& size)
+   * \copydoc NeXus::File::putSlab(void* data, DimSizeVector& start,
+   *                                DimSizeVector& size)
    */
   void putSlab(const void *data, const std::vector<int> &start, const std::vector<int> &size);
 
@@ -388,11 +386,11 @@ public:
    * \param start The starting index to insert the data.
    * \param size The size of the array to put in the file.
    */
-  void putSlab(const void *data, const std::vector<int64_t> &start, const std::vector<int64_t> &size);
+  void putSlab(const void *data, const DimSizeVector &start, const DimSizeVector &size);
 
   /**
-   * \copydoc NeXus::File::putSlab(std::vector<NumT>& data, std::vector<int64_t>&,
-   *                               std::vector<int64_t>&)
+   * \copydoc NeXus::File::putSlab(std::vector<NumT>& data, DimSizeVector&,
+   *                               DimSizeVector&)
    */
   template <typename NumT>
   void putSlab(const std::vector<NumT> &data, const std::vector<int> &start, const std::vector<int> &size);
@@ -406,7 +404,7 @@ public:
    * \tparam NumT numeric data type of \a data
    */
   template <typename NumT>
-  void putSlab(const std::vector<NumT> &data, const std::vector<int64_t> &start, const std::vector<int64_t> &size);
+  void putSlab(const std::vector<NumT> &data, const DimSizeVector &start, const DimSizeVector &size);
 
   /**
    * \copydoc NeXus::File::putSlab(std::vector<NumT>&, int64_t, int64_t)
@@ -421,7 +419,7 @@ public:
    * \param size The size of the array to put in the file.
    * \tparam NumT numeric data type of \a data
    */
-  template <typename NumT> void putSlab(const std::vector<NumT> &data, int64_t start, int64_t size);
+  template <typename NumT> void putSlab(const std::vector<NumT> &data, dimsize_t start, dimsize_t size);
 
   /**
    * \return The id of the data used for linking.
@@ -528,8 +526,8 @@ public:
   void getEntries(Entries &result);
 
   /**
-   * \copydoc NeXus::File::getSlab(void*, const std::vector<int64_t>&,
-   *                               const std::vector<int64_t>&)
+   * \copydoc NeXus::File::getSlab(void*, const DimSizeVector&,
+   *                               const DimSizeVector&)
    */
   void getSlab(void *data, const std::vector<int> &start, const std::vector<int> &size);
 
@@ -541,7 +539,7 @@ public:
    * from.
    * \param size The size of the block to read from the file.
    */
-  void getSlab(void *data, const std::vector<int64_t> &start, const std::vector<int64_t> &size);
+  void getSlab(void *data, const DimSizeVector &start, const DimSizeVector &size);
 
   /**
    * \return Information about all attributes on the data that is

--- a/Framework/NexusCpp/inc/MantidNexusCpp/NeXusFile_fwd.h
+++ b/Framework/NexusCpp/inc/MantidNexusCpp/NeXusFile_fwd.h
@@ -171,6 +171,14 @@ MANTID_NEXUSCPP_DLL std::ostream &operator<<(std::ostream &stm, const NXnumtype 
 // forward declare
 namespace NeXus {
 
+// TODO change to std::size_t
+typedef std::int64_t dimsize_t;
+// TODO replace all instances with DimArray
+typedef std::vector<dimsize_t> DimVector; ///< usef specifically for the dims array
+// typedef std::array<DimSize, 4> DimArray;
+//  TODO this is probably the same as DimVector
+typedef std::vector<dimsize_t> DimSizeVector; ///< used for start, size, chunk, buffsize, etc.
+
 /**
  * The available compression types. These are all ignored in xml files.
  * \li NONE no compression
@@ -196,7 +204,7 @@ struct Info {
   /** The primative type for the field. */
   NXnumtype type;
   /** The dimensions of the file. */
-  std::vector<int64_t> dims;
+  DimVector dims;
 };
 
 /** Information about an attribute. */
@@ -208,7 +216,7 @@ struct AttrInfo {
   /** The name of the attribute. */
   std::string name;
   /** The dimensions of the attribute. */
-  std::vector<int> dims;
+  DimVector dims;
 };
 
 /** Forward declare of NeXus::File */


### PR DESCRIPTION
### Description of work

#### Summary of work

This had previous been done in PR #38791 .  However, since that was reverted, changes are slowly and gradually being added back in.

This updates the use of integer types to enable better refactoring, and hopefully changing all of these `int`s over to `int64_t` or `size_t` when the move to `NeXus::File` is made.

The original work had updated `NexusClasses` to use `int64_t`.  However, since this is still relying on `napi.h` it must interface with that, which requires using `int`s in a bunch of places.  Future work to remove `napi` functions from `NexusClasses` should also fix this.

Part of #38332 

Related to #38805


#### Further detail of work

Defines several types for handling the `dims` array on some of the Nexus classes, which are returned by file access.

### To test:

[![Build Status](https://builds.mantidproject.org/buildStatus/icon?job=build_packages_from_branch&build=1025)](https://builds.mantidproject.org/job/build_packages_from_branch/1025/console)

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
