### PR TITLE
Remove dev-docs about removed tool

### DIFF
--- a/dev-docs/source/ToolsOverview.rst
+++ b/dev-docs/source/ToolsOverview.rst
@@ -156,32 +156,6 @@ Linux only. Install it from your distro's repository.
 Wonder Shaper allows the user to limit the bandwidth of one or more network adapters. This is useful for debugging
 issues when a network interface is still active but very slow. More details can be found at http://xmodulo.com/limit-network-bandwidth-linux.html.
 
-Convert Wiki Docs to Sphinx
----------------------------
-
-``wiki2rst`` reads in mediawiki formatted webpages and converts them to ``.rst`` files, for use
-in ``Sphinx``. The code attempts to take all images and internal links and re-create the
-documentation structure in the ``Sphinx`` format.
-
-Use
-~~~
-
-- Having added ``mantid`` to your Python path ``wiki2rst`` is run by:
-
-.. code:: sh
-
-    python wiki2rst.py -o <output_file.rst> <url_extension>
-
-- The ``<url_extension>`` is the part of the url after the main address (``https://www.mantidproject.org/``).
-- There are several additional options:
-	- ``--index_url`` change the name of the main url address
-	- ``--images-dir`` set a relative location for the images directory
-	- ``--ref-link`` give a reference link
-	- ``--ref-link-prefix`` give a link prefix
-	- ``--add_handle`` add a handle for linking to the page
-	- ``--page_handle`` the page handle to use [default page name]
-	- ``--add_heading`` add a heading to the page (uses the page name)
-
 Clang-tidy
 ----------
 


### PR DESCRIPTION
The tool `wiki2rst` stopped existing a long time ago after the mantid docs were moved from media-wiki to a sphinx site. This tool does not need description or usage in the developer documentation.
*There is no associated issue.*

### To test:

```
ninja dev-docs-html
```
should run without issue and wiki2rst will be gone from the docs.

*This does not require release notes* because it removes documentation for a non-existent tool.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
