### PR TITLE
Add optional `IncludeDetectorPosition` to `CreateDetectorTable`

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CreateDetectorTable.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CreateDetectorTable.h
@@ -64,7 +64,7 @@ void populateTable(Mantid::API::ITableWorkspace_sptr &t, const Mantid::API::Matr
                    bool signedThetaParamRetrieved, bool showSignedTwoTheta,
                    const Mantid::Geometry::PointingAlong &beamAxisIndex, const double sampleDist, const bool isScanning,
                    const bool include_data, const bool calcQ, const bool includeDiffConstants,
-                   const bool IncludeDetectorPosition, Kernel::Logger &logger);
+                   const bool includeDetectorPosition, Kernel::Logger &logger);
 std::vector<std::pair<std::string, std::string>> createColumns(const bool isScanning, const bool includeData,
                                                                const bool calcQ, const bool hasDiffConstants,
                                                                const bool includeDetectorPosition);

--- a/Framework/Algorithms/inc/MantidAlgorithms/CreateDetectorTable.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CreateDetectorTable.h
@@ -54,7 +54,7 @@ private:
 /// Creates table workspace of detector information from a given workspace
 API::ITableWorkspace_sptr createDetectorTableWorkspace(const API::MatrixWorkspace_sptr &ws,
                                                        const std::vector<int> &indices, const bool includeData,
-                                                       Kernel::Logger &logger);
+                                                       const bool includeDetectorPosition, Kernel::Logger &logger);
 
 /// Converts a list to a string, shortened if necessary
 std::string createTruncatedList(const std::set<int> &elements);
