### PR TITLE
Take into account period filtering in getProtonCharge

### DIFF
--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -207,7 +207,7 @@ public:
   bool operator!=(const LogManager &other) const;
 
   const std::string &getProtonChargeLogName() const { return PROTON_CHARGE_LOG_NAME; }
-  const std::string getProtonChargeUnfilteredName() const { return PROTON_CHARGE_LOG_NAME + "_unfiltered"; }
+  const std::string &getProtonChargeUnfilteredName() const { return PROTON_CHARGE_UNFILTERED_LOG_NAME; }
 
 protected:
   bool hasStartTime() const;
@@ -223,6 +223,8 @@ protected:
   /// Name of the log entry containing the proton charge when retrieved using
   /// getProtonCharge
   static const std::string PROTON_CHARGE_LOG_NAME;
+  /// Flag to signify if a filter has been applied to getProtonCharge
+  static const std::string PROTON_CHARGE_UNFILTERED_LOG_NAME;
 
 private:
   /// Cache for the retrieved single values

--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -223,7 +223,7 @@ protected:
   /// Name of the log entry containing the proton charge when retrieved using
   /// getProtonCharge
   static const std::string PROTON_CHARGE_LOG_NAME;
-  /// Flag to signify if a filter has been applied to getProtonCharge
+  /// Flag to signify if a filter has been applied to the proton charge log
   static const std::string PROTON_CHARGE_UNFILTERED_LOG_NAME;
 
 private:

--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -206,6 +206,9 @@ public:
   bool operator==(const LogManager &other) const;
   bool operator!=(const LogManager &other) const;
 
+  const std::string &getProtonChargeLogName() const { return PROTON_CHARGE_LOG_NAME; }
+  const std::string getProtonChargeUnfilteredName() const { return PROTON_CHARGE_LOG_NAME + "_unfiltered"; }
+
 protected:
   bool hasStartTime() const;
   bool hasEndTime() const;
@@ -219,7 +222,7 @@ protected:
   std::unique_ptr<Kernel::TimeROI> m_timeroi;
   /// Name of the log entry containing the proton charge when retrieved using
   /// getProtonCharge
