### PR TITLE
CMake build with `-DUSE_SANITIZER=Address`

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProductFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProductFunction.h
@@ -26,16 +26,16 @@ more other fit functions.
 */
 class MANTID_CURVEFITTING_DLL ProductFunction : public API::CompositeFunction {
 public:
-  /// overwrite IFunction base class methods
-  std::string name() const override { return "ProductFunction"; }
+  /// override IFunction base class methods
+  std::string name() const override;
   /// Function you want to fit to.
   void function(const API::FunctionDomain &domain, API::FunctionValues &values) const override;
   /// Calculate the derivatives
   void functionDeriv(const API::FunctionDomain &domain, API::Jacobian &jacobian) override;
 
 protected:
-  /// overwrite IFunction base class method, which declare function parameters
-  void init() override {};
+  /// overwrite IFunction base class method, which declares function parameters
+  void init() override;
 };
 
 } // namespace Functions

--- a/Framework/CurveFitting/src/Functions/ProductFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/ProductFunction.cpp
@@ -16,6 +16,9 @@ using namespace CurveFitting;
 
 DECLARE_FUNCTION(ProductFunction)
 
+/// override IFunction base class methods
+std::string ProductFunction::name() const { return "ProductFunction"; }
+
 /** Function you want to fit to.
  *  @param domain :: The buffer for writing the calculated values. Must be big enough to accept dataSize() values
  *  @param values :: The function values to evaluate for the function domain
@@ -38,5 +41,8 @@ void ProductFunction::function(const API::FunctionDomain &domain, API::FunctionV
 void ProductFunction::functionDeriv(const API::FunctionDomain &domain, API::Jacobian &jacobian) {
   calNumericalDeriv(domain, jacobian);
 }
+
+/// overwrite IFunction base class method, which declares function parameters
+void ProductFunction::init() {};
 
 } // namespace Mantid::CurveFitting::Functions

--- a/buildconfig/CMake/FindAsanLib.cmake
+++ b/buildconfig/CMake/FindAsanLib.cmake
@@ -1,0 +1,13 @@
+# Try to find the asan library and include files
+#
+# ASAN_INCLUDE_DIR where to find asan.h, etc. ASAN_LIBRARIES libraries to link against ASANLIB_FOUND If false, do not
+# try to use ASAN
+
+find_library(ASAN_LIB NAMES asan)
+set(ASAN_LIBRARIES ${ASAN_LIB})
+
+# handle the QUIETLY and REQUIRED arguments and set ASANLIB_FOUND to TRUE if all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(AsanLib DEFAULT_MSG ASAN_LIBRARIES)
+
+mark_as_advanced(ASAN_LIB ASAN_LIBRARIES ASANLIB_FOUND)

--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -64,10 +64,11 @@ if(JEMALLOCLIB_FOUND)
 endif()
 
 # definitions to preload jemalloc but not if we are using address sanitizer as this confuses things
-if(WITH_ASAN)
+string(TOLOWER "${USE_SANITIZER}" USE_SANITIZERS_LOWER)
+if(${USE_SANITIZERS_LOWER} MATCHES "address")
   set(JEMALLOC_DEFINITIONS
       "
-LOCAL_PRELOAD=\${LD_PRELOAD}
+LOCAL_PRELOAD=${ASAN_LIB}
 "
   )
 else()

--- a/buildconfig/CMake/LinuxSetup.cmake
+++ b/buildconfig/CMake/LinuxSetup.cmake
@@ -19,6 +19,17 @@ else(USE_JEMALLOC)
   message(STATUS "Jemalloc will not be included in startup scripts")
 endif()
 
+# ######################################################################################################################
+# If required, find the address sanitizer library: libasan
+# ######################################################################################################################
+string(TOLOWER "${USE_SANITIZER}" USE_SANITIZERS_LOWER)
+if(${USE_SANITIZERS_LOWER} MATCHES "address")
+  find_package(AsanLib REQUIRED)
+  if(ASANLIB_FOUND)
+    set(ASAN_LIBRARY ${ASAN_LIBRARIES})
+  endif(ASANLIB_FOUND)
+endif()
+
 # Tag used by dynamic loader to identify directory of loading library
 set(DL_ORIGIN_TAG \$ORIGIN)
 

--- a/docs/source/release/v6.13.0/Framework/Build_tools/Bugfixes/38943.rst
+++ b/docs/source/release/v6.13.0/Framework/Build_tools/Bugfixes/38943.rst
@@ -1,0 +1,1 @@
+- CMake now successfully builds with ``-DUSE_SANITIZER=address``. For more details see  :doc:`RunningSanitizers <mantid-dev:RunningSanitizers>`.

--- a/docs/source/release/v6.13.0/framework.rst
+++ b/docs/source/release/v6.13.0/framework.rst
@@ -1,0 +1,98 @@
+=================
+Framework Changes
+=================
+
+.. contents:: Table of Contents
+   :local:
+
+Algorithms
+----------
+
+New features
+############
+.. amalgamate:: Framework/Algorithms/New_features
+
+Bugfixes
+############
+.. amalgamate:: Framework/Algorithms/Bugfixes
+
+Deprecated
+############
+.. amalgamate:: Framework/Algorithms/Deprecated
+
+Removed
+############
+.. amalgamate:: Framework/Algorithms/Removed
+
+Fit Functions
+-------------
+
+New features
+############
+.. amalgamate:: Framework/Fit_Functions/New_features
+
+Bugfixes
+############
+.. amalgamate:: Framework/Fit_Functions/Bugfixes
+
+Deprecated
+############
+.. amalgamate:: Framework/Fit_Functions/Deprecated
+
+Removed
+############
+.. amalgamate:: Framework/Fit_Functions/Removed
+
+
+Data Objects
+------------
+
+New features
+############
+.. amalgamate:: Framework/Data_Objects/New_features
+
+Bugfixes
+############
+.. amalgamate:: Framework/Data_Objects/Bugfixes
+
+
+Python
+------
+
+New features
+############
+.. amalgamate:: Framework/Python/New_features
+
+Bugfixes
+############
+.. amalgamate:: Framework/Python/Bugfixes
+
+
+Dependencies
+------------
+
+New features
+############
+.. amalgamate:: Framework/Dependencies/New_features
+
+Bugfixes
+############
+.. amalgamate:: Framework/Dependencies/Bugfixes
+
+
+Build Tools
+-----------
+
+Bugfixes
+############
+.. amalgamate:: Framework/Build_tools/Bugfixes
+
+
+MantidWorkbench
+---------------
+
+..
+  This section doesn't exist yet:
+  See :doc:`mantidworkbench`.
+
+:ref:`Release 6.13.0 <v6.13.0>`

--- a/docs/source/release/v6.13.0/index.rst
+++ b/docs/source/release/v6.13.0/index.rst
@@ -1,0 +1,94 @@
+.. _v6.13.0:
+
+===========================
+Mantid 6.13.0 Release Notes
+===========================
+
+.. figure:: ../../images/ImageNotFound.png
+   :class: screenshot
+   :width: 385px
+   :align: right
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: This release is still under construction. The changes can be found in the nightly builds on the `download page`_.
+
+We are proud to announce version 6.13.0 of Mantid.
+
+**TODO: Add paragraph summarizing big changes**
+
+These are just some of the many improvements in this release, so please take a
+look at the release notes, which are filled with details of the
+important changes and improvements in many areas. The development team
+has put a great effort into making all of these improvements within
+Mantid, and we would like to thank all of our beta testers for their
+time and effort helping us to make this another reliable version of Mantid.
+
+Throughout the Mantid project we put a lot of effort into ensuring
+Mantid is a robust and reliable product. Thank you to everyone that has
+reported any issues to us. Please keep on reporting any problems you
+have, or crashes that occur on our `forum`_.
+
+Installation packages can be found on our `download page`_
+which now links to the assets on our `GitHub release page`_, where you can also
+access the source code for the release.
+
+Citation
+--------
+
+Please cite any usage of Mantid as follows:
+
+- *Mantid 6.13.0: Manipulation and Analysis Toolkit for Instrument Data.; Mantid Project*. `doi: 10.5286/SOFTWARE/MANTID6.13 <https://dx.doi.org/10.5286/SOFTWARE/MANTID6.13>`_
+
+- Arnold, O. et al. *Mantid-Data Analysis and Visualization Package for Neutron Scattering and mu-SR Experiments.* Nuclear Instruments
+  and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment 764 (2014): 156-166
+  `doi: 10.1016/j.nima.2014.07.029 <https://doi.org/10.1016/j.nima.2014.07.029>`_
+  (`download bibtex <https://raw.githubusercontent.com/mantidproject/mantid/master/docs/source/mantid.bib>`_)
+
+
+Changes
+-------
+
+.. toctree::
+   :hidden:
+   :glob:
+
+   *
+
+- :doc:`Framework <framework>`
+
+..
+  These sections don't exist yet:
+  - :doc:`Mantid Workbench <mantidworkbench>`
+  - :doc:`Diffraction <diffraction>`
+  - :doc:`Muon Analysis <muon>`
+
+- Low Q
+
+..
+  These sections don't exist yet:
+  - :doc:`Reflectometry <reflectometry>`
+  - :doc:`SANS <sans>`
+
+- Spectroscopy
+
+..
+  These sections don't exist yet:
+  - :doc:`Direct Geometry <direct_geometry>`
+  - :doc:`Indirect Geometry <indirect_geometry>`
+  - :doc:`Inelastic <inelastic>`
+
+
+Full Change Listings
+--------------------
+
+For a full list of all issues addressed during this release please see the `GitHub milestone`_.
+
+.. _download page: https://download.mantidproject.org
+
+.. _forum: https://forum.mantidproject.org
+
+.. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.13%22+is%3Amerged
+
+.. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v6.13.0


### PR DESCRIPTION
From main: [PR #38943](https://github.com/mantidproject/mantid/pull/38943)
### Description of work
During diagnosis of a buffer-overflow error, it was found that Mantid's cmake build with '-DUSE_SANITIZER=address' no longer completes successfully.

#### Summary of work
The build problem occurs because several required `virtual` functions of the `IFunction` interface for `ProductFunction` were erroneously defined as `inline`.  The solution is to move the definitions of these functions away from their class body.


Fixes [EWM defect #9223](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9223)

### To test:

Build Mantid `main` using:
```
mkdir build; cd build
cmake .. -DUSE_SANITIZER=Address -DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja
cmake --build . --target AllTests
```
This build is expected to _fail_ with an error:
```
...../x86_64-conda-linux-gnu/bin/ld:  Framework/CurveFitting/test/CMakeFiles/CurveFittingTest.dir/ProductLinearExpTest.cpp.o: in function `Mantid::API::IFunction::initialize()':
/mnt/R5_data1/data1/workspaces/ORNL-work/mantid/Framework/API/inc/MantidAPI/IFunction.h:425:(.text._ZN20ProductLinearExpTest28do_test_function_calculationERKdS1_S1_S1_[_ZN20ProductLinearExpTest28do_test_function_calculationERKdS1_S1_S1_]+0x242e): undefined reference to `virtual thunk to Mantid::CurveFitting::Functions::ProductFunction::init()'
collect2: error: ld returned 1 exit status

```
Now follow the same instructions to build this branch:  the build is expected to succeed.  (Note that there will be lots and lots of "sanitizer" warnings, but that is expected.)

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
