### PR TITLE
Forward declares of NexusClasses inside DataHandling files

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/DataBlock.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/DataBlock.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <memory>
-#include <vector>
 
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidGeometry/IDTypes.h"

--- a/Framework/DataHandling/inc/MantidDataHandling/DataBlock.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/DataBlock.h
@@ -6,9 +6,12 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include <memory>
+#include <vector>
+
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidGeometry/IDTypes.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/DataBlockComposite.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/DataBlockComposite.h
@@ -8,6 +8,7 @@
 
 #include "MantidDataHandling/DataBlock.h"
 #include "MantidDataHandling/DllConfig.h"
+#include <algorithm>
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/DataBlockComposite.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/DataBlockComposite.h
@@ -9,6 +9,7 @@
 #include "MantidDataHandling/DataBlock.h"
 #include "MantidDataHandling/DllConfig.h"
 #include <algorithm>
+#include <vector>
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/DataBlockGenerator.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/DataBlockGenerator.h
@@ -8,6 +8,7 @@
 
 #include "MantidDataHandling/DataBlock.h"
 #include <optional>
+#include <vector>
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadANSTOHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadANSTOHelper.h
@@ -13,7 +13,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Instrument.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 #include <regex>
 
 #define TarTypeFlag_NormalFile '0'

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadBBY.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadBBY.h
@@ -16,7 +16,7 @@
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/FileDescriptor.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEMU.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEMU.h
@@ -19,7 +19,6 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/FileDescriptor.h"
 #include "MantidKernel/NexusDescriptor.h"
-#include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadHelper.h
@@ -10,8 +10,8 @@
 #include "MantidAPI/Run.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidKernel/Quat.h"
-#include "MantidNexus/NeXusFile.hpp"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NeXusFile_fwd.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 namespace Mantid {
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLDiffraction.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLDiffraction.h
@@ -13,7 +13,7 @@
 #include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/NexusDescriptor.h"
 #include "MantidKernel/V3D.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLIndirect2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLIndirect2.h
@@ -9,7 +9,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidKernel/NexusDescriptor.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLLagrange.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLLagrange.h
@@ -9,7 +9,6 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidKernel/NexusDescriptor.h"
-#include "MantidNexus/NexusClasses.h"
 
 #include <H5Cpp.h>
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLPolarizedDiffraction.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLPolarizedDiffraction.h
@@ -11,7 +11,7 @@
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/NexusDescriptor.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 #include <utility>
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLReflectometry.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLReflectometry.h
@@ -10,7 +10,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidKernel/NexusDescriptor.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 #include "MantidTypes/Core/DateAndTime.h"
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLSANS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLSANS.h
@@ -9,7 +9,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidKernel/NexusDescriptor.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 #include <H5Cpp.h>
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadILLTOF2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadILLTOF2.h
@@ -10,7 +10,7 @@
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidGeometry/IDTypes.h"
 #include "MantidKernel/NexusDescriptor.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
