### PR TITLE
38882 gsas2scriptable path search revision

### DIFF
--- a/docs/source/release/v6.13.0/Diffraction/Engineering/Bugfixes/38882.rst
+++ b/docs/source/release/v6.13.0/Diffraction/Engineering/Bugfixes/38882.rst
@@ -1,0 +1,1 @@
+- `#38882 <https://github.com/mantidproject/mantid/issues/38882>`_ : Fix issue with ``GSAS-II GSASIIscriptable.py`` hard-coded path which is invalid for newer version of GSAS-II (versions 5758 and later).

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/call_G2sc.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/call_G2sc.py
@@ -8,6 +8,9 @@
 import os
 import sys
 import json
+from pathlib import Path
+import fnmatch
+from typing import Generator
 
 
 def print_histogram_R_factors(project):
@@ -162,6 +165,22 @@ def export_lattice_parameters(temp_save_directory, name_of_project, project):
         parameters_file_path = os.path.join(temp_save_directory, name_of_project + f"_cell_parameters_{loop_phase.name}.txt")
         with open(parameters_file_path, "wt", encoding="utf-8") as file:
             file.write(parameters_json)
+
+
+def limited_rglob(directory: Path, pattern: str, max_depth: int) -> Generator[Path, None, None]:
+    """
+    Recursively search for files matching the pattern in the directory up to a specified depth.
+    """
+    if not directory.is_dir():
+        raise FileNotFoundError(f"The provided directory path '{directory}' is not a valid directory.")
+    for root, dirs, files in os.walk(directory):
+        current_depth = len(Path(root).parts) - len(directory.parts)
+        if current_depth > max_depth:
+            dirs[:] = []
+        if current_depth <= max_depth:
+            for file in files:
+                if fnmatch.fnmatch(file, pattern):
+                    yield Path(root) / file
 
 
 def main():

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -286,7 +286,8 @@ class GSAS2Model(object):
         except Exception as exc:
             logger.error(
                 f"GSAS-II call failed with error: {str(exc)}. "
-                "Please check the Path to GSASII in the Engineering Diffraction Settings is valid"
+                "Please check the Path to GSASII in the Engineering Diffraction Settings is valid. "
+                "Path must be outer most directory of GSAS-II installation."
             )
             return None
 


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Dynamically search for `GSASIIscriptable.py` from outer most parent library of [GSAS-II](https://github.com/AdvancedPhotonSource/GSAS-II-buildtools/) using a recursive directory search with a depth limit of 3 set to avoid searching too deeply into a given directory structure.

Improve error message return descriptions where:
* `GSASIIscriptable.py` is not found.
* `GSASIIscriptable.py` has been found, but an import error occurred.
* Python binaries could not been found in `/gsas2_parent_dir/GSAS-II/bin/python`


<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

The location of `GSASIIscriptable.py` is not consistent across different versions of [GSAS-II](https://github.com/AdvancedPhotonSource/GSAS-II-buildtools/). For newer version of GSAS-II ([5758](https://github.com/AdvancedPhotonSource/GSAS-II-buildtools/releases/tag/5758) or [later](https://github.com/AdvancedPhotonSource/GSAS-II-buildtools/releases/tag/latest)), `GSASIIscriptable.py` is not correctly located

### Fixes #38882  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
[Mantid anaconda label](https://anaconda.org/mantid/mantidworkbench): `new_gsas_path_search_test` - **PLEASE REMOVE LABEL FROM ANACONDA ONCE PR IS APPROVED.**

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

**Testing with newer versions of GSAS-II:**

1. Install a newer version of GSAS-II such as version [5758](https://github.com/AdvancedPhotonSource/GSAS-II-buildtools/releases/tag/5758) or [later](https://github.com/AdvancedPhotonSource/GSAS-II-buildtools/releases/tag/latest).
2. Checkout the `main` branch: `git switch main && git fetch && git pull`
3. Launch workbench from CLI `workbench` and follow the [Engineering Diffraction Test 11](https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html#test-11)
4. Notice that if the path is set to the outer most directory of GSAS-II, you will receive an error similar to:
```python
GSAS-II call failed with error: Traceback (most recent call last):
  File "/mantidproject/mantid/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/call_G2sc.py", line 195, in main
    import GSASIIscriptable as G2sc
ModuleNotFoundError: No module named 'GSASIIscriptable'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/mantidproject/mantid/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/call_G2sc.py", line 232, in <module>
    main()
  File "/mantidproject/mantid/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/call_G2sc.py", line 197, in main
    raise ImportError(f"GSAS-II was not found at {import_path}")
ImportError: GSAS-II was not found at /gsas2/GSASII
```
5. If the path is intuitively set closer to `GSASIIscriptable.py`, maybe `gsas2/GSAS-II`, you will receive an similar error to:
```python
GSAS-II call failed with error: [Errno 2] No such file or directory: '/gsas2/GSAS-II/bin/python'. Please check the Path to GSASII in the Engineering Diffraction Settings is valid
```
6. Switch to the the PR branch: `git switch 38882_gsas2scriptable_path_search_revision`
7. Repeat steps `3-5`, and notice that the error for step `4` GSAS should now load correctly. For step `5`, notice that the same error will be returned with the additional statement: `Path must be outer most directory of GSAS-II installation.` This message should better aid a user to the directory needed for GSAS-II to load correctly.
8. Move the `GSASIIscriptable.py` to another directory within the GSAS library such as directly under the parent folder. the rough location of `GSASIIscriptable.py` from the parent directory of the library will be: `/gsas2/GSAS-II/GSASII/GSASIIscriptable.py` for newer versions of GSAS-II
9. On the GSAS II tab in the Engineering Diffraction interface, click refine after following step `3`. You should receive an import error that specified that `GSASIIscriptable.py`has been found, but an import error occurred similar to:
 ```python
  File "/mantidproject/mantid/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/call_G2sc.py", line 200, in find_gsasii
    raise ImportError(
ImportError: GSASIIscriptable (GSASIIscriptable.py) module found in /gsas2 but could not be imported
```
10. Move the `GSASIIscriptable.py` back to it's original location: ~`/gsas2/GSAS-II/GSASII/GSASIIscriptable.py`

**Testing with older versions of GSAS-II:**
1. Login to [IDAaaS](https://isis.analysis.stfc.ac.uk/) and create a new EnginX workspace.
2. Check the version of GSAS in the workspace is `4579`. This can be checked before launching the workspace by clicking on the setting cog at the top right of the workspace under the "Included Software" subheading.
3. Launch the EnginX workspace.
4. Open a terminal `Applications >> System >> Terminal`
5. Execute the following command: 
```bash
mamba create -n mantid-test -c mantid/label/new_gsas_path_search_test -c mantid/label/nightly mantidworkbench
``` 
`-c mantid/label/nightly` is required due to a an mslice version being pinned which will prevent you from creating a valid environment otherwise.
6. Activate your environment `mamba activate mantid-test` and open workbench `workbench` from the CLI.
7. Repeat steps `3-5`, from "Testing with newer versions of GSAS-II" and notice the update error messages, mentioned in step `7`.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
