### PR TITLE
Fix an error when exporting Sliceviewer pixel cuts from MDHisto workspaces

### DIFF
--- a/docs/source/release/v6.13.0/Workbench/SliceViewer/Bugfixes/36084.rst
+++ b/docs/source/release/v6.13.0/Workbench/SliceViewer/Bugfixes/36084.rst
@@ -1,0 +1,1 @@
+- Sliceviwer no longer raises an error when exporting a pixel cut from a MDHistoWorkspace

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -476,13 +476,19 @@ class SliceViewerModel(SliceViewerBaseModel):
         :param axis: A string 'x' or 'y' identifying the axis to cut along
         """
         # Form single pixel limits for a cut
-        xindex, yindex = WorkspaceInfo.display_indices(slicepoint, transpose)
+        xindex, yindex = WorkspaceInfo.display_indices(slicepoint)
         workspace = self._get_ws()
-        deltax, deltay = workspace.getDimension(xindex).getBinWidth(), workspace.getDimension(yindex).getBinWidth()
+        xdim = workspace.getDimension(xindex)
+        ydim = workspace.getDimension(yindex)
+        deltax, deltay = xdim.getBinWidth(), ydim.getBinWidth()
+
         xpos, ypos = pos
-        if transpose:
-            xpos, ypos = ypos, xpos
-        limits = (xpos - 0.5 * deltax, xpos + 0.5 * deltax), (ypos - 0.5 * deltay, ypos + 0.5 * deltay)
+
+        if axis == "x" and not transpose or axis == "y" and transpose:
+            limits = ((xdim.getMinimum(), xdim.getMaximum()), (ypos - 0.5 * deltay, ypos + 0.5 * deltay))
+        else:
+            limits = ((xpos - 0.5 * deltax, xpos + 0.5 * deltax), (ydim.getMinimum(), ydim.getMaximum()))
+
         return self.export_cuts_to_workspace_mdhisto(slicepoint, bin_params, limits, transpose, dimension_indices, axis)
 
     def export_pixel_cut_to_workspace_mdevent(
@@ -497,13 +503,19 @@ class SliceViewerModel(SliceViewerBaseModel):
         :param axis: A string 'x' or 'y' identifying the axis to cut along
         """
         # Form single pixel limits for a cut
-        xindex, yindex = WorkspaceInfo.display_indices(slicepoint, transpose)
+        xindex, yindex = WorkspaceInfo.display_indices(slicepoint)
         workspace = self._get_ws()
-        deltax, deltay = workspace.getDimension(xindex).getBinWidth(), workspace.getDimension(yindex).getBinWidth()
+        xdim = workspace.getDimension(xindex)
+        ydim = workspace.getDimension(yindex)
+        deltax, deltay = xdim.getBinWidth(), ydim.getBinWidth()
+
         xpos, ypos = pos
-        if transpose:
-            xpos, ypos = ypos, xpos
-        limits = (xpos - 0.5 * deltax, xpos + 0.5 * deltax), (ypos - 0.5 * deltay, ypos + 0.5 * deltay)
+
+        if axis == "x" and not transpose or axis == "y" and transpose:
+            limits = ((xdim.getMinimum(), xdim.getMaximum()), (ypos - 0.5 * deltay, ypos + 0.5 * deltay))
+        else:
+            limits = ((xpos - 0.5 * deltax, xpos + 0.5 * deltax), (ydim.getMinimum(), ydim.getMaximum()))
+
         return self.export_cuts_to_workspace_mdevent(slicepoint, bin_params, limits, transpose, dimension_indices, axis)
 
     def export_pixel_cut_to_workspace_matrix(
@@ -520,7 +532,6 @@ class SliceViewerModel(SliceViewerBaseModel):
         workspace = self._get_ws()
         xpos, ypos = pos
         if transpose:
-            # swap back to model order
             xpos, ypos = ypos, xpos
 
         xcut_name, ycut_name, help_msg = self._cut_names(axis)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -484,19 +484,19 @@ class SliceViewerModel(SliceViewerBaseModel):
         elif ws_type == WS_TYPE.MDH:
             export_cut_fun = self.export_cuts_to_workspace_mdhisto
 
-        xindex, yindex = WorkspaceInfo.display_indices(slicepoint)
+        xindex, yindex = WorkspaceInfo.display_indices(slicepoint, transpose)
         workspace = self._get_ws()
         xdim = workspace.getDimension(xindex)
         ydim = workspace.getDimension(yindex)
         deltax, deltay = xdim.getBinWidth(), ydim.getBinWidth()
 
+        if ws_type is WS_TYPE.MDE:
+            deltax, deltay = deltax / bin_params[xindex], deltay / bin_params[yindex]
+
         xpos, ypos = pos
 
         limits_x = ((xdim.getMinimum(), xdim.getMaximum()), (ypos - 0.5 * deltay, ypos + 0.5 * deltay))
         limits_y = ((xpos - 0.5 * deltax, xpos + 0.5 * deltax), (ydim.getMinimum(), ydim.getMaximum()))
-
-        if transpose:
-            limits_x, limits_y = limits_y, limits_x
 
         if axis == "c":
             export_cut_fun(slicepoint, bin_params, limits_x, transpose, dimension_indices, "x")

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -294,6 +294,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
                     bin_params=data_view.dimensions.get_bin_params(),
                     pos=pos,
                     transpose=data_view.dimensions.transpose,
+                    dimension_indices=data_view.dimensions.get_states(),
                     axis=axis,
                 )
             )

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -812,45 +812,40 @@ class SliceViewerModelTest(unittest.TestCase):
                 BasisVector2="l,rlu,0.0,0.0,1.0",
             )
 
