### PR TITLE
Remove fix for IB21 for C1 and Ci symmetries

### DIFF
--- a/Framework/CurveFitting/src/Functions/CrystalFieldPeaksBase.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldPeaksBase.cpp
@@ -50,8 +50,6 @@ void setSymmetryC1(API::IFunction &fun) {
   for (; i < fun.nParams(); ++i) {
     fun.unfix(i);
   }
-  fun.setParameter("IB21", 0.0);
-  fun.fixParameter("IB21");
 }
 
 // Set symmetry C2, Cs or C2h

--- a/Framework/CurveFitting/test/Functions/CrystalFieldPeaksTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldPeaksTest.h
@@ -230,7 +230,7 @@ public:
     fun.setAttributeValue("Ion", "Ce");
     TS_ASSERT(!isFixed(fun, "B20"));
     TS_ASSERT(!isFixed(fun, "B21"));
-    TS_ASSERT(isFixed(fun, "IB21"));
+    TS_ASSERT(!isFixed(fun, "IB21"));
     TS_ASSERT(!isFixed(fun, "B22"));
     TS_ASSERT(!isFixed(fun, "IB22"));
 

--- a/docs/source/release/v6.13.0/Direct_Geometry/CrystalField/Bugfixes/39039.rst
+++ b/docs/source/release/v6.13.0/Direct_Geometry/CrystalField/Bugfixes/39039.rst
@@ -1,1 +1,1 @@
-- Removed unnecessary fix for IB21 for C1 and Ci symmetries in the Crystal Field peak base function.
+- Removed unnecessary fix for IB21 for C1 and Ci symmetries in the Crystal Field peak base function to match the documentation: https://docs.mantidproject.org/nightly/concepts/CrystalField.html#appendix-b-tables

--- a/docs/source/release/v6.13.0/Direct_Geometry/CrystalField/Bugfixes/39039.rst
+++ b/docs/source/release/v6.13.0/Direct_Geometry/CrystalField/Bugfixes/39039.rst
@@ -1,0 +1,1 @@
+- Removed unnecessary fix for IB21 for C1 and Ci symmetries in the Crystal Field peak base function.


### PR DESCRIPTION
### Description of work

Removed unnecessary fix for IB21 for C1 and Ci symmetries in the Crystal Field peak base function.

Fixes #[39038](https://github.com/mantidproject/mantid/issues/39038)

### To test:

Compare the code change with the corresponding entry in the symmetry table in https://docs.mantidproject.org/nightly/concepts/CrystalField.html#crystal-field-theory.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
