### PR TITLE
Change Rasterize function to take separate Gauge Volume Shape and Sample Shape

### DIFF
--- a/Framework/Algorithms/src/AnyShapeAbsorption.cpp
+++ b/Framework/Algorithms/src/AnyShapeAbsorption.cpp
@@ -52,7 +52,7 @@ void AnyShapeAbsorption::initialiseCachedDistances() {
     integrationVolume = constructGaugeVolume();
   }
 
-  auto raster = Geometry::Rasterize::calculate(m_beamDirection, *integrationVolume, m_cubeSide);
+  auto raster = Geometry::Rasterize::calculate(m_beamDirection, *integrationVolume, *m_sampleObject, m_cubeSide);
   m_sampleVolume = raster.totalvolume;
   if (raster.l1.size() == 0)
     throw std::runtime_error("Failed to rasterize shape");

--- a/Framework/Algorithms/src/CylinderAbsorption.cpp
+++ b/Framework/Algorithms/src/CylinderAbsorption.cpp
@@ -164,7 +164,7 @@ void CylinderAbsorption::initialiseCachedDistances() {
   const auto *shape = dynamic_cast<const Geometry::CSGObject *>(m_sampleObject);
   if (!shape)
     throw std::runtime_error("Failed to convert shape from IObject to CSGObject");
-  auto raster = Geometry::Rasterize::calculateCylinder(m_beamDirection, *shape, m_numSlices, m_numAnnuli);
+  auto raster = Geometry::Rasterize::calculateCylinder(m_beamDirection, *shape, *shape, m_numSlices, m_numAnnuli);
   m_sampleVolume = raster.totalvolume;
   if (raster.l1.size() == 0)
     throw std::runtime_error("Failed to rasterize shape");

--- a/Framework/Algorithms/src/MultipleScatteringCorrectionDistGraber.cpp
+++ b/Framework/Algorithms/src/MultipleScatteringCorrectionDistGraber.cpp
@@ -45,7 +45,7 @@ void MultipleScatteringCorrectionDistGraber::cacheLS1(const V3D &beamDirection) 
   auto integrationVolume = std::shared_ptr<const IObject>(m_sampleShape->clone());
 
   // create the raster
-  auto raster = Geometry::Rasterize::calculate(beamDirection, *integrationVolume, m_elementSize);
+  auto raster = Geometry::Rasterize::calculate(beamDirection, *integrationVolume, *integrationVolume, m_elementSize);
 
   // check if the raster is empty
   if (raster.l1.size() == 0) {

--- a/Framework/Algorithms/src/PaalmanPingsAbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/PaalmanPingsAbsorptionCorrection.cpp
@@ -289,7 +289,7 @@ void PaalmanPingsAbsorptionCorrection::initialiseCachedDistances() {
     integrationVolume = constructGaugeVolume();
   }
 
-  auto raster = Geometry::Rasterize::calculate(m_beamDirection, *integrationVolume, m_cubeSideSample);
+  auto raster = Geometry::Rasterize::calculate(m_beamDirection, *integrationVolume, *m_sampleObject, m_cubeSideSample);
   m_sampleVolume = raster.totalvolume;
   if (raster.l1.size() == 0)
     throw std::runtime_error("Failed to rasterize shape");
@@ -305,7 +305,7 @@ void PaalmanPingsAbsorptionCorrection::initialiseCachedDistances() {
     integrationVolume = constructGaugeVolume();
   }
 
-  raster = Geometry::Rasterize::calculate(m_beamDirection, *integrationVolume, m_cubeSideContainer);
+  raster = Geometry::Rasterize::calculate(m_beamDirection, *integrationVolume, *m_containerObject, m_cubeSideContainer);
   m_containerVolume = raster.totalvolume;
   if (raster.l1.size() == 0)
     throw std::runtime_error("Failed to rasterize shape");

--- a/Framework/Algorithms/test/AnyShapeAbsorptionTest.h
+++ b/Framework/Algorithms/test/AnyShapeAbsorptionTest.h
@@ -204,8 +204,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(atten.setPropertyValue("ScatteringXSection", "5.1"));
     TS_ASSERT_THROWS_NOTHING(atten.setPropertyValue("SampleNumberDensity", "0.07192"));
     atten.setRethrows(true); // needed for the next check to work
-    TS_ASSERT_THROWS(atten.execute(), const std::runtime_error &);
-    TS_ASSERT(!atten.isExecuted());
+    TS_ASSERT_THROWS_NOTHING(atten.execute());
+    TS_ASSERT(atten.isExecuted());
 
     AnalysisDataService::Instance().remove(flatWS);
   }

--- a/Framework/Geometry/inc/MantidGeometry/Rasterize.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rasterize.h
@@ -30,8 +30,8 @@ public:
 
 namespace Rasterize {
 
-MANTID_GEOMETRY_DLL Raster calculate(const Kernel::V3D &beamDirection, const IObject &shape,
-                                     const double cubeSizeInMetre);
+MANTID_GEOMETRY_DLL Raster calculate(const Kernel::V3D &beamDirection, const IObject &integShape,
+                                     const IObject &sampleShape, const double cubeSizeInMetre);
 
 MANTID_GEOMETRY_DLL Raster calculateCylinder(const Kernel::V3D &beamDirection, const IObject &shape,
                                              const size_t numSlices, const size_t numAnnuli);

--- a/Framework/Geometry/inc/MantidGeometry/Rasterize.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rasterize.h
@@ -33,11 +33,13 @@ namespace Rasterize {
 MANTID_GEOMETRY_DLL Raster calculate(const Kernel::V3D &beamDirection, const IObject &integShape,
                                      const IObject &sampleShape, const double cubeSizeInMetre);
 
-MANTID_GEOMETRY_DLL Raster calculateCylinder(const Kernel::V3D &beamDirection, const IObject &shape,
-                                             const size_t numSlices, const size_t numAnnuli);
+MANTID_GEOMETRY_DLL Raster calculateCylinder(const Kernel::V3D &beamDirection, const IObject &integShape,
+                                             const IObject &sampleShape, const size_t numSlices,
+                                             const size_t numAnnuli);
 
-MANTID_GEOMETRY_DLL Raster calculateHollowCylinder(const Kernel::V3D &beamDirection, const IObject &shape,
-                                                   const size_t numSlices, const size_t numAnnuli);
+MANTID_GEOMETRY_DLL Raster calculateHollowCylinder(const Kernel::V3D &beamDirection, const IObject &integShape,
+                                                   const IObject &sampleShape, const size_t numSlices,
+                                                   const size_t numAnnuli);
 
 } // namespace Rasterize
 } // namespace Geometry

--- a/Framework/Geometry/src/Rasterize.cpp
+++ b/Framework/Geometry/src/Rasterize.cpp
@@ -118,13 +118,13 @@ Raster calculateGeneric(const V3D &beamDirection, const IObject &integShape, con
   // go through the bounding box generating cubes and seeing if they are
   // inside the shape
   for (size_t i = 0; i < numZSlices; ++i) {
-    const double z = (static_cast<double>(i) + 0.5) * ZSliceThickness + integBbox.xMin();
+    const double z = (static_cast<double>(i) + 0.5) * ZSliceThickness + integBbox.zMin();
 
     for (size_t j = 0; j < numYSlices; ++j) {
       const double y = (static_cast<double>(j) + 0.5) * YSliceThickness + integBbox.yMin();
 
       for (size_t k = 0; k < numXSlices; ++k) {
-        const double x = (static_cast<double>(k) + 0.5) * XSliceThickness + integBbox.zMin();
+        const double x = (static_cast<double>(k) + 0.5) * XSliceThickness + integBbox.xMin();
         // Set the current position in the sample in Cartesian coordinates.
         const Kernel::V3D currentPosition = V3D(x, y, z);
         // Check if the current point is within the object. If not, skip.

--- a/Framework/Geometry/test/RasterizeTest.h
+++ b/Framework/Geometry/test/RasterizeTest.h
@@ -284,9 +284,11 @@ public:
         ComponentCreationHelper::createCuboid(1, 1, 1, sampleCenter, "sample");
     const auto raster_result = Rasterize::calculate(V3D(0., 0., 1.), *integVolume, *sample, 1.0);
 
-    TS_ASSERT_EQUALS(raster_result.l1.size(), 8);
+    const int size = static_cast<int>(raster_result.l1.size());
+
+    TS_ASSERT_EQUALS(size, 8);
     TS_ASSERT_DELTA(raster_result.totalvolume, 8.0, 0.001);
-    for (int i = 0; i < raster_result.l1.size(); i++) {
+    for (int i = 0; i < size; i++) {
       // all l1s should be greater or equal to 1
       TS_ASSERT_LESS_THAN_EQUALS(1.0, raster_result.l1[i])
     };
@@ -299,9 +301,11 @@ public:
     const std::shared_ptr<CSGObject> sample = ComponentCreationHelper::createCuboid(1, 1, 1, sampleCenter, "sample");
     const auto raster_result = Rasterize::calculate(V3D(0., 0., 1.), *integVolume, *sample, 1.0);
 
-    TS_ASSERT_EQUALS(raster_result.l1.size(), 8);
+    const int size = static_cast<int>(raster_result.l1.size());
+
+    TS_ASSERT_EQUALS(size, 8);
     TS_ASSERT_DELTA(raster_result.totalvolume, 8.0, 0.001);
-    for (int i = 0; i < raster_result.l1.size(); i++) {
+    for (int i = 0; i < size; i++) {
       // all l1s should be less than or equal to 2
       TS_ASSERT_LESS_THAN_EQUALS(raster_result.l1[i], 2.0)
     };

--- a/Framework/Geometry/test/RasterizeTest.h
+++ b/Framework/Geometry/test/RasterizeTest.h
@@ -276,4 +276,34 @@ public:
     // boxes
     simpleRasterChecks(raster, sphere, 912, SPHERE_VOLUME, .01);
   }
+
+  void test_SmallerIntegrationVolumeWithinBiggerSample() {
+    V3D sampleCenter(0., 0., 0.);
+    const std::shared_ptr<CSGObject> sample = ComponentCreationHelper::createCuboid(2, 2, 2, sampleCenter, "sample");
+    const std::shared_ptr<CSGObject> integVolume =
+        ComponentCreationHelper::createCuboid(1, 1, 1, sampleCenter, "sample");
+    const auto raster_result = Rasterize::calculate(V3D(0., 0., 1.), *integVolume, *sample, 1.0);
+
+    TS_ASSERT_EQUALS(raster_result.l1.size(), 8);
+    TS_ASSERT_DELTA(raster_result.totalvolume, 8.0, 0.001);
+    for (int i = 0; i < raster_result.l1.size(); i++) {
+      // all l1s should be greater or equal to 1
+      TS_ASSERT_LESS_THAN_EQUALS(1.0, raster_result.l1[i])
+    };
+  }
+
+  void test_LargerIntegrationVolumeThanSample() {
+    V3D sampleCenter(0., 0., 0.);
+    const std::shared_ptr<CSGObject> integVolume =
+        ComponentCreationHelper::createCuboid(2, 2, 2, sampleCenter, "sample");
+    const std::shared_ptr<CSGObject> sample = ComponentCreationHelper::createCuboid(1, 1, 1, sampleCenter, "sample");
+    const auto raster_result = Rasterize::calculate(V3D(0., 0., 1.), *integVolume, *sample, 1.0);
+
+    TS_ASSERT_EQUALS(raster_result.l1.size(), 8);
+    TS_ASSERT_DELTA(raster_result.totalvolume, 8.0, 0.001);
+    for (int i = 0; i < raster_result.l1.size(); i++) {
+      // all l1s should be less than or equal to 2
+      TS_ASSERT_LESS_THAN_EQUALS(raster_result.l1[i], 2.0)
+    };
+  }
 };

--- a/Framework/Geometry/test/RasterizeTest.h
+++ b/Framework/Geometry/test/RasterizeTest.h
@@ -118,7 +118,7 @@ public:
     constexpr size_t NUM_ANNULLI{3};
 
     const auto cylinder = createCylinder(true);
-    const auto raster = Rasterize::calculateCylinder(V3D(0., 0., 1.), cylinder, NUM_SLICE, NUM_ANNULLI);
+    const auto raster = Rasterize::calculateCylinder(V3D(0., 0., 1.), cylinder, cylinder, NUM_SLICE, NUM_ANNULLI);
 
     // all the vector lengths should match
     constexpr size_t NUM_ELEMENTS = NUM_SLICE * NUM_ANNULLI * (NUM_ANNULLI + 1) * 3;
@@ -130,7 +130,8 @@ public:
     constexpr size_t NUM_ANNULLI{3};
 
     const auto hollowCylinder = createHollowCylinder(true);
-    const auto raster = Rasterize::calculateHollowCylinder(V3D(0., 0., 1.), hollowCylinder, NUM_SLICE, NUM_ANNULLI);
+    const auto raster =
+        Rasterize::calculateHollowCylinder(V3D(0., 0., 1.), hollowCylinder, hollowCylinder, NUM_SLICE, NUM_ANNULLI);
 
     // all the vector lengths should match
     size_t NUM_ELEMENTS = 0;
@@ -167,7 +168,7 @@ public:
     constexpr size_t NUM_ANNULLI{3};
 
     const auto cylinder = createCylinder(false);
-    const auto raster = Rasterize::calculateCylinder(V3D(0., 0., 1.), cylinder, NUM_SLICE, NUM_ANNULLI);
+    const auto raster = Rasterize::calculateCylinder(V3D(0., 0., 1.), cylinder, cylinder, NUM_SLICE, NUM_ANNULLI);
 
     // all the vector lengths should match
     constexpr size_t NUM_ELEMENTS = NUM_SLICE * NUM_ANNULLI * (NUM_ANNULLI + 1) * 3;
@@ -179,7 +180,8 @@ public:
     constexpr size_t NUM_ANNULLI{3};
 
     const auto hollowCylinder = createHollowCylinder(false);
-    const auto raster = Rasterize::calculateHollowCylinder(V3D(0., 0., 1.), hollowCylinder, NUM_SLICE, NUM_ANNULLI);
+    const auto raster =
+        Rasterize::calculateHollowCylinder(V3D(0., 0., 1.), hollowCylinder, hollowCylinder, NUM_SLICE, NUM_ANNULLI);
 
     // all the vector lengths should match
     size_t NUM_ELEMENTS = 0;
@@ -203,7 +205,7 @@ public:
 
     std::shared_ptr<CSGObject> hollowCylinder =
         ComponentCreationHelper::createHollowCylinder(RADIUS - ELEMENT_SIZE, RADIUS, HEIGHT, BASE, AXIS, "shape");
-    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), *hollowCylinder, ELEMENT_SIZE);
+    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), *hollowCylinder, *hollowCylinder, ELEMENT_SIZE);
 
     const double vol = M_PI * HEIGHT * (RADIUS * RADIUS - (RADIUS - ELEMENT_SIZE) * (RADIUS - ELEMENT_SIZE));
     simpleRasterChecks(raster, *hollowCylinder, raster.l1.size(), vol);
@@ -220,7 +222,7 @@ public:
     std::shared_ptr<CSGObject> hollowCylinder =
         ComponentCreationHelper::createHollowCylinder(RADIUS - ELEMENT_SIZE, RADIUS, HEIGHT, BASE, AXIS, "shape");
     // test using the generic calculate function
-    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), *hollowCylinder, ELEMENT_SIZE);
+    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), *hollowCylinder, *hollowCylinder, ELEMENT_SIZE);
 
     const double vol = M_PI * HEIGHT * (RADIUS * RADIUS - (RADIUS - ELEMENT_SIZE) * (RADIUS - ELEMENT_SIZE));
     simpleRasterChecks(raster, *hollowCylinder, raster.l1.size(), vol);
