### PR TITLE
Exposing more Instrument methods to python

### DIFF
--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
@@ -11,6 +11,7 @@
 #include "MantidPythonInterface/core/Policies/RemoveConst.h"
 
 #include <boost/python/class.hpp>
+#include <boost/python/copy_const_reference.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
@@ -73,6 +74,12 @@ void export_Instrument() {
       .def("getValidToDate", &Instrument::getValidToDate, arg("self"),
            "Return the valid to :class:`~mantid.kernel.DateAndTime` of the "
            "instrument")
+
+      .def("getFilename", &Instrument::getFilename, arg("self"), return_value_policy<copy_const_reference>(),
+           "Return the name of the file that the original IDF was from")
+
+      .def("setFilename", &Instrument::setFilename, (arg("self"), arg("filename")),
+           "Set the name of the file that the original IDF was from")
 
       .def("getBaseInstrument", &Instrument::baseInstrument, arg("self"), return_value_policy<RemoveConstSharedPtr>(),
            "Return reference to the base instrument")

--- a/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
@@ -44,6 +44,20 @@ class InstrumentTest(unittest.TestCase):
         frame = self.__testws.getInstrument().getReferenceFrame()
         self.assertTrue(isinstance(frame, ReferenceFrame))
 
+    def test_getFilename(self):
+        inst = self.__testws.getInstrument()
+
+        # get the filename
+        NAME_ORIG = inst.getFilename()
+
+        # check that the filename can be set
+        NAME_NEW = "testable"
+        inst.setFilename(NAME_NEW)
+        self.assertEqual(inst.getFilename(), NAME_NEW)
+
+        # put the filename back to what it was
+        inst.setFilename(NAME_ORIG)
+
     def test_ValidDates(self):
         inst = self.__testws.getInstrument()
         valid_from = inst.getValidFromDate()

--- a/docs/source/release/v6.13.0/Framework/Python/New_features/39044.rst
+++ b/docs/source/release/v6.13.0/Framework/Python/New_features/39044.rst
@@ -1,0 +1,1 @@
+- Exposed ``Instrument.getFilename()`` and ``Instrument.setFilename()`` to python


### PR DESCRIPTION
People wanted to know what filenamethe IDF came from in python. This exposes that information.

*There is no associated issue.*

### To test:

The additional unit test shows a great example.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
