### PR TITLE
Exposing more Instrument methods to python - ornl-next

### DIFF
--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
@@ -11,6 +11,7 @@
 #include "MantidPythonInterface/core/Policies/RemoveConst.h"
 
 #include <boost/python/class.hpp>
+#include <boost/python/copy_const_reference.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
@@ -73,6 +74,12 @@ void export_Instrument() {
       .def("getValidToDate", &Instrument::getValidToDate, arg("self"),
            "Return the valid to :class:`~mantid.kernel.DateAndTime` of the "
            "instrument")
+
+      .def("getFilename", &Instrument::getFilename, arg("self"), return_value_policy<copy_const_reference>(),
+           "Return the name of the file that the original IDF was from")
+
+      .def("setFilename", &Instrument::setFilename, (arg("self"), arg("filename")),
+           "Set the name of the file that the original IDF was from")
 
       .def("getBaseInstrument", &Instrument::baseInstrument, arg("self"), return_value_policy<RemoveConstSharedPtr>(),
            "Return reference to the base instrument")

--- a/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
@@ -44,6 +44,20 @@ class InstrumentTest(unittest.TestCase):
         frame = self.__testws.getInstrument().getReferenceFrame()
         self.assertTrue(isinstance(frame, ReferenceFrame))
 
+    def test_getFilename(self):
+        inst = self.__testws.getInstrument()
+
+        # get the filename
+        NAME_ORIG = inst.getFilename()
+
+        # check that the filename can be set
+        NAME_NEW = "testable"
+        inst.setFilename(NAME_NEW)
+        self.assertEqual(inst.getFilename(), NAME_NEW)
+
+        # put the filename back to what it was
+        inst.setFilename(NAME_ORIG)
+
     def test_ValidDates(self):
         inst = self.__testws.getInstrument()
         valid_from = inst.getValidFromDate()

--- a/docs/source/release/v6.13.0/Framework/Python/New_features/39044.rst
+++ b/docs/source/release/v6.13.0/Framework/Python/New_features/39044.rst
@@ -1,0 +1,1 @@
+- Exposed ``Instrument.getFilename()`` and ``Instrument.setFilename()`` to python


### PR DESCRIPTION
This is a version of #39044 into `ornl-next`