### PR TITLE
SANS TOML V2: Polarization Options Added to User Files

### DIFF
--- a/docs/source/release/v6.13.0/SANS/New_features/38524.rst
+++ b/docs/source/release/v6.13.0/SANS/New_features/38524.rst
@@ -1,0 +1,2 @@
+- Polarization options have been added the :ref:`sans_toml_v1-ref` format.
+  As a result, the most up-to-date version of SANS TOML, which supports these options, has been bumped to 2.

--- a/docs/source/techniques/SANS-Toml-v1.rst
+++ b/docs/source/techniques/SANS-Toml-v1.rst
@@ -16,6 +16,42 @@ General Notes
 Format Changes
 ==============
 
+V1 (Mantid 6.4+) to V2 (Mantid 6.13+)
+-------------------------------------
+**NOTE: These are valid user file entries but have not yet been implemented as part of the reduction process.**
+
+*polarization* options have been added to the TOML format.
+
+- *flipper_configuration*
+- *spin_configuration*
+- *polarization.flipper.NAME*
+
+  - *idf_component_name*
+  - *device_name*
+  - *location*
+
+    - *x*, *y*, and *z*
+
+  - *transmission*
+  - *efficiency*
+
+- *polarization.polarizer* and *polarization.analyzer*
+
+  - All fields from the flippers plus:
+  - *cell_length*
+  - *gas_pressure*
+  - *empty_cell*
+  - *initial_polarization*
+
+- *polarization.magnetic_field* and *polarization.electric_field*
+
+  - *sample_strength_log*
+  - *sample_direction*
+
+    - *a*, *p*, and *d*
+
+  - *sample_direction_log*
+
 V0 (Mantid 6.3+) to V1 (Mantid 6.4+)
 --------------------------------------
 
@@ -50,6 +86,7 @@ file version. Long-term this allows us to make changes in a backwards compatible
 Available TOML Versions:
 
 - 1
+- 2
 
 ..  code-block:: none
 

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -18,7 +18,7 @@ from functools import wraps
 from typing import Optional
 
 from mantidqt.utils.observer_pattern import GenericObserver
-from sans.user_file.toml_parsers.toml_v1_schema import TomlValidationError
+from sans.user_file.toml_parsers.toml_base_schema import TomlValidationError
 from ui.sans_isis import SANSSaveOtherWindow
 from ui.sans_isis.sans_data_processor_gui import SANSDataProcessorGui
 from ui.sans_isis.sans_gui_observable import SansGuiObservable

--- a/scripts/SANS/sans/state/AllStates.py
+++ b/scripts/SANS/sans/state/AllStates.py
@@ -27,6 +27,7 @@ from sans.state.StateObjects.StateSliceEvent import StateSliceEvent
 from sans.state.StateObjects.StateWavelength import StateWavelength
 from sans.state.StateObjects.state_instrument_info import StateInstrumentInfo
 from sans.state.StateObjects.StateBackgroundSubtraction import StateBackgroundSubtraction
+from sans.state.StateObjects.StatePolarization import StatePolarization
 from sans.state.automatic_setters import automatic_setters
 
 
@@ -51,6 +52,7 @@ class AllStates(metaclass=JsonSerializable):
         self.convert_to_q: StateConvertToQ = StateConvertToQ()
         self.compatibility: StateCompatibility = StateCompatibility()
         self.background_subtraction: StateBackgroundSubtraction = StateBackgroundSubtraction()
+        self.polarization: StatePolarization = StatePolarization()
 
     def validate(self):
         is_invalid = dict()
@@ -78,6 +80,8 @@ class AllStates(metaclass=JsonSerializable):
             is_invalid.update("State: The state object needs to include a StateConvertToQ object.")
         if not self.background_subtraction:
             is_invalid.update("State: The state object needs to include a StateBackgroundSubtraction object.")
+        if not self.polarization:
+            is_invalid.update("State: The state object needs to include a StatePolarization object.")
 
         # We don't enforce a compatibility mode, we just create one if it does not exist
         if not self.compatibility:

--- a/scripts/SANS/sans/state/IStateParser.py
+++ b/scripts/SANS/sans/state/IStateParser.py
@@ -16,6 +16,7 @@ from sans.state.StateObjects.StateData import StateData, get_data_builder
 from sans.state.StateObjects.StateMaskDetectors import StateMask
 from sans.state.StateObjects.StateMoveDetectors import StateMove
 from sans.state.StateObjects.StateNormalizeToMonitor import StateNormalizeToMonitor
+from sans.state.StateObjects.StatePolarization import StatePolarization
 from sans.state.StateObjects.StateReductionMode import StateReductionMode
 from sans.state.StateObjects.StateSave import StateSave
 from sans.state.StateObjects.StateScale import StateScale
@@ -40,6 +41,7 @@ class IStateParser(metaclass=ABCMeta):
         all_states.compatibility = self.get_state_compatibility()
         all_states.data = self.get_state_data(file_information)
         all_states.instrument_info = StateInstrumentInfo.build_from_data_info(all_states.data)
+        all_states.polarization = self.get_state_polarization()
 
         return all_states
 
@@ -100,4 +102,8 @@ class IStateParser(metaclass=ABCMeta):
 
     @abstractmethod
     def get_state_wavelength_and_pixel_adjustment(self) -> StateWavelengthAndPixelAdjustment:
+        pass
+
+    @abstractmethod
+    def get_state_polarization(self) -> StatePolarization:
         pass

--- a/scripts/SANS/sans/state/StateObjects/StatePolarization.py
+++ b/scripts/SANS/sans/state/StateObjects/StatePolarization.py
@@ -13,9 +13,42 @@ from sans.state.JsonSerializable import JsonSerializable
 # ----------------------------------------------------------------------------------------------------------------------
 
 
+class StateComponent(metaclass=JsonSerializable):
+    idf_component_name: None | str
+    device_name: None | str
+    device_type: None | str
+    location_x: None | int
+    location_y: None | int
+    location_z: None | int
+    transmission: None | str
+    efficiency: None | str
+
+    def __init__(self):
+        super(StateComponent, self).__init__()
+        # Name of the component in the IDF.
+        self.idf_component_name = None
+
+        # Only used if we want to use a name different from what is defined in the IDF.
+        self.device_name = None
+
+        # Used when overriding values in the IDF, or if the device is not in the IDF at all.
+        self.device_type = None
+        self.location_x = None
+        self.location_y = None
+        self.location_z = None
+
+        # Workspace names for correction workspaces
+        self.transmission = None
+        self.efficiency = None
+
+
 class StatePolarization(metaclass=JsonSerializable):
+    flipper_configuration: None | str
+    spin_configuration: None | str
+    flippers: list[StateComponent]
+
     def __init__(self):
         super(StatePolarization, self).__init__()
-
-        self.flipper_configuraiton = None  # : Str()
-        self.spin_configuration = None  # : Str()
+        self.flipper_configuration = None
+        self.spin_configuration = None
+        self.flippers = []

--- a/scripts/SANS/sans/state/StateObjects/StatePolarization.py
+++ b/scripts/SANS/sans/state/StateObjects/StatePolarization.py
@@ -42,13 +42,31 @@ class StateComponent(metaclass=JsonSerializable):
         self.efficiency = None
 
 
+class StateFilter(StateComponent, metaclass=JsonSerializable):
+    cell_length: None | int
+    gas_pressure: None | int
+    initial_polarization: None | str
+
+    def __init__(self):
+        super(StateFilter, self).__init__()
+        # Relevant to He3 filters (Polarisers and Analysers)
+        self.cell_length = None
+        self.gas_pressure = None
+        # Relevant to all polarisers and analysers.
+        self.initial_polarization = None
+
+
 class StatePolarization(metaclass=JsonSerializable):
     flipper_configuration: None | str
     spin_configuration: None | str
     flippers: list[StateComponent]
+    polarizer: None | StateFilter
+    analyzer: None | StateFilter
 
     def __init__(self):
         super(StatePolarization, self).__init__()
         self.flipper_configuration = None
         self.spin_configuration = None
+        self.analyzer = None
+        self.polarizer = None
         self.flippers = []

--- a/scripts/SANS/sans/state/StateObjects/StatePolarization.py
+++ b/scripts/SANS/sans/state/StateObjects/StatePolarization.py
@@ -149,13 +149,13 @@ class StatePolarization(metaclass=JsonSerializable):
         self.electric_field = None
 
     def validate(self):
