### PR TITLE
Revert added crosshair option in mantid

### DIFF
--- a/docs/source/release/v6.12.0/mantidworkbench.rst
+++ b/docs/source/release/v6.12.0/mantidworkbench.rst
@@ -9,7 +9,7 @@ New Features
 ------------
 - ``mantidworkbench`` is now an additional entry point for launching the ``mantidworkbench`` Conda package.
 - ``workbench`` and ``mantidworkbench`` Conda entry points now launch workbench with ``jemalloc`` configured as the memory allocator on Linux.
-- Surface and contour plots can now be generated more easily for multiple single-spectrum workspaces (via the `Plot Advanced` dialog when multiple single-spectrum workspaces are select
+- Surface and contour plots can now be generated more easily for multiple single-spectrum workspaces (via the `Plot Advanced` dialog when multiple single-spectrum workspaces are selected).
 - Added an `Email mantid-help@mantidproject.org` action to the Help menu.
 - The settings dialog now has `Okay`, `Apply` and `Cancel` buttons. Settings are no longer immediately applied when parameters are changed.
 - MacOS compiler updated from version 16 to version 18, which should result in performance improvements. See https://releases.llvm.org for release notes.

--- a/docs/source/release/v6.12.0/mantidworkbench.rst
+++ b/docs/source/release/v6.12.0/mantidworkbench.rst
@@ -9,8 +9,7 @@ New Features
 ------------
 - ``mantidworkbench`` is now an additional entry point for launching the ``mantidworkbench`` Conda package.
 - ``workbench`` and ``mantidworkbench`` Conda entry points now launch workbench with ``jemalloc`` configured as the memory allocator on Linux.
-- Surface and contour plots can now be generated more easily for multiple single-spectrum workspaces (via the `Plot Advanced` dialog when multiple single-spectrum workspaces are selected).
-- A crosshair tool has been added to plot toolbars.
+- Surface and contour plots can now be generated more easily for multiple single-spectrum workspaces (via the `Plot Advanced` dialog when multiple single-spectrum workspaces are select
 - Added an `Email mantid-help@mantidproject.org` action to the Help menu.
 - The settings dialog now has `Okay`, `Apply` and `Cancel` buttons. Settings are no longer immediately applied when parameters are changed.
 - MacOS compiler updated from version 16 to version 18, which should result in performance improvements. See https://releases.llvm.org for release notes.

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -232,7 +232,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             self.toolbar.sig_waterfall_conversion.connect(self.update_toolbar_waterfall_plot)
             self.toolbar.sig_change_line_collection_colour_triggered.connect(self.change_line_collection_colour)
             self.toolbar.sig_hide_plot_triggered.connect(self.hide_plot)
-            self.toolbar.sig_crosshair_toggle_triggered.connect(self.crosshair_toggle)
             self.toolbar.setFloatable(False)
             tbs_height = self.toolbar.sizeHint().height()
         else:
@@ -252,7 +251,9 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         self.window.addDockWidget(Qt.LeftDockWidgetArea, self.fit_browser)
 
         self.superplot = None
+
         self.fit_browser.hide()
+
         if matplotlib.is_interactive():
             self.window.show()
             canvas.draw_idle()
@@ -263,9 +264,11 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
                 self.toolbar.update()
 
         canvas.figure.add_axobserver(notify_axes_change)
+
         # Register canvas observers
         self._fig_interaction = FigureInteraction(self)
         self._ads_observer = FigureManagerADSObserver(self)
+
         self.window.raise_()
 
     def full_screen_toggle(self):
@@ -599,41 +602,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         for line in lines:
             line.remove()
             ax.add_line(line)
-
-    def crosshair_toggle(self, on):
-        cid = self.canvas.mpl_connect("motion_notify_event", self.crosshair)
-        if not on:
-            self.canvas.mpl_disconnect(cid)
-
-    def crosshair(self, event):
-        axes = self.canvas.figure.gca()
-
-        # create a crosshair made from horizontal and verticle lines.
-        self.horizontal_line = axes.axhline(color="r", lw=1.0, ls="-")
-        self.vertical_line = axes.axvline(color="r", lw=1.0, ls="-")
-
-        def set_cross_hair_visible(visible):
-            need_redraw = self.horizontal_line.get_visible() != visible
-            self.horizontal_line.set_visible(visible)
-            self.vertical_line.set_visible(visible)
-            return need_redraw
-
-        # if event is out-of-bound we update
-        if not event.inaxes:
-            need_redraw = set_cross_hair_visible(False)
-            if need_redraw:
-                axes.figure.canvas.draw()
-
-        else:
-            set_cross_hair_visible(True)
-            x, y = event.xdata, event.ydata
-            self.horizontal_line.set_ydata([y])
-            self.vertical_line.set_xdata([x])
-            self.canvas.draw()
-
-        # after update we remove
-        self.horizontal_line.remove()
-        self.vertical_line.remove()
 
 
 # -----------------------------------------------------------------------------

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -118,15 +118,6 @@ class ToolBarTest(unittest.TestCase):
         self.assertTrue(self._is_grid_button_checked(fig))
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")
-    def test_button_checked_for_plot_with_no_crosshair(self, mock_qappthread):
-        mock_qappthread.return_value = mock_qappthread
-
-        fig, axes = plt.subplots(subplot_kw={"projection": "mantid"})
-        axes.plot([-10, 10], [1, 2])
-        # Grid button should be OFF because we have not enabled the crosshair.
-        self.assertFalse(self._is_crosshair_button_checked(fig))
-
-    @patch("workbench.plotting.figuremanager.QAppThreadCall")
     def test_button_checked_for_plot_with_grid_using_kwargs(self, mock_qappthread):
         mock_qappthread.return_value = mock_qappthread
 
@@ -274,19 +265,6 @@ class ToolBarTest(unittest.TestCase):
         # This is only called when show() is called on the figure manager, so we have to manually call it here.
         fig_manager.toolbar.set_buttons_visibility(fig)
         return fig_manager.toolbar._actions[button].isEnabled()
-
-    @classmethod
-    def _is_crosshair_button_checked(cls, fig):
-        """
-        Create the figure manager and check whether its toolbar is toggled on or off for the given figure.
-        We have to explicitly call set_button_visibility() here, which would otherwise be called within the show()
-        function.
-        """
-        canvas = MantidFigureCanvas(fig)
-        fig_manager = FigureManagerWorkbench(canvas, 1)
-        # This is only called when show() is called on the figure manager, so we have to manually call it here.
-        fig_manager.toolbar.set_buttons_visibility(fig)
-        return fig_manager.toolbar._actions["toggle_crosshair"].isChecked()
 
 
 if __name__ == "__main__":

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -35,7 +35,6 @@ def _create_script_action(self, text, tooltip_text, mdi_icon, *args):
 class WorkbenchNavigationToolbar(MantidNavigationToolbar):
     sig_home_clicked = QtCore.Signal()
     sig_grid_toggle_triggered = QtCore.Signal(bool)
-    sig_crosshair_toggle_triggered = QtCore.Signal(bool)
     sig_active_triggered = QtCore.Signal()
     sig_hold_triggered = QtCore.Signal()
     sig_toggle_fit_triggered = QtCore.Signal()
@@ -85,7 +84,6 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         MantidNavigationTool("Fill Area", "Fill area under curves", "mdi.format-color-fill", "waterfall_fill_area", None),
         MantidStandardNavigationTools.SEPARATOR,
         MantidNavigationTool("Help", "Open plotting help documentation", "mdi.help", "launch_plot_help", None),
-        MantidNavigationTool("Crosshair", "Toggle crosshair", "mdi.plus", "toggle_crosshair", False),
         MantidNavigationTool("Hide", "Hide the plot", "mdi.eye", "hide_plot", None),
     )
 
@@ -95,13 +93,6 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         # Adjust icon size or they are too small in PyQt5 by default
         dpi_ratio = QtWidgets.QApplication.instance().desktop().physicalDpiX() / 100
         self.setIconSize(QtCore.QSize(int(24 * dpi_ratio), int(24 * dpi_ratio)))
-
-    def toggle_crosshair(self, enable=None):
-        if enable is None:
-            enable = self._actions["toggle_crosshair"].isChecked()
-        else:
-            self._actions["toggle_crosshair"].setChecked(enable)
-        self.sig_crosshair_toggle_triggered.emit(enable)
 
     def hide_plot(self):
         self.sig_hide_plot_triggered.emit()


### PR DESCRIPTION
This reverts #38186

During manual testing v6.12, the feature was easily used in ways not originally designed for when the work was done. It will be reintroduced in v6.13 with these other cases accounted for.

We will address use cases of tile plots (subplots), axis scaling issues and auto-disable this feature in 3D plots.

*This does not require release notes* because it removes a feature added during the development cycle. The previous release note was removed.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