@@ -237,7 +239,7 @@ public:
 
     std::shared_ptr<CSGObject> hollowCylinder =
         ComponentCreationHelper::createHollowCylinder(INNER_RADIUS, OUTER_RADIUS, HEIGHT, BASE, AXIS, "shape");
-    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), *hollowCylinder, ELEMENT_SIZE);
+    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), *hollowCylinder, *hollowCylinder, ELEMENT_SIZE);
 
     const double vol = M_PI * HEIGHT * (OUTER_RADIUS * OUTER_RADIUS - INNER_RADIUS * INNER_RADIUS);
     simpleRasterChecks(raster, *hollowCylinder, raster.l1.size(), vol);
@@ -245,12 +247,13 @@ public:
 
   void test_calculateCylinderOnSphere() {
     const auto sphere = createSphere(true);
-    TS_ASSERT_THROWS(Rasterize::calculateCylinder(V3D(0., 0., 1.), sphere, 3, 3), const std::invalid_argument &);
+    TS_ASSERT_THROWS(Rasterize::calculateCylinder(V3D(0., 0., 1.), sphere, sphere, 3, 3),
+                     const std::invalid_argument &);
   }
 
   void test_calculateArbitraryOnCylinder() {
     const auto cylinder = createCylinder(true);
-    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), cylinder, .1);
+    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), cylinder, cylinder, .1);
 
     // all the vector lengths should match
     simpleRasterChecks(raster, cylinder, 180, CYLINDER_VOLUME);
