### PR TITLE
Revert "Update quickbayes in standalone to 1.0.1b0"

### DIFF
--- a/docs/source/release/v6.13.0/Workbench/New_features/39014.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/39014.rst
@@ -1,1 +1,0 @@
-- The ``quickbayes`` package distributed in the installer has been updated from version 1.0.0b15 to 1.0.1b0.

--- a/installers/conda/linux/create_tarball.sh
+++ b/installers/conda/linux/create_tarball.sh
@@ -157,7 +157,7 @@ echo
 "$CONDA_EXE" remove --quiet --prefix "$bundle_conda_prefix" --yes jq
 
 # Pip install quickBayes until there's a conda package
-$bundle_conda_prefix/bin/python -m pip install quickBayes==1.0.1b0
+$bundle_conda_prefix/bin/python -m pip install quickBayes==1.0.0b15
 
 # Trim and fixup bundle
 trim_conda "$bundle_conda_prefix"

--- a/installers/conda/osx/create_bundle.sh
+++ b/installers/conda/osx/create_bundle.sh
@@ -226,7 +226,7 @@ echo
 "$CONDA_EXE" remove --quiet --prefix "$bundle_conda_prefix" --yes jq
 
 # Pip install quickBayes until there's a conda package
-$bundle_conda_prefix/bin/python -m pip install quickBayes==1.0.1b0
+$bundle_conda_prefix/bin/python -m pip install quickBayes==1.0.0b15
 
 # Trim and fixup bundle
 trim_conda "$bundle_conda_prefix"

--- a/installers/conda/win/create_package.sh
+++ b/installers/conda/win/create_package.sh
@@ -95,7 +95,7 @@ echo "Removing jq from conda env"
 echo "jq removed from conda env"
 
 # Pip install quickBayes until there's a conda package
-$CONDA_ENV_PATH/python.exe -m pip install quickBayes==1.0.1b0
+$CONDA_ENV_PATH/python.exe -m pip install quickBayes==1.0.0b15
 
 
 echo "Copying root packages of env files (Python, DLLs, Lib, Scripts, ucrt, and msvc files) to package/bin"


### PR DESCRIPTION
This newer version of quickBayes is not compatible with BayesQuasi2 algorithm. Code changes are required in mantid to comply with the changes to the quickBayes API.