### PR TITLE
Add caching mechanism to GetIPTS

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -59,6 +59,7 @@ set(TEST_PY_FILES
     GenerateGroupingSNSInelasticTest.py
     GenerateLogbookTest.py
     GetEiT0atSNSTest.py
+    GetIPTSTest.py
     GroupBySampleChangerPositionTest.py
     HB2AReduceTest.py
     HB3AAdjustSampleNormTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/GetIPTSTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/GetIPTSTest.py
@@ -1,0 +1,60 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+from mantid.simpleapi import GetIPTS
+
+
+class GetIPTSTest(unittest.TestCase):
+    @mock.patch("plugins.algorithms.GetIPTS.GetIPTS.findFile")
+    def test_getIPTS_bad(self, mockFindFile):
+        mockFindFile.return_value = "nowhere/"
+        runNumber = "123456"
+        with self.assertRaises(RuntimeError) as context:
+            GetIPTS(RunNumber=runNumber, Instrument="SNAP")
+        assert "Failed to determine IPTS directory" in str(context.exception)
+
+    @mock.patch("plugins.algorithms.GetIPTS.GetIPTS.findFile")
+    def test_getIPTS_good(self, mockFindFile):
+        mockFindFile.return_value = "somewhere/IPTS/folder"
+        runNumber = "123456"
+        res = GetIPTS(RunNumber=runNumber, Instrument="SNAP")
+        assert res == "somewhere/IPTS/"
+
+    @mock.patch("plugins.algorithms.GetIPTS.FileFinder")
+    def test_getIPTS_cache(self, mockFileFinder):
+        mockFileFinder.findRuns.return_value = ["somewhere/IPTS/folder"]
+        runNumber = "123456"
+        res = GetIPTS(RunNumber=runNumber, Instrument="SNAP", ClearCache=True)
+        assert res == "somewhere/IPTS/"
+        mockFileFinder.findRuns.assert_called_once_with(f"SNAP_{runNumber}")
+
+        # call again -- still only called once
+        res = GetIPTS(RunNumber=runNumber, Instrument="SNAP")
+        mockFileFinder.findRuns.assert_called_once_with(f"SNAP_{runNumber}")
+
+    @mock.patch("plugins.algorithms.GetIPTS.FileFinder")
+    def test_getIPTS_cache_clear(self, mockFileFinder):
+        mockFileFinder.findRuns.return_value = ["somewhere/IPTS/folder"]
+        runNumber = "123456"
+        res = GetIPTS(RunNumber=runNumber, Instrument="SNAP", ClearCache=True)
+        assert res == "somewhere/IPTS/"
+        mockFileFinder.findRuns.assert_called_once_with(f"SNAP_{runNumber}")
+
+        # call again -- still only called once
+        res = GetIPTS(RunNumber=runNumber, Instrument="SNAP")
+        mockFileFinder.findRuns.assert_called_once_with(f"SNAP_{runNumber}")
+
+        # clear cache
+        res = GetIPTS(RunNumber=runNumber, Instrument="SNAP", ClearCache=True)
+        with self.assertRaises(AssertionError):
+            mockFileFinder.findRuns.assert_called_once_with(f"SNAP_{runNumber}")
+        assert mockFileFinder.findRuns.call_count == 2
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/source/algorithms/GetIPTS-v1.rst
+++ b/docs/source/algorithms/GetIPTS-v1.rst
@@ -13,6 +13,9 @@ Description
 This returns a string the full path to the IPTS shared folder to allow
 for saving of files in accessible user folders (e.g. ``shared``).
 
+The algorithm has a cache of runnumbers that is stores while mantid is running.
+This cache can be reset using the ``ClearCache`` argument or by restarting mantid.
+
 .. warning::
 
     This only works at ORNL.

--- a/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39032.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39032.rst
@@ -1,0 +1,1 @@
+- New option in :ref:`algm-GetIPTS` to maintain a list of IPTS for supplied runs. This does not persist across sessions.


### PR DESCRIPTION
Often a user looks at runs from the same proposal. This adds a cache for run information within a single session of mantid to speed up repeatedly getting information on a run.

This also introduces a unit test.

*There is no associated issue.*

### To test:

This only works with the actual HFIR/SNS data mount in place.
1. Set the log level to DEBUG
2. Run `GetIPTS` twice with the same run number. The first time there will be a log message about FileFinder/ArchiveSearch finding the run. The second time there will not be.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