@@ -258,7 +261,7 @@ public:
 
   void test_calculateArbitraryOnSphere() {
     const auto sphere = createSphere(true);
-    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), sphere, .5);
+    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), sphere, sphere, .5);
 
     // volume is calculated poorly due to approximating all volume elements as
     // boxes
@@ -267,7 +270,7 @@ public:
 
   void test_calculateArbitraryOnOffsetSphere() {
     const auto sphere = createSphere(false);
-    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), sphere, .5);
+    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), sphere, sphere, .5);
 
     // volume is calculated poorly due to approximating all volume elements as
     // boxes

--- a/docs/source/release/v6.13.0/Diffraction/Engineering/Bugfixes/39084.rst
+++ b/docs/source/release/v6.13.0/Diffraction/Engineering/Bugfixes/39084.rst
@@ -1,0 +1,1 @@
+- Within  :ref:`algm-AbsorptionCorrection` algorithm, when ``Rasterize`` is called, it now takes both the Integration Volume Shape and the Sample Shape to calculate L1 paths. Before, it would only take the integration volume and would assume that the paths within this shape are equal to the paths within the sample.


### PR DESCRIPTION
### Description of work

#### Summary of work
As title implies now the rasterize function takes two shapes rather than one. 

Addresses #39079

#### Further detail of work
Previously the function was assuming that the integration volume provided was entirely matching the volume of the sample from which scattering can occur and that the path lengths within this shape are exactly the same as path lengths within the sample. To achieve this, the onus is put upon the user to provide this correct integration volume - which seemingly would depend on sample shape and orientation. 