-        if self.analyzer is not None:
-            self.analyzer.validate()
-        if self.polarizer is not None:
-            self.polarizer.validate()
-        if self.magnetic_field is not None:
-            self.magnetic_field.validate()
-        if self.electric_field is not None:
-            self.electric_field.validate()
-        for flipper in self.flippers:
-            flipper.validate()
+        for attribute in vars(self).keys():
+            sub_state = getattr(self, attribute)
+            if isinstance(sub_state, str):
+                pass
+            elif isinstance(sub_state, list):
+                for flipper in sub_state:
+                    flipper.validate()
+            else:
+                if sub_state:
+                    sub_state.validate()

--- a/scripts/SANS/sans/state/StateObjects/StatePolarization.py
+++ b/scripts/SANS/sans/state/StateObjects/StatePolarization.py
@@ -58,6 +58,7 @@ class StateFilter(StateComponent, metaclass=JsonSerializable):
         # Relevant to He3 filters (Polarisers and Analysers)
         self.cell_length = None
         self.gas_pressure = None
+        self.empty_cell = None
         # Relevant to all polarisers and analysers.
         self.initial_polarization = None
 

--- a/scripts/SANS/sans/state/StateObjects/StatePolarization.py
+++ b/scripts/SANS/sans/state/StateObjects/StatePolarization.py
@@ -101,19 +101,18 @@ class StateField(metaclass=JsonSerializable):
     def validate(self):
         is_invalid = dict()
         direction = [self.sample_direction_a, self.sample_direction_p, self.sample_direction_d]