+            assert_called = mock_binmd.assert_called_with if cut_type == "c" else mock_binmd.assert_called_once_with
+
             if not transpose:
                 extents = [xmin, xmax, ymin, ymax, zmin, zmax]
 
-                if cut_type == "x" or cut_type == "c":
-                    expected_bins = [100, 1, 1]
-                    expected_ws = "ws_MDE_3D_cut_x"
-                    expected_msg = "Cut along X created: ws_MDE_3D_cut_x"
-
-                    mock_binmd.assert_called_once_with(
-                        **common_params, OutputExtents=extents, OutputBins=expected_bins, OutputWorkspace=expected_ws
-                    )
-                elif cut_type == "y" or cut_type == "c":
+                if cut_type == "y" or cut_type == "c":
                     expected_bins = [1, 100, 1]
                     expected_ws = "ws_MDE_3D_cut_y"
                     expected_msg = "Cut along Y created: ws_MDE_3D_cut_y"
 
-                    mock_binmd.assert_called_once_with(
-                        **common_params, OutputExtents=extents, OutputBins=expected_bins, OutputWorkspace=expected_ws
-                    )
+                    assert_called(**common_params, OutputExtents=extents, OutputBins=expected_bins, OutputWorkspace=expected_ws)
+                elif cut_type == "x" or cut_type == "c":
+                    expected_bins = [100, 1, 1]
+                    expected_ws = "ws_MDE_3D_cut_x"
+                    expected_msg = "Cut along X created: ws_MDE_3D_cut_x"
+
+                    assert_called(**common_params, OutputExtents=extents, OutputBins=expected_bins, OutputWorkspace=expected_ws)
+
             else:
                 extents = [ymin, ymax, xmin, xmax, zmin, zmax]
 
-                if cut_type == "x" or cut_type == "c":
-                    expected_bins = [1, 100, 1]
-                    expected_ws = "ws_MDE_3D_cut_x"
-                    expected_msg = "Cut along X created: ws_MDE_3D_cut_x"
-                    mock_binmd.assert_called_once_with(
-                        **common_params, OutputExtents=extents, OutputBins=expected_bins, OutputWorkspace=expected_ws
-                    )
-                elif cut_type == "y" or cut_type == "c":
+                if cut_type == "y" or cut_type == "c":
                     expected_bins = [100, 1, 1]
                     expected_ws = "ws_MDE_3D_cut_y"
                     expected_msg = "Cut along Y created: ws_MDE_3D_cut_y"
-                    mock_binmd.assert_called_once_with(
-                        **common_params, OutputExtents=extents, OutputBins=expected_bins, OutputWorkspace=expected_ws
-                    )
+                    assert_called(**common_params, OutputExtents=extents, OutputBins=expected_bins, OutputWorkspace=expected_ws)
+                elif cut_type == "x" or cut_type == "c":
+                    expected_bins = [1, 100, 1]
+                    expected_ws = "ws_MDE_3D_cut_x"
+                    expected_msg = "Cut along X created: ws_MDE_3D_cut_x"
+                    assert_called(**common_params, OutputExtents=extents, OutputBins=expected_bins, OutputWorkspace=expected_ws)
 
             if cut_type == "c":
-                expected_msg = "Cuts along X/Y created: ws_MD_3D_cut_x & ws_MD_3D_cut_y"
+                expected_msg = "Cuts along X/Y created: ws_MDE_3D_cut_x & ws_MDE_3D_cut_y"
             elif cut_type == "x":
                 expected_msg = "Cut along X created: ws_MDE_3D_cut_x"
             elif cut_type == "y":