Now, with the shape and integration volume passed separately, the integration volume provided can be sample independent, as the function determines internally whether each voxel within the integration volume correspond to valid scattering locations and then explicitly calculates the path lengths from these voxels within the provided sample shape.

### To test:

You can rerun the test script from the issue and should see sensible changes. I'll also add a test script here, that will ultimately be a system test once we agree that this change is something we want

script: 

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from mantid.api import AnalysisDataService as ADS

def cuboid_shape(l, id, z = 0.0):
   return f" \
<cuboid id='{id}'> \
<height val='{l}'  /> \
<width val='{l}' />  \
<depth  val='{l}' />  \
<centre x='0.0' y='0.0' z='{z}'  />  \
</cuboid>  \
<algebra val='{id}' /> \
"

def run_abs_corr(run_name, sample_len, gv_len, z_offset, theta):
    muR = 1
    CreateSampleWorkspace(OutputWorkspace = f"ws_{run_name}", Function='Powder Diffraction', 
        XMin=2000, XMax=20000, BinWidth=200, NumBanks=1, BankPixelWidth=1, PixelSpacing=0.02,
        WorkspaceType="Histogram")
    EditInstrumentGeometry(Workspace=f"ws_{run_name}", L2=0.5, Polar=2*theta)
    ConvertUnits(InputWorkspace=f"ws_{run_name}", OutputWorkspace=f"ws_{run_name}", Target='Wavelength')
    
    sample_shape = cuboid_shape(sample_len, "sample", z_offset)
    
    SetSample(f"ws_{run_name}", Geometry={'Shape': 'CSG', 'Value': sample_shape})
    SetSampleMaterial(f"ws_{run_name}",ChemicalFormula="Fe")
    
    gv = cuboid_shape(gv_len, "gv")
    
    DefineGaugeVolume(f"ws_{run_name}", gv)
    
    AbsorptionCorrection(InputWorkspace = f"ws_{run_name}", 
                        OutputWorkspace = f"abs_corr_{run_name}",
                        ElementSize = 1.0)
    