-  static const char *PROTON_CHARGE_LOG_NAME;
+  static const std::string PROTON_CHARGE_LOG_NAME;
 
 private:
   /// Cache for the retrieved single values

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -80,6 +80,7 @@ bool convertPropertyToDouble(const Property *property, double &value, const Math
 /// Name of the log entry containing the proton charge when retrieved using
 /// getProtonCharge
 const std::string LogManager::PROTON_CHARGE_LOG_NAME = "gd_prtn_chrg";
+const std::string LogManager::PROTON_CHARGE_UNFILTERED_LOG_NAME = LogManager::PROTON_CHARGE_LOG_NAME + "_unfiltered";
 
 //----------------------------------------------------------------------
 // Public member functions

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -79,7 +79,8 @@ bool convertPropertyToDouble(const Property *property, double &value, const Math
 
 /// Name of the log entry containing the proton charge when retrieved using
 /// getProtonCharge
-const char *LogManager::PROTON_CHARGE_LOG_NAME = "gd_prtn_chrg";
+const std::string LogManager::PROTON_CHARGE_LOG_NAME = "gd_prtn_chrg";
+
 //----------------------------------------------------------------------
 // Public member functions
 //----------------------------------------------------------------------

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -339,8 +339,7 @@ void Run::integrateProtonCharge(const std::string &logname) const {
     const_cast<Run *>(this)->setProtonCharge(total);
     // Mark gd_prtn_chrg as filtered as this method accounts for period filtering
     const auto proton_charge_unfiltered_name = getProtonChargeUnfilteredName();
-    if (m_manager->existsProperty(proton_charge_unfiltered_name) &&
-        m_manager->getProperty(proton_charge_unfiltered_name)) {
+    if (m_manager->existsProperty(proton_charge_unfiltered_name)) {
       m_manager->setProperty(proton_charge_unfiltered_name, false);
     }
 

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -259,15 +259,14 @@ double Run::getProtonCharge() const {
     return charge;
   }
 
-  const auto proton_charge_unfiltered_name = getProtonChargeUnfilteredName();
   if (!m_manager->existsProperty(PROTON_CHARGE_LOG_NAME)) {
     integrateProtonCharge();
-  } else if (m_manager->existsProperty(proton_charge_unfiltered_name) &&
-             m_manager->getProperty(proton_charge_unfiltered_name)) {
+  } else if (m_manager->existsProperty(PROTON_CHARGE_UNFILTERED_LOG_NAME) &&
+             m_manager->getProperty(PROTON_CHARGE_UNFILTERED_LOG_NAME)) {
     const std::vector<double> &protonChargeByPeriod = m_manager->getProperty("proton_charge_by_period");
     const int currentPeriod = m_manager->getProperty("current_period");
     m_manager->setProperty(PROTON_CHARGE_LOG_NAME, protonChargeByPeriod[currentPeriod - 1]);
-    m_manager->setProperty(proton_charge_unfiltered_name, false);
+    m_manager->setProperty(PROTON_CHARGE_UNFILTERED_LOG_NAME, false);
   }
 
   if (m_manager->existsProperty(PROTON_CHARGE_LOG_NAME)) {
@@ -338,9 +337,8 @@ void Run::integrateProtonCharge(const std::string &logname) const {
     }
     const_cast<Run *>(this)->setProtonCharge(total);
     // Mark gd_prtn_chrg as filtered as this method accounts for period filtering
-    const auto proton_charge_unfiltered_name = getProtonChargeUnfilteredName();
-    if (m_manager->existsProperty(proton_charge_unfiltered_name)) {
-      m_manager->setProperty(proton_charge_unfiltered_name, false);
+    if (m_manager->existsProperty(PROTON_CHARGE_UNFILTERED_LOG_NAME)) {
+      m_manager->setProperty(PROTON_CHARGE_UNFILTERED_LOG_NAME, false);
     }
 
   } else {

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -607,13 +607,13 @@ void LoadNexusLogs::execLoader() {
 
   if (!workspace->run().hasProperty(workspace->run().getProtonChargeLogName())) {
     try {
-      // For period data mark proton charge log value as unfiltered to enable subsequent filtering.
+      // For period data mark proton charge log value as unfiltered to enable subsequent filtering by period.
       if (workspace->run().hasProperty("proton_charge_by_period")) {
         Kernel::PropertyWithValue<bool> *pChargeUnfiltered =
             new Kernel::PropertyWithValue<bool>(workspace->run().getProtonChargeUnfilteredName(), true);
         workspace->mutableRun().addProperty(pChargeUnfiltered, true);
       }
-      // Try pulling proton charge it from the main proton_charge entry
+      // Try pulling proton charge from the main proton_charge entry
       file.openData("proton_charge");
       std::vector<double> values;
       file.getDataCoerce(values);

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -605,9 +605,15 @@ void LoadNexusLogs::execLoader() {
     }
   }
 
-  if (!workspace->run().hasProperty("gd_prtn_chrg")) {
-    // Try pulling it from the main proton_charge entry first
+  if (!workspace->run().hasProperty(workspace->run().getProtonChargeLogName())) {
     try {
+      // For period data mark proton charge log value as unfiltered to enable subsequent filtering.
+      if (workspace->run().hasProperty("proton_charge_by_period")) {
+        Kernel::PropertyWithValue<bool> *pChargeUnfiltered =
+            new Kernel::PropertyWithValue<bool>(workspace->run().getProtonChargeUnfilteredName(), true);
+        workspace->mutableRun().addProperty(pChargeUnfiltered, true);
+      }
+      // Try pulling proton charge it from the main proton_charge entry
       file.openData("proton_charge");
       std::vector<double> values;
       file.getDataCoerce(values);

--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -88,8 +88,9 @@ public:
     const API::Run &run = testWS->run();
     const std::vector<Property *> &logs = run.getLogData();
     TS_ASSERT_EQUALS(logs.size(),
-                     36); // 34 logs in file + 1 synthetic nperiods log
+                     37); // 34 logs in file + 1 synthetic nperiods log
                           // + 1 proton_charge_by_period log
+                          // + 1 gd_prtn_chrg_unfiltered log
 
     TimeSeriesProperty<std::string> *slog =
         dynamic_cast<TimeSeriesProperty<std::string> *>(run.getLogData("icp_event"));
@@ -359,6 +360,7 @@ public:
     allowed.push_back("gd_prtn_chrg");
     allowed.push_back("proton_charge_by_period");
     allowed.push_back("nperiods");
+    allowed.push_back("gd_prtn_chrg_unfiltered");
 
     // The default logs that are always present:
     allowed.push_back("start_time");
@@ -406,7 +408,7 @@ public:
     auto properties = run.getProperties();
 
     // add 2 to account for selog_ versions of properties
-    TS_ASSERT_EQUALS(properties.size(), 94 - blocked.size() - 2);
+    TS_ASSERT_EQUALS(properties.size(), 95 - blocked.size() - 2);
 
     // Lookup each name in the workspace property list
     for (const auto &name : blocked) {
@@ -440,7 +442,7 @@ public:
     auto run = testWS->run();
     auto properties = run.getProperties();
 
-    TS_ASSERT_EQUALS(properties.size(), 94);
+    TS_ASSERT_EQUALS(properties.size(), 95);
   }
 
 private:

--- a/Framework/PythonInterface/test/python/mantid/api/RunTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/RunTest.py
@@ -38,6 +38,19 @@ class RunTest(unittest.TestCase):
         self.assertEqual(type(charge), float)
         self.assertAlmostEqual(charge, 10.05)
 
+    def test_proton_charge_accounts_for_period_filtering(self):
+        run = self._run
+        run.addProperty("gd_prtn_chrg_unfiltered", True, True)
+        run.addProperty("proton_charge_by_period", [6.0, 4.05], True)
+        run.addProperty("current_period", 1, True)
+        charge = run.getProtonCharge()
+        self.assertAlmostEqual(charge, 6.0)
+
+        run.addProperty("gd_prtn_chrg_unfiltered", True, True)
+        run.addProperty("current_period", 2, True)
+        charge = run.getProtonCharge()
+        self.assertAlmostEqual(charge, 4.05)
+
     def test_get_time_roi(self):
         # there is intentionally no way create a TimeROI from python
         run = Run()

--- a/docs/source/release/v6.13.0/Framework/Bugfixes/39020.rst
+++ b/docs/source/release/v6.13.0/Framework/Bugfixes/39020.rst
@@ -1,0 +1,1 @@
+- ``getProtonCharge`` method of ``Run`` object was modified to account for period filtering on multi-period NeXus files.

--- a/docs/source/release/v6.13.0/Framework/Bugfixes/39020.rst
+++ b/docs/source/release/v6.13.0/Framework/Bugfixes/39020.rst
@@ -1,1 +1,1 @@
-- ``getProtonCharge`` method of ``Run`` object was modified to account for period filtering on multi-period NeXus files.
+- ``getProtonCharge`` method of ``Run`` object now consistently returns a period filtered log value when called on multi-period NeXus files.


### PR DESCRIPTION
### Description of work

Currently the total proton charge is read from a NeXus file into the `gd_prtn_chrg` property.

The value of this property is returned by the `getProtonCharge()` function of a `Run` object.

If a NeXuS file has multiple periods, a workspace is produced for each period with a filter applied to remove data outside of the period.

When this filtering takes place, time-series properties are amended to suit, but single value properties such as `gd_prtn_chrg` are not. This means that `getProtonCharge` returns a value that represents the total proton charge across all periods, irrespective of the period filter.

This PR introduces a flag which enables the `gd_prtn_chrg` property to be updated to account for period filtering on the first call of  `getProtonCharge()` on a run object.

An alternative approach would have just been for period data to initially not add the  `gd_prtn_chrg` property at all. In this instance when `getProtonCharge()` was called a method to compute `gd_prtn_chrg` via integration would have been called. I decided against this as I was concerned that (A) somewhere the `gd_prtn_chrg` property could be accessed directly without checking if it exists (B) integration returns a slightly different result when compared to the `proton_charge_by_period` property.

Fixes #39020

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

Run the example in the issue and observe output.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
