### PR TITLE
Fix addProperty python export when value is a Property

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/Property.h
+++ b/Framework/Kernel/inc/MantidKernel/Property.h
@@ -104,6 +104,8 @@ public:
   const std::type_info *type_info() const;
   const std::string type() const;
 
+  void setName(const std::string &name);
+
   /// Overridden function that checks whether the property, if not overriden
   /// returns ""
   virtual std::string isValid() const;

--- a/Framework/Kernel/src/Property.cpp
+++ b/Framework/Kernel/src/Property.cpp
@@ -59,6 +59,16 @@ Property::~Property() = default;
  */
 const std::string &Property::name() const { return m_name; }
 
+/** Set the property's name
+ *  @param name :: The name of the property
+ */
+void Property::setName(const std::string &name) {
+  if (name.empty()) {
+    throw std::invalid_argument("An empty property name is not permitted");
+  }
+  m_name = name;
+}
+
 /** Get the property's documentation string
  *  @return The documentation string
  */

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -74,8 +74,15 @@ void addPropertyWithUnit(Run &self, const std::string &name, const bpl::object &
   extract<Property *> extractor(value);
   if (extractor.check()) {
     Property *prop = extractor();
-    self.addProperty(prop->clone(),
-                     replace); // Clone the property as Python owns the one that is passed in
+    // Clone the property as Python owns the one that is passed in
+    auto new_prop = prop->clone();
+    // set name and units if provided
+    if (!name.empty())
+      new_prop->setName(name);
+
+    if (!units.empty())
+      new_prop->setUnits(units);
+    self.addProperty(new_prop, replace);
     return;
   }
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -931,7 +931,7 @@ unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Export
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/MDGeometry.cpp:96
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp:65
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/MultipleExperimentInfos.cpp:36
-syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp:251
+syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp:258
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp:81
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/SpectrumDefinition.cpp:40
 cstyleCast:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp:87

--- a/docs/source/release/v6.13.0/Framework/Python/Bugfixes/38886.rst
+++ b/docs/source/release/v6.13.0/Framework/Python/Bugfixes/38886.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where the method :meth:`mantid.api.Run.addProperty` was ignoring the ``name`` and ``units`` parameters if the ``value`` was of type :class:`mantid.kernel.Property`. Now only if the ``name`` and ``units`` are empty will the existing values on the ``Property`` be used.


### PR DESCRIPTION
### Description of work

The ``Run.addProperty`` method has a `name` parameter but when the value was already a `Property` the `name` was ignored. This also applied to the `units`.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [9220: addProperty doesn't use specified key](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/9220)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

This was the script provided by the defect
```python
from mantid.simpleapi import (
    CreateWorkspace,
    mtd
)

testWs1 = "test1"
testWs2 = "test2"

CreateWorkspace(
    OutputWorkspace=testWs1,
    DataX=[0.5, 1.5] * 16,
    DataY=[3] * 16,
    NSpec=16,
)

CreateWorkspace(
    OutputWorkspace=testWs2,
    DataX=[0.5, 1.5] * 16,
    DataY=[3] * 16,
    NSpec=16,
)


logs1 = mtd[testWs1].mutableRun()
logs2 = mtd[testWs2].mutableRun()

logs1.addProperty('one', 1.0, replace=True)
logs1.addProperty('two', 2.0, replace=True)
logs1.addProperty('three', 3.0, replace=True)

logs2.addProperty('new_key_for_one', logs1.getProperty('one'), replace=True)
logs2.addProperty('new_key_for_two', logs1.getProperty('two'), replace=True)
logs2.addProperty('new_key_for_three', logs1.getProperty('three'), replace=True)

print(f"logs1.keys(): {[k for k in logs1.keys()]}")
# Should be "['one', 'two', 'three']".


print(f"logs2.keys(): {[k for k in logs2.keys()]}")
# Should be "['new_key_for_one', 'new_key_for_two', 'new_key_forthree']".
# But instead, it will use the _original_ keys from the incoming properties.
```


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