def plot_range_gv_pos(sample_size = 0.1, gv_size = 0.005, n_pos = 10, theta = 90):
    
    z_offsets = np.linspace(-sample_size/2 + gv_size/2, sample_size/2 - gv_size/2, n_pos)
    
    for i, z_off in enumerate(z_offsets):
        name = f"{i}_{2*theta}"
        run_abs_corr(name, sample_size, gv_size, -z_off, theta)
    

    fig, axs = plt.subplots(1,3)
    fracs, meanYs = [], []
    for i in range(len(z_offsets)):
        spec = ADS.retrieve(f"abs_corr_{i}_{2*theta}")
        X, Y = spec.readX(0)[:-1], spec.readY(0)
        logY = np.log(Y)
        gv_frac = (z_offsets[i]+(sample_size/2))/sample_size
        
        axs[0].plot(X, Y)
        axs[1].plot(X, logY)
        
        fracs.append(gv_frac)
        meanYs.append(logY.mean())
        
    leg = [f"frac: {np.round(x,3)}" for x in fracs]
    
    axs[2].scatter(fracs, meanYs)
    
    axs[0].set_xlabel("Wavelength/ A")
    axs[1].set_xlabel("Wavelength/ A")
    axs[2].set_xlabel("Gauge Volume Position Fraction")
    
    axs[0].set_ylabel("Attenuation Correction")
    axs[1].set_ylabel("Log Attenuation Correction")
    axs[2].set_ylabel("Log Attenuation Correction")
    
    axs[0].legend(leg)
    axs[1].legend(leg)
    
    fig.suptitle(f"Backscattering Correction: Moving ${gv_size}^3$ GV along ${sample_size}^3$ sample")
        
    fig.show()
    
