### PR TITLE
39013 highlight bool keywords in script editor

### DIFF
--- a/docs/source/release/v6.13.0/Workbench/New_features/39013.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/39013.rst
@@ -1,0 +1,1 @@
+- The :ref:`Python script editor <WorkbenchScriptWindow>` now supports Bool syntax highlighting.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlternateCSPythonLexer.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlternateCSPythonLexer.h
@@ -18,7 +18,9 @@ public:
 
   QColor defaultColor(int style) const override;
   QFont defaultFont(int style) const override;
+  const char *keywords(int set) const override;
 
 private:
   QFont m_font;
+  QStringList m_customKeywords = {"True", "False"};
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlternateCSPythonLexer.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlternateCSPythonLexer.h
@@ -22,5 +22,5 @@ public:
 
 private:
   QFont m_font;
-  QStringList m_customKeywords = {"True", "False"};
+  const QStringList m_customKeywords = {"True", "False"};
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlternateCSPythonLexer.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlternateCSPythonLexer.h
@@ -22,5 +22,5 @@ public:
 
 private:
   QFont m_font;
-  const QStringList m_customKeywords = {"True", "False"};
+  static constexpr const char *customKeywords = "True False";
 };

--- a/qt/widgets/common/src/AlternateCSPythonLexer.cpp
+++ b/qt/widgets/common/src/AlternateCSPythonLexer.cpp
@@ -88,21 +88,21 @@ QFont AlternateCSPythonLexer::defaultFont(int style) const {
 // * @param set The keyword set to retrieve (1 is for keywords)
 // * @return A string containing the keywords
 // */
-// const char *AlternateCSPythonLexer::keywords(int set) const {
-//  if (set == 1) {
-//    // Retrieve default Python keywords from qscintilla
-//    const char *defaultKeywords = QsciLexerPython::keywords(1);
-//    QStringList keywordList = QString::fromUtf8(defaultKeywords).split(" ");
-//
-//    for (const QString &keyword : m_customKeywords) {
-//      if (!keywordList.contains(keyword)) {
-//        keywordList.append(keyword);
-//      }
-//    }
-//
-//    QByteArray m_keywordsBuffer = keywordList.join(" ").toUtf8();
-//    return m_keywordsBuffer.constData();
-//  }
-//
-//  return QsciLexerPython::keywords(set);
-//}
+const char *AlternateCSPythonLexer::keywords(int set) const {
+  if (set == 1) {
+    // Retrieve default Python keywords from qscintilla
+    const char *defaultKeywords = QsciLexerPython::keywords(1);
+    QStringList keywordList = QString::fromUtf8(defaultKeywords).split(" ");
+
+    for (const QString &keyword : m_customKeywords) {
+      if (!keywordList.contains(keyword)) {
+        keywordList.append(keyword);
+      }
+    }
+
+    QByteArray m_keywordsBuffer = keywordList.join(" ").toUtf8();
+    return m_keywordsBuffer.constData();
+  }
+
+  return QsciLexerPython::keywords(set);
+}

--- a/qt/widgets/common/src/AlternateCSPythonLexer.cpp
+++ b/qt/widgets/common/src/AlternateCSPythonLexer.cpp
@@ -92,16 +92,12 @@ const char *AlternateCSPythonLexer::keywords(int set) const {
   if (set == 1) {
     // Retrieve default Python keywords from qscintilla
     const char *defaultKeywords = QsciLexerPython::keywords(1);
-    QStringList keywordList = QString::fromUtf8(defaultKeywords).split(" ");
+    static std::string combinedKeywords;
+    std::ostringstream stream;
+    stream << defaultKeywords << " " << customKeywords;
 
-    for (const QString &keyword : m_customKeywords) {
-      if (!keywordList.contains(keyword)) {
-        keywordList.append(keyword);
-      }
-    }
-
-    QByteArray m_keywordsBuffer = keywordList.join(" ").toUtf8();
-    return m_keywordsBuffer.constData();
+    combinedKeywords = stream.str();
+    return combinedKeywords.c_str();
   }
 
   return QsciLexerPython::keywords(set);

--- a/qt/widgets/common/src/AlternateCSPythonLexer.cpp
+++ b/qt/widgets/common/src/AlternateCSPythonLexer.cpp
@@ -82,3 +82,27 @@ QFont AlternateCSPythonLexer::defaultFont(int style) const {
   Q_UNUSED(style);
   return m_font;
 }
+
+///**
+// * Returns the keywords used by the lexer for a given set.
+// * @param set The keyword set to retrieve (1 is for keywords)
+// * @return A string containing the keywords
+// */
+// const char *AlternateCSPythonLexer::keywords(int set) const {
+//  if (set == 1) {
+//    // Retrieve default Python keywords from qscintilla
+//    const char *defaultKeywords = QsciLexerPython::keywords(1);
+//    QStringList keywordList = QString::fromUtf8(defaultKeywords).split(" ");
+//
+//    for (const QString &keyword : m_customKeywords) {
+//      if (!keywordList.contains(keyword)) {
+//        keywordList.append(keyword);
+//      }
+//    }
+//
+//    QByteArray m_keywordsBuffer = keywordList.join(" ").toUtf8();
+//    return m_keywordsBuffer.constData();
+//  }
+//
+//  return QsciLexerPython::keywords(set);
+//}


### PR DESCRIPTION
### Description of work
Add support for syntax highlighting of Bool Keywords in mantid python script editor

Fixes #39013

### To test:
- open the Mantid python code editor.
- enter True or False
- verify that the keywords are highlighted in blue