### PR TITLE
More changes to size_t and int64_t types

### DIFF
--- a/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -76,21 +76,21 @@ public:
    * @param peakNum :: index of the peak to get.
    * @return a reference to a Peak object.
    */
-  virtual Mantid::Geometry::IPeak &getPeak(int peakNum) = 0;
+  virtual Mantid::Geometry::IPeak &getPeak(size_t const peakNum) = 0;
 
   //---------------------------------------------------------------------------------------------
   /** Return a reference to the Peak (const version)
    * @param peakNum :: index of the peak to get.
    * @return a reference to a Peak object.
    */
-  virtual const Mantid::Geometry::IPeak &getPeak(int peakNum) const = 0;
+  virtual const Mantid::Geometry::IPeak &getPeak(size_t const peakNum) const = 0;
 
   //---------------------------------------------------------------------------------------------
   /** Return a pointer to the Peak
    * @param peakNum :: index of the peak to get.
    * @return a pointer to a Peak object.
    */
-  Mantid::Geometry::IPeak *getPeakPtr(const int peakNum) { return &this->getPeak(peakNum); }
+  Mantid::Geometry::IPeak *getPeakPtr(size_t const peakNum) { return &this->getPeak(peakNum); }
 
   //---------------------------------------------------------------------------------------------
   /** Create an instance of a Peak

--- a/Framework/DataHandling/inc/MantidDataHandling/DataBlock.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/DataBlock.h
@@ -27,7 +27,7 @@ class MANTID_DATAHANDLING_DLL DataBlock {
 public:
   DataBlock();
   DataBlock(const Mantid::NeXus::NXInt &data);
-  DataBlock(int numberOfperiods, size_t numberOfSpectra, size_t numberOfChannels);
+  DataBlock(size_t numberOfperiods, size_t numberOfSpectra, size_t numberOfChannels);
 
   virtual ~DataBlock() = default;
 
@@ -38,7 +38,7 @@ public:
   virtual void setMaxSpectrumID(specnum_t minSpecID);
 
   virtual size_t getNumberOfSpectra() const;
-  virtual int getNumberOfPeriods() const;
+  virtual size_t getNumberOfPeriods() const;
   virtual size_t getNumberOfChannels() const;
 
   bool operator==(const DataBlock &other) const;
@@ -46,7 +46,7 @@ public:
   virtual std::unique_ptr<DataBlockGenerator> getGenerator() const;
 
 protected:
-  int m_numberOfPeriods;
+  size_t m_numberOfPeriods;
   // The number of spectra
   size_t m_numberOfSpectra;
   // The number of time channels per spectrum (N histogram bins -1)

--- a/Framework/DataHandling/inc/MantidDataHandling/DataBlockComposite.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/DataBlockComposite.h
@@ -26,7 +26,7 @@ public:
 
   size_t getNumberOfSpectra() const override;
   size_t getNumberOfChannels() const override;
-  int getNumberOfPeriods() const override;
+  size_t getNumberOfPeriods() const override;
 
   std::unique_ptr<DataBlockGenerator> getGenerator() const override;
 
@@ -60,7 +60,7 @@ private:
  */
 template <typename T>
 void DLLExport populateDataBlockCompositeWithContainer(DataBlockComposite &dataBlockComposite, T &indexContainer,
-                                                       int64_t nArray, int numberOfPeriods, size_t numberOfChannels,
+                                                       int64_t nArray, size_t numberOfPeriods, size_t numberOfChannels,
                                                        std::vector<specnum_t> monitorSpectra) {
   auto isMonitor = [&monitorSpectra](specnum_t index) {
     return std::find(std::begin(monitorSpectra), std::end(monitorSpectra), index) != std::end(monitorSpectra);
@@ -72,7 +72,7 @@ void DLLExport populateDataBlockCompositeWithContainer(DataBlockComposite &dataB
   // the
   // monitor itself
   struct HandleWhenElementIsMonitor {
-    void operator()(Mantid::DataHandling::DataBlockComposite &dataBlockComposite, int numberOfPeriods,
+    void operator()(Mantid::DataHandling::DataBlockComposite &dataBlockComposite, size_t numberOfPeriods,
                     size_t numberOfChannels, specnum_t previousValue, specnum_t startValue) {
       if (previousValue - startValue > 0) {
         auto numberOfSpectra = previousValue - startValue; /* Should be from [start,
@@ -95,7 +95,7 @@ void DLLExport populateDataBlockCompositeWithContainer(DataBlockComposite &dataB
   // be a gap between neighbouring spetrum numbers. Then we need to
   // write out this range as a data block.
   struct HandleWhenElementMadeAJump {
-    void operator()(Mantid::DataHandling::DataBlockComposite &dataBlockComposite, int numberOfPeriods,
+    void operator()(Mantid::DataHandling::DataBlockComposite &dataBlockComposite, size_t numberOfPeriods,
                     size_t numberOfChannels, specnum_t previousValue, specnum_t startValue) {
       auto numberOfSpectra = previousValue - startValue + 1;
       DataBlock dataBlock(static_cast<int>(numberOfPeriods), numberOfSpectra, numberOfChannels);

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadHelper.h
@@ -46,7 +46,7 @@ void fillStaticWorkspace(const API::MatrixWorkspace_sptr &, const Mantid::NeXus:
                          const std::tuple<short, short, short> &axisOrder = std::tuple<short, short, short>(0, 1, 2));
 
 void fillMovingWorkspace(const API::MatrixWorkspace_sptr &, const Mantid::NeXus::NXInt &,
-                         const std::vector<double> &xAxis, int initialSpectrum = 0,
+                         const std::vector<double> &xAxis, int64_t initialSpectrum = 0,
                          const std::set<int> &acceptedID = std::set<int>(),
                          const std::vector<int> &customID = std::vector<int>(),
                          const std::tuple<short, short, short> &axisOrder = std::tuple<short, short, short>(0, 1, 2));

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
@@ -147,20 +147,20 @@ private:
   /// bins have already been cached
   void loadBlock(Mantid::NeXus::NXDataSetTyped<double> &data, Mantid::NeXus::NXDataSetTyped<double> &errors,
                  Mantid::NeXus::NXDataSetTyped<double> &farea, bool hasFArea, Mantid::NeXus::NXDouble &xErrors,
-                 bool hasXErrors, int blocksize, int nchannels, int &hist,
+                 bool hasXErrors, int64_t blocksize, int64_t nchannels, int64_t &hist,
                  const API::MatrixWorkspace_sptr &local_workspace);
 
   /// Load a block of data into the workspace where it is assumed that the x
   /// bins have already been cached
   void loadBlock(Mantid::NeXus::NXDataSetTyped<double> &data, Mantid::NeXus::NXDataSetTyped<double> &errors,
                  Mantid::NeXus::NXDataSetTyped<double> &farea, bool hasFArea, Mantid::NeXus::NXDouble &xErrors,
-                 bool hasXErrors, int64_t blocksize, int64_t nchannels, int &hist, int &wsIndex,
+                 bool hasXErrors, int64_t blocksize, int64_t nchannels, int64_t &hist, int64_t &wsIndex,
                  const API::MatrixWorkspace_sptr &local_workspace);
   /// Load a block of data into the workspace
   void loadBlock(Mantid::NeXus::NXDataSetTyped<double> &data, Mantid::NeXus::NXDataSetTyped<double> &errors,
                  Mantid::NeXus::NXDataSetTyped<double> &farea, bool hasFArea, Mantid::NeXus::NXDouble &xErrors,
-                 bool hasXErrors, Mantid::NeXus::NXDouble &xbins, int64_t blocksize, int64_t nchannels, int &hist,
-                 int &wsIndex, const API::MatrixWorkspace_sptr &local_workspace);
+                 bool hasXErrors, Mantid::NeXus::NXDouble &xbins, int64_t blocksize, int64_t nchannels, int64_t &hist,
+                 int64_t &wsIndex, const API::MatrixWorkspace_sptr &local_workspace);
 
   /// Load the data from a non-spectra axis (Numeric/Text) into the workspace
   void loadNonSpectraAxis(const API::MatrixWorkspace_sptr &local_workspace, const Mantid::NeXus::NXData &data);

--- a/Framework/DataHandling/src/DataBlock.cpp
+++ b/Framework/DataHandling/src/DataBlock.cpp
@@ -22,7 +22,7 @@ DataBlock::DataBlock(const Mantid::NeXus::NXInt &data)
     : m_numberOfPeriods(static_cast<int>(data.dim0())), m_numberOfSpectra(data.dim1()), m_numberOfChannels(data.dim2()),
       m_minSpectraID(std::numeric_limits<specnum_t>::max()), m_maxSpectraID(0) {}
 
-DataBlock::DataBlock(int numberOfPeriods, size_t numberOfSpectra, size_t numberOfChannels)
+DataBlock::DataBlock(size_t numberOfPeriods, size_t numberOfSpectra, size_t numberOfChannels)
     : m_numberOfPeriods(numberOfPeriods), m_numberOfSpectra(numberOfSpectra), m_numberOfChannels(numberOfChannels),
       m_minSpectraID(std::numeric_limits<specnum_t>::max()), m_maxSpectraID(0) {}
 
@@ -36,7 +36,7 @@ void DataBlock::setMaxSpectrumID(specnum_t maxSpecID) { m_maxSpectraID = maxSpec
 
 size_t DataBlock::getNumberOfSpectra() const { return m_numberOfSpectra; }
 
-int DataBlock::getNumberOfPeriods() const { return m_numberOfPeriods; }
+size_t DataBlock::getNumberOfPeriods() const { return m_numberOfPeriods; }
 
 size_t DataBlock::getNumberOfChannels() const { return m_numberOfChannels; }
 

--- a/Framework/DataHandling/src/DataBlockComposite.cpp
+++ b/Framework/DataHandling/src/DataBlockComposite.cpp
@@ -247,7 +247,7 @@ size_t DataBlockComposite::getNumberOfChannels() const {
   return m_dataBlocks.empty() ? 0 : m_dataBlocks[0].getNumberOfChannels();
 }
 
-int DataBlockComposite::getNumberOfPeriods() const {
+size_t DataBlockComposite::getNumberOfPeriods() const {
   return m_dataBlocks.empty() ? 0 : m_dataBlocks[0].getNumberOfPeriods();
 }
 

--- a/Framework/DataHandling/src/LoadHelper.cpp
+++ b/Framework/DataHandling/src/LoadHelper.cpp
@@ -490,7 +490,7 @@ void LoadHelper::loadingOrder(const std::tuple<short, short, short> &dataOrder, 
  * tube-pixel-channel order
  */
 void LoadHelper::fillMovingWorkspace(const API::MatrixWorkspace_sptr &ws, const Mantid::NeXus::NXInt &data,
-                                     const std::vector<double> &xAxis, int initialSpectrum,
+                                     const std::vector<double> &xAxis, int64_t initialSpectrum,
                                      const std::set<int> &acceptedDetectorIDs,
                                      const std::vector<int> &customDetectorIDs,
                                      const std::tuple<short, short, short> &axisOrder) {

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -283,7 +283,7 @@ void LoadISISNexus2::exec() {
     const std::string base_name = getPropertyValue("OutputWorkspace") + "_";
     const std::string prop_name = "OutputWorkspace_";
 
-    for (int p = 1; p <= m_loadBlockInfo.getNumberOfPeriods(); ++p) {
+    for (std::size_t p = 1; p <= m_loadBlockInfo.getNumberOfPeriods(); ++p) {
       std::ostringstream os;
       os << p;
       m_progress->report("Loading period " + os.str());
@@ -344,7 +344,7 @@ void LoadISISNexus2::exec() {
         WorkspaceGroup_sptr monitor_group(new WorkspaceGroup);
         monitor_group->setTitle(monitor_workspace->getTitle());
 
-        for (int p = 1; p <= m_detBlockInfo.getNumberOfPeriods(); ++p) {
+        for (std::size_t p = 1; p <= m_detBlockInfo.getNumberOfPeriods(); ++p) {
           std::ostringstream os;
           os << "_" << p;
           m_progress->report("Loading period " + os.str());
@@ -352,7 +352,7 @@ void LoadISISNexus2::exec() {
             monitor_workspace = std::dynamic_pointer_cast<DataObjects::Workspace2D>(
                 WorkspaceFactory::Instance().create(period_free_workspace));
             loadPeriodData(p, entry, monitor_workspace, m_load_selected_spectra);
-            monLogCreator.addPeriodLogs(p, monitor_workspace->mutableRun());
+            monLogCreator.addPeriodLogs(static_cast<int>(p), monitor_workspace->mutableRun());
             // Check consistency of logs data for multi-period workspaces and
             // raise
             // warnings where necessary.
@@ -454,7 +454,7 @@ bool LoadISISNexus2::checkOptionalProperties(bool bseparateMonitors, bool bexclu
 
   // Check the entry number
   m_entrynumber = getProperty("EntryNumber");
-  if (static_cast<int>(m_entrynumber) > m_loadBlockInfo.getNumberOfPeriods() || m_entrynumber < 0) {
+  if (static_cast<size_t>(m_entrynumber) > m_loadBlockInfo.getNumberOfPeriods()) {
     std::string err = "Invalid entry number entered. File contains " +
                       std::to_string(m_loadBlockInfo.getNumberOfPeriods()) + " period. ";
     throw std::invalid_argument(err);

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -68,7 +68,7 @@ using IntArray = std::vector<int>;
 // Struct to contain spectrum information.
 struct SpectraInfo {
   // Number of spectra
-  int nSpectra{0};
+  int64_t nSpectra{0};
   // Do we have any spectra
   bool hasSpectra{false};
   // Contains spectrum numbers for each workspace index
@@ -296,7 +296,7 @@ Workspace_sptr LoadNexusProcessed::doAccelleratedMultiPeriodLoading(NXRoot &root
   NXDataSetTyped<double> errors(wsEntry, "errors");
   errors.openLocal();
 
-  const int nChannels = static_cast<int>(data.dim1());
+  const int64_t nChannels = data.dim1();
 
   int blockSize = 8; // Read block size. Set to 8 for efficiency. i.e. read
                      // 8 histograms at a time.
@@ -323,7 +323,7 @@ Workspace_sptr LoadNexusProcessed::doAccelleratedMultiPeriodLoading(NXRoot &root
     double *errorStart = errors();
     double *errorEnd = errorStart + nChannels;
 
-    int final(histIndex + blockSize);
+    int64_t final(histIndex + blockSize);
     while (histIndex < final) {
       auto &Y = periodWorkspace->mutableY(wsIndex);
       Y.assign(dataStart, dataEnd);
@@ -964,8 +964,8 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
 
   NXData nx_tw = entry.openNXData("peaks_workspace");
 
-  int columnNumber = 1;
-  int64_t numberPeaks = 0;
+  size_t columnNumber = 1;
+  size_t numberPeaks = 0;
   std::vector<std::string> columnNames;
   do {
     std::string str = "column_" + std::to_string(columnNumber);
@@ -1056,7 +1056,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
   if (convention != m_QConvention)
     qSign = -1.0;
 
-  for (int r = 0; r < numberPeaks; r++) {
+  for (size_t r = 0; r < numberPeaks; r++) {
     // Create individual LeanElasticPeak
     const auto &goniometer = peakWS->run().getGoniometer();
     LeanElasticPeak peak;
@@ -1070,7 +1070,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = qSign * nxDouble[r];
         peakWS->getPeak(r).setH(val);
       }
@@ -1078,7 +1078,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = qSign * nxDouble[r];
         peakWS->getPeak(r).setK(val);
       }
@@ -1086,7 +1086,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = qSign * nxDouble[r];
         peakWS->getPeak(r).setL(val);
       }
@@ -1094,7 +1094,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = nxDouble[r];
         peakWS->getPeak(r).setIntensity(val);
       }
@@ -1102,7 +1102,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = nxDouble[r];
         peakWS->getPeak(r).setSigmaIntensity(val);
       }
@@ -1110,7 +1110,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = nxDouble[r];
         peakWS->getPeak(r).setBinCount(val);
       }
@@ -1118,7 +1118,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = nxDouble[r];
         peakWS->getPeak(r).setWavelength(val);
       }
@@ -1126,7 +1126,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXInt nxInt = nx_tw.openNXInt(str);
       nxInt.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         int ival = nxInt[r];
         if (ival != -1)
           peakWS->getPeak(r).setRunNumber(ival);
@@ -1135,7 +1135,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXInt nxInt = nx_tw.openNXInt(str);
       nxInt.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         int ival = nxInt[r];
         peakWS->getPeak(r).setPeakNumber(ival);
       }
@@ -1143,7 +1143,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = nxDouble[r];
         peakWS->getPeak(r).setAbsorptionWeightedPathLength(val);
       }
@@ -1152,7 +1152,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       nxDouble.load();
       Kernel::Matrix<double> gm(3, 3, false);
       int k = 0;
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         for (int j = 0; j < 9; j++) {
           double val = nxDouble[k];
           k++;
@@ -1178,7 +1178,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
 
       nxdimsize_t const maxShapeJSONLength = info.dims[1];
       data.load();
-      for (int i = 0; i < numberPeaks; ++i) {
+      for (size_t i = 0; i < numberPeaks; ++i) {
 
         // iR = peak row number
         auto startPoint = data() + (maxShapeJSONLength * i);
@@ -1195,7 +1195,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
       V3D qlab;
-      for (int r = 0; r < numberPeaks; ++r) {
+      for (size_t r = 0; r < numberPeaks; ++r) {
         qlab = V3D(nxDouble[r * 3], nxDouble[r * 3 + 1], nxDouble[r * 3 + 2]);
         peakWS->getPeak(r).setQLabFrame(qlab, 0.0);
       }
@@ -1203,7 +1203,7 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
       V3D hkl;
-      for (int r = 0; r < numberPeaks; ++r) {
+      for (size_t r = 0; r < numberPeaks; ++r) {
         hkl = V3D(nxDouble[r * 3], nxDouble[r * 3 + 1], nxDouble[r * 3 + 2]);
         peakWS->getPeak(r).setIntHKL(hkl);
       }
@@ -1211,14 +1211,14 @@ API::Workspace_sptr LoadNexusProcessed::loadLeanElasticPeaksEntry(const NXEntry 
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
       V3D mnp;
-      for (int r = 0; r < numberPeaks; ++r) {
+      for (size_t r = 0; r < numberPeaks; ++r) {
         mnp = V3D(nxDouble[r * 3], nxDouble[r * 3 + 1], nxDouble[r * 3 + 2]);
         peakWS->getPeak(r).setIntMNP(mnp);
       }
     }
 
     // After all columns read set IntHKL if not set
-    for (int r = 0; r < numberPeaks; r++) {
+    for (size_t r = 0; r < numberPeaks; r++) {
       V3D intHKL = peakWS->getPeak(r).getIntHKL();
       if (intHKL.norm2() == 0) {
         intHKL = V3D(peakWS->getPeak(r).getH(), peakWS->getPeak(r).getK(), peakWS->getPeak(r).getL());
@@ -1244,8 +1244,8 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
 
   NXData nx_tw = entry.openNXData("peaks_workspace");
 
-  int columnNumber = 1;
-  int64_t numberPeaks = 0;
+  size_t columnNumber = 1;
+  size_t numberPeaks = 0;
   std::vector<std::string> columnNames;
   do {
     std::string str = "column_" + std::to_string(columnNumber);
@@ -1336,7 +1336,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
   if (convention != m_QConvention)
     qSign = -1.0;
 
-  for (int r = 0; r < numberPeaks; r++) {
+  for (size_t r = 0; r < numberPeaks; r++) {
     // Warning! Do not use anything other than the default constructor here
     // It is currently important (10/05/17) that the DetID (set in the loop
     // below this one) is set before QLabFrame as this causes Peak to ray trace
@@ -1355,7 +1355,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXInt nxInt = nx_tw.openNXInt(str);
       nxInt.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         int ival = nxInt[r];
         if (ival != -1)
           peakWS->getPeak(r).setDetectorID(ival);
@@ -1364,7 +1364,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = qSign * nxDouble[r];
         peakWS->getPeak(r).setH(val);
       }
@@ -1372,7 +1372,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = qSign * nxDouble[r];
         peakWS->getPeak(r).setK(val);
       }
@@ -1380,7 +1380,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = qSign * nxDouble[r];
         peakWS->getPeak(r).setL(val);
       }
@@ -1388,7 +1388,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = nxDouble[r];
         peakWS->getPeak(r).setIntensity(val);
       }
@@ -1396,7 +1396,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = nxDouble[r];
         peakWS->getPeak(r).setSigmaIntensity(val);
       }
@@ -1404,7 +1404,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = nxDouble[r];
         peakWS->getPeak(r).setBinCount(val);
       }
@@ -1412,7 +1412,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = nxDouble[r];
         peakWS->getPeak(r).setWavelength(val);
       }
@@ -1420,7 +1420,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXInt nxInt = nx_tw.openNXInt(str);
       nxInt.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         int ival = nxInt[r];
         if (ival != -1)
           peakWS->getPeak(r).setRunNumber(ival);
@@ -1429,7 +1429,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXInt nxInt = nx_tw.openNXInt(str);
       nxInt.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         int ival = nxInt[r];
         peakWS->getPeak(r).setPeakNumber(ival);
       }
@@ -1437,7 +1437,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
 
-      for (int r = 0; r < numberPeaks; r++) {
+      for (size_t r = 0; r < numberPeaks; r++) {
         double val = nxDouble[r];
         peakWS->getPeak(r).setAbsorptionWeightedPathLength(val);
       }
@@ -1445,9 +1445,9 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
       Kernel::Matrix<double> gm(3, 3, false);
-      int k = 0;
-      for (int r = 0; r < numberPeaks; r++) {
-        for (int j = 0; j < 9; j++) {
+      size_t k = 0;
+      for (size_t r = 0; r < numberPeaks; r++) {
+        for (size_t j = 0; j < 9; j++) {
           double val = nxDouble[k];
           k++;
           gm[j % 3][j / 3] = val;
@@ -1472,7 +1472,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
 
       nxdimsize_t const maxShapeJSONLength = info.dims[1];
       data.load();
-      for (int i = 0; i < numberPeaks; ++i) {
+      for (size_t i = 0; i < numberPeaks; ++i) {
 
         // iR = peak row number
         auto startPoint = data() + (maxShapeJSONLength * i);
@@ -1489,7 +1489,7 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
       V3D hkl;
-      for (int r = 0; r < numberPeaks; ++r) {
+      for (size_t r = 0; r < numberPeaks; ++r) {
         hkl = V3D(nxDouble[r * 3], nxDouble[r * 3 + 1], nxDouble[r * 3 + 2]);
         peakWS->getPeak(r).setIntHKL(hkl);
       }
@@ -1497,14 +1497,14 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(const NXEntry &entry) {
       NXDouble nxDouble = nx_tw.openNXDouble(str);
       nxDouble.load();
       V3D mnp;
-      for (int r = 0; r < numberPeaks; ++r) {
+      for (size_t r = 0; r < numberPeaks; ++r) {
         mnp = V3D(nxDouble[r * 3], nxDouble[r * 3 + 1], nxDouble[r * 3 + 2]);
         peakWS->getPeak(r).setIntMNP(mnp);
       }
     }
   }
   // After all columns read set IntHKL if not set
-  for (int r = 0; r < numberPeaks; r++) {
+  for (size_t r = 0; r < numberPeaks; r++) {
     V3D intHKL = peakWS->getPeak(r).getIntHKL();
     if (intHKL.norm2() == 0) {
       intHKL = V3D(peakWS->getPeak(r).getH(), peakWS->getPeak(r).getK(), peakWS->getPeak(r).getL());
@@ -1641,8 +1641,8 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(NXData &wksp_cls
   int read_stop = (fullblocks * blocksize);
   const double progressBegin = progressStart + 0.25 * progressRange;
   const double progressScaler = 0.75 * progressRange;
-  int hist_index = 0;
-  int wsIndex = 0;
+  int64_t hist_index = 0;
+  int64_t wsIndex = 0;
   if (m_shared_bins) {
     // if spectrum min,max,list properties are set
     if (m_interval || m_list) {
@@ -1669,15 +1669,15 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(NXData &wksp_cls
         }
         size_t finalblock = m_spec_max - 1 - read_stop;
         if (finalblock > 0) {
-          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, static_cast<int>(finalblock), nchannels,
-                    hist_index, wsIndex, local_workspace);
+          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, finalblock, nchannels, hist_index,
+                    wsIndex, local_workspace);
         }
       }
       // if spectrum list property is set read each spectrum separately by
       // setting blocksize=1
       if (m_list) {
         for (const auto itr : m_spec_list) {
-          int specIndex = itr - 1;
+          int64_t specIndex = itr - 1;
           progress(progressBegin +
                        progressScaler * static_cast<double>(specIndex) / static_cast<double>(m_spec_list.size()),
                    "Reading workspace data...");
@@ -1694,8 +1694,8 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(NXData &wksp_cls
       }
       size_t finalblock = total_specs - read_stop;
       if (finalblock > 0) {
-        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, static_cast<int>(finalblock), nchannels,
-                  hist_index, wsIndex, local_workspace);
+        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, finalblock, nchannels, hist_index, wsIndex,
+                  local_workspace);
       }
     }
 
@@ -1720,14 +1720,14 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(NXData &wksp_cls
         }
         size_t finalblock = m_spec_max - 1 - read_stop;
         if (finalblock > 0) {
-          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, static_cast<int>(finalblock),
-                    nchannels, hist_index, wsIndex, local_workspace);
+          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, finalblock, nchannels, hist_index,
+                    wsIndex, local_workspace);
         }
       }
       //
       if (m_list) {
         for (const auto itr : m_spec_list) {
-          int specIndex = itr - 1;
+          int64_t specIndex = itr - 1;
           progress(progressBegin + progressScaler * static_cast<double>(specIndex) / static_cast<double>(read_stop),
                    "Reading workspace data...");
           loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, 1, nchannels, specIndex, wsIndex,
@@ -1743,8 +1743,8 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(NXData &wksp_cls
       }
       size_t finalblock = total_specs - read_stop;
       if (finalblock > 0) {
-        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, static_cast<int>(finalblock),
-                  nchannels, hist_index, wsIndex, local_workspace);
+        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, finalblock, nchannels, hist_index,
+                  wsIndex, local_workspace);
       }
     }
 
@@ -2188,7 +2188,7 @@ void LoadNexusProcessed::readBinMasking(const NXData &wksp_cls, const API::Matri
  */
 void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data, NXDataSetTyped<double> &errors,
                                    NXDataSetTyped<double> &farea, bool hasFArea, NXDouble &xErrors, bool hasXErrors,
-                                   int blocksize, int nchannels, int &hist,
+                                   int64_t blocksize, int64_t nchannels, int64_t &hist,
                                    const API::MatrixWorkspace_sptr &local_workspace) {
   data.load(blocksize, hist);
   errors.load(blocksize, hist);
@@ -2219,7 +2219,7 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data, NXDataSetTyped<
     xErrors_end = xErrors_start + dx_increment;
   }
 
-  int final(hist + blocksize);
+  int64_t final(hist + blocksize);
   while (hist < final) {
     auto &Y = local_workspace->mutableY(hist);
     Y.assign(data_start, data_end);
@@ -2266,7 +2266,7 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data, NXDataSetTyped<
 
 void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data, NXDataSetTyped<double> &errors,
                                    NXDataSetTyped<double> &farea, bool hasFArea, NXDouble &xErrors, bool hasXErrors,
-                                   int64_t blocksize, int64_t nchannels, int &hist, int &wsIndex,
+                                   int64_t blocksize, int64_t nchannels, int64_t &hist, int64_t &wsIndex,
                                    const API::MatrixWorkspace_sptr &local_workspace) {
   data.load(blocksize, hist);
   errors.load(blocksize, hist);
@@ -2344,8 +2344,8 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data, NXDataSetTyped<
  */
 void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data, NXDataSetTyped<double> &errors,
                                    NXDataSetTyped<double> &farea, bool hasFArea, NXDouble &xErrors, bool hasXErrors,
-                                   NXDouble &xbins, int64_t blocksize, int64_t nchannels, int &hist, int &wsIndex,
-                                   const API::MatrixWorkspace_sptr &local_workspace) {
+                                   NXDouble &xbins, int64_t blocksize, int64_t nchannels, int64_t &hist,
+                                   int64_t &wsIndex, const API::MatrixWorkspace_sptr &local_workspace) {
   data.load(blocksize, hist);
   double *data_start = data();
   double *data_end = data_start + nchannels;

--- a/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeaksWorkspace.h
@@ -83,8 +83,8 @@ public:
   /// Move a peak object into this peaks workspace
   void addPeak(LeanElasticPeak &&peak);
   void addPeak(const Kernel::V3D &position, const Kernel::SpecialCoordinateSystem &frame) override;
-  LeanElasticPeak &getPeak(int peakNum) override;
-  const LeanElasticPeak &getPeak(int peakNum) const override;
+  LeanElasticPeak &getPeak(size_t const peakNum) override;
+  const LeanElasticPeak &getPeak(size_t const peakNum) const override;
 
   std::unique_ptr<Geometry::IPeak> createPeak(const Kernel::V3D &QLabFrame,
                                               std::optional<double> detectorDistance = std::nullopt) const override;

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -79,8 +79,8 @@ public:
   /// Move a peak object into this peaks workspace
   void addPeak(Peak &&peak);
   void addPeak(const Kernel::V3D &position, const Kernel::SpecialCoordinateSystem &frame) override;
-  Peak &getPeak(int peakNum) override;
-  const Peak &getPeak(int peakNum) const override;
+  Peak &getPeak(size_t const peakNum) override;
+  const Peak &getPeak(size_t const peakNum) const override;
 
   IPeak_uptr createPeak(const Kernel::V3D &QLabFrame,
                         std::optional<double> detectorDistance = std::nullopt) const override;

--- a/Framework/DataObjects/src/LeanElasticPeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/LeanElasticPeaksWorkspace.cpp
@@ -169,8 +169,8 @@ void LeanElasticPeaksWorkspace::addPeak(LeanElasticPeak &&peak) { m_peaks.emplac
  * @param peakNum :: index of the peak to get.
  * @return a reference to a Peak object.
  */
-LeanElasticPeak &LeanElasticPeaksWorkspace::getPeak(const int peakNum) {
-  if (peakNum >= static_cast<int>(m_peaks.size()) || peakNum < 0) {
+LeanElasticPeak &LeanElasticPeaksWorkspace::getPeak(size_t const peakNum) {
+  if (peakNum >= m_peaks.size()) {
     throw std::invalid_argument("LeanElasticPeaksWorkspace::getPeak(): peakNum is out of range.");
   }
   return m_peaks[peakNum];
@@ -181,8 +181,8 @@ LeanElasticPeak &LeanElasticPeaksWorkspace::getPeak(const int peakNum) {
  * @param peakNum :: index of the peak to get.
  * @return a reference to a Peak object.
  */
-const LeanElasticPeak &LeanElasticPeaksWorkspace::getPeak(const int peakNum) const {
-  if (peakNum >= static_cast<int>(m_peaks.size()) || peakNum < 0) {
+const LeanElasticPeak &LeanElasticPeaksWorkspace::getPeak(size_t const peakNum) const {
+  if (peakNum >= m_peaks.size()) {
     throw std::invalid_argument("LeanElasticPeaksWorkspace::getPeak(): peakNum is out of range.");
   }
   return m_peaks[peakNum];

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -179,8 +179,8 @@ void PeaksWorkspace::addPeak(Peak &&peak) { m_peaks.emplace_back(peak); }
  * @param peakNum :: index of the peak to get.
  * @return a reference to a Peak object.
  */
-Peak &PeaksWorkspace::getPeak(const int peakNum) {
-  if (peakNum >= static_cast<int>(m_peaks.size()) || peakNum < 0) {
+Peak &PeaksWorkspace::getPeak(size_t const peakNum) {
+  if (peakNum >= m_peaks.size()) {
     throw std::invalid_argument("PeaksWorkspace::getPeak(): peakNum is out of range.");
   }
   return m_peaks[peakNum];
@@ -191,8 +191,8 @@ Peak &PeaksWorkspace::getPeak(const int peakNum) {
  * @param peakNum :: index of the peak to get.
  * @return a reference to a Peak object.
  */
-const Peak &PeaksWorkspace::getPeak(const int peakNum) const {
-  if (peakNum >= static_cast<int>(m_peaks.size()) || peakNum < 0) {
+const Peak &PeaksWorkspace::getPeak(size_t const peakNum) const {
+  if (peakNum >= m_peaks.size()) {
     throw std::invalid_argument("PeaksWorkspace::getPeak(): peakNum is out of range.");
   }
   return m_peaks[peakNum];
@@ -309,8 +309,8 @@ std::vector<std::pair<std::string, std::string>> PeaksWorkspace::peakInfo(const 
   int seqNum = -1;
   bool hasOneRunNumber = true;
   int runNum = -1;
-  int NPeaks = getNumberPeaks();
   try {
+    int NPeaks = getNumberPeaks();
     double minDist = 10000000;
     for (int i = 0; i < NPeaks; i++) {
       Peak pk = getPeak(i);

--- a/Framework/Muon/src/LoadMuonNexus1.cpp
+++ b/Framework/Muon/src/LoadMuonNexus1.cpp
@@ -392,7 +392,7 @@ void LoadMuonNexus1::loadDeadTimes(NXRoot &root) {
     NXFloat deadTimesData = detector.openNXFloat("deadtimes");
     deadTimesData.load();
 
-    int64_t numDeadTimes = deadTimesData.dim0();
+    auto numDeadTimes = deadTimesData.dim0();
 
     std::vector<int> specToLoad;
     std::vector<double> deadTimes;
@@ -490,7 +490,7 @@ Workspace_sptr LoadMuonNexus1::loadDetectorGrouping(NXRoot &root, const Geometry
     NXInt groupingData = dataEntry.openNXInt("grouping");
     groupingData.load();
 
-    int numGroupingEntries = static_cast<int>(groupingData.dim0());
+    auto numGroupingEntries = groupingData.dim0();
 
     std::vector<int> specToLoad;
     std::vector<int> grouping;

--- a/Framework/Muon/src/LoadMuonNexus2.cpp
+++ b/Framework/Muon/src/LoadMuonNexus2.cpp
@@ -113,7 +113,7 @@ void LoadMuonNexus2::exec() {
 
   NXFloat raw_time = dataGroup.openNXFloat("raw_time");
   raw_time.load();
-  int nBins = raw_time.dim0();
+  auto nBins = raw_time.dim0();
   std::vector<double> timeBins;
   timeBins.assign(raw_time(), raw_time() + nBins);
   timeBins.emplace_back(raw_time[nBins - 1] + raw_time[1] - raw_time[0]);
@@ -267,7 +267,7 @@ void LoadMuonNexus2::exec() {
  */
 Histogram LoadMuonNexus2::loadData(const BinEdges &edges, const Mantid::LegacyNexus::NXInt &counts, int period,
                                    int spec) {
-  int nBins = 0;
+  int64_t nBins = 0;
   const int *data = nullptr;
 
   if (counts.rank() == 3) {
@@ -424,7 +424,7 @@ int LoadMuonNexus2::confidence(Kernel::LegacyNexusDescriptor &descriptor) const 
  */
 std::map<int, std::set<int>> LoadMuonNexus2::loadDetectorMapping(const Mantid::LegacyNexus::NXInt &spectrumIndex) {
   std::map<int, std::set<int>> mapping;
-  const int nSpectra = static_cast<int>(spectrumIndex.dim0());
+  auto const nSpectra = spectrumIndex.dim0();
 
   // Find and open the data group
   NXRoot root(getPropertyValue("Filename"));

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -20,7 +20,7 @@ namespace Mantid::NeXus {
 static NXDimArray nxdimArray(::NeXus::DimVector xd) {
   NXDimArray ret{0};
   for (std::size_t i = 0; i < xd.size(); i++) {
-    ret[i] = static_cast<nxdimsize_t>(xd[i]);
+    ret[i] = xd[i];
   }
   return ret;
 }

--- a/Framework/NexusCpp/inc/MantidNexusCpp/NeXusFile_fwd.h
+++ b/Framework/NexusCpp/inc/MantidNexusCpp/NeXusFile_fwd.h
@@ -174,8 +174,7 @@ namespace NeXus {
 // TODO change to std::size_t
 typedef std::int64_t dimsize_t;
 // TODO replace all instances with DimArray
-typedef std::vector<dimsize_t> DimVector; ///< usef specifically for the dims array
-// typedef std::array<dimsize_t, 4> DimArray;
+typedef std::vector<dimsize_t> DimVector; ///< use specifically for the dims array
 //  TODO this is probably the same as DimVector
 typedef std::vector<dimsize_t> DimSizeVector; ///< used for start, size, chunk, buffsize, etc.
 


### PR DESCRIPTION
### Description of work

#### Summary of work

`NexusClasses` was originally written to work with `napi,h`, which uses standard `int` for all integer quantities.  However, some of these quantities are better expressed as `size_t`.  Some are better expressed as `size_t` but can't due to some compatibility expectations for negative numbers, and must be `int64_t`.

It seems some places in code were constrained by this limitation of `NexusClasses` to use `int`s.  Several of these places were fixed by resetting types to a more appropriate type.

This should improve the overall code quality of Mantid, by allowing for easier setting of whole counting numbers with unsigned int types, or at least with double width ints.

Part of #38332 

Compare and/or combine with #38805

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work

There should be no changes in this PR, except for:
1. `int` changed to `size_t` or `int64_t`
2. places with `size_t` *and* a `<0` check fixed to avoid compiler and CppCheck warnings

This does not require release notes because it is an internal change invisible to users.

### To test:

Make sure all existing tests pass.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
