### PR TITLE
Pass DOCS_QTHELP to compiler to control registering MantidHelpWindow

### DIFF
--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -636,6 +636,11 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   list(APPEND TARGET_LIBRARIES "-framework CoreFoundation")
 endif()
 
+# Add option to the compiler to register MantidHelpWindow
+if(DOCS_QTHELP)
+  add_definitions(-DDOCS_QTHELP)
+endif()
+
 # Target Additional components for this module
 find_package(
   Qt5 ${QT_MIN_VERSION}

--- a/qt/widgets/common/src/InterfaceManager.cpp
+++ b/qt/widgets/common/src/InterfaceManager.cpp
@@ -240,27 +240,32 @@ MantidHelpInterface *InterfaceManager::createHelpWindow() const {
 
 void InterfaceManager::showHelpPage(const QString &url) {
   auto window = createHelpWindow();
-  window->showPage(url);
+  if (window)
+    window->showPage(url);
 }
 
 void InterfaceManager::showAlgorithmHelp(const QString &name, const int version) {
   auto window = createHelpWindow();
-  window->showAlgorithm(name, version);
+  if (window)
+    window->showAlgorithm(name, version);
 }
 
 void InterfaceManager::showConceptHelp(const QString &name) {
   auto window = createHelpWindow();
-  window->showConcept(name);
+  if (window)
+    window->showConcept(name);
 }
 
 void InterfaceManager::showFitFunctionHelp(const QString &name) {
   auto window = createHelpWindow();
-  window->showFitFunction(name);
+  if (window)
+    window->showFitFunction(name);
 }
 
 void InterfaceManager::showCustomInterfaceHelp(const QString &name, const QString &area, const QString &section) {
   auto window = createHelpWindow();
-  window->showCustomInterface(name, area, section);
+  if (window)
+    window->showCustomInterface(name, area, section);
 }
 
 void InterfaceManager::showWebPage(const QString &url) { MantidDesktopServices::openUrl(url); }
@@ -268,6 +273,7 @@ void InterfaceManager::showWebPage(const QString &url) { MantidDesktopServices::
 void InterfaceManager::closeHelpWindow() {
   if (MantidHelpWindow::helpWindowExists()) {
     auto window = createHelpWindow();
-    window->shutdown();
+    if (window)
+      window->shutdown();
   }
 }


### PR DESCRIPTION
### Description of work

In #38736 registering the `MantidHelpWindow` was put behind `#ifdef DOCS_QTHELP` but `DOCS_QTHELP` is currently only a CMake options. This converts that option to a compiler definition re-enabling the qt-docs.

In the current state, even with `DOCS_QTHELP=ON`, you get the message `InterfaceManager-[Information] Offline help is not available in this version of Workbench.` and the docs are opened by the browser instead.

There is also an issue when `DOCS_QTHELP=OFF` and you opened the help from the Help menu in the workbench it would segfault because there is no help viewer registered. This won't be an issue when #37248 is done and the new help window is registered.

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

*There is no associated issue.*


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

With the `DOCS_QTHELP=ON` in cmake, which is the default, build `ninja docs-qthelp` and check that you can once again open the help from the workbench.

Notes: I had to set `SPHINX_WARNINGS_AS_ERRORS=OFF` to get the qthelp to build but that is a different issue.

If you try with `DOCS_QTHELP=OFF` in cmake it should give you the message `InterfaceManager-[Information] Offline help is not available in this version of Workbench.` and open the browser. But this only works for me when opening the docs from an algorithm dialog. Opening the help from the Help menu should not segfault anymore either.

*This does not require release notes* because this bug was only introduced this same release.


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
