### PR TITLE
Update cmake docs with regards to plugin libraries

### DIFF
--- a/dev-docs/source/CMakeBestPractices.rst
+++ b/dev-docs/source/CMakeBestPractices.rst
@@ -130,9 +130,25 @@ With the move to conda, we have created a CMake export target for the Framework 
 
 2. Add the install commands which ensures the target is exported.
 
+A Framework library can either be installed as a regular or plugin library.
+
+Regular library:
+
 .. code-block:: cmake
 
     set(TARGET_EXPORT_NAME "MantidNewTargetTargets")
     mtd_install_framework_lib(TARGETS NewTarget EXPORT_NAME ${TARGET_EXPORT_NAME})
+
+Plugin library:
+
+.. code-block:: cmake
+
+    set(TARGET_EXPORT_NAME "MantidNewTargetTargets")
+    mtd_install_framework_lib(TARGETS NewTarget PLUGIN_LIB)
+
+If a library is installed as a plugin library in will be installed in the plugin directory as opposed to the library directory. No headers, export files, or CMake targets are installed as plugin libraries are to be loaded dynamically
+and will not be linked against at build time.
+
+A library cannot be linked to a plugin library as a dependency; a plugin library is not guaranteed to be present. If this is done, errors will occur during the packaging stage.
 
 3. Add the new target to the MODULES variable in ``MantidFrameworkConfig.cmake.in``. If it added new dependencies also add the relevant ``find_dependency`` calls.

--- a/dev-docs/source/CMakeBestPractices.rst
+++ b/dev-docs/source/CMakeBestPractices.rst
@@ -146,7 +146,7 @@ With the move to conda, we have created a CMake export target for the Framework 
         set(TARGET_EXPORT_NAME "MantidNewTargetTargets")
         mtd_install_framework_lib(TARGETS NewTarget PLUGIN_LIB)
 
-    If a library is installed as a plugin library in will be installed in the plugin directory as opposed to the library directory. No headers, export files, or CMake targets are installed as plugin libraries are to be loaded dynamically
+    If a library is installed as a plugin library it will be installed in the plugin directory as opposed to the library directory. No headers, export files, or CMake targets are installed, as plugin libraries are to be loaded dynamically
     and will not be linked against at build time.
 
     A library cannot be linked to a plugin library as a dependency; a plugin library is not guaranteed to be present. If this is done, errors will occur during the packaging stage.

--- a/dev-docs/source/CMakeBestPractices.rst
+++ b/dev-docs/source/CMakeBestPractices.rst
@@ -123,32 +123,32 @@ With the move to conda, we have created a CMake export target for the Framework 
 
 1. When you add a new Framework library, alias it using the namespace Mantid:: - This means when we link to Mantid::NewTarget it can either link to our inbuilt library, or one on our system. This ensures we can have a standalone mantidqt build.
 
-.. code-block:: cmake
+    .. code-block:: cmake
 
-    add_library(NewTarget ${SRC_FILES} ${INC_FILES})
-    add_library(Mantid::NewTarget ALIAS NewTarget)
+        add_library(NewTarget ${SRC_FILES} ${INC_FILES})
+        add_library(Mantid::NewTarget ALIAS NewTarget)
 
-2. Add the install commands which ensures the target is exported.
+2. Add the install commands.
 
-A Framework library can either be installed as a regular or plugin library.
+    A Framework library can either be installed as a regular or plugin library.
 
-Regular library:
+    Regular library (ensures target is exported):
 
-.. code-block:: cmake
+    .. code-block:: cmake
 
-    set(TARGET_EXPORT_NAME "MantidNewTargetTargets")
-    mtd_install_framework_lib(TARGETS NewTarget EXPORT_NAME ${TARGET_EXPORT_NAME})
+        set(TARGET_EXPORT_NAME "MantidNewTargetTargets")
+        mtd_install_framework_lib(TARGETS NewTarget EXPORT_NAME ${TARGET_EXPORT_NAME})
 
-Plugin library:
+    Plugin library:
 
-.. code-block:: cmake
+    .. code-block:: cmake
 
-    set(TARGET_EXPORT_NAME "MantidNewTargetTargets")
-    mtd_install_framework_lib(TARGETS NewTarget PLUGIN_LIB)
+        set(TARGET_EXPORT_NAME "MantidNewTargetTargets")
+        mtd_install_framework_lib(TARGETS NewTarget PLUGIN_LIB)
 
-If a library is installed as a plugin library in will be installed in the plugin directory as opposed to the library directory. No headers, export files, or CMake targets are installed as plugin libraries are to be loaded dynamically
-and will not be linked against at build time.
+    If a library is installed as a plugin library in will be installed in the plugin directory as opposed to the library directory. No headers, export files, or CMake targets are installed as plugin libraries are to be loaded dynamically
+    and will not be linked against at build time.
 
-A library cannot be linked to a plugin library as a dependency; a plugin library is not guaranteed to be present. If this is done, errors will occur during the packaging stage.
+    A library cannot be linked to a plugin library as a dependency; a plugin library is not guaranteed to be present. If this is done, errors will occur during the packaging stage.
 
 3. Add the new target to the MODULES variable in ``MantidFrameworkConfig.cmake.in``. If it added new dependencies also add the relevant ``find_dependency`` calls.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

Updates cmake docs with information regarding regular and plugin libraries and how they behave.

This arose when trying to link the `Datahandling` library to the `Muon` library, which did not work was expected.

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
