### PR TITLE
Fix for User Function Dialog button hidden behind scroll bar

### DIFF
--- a/docs/source/release/v6.13.0/Framework/Fit_Functions/Bugfixes/39049.rst
+++ b/docs/source/release/v6.13.0/Framework/Fit_Functions/Bugfixes/39049.rst
@@ -1,0 +1,1 @@
+- Fixed the user defined fit function box hidden behind a scroll bar.

--- a/docs/source/release/v6.13.0/Framework/Fit_Functions/Bugfixes/39049.rst
+++ b/docs/source/release/v6.13.0/Framework/Fit_Functions/Bugfixes/39049.rst
@@ -1,1 +1,0 @@
-- Fixed the user defined fit function box hidden behind a scroll bar.

--- a/docs/source/release/v6.13.0/Workbench/Bugfixes/39049.rst
+++ b/docs/source/release/v6.13.0/Workbench/Bugfixes/39049.rst
@@ -1,0 +1,1 @@
+- The ``...`` button for a :ref:`user defined function <user_defined_function>` is no longer obscured by the scroll bar in the :ref:`Fit Property Browser <WorkbenchPlotWindow_Fitting>` on macOS.

--- a/docs/source/tutorials/mantid_basic_course/fitting_data/03_fit_model_choices.rst
+++ b/docs/source/tutorials/mantid_basic_course/fitting_data/03_fit_model_choices.rst
@@ -51,6 +51,8 @@ Next, add the other function : `GausOsc` and run the Fit again. You should find 
 Custom fitting function
 =======================
 
+.. _user_defined_function:
+
 User defined function
 ---------------------
 

--- a/qt/widgets/common/src/QtPropertyBrowser/StringDialogEditor.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/StringDialogEditor.cpp
@@ -43,8 +43,7 @@ StringDialogEditor::StringDialogEditor(QtProperty *property, QWidget *parent) : 
   button->setMaximumSize(20, 1000000);
   connect(button, SIGNAL(clicked()), this, SLOT(runDialog()));
   layout->addWidget(button);
-  layout->setContentsMargins(0, 0, 0, 0);
-  layout->setSpacing(0);
+  layout->setContentsMargins(0, 0, 20, 0);
   layout->setStretchFactor(button, 0);
   this->setLayout(layout);
 }


### PR DESCRIPTION
### Description of work

On macOS, a scroll bar made it impossible to click the `User Function Dialog` button in the `Formula` box for the fit toolbar on a plot. Removing the 0 spacing setting and increasing the margin to the right for the `User Function Dialog` button solved this problem.

Fixes #[37579](https://github.com/mantidproject/mantid/issues/37579)

### To test:

Follow the instructions in the original issue on macOS.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
