### PR TITLE
Enable user defined sample and container geometry for abs correction

### DIFF
--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -660,7 +660,7 @@ def create_absorption_input(
             <left-back-bottom-point  x="-0.02" y="-{0:4.2F}" z="-0.02"  />
             <right-front-bottom-point  x="0.02" y="{0:4.2F}" z="-0.02"  />
             </cuboid>"""
-        gauge_vol = gauge_vol.format(beam_height)
+        gauge_vol = gauge_vol.format(beam_height / 2.)
 
     if gauge_vol:
         DefineGaugeVolume(absName, gauge_vol)

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -638,8 +638,6 @@ def create_absorption_input(
         geometry = {}
     if not environment:
         environment = {}
-    if can_geometry and can_material:
-        environment = {}
 
     # Make sure one is set before calling SetSample
     if material or geometry or environment:

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -361,14 +361,18 @@ def calculate_absorption_correction(
             environment["Container"] = container_shape
 
     donorWS = create_absorption_input(
-        filename, props, num_wl_bins,
-        material=material, geometry=sample_geometry,
-        can_geometry=can_geometry, can_material=can_material,
+        filename,
+        props,
+        num_wl_bins,
+        material=material,
+        geometry=sample_geometry,
+        can_geometry=can_geometry,
+        can_material=can_material,
         gauge_vol=gauge_vol,
         beam_height=beam_height,
         environment=environment,
         find_environment=find_env,
-        metaws=metaws
+        metaws=metaws,
     )
 
     # NOTE: Ideally we want to separate cache related task from calculation,
@@ -644,18 +648,22 @@ def create_absorption_input(
     # Make sure one is set before calling SetSample
     if material or geometry or environment:
         mantid.simpleapi.SetSampleFromLogs(
-            InputWorkspace=absName, Material=material, Geometry=geometry,
-            ContainerGeometry=can_geometry, ContainerMaterial=can_material,
-            Environment=environment, FindEnvironment=find_environment
+            InputWorkspace=absName,
+            Material=material,
+            Geometry=geometry,
+            ContainerGeometry=can_geometry,
+            ContainerMaterial=can_material,
+            Environment=environment,
+            FindEnvironment=find_environment,
         )
 
     if beam_height != Property.EMPTY_DBL and not gauge_vol:
-        gauge_vol = '''<cuboid id="shape">
+        gauge_vol = """<cuboid id="shape">
             <left-front-bottom-point x="0.02" y="-{0:4.2F}" z="-0.02"  />
             <left-front-top-point  x="0.02" y="-{0:4.2F}" z="0.02"  />
             <left-back-bottom-point  x="-0.02" y="-{0:4.2F}" z="-0.02"  />
             <right-front-bottom-point  x="0.02" y="{0:4.2F}" z="-0.02"  />
-            </cuboid>'''
+            </cuboid>"""
         gauge_vol = gauge_vol.format(beam_height)
 
     if gauge_vol:

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -697,7 +697,11 @@ def create_absorption_input(
             <radius val="{1:7.5F}" />
             <height val="{2:4.2F}" />
             </cylinder>"""
-        gauge_vol = gauge_vol.format(beam_height / 200.0, geometry["Radius"].value / 100.0, beam_height / 100.0)
+        if isinstance(geometry["Radius"], float):
+            sam_rad = geometry["Radius"]
+        else:
+            sam_rad = geometry["Radius"].value
+        gauge_vol = gauge_vol.format(beam_height / 200.0, sam_rad / 100.0, beam_height / 100.0)
 
     if gauge_vol:
         DefineGaugeVolume(absName, gauge_vol)

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -660,7 +660,7 @@ def create_absorption_input(
             <left-back-bottom-point  x="-0.02" y="-{0:4.2F}" z="-0.02"  />
             <right-front-bottom-point  x="0.02" y="{0:4.2F}" z="-0.02"  />
             </cuboid>"""
-        gauge_vol = gauge_vol.format(beam_height / 2.)
+        gauge_vol = gauge_vol.format(beam_height / 2.0)
 
     if gauge_vol:
         DefineGaugeVolume(absName, gauge_vol)

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -638,10 +638,6 @@ def create_absorption_input(
         geometry = {}
     if not environment:
         environment = {}
-    if not can_geometry:
-        can_geometry = {}
-    if not can_material:
-        can_material = {}
     if can_geometry and can_material:
         environment = {}
 

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -652,13 +652,15 @@ def create_absorption_input(
         )
 
     if beam_height != Property.EMPTY_DBL and not gauge_vol:
-        gauge_vol = """<cuboid id="shape">
-            <left-front-bottom-point x="0.02" y="-{0:4.2F}" z="-0.02"  />
-            <left-front-top-point  x="0.02" y="-{0:4.2F}" z="0.02"  />
-            <left-back-bottom-point  x="-0.02" y="-{0:4.2F}" z="-0.02"  />
-            <right-front-bottom-point  x="0.02" y="{0:4.2F}" z="-0.02"  />
-            </cuboid>"""
-        gauge_vol = gauge_vol.format(beam_height / 2.0)
+        # If the gauge volume is not defined, use the beam height to define it,
+        # and we will be assuming a cylinder shape of the sample.
+        gauge_vol = """<cylinder id="shape">
+            <centre-of-bottom-base r="{0:4.2F}" t="90.0" p="270.0" />
+            <axis x="0.0" y="0.2" z="0.0" />
+            <radius val="{1:4.2F}" />
+            <height val="{2:4.2F}" />
+            </cylinder>"""
+        gauge_vol = gauge_vol.format(beam_height / 2.0, geometry["Radius"], beam_height)
 
     if gauge_vol:
         DefineGaugeVolume(absName, gauge_vol)

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -524,7 +524,10 @@ def calc_1st_absorption_corr_using_wksp(
     elif abs_method == "SampleAndContainer":
         AbsorptionCorrection(donor_wksp, OutputWorkspace=absName + "_ass", ScatterFrom="Sample", ElementSize=element_size)
         if container_gauge_vol and is_valid_xml(container_gauge_vol):
-            DefineGaugeVolume(donor_wksp, container_gauge_vol)
+            try:
+                DefineGaugeVolume(donor_wksp, container_gauge_vol)
+            except ValueError:
+                pass
         elif container_gauge_vol and beam_height != Property.EMPTY_DBL:
             gauge_vol = """<hollow-cylinder id="container_gauge">
                 <centre-of-bottom-base r="{0:4.2F}" t="90.0" p="270.0" />

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -297,6 +297,9 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             "GaugeVolume", "", "A string in XML form for gauge volume definition indicating sample portion visible to the beam."
         )
         self.declareProperty(
+            "ContainerGaugeVolume", "", "A string in XML form for gauge volume definition indicating container portion visible to the beam."
+        )
+        self.declareProperty(
             "BeamHeight",
             defaultValue=Property.EMPTY_DBL,
             doc="Height of the neutron beam cross section in cm",
@@ -436,6 +439,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         self._containerGeometry = self.getProperty("ContainerGeometry").value
         self._containerMaterial = self.getProperty("ContainerMaterial").value
         self._gaugeVolume = self.getProperty("GaugeVolume").value
+        self._containerGaugeVolume = self.getProperty("ContainerGaugeVolume").value
         self._beamHeight = self.getProperty("BeamHeight").value
         self._massDensity = self.getProperty("MeasuredMassDensity").value
         self._numberDensity = self.getProperty("SampleNumberDensity").value
@@ -540,7 +544,8 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             self._sampleGeometry,  # Geometry parameters for the sample
             self._containerGeometry,  # Geometry parameters for the container
             self._containerMaterial,  # Material parameters for the container
-            self._gaugeVolume,  # Gauge volume definition
+            self._gaugeVolume,  # Gauge volume definition for sample
+            self._containerGaugeVolume,  # Gauge volume definition for container
             self._beamHeight,  # Height of the neutron beam cross section in cm
             self._numberDensity,  # Optional number density of sample to be added
             self._containerShape,  # Shape definition of container

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -291,20 +291,10 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         )
         self.declareProperty("SampleFormula", "", doc="Chemical formula of the sample")
         self.declareProperty("SampleGeometry", {}, doc="A dictionary of geometry parameters for the sample.")
+        self.declareProperty("ContainerGeometry", {}, doc="A dictionary of geometry parameters for the container.")
+        self.declareProperty("ContainerMaterial", {}, doc="A dictionary of material parameters for the container.")
         self.declareProperty(
-            "ContainerGeometry",
-            {},
-            doc="A dictionary of geometry parameters for the container."
-        )
-        self.declareProperty(
-            "ContainerMaterial",
-            {},
-            doc="A dictionary of material parameters for the container."
-        )
-        self.declareProperty(
-            "GaugeVolume",
-            "",
-            "A string in XML form for gauge volume definition indicating sample portion visible to the beam."
+            "GaugeVolume", "", "A string in XML form for gauge volume definition indicating sample portion visible to the beam."
         )
         self.declareProperty(
             "BeamHeight",

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -292,6 +292,26 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         self.declareProperty("SampleFormula", "", doc="Chemical formula of the sample")
         self.declareProperty("SampleGeometry", {}, doc="A dictionary of geometry parameters for the sample.")
         self.declareProperty(
+            "ContainerGeometry",
+            {},
+            doc="A dictionary of geometry parameters for the container."
+        )
+        self.declareProperty(
+            "ContainerMaterial",
+            {},
+            doc="A dictionary of material parameters for the container."
+        )
+        self.declareProperty(
+            "GaugeVolume",
+            "",
+            "A string in XML form for gauge volume definition indicating sample portion visible to the beam."
+        )
+        self.declareProperty(
+            "BeamHeight",
+            defaultValue=Property.EMPTY_DBL,
+            doc="Height of the neutron beam cross section in cm",
+        )
+        self.declareProperty(
             "MeasuredMassDensity",
             defaultValue=0.1,
             validator=FloatBoundedValidator(lower=0.0, exclusive=True),
@@ -423,6 +443,10 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         self._absMethod = self.getProperty("TypeOfCorrection").value
         self._sampleFormula = self.getProperty("SampleFormula").value
         self._sampleGeometry = self.getProperty("SampleGeometry").value
+        self._containerGeometry = self.getProperty("ContainerGeometry").value
+        self._containerMaterial = self.getProperty("ContainerMaterial").value
+        self._gaugeVolume = self.getProperty("GaugeVolume").value
+        self._beamHeight = self.getProperty("BeamHeight").value
         self._massDensity = self.getProperty("MeasuredMassDensity").value
         self._numberDensity = self.getProperty("SampleNumberDensity").value
         self._containerShape = self.getProperty("ContainerShape").value
@@ -524,6 +548,10 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             self._sampleFormula,  # Material for absorption correction
             self._massDensity,  # Mass density of the sample
             self._sampleGeometry,  # Geometry parameters for the sample
+            self._containerGeometry,  # Geometry parameters for the container
+            self._containerMaterial,  # Material parameters for the container
+            self._gaugeVolume,  # Gauge volume definition
+            self._beamHeight,  # Height of the neutron beam cross section in cm
             self._numberDensity,  # Optional number density of sample to be added
             self._containerShape,  # Shape definition of container
             self._num_wl_bins,  # Number of bins: len(ws.readX(0))-1

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -1538,6 +1538,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                 self._num_wl_bins,
                 material={"ChemicalFormula": "V", "SampleNumberDensity": absorptioncorrutils.VAN_SAMPLE_DENSITY},
                 geometry={"Shape": "Cylinder", "Height": 7.0, "Radius": self._vanRadius, "Center": [0.0, 0.0, 0.0]},
+                beam_height=self._beamHeight,
                 find_environment=False,
                 opt_wl_min=self._wavelengthMin,
                 opt_wl_max=self._wavelengthMax,
@@ -1566,6 +1567,9 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             )
             api.RenameWorkspace(abs_v_wsn, "__V_corr_abs")
 
+            # Here, we are using a combo of absorption correction with the numerical integration approach and multiple
+            # scattering correction with the Carpenter approach - `Absorption` param set to `False` below, making sure
+            # only `__V_corr_ms` will be created without overwriting the already calculated `__V_corr_abs`.
             api.CalculateCarpenterSampleCorrection(
                 InputWorkspace=absWksp, OutputWorkspaceBaseName="__V_corr", CylinderSampleRadius=self._vanRadius, Absorption=False
             )

--- a/docs/source/release/v6.13.0/Diffraction/Powder/New_features/38887.rst
+++ b/docs/source/release/v6.13.0/Diffraction/Powder/New_features/38887.rst
@@ -1,0 +1,1 @@
+- Enable user defined sample and container geometry together with the definition of gauge volume to account for the beam size. Implementation made in :ref:`SNSPowderReduction <algm-SNSPowderReduction>` and ``mantid.utils.absorptioncorrutils``.


### PR DESCRIPTION
### Description of work

#### Summary of work
With this PR, we enable user defined sample and container geometry for absorption correction. Top level changes are in place for `SNSPowderReduction` and accordingly necessary parameters are introduced for those bottom level algorithms concerning the setup of the absorption correction inputs. The defined sample and container geometry is finally passed to `SetSample`. This gives users the flexibility to define their own geometry as needed. For example, on POWGEN, some times irregular containers that are not defined in the sample environment XML file will be used for the measurement, e.g., the annular container where the sample is loaded into the hollow cylinder wall.

Also, we implement the definition of beam gauge volume for absorption correction. Without this implementation, the assumption would be that the beam size is the same as the sample size. In practice, this is often not true. In that case, the absorption correction is imperfect in principle. Detailed discussion about this is posted [here](https://iris2020.net/2025-02-12-abs_geo/).

### To test:

#### This is the one for testing the gauge volume definition

```python
from mantid.simpleapi import *

gauge_vol = '''<cuboid id="shape">
     <left-front-bottom-point x="0.01" y="-0.1" z="0.0"  />
     <left-front-top-point  x="0.01" y="-0.1" z="0.02"  />
     <left-back-bottom-point  x="-0.01" y="-0.1" z="0.0"  />
     <right-front-bottom-point  x="0.01" y="0.1" z="0.0"  />
   </cuboid>'''

SNSPowderReduction(
    Filename='/SNS/PG3/IPTS-34523/nexus/PG3_58812.nxs.h5',
    CalibrationFile='/SNS/PG3/shared/CALIBRATION/2025-1_11A_CAL/PG3_OC_d58772_2025-02-12.h5',
    CharacterizationRunsFile='/SNS/PG3/shared/CALIBRATION/2025-1_11A_CAL/PG3_char_2025_2-HighRes_OC.txt,/SNS/PG3/shared/CALIBRATION/2025-1_11A_CAL/PG3_char_2025_2_OC_limit.txt',
    RemovePromptPulseWidth=50,
    Binning='-0.0008',
    BackgroundSmoothParams='5, 2',
    FilterBadPulses=90,
    ScaleData=100,
    TypeOfCorrection='SampleAndContainer',
    SampleFormula='Ba-Nb-Cr-Ru',
    MeasuredMassDensity='6.0',
    SampleGeometry={'Height': 5},
    SampleNumberDensity='0.088',
    ContainerShape='PAC06',
    GaugeVolume=gauge_vol,
    SaveAs='gsas topas and fullprof',
    OutputDirectory='/SNS/NOM/shared/tmp',
    CacheDir='/SNS/NOM/shared/tmp'
)
```

#### Here is the one for testing the geometry definition,

```python
from mantid.simpleapi import *

sam_geo = {
    'Shape': 'HollowCylinder', 'Height': 4.0,
    'InnerRadius': 2.0,
    'OuterRadius': 3.0,
    'Center': [0.,0.,0.]
}

c_geo = {
    'Shape': 'HollowCylinderHolder',
    'Height': 4.0,
    'InnerRadius': 1.5,
    'InnerOuterRadius': 2.0,
    'OuterInnerRadius': 3.0,
    'OuterRadius': 4.0,
    'Center': [0.,0.,0.]
}

c_mat = {
    'ChemicalFormula': 'V',
    'NumberDensity': 0.072324
}

gauge_vol = '''<cuboid id="shape">
     <left-front-bottom-point x="0.01" y="-0.1" z="0.0"  />
     <left-front-top-point  x="0.01" y="-0.1" z="0.02"  />
     <left-back-bottom-point  x="-0.01" y="-0.1" z="0.0"  />
     <right-front-bottom-point  x="0.01" y="0.1" z="0.0"  />
   </cuboid>'''

SNSPowderReduction(
    Filename='/SNS/PG3/IPTS-34523/nexus/PG3_58812.nxs.h5',
    CalibrationFile='/SNS/PG3/shared/CALIBRATION/2025-1_11A_CAL/PG3_OC_d58772_2025-02-12.h5',
    CharacterizationRunsFile='/SNS/PG3/shared/CALIBRATION/2025-1_11A_CAL/PG3_char_2025_2-HighRes_OC.txt,/SNS/PG3/shared/CALIBRATION/2025-1_11A_CAL/PG3_char_2025_2_OC_limit.txt',
    RemovePromptPulseWidth=50,
    Binning='-0.0008',
    BackgroundSmoothParams='5, 2',
    FilterBadPulses=90,
    ScaleData=100,
    TypeOfCorrection='SampleAndContainer',
    SampleFormula='Ba-Nb-Cr-Ru',
    MeasuredMassDensity='6.0',
    SampleGeometry=sam_geo,
    SampleNumberDensity='0.088',
    ContainerGeometry=c_geo,
    ContainerMaterial=c_mat,
    GaugeVolume=gauge_vol,
    SaveAs='gsas topas and fullprof',
    OutputDirectory='/SNS/NOM/shared/tmp',
    CacheDir='/SNS/NOM/shared/tmp'
)
```

#### Here is another one for testing the geometry definition, with only beam height defined (and therefore the gauge volume will be defined internally in Mantid by assuming the beam location),

```python
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

SNSPowderReduction(
    Filename='/SNS/PG3/IPTS-34523/nexus/PG3_58812.nxs.h5',
    CalibrationFile='/SNS/PG3/shared/CALIBRATION/2025-1_11A_CAL/PG3_OC_d58772_2025-02-12.h5',
    CharacterizationRunsFile='/SNS/PG3/shared/CALIBRATION/2025-1_11A_CAL/PG3_char_2025_2-HighRes_OC.txt,/SNS/PG3/shared/CALIBRATION/2025-1_11A_CAL/PG3_char_2025_2_OC_limit.txt',
    RemovePromptPulseWidth=50,
    Binning='-0.0008',
    BackgroundSmoothParams='5, 2',
    FilterBadPulses=90,
    ScaleData=100,
    TypeOfCorrection='SampleAndContainer',
    SampleFormula='Ba-Nb-Cr-Ru',
    MeasuredMassDensity='6.0',
    SampleGeometry={
        'Height': 5,
        'Radius': 0.295
    },
    BeamHeight=2,
    SampleNumberDensity='0.088',
    ContainerShape='PAC06',
    ContainerGaugeVolume='0.295 0.315',
    SaveAs='gsas topas and fullprof',
    OutputDirectory='/SNS/NOM/shared/tmp',
    CacheDir='/SNS/NOM/shared/tmp'
)
```

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