@@ -63,9 +63,11 @@ void populateTable(Mantid::API::ITableWorkspace_sptr &t, const Mantid::API::Matr
                    const std::vector<int> &indices, const Mantid::API::SpectrumInfo &spectrumInfo,
                    bool signedThetaParamRetrieved, bool showSignedTwoTheta,
                    const Mantid::Geometry::PointingAlong &beamAxisIndex, const double sampleDist, const bool isScanning,
-                   const bool include_data, const bool calcQ, const bool includeDiffConstants, Kernel::Logger &logger);
+                   const bool include_data, const bool calcQ, const bool includeDiffConstants,
+                   const bool IncludeDetectorPosition, Kernel::Logger &logger);
 std::vector<std::pair<std::string, std::string>> createColumns(const bool isScanning, const bool includeData,
-                                                               const bool calcQ, const bool hasDiffConstants);
+                                                               const bool calcQ, const bool hasDiffConstants,
+                                                               const bool includeDetectorPosition);
 
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -27,7 +27,8 @@ void CreateDetectorTable::init() {
   declareProperty("IncludeData", false, "Include the first value from each spectrum.");
   setPropertySettings("IncludeData",
                       std::make_unique<EnabledWhenWorkspaceIsType<MatrixWorkspace>>("InputWorkspace", true));
-  declareProperty("IncludeDetectorPosition", false, "Include the absolute position of the detector group as a column.");
+  declareProperty<bool>("IncludeDetectorPosition", false,
+                        "Include the absolute position of the detector group for each spectrum.", Direction::Input);
 
   declareProperty(std::make_unique<WorkspaceProperty<TableWorkspace>>("DetectorTableWorkspace", "", Direction::Output,
                                                                       PropertyMode::Optional),

--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -29,7 +29,8 @@ void CreateDetectorTable::init() {
                       std::make_unique<EnabledWhenWorkspaceIsType<MatrixWorkspace>>("InputWorkspace", true));
   declareProperty<bool>("IncludeDetectorPosition", false,
                         "Include the absolute position of the detector group for each spectrum.", Direction::Input);
-
+  setPropertySettings("IncludeDetectorPosition",
+                      std::make_unique<EnabledWhenWorkspaceIsType<MatrixWorkspace>>("InputWorkspace", true));
   declareProperty(std::make_unique<WorkspaceProperty<TableWorkspace>>("DetectorTableWorkspace", "", Direction::Output,
                                                                       PropertyMode::Optional),
                   "The name of the outputted detector table workspace, if left empty then "

--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -329,6 +329,9 @@ void populateTable(ITableWorkspace_sptr &t, const MatrixWorkspace_sptr &ws, cons
       if (includeDiffConstants) {
         colValues << 0.0 << 0.0 << 0.0 << 0.0;
       }
+      if (includeDetectorPosition) {
+        colValues << V3D(0.0, 0.0, 0.0);
+      }
     } // End catch for no spectrum
   }
 }

--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -101,6 +101,8 @@ std::map<std::string, std::string> CreateDetectorTable::validateInputs() {
  * @param indices :: Limit the table to these workspace indices
  * @param includeData :: If true then first value from the each spectrum is
  * displayed
+ * @param includeDetectorPosition :: If true then include the absolute position of
+ * the detector group for each spectrum
  * @param logger: The Mantid logger so errors can be written to it.
  *
  * @return A pointer to the table workspace of detector information

--- a/Framework/Algorithms/test/CreateDetectorTableTest.h
+++ b/Framework/Algorithms/test/CreateDetectorTableTest.h
@@ -64,8 +64,8 @@ public:
     Workspace2D_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(2, 10);
 
     CreateDetectorTable alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", std::dynamic_pointer_cast<MatrixWorkspace>(inputWS)));
     TS_ASSERT_THROWS_NOTHING(alg.execute();)
     TS_ASSERT(alg.isExecuted());
@@ -95,8 +95,8 @@ public:
     spec.clearDetectorIDs(); // clear the detectors to test the exception catching
 
     CreateDetectorTable alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", std::dynamic_pointer_cast<MatrixWorkspace>(inputWS)));
     TS_ASSERT_THROWS_NOTHING(alg.execute();)
     TS_ASSERT(alg.isExecuted());
@@ -126,8 +126,8 @@ public:
     std::string outWSName{"Detector Table Test"};
 
     CreateDetectorTable alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", std::dynamic_pointer_cast<MatrixWorkspace>(inputWS)));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("WorkspaceIndices", "1"));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("IncludeData", true));
@@ -166,11 +166,11 @@ public:
     PeaksWorkspace_sptr inputWS = WorkspaceCreationHelper::createPeaksWorkspace(5, false);
 
     CreateDetectorTable alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
-    TS_ASSERT_THROWS_NOTHING(alg.execute())
-    TS_ASSERT(alg.isExecuted())
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
 
     TableWorkspace_sptr ws;
     TS_ASSERT_THROWS_NOTHING(
@@ -182,8 +182,8 @@ public:
     }
 
     // Check the results
-    TS_ASSERT_EQUALS(ws->columnCount(), 2)
-    TS_ASSERT_EQUALS(ws->rowCount(), 5)
+    TS_ASSERT_EQUALS(ws->columnCount(), 2);
+    TS_ASSERT_EQUALS(ws->rowCount(), 5);
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(ws->getName());
@@ -193,9 +193,9 @@ public:
     ITableWorkspace_sptr inputWS = std::make_shared<TableWorkspace>();
 
     CreateDetectorTable alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
 
     TS_ASSERT_THROWS(alg.executeAsChildAlg(), const std::runtime_error &);
   }
@@ -204,11 +204,11 @@ public:
     Workspace2D_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(2, 10);
 
     CreateDetectorTable alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", std::dynamic_pointer_cast<MatrixWorkspace>(inputWS)));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("IncludeDetectorPosition", true));
-    TS_ASSERT_THROWS_NOTHING(alg.execute();)
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
     TS_ASSERT(alg.isExecuted());
 
     // Not setting an output workspace name should give the name:
@@ -236,11 +236,11 @@ public:
     spec.clearDetectorIDs(); // clear the detectors to test the exception catching
 
     CreateDetectorTable alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize())
-    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", std::dynamic_pointer_cast<MatrixWorkspace>(inputWS)));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("IncludeDetectorPosition", true));
-    TS_ASSERT_THROWS_NOTHING(alg.execute();)
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
     TS_ASSERT(alg.isExecuted());
 
     // Not setting an output workspace name should give the name:

