### PR TITLE
create specialized vector 3D comparison operators

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -300,13 +300,12 @@ inline bool TableColumn<API::Boolean>::compareVectors(const std::vector<API::Boo
 template <>
 inline bool TableColumn<Kernel::V3D>::compareVectors(const std::vector<Kernel::V3D> &newVector, double tolerance,
                                                      bool const nanEqual) const {
-  for (size_t i = 0; i < m_data.size(); i++) {
-    for (std::size_t xyz = 0; xyz < m_data[i].size(); xyz++) {
-      double left = m_data[i][xyz], right = newVector[i][xyz];
-      if (nanEqual && std::isnan(left) && isnan(right))
-        continue;
-      else if (!Kernel::withinAbsoluteDifference(left, right, tolerance))
-        return false;
+  // must specify for it to use pass-by-references
+  for (std::size_t i = 0; i < m_data.size(); i++) {
+    if (nanEqual && Kernel::V3D::isnan(m_data[i]) && Kernel::V3D::isnan(newVector[i])) {
+      continue;
+    } else if (!Kernel::withinAbsoluteDifference(m_data[i], newVector[i], tolerance)) {
+      return false;
     }
   }
   return true;
@@ -330,13 +329,12 @@ inline bool TableColumn<API::Boolean>::compareVectorsRelError(const std::vector<
 template <>
 inline bool TableColumn<Kernel::V3D>::compareVectorsRelError(const std::vector<Kernel::V3D> &newVector,
                                                              double tolerance, bool const nanEqual) const {
+  // must specify for it to use pass-by-references
   for (size_t i = 0; i < m_data.size(); i++) {
-    for (std::size_t xyz = 0; xyz < m_data[i].size(); xyz++) {
-      double left = m_data[i][xyz], right = newVector[i][xyz];
-      if (nanEqual && std::isnan(left) && isnan(right))
-        continue;
-      else if (!Kernel::withinRelativeDifference(m_data[i][xyz], newVector[i][xyz], tolerance))
-        return false;
+    if (nanEqual && Kernel::V3D::isnan(m_data[i]) && Kernel::V3D::isnan(newVector[i])) {
+      continue;
+    } else if (!Kernel::withinRelativeDifference(m_data[i], newVector[i], tolerance)) {
+      return false;
     }
   }
   return true;

--- a/Framework/Kernel/inc/MantidKernel/V3D.h
+++ b/Framework/Kernel/inc/MantidKernel/V3D.h
@@ -331,6 +331,9 @@ public:
   void saveNexus(::NeXus::File *file, const std::string &name) const;
   void loadNexus(::NeXus::File *file, const std::string &name);
 
+  /// @brief  Determine if a V3D can be considered nan
+  /// @param vec
+  /// @return True if any of x, y, or z is nan; False otherwise
   static bool isnan(V3D const &vec) { return (std::isnan(vec.X()) || std::isnan(vec.Y()) || std::isnan(vec.Z())); }
 
 private:

--- a/Framework/Kernel/inc/MantidKernel/V3D.h
+++ b/Framework/Kernel/inc/MantidKernel/V3D.h
@@ -300,7 +300,7 @@ public:
   /// Direction angles
   V3D directionAngles(bool inDegrees = true) const;
   /// Maximum absolute integer value
-  int maxCoeff();
+  int maxCoeff() const;
   /// Absolute value
   V3D absoluteValue() const;
   /// Calculates the error in hkl
@@ -330,6 +330,8 @@ public:
 
   void saveNexus(::NeXus::File *file, const std::string &name) const;
   void loadNexus(::NeXus::File *file, const std::string &name);
+
+  static bool isnan(V3D vec) { return (std::isnan(vec[0]) || std::isnan(vec[1]) || std::isnan(vec[2])); }
 
 private:
   std::array<double, 3> m_pt;

--- a/Framework/Kernel/inc/MantidKernel/V3D.h
+++ b/Framework/Kernel/inc/MantidKernel/V3D.h
@@ -331,7 +331,7 @@ public:
   void saveNexus(::NeXus::File *file, const std::string &name) const;
   void loadNexus(::NeXus::File *file, const std::string &name);
 
-  static bool isnan(V3D vec) { return (std::isnan(vec[0]) || std::isnan(vec[1]) || std::isnan(vec[2])); }
+  static bool isnan(V3D const &vec) { return (std::isnan(vec.X()) || std::isnan(vec.Y()) || std::isnan(vec.Z())); }
 
 private:
   std::array<double, 3> m_pt;

--- a/Framework/Kernel/src/FloatingPointComparison.cpp
+++ b/Framework/Kernel/src/FloatingPointComparison.cpp
@@ -318,6 +318,7 @@ template <> DLLExport bool withinAbsoluteDifference<V3D, double>(V3D const V1, V
  */
 template <> DLLExport bool withinRelativeDifference<V3D, double>(V3D const V1, V3D const V2, double const tolerance) {
   // NOTE we must avoid sqrt as much as possible
+  // cppcheck-suppress variableScope
   double tol2 = tolerance * tolerance;
   double diff2 = (V1 - V2).norm2(), denom4;
   if (diff2 < 1 && diff2 <= std::numeric_limits<double>::epsilon()) {

--- a/Framework/Kernel/src/FloatingPointComparison.cpp
+++ b/Framework/Kernel/src/FloatingPointComparison.cpp
@@ -165,7 +165,7 @@ inline bool withinAbsoluteDifference(T const x, T const y, S const tolerance, MA
   // handle the case of infinities
   if (std::isinf(x) && std::isinf(y))
     // if both are +inf, return true; if both -inf, return true; else false
-    return isnan(static_cast<S>(x - y));
+    return std::isnan(static_cast<S>(x - y));
   return ltEquals(static_cast<S>(absoluteDifference<T>(x, y)), tolerance);
 }
 
@@ -285,5 +285,75 @@ template DLLExport bool withinRelativeDifference<long long, double>(long long co
 template DLLExport bool withinRelativeDifference<unsigned long long, double>(unsigned long long const,
                                                                              unsigned long long const, double const);
 ///@endcond
+
+/// Template specialization for V3D
+
+/**
+ * Compare 3D vectors (class V3D) for absolute difference to
+ * within the given tolerance.  The ansolute difference is calculated as
+ *   abs diff = ||V1 - V2||
+ * consistent with other normalized vector binary operations.
+ * @param V1 :: first value
+ * @param V2 :: second value
+ * @param tolerance :: the tolerance
+ * @returns True if the vectorsare considered equal within the given tolerance,
+ * false otherwise.  False if any value in either vector is an NaN.
+ */
+template <> DLLExport bool withinAbsoluteDifference<V3D, double>(V3D const V1, V3D const V2, double const tolerance) {
+  // we want ||V1-V2|| < tol
+  // NOTE ||V1-V2||^2 < tol^2 --> ||V1-V2|| < tol, since both are non-negative
+  return ltEquals((V1 - V2).norm2(), tolerance * tolerance);
+}
+
+/**
+ * Compare 3D vectors (class V3D) for relative difference to
+ * within the given tolerance.  The relative difference is calculated as
+ *   rel diff = ||V1 - V2||/sqrt(||V1||*||V2||)
+ * consistent with other normalized vector binary operations.
+ * @param V1 :: first value
+ * @param V2 :: second value
+ * @param tolerance :: the tolerance
+ * @returns True if the vectorsare considered equal within the given tolerance,
+ * false otherwise.  False if any value in either vector is an NaN.
+ */
+template <> DLLExport bool withinRelativeDifference<V3D, double>(V3D const V1, V3D const V2, double const tolerance) {
+  // NOTE we must avoid sqrt as much as possible
+  double tol2 = tolerance * tolerance;
+  double diff2 = (V1 - V2).norm2(), denom4;
+  if (diff2 < 1 && diff2 <= std::numeric_limits<double>::epsilon()) {
+    // make sure not due to underflow
+    double const scale = std::max({V1.X(), V1.Y(), V1.Z()});
+    if (scale < 1 && scale * scale < std::numeric_limits<double>::epsilon()) {
+      V3D const v1 = V1 / scale, v2 = V2 / scale;
+      diff2 = (v1 - v2).norm();
+      denom4 = std::sqrt(v1.norm()) * sqrt(v2.norm());
+      return ltEquals(diff2, denom4 * tolerance);
+    }
+    // if the difference has zero length, the vectors are equal, this test passes
+    return true;
+  } else {
+    // otherwise we must calculate the denominator
+    denom4 = static_cast<double>(V1.norm2() * V2.norm2());
+    // NOTE for large numbers, risk of overflow -- normalize by max(V1)
+    // ||V1-V2||/sqrt(||V1||*||V2||) * (a/a) = ||(aV1)-(aV2)||/sqrt(||aV1||*||aV2||)
+    if (std::isinf(denom4)) {
+      double const scale = 1.0 / std::max({V1.X(), V1.Y(), V1.Z(), V2.X(), V2.Y(), V2.Z()});
+      V3D const v1 = V1 * scale, v2 = V2 * scale;
+      diff2 = (v1 - v2).norm();
+      denom4 = std::sqrt(v1.norm()) * sqrt(v2.norm());
+      tol2 = tolerance;
+    }
+    // if denom <= 1, then |x-y| > tol implies |x-y|/denom > tol, can return early
+    // NOTE can only return early if BOTH denom <= 1. AND |x-y| > tol.
+    if (denom4 <= 1. && !ltEquals(diff2, tol2)) { // NOTE ||V1||^2.||V2||^2 <= 1 --> sqrt(||V1||.||V2||) <= 1
+      return false;
+    } else {
+      // avoid division and sqrt for improved performance
+      // we want ||V1-V2||/sqrt(||V1||*||V2||) < tol
+      // NOTE ||V1-V2||^4 < ||V1||^2.||V2||^2 * tol^4 --> ||V1-V2||/sqrt(||V1||*||V2||) < tol
+      return ltEquals(diff2 * diff2, denom4 * tol2 * tol2);
+    }
+  }
+}
 
 } // namespace Mantid::Kernel

--- a/Framework/Kernel/src/V3D.cpp
+++ b/Framework/Kernel/src/V3D.cpp
@@ -498,7 +498,7 @@ V3D V3D::directionAngles(bool inDegrees) const {
   Vector maximum absolute integer value
   @return maxCoeff()
 */
-int V3D::maxCoeff() {
+int V3D::maxCoeff() const {
   int MaxOrder = 0;
   if (std::abs(static_cast<int>(m_pt[0])) > MaxOrder)
     MaxOrder = std::abs(static_cast<int>(m_pt[0]));


### PR DESCRIPTION
### Description of work

#### Summary of work

This adds special relative and absolute comparison operators to the `FloatingPointComparison` utility, and uses them for comparing table columns of vectors.

#### Purpose of work

The natural way to compare 3D vectors is defining neighborhoods from spheres.  This makes the algebra most simply expressed in terms of inner products and norms.

The prior comparisons for V3D used rectangular boxes, which are not as natural to work with (in Euclidean geometries, anyway).

Came out of work in PR #37931, and didn't quite have time for it.  Related to ORNL EWM #[7196](https://ornjlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=7196)

*There is no associated issue.*

#### Further detail of work

The standard way to compare absolute tolerance for vectors is

$$\lVert \vec{v}_1 - \vec{v}_2 \rVert \leq\epsilon$$ 

while for relative tolerance is

$$\frac{\lVert \vec{v}_1 - \vec{v}_2\rVert}{\sqrt{\lVert\vec{v}_1\rVert\cdot\lVert\vec{v}_2\rVert}} \leq\epsilon$$

The norm operator $\lVert\cdot\rVert$ usually involves a square root, but because everything is positive, some clever use of squaring both sides can avoid the costly square root and division operations.

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
