### PR TITLE
Update `H5Util` type narrowing/coercion methods

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/H5Util.h
+++ b/Framework/Nexus/inc/MantidNexus/H5Util.h
@@ -31,6 +31,9 @@ namespace H5Util {
 /** H5Util : TODO: DESCRIPTION
  */
 
+/** Controls whether narrowing is allowed within type coercion. */
+enum class Narrowing : bool { Allow = true, Prevent = false };
+
 /** Default file access is H5F_CLOSE_STRONG. This should be set consistently for all access of a file. */
 MANTID_NEXUS_DLL H5::FileAccPropList defaultFileAcc();
 
@@ -89,17 +92,19 @@ MANTID_NEXUS_DLL bool hasAttribute(const H5::H5Object &object, const char *attri
 MANTID_NEXUS_DLL void readStringAttribute(const H5::H5Object &object, const std::string &attributeName,
                                           std::string &output);
 
-template <typename NumT> NumT readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
+template <typename NumT, Narrowing narrow = Narrowing::Allow>
+NumT readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 
-template <typename NumT>
+template <typename NumT, Narrowing narrow = Narrowing::Allow>
 std::vector<NumT> readNumArrayAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 
-template <typename NumT>
+template <typename NumT, Narrowing narrow = Narrowing::Allow>
 void readArray1DCoerce(const H5::Group &group, const std::string &name, std::vector<NumT> &output);
 
-template <typename NumT> std::vector<NumT> readArray1DCoerce(const H5::Group &group, const std::string &name);
+template <typename NumT, Narrowing narrow = Narrowing::Allow>
+std::vector<NumT> readArray1DCoerce(const H5::Group &group, const std::string &name);
 
-template <typename NumT>
+template <typename NumT, Narrowing narrow = Narrowing::Allow>
 void readArray1DCoerce(const H5::DataSet &dataset, std::vector<NumT> &output,
                        const size_t length = std::numeric_limits<size_t>::max(),
                        const size_t offset = static_cast<size_t>(0));

--- a/Framework/Nexus/inc/MantidNexus/NexusIOHelper.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusIOHelper.h
@@ -48,7 +48,8 @@ namespace {
   case NXnumtype::UINT64:                                                                                              \
     return func_name<T, uint64_t, narrow>(__VA_ARGS__);                                                                \
   default:                                                                                                             \
-    throw std::runtime_error("NeXusIOHelper: Unknown type in Nexus file");                                             \
+    std::string msg = "NexusIOHelper: Unknown type " + std::to_string((int)type) + " in Nexus file";                   \
+    throw std::runtime_error(msg);                                                                                     \
   }
 
 int64_t vectorVolume(const std::vector<int64_t> &size) {

--- a/Framework/Nexus/src/H5Util.cpp
+++ b/Framework/Nexus/src/H5Util.cpp
@@ -367,6 +367,10 @@ void convertingScalarRead(Attribute &attribute, const DataType &dataType, OutT &
 
 } // namespace
 
+/** Read a single quantity from an attribute, coerced to type of OutT.
+ * Narrowing behavior can be controlled with optional template param narrow,
+ * which, if narrow = Prevent, will throw an error if type coercion would cause narrowing.
+ */
 template <typename OutT, Narrowing narrow>
 OutT readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName) {
   auto attribute = object.openAttribute(attributeName);
@@ -377,6 +381,10 @@ OutT readNumAttributeCoerce(const H5::H5Object &object, const std::string &attri
   return value;
 }
 
+/** Read a numerical array from an attribute, coerced to type of OutT.
+ * Narrowing behavior can be controlled with optional template param narrow,
+ * which, if narrow = Prevent, will throw an error if type coercion would cause narrowing.
+ */
 template <typename OutT, Narrowing narrow>
 std::vector<OutT> readNumArrayAttributeCoerce(const H5::H5Object &object, const std::string &attributeName) {
   auto attribute = object.openAttribute(attributeName);
@@ -387,6 +395,10 @@ std::vector<OutT> readNumArrayAttributeCoerce(const H5::H5Object &object, const 
   return value;
 }
 
+/** Read a standard vector from a dataset, coerced to type of OutT.
+ * Narrowing behavior can be controlled with optional template param narrow,
+ * which, if narrow = Prevent, will throw an error if type coercion would cause narrowing.
+ */
 template <typename OutT, Narrowing narrow>
 void readArray1DCoerce(const H5::DataSet &dataset, std::vector<OutT> &output, const size_t length,
                        const size_t offset) {
@@ -508,15 +520,26 @@ template MANTID_NEXUS_DLL void writeNumAttribute(const H5::H5Object &object, con
 // -------------------------------------------------------------------
 // instantiations for readNumAttributeCoerce
 // -------------------------------------------------------------------
+
+/* NOTE these instantiations are for case Narrowing::Allow
+/ To use Narrowing:Prevent, will need to instantiate and export those methods
+*/
+
 template MANTID_NEXUS_DLL float readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 template MANTID_NEXUS_DLL double readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 template MANTID_NEXUS_DLL int32_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 template MANTID_NEXUS_DLL uint32_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 template MANTID_NEXUS_DLL int64_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
 template MANTID_NEXUS_DLL uint64_t readNumAttributeCoerce(const H5::H5Object &object, const std::string &attributeName);
+
 // -------------------------------------------------------------------
 // instantiations for readNumArrayAttributeCoerce
 // -------------------------------------------------------------------
+
+/* NOTE these instantiations are for case Narrowing::Allow
+/ To use Narrowing:Prevent, will need to instantiate and export those methods
+*/
+
 template MANTID_NEXUS_DLL std::vector<float> readNumArrayAttributeCoerce(const H5::H5Object &object,
                                                                          const std::string &attributeName);
 template MANTID_NEXUS_DLL std::vector<double> readNumArrayAttributeCoerce(const H5::H5Object &object,
@@ -533,6 +556,11 @@ template MANTID_NEXUS_DLL std::vector<uint64_t> readNumArrayAttributeCoerce(cons
 // -------------------------------------------------------------------
 // instantiations for writeArray1D
 // -------------------------------------------------------------------
+
+/* NOTE these instantiations are for case Narrowing::Allow
+/ To use Narrowing:Prevent, will need to instantiate and export those methods
+*/
+
 template MANTID_NEXUS_DLL void writeArray1D(H5::Group &group, const std::string &name,
                                             const std::vector<float> &values);
 template MANTID_NEXUS_DLL void writeArray1D(H5::Group &group, const std::string &name,


### PR DESCRIPTION
### Description of work

#### Summary of work

Borrowed macro methods from `NexusIOHelper` to `H5Util` to better handle type coercion and narrowing.  This better wraps the coercion read methods in a macro that handles conversion from `H5::PredType` to primitive C++ types, and reimplments some methods to do the compatibility checks and narrowing checks.

#### Purpose of work

Related to Plan #38332

Related to [ORNL EWM 8453](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=8453)
> The methods in NexusIOHelper are thin wrappers around NeXusFile with type coercion. Migrate these methods into NeXusFile itself and change the code that uses these methods. At the moment, the classes that use NexusIOHelper are LoadBankFromDiskTask, LoadErrorEventsNexus, LoadEventNexus, LoadEventNexusAsWorkspace2D, and LoadNexusMontors2.

Related to [ORNL EWM 9109](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9109)
> MantidNexus/H5Util, MantidNexusCpp/NeXusFile, and MantidNexus/NexusIOHelper (which will be brought into NexusFile as part of EWM8453) all have type coercsion code in them. Review the three approaches, determine how to combine the conversion portion, extract that into a collection of functions used by all, then refactor the code to use it. Since all three will use H5Cpp underneath, it may be most appropriate to add then functionality to H5Util and have the others call that.


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

The existing tests in `H5UtilTest.h` should cover the changes made here.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
