### PR TITLE
Fix for slab size to data size mismatch, on write of ragged workspaces.

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/SaveNexusProcessedHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveNexusProcessedHelper.h
@@ -30,7 +30,7 @@ namespace Mantid {
 namespace NeXus {
 /** @class NexusFileIO SaveNexusProcessedHelper.h NeXus/SaveNexusProcessedHelper.h
 
-Utility method for saving NeXus format of Mantid Workspace
+Utility methods for saving Mantid Workspaces in NeXus format.
 This class interfaces to the C Nexus API. This is written for use by
 Save and Load NexusProcessed classes, though it could be extended to
 other Nexus formats. It might be replaced in future by methods using

--- a/Framework/DataHandling/test/SaveNexusProcessedTest.h
+++ b/Framework/DataHandling/test/SaveNexusProcessedTest.h
@@ -41,8 +41,10 @@
 
 #include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
 #include "MantidFrameworkTestHelpers/FakeObjects.h"
+#include "MantidFrameworkTestHelpers/InstrumentCreationHelper.h"
 #include "MantidFrameworkTestHelpers/NexusTestHelper.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.hxx"
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
@@ -822,7 +824,7 @@ public:
     SaveNexusProcessed saveAlg;
     saveAlg.initialize();
     saveAlg.setPropertyValue("InputWorkspace", "testSpace");
-    std::string file = "SaveNexusProcessedTest_test_masking.nxs";
+    std::string file = "SaveNexusProcessedTest_test_ragged_bins_spectrum_indices.nxs";
     if (Poco::File(file).exists())
       Poco::File(file).remove();
     TS_ASSERT_THROWS_NOTHING(saveAlg.setPropertyValue("Filename", file));
@@ -843,6 +845,77 @@ public:
 
     if (clearfiles)
       Poco::File(file).remove();
+    AnalysisDataService::Instance().remove("testSpace");
+  }
+
+  void test_ragged_x_bins_input_data_bounds() {
+    // Fix SEGFAULT when writing ragged data: respect input vector bounds at `putSlab`.
+
+    // Implementation note:
+    //   The preliminary implementation separated this test into a "negative" test (producing the SEGFAULT),
+    // and a "positive" test (not producing the SEGFAULT).
+    // The negative test was then wrapped, using `Poco::SignalHandler` and the `poco_throw_on_signal` macro.
+    // Unfortunately, the current `CTest` implementation bypasses these mechanisms (how?),
+    // and treats any abnormal termination as a failed test.  For the moment, the negative test requires
+    // a "by hand" treatment:
+    //   that is, test the previous version of `Mantid` using this version of `SaveNexusProcessedTest`,
+    // and verify that this test fails due to a SEGFAULT.
+
+    // Create a ragged workspace with rapidly decreasing spectrum lengths.
+    using Counts = Mantid::HistogramData::Counts;
+    using CountStandardDeviations = Mantid::HistogramData::CountStandardDeviations;
+    using Histogram = Mantid::HistogramData::Histogram;
+    using Histogram_sptr = std::shared_ptr<Histogram>;
+    std::function<Histogram_sptr(double, double, std::size_t)> spectrumFunc = [](double x_0, double x_1,
+                                                                                 std::size_t N_x) -> Histogram_sptr {
+      const double dx = (x_1 - x_0) / (double(N_x - 1));
+      Histogram_sptr rval = std::make_shared<Histogram>(Histogram::XMode::Points, Histogram::YMode::Counts);
+      rval->resize(N_x); // resizes x: Points
+      rval->setCounts(Counts(N_x));
+      rval->setCountStandardDeviations(CountStandardDeviations(N_x));
+
+      auto &vx = rval->mutableX();
+      auto &vy = rval->mutableY();
+      auto &ve = rval->mutableE();
+      double x = x_0;
+      for (std::size_t n = 0; n < N_x; ++n, x += dx) {
+        vx[n] = x;
+        vy[n] = 2.0;
+        ve[n] = M_SQRT2;
+      }
+      return rval;
+    };
+
+    const std::size_t PAGE_SIZE(4096);
+    Workspace2D_sptr ws = WorkspaceCreationHelper::create2DWorkspaceFromFunctionAndArgsList(
+        spectrumFunc, {{0.0, 25600.0, std::size_t(256 * PAGE_SIZE)},
+                       {0.0, 12800.0, std::size_t(128 * PAGE_SIZE)},
+                       {0.0, 6400.0, std::size_t(64 * PAGE_SIZE)},
+                       {0.0, 3200.0, std::size_t(32 * PAGE_SIZE)},
+                       {0.0, 1600.0, std::size_t(16 * PAGE_SIZE)},
+                       {0.0, 800.0, std::size_t(8 * PAGE_SIZE)},
+                       {0.0, 400.0, std::size_t(4 * PAGE_SIZE)},
+                       {0.0, 200.0, std::size_t(2 * PAGE_SIZE)}});
+    ws->getAxis(0)->unit() = Mantid::Kernel::UnitFactory::Instance().create("dSpacing");
+    InstrumentCreationHelper::addFullInstrumentToWorkspace(*ws, false, false, "test instrument");
+    TS_ASSERT(ws->isRaggedWorkspace());
+    AnalysisDataService::Instance().add("testSpace", ws);
+
+    SaveNexusProcessed saveAlg;
+    saveAlg.initialize();
+    saveAlg.setPropertyValue("InputWorkspace", "testSpace");
+    std::string fileName = "SaveNexusProcessedTest_test_ragged_bins_data_bounds.nxs";
+    if (Poco::File(fileName).exists())
+      Poco::File(fileName).remove();
+    TS_ASSERT_THROWS_NOTHING(saveAlg.setPropertyValue("Filename", fileName));
+
+    // Verify that the current implementation doesn't produce a SEGFAULT.
+    TS_ASSERT_THROWS_NOTHING(saveAlg.execute());
+    TS_ASSERT(saveAlg.isExecuted());
+
+    // If the save successfully executed without producing a SEGFAULT, this test is complete.
+    if (clearfiles)
+      Poco::File(fileName).remove();
     AnalysisDataService::Instance().remove("testSpace");
   }
 

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/WorkspaceCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/WorkspaceCreationHelper.h
@@ -253,6 +253,7 @@ Mantid::DataObjects::Workspace2D_sptr create2DWorkspaceThetaVsTOF(int nHist, int
 Mantid::DataObjects::Workspace2D_sptr
 create2DWorkspaceWithRectangularInstrument(int numBanks, int numPixels, int numBins,
                                            const std::string &instrumentName = "basic_rect");
+
 Mantid::DataObjects::Workspace2D_sptr create2DWorkspace123WithMaskedBin(int numHist, int numBins,
                                                                         int maskedWorkspaceIndex, int maskedBinIndex);
 

--- a/docs/source/release/v6.13.0/Framework/Algorithms/Bugfixes/39094.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/Bugfixes/39094.rst
@@ -1,0 +1,1 @@
+- :ref:`SaveNexusProcessed <algm-SaveNexusProcessed>`: fix SEGFAULT due to slab size to data size mismatch, on write of ragged workspaces.


### PR DESCRIPTION
### Description of work
Fix SEGFAULT in 'NexusFileIO::writeNexusProcessedData2D'.

#### Summary of work
This commit includes the following changes:

  * Fix for slab size to data size mismatch, on write of ragged workspaces;

  * Cleanup of duplicate code sections in 'writeNexusProcessedData2D';

  * Fix some conditional logic errors in 'writeNexusProcessedData2D'.


Fixes [EWM defect #10343](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=10343)

### To test:

**NEGATIVE test:**
(Please see "Implementation note" comment at the new test about _why_ this negative test isn't actually a unit test.)

1. Create a new installation of the `mantid-developer` environment.
2. Fetch and update to the latest version of `ornl-next`.
3. Substitute the `Framework/DataHandling/test/SaveNexusProcessedTest.h` from _this_ branch:  
    `git fetch origin`
    `git checkout EWM10343_ragged_workspace_write_slab_segfault` # this ensures that the branch exists locally
    `git checkout ornl-next`
 `git checkout EWM10343_ragged_workspace_write_slab_segfault -- < commandline continues > Framework/DataHandling/test/SaveNexusProcessedTest.h` 
4. Build targets `AllTests` `SystemTestData` and `StandardTestData`.
5. run `ctest -R SaveNexusProcessed` # this test should FAIL with a SEGFAULT.

**POSITIVE test:**
1. `git checkout EWM10343_ragged_workspace_write_slab_segfault`
2. Build targets `AllTests` `SystemTestData` and `StandardTestData`.
3.  run `ctest -R SaveNexusProcessed` # this test should SUCCEED.

**NOTES on testing:**
When run locally (and on analysis) up to _five_ unit tests fail for both the `ornl-next` branch and this branch.  These tests have nothing to do with the current changes.  Apparently these are written in a manner that is overly sensitive to the machine they're run on.

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