def plot_range_gv_vol(sample_size = 0.1, n_pos = 10, theta = 90):
    
    fracs = np.linspace(0, 1, n_pos + 1)[1:] 
    gv_sizes = fracs* sample_size
    
    for i, gv_size in enumerate(gv_sizes):
        name = f"{i}_{2*theta}"
        run_abs_corr(name, sample_size, gv_size, 0.0, theta)
    

    fig, axs = plt.subplots(1,3)
    meanYs = []
    for i in range(len(fracs)):
        spec = ADS.retrieve(f"abs_corr_{i}_{2*theta}")
        X, Y = spec.readX(0)[:-1], spec.readY(0)
        logY = np.log(Y)
        
        axs[0].plot(X, Y)
        axs[1].plot(X, logY)
        
        meanYs.append(logY.mean())
        
    leg = [f"frac: {np.round(x,3)}" for x in fracs]
    
    axs[0].legend(leg)
    axs[1].legend(leg)
    
    axs[2].scatter(fracs, meanYs)
    
    axs[0].set_xlabel("Wavelength/ A")
    axs[1].set_xlabel("Wavelength/ A")
    axs[2].set_xlabel("Gauge Volume Side Length Fraction")
    
    axs[0].set_ylabel("Attenuation Correction")
    axs[1].set_ylabel("Log Attenuation Correction")
    axs[2].set_ylabel("Log Attenuation Correction")
    
    fig.suptitle(f"Backscattering Correction: Scaling GV side lengths to fraction of ${sample_size}^3$ sample side length")
        
    fig.show()

plot_range_gv_pos(n_pos = 10)

#plot_range_gv_vol(n_pos = 5)

```

![image](https://github.com/user-attachments/assets/7d9d1d9e-0c50-45d5-9797-6fd68fbf7cbd)


![image](https://github.com/user-attachments/assets/d4bf19b5-6cac-40ed-bc1f-210891c3fd73)



Likewise release note to follow once agreed upon change

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