@@ -859,7 +854,7 @@ class SliceViewerModelTest(unittest.TestCase):
             self.assertEqual(expected_msg, help_msg)
             mock_binmd.reset_mock()
 
-        for cut_type in ("x", "y"):
+        for cut_type in ("x", "y", "c"):
             assert_call_as_expected(transpose=False, cut_type=cut_type)
             assert_call_as_expected(transpose=True, cut_type=cut_type)
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -677,6 +677,176 @@ class SliceViewerModelTest(unittest.TestCase):
             mock_ws.name.return_value = "mock_ws"
             assert_call_as_expected(mock_ws, transpose=False, export_type=export_type, is_spectra=is_spectra, is_ragged=is_ragged)
 
+    @patch("mantidqt.widgets.sliceviewer.models.model.IntegrateMDHistoWorkspace")
+    @patch("mantidqt.widgets.sliceviewer.models.model.TransposeMD")
+    def test_export_pixel_cut_to_workspace_mdhisto(self, mock_transpose, mock_intMD):
+        slicepoint = [None, None, 0.5]
+        bin_params = [100, 100, 0.1]
+        dimension_indices = [0, 1, None]
+        xpos, ypos = 0.0, 2.0
+
+        dim0_delta = self.ws_MD_3D.getDimension(0).getBinWidth()
+        dim1_delta = self.ws_MD_3D.getDimension(1).getBinWidth()
+
+        xmin, xmax = xpos - 0.5 * dim0_delta, xpos + 0.5 * dim0_delta
+        ymin, ymax = ypos - 0.5 * dim1_delta, ypos + 0.5 * dim1_delta
+        zmin, zmax = 0.45, 0.55
+
+        def assert_call_as_expected(transpose, cut_type):
+            model = SliceViewerModel(self.ws_MD_3D)
+
+            help_msg = model.export_pixel_cut_to_workspace(slicepoint, bin_params, (xpos, ypos), transpose, dimension_indices, cut_type)
+
+            if not transpose:
+                if cut_type == "x":
+                    # X-cut: integrate along X, keep Y dimension
+                    xcut_params = dict(
+                        InputWorkspace=self.ws_MD_3D,
+                        P1Bin=[xmin, 0, xmax],
+                        P2Bin=[ymin, ymax],
+                        P3Bin=[zmin, zmax],
+                        OutputWorkspace="ws_MD_3D_cut_x",
+                    )
+                    mock_intMD.assert_called_once_with(**xcut_params)
+                    self.assertEqual("Cut along X created: ws_MD_3D_cut_x", help_msg)
+                elif cut_type == "y":
+                    # Y-cut: integrate along Y, keep X dimension
+                    ycut_params = dict(
+                        InputWorkspace=self.ws_MD_3D,
+                        P1Bin=[xmin, xmax],
+                        P2Bin=[ymin, 0, ymax],
+                        P3Bin=[zmin, zmax],
+                        OutputWorkspace="ws_MD_3D_cut_y",
+                    )
+                    mock_intMD.assert_called_once_with(**ycut_params)
+                    self.assertEqual("Cut along Y created: ws_MD_3D_cut_y", help_msg)
+            else:
+                # In transposed mode, dimensions are swapped
+                if cut_type == "x":
+                    # X-cut: integrate along Y, keep X dimension (transposed)
+                    xcut_params = dict(
+                        InputWorkspace=self.ws_MD_3D,
+                        P1Bin=[ymin, ymax],
+                        P2Bin=[xmin, 0, xmax],
+                        P3Bin=[zmin, zmax],
+                        OutputWorkspace="ws_MD_3D_cut_x",
+                    )
+                    mock_intMD.assert_called_once_with(**xcut_params)
+                    self.assertEqual("Cut along X created: ws_MD_3D_cut_x", help_msg)
+                elif cut_type == "y":
+                    # Y-cut: integrate along X, keep Y dimension (transposed)
+                    ycut_params = dict(
+                        InputWorkspace=self.ws_MD_3D,
+                        P1Bin=[ymin, 0, ymax],
+                        P2Bin=[xmin, xmax],
+                        P3Bin=[zmin, zmax],
+                        OutputWorkspace="ws_MD_3D_cut_y",
+                    )
+                    mock_intMD.assert_called_once_with(**ycut_params)
+                    self.assertEqual("Cut along Y created: ws_MD_3D_cut_y", help_msg)
+
+            mock_intMD.reset_mock()
+
+        for cut_type in ("x", "y"):
+            assert_call_as_expected(transpose=False, cut_type=cut_type)
+            assert_call_as_expected(transpose=True, cut_type=cut_type)
+
+    @patch("mantidqt.widgets.sliceviewer.models.model.BinMD")
+    @patch("mantidqt.widgets.sliceviewer.models.model.TransposeMD")
+    def test_export_pixel_cut_to_workspace_mdevent(self, mock_transpose, mock_binmd):
+        slicepoint = [None, None, 0.5]
+        bin_params = [100, 100, 0.1]
+        dimension_indices = [0, 1, None]
+        xpos, ypos = 0.0, 2.0
+
+        dim0_delta = self.ws_MDE_3D.getDimension(0).getBinWidth()
+        dim1_delta = self.ws_MDE_3D.getDimension(1).getBinWidth()
+
+        xmin, xmax = xpos - 0.5 * dim0_delta, xpos + 0.5 * dim0_delta
+        ymin, ymax = ypos - 0.5 * dim1_delta, ypos + 0.5 * dim1_delta
+        zmin, zmax = 0.45, 0.55
+
+        def assert_call_as_expected(transpose, cut_type):
+            model = SliceViewerModel(self.ws_MDE_3D)
+
+            help_msg = model.export_pixel_cut_to_workspace_mdevent(
+                slicepoint, bin_params, (xpos, ypos), transpose, dimension_indices, cut_type
+            )
+
+            common_params = dict(
+                InputWorkspace=self.ws_MDE_3D,
+                AxisAligned=False,
+                BasisVector0="h,rlu,1.0,0.0,0.0",
+                BasisVector1="k,rlu,0.0,1.0,0.0",
+                BasisVector2="l,rlu,0.0,0.0,1.0",
+            )
+
+            if not transpose:
+                extents = [xmin, xmax, ymin, ymax, zmin, zmax]
+
+                if cut_type == "x":
+                    expected_bins = [100, 1, 1]
+                    expected_ws = "ws_MDE_3D_cut_x"
+                    expected_msg = "Cut along X created: ws_MDE_3D_cut_x"
+                else:
+                    expected_bins = [1, 100, 1]
+                    expected_ws = "ws_MDE_3D_cut_y"
+                    expected_msg = "Cut along Y created: ws_MDE_3D_cut_y"
+            else:
+                extents = [ymin, ymax, xmin, xmax, zmin, zmax]
+
+                if cut_type == "x":
+                    expected_bins = [1, 100, 1]
+                    expected_ws = "ws_MDE_3D_cut_x"
+                    expected_msg = "Cut along X created: ws_MDE_3D_cut_x"
+                else:
+                    expected_bins = [100, 1, 1]
+                    expected_ws = "ws_MDE_3D_cut_y"
+                    expected_msg = "Cut along Y created: ws_MDE_3D_cut_y"
+
+            mock_binmd.assert_called_once_with(
+                **common_params, OutputExtents=extents, OutputBins=expected_bins, OutputWorkspace=expected_ws
+            )
+
+            self.assertEqual(expected_msg, help_msg)
+            mock_binmd.reset_mock()
+
+        for cut_type in ("x", "y"):
+            assert_call_as_expected(transpose=False, cut_type=cut_type)
+            assert_call_as_expected(transpose=True, cut_type=cut_type)
+
+    @patch("mantidqt.widgets.sliceviewer.models.roi.extract_roi_matrix")
+    def test_export_pixel_cut_to_workspace_matrix(self, mock_extract_roi):
+        slicepoint = [None, None]
+        bin_params = [100, 100]
+        dimension_indices = [0, 1]
+        xpos, ypos = 1.5, 3.0
+
+        def assert_call_as_expected(transpose, cut_type):
+            model = SliceViewerModel(self.ws2d_histo)
+            mock_extract_roi.reset_mock()
+
+            help_msg = model.export_pixel_cut_to_workspace(slicepoint, bin_params, (xpos, ypos), transpose, dimension_indices, cut_type)
+
+            if not transpose:
+                if cut_type == "x":
+                    mock_extract_roi.assert_called_once_with(self.ws2d_histo, None, None, ypos, ypos, False, "ws2d_histo_cut_x")
+                    self.assertEqual("Cut along X created: ws2d_histo_cut_x", help_msg)
+                elif cut_type == "y":
+                    mock_extract_roi.assert_called_once_with(self.ws2d_histo, xpos, xpos, None, None, True, "ws2d_histo_cut_y")
+                    self.assertEqual("Cut along Y created: ws2d_histo_cut_y", help_msg)
+            else:
+                if cut_type == "x":
+                    mock_extract_roi.assert_called_once_with(self.ws2d_histo, ypos, ypos, None, None, True, "ws2d_histo_cut_y")
+                    self.assertEqual("Cut along X created: ws2d_histo_cut_y", help_msg)
+                elif cut_type == "y":
+                    mock_extract_roi.assert_called_once_with(self.ws2d_histo, None, None, xpos, xpos, False, "ws2d_histo_cut_x")
+                    self.assertEqual("Cut along Y created: ws2d_histo_cut_x", help_msg)
+
+            for cut_type in ("x", "y"):
+                assert_call_as_expected(transpose=False, cut_type=cut_type)
+                assert_call_as_expected(transpose=False, cut_type=cut_type)
+
     @patch("mantidqt.widgets.sliceviewer.models.model.TransposeMD")
     @patch("mantidqt.widgets.sliceviewer.models.model.IntegrateMDHistoWorkspace")
     def test_export_region_for_mdhisto_workspace(self, mock_intMD, mock_transposemd):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -874,23 +874,23 @@ class SliceViewerModelTest(unittest.TestCase):
             help_msg = model.export_pixel_cut_to_workspace(slicepoint, bin_params, (xpos, ypos), transpose, dimension_indices, cut_type)
 
             if not transpose:
