### PR TITLE
Add PeakShapeDetectorBin to IntegratePeaks1DProfile peak integration algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaks1DProfile.py
@@ -281,10 +281,6 @@ class IntegratePeaks1DProfile(DataProcessorAlgorithm):
         return issues
 
     def PyExec(self):
-        import pydevd_pycharm
-
-        pydevd_pycharm.settrace(stdoutToServer=True, stderrToServer=True)
-
         # get input
         ws = self.getProperty("InputWorkspace").value
         peaks = self.getProperty("PeaksWorkspace").value
@@ -449,8 +445,9 @@ class IntegratePeaks1DProfile(DataProcessorAlgorithm):
 
     def _set_peak_shape(self, peak, det_ids, fit_limits):
         det_bin_list = []
-        for detid, (startx, endx) in zip(det_ids, fit_limits):
-            det_bin_list.append((int(detid), startx, endx))
+        for detid, limits in zip(det_ids, fit_limits):
+            if limits:
+                det_bin_list.append((int(detid), limits[0], limits[-1]))
         if len(det_bin_list) > 0:
             peak_shape = PeakShapeDetectorBin(det_bin_list, SpecialCoordinateSystem.NONE, self.name(), self.version())
             peak.setPeakShape(peak_shape)

--- a/docs/source/release/v6.13.0/Diffraction/Single_Crystal/New_features/38969.rst
+++ b/docs/source/release/v6.13.0/Diffraction/Single_Crystal/New_features/38969.rst
@@ -1,0 +1,2 @@
+- Added ``detectorbin`` peak shape for the peaks integrated with :ref:`IntegratePeaks1DProfile <algm-IntegratePeaks1DProfile>` integration algorithm.
+- By accessing the detectorbin peak shape, users can now view the detector IDs and the corresponding range in the X dimension associated with each detector for each successfully integrated peak from the algorithm.


### PR DESCRIPTION
### Description of work
Following on from https://github.com/mantidproject/mantid/pull/38452 - this issue is to add the peak shape to the peak objects in the output table from `IntegratePeaks1DProfile`. Each successfully integrated peaks from `IntegratePeaks1DProfile` algorithm will now have detectorbin peak shape associated with it.

Fixes #38969. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
1. Run below code and generate output.pdf file
```
ws=Load(Filename="SXD34361.nxs")
peaks=FindSXPeaksConvolve(InputWorkspace=ws, PeaksWorkspace="peaks", ThresholdIoverSigma=50)
profile_kwargs = {
            "GetNBinsFromBackToBackParams": True,
            "CostFunction": "RSq",
            "IntegrateIfOnEdge": True,
            "LorentzCorrection": False,
            "IOverSigmaThreshold": 20,
            "NRowsEdge": 1,
            "NColsEdge": 1,
            "outputFile": "path/to/output.pdf"
        }
int_peaks=IntegratePeaks1DProfile(Inputworkspace=ws, PeaksWorkspace=peaks, OutputWorkspace="intpeaks1dprof", **profile_kwargs)
```
2. Access the shape of each of the peaks in `int_peaks` workspace as below and cross check with the results in output.pdf file.
```
for ipk, pk in enumerate(int_peaks):
    print(f"{ipk} - {pk.getPeakShape().toJSON()}")
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