--- a/Framework/Algorithms/test/CreateDetectorTableTest.h
+++ b/Framework/Algorithms/test/CreateDetectorTableTest.h
@@ -84,6 +84,7 @@ public:
     // Check the results
     TS_ASSERT_EQUALS(ws->columnCount(), 11);
     TS_ASSERT_EQUALS(ws->rowCount(), 2);
+    TS_ASSERT_EQUALS(ws->cell<int>(0, 1), 1); // Spectrum No should be 1, if not in the exception
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(ws->getName());
@@ -157,6 +158,7 @@ public:
     // Check the results
     TS_ASSERT_EQUALS(ws->columnCount(), 13);
     TS_ASSERT_EQUALS(ws->rowCount(), 1);
+    TS_ASSERT_EQUALS(ws->cell<int>(0, 1), 2); // Spectrum No should be 2 due to the WorkspaceIndex
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);
@@ -184,6 +186,7 @@ public:
     // Check the results
     TS_ASSERT_EQUALS(ws->columnCount(), 2);
     TS_ASSERT_EQUALS(ws->rowCount(), 5);
+    TS_ASSERT_EQUALS(ws->cell<int>(0, 1), 0); // First column is Index when exec on PeaksWorkspace, so expect 0
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(ws->getName());
@@ -201,7 +204,7 @@ public:
   }
 
   void test_Exec_Matrix_Workspace_with_Include_DetPos() {
-    Workspace2D_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(2, 10);
+    Workspace2D_sptr inputWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(3, 10, true);
 
     CreateDetectorTable alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
@@ -224,7 +227,10 @@ public:
 
     // Check the results
     TS_ASSERT_EQUALS(ws->columnCount(), 12); // extra column compared to test_Exec_Matrix_Workspace
-    TS_ASSERT_EQUALS(ws->rowCount(), 2);
+    TS_ASSERT_EQUALS(ws->rowCount(), 3);
+    TS_ASSERT_EQUALS(ws->cell<int>(0, 1), 1); // Spectrum No should be 1, if not in the exception
+    TS_ASSERT_EQUALS(ws->cell<V3D>(1, 11),
+                     V3D(0.0, 0.0, -9.0)); // Last two are monitors, first position should be (0.0, 0.0, -9.0)
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(ws->getName());

--- a/docs/source/release/v6.13.0/Framework/Algorithms/New_features/38960.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/New_features/38960.rst
@@ -1,0 +1,1 @@
+- :ref:`CreateDetectorTable<algm-CreateDetectorTable>` now has an optional argument, ``IncludeDetectorPosition``, which, if `True`, will add a column, ``Position``, to the end of the ``DetectorTable``. This column has the detector position as a ``V3D`` type object for each spectrum in the table.


### PR DESCRIPTION
### Description of work

#### Summary of work
Optional True/False `IncludeDetectorPosition` that, if `True`, will append the detector positions to the `DetectorTable`


Fixes #38958. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
Added the option, should default to False so shouldn't break any scripts and appends to the end so should have minimal impact even when columns referenced by index.

Added a test that the additional column is present with the flag included

### To test:

You can run the script:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws1 = Load("ENGINX00193749.nxs")

ws1_detectors_no_pos = CreateDetectorTable("ws1")                        
ws1_detectors = CreateDetectorTable("ws1", IncludeDetectorPosition = True)

group_ws = CreateGroupingWorkspace(InstrumentName='ENGINX', 
                        ComponentName='ENGIN-X', 
                        CustomGroupingString='100001-100100,101001-101100, 102001-102100')

ws2 = GroupDetectors(InputWorkspace="ws1", CopyGroupingFromWorkspace= "group_ws")
                     
ws2_detectors = CreateDetectorTable("ws2", IncludeDetectorPosition = True)
```

The file is in the System Test Data (`build\ExternalData\Testing\Data\SystemTest\ENGINX00193749.nxs`). This script should produce three `DetectorTables`, the first two should be identical except for the extra `Position` column. `ws2_detectors` should have only 3 spectra with the grouping defined in `group_ws` applied, each should have a single position. 

*The functionality of the presence of the position column is covered by the unit tests added, and the actual population of this column should be covered by the tests for the `spectrumInfo.position()` as that is what is being called.*

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