-                if cut_type == "x":
+                if cut_type == "x" or cut_type == "c":
                     mock_extract_roi.assert_called_once_with(self.ws2d_histo, None, None, ypos, ypos, False, "ws2d_histo_cut_x")
                     self.assertEqual("Cut along X created: ws2d_histo_cut_x", help_msg)
-                elif cut_type == "y":
+                elif cut_type == "y" or cut_type == "c":
                     mock_extract_roi.assert_called_once_with(self.ws2d_histo, xpos, xpos, None, None, True, "ws2d_histo_cut_y")
                     self.assertEqual("Cut along Y created: ws2d_histo_cut_y", help_msg)
             else:
-                if cut_type == "x":
+                if cut_type == "x" or cut_type == "c":
                     mock_extract_roi.assert_called_once_with(self.ws2d_histo, ypos, ypos, None, None, True, "ws2d_histo_cut_y")
                     self.assertEqual("Cut along X created: ws2d_histo_cut_y", help_msg)
-                elif cut_type == "y":
+                elif cut_type == "y" or cut_type == "c":
                     mock_extract_roi.assert_called_once_with(self.ws2d_histo, None, None, xpos, xpos, False, "ws2d_histo_cut_x")
                     self.assertEqual("Cut along Y created: ws2d_histo_cut_x", help_msg)
 