@@ -17,7 +17,7 @@
 #include "MantidHistogramData/HistogramX.h"
 #include "MantidKernel/NexusDescriptor.h"
 #include "MantidNexus/NeXusFile.hpp"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 #include <boost/scoped_ptr.hpp>
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexusHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexusHelper.h
@@ -9,7 +9,7 @@
 #define MANTID_DATAHANDLING_LOADISISNEXUSHELPER_H_
 
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 namespace Mantid {
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMLZ.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMLZ.h
@@ -12,7 +12,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidKernel/NexusDescriptor.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2.h
@@ -10,7 +10,6 @@
 #include "MantidDataHandling/LoadMuonNexusV2NexusHelper.h"
 #include "MantidDataHandling/LoadMuonStrategy.h"
 #include "MantidGeometry/IDTypes.h"
-#include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2NexusHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2NexusHelper.h
@@ -12,6 +12,7 @@
 #include "MantidNexus/NexusClasses_fwd.h"
 
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace Mantid {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2NexusHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexusV2NexusHelper.h
@@ -9,7 +9,7 @@
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidDataObjects/Workspace2D_fwd.h"
 #include "MantidGeometry/IDTypes.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 #include <optional>
 #include <vector>

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
@@ -17,7 +17,7 @@
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidHistogramData/BinEdges.h"
 #include "MantidKernel/cow_ptr.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 #include <map>
 #include <vector>
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPLN.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPLN.h
@@ -24,7 +24,6 @@
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/NexusDescriptor.h"
-#include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadSINQFocus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadSINQFocus.h
@@ -13,7 +13,7 @@
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidKernel/NexusDescriptor.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadTOFRawNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadTOFRawNexus.h
@@ -16,7 +16,7 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/NexusDescriptor.h"
-#include "MantidNexus/NexusClasses.h"
+#include "MantidNexus/NexusClasses_fwd.h"
 
 #include <mutex>
 

--- a/Framework/DataHandling/inc/MantidDataHandling/MultiPeriodLoadMuonStrategy.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/MultiPeriodLoadMuonStrategy.h
@@ -7,7 +7,6 @@
 #pragma once
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidDataHandling/LoadMuonStrategy.h"
-#include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/PatchBBY.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/PatchBBY.h
@@ -15,7 +15,6 @@
 #include "MantidDataHandling/DllConfig.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Instrument.h"
-#include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/inc/MantidDataHandling/SinglePeriodLoadMuonStrategy.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SinglePeriodLoadMuonStrategy.h
@@ -7,7 +7,6 @@
 #pragma once
 #include "MantidDataHandling/LoadMuonStrategy.h"
 #include "MantidDataObjects/Workspace2D_fwd.h"
-#include "MantidNexus/NexusClasses.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Framework/DataHandling/src/DataBlock.cpp
+++ b/Framework/DataHandling/src/DataBlock.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidDataHandling/DataBlock.h"
 #include "MantidDataHandling/DataBlockGenerator.h"
+#include "MantidNexus/NexusClasses.h"
 
 #include <limits>
 #include <vector>

--- a/Framework/DataHandling/src/DataBlockComposite.cpp
+++ b/Framework/DataHandling/src/DataBlockComposite.cpp
@@ -9,7 +9,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <iterator>
 #include <numeric>
+#include <stdexcept>
 
 namespace {
 

--- a/Framework/DataHandling/src/DataBlockGenerator.cpp
+++ b/Framework/DataHandling/src/DataBlockGenerator.cpp
@@ -8,6 +8,7 @@
 
 #include "MantidDataHandling/DataBlock.h"
 #include "MantidDataHandling/DataBlockGenerator.h"
+#include <algorithm>
 
 namespace Mantid::DataHandling {
 

--- a/Framework/DataHandling/src/LoadHelper.cpp
+++ b/Framework/DataHandling/src/LoadHelper.cpp
@@ -17,6 +17,7 @@
 #include "MantidKernel/PhysicalConstants.h"
 #include "MantidNexus/NeXusException.hpp"
 #include "MantidNexus/NeXusFile.hpp"
+#include "MantidNexus/NexusClasses.h"
 #include <strstream>
 
 namespace Mantid {

--- a/Framework/DataHandling/src/LoadILLDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLDiffraction.cpp
@@ -24,6 +24,7 @@
 #include "MantidNexus/H5Util.h"
 #include "MantidNexus/NeXusException.hpp"
 #include "MantidNexus/NeXusFile.hpp"
+#include "MantidNexus/NexusClasses.h"
 
 #include <H5Cpp.h>
 #include <Poco/Path.h>

--- a/Framework/DataHandling/src/LoadILLIndirect2.cpp
+++ b/Framework/DataHandling/src/LoadILLIndirect2.cpp
@@ -21,6 +21,7 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidNexus/NeXusException.hpp"
 #include "MantidNexus/NeXusFile.hpp"
+#include "MantidNexus/NexusClasses.h"
 
 #include <Poco/Path.h>
 #include <algorithm>

--- a/Framework/DataHandling/src/LoadILLLagrange.cpp
+++ b/Framework/DataHandling/src/LoadILLLagrange.cpp
@@ -18,6 +18,7 @@
 #include "MantidNexus/H5Util.h"
 #include "MantidNexus/NeXusException.hpp"
 #include "MantidNexus/NeXusFile.hpp"
+#include "MantidNexus/NexusClasses.h"
 
 #include <Poco/Path.h>
 

--- a/Framework/DataHandling/src/LoadILLPolarizedDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLPolarizedDiffraction.cpp
@@ -28,6 +28,7 @@
 #include "MantidKernel/VisibleWhenProperty.h"
 #include "MantidNexus/NeXusException.hpp"
 #include "MantidNexus/NeXusFile.hpp"
+#include "MantidNexus/NexusClasses.h"
 
 #include <Poco/Path.h>
 

--- a/Framework/DataHandling/src/LoadILLReflectometry.cpp
+++ b/Framework/DataHandling/src/LoadILLReflectometry.cpp
@@ -31,6 +31,7 @@
 #include "MantidKernel/V3D.h"
 #include "MantidNexus/NeXusException.hpp"
 #include "MantidNexus/NeXusFile.hpp"
+#include "MantidNexus/NexusClasses.h"
 
 namespace {
 

--- a/Framework/DataHandling/src/LoadILLSALSA.cpp
+++ b/Framework/DataHandling/src/LoadILLSALSA.cpp
@@ -15,6 +15,7 @@
 #include "MantidHistogramData/Points.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidNexus/H5Util.h"
+#include "MantidNexus/NeXusFile.hpp"
 
 #include <iterator>
 #include <sstream>

--- a/Framework/DataHandling/src/LoadILLSANS.cpp
+++ b/Framework/DataHandling/src/LoadILLSANS.cpp
@@ -29,6 +29,7 @@
 #include "MantidNexus/H5Util.h"
 #include "MantidNexus/NeXusException.hpp"
 #include "MantidNexus/NeXusFile.hpp"
+#include "MantidNexus/NexusClasses.h"
 
 #include <Poco/Path.h>
 

--- a/Framework/DataHandling/src/LoadILLTOF2.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF2.cpp
@@ -17,6 +17,7 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidNexus/NeXusException.hpp"
 #include "MantidNexus/NeXusFile.hpp"
+#include "MantidNexus/NexusClasses.h"
 
 namespace {
 /// An array containing the supported instrument names

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -26,6 +26,7 @@
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidNexus/NeXusFile.hpp"
+#include "MantidNexus/NexusClasses.h"
 
 #include <algorithm>
 #include <cctype>

--- a/Framework/DataHandling/src/LoadISISNexusHelper.cpp
+++ b/Framework/DataHandling/src/LoadISISNexusHelper.cpp
@@ -7,6 +7,7 @@
 #include "MantidDataHandling/LoadISISNexusHelper.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
+#include "MantidNexus/NexusClasses.h"
 namespace {
 static constexpr std::size_t RUN_TIME_STRING_LENGTH = 19;
 } // namespace

--- a/Framework/DataHandling/src/LoadMLZ.cpp
+++ b/Framework/DataHandling/src/LoadMLZ.cpp
@@ -20,6 +20,7 @@
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/UnitFactory.h"
+#include "MantidNexus/NexusClasses.h"
 
 #include <algorithm>
 #include <cmath>

--- a/Framework/DataHandling/src/LoadMuonNexusV2.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2.cpp
@@ -22,6 +22,7 @@
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/UnitLabelTypes.h"
+#include "MantidNexus/NexusClasses.h"
 
 #include <vector>
 

--- a/Framework/DataHandling/src/LoadMuonNexusV2NexusHelper.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2NexusHelper.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidNexus/NexusClasses.h"
 
 #include <algorithm>
 #include <cctype>

--- a/Framework/DataHandling/src/LoadMuonNexusV2NexusHelper.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2NexusHelper.cpp
@@ -15,7 +15,6 @@
 
 #include <algorithm>
 #include <cctype>
-#include <string>
 
 namespace {
 template <typename type> std::string convertVectorToString(const std::vector<type> &vector) {

--- a/Framework/DataHandling/src/LoadMuonNexusV2NexusHelper.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2NexusHelper.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <string>
 
 namespace {
 template <typename type> std::string convertVectorToString(const std::vector<type> &vector) {

--- a/Framework/DataHandling/src/LoadSINQFocus.cpp
+++ b/Framework/DataHandling/src/LoadSINQFocus.cpp
@@ -17,6 +17,7 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/UnitFactory.h"
+#include "MantidNexus/NexusClasses.h"
 
 #include <algorithm>
 #include <cmath>

--- a/Framework/DataHandling/src/LoadSINQFocus.cpp
+++ b/Framework/DataHandling/src/LoadSINQFocus.cpp
@@ -120,7 +120,7 @@ void LoadSINQFocus::setInstrumentName(const NeXus::NXEntry &entry) {
   }
   m_instrumentName = LoadHelper::getStringFromNexusPath(entry, m_instrumentPath + "/name");
   size_t pos = m_instrumentName.find(' ');
-  m_instrumentName = m_instrumentName.substr(0, pos);
+  m_instrumentName.erase(pos + 1, m_instrumentName.size());
 }
 
 void LoadSINQFocus::initWorkSpace(const NeXus::NXEntry &entry) {

--- a/Framework/DataHandling/src/MultiPeriodLoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/MultiPeriodLoadMuonStrategy.cpp
@@ -10,6 +10,7 @@
 #include "MantidDataHandling/LoadMuonNexusV2NexusHelper.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidNexus/NexusClasses.h"
 
 namespace Mantid::DataHandling {
 

--- a/Framework/DataHandling/src/PatchBBY.cpp
+++ b/Framework/DataHandling/src/PatchBBY.cpp
@@ -8,6 +8,7 @@
 #include "MantidAPI/FileProperty.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/PropertyWithValue.h"
+#include "MantidNexus/NexusClasses.h"
 
 #include <Poco/String.h>
 #include <Poco/TemporaryFile.h>

--- a/Framework/DataHandling/src/SinglePeriodLoadMuonStrategy.cpp
+++ b/Framework/DataHandling/src/SinglePeriodLoadMuonStrategy.cpp
@@ -10,6 +10,7 @@
 #include "MantidDataHandling/LoadMuonNexusV2NexusHelper.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidNexus/NexusClasses.h"
 
 namespace Mantid::DataHandling {
 

--- a/Framework/DataHandling/test/LoadSINQFocusTest.h
+++ b/Framework/DataHandling/test/LoadSINQFocusTest.h
@@ -11,6 +11,7 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidDataHandling/LoadSINQFocus.h"
+#include "MantidGeometry/Instrument.h"
 
 using namespace Mantid::API;
 using Mantid::DataHandling::LoadSINQFocus;
@@ -55,7 +56,7 @@ public:
     MatrixWorkspace_sptr output2D = std::dynamic_pointer_cast<MatrixWorkspace>(output);
 
     TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 375);
-
+    TS_ASSERT_EQUALS(output2D->getInstrument()->getName(), "FOCUS");
     AnalysisDataService::Instance().clear();
   }
 

--- a/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
+++ b/Framework/DataObjects/src/BoxControllerNeXusIO.cpp
@@ -257,10 +257,6 @@ void BoxControllerNeXusIO::prepareNxSToWrite_CurVersion() {
 void BoxControllerNeXusIO::prepareNxSdata_CurVersion() {
   // Open the data
   m_File->openData("event_data");
-  // There are rummors that this is faster. Not sure if it is important
-  //      int type = NXnumtype::FLOAT32;
-  //      int rank = 0;
-  //      NXgetinfo(file->getHandle(), &rank, dims, &type);
 
   NeXus::Info info = m_File->getInfo();
   NXnumtype Type = info.type;

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses_fwd.h
@@ -8,7 +8,7 @@
 
 namespace Mantid::NeXus {
 class NXClass;
-class NXClassInfo;
+struct NXClassInfo;
 class NXData;
 class NXEntry;
 class NXRoot;

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses_fwd.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses_fwd.h
@@ -1,0 +1,19 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2007 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+namespace Mantid::NeXus {
+class NXClass;
+class NXClassInfo;
+class NXData;
+class NXEntry;
+class NXRoot;
+template <typename T> class NXDataSetTyped;
+using NXInt = NXDataSetTyped<int>;
+using NXFloat = NXDataSetTyped<float>;
+using NXDouble = NXDataSetTyped<double>;
+} // namespace Mantid::NeXus

--- a/Framework/Nexus/src/NeXusException.cpp
+++ b/Framework/Nexus/src/NeXusException.cpp
@@ -1,6 +1,5 @@
 #include "MantidNexus/NeXusException.hpp"
-#include "MantidNexus/NeXusFile.hpp"
-#include "MantidNexus/napiconfig.h"
+#include "MantidNexus/NeXusFile_fwd.h"
 
 /**
  * \file NeXusException.cpp
@@ -9,10 +8,8 @@
 
 namespace NeXus {
 
-Exception::Exception(const std::string &msg, const NXstatus status) : std::runtime_error(msg) {
-  this->m_what = msg;
-  this->m_status = status;
-}
+Exception::Exception(const std::string &msg, const NXstatus status)
+    : std::runtime_error(msg), m_what(msg), m_status(status) {}
 
 const char *Exception::what() const throw() { return this->m_what.c_str(); }
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -388,7 +388,6 @@ unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/vms_co
 unusedStructMember:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/vms_convert.cpp:233
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/vms_convert.cpp:371
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/vms_convert.cpp:386
-uselessCallsSubstr:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadSINQFocus.cpp:122
 constParameterPointer:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadSpice2D.cpp:613
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadSpiceAscii.cpp:330
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp:453


### PR DESCRIPTION
### Description of work

#### Summary of work

Many classes inside the `DataHandling` package were importing the `NexusClasses.h` header into their own headers.  The `NexusClasses` header has a lot of implementation of template classes with one very long `load` function, that is then being passed around everywhere, no doubt clogging up compile times.

This creates a `NexusClasses_fwd.h` to forward-declare everything needed by these includes, without including the entire class definitions.  Any header including `NexusClasses.h` should include `NexusClasses_fwd.h` instead.  The `NexusClasses.h` should only be included inside `.cpp` files, never header files.

Related to Plan #38332 

<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Inside any `.h` file, the change was `NexusClasses.h` --> `NexusClasses_fwd.h`.

Inside the `,cpp` files, the change was to include `NexusClasses.h`.

Inside some files related to DataBlock, it was necessary to include some standard headers, namely algorithm, vector, and memory.  These are for a sort operation, a vector property, and a unique_ptr property.

There were two other cleanups handled, namely the removal of a comment, and fixing `NexusException` to have fewer includes and a better constructor.

If it compiles, then it should be good.

Update:

Got a CppCheck error, so fixed the suppressed issue and added a test to ensure continuity of behavior.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