-        if self.sample_direction_log is not None:
-            if any(coordinate is not None for coordinate in direction):
-                entry = validation_message(
-                    "Too many sample direction parameters.",
-                    "Either set the sample direction log OR set the a, p, and d values.",
-                    {
-                        "SampleDirectionLog": self.sample_direction_log,
-                        "SampleDirectionA": self.sample_direction_a,
-                        "SampleDirectionP": self.sample_direction_p,
-                        "SampleDirectionD": self.sample_direction_d,
-                    },
-                )
-                is_invalid.update(entry)
+        if self.sample_direction_log and any(direction):
+            entry = validation_message(
+                "Too many sample direction parameters.",
+                "Either set the sample direction log OR set the a, p, and d values.",
+                {
+                    "SampleDirectionLog": self.sample_direction_log,
+                    "SampleDirectionA": self.sample_direction_a,
+                    "SampleDirectionP": self.sample_direction_p,
+                    "SampleDirectionD": self.sample_direction_d,
+                },
+            )
+            is_invalid.update(entry)
         elif not is_pure_none_or_not_none(direction):
             entry = validation_message(
                 "Missing field sample direction parameters.",

--- a/scripts/SANS/sans/state/StateObjects/StatePolarization.py
+++ b/scripts/SANS/sans/state/StateObjects/StatePolarization.py
@@ -1,0 +1,21 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""Defines the state of the polarization taking place during the run."""
+
+from sans.state.JsonSerializable import JsonSerializable
+
+# ----------------------------------------------------------------------------------------------------------------------
+# State
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+class StatePolarization(metaclass=JsonSerializable):
+    def __init__(self):
+        super(StatePolarization, self).__init__()
+
+        self.flipper_configuraiton = None  # : Str()
+        self.spin_configuration = None  # : Str()

--- a/scripts/SANS/sans/state/StateObjects/StatePolarization.py
+++ b/scripts/SANS/sans/state/StateObjects/StatePolarization.py
@@ -26,6 +26,8 @@ class StateComponent(metaclass=JsonSerializable):
     efficiency: None | str
 
     def __init__(self):
+        # Note: Any new attributes added here should also be added to  construct_from_component in StateFilter below.
+
         super(StateComponent, self).__init__()
         # Name of the component in the IDF.
         self.idf_component_name = None
@@ -52,6 +54,19 @@ class StateFilter(StateComponent, metaclass=JsonSerializable):
     cell_length: None | int
     gas_pressure: None | int
     initial_polarization: None | str
+
+    @classmethod
+    def construct_from_component(cls, component: StateComponent):
+        filter_state = StateFilter()
+        filter_state.idf_component_name = component.idf_component_name
+        filter_state.device_name = component.device_name
+        filter_state.device_type = component.device_type
+        filter_state.location_x = component.location_x
+        filter_state.location_y = component.location_y
+        filter_state.location_z = component.location_z
+        filter_state.transmission = component.transmission
+        filter_state.efficiency = component.efficiency
+        return filter_state
 
     def __init__(self):
         super(StateFilter, self).__init__()

--- a/scripts/SANS/sans/state/StateObjects/StatePolarization.py
+++ b/scripts/SANS/sans/state/StateObjects/StatePolarization.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
@@ -56,12 +56,31 @@ class StateFilter(StateComponent, metaclass=JsonSerializable):
         self.initial_polarization = None
 
 
+class StateField(metaclass=JsonSerializable):
+    sample_strength_log: None | str
+    sample_direction_log: None | str
+
+    sample_direction_a: None | int
+    sample_direction_p: None | int
+    sample_direction_d: None | int
+
+    def __init__(self):
+        super(StateField, self).__init__()
+        self.sample_strength_log = None
+        self.sample_direction_log = None
+        self.sample_direction_a = None
+        self.sample_direction_p = None
+        self.sample_direction_d = None
+
+
 class StatePolarization(metaclass=JsonSerializable):
     flipper_configuration: None | str
     spin_configuration: None | str
     flippers: list[StateComponent]
     polarizer: None | StateFilter
     analyzer: None | StateFilter
+    magnetic_field: None | StateField
+    electric_field: None | StateField
 
     def __init__(self):
         super(StatePolarization, self).__init__()
@@ -70,3 +89,5 @@ class StatePolarization(metaclass=JsonSerializable):
         self.analyzer = None
         self.polarizer = None
         self.flippers = []
+        self.magnetic_field = None
+        self.electric_field = None

--- a/scripts/SANS/sans/test_helper/toml_parser_test_helpers.py
+++ b/scripts/SANS/sans/test_helper/toml_parser_test_helpers.py
@@ -5,8 +5,6 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 
-from typing import List, Dict
-
 from sans.common.enums import SANSInstrument, SANSFacility
 from sans.state.StateObjects.StateData import get_data_builder
 from sans.state.StateObjects.StateData import StateData
@@ -24,8 +22,8 @@ def get_mock_data_info():
 
 
 def setup_parser_dict(dict_vals) -> tuple[dict, StateData]:
-    def _add_missing_mandatory_key(dict_to_check: Dict, key_path: List[str], replacement_val):
-        _dict = dict_to_check
+    def _add_missing_mandatory_key(nested_dict_to_check: dict, key_path: list[str], replacement_val):
+        _dict = nested_dict_to_check
         for key in key_path[0:-1]:
             if key not in _dict:
                 _dict[key] = {}
@@ -33,7 +31,7 @@ def setup_parser_dict(dict_vals) -> tuple[dict, StateData]:
 
         if key_path[-1] not in _dict:
             _dict[key_path[-1]] = replacement_val  # Add in child value
-        return dict_to_check
+        return nested_dict_to_check
 
     mocked_data_info = get_mock_data_info()
     # instrument key needs to generally be present

--- a/scripts/SANS/sans/test_helper/toml_parser_test_helpers.py
+++ b/scripts/SANS/sans/test_helper/toml_parser_test_helpers.py
@@ -12,8 +12,6 @@ from sans.test_helper.file_information_mock import SANSFileInformationMock
 
 
 def get_mock_data_info():
-    # TODO I really really dislike having to do this in a test, but
-    # TODO de-coupling StateData is required to avoid it
     file_information = SANSFileInformationMock(instrument=SANSInstrument.SANS2D, run_number=22024)
     data_builder = get_data_builder(SANSFacility.ISIS, file_information)
     data_builder.set_sample_scatter("SANS2D00022024")

--- a/scripts/SANS/sans/test_helper/toml_parser_test_helpers.py
+++ b/scripts/SANS/sans/test_helper/toml_parser_test_helpers.py
@@ -1,0 +1,43 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from typing import List, Dict
+
+from sans.common.enums import SANSInstrument, SANSFacility
+from sans.state.StateObjects.StateData import get_data_builder
+from sans.state.StateObjects.StateData import StateData
+from sans.test_helper.file_information_mock import SANSFileInformationMock
+
+
+def get_mock_data_info():
+    # TODO I really really dislike having to do this in a test, but
+    # TODO de-coupling StateData is required to avoid it
+    file_information = SANSFileInformationMock(instrument=SANSInstrument.SANS2D, run_number=22024)
+    data_builder = get_data_builder(SANSFacility.ISIS, file_information)
+    data_builder.set_sample_scatter("SANS2D00022024")
+    data_builder.set_sample_scatter_period(3)
+    return data_builder.build()
+
+
+def setup_parser_dict(dict_vals) -> tuple[dict, StateData]:
+    def _add_missing_mandatory_key(dict_to_check: Dict, key_path: List[str], replacement_val):
+        _dict = dict_to_check
+        for key in key_path[0:-1]:
+            if key not in _dict:
+                _dict[key] = {}
+            _dict = _dict[key]
+
+        if key_path[-1] not in _dict:
+            _dict[key_path[-1]] = replacement_val  # Add in child value
+        return dict_to_check
+
+    mocked_data_info = get_mock_data_info()
+    # instrument key needs to generally be present
+    dict_vals = _add_missing_mandatory_key(dict_vals, ["instrument", "name"], "LOQ")
+    dict_vals = _add_missing_mandatory_key(dict_vals, ["detector", "configuration", "selected_detector"], "rear")
+
+    return dict_vals, mocked_data_info

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_base_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_base_parser.py
@@ -1,0 +1,27 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from abc import ABCMeta, abstractmethod
+
+from sans.state.IStateParser import IStateParser
+from sans.user_file.toml_parsers.toml_base_schema import TomlSchemaValidator
+
+
+class TomlParserBase(IStateParser, metaclass=ABCMeta):
+    def __init__(self, dict_to_parse, file_information, schema_validator: TomlSchemaValidator):
+        self._validator = schema_validator
+        self._validator.validate()
+
+        self._implementation = None
+        data_info = self.get_state_data(file_information)
+        self._implementation = self._get_impl(dict_to_parse, data_info)
+        self._implementation.parse_all()
+
+    @staticmethod
+    @abstractmethod
+    def _get_impl(*args):
+        pass

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_base_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_base_parser.py
@@ -16,7 +16,6 @@ class TomlParserBase(IStateParser, metaclass=ABCMeta):
         self._validator = schema_validator
         self._validator.validate()
 
-        self._implementation = None
         data_info = self.get_state_data(file_information)
         self._implementation = self._get_impl(dict_to_parse, data_info)
         self._implementation.parse_all()

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_base_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_base_parser.py
@@ -16,7 +16,7 @@ class TomlParserBase(IStateParser, metaclass=ABCMeta):
         self._validator = schema_validator
         self._validator.validate()
 
-        data_info = self.get_state_data(file_information)
+        data_info = super().get_state_data(file_information)
         self._implementation = self._get_impl(dict_to_parse, data_info)
         self._implementation.parse_all()
 

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_base_schema.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_base_schema.py
@@ -1,0 +1,73 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import re
+from abc import abstractmethod, ABCMeta
+
+
+class TomlValidationError(Exception):
+    # A key error would be more appropriate, but there is special
+    # handling on KeyError which escapes any new lines making it un-readable
+    pass
+
+
+class TomlSchemaValidator(object, metaclass=ABCMeta):
+    # As of the current TOML release there is no way to validate a schema so
+    # we must provide an implementation
+
+    def __init__(self, dict_to_validate):
+        self._expected_list = self._build_nested_keys(self.reference_schema())
+        self._to_validate_list = self._build_nested_keys(dict_to_validate)
+
+    def validate(self):
+        self._to_validate_list = filter(lambda s: not s.startswith("metadata"), self._to_validate_list)
+        unrecognised = set(self._to_validate_list).difference(self._expected_list)
+
+        if not unrecognised:
+            return
+
+        # Build any with wildcards
+        wildcard_matchers = [re.compile(s) for s in self._expected_list if "*" in s]
+        # Remove anything which matches any the regex wildcards
+        unrecognised = [s for s in unrecognised if not any(wild_matcher.match(s) for wild_matcher in wildcard_matchers)]
+
+        if len(unrecognised) > 0:
+            err = "The following keys were not recognised:\n"
+            err += "".join("{0} \n".format(k) for k in unrecognised)
+            raise TomlValidationError(err)
+
+    @staticmethod
+    @abstractmethod
+    def reference_schema():
+        """
+        Returns a dictionary layout of all supported keys
+        :return: Dictionary containing all keys, and values set to None
+        """
+        pass
+
+    @staticmethod
+    def _build_nested_keys(d, path="", current_out=None):
+        if not current_out:
+            current_out = []
+
+        def make_path(current_path, new_key):
+            return current_path + "." + new_key if current_path else new_key
+
+        for key, v in d.items():
+            new_path = make_path(path, key)
+            if isinstance(v, dict):
+                # Recurse into dict
+                current_out = TomlSchemaValidator._build_nested_keys(v, new_path, current_out)
+            elif isinstance(v, set):
+                # Pack all in from the set of names
+                for name in v:
+                    current_out.append(make_path(new_path, name))
+            else:
+                # This means its a value type with nothing special, so keep name
+                current_out.append(new_path)
+
+        return current_out

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_base_schema.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_base_schema.py
@@ -50,14 +50,14 @@ class TomlSchemaValidator(object, metaclass=ABCMeta):
         pass
 
     @staticmethod
-    def _build_nested_keys(d, path="", current_out=None):
+    def _build_nested_keys(nested_dict, path="", current_out=None):
         if not current_out:
             current_out = []
 
         def make_path(current_path, new_key):
             return current_path + "." + new_key if current_path else new_key
 
-        for key, v in d.items():
+        for key, v in nested_dict.items():
             new_path = make_path(path, key)
             if isinstance(v, dict):
                 # Recurse into dict

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_parser.py
@@ -8,6 +8,7 @@ from sans.state.AllStates import AllStates
 from sans.state.IStateParser import IStateParser
 from sans.user_file.toml_parsers.toml_reader import TomlReader
 from sans.user_file.toml_parsers.toml_v1_parser import TomlV1Parser
+from sans.user_file.toml_parsers.toml_v2_parser import TomlV2Parser
 
 
 class TomlParser(object):
@@ -33,5 +34,7 @@ class TomlParser(object):
         version = toml_dict["toml_file_version"]
         if version == 1:
             return TomlV1Parser(toml_dict, file_information=file_information)
+        if version == 2:
+            return TomlV2Parser(toml_dict, file_information=file_information)
         else:
             raise NotImplementedError("Version {0} of the SANS Toml Format is not supported".format(version))

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_parser.py
@@ -32,9 +32,10 @@ class TomlParser(object):
         :return: Appropriate parser for the associated TOML dictionary
         """
         version = toml_dict["toml_file_version"]
-        if version == 1:
-            return TomlV1Parser(toml_dict, file_information=file_information)
-        if version == 2:
-            return TomlV2Parser(toml_dict, file_information=file_information)
-        else:
-            raise NotImplementedError("Version {0} of the SANS Toml Format is not supported".format(version))
+        match version:
+            case 1:
+                return TomlV1Parser(toml_dict, file_information=file_information)
+            case 2:
+                return TomlV2Parser(toml_dict, file_information=file_information)
+            case _:
+                raise NotImplementedError("Version {0} of the SANS Toml Format is not supported".format(version))

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
@@ -18,7 +18,7 @@ from sans.state.StateObjects.StateData import StateData
 from sans.state.StateObjects.StateMaskDetectors import get_mask_builder, StateMaskDetectors
 from sans.state.StateObjects.StateMoveDetectors import get_move_builder
 from sans.state.StateObjects.StateNormalizeToMonitor import get_normalize_to_monitor_builder
-from sans.state.StateObjects.StatePolarization import StatePolarization, StateComponent
+from sans.state.StateObjects.StatePolarization import StatePolarization, StateComponent, StateFilter
 from sans.state.StateObjects.StateReductionMode import StateReductionMode
 from sans.state.StateObjects.StateSave import StateSave
 from sans.state.StateObjects.StateScale import StateScale
@@ -529,6 +529,8 @@ class _TomlV1ParserImpl(TomlParserImplBase):
         if flipper_dicts:
             for flipper_dict in flipper_dicts.values():
                 self.polarization.flippers.append(self._parse_component(flipper_dict))
+        self.polarization.polarizer = self._parse_filter(self.get_val("polarizer", polarization_dict))
+        self.polarization.analyzer = self._parse_filter(self.get_val("analyzer", polarization_dict))
 
     def _parse_component(self, component_dict: dict) -> StateComponent:
         component_state = StateComponent()
@@ -545,6 +547,15 @@ class _TomlV1ParserImpl(TomlParserImplBase):
         component_state.transmission = self.get_val("transmission", component_dict)
         component_state.efficiency = self.get_val("efficiency", component_dict)
         return component_state
+
+    def _parse_filter(self, filter_dict: dict) -> StateFilter:
+        if filter_dict is None:
+            return StateFilter()
+        filter_state = self._parse_component(filter_dict)
+        filter_state.__class__ = StateFilter
+        filter_state.cell_length = self.get_val("cell_length", filter_dict)
+        filter_state.gas_pressure = self.get_val("gas_pressure", filter_dict)
+        return filter_state
 
     @staticmethod
     def _get_1d_min_max(one_d_binning: str):

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
@@ -533,6 +533,7 @@ class _TomlV1ParserImpl(TomlParserImplBase):
         self.polarization.analyzer = self._parse_filter(self.get_val("analyzer", polarization_dict))
         self.polarization.magnetic_field = self._parse_field(self.get_val("magnetic_field", polarization_dict))
         self.polarization.electric_field = self._parse_field(self.get_val("electric_field", polarization_dict))
+        self.polarization.validate()
 
     def _parse_component(self, component_dict: dict) -> StateComponent:
         component_state = StateComponent()

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
@@ -18,7 +18,7 @@ from sans.state.StateObjects.StateData import StateData
 from sans.state.StateObjects.StateMaskDetectors import get_mask_builder, StateMaskDetectors
 from sans.state.StateObjects.StateMoveDetectors import get_move_builder
 from sans.state.StateObjects.StateNormalizeToMonitor import get_normalize_to_monitor_builder
-from sans.state.StateObjects.StatePolarization import StatePolarization, StateComponent, StateFilter
+from sans.state.StateObjects.StatePolarization import StatePolarization, StateComponent, StateFilter, StateField
 from sans.state.StateObjects.StateReductionMode import StateReductionMode
 from sans.state.StateObjects.StateSave import StateSave
 from sans.state.StateObjects.StateScale import StateScale
@@ -531,6 +531,8 @@ class _TomlV1ParserImpl(TomlParserImplBase):
                 self.polarization.flippers.append(self._parse_component(flipper_dict))
         self.polarization.polarizer = self._parse_filter(self.get_val("polarizer", polarization_dict))
         self.polarization.analyzer = self._parse_filter(self.get_val("analyzer", polarization_dict))
+        self.polarization.magnetic_field = self._parse_field(self.get_val("magnetic_field", polarization_dict))
+        self.polarization.electric_field = self._parse_field(self.get_val("electric_field", polarization_dict))
 
     def _parse_component(self, component_dict: dict) -> StateComponent:
         component_state = StateComponent()
@@ -556,6 +558,19 @@ class _TomlV1ParserImpl(TomlParserImplBase):
         filter_state.cell_length = self.get_val("cell_length", filter_dict)
         filter_state.gas_pressure = self.get_val("gas_pressure", filter_dict)
         return filter_state
+
+    def _parse_field(self, field_dict: dict) -> StateField:
+        field_state = StateField()
+        if field_dict is None:
+            return field_state
+        field_state.sample_strength_log = self.get_val("sample_strength_log", field_dict)
+        direction_dict = self.get_val("sample_direction", field_dict)
+        if direction_dict:
+            field_state.sample_direction_a = self.get_val("a", direction_dict)
+            field_state.sample_direction_p = self.get_val("p", direction_dict)
+            field_state.sample_direction_d = self.get_val("d", direction_dict)
+        field_state.sample_direction_log = self.get_val("sample_direction_log", field_dict)
+        return field_state
 
     @staticmethod
     def _get_1d_min_max(one_d_binning: str):

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
@@ -138,8 +138,20 @@ class TomlSchemaV1Validator(object):
         }
 
         polarization_keys = {
-            "flipper_configuration",
-            "spin_configuration",
+            "flipper_configuration": None,
+            "spin_configuration": None,
+            "flipper": {
+                "*": {
+                    "idf_component_name": None,
+                    "device_name": None,
+                    "device_type": None,
+                    "location": {"x", "y", "z"},
+                    "transmission": None,
+                    "efficiency": None,
+                    "empty_cell": None,
+                    "initial_polarization": None,
+                }
+            },
         }
 
         return {

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
@@ -4,46 +4,19 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import re
+
+from sans.user_file.toml_parsers.toml_base_schema import TomlSchemaValidator
 
 
-class TomlValidationError(Exception):
-    # A key error would be more appropriate, but there is special
-    # handling on KeyError which escapes any new lines making it un-readable
-    pass
-
-
-class TomlSchemaV1Validator(object):
+class TomlSchemaV1Validator(TomlSchemaValidator):
     # As of the current TOML release there is no way to validate a schema so
     # we must provide an implementation
 
-    # Note : To future devs, if we have a V2 schema a lot of this class could
-    # be split into a SchemaValidator and an inheriting V1 and V2 schema
-    # would override the reference schema with the new one
-
     def __init__(self, dict_to_validate):
-        self._expected_list = self._build_nested_keys(self._reference_schema())
-        self._to_validate_list = self._build_nested_keys(dict_to_validate)
-
-    def validate(self):
-        self._to_validate_list = filter(lambda s: not s.startswith("metadata"), self._to_validate_list)
-        unrecognised = set(self._to_validate_list).difference(self._expected_list)
-
-        if not unrecognised:
-            return
-
-        # Build any with wildcards
-        wildcard_matchers = [re.compile(s) for s in self._expected_list if "*" in s]
-        # Remove anything which matches any the regex wildcards
-        unrecognised = [s for s in unrecognised if not any(wild_matcher.match(s) for wild_matcher in wildcard_matchers)]
-
-        if len(unrecognised) > 0:
-            err = "The following keys were not recognised:\n"
-            err += "".join("{0} \n".format(k) for k in unrecognised)
-            raise TomlValidationError(err)
+        super(TomlSchemaV1Validator, self).__init__(dict_to_validate)
 
     @staticmethod
-    def _reference_schema():
+    def reference_schema():
         """
         Returns a dictionary layout of all supported keys
         :return: Dictionary containing all keys, and values set to None
@@ -137,32 +110,6 @@ class TomlSchemaV1Validator(object):
             },
         }
 
-        component_keys = {
-            "idf_component_name": None,
-            "device_name": None,
-            "device_type": None,
-            "location": {"x", "y", "z"},
-            "transmission": None,
-            "efficiency": None,
-            "empty_cell": None,
-            "initial_polarization": None,
-        }
-        filter_keys = dict(component_keys, **{"cell_length": None, "gas_pressure": None})
-        field_keys = {
-            "sample_strength_log": None,
-            "sample_direction": {"a", "p", "d"},
-            "sample_direction_log": None,
-        }
-        polarization_keys = {
-            "flipper_configuration": None,
-            "spin_configuration": None,
-            "flipper": {"*": component_keys},
-            "polarizer": filter_keys,
-            "analyzer": filter_keys,
-            "magnetic_field": field_keys,
-            "electric_field": field_keys,
-        }
-
         return {
             "toml_file_version": None,
             "binning": binning_keys,
@@ -175,28 +122,4 @@ class TomlSchemaV1Validator(object):
             "q_resolution": q_resolution_keys,
             "reduction": reduction_keys,
             "transmission": transmission_keys,
-            "polarization": polarization_keys,
         }
-
-    @staticmethod
-    def _build_nested_keys(d, path="", current_out=None):
-        if not current_out:
-            current_out = []
-
-        def make_path(current_path, new_key):
-            return current_path + "." + new_key if current_path else new_key
-
-        for key, v in d.items():
-            new_path = make_path(path, key)
-            if isinstance(v, dict):
-                # Recurse into dict
-                current_out = TomlSchemaV1Validator._build_nested_keys(v, new_path, current_out)
-            elif isinstance(v, set):
-                # Pack all in from the set of names
-                for name in v:
-                    current_out.append(make_path(new_path, name))
-            else:
-                # This means its a value type with nothing special, so keep name
-                current_out.append(new_path)
-
-        return current_out

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
@@ -137,21 +137,23 @@ class TomlSchemaV1Validator(object):
             },
         }
 
+        component_keys = {
+            "idf_component_name": None,
+            "device_name": None,
+            "device_type": None,
+            "location": {"x", "y", "z"},
+            "transmission": None,
+            "efficiency": None,
+            "empty_cell": None,
+            "initial_polarization": None,
+        }
+        filter_keys = dict(component_keys, **{"cell_length": None, "gas_pressure": None})
         polarization_keys = {
             "flipper_configuration": None,
             "spin_configuration": None,
-            "flipper": {
-                "*": {
-                    "idf_component_name": None,
-                    "device_name": None,
-                    "device_type": None,
-                    "location": {"x", "y", "z"},
-                    "transmission": None,
-                    "efficiency": None,
-                    "empty_cell": None,
-                    "initial_polarization": None,
-                }
-            },
+            "flipper": {"*": component_keys},
+            "polarizer": filter_keys,
+            "analyzer": filter_keys,
         }
 
         return {

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
@@ -148,12 +148,19 @@ class TomlSchemaV1Validator(object):
             "initial_polarization": None,
         }
         filter_keys = dict(component_keys, **{"cell_length": None, "gas_pressure": None})
+        field_keys = {
+            "sample_strength_log": None,
+            "sample_direction": {"a", "p", "d"},
+            "sample_direction_log": None,
+        }
         polarization_keys = {
             "flipper_configuration": None,
             "spin_configuration": None,
             "flipper": {"*": component_keys},
             "polarizer": filter_keys,
             "analyzer": filter_keys,
+            "magnetic_field": field_keys,
+            "electric_field": field_keys,
         }
 
         return {

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
@@ -137,6 +137,11 @@ class TomlSchemaV1Validator(object):
             },
         }
 
+        polarization_keys = {
+            "flipper_configuration",
+            "spin_configuration",
+        }
+
         return {
             "toml_file_version": None,
             "binning": binning_keys,
@@ -149,6 +154,7 @@ class TomlSchemaV1Validator(object):
             "q_resolution": q_resolution_keys,
             "reduction": reduction_keys,
             "transmission": transmission_keys,
+            "polarization": polarization_keys,
         }
 
     @staticmethod

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v2_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v2_parser.py
@@ -1,0 +1,94 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from sans.state.StateObjects.StateData import StateData
+from sans.state.StateObjects.StatePolarization import StatePolarization, StateComponent, StateFilter, StateField
+from sans.user_file.toml_parsers.toml_v1_parser import TomlV1Parser, TomlV1ParserImpl
+from sans.user_file.toml_parsers.toml_v2_schema import TomlSchemaV2Validator
+
+
+class TomlV2Parser(TomlV1Parser):
+    def __init__(self, dict_to_parse, file_information, schema_validator=None):
+        validator = schema_validator if schema_validator else TomlSchemaV2Validator(dict_to_parse)
+        super(TomlV2Parser, self).__init__(dict_to_parse, file_information, validator)
+
+    @staticmethod
+    def _get_impl(*args):
+        # Wrapper which can replaced with a mock
+        return TomlV2ParserImpl(*args)
+
+    def get_state_polarization(self) -> StatePolarization:
+        return self._implementation.polarization
+
+
+class TomlV2ParserImpl(TomlV1ParserImpl):
+    def __init__(self, input_dict, data_info: StateData):
+        super(TomlV2ParserImpl, self).__init__(input_dict, data_info)
+
+    def parse_all(self):
+        super().parse_all()
+        self._parse_polarization()
+
+    def _create_state_objs(self, data_info):
+        super()._create_state_objs(data_info)
+        self.polarization = StatePolarization()
+
+    def _parse_polarization(self):
+        polarization_dict = self.get_val("polarization")
+        if polarization_dict is None:
+            return
+        self.polarization.flipper_configuration = self.get_val("flipper_configuration", polarization_dict)
+        self.polarization.spin_configuration = self.get_val("spin_configuration", polarization_dict)
+        flipper_dicts = self.get_val("flipper", polarization_dict)
+        if flipper_dicts:
+            for flipper_dict in flipper_dicts.values():
+                self.polarization.flippers.append(self._parse_component(flipper_dict))
+        self.polarization.polarizer = self._parse_filter(self.get_val("polarizer", polarization_dict))
+        self.polarization.analyzer = self._parse_filter(self.get_val("analyzer", polarization_dict))
+        self.polarization.magnetic_field = self._parse_field(self.get_val("magnetic_field", polarization_dict))
+        self.polarization.electric_field = self._parse_field(self.get_val("electric_field", polarization_dict))
+        self.polarization.validate()
+
+    def _parse_component(self, component_dict: dict) -> StateComponent:
+        component_state = StateComponent()
+        if component_dict is None:
+            return component_state
+        component_state.idf_component_name = self.get_val("idf_component_name", component_dict)
+        component_state.device_name = self.get_val("device_name", component_dict)
+        component_state.device_type = self.get_val("device_type", component_dict)
+        location_dict = self.get_val("location", component_dict)
+        if location_dict:
+            component_state.location_x = self.get_val("x", location_dict)
+            component_state.location_y = self.get_val("y", location_dict)
+            component_state.location_z = self.get_val("z", location_dict)
+        component_state.transmission = self.get_val("transmission", component_dict)
+        component_state.efficiency = self.get_val("efficiency", component_dict)
+        return component_state
+
+    def _parse_filter(self, filter_dict: dict) -> StateFilter:
+        if filter_dict is None:
+            return StateFilter()
+        filter_state = self._parse_component(filter_dict)
+        filter_state.__class__ = StateFilter
+        filter_state.cell_length = self.get_val("cell_length", filter_dict)
+        filter_state.gas_pressure = self.get_val("gas_pressure", filter_dict)
+        filter_state.empty_cell = self.get_val("empty_cell", filter_dict)
+        filter_state.initial_polarization = self.get_val("initial_polarization", filter_dict)
+        return filter_state
+
+    def _parse_field(self, field_dict: dict) -> StateField:
+        field_state = StateField()
+        if field_dict is None:
+            return field_state
+        field_state.sample_strength_log = self.get_val("sample_strength_log", field_dict)
+        direction_dict = self.get_val("sample_direction", field_dict)
+        if direction_dict:
+            field_state.sample_direction_a = self.get_val("a", direction_dict)
+            field_state.sample_direction_p = self.get_val("p", direction_dict)
+            field_state.sample_direction_d = self.get_val("d", direction_dict)
+        field_state.sample_direction_log = self.get_val("sample_direction_log", field_dict)
+        return field_state

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v2_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v2_parser.py
@@ -72,8 +72,7 @@ class TomlV2ParserImpl(TomlV1ParserImpl):
     def _parse_filter(self, filter_dict: dict) -> StateFilter:
         if filter_dict is None:
             return StateFilter()
-        filter_state = self._parse_component(filter_dict)
-        filter_state.__class__ = StateFilter
+        filter_state = StateFilter.construct_from_component(self._parse_component(filter_dict))
         filter_state.cell_length = self.get_val("cell_length", filter_dict)
         filter_state.gas_pressure = self.get_val("gas_pressure", filter_dict)
         filter_state.empty_cell = self.get_val("empty_cell", filter_dict)

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v2_schema.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v2_schema.py
@@ -30,15 +30,14 @@ class TomlSchemaV2Validator(TomlSchemaValidator):
             "transmission": None,
             "efficiency": None,
         }
-        filter_keys = dict(
-            component_keys,
-            **{
-                "cell_length": None,
-                "gas_pressure": None,
-                "empty_cell": None,
-                "initial_polarization": None,
-            },
-        )
+        filter_keys = {
+            **component_keys,
+            "cell_length": None,
+            "gas_pressure": None,
+            "empty_cell": None,
+            "initial_polarization": None,
+        }
+
         field_keys = {
             "sample_strength_log": None,
             "sample_direction": {"a", "p", "d"},
@@ -54,4 +53,4 @@ class TomlSchemaV2Validator(TomlSchemaValidator):
             "electric_field": field_keys,
         }
 
-        return dict(TomlSchemaV1Validator.reference_schema(), **{"polarization": polarization_keys})
+        return {**TomlSchemaV1Validator.reference_schema(), "polarization": polarization_keys}

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v2_schema.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v2_schema.py
@@ -1,0 +1,57 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from sans.user_file.toml_parsers.toml_base_schema import TomlSchemaValidator
+from sans.user_file.toml_parsers.toml_v1_schema import TomlSchemaV1Validator
+
+
+class TomlSchemaV2Validator(TomlSchemaValidator):
+    # As of the current TOML release there is no way to validate a schema so
+    # we must provide an implementation
+
+    def __init__(self, dict_to_validate):
+        super(TomlSchemaV2Validator, self).__init__(dict_to_validate)
+
+    @staticmethod
+    def reference_schema():
+        """
+        Returns a dictionary layout of all supported keys. Extends from the V1 Schema.
+        :return: Dictionary containing all keys, and values set to None
+        """
+        component_keys = {
+            "idf_component_name": None,
+            "device_name": None,
+            "device_type": None,
+            "location": {"x", "y", "z"},
+            "transmission": None,
+            "efficiency": None,
+        }
+        filter_keys = dict(
+            component_keys,
+            **{
+                "cell_length": None,
+                "gas_pressure": None,
+                "empty_cell": None,
+                "initial_polarization": None,
+            },
+        )
+        field_keys = {
+            "sample_strength_log": None,
+            "sample_direction": {"a", "p", "d"},
+            "sample_direction_log": None,
+        }
+        polarization_keys = {
+            "flipper_configuration": None,
+            "spin_configuration": None,
+            "flipper": {"*": component_keys},
+            "polarizer": filter_keys,
+            "analyzer": filter_keys,
+            "magnetic_field": field_keys,
+            "electric_field": field_keys,
+        }
+
+        return dict(TomlSchemaV1Validator.reference_schema(), **{"polarization": polarization_keys})

--- a/scripts/SANS/sans/user_file/txt_parsers/ParsedDictConverter.py
+++ b/scripts/SANS/sans/user_file/txt_parsers/ParsedDictConverter.py
@@ -17,6 +17,7 @@ from sans.state.StateObjects.StateConvertToQ import StateConvertToQ
 from sans.state.StateObjects.StateMaskDetectors import get_mask_builder
 from sans.state.StateObjects.StateMoveDetectors import get_move_builder
 from sans.state.StateObjects.StateNormalizeToMonitor import get_normalize_to_monitor_builder
+from sans.state.StateObjects.StatePolarization import StatePolarization
 from sans.state.StateObjects.StateReductionMode import StateReductionMode
 from sans.state.StateObjects.StateSave import StateSave
 from sans.state.StateObjects.StateScale import StateScale
@@ -1062,6 +1063,10 @@ class ParsedDictConverter(IStateParser):
 
         _set_wavelength_limits(state, self._input_dict)
         return state
+
+    def get_state_polarization(self) -> StatePolarization:
+        # The polarization settings are not supported for the legacy txt user file format. Return a blank object.
+        return StatePolarization()
 
     def _set_single_entry(self, state_obj, attr_name, tag, apply_to_value=None):
         """

--- a/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
+++ b/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
@@ -23,7 +23,7 @@ from sans.test_helper.common import remove_file
 from sans.test_helper.mock_objects import create_mock_view
 from sans.test_helper.user_file_test_helper import create_user_file, sample_user_file
 from ui.sans_isis.sans_gui_observable import SansGuiObservable
-from sans.user_file.toml_parsers.toml_v1_schema import TomlValidationError
+from sans.user_file.toml_parsers.toml_base_schema import TomlValidationError
 
 BATCH_FILE_TEST_CONTENT_1 = [
     RowEntries(sample_scatter=1, sample_transmission=2, sample_direct=3, output_name="test_file", user_file="user_test_file"),

--- a/scripts/test/SANS/state/CMakeLists.txt
+++ b/scripts/test/SANS/state/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_PY_FILES
     data_test.py
     state_functions_test.py
     state_instrument_info_test.py
+    state_polarization_test.py
     scale_test.py
     mask_test.py
     move_test.py

--- a/scripts/test/SANS/state/state_polarization_test.py
+++ b/scripts/test/SANS/state/state_polarization_test.py
@@ -47,6 +47,10 @@ class StatePolarizationTest(unittest.TestCase):
         state_field = self.generate_field(a=1, p=2, d=4)
         state_field.validate()
 
+    def test_valid_when_nothing_set(self):
+        state_field = self.generate_field()
+        state_field.validate()
+
     # ------------------------------------------------------------------------------------------------------------------
     # StatePolarization
     # ------------------------------------------------------------------------------------------------------------------

--- a/scripts/test/SANS/state/state_polarization_test.py
+++ b/scripts/test/SANS/state/state_polarization_test.py
@@ -1,0 +1,75 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+
+from sans.state.StateObjects.StatePolarization import StateField, StateComponent, StateFilter, StatePolarization
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# State
+# ----------------------------------------------------------------------------------------------------------------------
+class StatePolarizationTest(unittest.TestCase):
+    # ------------------------------------------------------------------------------------------------------------------
+    # StateField
+    # ------------------------------------------------------------------------------------------------------------------
+    def generate_field(self, log: None | str = None, a: None | int = None, p: None | int = None, d: None | int = None) -> StateField:
+        state = StateField()
+        state.sample_direction_log = log
+        state.sample_direction_a = a
+        state.sample_direction_p = p
+        state.sample_direction_d = d
+        return state
+
+    def test_error_when_field_directions_and_log_set(self):
+        state_field = self.generate_field("alogfile.nxs", 1, 2, 3)
+        with self.assertRaisesRegex(
+            ValueError, 'StateField: Provided inputs are illegal. Please see: {"Too many sample direction parameters.":.*'
+        ):
+            state_field.validate()
+
+    def test_error_when_not_all_directions_set(self):
+        state_field = self.generate_field(a=1, d=3)
+        with self.assertRaisesRegex(
+            ValueError, 'StateField: Provided inputs are illegal. Please see: {"Missing field sample direction parameters.":.*'
+        ):
+            state_field.validate()
+
+    def test_valid_when_only_log_set(self):
+        state_field = self.generate_field("alogfile.txt")
+        state_field.validate()
+
+    def test_valid_when_only_directions_set(self):
+        state_field = self.generate_field(a=1, p=2, d=4)
+        state_field.validate()
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # StatePolarization
+    # ------------------------------------------------------------------------------------------------------------------
+    def test_all_substates_are_validated(self):
+        # Created as mocks to avoid inadvertently testing the substates as well.
+        flipper_a = mock.create_autospec(StateComponent)
+        flipper_b = mock.create_autospec(StateComponent)
+        analyser = mock.create_autospec(StateFilter)
+        polarizer = mock.create_autospec(StateFilter)
+        mag_field = mock.create_autospec(StateField)
+        elec_field = mock.create_autospec(StateField)
+
+        state = StatePolarization()
+        state.flippers.extend([flipper_a, flipper_b])
+        state.analyzer = analyser
+        state.polarizer = polarizer
+        state.magnetic_field = mag_field
+        state.electric_field = elec_field
+
+        state.validate()
+        for substate in [flipper_a, flipper_b, analyser, polarizer, mag_field, elec_field]:
+            self.assertEqual(substate.validate.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/SANS/user_file/toml_parsers/CMakeLists.txt
+++ b/scripts/test/SANS/user_file/toml_parsers/CMakeLists.txt
@@ -1,4 +1,6 @@
-set(TEST_PY_FILES toml_parser_test.py toml_v1_parser_test.py toml_v1_schema_test.py)
+set(TEST_PY_FILES toml_parser_test.py toml_v1_parser_test.py toml_v1_schema_test.py toml_v2_parser_test.py
+                  toml_v2_schema_test.py
+)
 
 add_subdirectory(parser_helpers)
 

--- a/scripts/test/SANS/user_file/toml_parsers/toml_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_parser_test.py
@@ -28,6 +28,17 @@ class TomlParserTest(unittest.TestCase):
             # Check correct params were forwarded on
             mocked_import.assert_called_once_with(test_dict, file_information=mocked_file_info)
 
+    def test_returns_v2_parser(self):
+        test_dict = {"toml_file_version": 2}
+
+        parser = TomlParser(toml_reader=self.get_mocked_reader(test_dict))
+        mocked_file_info = mock.NonCallableMock()
+        with mock.patch("sans.user_file.toml_parsers.toml_parser.TomlV2Parser") as mocked_import:
+            parser_version = parser.get_toml_parser(toml_file_path=mock.NonCallableMock, file_information=mocked_file_info)
+            self.assertEqual(mocked_import.return_value, parser_version)
+            # Check correct params were forwarded on
+            mocked_import.assert_called_once_with(test_dict, file_information=mocked_file_info)
+
     def test_throws_for_unknown_version(self):
         test_dict = {"toml_file_version": 100}
         parser = TomlParser(toml_reader=self.get_mocked_reader(test_dict))

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
@@ -743,6 +743,50 @@ class TomlV1ParserTest(unittest.TestCase):
         self.assertEqual("trans_ws", flippers[0].transmission)
         self.assertEqual("eff_ws", flippers[0].efficiency)
 
+    def test_parse_polarizer_and_analyzer(self):
+        top_level_dict = {
+            "polarization": {
+                "polarizer": {
+                    "idf_component_name": "name_in_IDF_pol",
+                    "device_name": "sm-polarizer",
+                    "device_type": "coil",
+                    "location": {"x": 1.17, "y": 0.05, "z": 0.045},
+                    "transmission": "trans_ws",
+                    "efficiency": "eff_ws",
+                    "cell_length": 0.005,
+                    "gas_pressure": 5,
+                },
+                "analyzer": {
+                    "idf_component_name": "name_in_IDF_ana",
+                    "device_name": "3He-analyzer",
+                    "device_type": "coil",
+                    "location": {"x": 2.17, "y": 0.05, "z": 0.045},
+                    "cell_length": 0.006,
+                    "gas_pressure": 6,
+                    "transmission": "trans_ws",
+                    "efficiency": "eff_ws",
+                },
+            }
+        }
+        parser_result = self._setup_parser(top_level_dict)
+        polarization_state = parser_result.get_state_polarization()
+        polarizer_state = polarization_state.polarizer
+        analyzer_state = polarization_state.analyzer
+        self.assertEqual(0.006, analyzer_state.cell_length)
+        self.assertEqual(0.005, polarizer_state.cell_length)
+        self.assertEqual(6, analyzer_state.gas_pressure)
+        self.assertEqual(5, polarizer_state.gas_pressure)
+        self.assertEqual("sm-polarizer", polarizer_state.device_name)
+        self.assertEqual("3He-analyzer", analyzer_state.device_name)
+        self.assertEqual(1.17, polarizer_state.location_x)
+        self.assertEqual(0.05, polarizer_state.location_y)
+        self.assertEqual(0.045, polarizer_state.location_z)
+        self.assertEqual(2.17, analyzer_state.location_x)
+        self.assertEqual("name_in_IDF_pol", polarizer_state.idf_component_name)
+        self.assertEqual("coil", polarizer_state.device_type)
+        self.assertEqual("trans_ws", polarizer_state.transmission)
+        self.assertEqual("eff_ws", polarizer_state.efficiency)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
@@ -705,6 +705,44 @@ class TomlV1ParserTest(unittest.TestCase):
         self.assertEqual("00,11,01,10", polarization_state.flipper_configuration)
         self.assertEqual("-1-1,-1+1,+1-1,+1+1", polarization_state.spin_configuration)
 
+    def test_parse_flippers(self):
+        top_level_dict = {
+            "polarization": {
+                "flipper": {
+                    "polarizing": {
+                        "idf_component_name": "name_in_IDF",
+                        "device_name": "flipper1",
+                        "device_type": "coil",
+                        "location": {"x": 1.17, "y": 0.05, "z": 0.045},
+                        "transmission": "trans_ws",
+                        "efficiency": "eff_ws",
+                    },
+                    "analyzing": {
+                        "idf_component_name": "name_in_IDF_a",
+                        "device_name": "flipper2",
+                        "device_type": "coil",
+                        "location": {"x": 2.17, "y": 0.05, "z": 0.045},
+                        "transmission": "trans_ws",
+                        "efficiency": "eff_ws",
+                    },
+                }
+            }
+        }
+        parser_result = self._setup_parser(top_level_dict)
+        polarization_state = parser_result.get_state_polarization()
+        flippers = polarization_state.flippers
+        self.assertEqual(2, len(flippers))
+        self.assertEqual("flipper1", flippers[0].device_name)
+        self.assertEqual("flipper2", flippers[1].device_name)
+        self.assertEqual(1.17, flippers[0].location_x)
+        self.assertEqual(0.05, flippers[0].location_y)
+        self.assertEqual(0.045, flippers[0].location_z)
+        self.assertEqual(2.17, flippers[1].location_x)
+        self.assertEqual("name_in_IDF", flippers[0].idf_component_name)
+        self.assertEqual("coil", flippers[0].device_type)
+        self.assertEqual("trans_ws", flippers[0].transmission)
+        self.assertEqual("eff_ws", flippers[0].efficiency)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
@@ -787,6 +787,34 @@ class TomlV1ParserTest(unittest.TestCase):
         self.assertEqual("trans_ws", polarizer_state.transmission)
         self.assertEqual("eff_ws", polarizer_state.efficiency)
 
+    def test_parse_fields(self):
+        top_level_dict = {
+            "polarization": {
+                "magnetic_field": {
+                    "sample_strength_log": "nameoflog",
+                    "sample_direction": {"a": 0, "p": 2.3, "d": 0.002},
+                },
+                "electric_field": {
+                    "sample_strength_log": "nameofotherlog",
+                    "sample_direction_log": "nameofanotherlog",
+                },
+            }
+        }
+        parser_result = self._setup_parser(top_level_dict)
+        polarization_state = parser_result.get_state_polarization()
+        electric_state = polarization_state.electric_field
+        magnetic_state = polarization_state.magnetic_field
+        self.assertEqual("nameoflog", magnetic_state.sample_strength_log)
+        self.assertEqual(0, magnetic_state.sample_direction_a)
+        self.assertEqual(2.3, magnetic_state.sample_direction_p)
+        self.assertEqual(0.002, magnetic_state.sample_direction_d)
+        self.assertIsNone(magnetic_state.sample_direction_log)
+        self.assertEqual("nameofotherlog", electric_state.sample_strength_log)
+        self.assertEqual("nameofanotherlog", electric_state.sample_direction_log)
+        self.assertIsNone(electric_state.sample_direction_a)
+        self.assertIsNone(electric_state.sample_direction_p)
+        self.assertIsNone(electric_state.sample_direction_d)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
@@ -21,6 +21,7 @@ from sans.common.enums import (
 )
 from sans.state.StateObjects.StateData import get_data_builder
 from sans.state.StateObjects.StateMaskDetectors import StateMaskDetectors, StateMask
+from sans.state.StateObjects.StatePolarization import StatePolarization
 from sans.test_helper.file_information_mock import SANSFileInformationMock
 from sans.user_file.parser_helpers.toml_parser_impl_base import MissingMandatoryParam
 from sans.user_file.toml_parsers.toml_v1_parser import TomlV1Parser
@@ -694,6 +695,15 @@ class TomlV1ParserTest(unittest.TestCase):
         self.assertEqual(101, norm_state.prompt_peak_correction_min)
         self.assertEqual(102, norm_state.prompt_peak_correction_max)
         self.assertTrue(norm_state.prompt_peak_correction_enabled)
+
+    def test_parse_polarization(self):
+        top_level_dict = {"polarization": {"flipper_configuration": "00,11,01,10", "spin_configuration": "-1-1,-1+1,+1-1,+1+1"}}
+        parser_result = self._setup_parser(top_level_dict)
+        polarization_state = parser_result.get_state_polarization()
+
+        self.assertIsInstance(polarization_state, StatePolarization)
+        self.assertEqual("00,11,01,10", polarization_state.flipper_configuration)
+        self.assertEqual("-1-1,-1+1,+1-1,+1+1", polarization_state.spin_configuration)
 
 
 if __name__ == "__main__":

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v1_schema_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v1_schema_test.py
@@ -7,7 +7,8 @@
 import unittest
 
 from unittest import mock
-from sans.user_file.toml_parsers.toml_v1_schema import TomlSchemaV1Validator, TomlValidationError
+from sans.user_file.toml_parsers.toml_v1_schema import TomlSchemaV1Validator
+from sans.user_file.toml_parsers.toml_base_schema import TomlValidationError
 
 
 class SchemaV1ValidatorTest(unittest.TestCase):

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v2_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v2_parser_test.py
@@ -1,0 +1,145 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import unittest
+
+from sans.common.enums import SANSInstrument
+from sans.state.StateObjects.StatePolarization import StatePolarization
+from sans.user_file.toml_parsers.toml_v2_parser import TomlV2Parser
+from sans.test_helper.toml_parser_test_helpers import setup_parser_dict
+
+
+class TomlV2ParserTest(unittest.TestCase):
+    def _setup_parser(self, dict_vals):
+        setup_dict, mocked_data_info = setup_parser_dict(dict_vals)
+        self._mocked_data_info = mocked_data_info
+        return TomlV2Parser(setup_dict, file_information=None)
+
+    # This test is a duplication of the one in the V1 parser test. It's to check the inheritance is working.
+    def test_instrument(self):
+        parser = self._setup_parser(dict_vals={"instrument": {"name": SANSInstrument.SANS2D.value}})
+        inst = parser._implementation.instrument
+        self.assertTrue(inst is SANSInstrument.SANS2D, msg="Got %r instead" % inst)
+
+    def test_parse_polarization(self):
+        top_level_dict = {"polarization": {"flipper_configuration": "00,11,01,10", "spin_configuration": "-1-1,-1+1,+1-1,+1+1"}}
+        parser_result = self._setup_parser(top_level_dict)
+        polarization_state = parser_result.get_state_polarization()
+
+        self.assertIsInstance(polarization_state, StatePolarization)
+        self.assertEqual("00,11,01,10", polarization_state.flipper_configuration)
+        self.assertEqual("-1-1,-1+1,+1-1,+1+1", polarization_state.spin_configuration)
+
+    def test_parse_flippers(self):
+        top_level_dict = {
+            "polarization": {
+                "flipper": {
+                    "polarizing": {
+                        "idf_component_name": "name_in_IDF",
+                        "device_name": "flipper1",
+                        "device_type": "coil",
+                        "location": {"x": 1.17, "y": 0.05, "z": 0.045},
+                        "transmission": "trans_ws",
+                        "efficiency": "eff_ws",
+                    },
+                    "analyzing": {
+                        "idf_component_name": "name_in_IDF_a",
+                        "device_name": "flipper2",
+                        "device_type": "coil",
+                        "location": {"x": 2.17, "y": 0.05, "z": 0.045},
+                        "transmission": "trans_ws",
+                        "efficiency": "eff_ws",
+                    },
+                }
+            }
+        }
+        parser_result = self._setup_parser(top_level_dict)
+        polarization_state = parser_result.get_state_polarization()
+        flippers = polarization_state.flippers
+        self.assertEqual(2, len(flippers))
+        self.assertEqual("flipper1", flippers[0].device_name)
+        self.assertEqual("flipper2", flippers[1].device_name)
+        self.assertEqual(1.17, flippers[0].location_x)
+        self.assertEqual(0.05, flippers[0].location_y)
+        self.assertEqual(0.045, flippers[0].location_z)
+        self.assertEqual(2.17, flippers[1].location_x)
+        self.assertEqual("name_in_IDF", flippers[0].idf_component_name)
+        self.assertEqual("coil", flippers[0].device_type)
+        self.assertEqual("trans_ws", flippers[0].transmission)
+        self.assertEqual("eff_ws", flippers[0].efficiency)
+
+    def test_parse_polarizer_and_analyzer(self):
+        top_level_dict = {
+            "polarization": {
+                "polarizer": {
+                    "idf_component_name": "name_in_IDF_pol",
+                    "device_name": "sm-polarizer",
+                    "device_type": "coil",
+                    "location": {"x": 1.17, "y": 0.05, "z": 0.045},
+                    "transmission": "trans_ws",
+                    "efficiency": "eff_ws",
+                    "cell_length": 0.005,
+                    "gas_pressure": 5,
+                },
+                "analyzer": {
+                    "idf_component_name": "name_in_IDF_ana",
+                    "device_name": "3He-analyzer",
+                    "device_type": "coil",
+                    "location": {"x": 2.17, "y": 0.05, "z": 0.045},
+                    "cell_length": 0.006,
+                    "gas_pressure": 6,
+                    "transmission": "trans_ws",
+                    "efficiency": "eff_ws",
+                },
+            }
+        }
+        parser_result = self._setup_parser(top_level_dict)
+        polarization_state = parser_result.get_state_polarization()
+        polarizer_state = polarization_state.polarizer
+        analyzer_state = polarization_state.analyzer
+        self.assertEqual(0.006, analyzer_state.cell_length)
+        self.assertEqual(0.005, polarizer_state.cell_length)
+        self.assertEqual(6, analyzer_state.gas_pressure)
+        self.assertEqual(5, polarizer_state.gas_pressure)
+        self.assertEqual("sm-polarizer", polarizer_state.device_name)
+        self.assertEqual("3He-analyzer", analyzer_state.device_name)
+        self.assertEqual(1.17, polarizer_state.location_x)
+        self.assertEqual(0.05, polarizer_state.location_y)
+        self.assertEqual(0.045, polarizer_state.location_z)
+        self.assertEqual(2.17, analyzer_state.location_x)
+        self.assertEqual("name_in_IDF_pol", polarizer_state.idf_component_name)
+        self.assertEqual("coil", polarizer_state.device_type)
+        self.assertEqual("trans_ws", polarizer_state.transmission)
+        self.assertEqual("eff_ws", polarizer_state.efficiency)
+
+    def test_parse_fields(self):
+        top_level_dict = {
+            "polarization": {
+                "magnetic_field": {
+                    "sample_strength_log": "nameoflog",
+                    "sample_direction": {"a": 0, "p": 2.3, "d": 0.002},
+                },
+                "electric_field": {
+                    "sample_strength_log": "nameofotherlog",
+                    "sample_direction_log": "nameofanotherlog",
+                },
+            }
+        }
+        parser_result = self._setup_parser(top_level_dict)
+        polarization_state = parser_result.get_state_polarization()
+        electric_state = polarization_state.electric_field
+        magnetic_state = polarization_state.magnetic_field
+        self.assertEqual("nameoflog", magnetic_state.sample_strength_log)
+        self.assertEqual(0, magnetic_state.sample_direction_a)
+        self.assertEqual(2.3, magnetic_state.sample_direction_p)
+        self.assertEqual(0.002, magnetic_state.sample_direction_d)
+        self.assertIsNone(magnetic_state.sample_direction_log)
+        self.assertEqual("nameofotherlog", electric_state.sample_strength_log)
+        self.assertEqual("nameofanotherlog", electric_state.sample_direction_log)
+        self.assertIsNone(electric_state.sample_direction_a)
+        self.assertIsNone(electric_state.sample_direction_p)
+        self.assertIsNone(electric_state.sample_direction_d)

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v2_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v2_parser_test.py
@@ -143,3 +143,7 @@ class TomlV2ParserTest(unittest.TestCase):
         self.assertIsNone(electric_state.sample_direction_a)
         self.assertIsNone(electric_state.sample_direction_p)
         self.assertIsNone(electric_state.sample_direction_d)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v2_schema_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v2_schema_test.py
@@ -1,0 +1,32 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+
+from sans.user_file.toml_parsers.toml_v2_schema import TomlSchemaV2Validator
+from sans.user_file.toml_parsers.toml_base_schema import TomlValidationError
+
+
+class SchemaV2ValidatorTest(unittest.TestCase):
+    def test_multiple_flippers_respected(self):
+        valid_example = {"polarization": {"flipper": {"F0": {"device_type": "coil"}, "F1": {"device_type": "magic"}}}}
+        invalid_example = {"polarization": {"flipper": {"F0": {"device_type": "coil"}}}, "flipper": {"F1": {"fake_key": "magic"}}}
+
+        obj = TomlSchemaV2Validator(valid_example)
+        self.assertIsNone(obj.validate())
+
+        with self.assertRaises(TomlValidationError):
+            TomlSchemaV2Validator(invalid_example).validate()
+
+    def test_duplicate_flippers_fails(self):
+        invalid_example = {"polarization": {"flipper": {"F0": {"device_type": "coil"}}}, "flipper": {"F0": {"device_type": "magic"}}}
+
+        with self.assertRaises(TomlValidationError):
+            TomlSchemaV2Validator(invalid_example).validate()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description of work

#### Summary of work
Allows specification of the polarisation options used in the experiment to be provided to the reduction via the user file (a file written in SANS' custom TOML format, usually one per experiment). 

Fixes #38524
 
#### Further detail of work
- Created `StatePolarization`. An JSON-serialisable object that holds the polarisation information to be passed around as part of SANSState to algorithms and interfaces.  
- Refactored the TOML parser into a base and sub-classes to support...
- Implemented SANS TOML V2 parser and schema. Upgrading to V2 means that files with the new information won't be supported by previous versions of Mantid. This is intentional. All V1 files continue to be backwards compatible, all V2 files will warn that the version is unsupported, forcing a version of Mantid to be used that can support the new polarisation options. 
- Refactored some tests to remove duplication caused by the additional parser. 

- Note: If required, this could be 2 PRs. The first implementing the State object and the second implementing the parsing. 

### To test:
1. Download this new user file, modified from the `loqdemo` in the training course data (you'll need that too): [MaskFile_polarization.toml.zip](https://github.com/user-attachments/files/18893469/MaskFile_polarization.toml.zip)
2. Open a nightly and open Interfaces -> SANS -> ISIS SANS
3. Attempt to select the downloaded file as the user file. It should throw. 
4. Open the workbench build of this PR. 
5. Repeat, it should load successfully.
6. Load the batch from the loqdemo
7. Process All
8. Find the output workspaces on the main mantid window and open the workspace history
9. Find the SANSState object
10. Copy it to clipboard, and paste it into a *nice* editor (I like VS code for this)
11. It'll paste in one giant line, reformat the file (install a JSON extension if necessary) 
12. Check that the new polarisation information from the downloaded file is present in the JSON. 


---

### Reviewer


Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