-            for cut_type in ("x", "y"):
+            for cut_type in ("x", "y", "c"):
                 assert_call_as_expected(transpose=False, cut_type=cut_type)
-                assert_call_as_expected(transpose=False, cut_type=cut_type)
+                assert_call_as_expected(transpose=True, cut_type=cut_type)
 
     @patch("mantidqt.widgets.sliceviewer.models.model.TransposeMD")
     @patch("mantidqt.widgets.sliceviewer.models.model.IntegrateMDHistoWorkspace")


### PR DESCRIPTION
### Description of work
This PR fixes a bug encountered when exporting pixel cuts from MDHisto workspaces. The issue arose because the `export_pixel_cut_to_workspace` is assigned to the MDEvent version in the model. I have added a new function for performing pixel cuts from MDHisto workspaces. Additionally, I have added unit tests for the export pixel cut functions.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #36084. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->

### To test:
1- Make the workspace `md_3D_histo`
```
md_4D = CreateMDWorkspace(Dimensions=4, Extents=[0,2,-1,1,-1.5,1.5,-0.25,0.25], Names="H,K,L,E", Frames='HKL,HKL,HKL,General Frame',Units='r.l.u.,r.l.u.,r.l.u.,meV')
FakeMDEventData(InputWorkspace=md_4D, UniformParams='5e5') # 4D data
FakeMDEventData(InputWorkspace=md_4D, UniformParams='1e5,0.5,1.5,-0.5,0.5,-0.75,0.75,-0.1,0.1') # 4D data

# Add a non-orthogonal UB
expt_info = CreateSampleWorkspace()
md_4D.addExperimentInfo(expt_info)
SetUB(Workspace='md_4D', c=2, gamma=120)

md_3D_histo = BinMD(InputWorkspace='md_4D', AlignedDim0='H,-2,2,100', AlignedDim1='K,-1,1,100', AlignedDim2='L,-1.5,1.5,100')
```
2- Open `md_3D_histo` in sliceviewer
3- Select the plot option
4- Press 'x' or 'y' to create a new cut along that axis
5- Check if the cut is correct


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
