### PR TITLE
Change results group workspace suffix for single fits in QENS Fitting interface 

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitUtilities.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitUtilities.h
@@ -16,7 +16,6 @@ namespace API {
 
 void renameWorkspacesInQENSFit(Algorithm *qensFit, IAlgorithm_sptr renameAlgorithm,
                                const WorkspaceGroup_sptr &outputGroup, std::string const &outputBaseName,
-                               std::string const &groupSuffix,
                                std::function<std::string(std::size_t)> const &getNameSuffix);
 
 bool containsMultipleData(const std::vector<MatrixWorkspace_sptr> &workspaces);

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -235,7 +235,7 @@ void renameWorkspacesWith(const WorkspaceGroup_sptr &groupWorkspace, F const &ge
 template <typename F>
 void renameWorkspacesInQENSFit(Algorithm *qensFit, const Algorithm_sptr &renameAlgorithm,
                                WorkspaceGroup_sptr outputGroup, std::string const &outputBaseName,
-                               std::string const &groupSuffix, const F &getNameSuffix) {
+                               const F &getNameSuffix) {
   Progress renamerProg(qensFit, 0.98, 1.0, outputGroup->size() + 1);
   renamerProg.report("Renaming group workspaces...");
 
@@ -246,10 +246,6 @@ void renameWorkspacesInQENSFit(Algorithm *qensFit, const Algorithm_sptr &renameA
     renamerProg.report("Renamed workspace in group.");
   };
   renameWorkspacesWith(outputGroup, getName, renamer);
-
-  auto const groupName = outputBaseName + groupSuffix;
-  if (outputGroup->getName() != groupName)
-    renameWorkspace(renameAlgorithm, outputGroup, groupName);
 }
 
 std::vector<std::size_t> createDatasetGrouping(const std::vector<MatrixWorkspace_sptr> &workspaces,
@@ -690,16 +686,14 @@ void QENSFitSequential::renameWorkspaces(WorkspaceGroup_sptr outputGroup, std::v
     std::string workspaceName = inputWorkspaceNames[i] + "_" + spectra[i] + endOfSuffix;
     return workspaceName;
   };
-  return renameWorkspacesInQENSFit(this, rename, std::move(outputGroup), outputBaseName, endOfSuffix + "s",
-                                   getNameSuffix);
+  return renameWorkspacesInQENSFit(this, rename, std::move(outputGroup), outputBaseName, getNameSuffix);
 }
 
 void QENSFitSequential::renameWorkspaces(WorkspaceGroup_sptr outputGroup, std::vector<std::string> const &spectra,
                                          std::string const &outputBaseName, std::string const &endOfSuffix) {
   auto rename = createChildAlgorithm("RenameWorkspace", -1.0, -1.0, false);
   auto getNameSuffix = [&](std::size_t i) { return spectra[i] + endOfSuffix; };
-  return renameWorkspacesInQENSFit(this, rename, std::move(outputGroup), outputBaseName, endOfSuffix + "s",
-                                   getNameSuffix);
+  return renameWorkspacesInQENSFit(this, rename, std::move(outputGroup), outputBaseName, getNameSuffix);
 }
 
 void QENSFitSequential::renameGroupWorkspace(std::string const &currentName, std::vector<std::string> const &spectra,

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -654,7 +654,7 @@ void QENSFitSimultaneous::renameWorkspaces(const API::WorkspaceGroup_sptr &outpu
     std::string workspaceName = inputWorkspaceNames[i] + "_" + spectra[i] + endOfSuffix;
     return workspaceName;
   };
-  return renameWorkspacesInQENSFit(this, rename, outputGroup, outputBaseName, endOfSuffix + "s", getNameSuffix);
+  return renameWorkspacesInQENSFit(this, rename, outputGroup, outputBaseName, getNameSuffix);
 }
 
 void QENSFitSimultaneous::renameWorkspaces(const API::WorkspaceGroup_sptr &outputGroup,
@@ -662,7 +662,7 @@ void QENSFitSimultaneous::renameWorkspaces(const API::WorkspaceGroup_sptr &outpu
                                            std::string const &endOfSuffix) {
   auto rename = createChildAlgorithm("RenameWorkspace", -1.0, -1.0, false);
   auto getNameSuffix = [&](std::size_t i) { return spectra[i] + endOfSuffix; };
-  return renameWorkspacesInQENSFit(this, rename, outputGroup, outputBaseName, endOfSuffix + "s", getNameSuffix);
+  return renameWorkspacesInQENSFit(this, rename, outputGroup, outputBaseName, getNameSuffix);
 }
 
 } // namespace Mantid::CurveFitting::Algorithms

--- a/Framework/CurveFitting/src/Algorithms/QENSFitUtilities.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitUtilities.cpp
@@ -40,7 +40,7 @@ bool containsMultipleData(const std::vector<MatrixWorkspace_sptr> &workspaces) {
 
 void renameWorkspacesInQENSFit(Algorithm *qensFit, IAlgorithm_sptr renameAlgorithm,
                                const WorkspaceGroup_sptr &outputGroup, std::string const &outputBaseName,
-                               std::string const &, std::function<std::string(std::size_t)> const &getNameSuffix) {
+                               std::function<std::string(std::size_t)> const &getNameSuffix) {
   Progress renamerProg(qensFit, 0.98, 1.0, outputGroup->size() + 1);
   renamerProg.report("Renaming group workspaces...");
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectReplaceFitResult.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectReplaceFitResult.py
@@ -26,7 +26,7 @@ def exists_in_ads(workspace_name: str) -> bool:
     return AnalysisDataService.doesExist(workspace_name)
 
 
-def get_ads_workspace(workspace_name: str) -> bool:
+def get_ads_workspace(workspace_name: str) -> Union[None, MatrixWorkspace, WorkspaceGroup]:
     return AnalysisDataService.retrieve(workspace_name) if exists_in_ads(workspace_name) else None
 
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectReplaceFitResult.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectReplaceFitResult.py
@@ -127,10 +127,10 @@ class IndirectReplaceFitResult(PythonAlgorithm):
         input_workspace = self.getProperty("InputWorkspace").value
         single_fit_workspace = self.getProperty("SingleFitWorkspace").value
 
-        if not string_ends_with(input_name, self._allowed_ws_extension):
+        if not string_ends_with(input_name, [self._allowed_ws_extension]):
             issues["InputWorkspace"] = "The input workspace must have a name ending in {0}".format(self._allowed_ws_extension)
 
-        if not string_ends_with(single_fit_name, self._allowed_ws_extension):
+        if not string_ends_with(single_fit_name, [self._allowed_ws_extension]):
             issues["SingleFitWorkspace"] = "This workspace must have a name ending in {0}".format(self._allowed_ws_extension)
 
         if not output_name:

--- a/docs/source/release/v6.13.0/Inelastic/Bugfixes/38827.rst
+++ b/docs/source/release/v6.13.0/Inelastic/Bugfixes/38827.rst
@@ -1,0 +1,2 @@
+- :ref:`QENSFitting <interface-inelastic-qens-fitting>` interface will generate a group workspace after fitting with suffix `_Result` when the output fit is a single fit, and suffix `_Results` when is a multiple fit.
+- Clicking plot button after a fit from :ref:`QENSFitting <interface-inelastic-qens-fitting>` no longer plot results twice.

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/EditResultsDialog.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/EditResultsDialog.cpp
@@ -11,7 +11,10 @@ namespace MantidQt::CustomInterfaces::Inelastic {
 EditResultsDialog::EditResultsDialog(QWidget *parent) : QDialog(parent) {
   m_uiForm.setupUi(this);
   m_uiForm.wsInputWorkspace->setLowerBinLimit(2);
+  m_uiForm.wsInputWorkspace->showWorkspaceGroups(false);
+
   m_uiForm.wsSingleFitWorkspace->setUpperBinLimit(1);
+  m_uiForm.wsSingleFitWorkspace->showWorkspaceGroups(false);
 
   connect(m_uiForm.pbPasteInputName, &QPushButton::clicked, this, &EditResultsDialog::setOutputWorkspaceName);
   connect(m_uiForm.pbReplaceFitResult, &QPushButton::clicked, this, &EditResultsDialog::replaceSingleFitResult);

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsModel.cpp
@@ -134,7 +134,7 @@ template <typename Predicate> void removeVectorElements(std::vector<std::string>
 }
 
 bool doesStringEndWith(std::string const &str, std::vector<std::string> const &delimiters) {
-  return std::any_of(delimiters.begin(), delimiters.end(),
+  return std::any_of(delimiters.cbegin(), delimiters.cend(),
                      [&str](std::string const &delimiter) { return str.ends_with(delimiter); });
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsModel.cpp
@@ -133,14 +133,14 @@ template <typename Predicate> void removeVectorElements(std::vector<std::string>
   strings.erase(std::remove_if(strings.begin(), strings.end(), filter), strings.end());
 }
 
-bool doesStringEndWith(std::string const &str, std::string const &delimiter) {
-  if (str.size() > delimiter.size())
-    return str.substr(str.size() - delimiter.size(), str.size()) == delimiter;
-  return false;
+bool doesStringEndWith(std::string const &str, std::vector<std::string> const &delimiters) {
+  return std::any_of(delimiters.begin(), delimiters.end(),
+                     [&str](std::string const &delimiter) { return str.ends_with(delimiter); });
 }
 
-std::vector<std::string> filterByEndSuffix(std::vector<std::string> &strings, std::string const &delimiter) {
-  removeVectorElements(strings, [&delimiter](std::string const &str) { return !doesStringEndWith(str, delimiter); });
+std::vector<std::string> filterByEndSuffix(std::vector<std::string> &strings,
+                                           std::vector<std::string> const &delimiters) {
+  removeVectorElements(strings, [&delimiters](std::string const &str) { return !doesStringEndWith(str, delimiters); });
   return strings;
 }
 
@@ -160,7 +160,7 @@ std::string filterByContents(std::vector<std::string> &strings, MatrixWorkspace_
 
 std::string findGroupWorkspaceContaining(MatrixWorkspace_sptr workspace) {
   auto workspaceNames = AnalysisDataService::Instance().getObjectNames();
-  auto resultGroups = filterByEndSuffix(workspaceNames, "_Results");
+  auto resultGroups = filterByEndSuffix(workspaceNames, std::vector<std::string>({"_Result", "_Results"}));
   return !resultGroups.empty() ? filterByContents(resultGroups, std::move(workspace)) : "";
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsView.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FitOutputOptionsView.cpp
@@ -20,7 +20,6 @@ FitOutputOptionsView::FitOutputOptionsView(QWidget *parent)
   connect(m_outputOptions->cbGroupWorkspace, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
           [=](int index) { this->notifyGroupWorkspaceChanged(m_outputOptions->cbGroupWorkspace->itemText(index)); });
   connect(m_outputOptions->pbPlot, &QPushButton::clicked, this, &FitOutputOptionsView::notifyPlotClicked);
-  connect(m_outputOptions->pbPlot, &QPushButton::clicked, this, &FitOutputOptionsView::notifyPlotClicked);
   connect(m_outputOptions->pbSave, &QPushButton::clicked, this, &FitOutputOptionsView::notifySaveClicked);
   connect(m_outputOptions->pbEditResult, &QPushButton::clicked, this, &FitOutputOptionsView::handleEditResultClicked);
 }

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.cpp
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.cpp
@@ -370,7 +370,7 @@ std::string FittingModel::createOutputName(const std::string &fitMode, const std
                                            const std::string &spectra) const {
   std::string inputWorkspace = isMultiFit() ? "Multi" : workspaceName;
   std::string inputSpectra = isMultiFit() ? "" : spectra;
-  return inputWorkspace + "_" + m_fitType + "_" + fitMode + "_" + m_fitString + "_" + inputSpectra + "_Results";
+  return inputWorkspace + "_" + m_fitType + "_" + fitMode + "_" + m_fitString + "_" + inputSpectra + getResultsSuffix();
 }
 
 std::optional<std::string> FittingModel::sequentialFitOutputName() const {
@@ -608,16 +608,16 @@ IAlgorithm_sptr FittingModel::createSimultaneousFit(const MultiDomainFunction_sp
   fitAlgorithm->setProperty("OutputWorkspace", *outputName);
   return fitAlgorithm;
 }
-
+std::string FittingModel::getResultsSuffix() const { return isMultiFit() ? "_Results" : "_Result"; }
 std::string FittingModel::singleFitOutputName(std::string workspaceName, WorkspaceIndex spectrum) const {
   std::string inputWorkspace = isMultiFit() ? "Multi" : workspaceName;
   std::string spectra = std::to_string(spectrum.value);
-  return inputWorkspace + "_" + m_fitType + "_" + m_fitString + "_" + spectra + "_Results";
+  return inputWorkspace + "_" + m_fitType + "_" + m_fitString + "_" + spectra + getResultsSuffix();
 }
 
 std::optional<std::string> FittingModel::getOutputBasename() const {
   if (auto const outputName = sequentialFitOutputName())
-    return cutLastOf(*outputName, "_Results");
+    return cutLastOf(*outputName, getResultsSuffix());
   return std::nullopt;
 }
 

--- a/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.h
+++ b/qt/scientific_interfaces/Inelastic/QENSFitting/FittingModel.h
@@ -112,6 +112,7 @@ protected:
 
 private:
   void removeWorkspaceFromFittingData(WorkspaceID const &workspaceIndex);
+  std::string getResultsSuffix() const;
 
   Mantid::API::IAlgorithm_sptr createSequentialFit(Mantid::API::IFunction_sptr function) const;
   Mantid::API::IAlgorithm_sptr createSequentialFit(const Mantid::API::IFunction_sptr function,

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/FittingModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/FittingModelTest.h
@@ -25,7 +25,7 @@ using namespace MantidQt::CustomInterfaces;
 
 namespace {
 
-constexpr std::string WS_NAME = "wsName";
+static const std::string WS_NAME = "wsName";
 
 MultiDomainFunction_sptr getFunction(std::string const &functionString, size_t domainNumber = 1) {
   return FunctionFactory::Instance().createInitializedMultiDomainFunction(functionString, domainNumber);

--- a/qt/scientific_interfaces/Inelastic/test/QENSFitting/FittingModelTest.h
+++ b/qt/scientific_interfaces/Inelastic/test/QENSFitting/FittingModelTest.h
@@ -25,14 +25,17 @@ using namespace MantidQt::CustomInterfaces;
 
 namespace {
 
-MultiDomainFunction_sptr getFunction(std::string const &functionString) {
-  return FunctionFactory::Instance().createInitializedMultiDomainFunction(functionString, 1);
+constexpr std::string WS_NAME = "wsName";
+
+MultiDomainFunction_sptr getFunction(std::string const &functionString, size_t domainNumber = 1) {
+  return FunctionFactory::Instance().createInitializedMultiDomainFunction(functionString, domainNumber);
 }
 
 auto &ads_instance = Mantid::API::AnalysisDataService::Instance();
 
-void setFittingFunction(std::unique_ptr<FittingModel> &model, std::string const &functionString) {
-  model->setFitFunction(getFunction(functionString));
+void setFittingFunction(std::unique_ptr<FittingModel> &model, std::string const &functionString,
+                        size_t domainNumber = 1) {
+  model->setFitFunction(getFunction(functionString, domainNumber));
 }
 
 IAlgorithm_sptr setupFitAlgorithm(const MatrixWorkspace_sptr &workspace, std::string const &functionString) {
@@ -52,15 +55,19 @@ IAlgorithm_sptr setupFitAlgorithm(const MatrixWorkspace_sptr &workspace, std::st
   return alg;
 }
 
+std::string getSingleDomainTestFunction(std::string const &workspaceName) {
+  return "name=LinearBackground,A0=0,A1=0,ties=(A0=0.000000,A1=0.0);"
+         "(composite=Convolution,FixResolution=true,NumDeriv=true;"
+         "name=Resolution,Workspace=" +
+         workspaceName +
+         ",WorkspaceIndex=0;((composite=ProductFunction,NumDeriv="
+         "false;name=Lorentzian,Amplitude=1,PeakCentre=0,FWHM=0."
+         "0175)))";
+}
+
 IAlgorithm_sptr getSetupFitAlgorithm(std::unique_ptr<FittingModel> &model, const MatrixWorkspace_sptr &workspace,
                                      std::string const &workspaceName) {
-  std::string const function = "name=LinearBackground,A0=0,A1=0,ties=(A0=0.000000,A1=0.0);"
-                               "(composite=Convolution,FixResolution=true,NumDeriv=true;"
-                               "name=Resolution,Workspace=" +
-                               workspaceName +
-                               ",WorkspaceIndex=0;((composite=ProductFunction,NumDeriv="
-                               "false;name=Lorentzian,Amplitude=1,PeakCentre=0,FWHM=0."
-                               "0175)))";
+  std::string const function = getSingleDomainTestFunction(workspaceName);
   setFittingFunction(model, function);
   auto alg = setupFitAlgorithm(std::move(workspace), function);
   return alg;
@@ -94,36 +101,36 @@ public:
   }
 
   void test_that_a_workspace_is_stored_correctly_in_the_ADS() {
-    SetUpADSWithWorkspace ads("WorkspaceName", createWorkspace(3));
+    SetUpADSWithWorkspace ads(WS_NAME, createWorkspace(3));
 
-    TS_ASSERT(ads.doesExist("WorkspaceName"));
-    auto const storedWorkspace = ads.retrieveWorkspace("WorkspaceName");
+    TS_ASSERT(ads.doesExist(WS_NAME));
+    auto const storedWorkspace = ads.retrieveWorkspace(WS_NAME);
     TS_ASSERT_EQUALS(storedWorkspace->getNumberHistograms(), 3);
   }
 
   void test_that_getWorkspace_returns_a_nullptr_when_getWorkspace_is_provided_an_out_of_range_index() {
-    addWorkspaceToModel("WorkspaceName", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
     TS_ASSERT_EQUALS(m_model->getWorkspace(1), nullptr);
   }
 
   void test_that_isMultiFit_returns_true_when_there_are_more_than_one_workspaces_stored_in_the_model() {
-    addWorkspaceToModel("Workspace1", 3, "0-2");
-    addWorkspaceToModel("Workspace2", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
+    addWorkspaceToModel(WS_NAME + "_1", 3, "0-2");
     TS_ASSERT(m_model->isMultiFit());
   }
 
   void test_that_isMultiFit_returns_false_when_there_is_one_workspace_stored_in_the_model() {
-    addWorkspaceToModel("Workspace1", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
     TS_ASSERT(!m_model->isMultiFit());
   }
 
   void test_that_isPreviouslyFit_returns_false_if_there_is_no_previous_fit_output_data() {
-    addWorkspaceToModel("WorkspaceName", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
     TS_ASSERT(!m_model->isPreviouslyFit(0, 0));
   }
 
   void test_that_isPreviouslyFit_returns_false_if_the_dataIndex_is_out_of_range() {
-    addWorkspaceToModel("WorkspaceName", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
     TS_ASSERT(!m_model->isPreviouslyFit(4, 0));
   }
 
@@ -140,29 +147,29 @@ public:
   }
 
   void test_that_ConvolutionSequentialFit_algorithm_initializes() {
-    addInstrumentWorkspaceToModel("WorkspaceName", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     auto const modelWorkspace = m_model->getWorkspace(0);
 
-    auto const alg = getSetupFitAlgorithm(m_model, modelWorkspace, "WorkspaceName");
+    auto const alg = getSetupFitAlgorithm(m_model, modelWorkspace, WS_NAME);
 
     TS_ASSERT(alg->isInitialized());
   }
 
   void test_that_ConvolutionSequentialFit_algorithm_executes_without_error() {
-    addInstrumentWorkspaceToModel("WorkspaceName", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     auto const modelWorkspace = m_model->getWorkspace(0);
 
-    auto const alg = getSetupFitAlgorithm(m_model, modelWorkspace, "WorkspaceName");
+    auto const alg = getSetupFitAlgorithm(m_model, modelWorkspace, WS_NAME);
 
     TS_ASSERT_THROWS_NOTHING(alg->execute());
     TS_ASSERT(alg->isExecuted());
   }
 
   void test_that_addOutput_adds_the_output_of_a_fit_into_the_model() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     auto const modelWorkspace = m_model->getWorkspace(0);
 
-    auto const alg = getExecutedFitAlgorithm(m_model, modelWorkspace, "__Convolution");
+    auto const alg = getExecutedFitAlgorithm(m_model, modelWorkspace, WS_NAME);
     m_model->addOutput(alg);
 
     TS_ASSERT(m_model->getResultWorkspace());
@@ -170,10 +177,10 @@ public:
   }
 
   void test_that_addOutput_adds_the_output_of_a_single_fit_into_the_model() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     auto const modelWorkspace = m_model->getWorkspace(0);
 
-    auto const alg = getExecutedFitAlgorithm(m_model, modelWorkspace, "__Convolution");
+    auto const alg = getExecutedFitAlgorithm(m_model, modelWorkspace, WS_NAME);
     m_model->addOutput(alg);
 
     TS_ASSERT(m_model->getResultWorkspace());
@@ -181,18 +188,18 @@ public:
   }
 
   void test_that_isPreviouslyFit_returns_true_if_the_spectrum_has_been_fitted_previously() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     addFitOutputDataToModel();
     TS_ASSERT(m_model->isPreviouslyFit(WorkspaceID(0), WorkspaceIndex(0)));
   }
 
   void test_that_isInvalidFunction_returns_a_message_when_no_activeFunction_exists() {
-    addWorkspaceToModel("WorkspaceName", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
     TS_ASSERT(m_model->isInvalidFunction());
   }
 
   void test_that_isInvalidFunction_returns_a_message_when_the_activeFunction_contains_zero_parameters_or_functions() {
-    addWorkspaceToModel("WorkspaceName", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
     auto const function = getFunction("name=Convolution;name=Resolution");
     m_model->setFitFunction(function);
 
@@ -200,39 +207,39 @@ public:
   }
 
   void test_isInvalidFunction_returns_none_if_the_activeFunction_is_valid() {
-    addInstrumentWorkspaceToModel("WorkspaceName", 6, 5, "0-2");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-2");
     auto const modelWorkspace = m_model->getWorkspace(0);
 
-    (void)getSetupFitAlgorithm(m_model, modelWorkspace, "WorkspaceName");
+    (void)getSetupFitAlgorithm(m_model, modelWorkspace, WS_NAME);
 
     TS_ASSERT(!m_model->isInvalidFunction());
   }
 
   void test_that_getNumberOfWorkspace_returns_the_number_of_workspace_stored_by_model() {
-    addWorkspaceToModel("Workspace1", 3, "0-2");
-    addWorkspaceToModel("Workspace2", 3, "0-2");
-    addWorkspaceToModel("Workspace3", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
+    addWorkspaceToModel(WS_NAME + "_1", 3, "0-2");
+    addWorkspaceToModel(WS_NAME + "_2", 3, "0-2");
     TS_ASSERT_EQUALS(m_model->getNumberOfWorkspaces(), 3);
   }
 
   void test_that_getFitParameterNames_returns_an_empty_vector_if_the_fitOutput_is_empty() {
-    addWorkspaceToModel("Workspace1", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
     TS_ASSERT_EQUALS(m_model->getFitParameterNames(), std::vector<std::string>());
   }
 
   void test_that_getFitParameterNames_returns_a_vector_of_fit_parameters_if_the_fitOutput_contains_parameters() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-2");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-2");
     auto const modelWorkspace = m_model->getWorkspace(0);
 
-    auto const alg = getExecutedFitAlgorithm(m_model, modelWorkspace, "__Convolution");
+    auto const alg = getExecutedFitAlgorithm(m_model, modelWorkspace, WS_NAME);
     m_model->addOutput(alg);
 
     TS_ASSERT(!m_model->getFitParameterNames().empty());
   }
 
   void test_that_clearWorkspaces_will_empty_the_fittingData() {
-    addWorkspaceToModel("Workspace1", 3, "0-2");
-    addWorkspaceToModel("Workspace2", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
+    addWorkspaceToModel(WS_NAME + "_1", 3, "0-2");
     m_model->clearWorkspaces();
 
     TS_ASSERT(!m_model->getWorkspace(0));
@@ -240,11 +247,56 @@ public:
     TS_ASSERT_EQUALS(m_model->getNumberOfWorkspaces(), 0);
   }
 
+  void test_output_group_name_ends_with_correct_suffix_for_single_fit_function_sequential_fitting() {
+    addWorkspaceToModel(WS_NAME, 1, "0");
+    setFittingFunction(m_model,
+                       "composite=MultiDomainFunction,NumDeriv=true;"
+                       "name=FlatBackground,A0=1,$domains=i;",
+                       2);
+    setFittingFunction(m_model, getSingleDomainTestFunction(WS_NAME));
+    auto fitAlg = m_model->getFittingAlgorithm(FittingMode::SEQUENTIAL);
+
+    TS_ASSERT(fitAlg->getPropertyValue("OutputWorkspace").ends_with("_Result"));
+  }
+
+  void test_output_group_name_ends_with_correct_suffix_for_single_fit_function_simultaneous_fitting() {
+    addWorkspaceToModel(WS_NAME, 1, "0");
+    setFittingFunction(m_model, getSingleDomainTestFunction(WS_NAME));
+    auto fitAlg = m_model->getFittingAlgorithm(FittingMode::SIMULTANEOUS);
+
+    TS_ASSERT(fitAlg->getPropertyValue("OutputWorkspace").ends_with("_Result"));
+  }
+
+  void test_output_group_name_ends_with_correct_suffix_for_multi_fit_function_sequential_fitting() {
+    addWorkspaceToModel(WS_NAME, 1, "0");
+    addWorkspaceToModel(WS_NAME + "_1", 1, "0");
+    setFittingFunction(m_model,
+                       "composite=MultiDomainFunction,NumDeriv=true;"
+                       "name=FlatBackground,A0=1,$domains=i;",
+                       2);
+
+    auto fitAlg = m_model->getFittingAlgorithm(FittingMode::SEQUENTIAL);
+
+    TS_ASSERT(fitAlg->getPropertyValue("OutputWorkspace").ends_with("_Results"));
+  }
+
+  void test_output_group_name_ends_with_correct_suffix_for_multi_fit_function_simultaneous_fitting() {
+    addWorkspaceToModel(WS_NAME, 1, "0");
+    addWorkspaceToModel(WS_NAME + "_1", 1, "0");
+    setFittingFunction(m_model,
+                       "composite=MultiDomainFunction,NumDeriv=true;"
+                       "name=FlatBackground,A0=1,$domains=i;",
+                       2);
+
+    auto fitAlg = m_model->getFittingAlgorithm(FittingMode::SIMULTANEOUS);
+
+    TS_ASSERT(fitAlg->getPropertyValue("OutputWorkspace").ends_with("_Results"));
+  }
   void test_that_setDefaultParameterValue_will_set_the_value_of_the_provided_parameter() {
-    addWorkspaceToModel("WorkspaceName", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
     auto const modelWorkspace = m_model->getWorkspace(0);
 
-    (void)getSetupFitAlgorithm(m_model, modelWorkspace, "WorkspaceName");
+    (void)getSetupFitAlgorithm(m_model, modelWorkspace, WS_NAME);
     m_model->setDefaultParameterValue("Amplitude", 1.5, 0);
 
     auto const parameters = m_model->getDefaultParameters(0);
@@ -252,16 +304,16 @@ public:
   }
 
   void test_that_getParameterValues_returns_an_empty_map_if_the_dataIndex_is_out_of_range() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     addFitOutputDataToModel();
     TS_ASSERT(m_model->getParameterValues(1, 0).empty());
   }
 
   void test_that_getParameterValues_returns_the_default_parameters_if_there_are_no_fit_parameters() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     auto const modelWorkspace = m_model->getWorkspace(0);
 
-    (void)getSetupFitAlgorithm(m_model, modelWorkspace, "__Convolution");
+    (void)getSetupFitAlgorithm(m_model, modelWorkspace, WS_NAME);
     m_model->setDefaultParameterValue("Amplitude", 1.5, 0);
 
     auto const parameters = m_model->getParameterValues(0, 0);
@@ -269,7 +321,7 @@ public:
   }
 
   void test_that_getParameterValues_returns_the_fit_parameters_after_a_fit_has_been_executed() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     addFitOutputDataToModel();
     auto const parameters = m_model->getParameterValues(0, 0);
     TS_ASSERT_DELTA(parameters.at("f1.f1.f0.Amplitude").value, 1.0, 0.0001);
@@ -278,16 +330,16 @@ public:
   }
 
   void test_getFitParameters_returns_an_empty_map_when_there_is_no_fitOutput() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     auto const modelWorkspace = m_model->getWorkspace(0);
 
-    (void)getSetupFitAlgorithm(m_model, modelWorkspace, "__Convolution");
+    (void)getSetupFitAlgorithm(m_model, modelWorkspace, WS_NAME);
 
     TS_ASSERT(m_model->getFitParameters(0, 0).empty());
   }
 
   void test_getFitParameters_returns_the_fitParameters_after_a_fit() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     addFitOutputDataToModel();
     auto const parameters = m_model->getFitParameters(0, 0);
     TS_ASSERT_DELTA(parameters.at("f1.f1.f0.Amplitude").value, 1.0, 0.0001);
@@ -296,13 +348,13 @@ public:
   }
 
   void test_getDefaultParameters_returns_an_empty_map_when_the_dataIndex_is_out_of_range() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     addFitOutputDataToModel();
     TS_ASSERT(m_model->getDefaultParameters(1).empty());
   }
 
   void test_getDefaultParameters_returns_the_default_parameters_which_have_been_set() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     addFitOutputDataToModel();
 
     m_model->setDefaultParameterValue("Amplitude", 1.5, 0);
@@ -313,18 +365,18 @@ public:
   }
 
   void test_that_getResultLocation_returns_a_location_for_the_output_data() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     addFitOutputDataToModel();
     TS_ASSERT(m_model->getResultLocation(0, 0));
   }
 
   void test_that_cleanFailedRun_removes_the_temporary_workspace_from_the_ADS_when_a_fit_fails() {
     /// Fails the fit algorithm on purpose by providing an invalid function
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     auto const modelWorkspace = m_model->getWorkspace(0);
-    SetUpADSWithWorkspace ads("Name", modelWorkspace);
+    SetUpADSWithWorkspace ads(WS_NAME, modelWorkspace);
 
-    std::string const functionString = "name=Convolution;name=Resolution,Workspace=Name,WorkspaceIndex=0;";
+    std::string const functionString = "name=Convolution;name=Resolution,Workspace=wsName,WorkspaceIndex=0;";
     auto alg = setupFitAlgorithm(modelWorkspace, functionString);
     alg->execute();
 
@@ -336,11 +388,11 @@ public:
   void
   test_that_cleanFailedRun_removes_the_temporary_workspace_from_the_ADS_when_a_fit_fails_for_a_single_workspaceIndex() {
     /// Fails the fit algorithm on purpose by providing an invalid function
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     auto const modelWorkspace = m_model->getWorkspace(0);
-    SetUpADSWithWorkspace ads("Name", modelWorkspace);
+    SetUpADSWithWorkspace ads(WS_NAME, modelWorkspace);
 
-    std::string const functionString = "name=Convolution;name=Resolution,Workspace=Name,WorkspaceIndex=0;";
+    std::string const functionString = "name=Convolution;name=Resolution,Workspace=wsName,WorkspaceIndex=0;";
     auto alg = setupFitAlgorithm(modelWorkspace, functionString);
     alg->execute();
 
@@ -350,7 +402,7 @@ public:
   }
 
   void test_that_getDefaultParameters_returns_full_list_of_names_for_multi_domain_functions() {
-    addWorkspaceToModel("Workspace1", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
     auto const function = getFunction("composite=MultiDomainFunction,NumDeriv=true;(composite=Convolution,"
                                       "NumDeriv=true,FixResolution=true,$domains=i;name=Resolution,"
                                       "WorkspaceIndex=0,X=(),Y=();(name=Lorentzian,Amplitude=1,PeakCentre=0,"
@@ -367,7 +419,7 @@ public:
   }
 
   void test_set_fitting_mode_fucntions() {
-    addWorkspaceToModel("Workspace1", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
     auto sequential = FittingMode::SEQUENTIAL;
     auto simultaneous = FittingMode::SIMULTANEOUS;
     m_model->setFittingMode(sequential);
@@ -377,61 +429,43 @@ public:
   }
 
   void test_updateFitTypeString_does_not_throw() {
-    addWorkspaceToModel("Workspace1", 3, "0-2");
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
     TS_ASSERT_THROWS_NOTHING(m_model->updateFitTypeString());
   }
 
   void test_getResultLocation_returns_none_when_out_of_index() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     addFitOutputDataToModel();
     TS_ASSERT(!m_model->getResultLocation(WorkspaceID{1}, WorkspaceIndex{0}));
   }
 
   void test_getResultWorkspace_does_not_throw() {
-    addInstrumentWorkspaceToModel("__Convolution", 6, 5, "0-5");
+    addInstrumentWorkspaceToModel(WS_NAME, 6, 5, "0-5");
     addFitOutputDataToModel();
     TS_ASSERT_THROWS_NOTHING(m_model->getResultWorkspace());
   }
 
   void test_getFittingAlgorithm_does_not_throw() {
-    addWorkspaceToModel("wsName", 3, "0");
-    std::string const function = "name=LinearBackground,A0=0,A1=0,ties=(A0=0.000000,A1=0.0);"
-                                 "(composite=Convolution,FixResolution=true,NumDeriv=true;"
-                                 "name=Resolution,Workspace=wsName,WorkspaceIndex=0;((composite="
-                                 "ProductFunction,NumDeriv="
-                                 "false;name=Lorentzian,Amplitude=1,PeakCentre=0,FWHM=0."
-                                 "0175)))";
-    setFittingFunction(m_model, function);
+    addWorkspaceToModel(WS_NAME, 3, "0");
+    setFittingFunction(m_model, getSingleDomainTestFunction(WS_NAME));
     TS_ASSERT_THROWS_NOTHING(m_model->getFittingAlgorithm(FittingMode::SEQUENTIAL));
   }
 
   void test_getSingleFit_does_not_throw() {
-    addWorkspaceToModel("wsName", 3, "0");
-    std::string const function = "name=LinearBackground,A0=0,A1=0,ties=(A0=0.000000,A1=0.0);"
-                                 "(composite=Convolution,FixResolution=true,NumDeriv=true;"
-                                 "name=Resolution,Workspace=wsName,WorkspaceIndex=0;((composite="
-                                 "ProductFunction,NumDeriv="
-                                 "false;name=Lorentzian,Amplitude=1,PeakCentre=0,FWHM=0."
-                                 "0175)))";
-    setFittingFunction(m_model, function);
+    addWorkspaceToModel(WS_NAME, 3, "0");
+    setFittingFunction(m_model, getSingleDomainTestFunction(WS_NAME));
     TS_ASSERT_THROWS_NOTHING(m_model->getSingleFittingAlgorithm());
   }
 
   void test_getSingleFunction_does_not_throw() {
-    addWorkspaceToModel("wsName", 3, "0");
-    std::string const function = "name=LinearBackground,A0=0,A1=0,ties=(A0=0.000000,A1=0.0);"
-                                 "(composite=Convolution,FixResolution=true,NumDeriv=true;"
-                                 "name=Resolution,Workspace=wsName,WorkspaceIndex=0;((composite="
-                                 "ProductFunction,NumDeriv="
-                                 "false;name=Lorentzian,Amplitude=1,PeakCentre=0,FWHM=0."
-                                 "0175)))";
-    setFittingFunction(m_model, function);
+    addWorkspaceToModel(WS_NAME, 3, "0");
+    setFittingFunction(m_model, getSingleDomainTestFunction(WS_NAME));
     TS_ASSERT_THROWS_NOTHING(m_model->getSingleFunction(WorkspaceID{0}, WorkspaceIndex{0}));
   }
 
   void test_getOutputBasename_returns_correct_sequential_name() {
-    addWorkspaceToModel("wsName", 3, "0-2");
-    std::string outputString = "wsName_FitType_seq_FitString_0-2";
+    addWorkspaceToModel(WS_NAME, 3, "0-2");
+    std::string outputString = WS_NAME + "_FitType_seq_FitString_0-2";
     TS_ASSERT_EQUALS(m_model->getOutputBasename(), outputString);
   }
 
@@ -476,13 +510,14 @@ public:
   }
 
 private:
-  void addWorkspaceToModel(std::string workspaceName, int numberOfSpectra, std::string const &spectra) {
+  void addWorkspaceToModel(std::string const &workspaceName, int numberOfSpectra, std::string const &spectra) {
     SetUpADSWithWorkspace ads(workspaceName, createWorkspace(numberOfSpectra));
     m_model->getFitDataModel()->addWorkspace(workspaceName, FunctionModelSpectra(spectra));
     m_model->addDefaultParameters();
   }
 
-  void addInstrumentWorkspaceToModel(std::string workspaceName, int xLength, int yLength, std::string const &spectra) {
+  void addInstrumentWorkspaceToModel(std::string const &workspaceName, int xLength, int yLength,
+                                     std::string const &spectra) {
     SetUpADSWithWorkspace ads(workspaceName, createWorkspaceWithInstrument(xLength, yLength));
     m_model->getFitDataModel()->addWorkspace(workspaceName, FunctionModelSpectra(spectra));
     m_model->addDefaultParameters();


### PR DESCRIPTION
### Description of work
Fixes #38827 . 

This PR changes the suffix of the results output groups that are generated form the qens fitting interface after a fitting. When the fit involves more than one workspace (multifit), the results group has multiple workspaces, while when the fit contains only one single workspace (single fit) the results group has one workspace. 
The group has the suffix `_Results` while the workspaces within the group have each suffix `_Result`. 
This generates problems when mantid project is saved: The group workspaces containing one member are saved and reloaded as matrix workspaces instead of group workspaces, but with the name of the group (so that workspaces with groups ending in "_Result" will take the name of the group and end with "_Results" when loaded back). This is generally inconsequential for most Mantid workflows, but in the case of the Function Q tab of the QENS fitting interface, the load dialog seeks for a workspace or file ending with the suffix "_Result", and compatible files are not detected. 
This is not really a bug in the Function Q interface, but rather a clash between two incompatible designs within Mantid. 
1) Is it not ideal that group workspaces with one member only are loaded as matrix workspaces, as it may override the intent of the user in some cases (as in function q interface). This is a consequence of the hierarchical structure of the nexus files, each workspace is saved as a NXgroup in the nexus files, so the way of the loader to distinguish groups is whether the root contains multiple NXgroups. Therefore is it not possible to distinguish whether something is a matrix workspace or a group of one member and ws are loaded as the former. One solution to this would be to alter SaveNexusProcessed algorithm and add a metadata field to the nexus field indicating whether something is being saved as a one workspace group, so that the loader can distinguish. This change is not very complicated but alters the savers/loaders in a more fundamental way and will likely require a separate investigation, as it may not be a good change when this is only affecting the funciton q interface. 
2) The QENS Fitting interface is composed of many intertwined classes and relies too much on cues like particular workspace suffices to load data. Adding small features or changing the way to retrieve data from ADS is constantly a source of bugs and errors (still to this day). In my opinion this interface would benefit from a deep overhaul, but as adding new features in spectroscopy is discontinued at the moment and would required long developing time, I have disregarded this.


#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

What I have done in this PR is to choose a compromise solution, when the `_Results` group contains only one workspace member, the whole group will end with the suffix `_Result` instead. This will prompt the project saver to save the file with the correct suffix so when the workspace is loaded as a matrix workspace, it will be detected by the function q interface. 

Additionally, Spencer made me aware of a bug that involved double plotting of some data from the output plot widget of the interfaces when the `Plot` button is clicked. As the solution for this was very simple, I have added it on this PR (and on release notes) 


<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #38827. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
Additionally, tests are added. I have slightly refactored the test suite, and also added type hints to `IndirectReplaceFit...` algorithm.  

### To test:

- Check everything is in order in manual testing for qens fitting: https://developer.mantidproject.org/Testing/Inelastic/QENSFittingTests.html 
- Note that the fit for single workspaces will create a group workspace ending in `_Result`. 
- When you have finished testing the convolution tab. Save Mantid project, then load Mantid project, when the project is loaded, the matrix workspace on the ADS should end in `_Result` and be detectable from the Function Q tab. 


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*Added release notes*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
