### PR TITLE
Remove napi functions from `NexusClasses`

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -167,20 +167,12 @@ public:
    *   @param j :: Non-negative value makes it read a chunk of dimension
    * rank()-2. i and j are its indices.
    *            The rank of the data must be >= 2
-   *   @param k :: Non-negative value makes it read a chunk of dimension
-   * rank()-3. i,j and k are its indices.
-   *            The rank of the data must be >= 3
-   *   @param l :: Non-negative value makes it read a chunk of dimension
-   * rank()-4. i,j,k and l are its indices.
-   *            The rank of the data must be 4
    */
-  virtual void load(int const blocksize, int const i, int const j, int const k, int const l) {
+  virtual void load(int const blocksize, int const i, int const j) {
     // we need the var names for docs build, need below void casts to stop compiler warnings
     UNUSED_ARG(blocksize);
     UNUSED_ARG(i);
     UNUSED_ARG(j);
-    UNUSED_ARG(k);
-    UNUSED_ARG(l);
   };
 
 protected:
@@ -283,11 +275,11 @@ public:
    * rank()-2. i and j are its indeces.
    *            The rank of the data must be >= 2
    */
-  void load(int const blocksize = 1, int const i = -1, int const j = -1, int const k = -1, int const l = -1) override {
+  void load(int const blocksize = 1, int const i = -1, int const j = -1) override {
     if (rank() > 4) {
       throw std::runtime_error("Cannot load dataset of rank greater than 4");
     }
-    nxdimsize_t n = 0, id(i), jd(j), kd(k), ld(l); // cppcheck-suppress variableScope
+    nxdimsize_t n = 0, id(i), jd(j); // cppcheck-suppress variableScope
     std::vector<int64_t> datastart, datasize;
     if (rank() == 4) {
       if (i < 0) // load all data
@@ -302,24 +294,12 @@ public:
         n = dim1() * dim2() * dim3();
         datastart = {i, 0, 0, 0};
         datasize = {1, dim1(), dim2(), dim2()};
-      } else if (k < 0) {
+      } else {
         if (id >= dim0() || jd >= dim1())
           rangeError();
         n = dim2() * dim3();
         datastart = {i, j, 0, 0};
         datasize = {1, 1, dim2(), dim2()};
-      } else if (l < 0) {
-        if (id >= dim0() || jd >= dim1() || kd >= dim2())
-          rangeError();
-        n = dim3();
-        datastart = {i, j, k, 0};
-        datasize = {1, 1, 1, dim2()};
-      } else {
-        if (id >= dim0() || jd >= dim1() || kd >= dim2() || ld >= dim3())
-          rangeError();
-        n = dim3();
-        datastart = {i, j, k, l};
-        datasize = {1, 1, 1, 1};
       }
     } else if (rank() == 3) {
       if (i < 0) {
@@ -333,7 +313,7 @@ public:
         n = dim1() * dim2();
         datastart = {i, 0, 0};
         datasize = {1, dim1(), dim2()};
-      } else if (k < 0) {
+      } else {
         if (id >= dim0() || jd >= dim1())
           rangeError();
         nxdimsize_t m = blocksize;
@@ -342,12 +322,6 @@ public:
         n = dim2() * m;
         datastart = {i, j, 0};
         datasize = {1, m, dim2()};
-      } else {
-        if (id >= dim0() || jd >= dim1() || kd >= dim2())
-          rangeError();
-        n = 1;
-        datastart = {i, j, k};
-        datasize = {1, 1, 1};
       }
     } else if (rank() == 2) {
       if (i < 0) {

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -36,8 +36,9 @@ typedef std::array<nxdimsize_t, 4> NXDimArray;
  */
 struct NXInfo {
   NXInfo() : nxname(), rank(0), dims(), type(NXnumtype::BAD), stat(NXstatus::NX_ERROR) {}
+  NXInfo(::NeXus::Info const &info, std::string const &name);
   std::string nxname; ///< name of the object
-  int rank;           ///< number of dimensions of the data -- TODO change to size_t or int64_t
+  std::size_t rank;   ///< number of dimensions of the data
   NXDimArray dims;    ///< sizes along each dimension
   NXnumtype type;     ///< type of the data, e.g. NX_CHAR, NXnumtype::FLOAT32, see napi.h
   NXstatus stat;      ///< return status
@@ -47,6 +48,7 @@ struct NXInfo {
 /**  Information about a Nexus class
  */
 struct NXClassInfo {
+  NXClassInfo(::NeXus::Entry e) : nxname(e.first), nxclass(e.second), datatype(NXnumtype::BAD), stat(NXstatus::NX_OK) {}
   NXClassInfo() : nxname(), nxclass(), datatype(NXnumtype::BAD), stat(NXstatus::NX_ERROR) {}
   std::string nxname;  ///< name of the object
   std::string nxclass; ///< NX class of the object or "SDS" if a dataset
@@ -90,7 +92,8 @@ class MANTID_NEXUS_DLL NXObject {
   friend class NXRoot;    ///< a friend class declaration
 public:
   // Constructor
-  NXObject(const NXhandle fileID, const NXClass *parent, const std::string &name);
+  NXObject(::NeXus::File *fileID, NXClass const *parent, std::string const &name);
+  NXObject(std::shared_ptr<::NeXus::File> fileID, NXClass const *parent, std::string const &name);
   virtual ~NXObject() = default;
   /// Return the NX class name for a class (HDF group) or "SDS" for a data set;
   virtual std::string NX_class() const = 0;
@@ -104,13 +107,13 @@ public:
   /// Attributes
   NXAttributes attributes;
   /// Nexus file id
-  NXhandle m_fileID;
+  std::shared_ptr<::NeXus::File> m_fileID;
 
 protected:
   std::string m_path; ///< Keeps the absolute path to the object
   bool m_open;        ///< Set to true if the object has been open
 private:
-  NXObject() : m_fileID(), m_open(false) {} ///< Private default constructor
+  NXObject(); ///< Private default constructor
   void getAttributes();
 };
 
@@ -182,7 +185,7 @@ public:
 
 protected:
   void getData(void *data);
-  void getSlab(void *data, NXDimArray const &start, NXDimArray const &size);
+  void getSlab(void *data, ::NeXus::DimSizeVector const &start, ::NeXus::DimSizeVector const &size);
 
 private:
   NXInfo m_info; ///< Holds the data info
@@ -279,19 +282,13 @@ public:
    *   @param j :: Non-negative value makes it read a chunk of dimension
    * rank()-2. i and j are its indeces.
    *            The rank of the data must be >= 2
-   *   @param k :: Non-negative value makes it read a chunk of dimension
-   * rank()-3. i,j and k are its indeces.
-   *            The rank of the data must be >= 3
-   *   @param l :: Non-negative value makes it read a chunk of dimension
-   * rank()-4. i,j,k and l are its indeces.
-   *            The rank of the data must be 4
    */
   void load(int const blocksize = 1, int const i = -1, int const j = -1, int const k = -1, int const l = -1) override {
     if (rank() > 4) {
       throw std::runtime_error("Cannot load dataset of rank greater than 4");
     }
-    nxdimsize_t n = 0, id(i), jd(j), kd(l), ld(l); // cppcheck-suppress variableScope
-    NXDimArray datastart, datasize;
+    nxdimsize_t n = 0, id(i), jd(j), kd(k), ld(l); // cppcheck-suppress variableScope
+    std::vector<int64_t> datastart, datasize;
     if (rank() == 4) {
       if (i < 0) // load all data
       {
@@ -303,50 +300,26 @@ public:
         if (id >= dim0())
           rangeError();
         n = dim1() * dim2() * dim3();
-        datastart[0] = i;
-        datasize[0] = 1;
-        datastart[1] = 0;
-        datasize[1] = dim1();
-        datastart[2] = 0;
-        datasize[2] = dim2();
-        datastart[3] = 0;
-        datasize[3] = dim2();
+        datastart = {i, 0, 0, 0};
+        datasize = {1, dim1(), dim2(), dim2()};
       } else if (k < 0) {
         if (id >= dim0() || jd >= dim1())
           rangeError();
         n = dim2() * dim3();
-        datastart[0] = i;
-        datasize[0] = 1;
-        datastart[1] = j;
-        datasize[1] = 1;
-        datastart[2] = 0;
-        datasize[2] = dim2();
-        datastart[3] = 0;
-        datasize[3] = dim2();
+        datastart = {i, j, 0, 0};
+        datasize = {1, 1, dim2(), dim2()};
       } else if (l < 0) {
         if (id >= dim0() || jd >= dim1() || kd >= dim2())
           rangeError();
         n = dim3();
-        datastart[0] = i;
-        datasize[0] = 1;
-        datastart[1] = j;
-        datasize[1] = 1;
-        datastart[2] = k;
-        datasize[2] = 1;
-        datastart[3] = 0;
-        datasize[3] = dim2();
+        datastart = {i, j, k, 0};
+        datasize = {1, 1, 1, dim2()};
       } else {
         if (id >= dim0() || jd >= dim1() || kd >= dim2() || ld >= dim3())
           rangeError();
         n = dim3();
-        datastart[0] = i;
-        datasize[0] = 1;
-        datastart[1] = j;
-        datasize[1] = 1;
-        datastart[2] = k;
-        datasize[2] = 1;
-        datastart[3] = l;
-        datasize[3] = 1;
+        datastart = {i, j, k, l};
+        datasize = {1, 1, 1, 1};
       }
     } else if (rank() == 3) {
       if (i < 0) {
@@ -358,12 +331,8 @@ public:
         if (id >= dim0())
           rangeError();
         n = dim1() * dim2();
-        datastart[0] = i;
-        datasize[0] = 1;
-        datastart[1] = 0;
-        datasize[1] = dim1();
-        datastart[2] = 0;
-        datasize[2] = dim2();
+        datastart = {i, 0, 0};
+        datasize = {1, dim1(), dim2()};
       } else if (k < 0) {
         if (id >= dim0() || jd >= dim1())
           rangeError();
@@ -371,22 +340,14 @@ public:
         if (jd + m > dim1())
           m = dim1() - jd;
         n = dim2() * m;
-        datastart[0] = i;
-        datasize[0] = 1;
-        datastart[1] = j;
-        datasize[1] = m;
-        datastart[2] = 0;
-        datasize[2] = dim2();
+        datastart = {i, j, 0};
+        datasize = {1, m, dim2()};
       } else {
         if (id >= dim0() || jd >= dim1() || kd >= dim2())
           rangeError();
         n = 1;
-        datastart[0] = i;
-        datasize[0] = 1;
-        datastart[1] = j;
-        datasize[1] = 1;
-        datastart[2] = k;
-        datasize[2] = 1;
+        datastart = {i, j, k};
+        datasize = {1, 1, 1};
       }
     } else if (rank() == 2) {
       if (i < 0) {
@@ -401,18 +362,14 @@ public:
         if (id + m > dim0())
           m = dim0() - id;
         n = dim1() * m;
-        datastart[0] = i;
-        datasize[0] = m;
-        datastart[1] = 0;
-        datasize[1] = dim1();
+        datastart = {i, 0};
+        datasize = {m, dim1()};
       } else {
         if (id >= dim0() || jd >= dim1())
           rangeError();
         n = 1;
-        datastart[0] = i;
-        datasize[0] = 1;
-        datastart[1] = j;
-        datasize[1] = 1;
+        datastart = {i, j};
+        datasize = {1, 1};
       }
     } else if (rank() == 1) {
       if (i < 0) {
@@ -424,8 +381,8 @@ public:
         if (id >= dim0())
           rangeError();
         n = 1 * blocksize;
-        datastart[0] = i;
-        datasize[0] = blocksize;
+        datastart = {i};
+        datasize = {blocksize};
       }
     }
     alloc(n);

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -8,12 +8,24 @@
 
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/PropertyWithValue.h"
-#include "MantidNexusCpp/napi.h"
+#include "MantidNexusCpp/NeXusException.hpp"
+#include "MantidNexusCpp/NeXusFile.hpp"
 
 #include <memory>
 #include <utility>
 
 namespace Mantid::NeXus {
+
+static NXDimArray nxdimArray(::NeXus::DimVector xd) {
+  NXDimArray ret{0};
+  for (std::size_t i = 0; i < xd.size(); i++) {
+    ret[i] = static_cast<nxdimsize_t>(xd[i]);
+  }
+  return ret;
+}
+
+NXInfo::NXInfo(::NeXus::Info const &info, std::string const &name)
+    : nxname(name), rank(info.dims.size()), dims(nxdimArray(info.dims)), type(info.type), stat(NXstatus::NX_OK) {}
 
 std::vector<std::string> NXAttributes::names() const {
   std::vector<std::string> out;
@@ -63,13 +75,30 @@ template <typename T> void NXAttributes::set(const std::string &name, T value) {
 //          NXObject methods
 //---------------------------------------------------------
 
+/**  NXObject private default constructor
+ */
+NXObject::NXObject() : m_fileID(nullptr), m_open(false) {}
+
 /**  NXObject constructor.
  *   @param fileID :: The Nexus file id
  *   @param parent :: The parent Nexus class. In terms of HDF it is the group
  * containing the object.
  *   @param name :: The name of the object relative to its parent
  */
-NXObject::NXObject(const NXhandle fileID, const NXClass *parent, const std::string &name)
+NXObject::NXObject(::NeXus::File *fileID, NXClass const *parent, const std::string &name)
+    : m_fileID(fileID), m_open(false) {
+  if (parent && !name.empty()) {
+    m_path = parent->path() + "/" + name;
+  }
+}
+
+/**  NXObject constructor.
+ *   @param fileID :: The Nexus file id
+ *   @param parent :: The parent Nexus class. In terms of HDF it is the group
+ * containing the object.
+ *   @param name :: The name of the object relative to its parent
+ */
+NXObject::NXObject(std::shared_ptr<::NeXus::File> fileID, NXClass const *parent, const std::string &name)
     : m_fileID(fileID), m_open(false) {
   if (parent && !name.empty()) {
     m_path = parent->path() + "/" + name;
@@ -87,48 +116,27 @@ std::string NXObject::name() const {
 /**  Reads in attributes
  */
 void NXObject::getAttributes() {
-  NXname pName;
-  NXnumtype iType;
-  int iLength;
-  int rank;
-  int dims[4];
   std::vector<char> buff(128);
-
-  while (NXgetnextattra(m_fileID, pName, &rank, dims, &iType) != NXstatus::NX_EOD) {
-    if (rank > 1) { // mantid only supports single value attributes
-      throw std::runtime_error("Encountered attribute with multi-dimensional array value");
-    }
-    iLength = dims[0]; // to clarify things
-    if (iType != NXnumtype::CHAR && iLength != 1) {
+  for (::NeXus::AttrInfo const &ainfo : m_fileID->getAttrInfos()) {
+    if (ainfo.type != NXnumtype::CHAR && ainfo.length != 1) {
       throw std::runtime_error("Encountered attribute with array value");
     }
 
-    switch (iType) {
+    switch (ainfo.type) {
     case NXnumtype::CHAR: {
-      if (iLength >= 0 && (unsigned)iLength > buff.size()) {
-        buff.resize(iLength);
-      }
-      int nz = iLength + 1;
-      NXgetattr(m_fileID, pName, buff.data(), &nz, &iType);
-      attributes.set(pName, buff.data());
+      attributes.set(ainfo.name, m_fileID->getStrAttr(ainfo));
       break;
     }
     case NXnumtype::INT16: {
-      short int value;
-      NXgetattr(m_fileID, pName, &value, &iLength, &iType);
-      attributes.set(pName, value);
+      attributes.set(ainfo.name, m_fileID->getAttr<short int>(ainfo));
       break;
     }
     case NXnumtype::INT32: {
-      int value;
-      NXgetattr(m_fileID, pName, &value, &iLength, &iType);
-      attributes.set(pName, value);
+      attributes.set(ainfo.name, m_fileID->getAttr<int>(ainfo));
       break;
     }
     case NXnumtype::UINT16: {
-      short unsigned int value;
-      NXgetattr(m_fileID, pName, &value, &iLength, &iType);
-      attributes.set(pName, value);
+      attributes.set(ainfo.name, m_fileID->getAttr<short unsigned int>(ainfo));
       break;
     }
     default:
@@ -142,52 +150,33 @@ void NXObject::getAttributes() {
 
 NXClass::NXClass(const NXClass &parent, const std::string &name) : NXObject(parent.m_fileID, &parent, name) { clear(); }
 
-NXClassInfo NXClass::getNextEntry() {
-  NXClassInfo res;
-  char nxname[NX_MAXNAMELEN], nxclass[NX_MAXNAMELEN];
-  // cppcheck-suppress argumentSize
-  res.stat = NXgetnextentry(m_fileID, nxname, nxclass, &res.datatype);
-  if (res) // Check if previous call was successful
-  {
-    res.nxname = nxname;
-    res.nxclass = nxclass;
-  }
-  return res;
-}
-
 void NXClass::readAllInfo() {
   clear();
-  NXClassInfo info;
-  while ((info = getNextEntry())) {
-    if (info.nxclass == "SDS") {
-      NXInfo data_info;
-      NXopendata(m_fileID, info.nxname.c_str());
-      data_info.stat = NXgetinfo(m_fileID, &data_info.rank, &(data_info.dims[0]), &data_info.type);
-      NXclosedata(m_fileID);
-      data_info.nxname = info.nxname;
-      m_datasets->emplace_back(data_info);
-    } else if (info.nxclass.substr(0, 2) == "NX" || info.nxclass.substr(0, 2) == "IX") {
-      m_groups->emplace_back(info);
+  for (auto const &entry : m_fileID->getEntries()) {
+    if (entry.second == "SDS") {
+      m_fileID->openData(entry.first);
+      NXInfo info(m_fileID->getInfo(), entry.first);
+      m_fileID->closeData();
+      m_datasets->emplace_back(info);
+    } else if (entry.second.substr(0, 2) == "NX" || entry.second.substr(0, 2) == "IX") {
+      m_groups->emplace_back(NXClassInfo(entry));
     }
   }
   reset();
 }
 
 bool NXClass::isValid(const std::string &path) const {
-  if (NXopengrouppath(m_fileID, path.c_str()) == NXstatus::NX_OK) {
-    NXclosegroup(m_fileID);
+  try {
+    m_fileID->openGroupPath(path);
+    m_fileID->closeGroup();
     return true;
-  } else
+  } catch (::NeXus::Exception const &) {
     return false;
+  }
 }
 
 void NXClass::open() {
-  if (NXopengrouppath(m_fileID, m_path.c_str()) == NXstatus::NX_ERROR) {
-
-    throw std::runtime_error("Cannot open group " + name() + " of class " + NX_class() + " (trying to open path " +
-                             m_path + ")");
-  }
-  //}
+  m_fileID->openGroupPath(m_path);
   m_open = true;
   readAllInfo();
 }
@@ -204,13 +193,9 @@ void NXClass::open() {
  */
 bool NXClass::openLocal(const std::string &nxclass) {
   std::string className = nxclass.empty() ? NX_class() : nxclass;
-  if (NXopengroup(m_fileID, name().c_str(), className.c_str()) == NXstatus::NX_ERROR) {
-    // It would be nice if this worked
-    // if (NXstatus::NX_ERROR == NXopengrouppath(m_fileID,m_path.c_str()))
-    //{
-    //  throw std::runtime_error("Cannot open group "+m_path+" of class
-    //  "+NX_class());
-    //}
+  try {
+    m_fileID->openGroup(name(), className);
+  } catch (::NeXus::Exception const &) {
     return false;
   }
   m_open = true;
@@ -219,14 +204,16 @@ bool NXClass::openLocal(const std::string &nxclass) {
 }
 
 void NXClass::close() {
-  if (NXclosegroup(m_fileID) == NXstatus::NX_ERROR) {
+  try {
+    m_fileID->closeGroup();
+  } catch (::NeXus::Exception const &) {
     throw std::runtime_error("Cannot close group " + name() + " of class " + NX_class() + " (trying to close path " +
                              m_path + ")");
   }
   m_open = false;
 }
 
-void NXClass::reset() { NXinitgroupdir(m_fileID); }
+void NXClass::reset() { m_fileID->initGroupDir(); }
 
 void NXClass::clear() {
   m_groups.reset(new std::vector<NXClassInfo>);
@@ -302,9 +289,10 @@ bool NXClass::containsDataSet(const std::string &query) const {
  */
 NXRoot::NXRoot(std::string fname) : m_filename(std::move(fname)) {
   // Open NeXus file
-  NXstatus stat = NXopen(m_filename.c_str(), NXACC_READ, &m_fileID);
-  if (stat == NXstatus::NX_ERROR) {
-    std::cout << "NXRoot: Error loading " << m_filename;
+  try {
+    m_fileID = std::make_shared<::NeXus::File>(m_filename, NXACC_READ);
+  } catch (::NeXus::Exception const &e) {
+    std::cout << "NXRoot: Error loading " << m_filename << "\" in read mode: " << e.what() << "\n";
     throw Kernel::Exception::FileError("Unable to open File:", m_filename);
   }
   readAllInfo();
@@ -316,15 +304,16 @@ NXRoot::NXRoot(std::string fname) : m_filename(std::move(fname)) {
  *   @param entry :: The name of the first entry in the new file
  */
 NXRoot::NXRoot(std::string fname, const std::string &entry) : m_filename(std::move(fname)) {
-  (void)entry;
+  UNUSED_ARG(entry);
   // Open NeXus file
-  NXstatus stat = NXopen(m_filename.c_str(), NXACC_CREATE5, &m_fileID);
-  if (stat == NXstatus::NX_ERROR) {
+  try {
+    m_fileID = std::make_shared<::NeXus::File>(m_filename, NXACC_CREATE5);
+  } catch (::NeXus::Exception const &) {
     throw Kernel::Exception::FileError("Unable to open File:", m_filename);
   }
 }
 
-NXRoot::~NXRoot() { NXclose(&m_fileID); }
+NXRoot::~NXRoot() { m_fileID->close(); }
 
 bool NXRoot::isStandard() const { return true; }
 
@@ -369,30 +358,18 @@ void NXDataSet::open() {
   if (i == std::string::npos || i == 0)
     return; // we are in the root group, assume it is open
   std::string group_path = m_path.substr(0, i);
-  if (NXopenpath(m_fileID, group_path.c_str()) == NXstatus::NX_ERROR) {
-    throw std::runtime_error("Cannot open dataset " + m_path);
-  }
-  if (NXopendata(m_fileID, name().c_str()) != NXstatus::NX_OK) {
-    throw std::runtime_error("Error opening data in group \"" + name() + "\"");
-  }
-
-  if (NXgetinfo(m_fileID, &m_info.rank, &(m_info.dims[0]), &m_info.type) != NXstatus::NX_OK) {
-    throw std::runtime_error("Error retrieving information for " + name() + " group");
-  }
-
+  m_fileID->openPath(group_path);
+  m_fileID->openData(name());
+  m_info = NXInfo(m_fileID->getInfo(), name());
   getAttributes();
-  NXclosedata(m_fileID);
+  m_fileID->closeData();
 }
 
 void NXDataSet::openLocal() {
-  if (NXopendata(m_fileID, name().c_str()) != NXstatus::NX_OK) {
-    throw std::runtime_error("Error opening data in group \"" + name() + "\"");
-  }
-  if (NXgetinfo(m_fileID, &m_info.rank, &(m_info.dims[0]), &m_info.type) != NXstatus::NX_OK) {
-    throw std::runtime_error("Error retrieving information for " + name() + " group");
-  }
+  m_fileID->openData(name());
+  m_info = NXInfo(m_fileID->getInfo(), name());
   getAttributes();
-  NXclosedata(m_fileID);
+  m_fileID->closeData();
 }
 
 /**
@@ -448,10 +425,9 @@ nxdimsize_t NXDataSet::dim3() const {
  *   @throw runtime_error if the operation fails.
  */
 void NXDataSet::getData(void *data) {
-  NXopendata(m_fileID, name().c_str());
-  if (NXgetdata(m_fileID, data) != NXstatus::NX_OK)
-    throw std::runtime_error("Cannot read data from NeXus file");
-  NXclosedata(m_fileID);
+  m_fileID->openData(name());
+  m_fileID->getData(data);
+  m_fileID->closeData();
 }
 
 /**  Wrapper to the NXgetslab.
@@ -465,11 +441,10 @@ void NXDataSet::getData(void *data) {
  * the rank of the data.
  *   @throw runtime_error if the operation fails.
  */
-void NXDataSet::getSlab(void *data, NXDimArray const &start, NXDimArray const &size) {
-  NXopendata(m_fileID, name().c_str());
-  if (NXgetslab(m_fileID, data, &(start[0]), &(size[0])) != NXstatus::NX_OK)
-    throw std::runtime_error("Cannot read data slab from NeXus file");
-  NXclosedata(m_fileID);
+void NXDataSet::getSlab(void *data, ::NeXus::DimSizeVector const &start, ::NeXus::DimSizeVector const &size) {
+  m_fileID->openData(name());
+  m_fileID->getSlab(data, start, size);
+  m_fileID->closeData();
 }
 
 //---------------------------------------------------------

--- a/Framework/NexusCpp/inc/MantidNexusCpp/NeXusFile.hpp
+++ b/Framework/NexusCpp/inc/MantidNexusCpp/NeXusFile.hpp
@@ -3,6 +3,7 @@
 #include "MantidNexusCpp/DllConfig.h"
 #include "MantidNexusCpp/NeXusFile_fwd.h"
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -28,6 +29,8 @@ static Entry const EOD_ENTRY(NULL_STR, NULL_STR);
  */
 class MANTID_NEXUSCPP_DLL File {
 private:
+  std::string m_filename;
+  NXaccess m_access;
   /** The handle for the C-API. */
   NXhandle m_file_id;
   /** should be close handle on exit */
@@ -79,12 +82,32 @@ public:
   File(const char *filename, const NXaccess access = NXACC_READ);
 
   /**
-   * Use an existing handle returned from NXopen()
+   * Copy constructor
    *
-   * \param handle Handle to connect to
-   * \param close_handle Should the handle be closed on destruction
+   * \param f File to copy over, to complete rule of three
    */
-  File(NXhandle handle, bool close_handle = false);
+  File(File const &f);
+
+  /**
+   * Copy constructor from pointer
+   *
+   * \param pf Pointer to file to copy over
+   */
+  File(File const *const pf);
+
+  /**
+   * Copy constructor from pointer
+   *
+   * \param pf Pointer to file to copy over
+   */
+  File(std::shared_ptr<File> pf);
+
+  /**
+   * Assignment operator, to complete the rule of three
+   *
+   * \param f File to assign
+   */
+  File &operator=(File const &f);
 
   /** Destructor. This does close the file. */
   ~File();

--- a/Framework/NexusCpp/src/NeXusFile.cpp
+++ b/Framework/NexusCpp/src/NeXusFile.cpp
@@ -91,14 +91,34 @@ static int check_char_too_big[1 - sizeof(char) + ARRAY_OFFSET]; // error if char
 */
 
 namespace NeXus {
-File::File(NXhandle handle, bool close_handle) : m_file_id(handle), m_close_handle(close_handle) {}
 
-File::File(const string &filename, const NXaccess access) : m_close_handle(true) {
-  this->initOpenFile(filename, access);
+File::File(const string &filename, const NXaccess access)
+    : m_filename(filename), m_access(access), m_close_handle(true) {
+  this->initOpenFile(m_filename, m_access);
 }
 
-File::File(const char *filename, const NXaccess access) : m_close_handle(true) {
-  this->initOpenFile(string(filename), access);
+File::File(const char *filename, const NXaccess access) : m_filename(filename), m_access(access), m_close_handle(true) {
+  this->initOpenFile(m_filename, m_access);
+}
+
+File::File(File const &f)
+    : m_filename(f.m_filename), m_access(f.m_access), m_file_id(f.m_file_id), m_close_handle(false) {}
+
+File::File(File const *const pf)
+    : m_filename(pf->m_filename), m_access(pf->m_access), m_file_id(pf->m_file_id), m_close_handle(false) {}
+
+File::File(std::shared_ptr<File> pf)
+    : m_filename(pf->m_filename), m_access(pf->m_access), m_file_id(pf->m_file_id), m_close_handle(false) {}
+
+File &File::operator=(File const &f) {
+  if (this == &f) {
+  } else {
+    this->m_filename = f.m_filename;
+    this->m_access = f.m_access;
+    this->m_file_id = f.m_file_id;
+    this->m_close_handle = f.m_close_handle;
+  }
+  return *this;
 }
 
 void File::initOpenFile(const string &filename, const NXaccess access) {


### PR DESCRIPTION
### Description of work

#### Summary of work

This finishes un-reverting work in PR #38791 .

This will remove all instances of `napi` functions from `NexusClasses`, which also finishes the process of consolidating access of NeXus through `NeXus::File`.

The `NXDataSetTyped::load` method was gently refactored to remove the `k`,`l` parameters, which are never used, as well as the branching logic for those being non-negative, which never happened.

Changes to `NeXus::File` are minimal, including adding additional constructors, and an assignment operator.

Related to #38332 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Windows build from commit bfd6f2505b78d2a330c4c2e8a3d4cfa423bd3662 (NOT tip of branch)
[![Build Status](https://builds.mantidproject.org/buildStatus/icon?job=build_packages_from_branch&build=1028)](https://builds.mantidproject.org/job/build_packages_from_branch/1028/)

Windows build **NOT** re-run on commit de12700d0082e312ce1c380f2791e04d7e00d592, but this should not impact any behavior.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
