### PR TITLE
added colors for f-string syntax highlighting in mantid code editor

### DIFF
--- a/docs/source/release/v6.13.0/Workbench/New_features/38080.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/38080.rst
@@ -1,1 +1,1 @@
-Mantid's Python code editor now supports F-string syntax highlighting
+- The :ref:`Python script editor <WorkbenchScriptWindow>` now supports f-string syntax highlighting.

--- a/docs/source/release/v6.13.0/Workbench/New_features/38080.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/38080.rst
@@ -1,0 +1,1 @@
+Mantid's Python code editor now supports F-string syntax highlighting

--- a/qt/widgets/common/src/AlternateCSPythonLexer.cpp
+++ b/qt/widgets/common/src/AlternateCSPythonLexer.cpp
@@ -43,6 +43,10 @@ QColor AlternateCSPythonLexer::defaultColor(int style) const {
   case TripleDoubleQuotedString:
     return QColor(0x00, 0xaa, 0x00);
 
+  case TripleSingleQuotedFString:
+  case TripleDoubleQuotedFString:
+    return QColor(0x00, 0xaa, 0x00);
+
   case ClassName:
     return QColor(0x00, 0x00, 0x00);
 

--- a/qt/widgets/common/src/AlternateCSPythonLexer.cpp
+++ b/qt/widgets/common/src/AlternateCSPythonLexer.cpp
@@ -32,14 +32,17 @@ QColor AlternateCSPythonLexer::defaultColor(int style) const {
   case SingleQuotedString:
     return QColor(0x00, 0xaa, 0x00);
 
+  case DoubleQuotedFString:
+  case SingleQuotedFString:
+    return QColor(0x00, 0xaa, 0x00);
+
   case Keyword:
     return QColor(0x00, 0x00, 0xff);
 
   case TripleSingleQuotedString:
-  case TripleDoubleQuotedString:
-    return QColor(0x00, 0xaa, 0x00);
+  case TripleDoubleQuotedString return QColor(0x00, 0xaa, 0x00);
 
-  case ClassName:
+      case ClassName:
     return QColor(0x00, 0x00, 0x00);
 
   case FunctionMethodName:

--- a/qt/widgets/common/src/AlternateCSPythonLexer.cpp
+++ b/qt/widgets/common/src/AlternateCSPythonLexer.cpp
@@ -40,9 +40,10 @@ QColor AlternateCSPythonLexer::defaultColor(int style) const {
     return QColor(0x00, 0x00, 0xff);
 
   case TripleSingleQuotedString:
-  case TripleDoubleQuotedString return QColor(0x00, 0xaa, 0x00);
+  case TripleDoubleQuotedString:
+    return QColor(0x00, 0xaa, 0x00);
 
-      case ClassName:
+  case ClassName:
     return QColor(0x00, 0x00, 0x00);
 
   case FunctionMethodName:


### PR DESCRIPTION
### Description of work
added support for f-string in code editor
added colors for f-string syntax highlighting

Fixes #38080


### To test:
- Open the Mantid python code editor.
- Enter a Python F-string (e.g., f"Hello, {name}!").
- Verify that the F-string syntax is correctly highlighted in green