### PR TITLE
Deprecate UnwrapSNS

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/UnwrapSNS.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/UnwrapSNS.h
@@ -10,6 +10,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAlgorithms/DllConfig.h"
 #include "MantidDataObjects/EventWorkspace.h"
 
@@ -31,7 +32,7 @@ namespace Algorithms {
     @author Russell Taylor, Tessella Support Services plc
     @date 25/07/2008
 */
-class MANTID_ALGORITHMS_DLL UnwrapSNS final : public API::Algorithm {
+class MANTID_ALGORITHMS_DLL UnwrapSNS final : public API::Algorithm, public API::DeprecatedAlgorithm {
 public:
   UnwrapSNS();
   ~UnwrapSNS() override = default;

--- a/Framework/Algorithms/src/UnwrapSNS.cpp
+++ b/Framework/Algorithms/src/UnwrapSNS.cpp
@@ -32,7 +32,9 @@ using std::size_t;
 /// Default constructor
 UnwrapSNS::UnwrapSNS()
     : m_conversionConstant(0.), m_inputWS(), m_inputEvWS(), m_LRef(0.), m_Tmin(0.), m_Tmax(0.), m_frameWidth(0.),
-      m_numberOfSpectra(0), m_XSize(0) {}
+      m_numberOfSpectra(0), m_XSize(0) {
+  deprecatedDate("2025-03-24");
+}
 
 /// Initialisation method
 void UnwrapSNS::init() {

--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -195,6 +195,8 @@ class AlignAndFocusPowderFromFiles(DataProcessorAlgorithm):
         if (not self.getProperty("LogAllowList").isDefault) and (not self.getProperty("LogBlockList").isDefault):
             errors["LogAllowList"] = "Cannot specify with LogBlockList"
             errors["LogBlockList"] = "Cannot specify with LogAllowList"
+        if not self.getProperty("UnwrapRef").isDefault:
+            errors["UnwrapRef"] = "AlignAndFocusPowderFromFiles property UnwrapRef is deprecated since 2025-03-24."
 
         return errors
 

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -136,7 +136,6 @@ class SNSPowderReduction(DataProcessorAlgorithm):
     _instrument = None
     _filterBadPulses = None
     _removePromptPulseWidth = None
-    _LRef = None
     _DIFCref = None
     _wavelengthMin = None
     _wavelengthMax = None
@@ -392,6 +391,10 @@ class SNSPowderReduction(DataProcessorAlgorithm):
 
         if self.getProperty("InterpolateTargetTemp").value > 0.0 and not len(self.getProperty("BackgroundNumber").value) == 2:
             issues["InterpolateTargetTemp"] = "If InterpolateTargetTemp specified, you must provide two background run numbers"
+
+        # Deprecated properties
+        if not self.getProperty("UnwrapRef").isDefault:
+            issues["UnwrapRef"] = "SNSPowderReduction property UnwrapRef is deprecated since 2025-03-24."
         return issues
 
     # pylint: disable=too-many-locals,too-many-branches,too-many-statements
@@ -413,7 +416,6 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         self._filterBadPulses = self.getProperty("FilterBadPulses").value
         self._removePromptPulseWidth = self.getProperty("RemovePromptPulseWidth").value
         self._lorentz = self.getProperty("LorentzCorrection").value
-        self._LRef = self.getProperty("UnwrapRef").value
         self._DIFCref = self.getProperty("LowResRef").value
         self._wavelengthMin = self.getProperty("CropWavelengthMin").value
         self._wavelengthMax = self.getProperty("CropWavelengthMax").value
@@ -944,7 +946,6 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             CompressTolerance=self.COMPRESS_TOL_TOF,
             CompressBinningMode=self._compressBinningMode,
             LorentzCorrection=self._lorentz,
-            UnwrapRef=self._LRef,
             LowResRef=self._DIFCref,
             LowResSpectrumOffset=self._lowResTOFoffset,
             CropWavelengthMin=self._wavelengthMin,
@@ -1060,7 +1061,6 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                     CompressTolerance=self.COMPRESS_TOL_TOF,
                     CompressBinningMode=self._compressBinningMode,
                     LorentzCorrection=self._lorentz,
-                    UnwrapRef=self._LRef,
                     LowResRef=self._DIFCref,
                     LowResSpectrumOffset=self._lowResTOFoffset,
                     CropWavelengthMin=self._wavelengthMin,

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
@@ -97,7 +97,6 @@ private:
   bool binInDspace{false};
   double xmin{0.0};
   double xmax{0.0};
-  double LRef{0.0};
   double DIFCref{0.0};
   double minwl{0.0};
   double maxwl{0.0};

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -493,7 +493,7 @@ void AlignAndFocusPowder::exec() {
   }
 
   // set up a progress bar with the "correct" number of steps
-  m_progress = std::make_unique<Progress>(this, 0., 1., 22);
+  m_progress = std::make_unique<Progress>(this, 0., 1., 21);
 
   if (m_maskWS) {
     g_log.information() << "running MaskDetectors started at " << Types::Core::DateAndTime::getCurrentTime() << "\n";

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -215,9 +215,7 @@ void AlignAndFocusPowder::init() {
                   "Multiply each spectrum by "
                   "sin(theta) where theta is "
                   "half of the Bragg angle");
-  declareProperty(PropertyNames::UNWRAP_REF, 0.,
-                  "Reference total flight path for frame "
-                  "unwrapping. Zero skips the correction");
+  declareProperty(PropertyNames::UNWRAP_REF, 0., "This property is deprecated (since v6.13).");
   declareProperty(PropertyNames::LOWRES_REF, 0., "Reference DIFC for resolution removal. Zero skips the correction");
   declareProperty("CropWavelengthMin", 0., "Crop the data at this minimum wavelength. Overrides LowResRef.");
   mapPropertyName(PropertyNames::WL_MIN, "wavelength_min");
@@ -292,6 +290,11 @@ std::map<std::string, std::string> AlignAndFocusPowder::validateInputs() {
         "Must have same number of values as " + PropertyNames::RESONANCE_UPPER_LIMITS;
     result[PropertyNames::RESONANCE_UPPER_LIMITS] =
         "Must have same number of values as " + PropertyNames::RESONANCE_LOWER_LIMITS;
+  }
+
+  // Deprecated properties
+  if (!isDefault(PropertyNames::UNWRAP_REF)) {
+    g_log.error("AlignAndFocusPowder property UnwrapRef is deprecated since 2025-03-24.");
   }
 
   return result;
@@ -378,7 +381,6 @@ void AlignAndFocusPowder::exec() {
   auto dmin = getVecPropertyFromPmOrSelf(PropertyNames::D_MINS, m_dmins);
   auto dmax = getVecPropertyFromPmOrSelf(PropertyNames::D_MAXS, m_dmaxs);
   this->getVecPropertyFromPmOrSelf(PropertyNames::RAGGED_DELTA, m_delta_ragged);
-  LRef = getProperty(PropertyNames::UNWRAP_REF);
   DIFCref = getProperty(PropertyNames::LOWRES_REF);
   const bool applyLorentz = getProperty(PropertyNames::LORENTZ);
   minwl = getProperty(PropertyNames::WL_MIN);
@@ -651,26 +653,6 @@ void AlignAndFocusPowder::exec() {
   m_progress->report();
 
   // Beyond this point, low resolution TOF workspace is considered.
-  if (LRef > 0.) {
-    // this algorithm was originally created for POWGEN before issues in the DAS were fixed
-    // it is not used in any current reduction and remains for legacy data processing
-    m_outputW = convertUnits(m_outputW, "TOF");
-
-    g_log.information() << "running UnwrapSNS(LRef=" << LRef << ",Tmin=" << tmin << ",Tmax=" << tmax << ") started at "
-                        << Types::Core::DateAndTime::getCurrentTime() << "\n";
-    API::IAlgorithm_sptr removeAlg = createChildAlgorithm("UnwrapSNS");
-    removeAlg->setProperty("InputWorkspace", m_outputW);
-    removeAlg->setProperty("OutputWorkspace", m_outputW);
-    removeAlg->setProperty("LRef", LRef);
-    if (tmin > 0.)
-      removeAlg->setProperty("Tmin", tmin);
-    if (tmax > tmin)
-      removeAlg->setProperty("Tmax", tmax);
-    removeAlg->executeAsChildAlg();
-    m_outputW = removeAlg->getProperty("OutputWorkspace");
-  }
-  m_progress->report();
-
   if (minwl > 0. || (!isEmpty(maxwl))) { // just crop the workspace
     // turn off the low res stuff
     m_processLowResTOF = false;
@@ -735,7 +717,7 @@ void AlignAndFocusPowder::exec() {
   m_progress->report();
 
   // Convert units
-  if (LRef > 0. || minwl > 0. || DIFCref > 0. || (!isEmpty(maxwl))) {
+  if (minwl > 0. || DIFCref > 0. || (!isEmpty(maxwl))) {
     m_outputW = convertUnits(m_outputW, "dSpacing");
     if (m_processLowResTOF)
       m_lowResW = convertUnits(m_lowResW, "dSpacing");

--- a/docs/source/algorithms/AlignAndFocusPowder-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowder-v1.rst
@@ -32,7 +32,6 @@ The way that algorithms are connected together is better described in the workfl
 - :ref:`algm-RemoveLowResTOF` ``CropWavelengthMin`` and ``CropWavelengthMax`` are prefered
 - :ref:`algm-RemovePromptPulse`
 - :ref:`algm-SortEvents` (event workspace only)
-- :ref:`algm-UnwrapSNS`
 
 
 

--- a/docs/source/diagrams/AlignAndFocusPowder-v1_wkflw.dot
+++ b/docs/source/diagrams/AlignAndFocusPowder-v1_wkflw.dot
@@ -13,7 +13,6 @@ digraph AlignAndFocusPowder {
     MaskBinTable
     CalibrationWorkspace
     GroupingWorkspace
-    UnwrapRef
     LowResRef
     params1 [label="Params"]
     params2 [label="Params"]
@@ -25,7 +24,6 @@ digraph AlignAndFocusPowder {
     clearDiffCal      [label="ApplyDiffCal v1\nClear parameters"]
     compressEvents    [label="CompressEvents v1"]
     compressEvents2   [label="CompressEvents v1"]
-    convertUnitsTof1     [label="ConvertUnits v1\nTime-of-Flight"]
     convertUnitsTof2     [label="ConvertUnits v1\nTime-of-Flight"]
     convertUnitsD1     [label="ConvertUnits v1\nd-spacing"]
     convertUnitsD2     [label="ConvertUnits v1\nd-spacing"]
@@ -46,7 +44,6 @@ digraph AlignAndFocusPowder {
     rebinRagged       [label="RebinRagged v1"]
     removeLowResTOF   [label="RemoveLowResTOF v1"]
     removePromptPulse [label="RemovePromptPulse v1"]
-    unwrapSNS         [label="UnwrapSNS v1"]
   }
 
   subgraph decisions {
@@ -58,7 +55,6 @@ digraph AlignAndFocusPowder {
     isDspace1         [label="Is d-space binning?"]
     isDspace2         [label="Is d-space binning?"]
     isDspace3         [label="Is d-space binning?"]
-    ifLref          [label="LRef specified?"]
     ifDIFCref          [label="DIFCref specified?"]
     ifRaggedTof       [label="ragged rebin\nand tof binning"]
   }
@@ -98,25 +94,18 @@ digraph AlignAndFocusPowder {
   maskBins               -> convertUnitsD3
   convertUnitsD3          -> lorentz
 
-  lorentz                -> ifLref
+  lorentz                -> ifDIFCref
 
-  ifLref               -> convertUnitsWL2            [label="No"]
-  cropWorkspaceWL        -> convertUnitsD1
-
-  convertUnitsD1          -> isDspace2
-
-  ifLref               -> convertUnitsTof1        [label="Yes"]
-  convertUnitsTof1          -> unwrapSNS
-  UnwrapRef              -> unwrapSNS
-  unwrapSNS              -> convertUnitsWL2
-  convertUnitsWL2 -> ifDIFCref
-
-
-  ifDIFCref -> cropWorkspaceWL  [label="No"]
+  ifDIFCref -> convertUnitsWL2  [label="No"]
   ifDIFCref -> removeLowResTOF  [label="Yes"]
 
   LowResRef              -> removeLowResTOF
   removeLowResTOF        -> convertUnitsD1
+
+  convertUnitsWL2        -> cropWorkspaceWL
+  cropWorkspaceWL        -> convertUnitsD1
+
+  convertUnitsD1          -> isDspace2
 
   isDspace2              -> diffFocus            [label="No"]
   isDspace2              -> rebin2               [label="Yes"]

--- a/docs/source/release/v6.13.0/Framework/Algorithms/Deprecated/39097.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/Deprecated/39097.rst
@@ -1,0 +1,6 @@
+- :ref:`UnwrapSNS <algm-UnwrapSNS>` has been deprecated. There is no replacement.
+- Property ``Unwrap Ref`` has been deprecated for algorithms that previously
+  called deprecated algorithm :ref:`UnwrapSNS <algm-UnwrapSNS>`:
+  :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>`,
+  :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles>`
+  and :ref:`SNSPowderReduction <algm-SNSPowderReduction>`.

--- a/docs/source/release/v6.13.0/Framework/Algorithms/Deprecated/39097.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/Deprecated/39097.rst
@@ -1,5 +1,5 @@
 - :ref:`UnwrapSNS <algm-UnwrapSNS>` has been deprecated. There is no replacement.
-- Property ``Unwrap Ref`` has been deprecated for algorithms that previously
+- Property ``UnwrapRef`` has been deprecated for algorithms that previously
   called deprecated algorithm :ref:`UnwrapSNS <algm-UnwrapSNS>`:
   :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>`,
   :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles>`

--- a/docs/source/release/v6.13.0/Workbench/New_features/39097.rst
+++ b/docs/source/release/v6.13.0/Workbench/New_features/39097.rst
@@ -1,0 +1,2 @@
+- Deprecated parameter ``Unwrap Ref`` has been removed from the Powder
+  Diffraction Reduction Interface.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_gui/widgets/diffraction/diffraction_adv_setup.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_gui/widgets/diffraction/diffraction_adv_setup.py
@@ -62,9 +62,6 @@ class AdvancedSetupWidget(BaseWidget):
         iv4.setBottom(0)
         self._content.maxchunksize_edit.setValidator(iv4)
 
-        dv0 = QDoubleValidator(self._content.unwrap_edit)
-        self._content.unwrap_edit.setValidator(dv0)
-
         dv2 = QDoubleValidator(self._content.lowres_edit)
         self._content.lowres_edit.setValidator(dv2)
 
@@ -157,7 +154,6 @@ class AdvancedSetupWidget(BaseWidget):
             self._content.offsetdata_edit.setText(str(state.offsetdata).strip())
         else:
             self._content.offsetdata_edit.setText("0")
-        self._content.unwrap_edit.setText(str(state.unwrapref))
         self._content.lowres_edit.setText(str(state.lowresref))
         self._content.removepromptwidth_edit.setText(str(state.removepropmppulsewidth))
         self._content.maxchunksize_edit.setText(str(state.maxchunksize))
@@ -208,7 +204,6 @@ class AdvancedSetupWidget(BaseWidget):
         #
         s.pushdatapositive = str(self._content.pushdatapos_combo.currentText())
         s.offsetdata = self._content.offsetdata_edit.text().strip()
-        s.unwrapref = self._content.unwrap_edit.text()
         s.lowresref = self._content.lowres_edit.text()
         s.cropwavelengthmin = str(self._content.cropwavelengthmin_edit.text())
         s.cropwavelengthmax = str(self._content.lineEdit_croppedWavelengthMax.text())

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/ui/diffraction/diffraction_adv_setup.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/ui/diffraction/diffraction_adv_setup.ui
@@ -224,23 +224,7 @@
             <item row="1" column="4">
              <widget class="QLineEdit" name="lineEdit_croppedWavelengthMax"/>
             </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="unwrap_label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reference total flight path for frame unwrapping.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Unwrap Ref</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
+            <item row="2" column="1">
              <widget class="QLineEdit" name="maxchunksize_edit">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -383,31 +367,6 @@
               </property>
               <property name="text">
                <string>Push Data Positive</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QLineEdit" name="unwrap_edit">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>200</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter value for reference total flight path for frame unwrapping. Zero skips the correction. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
@@ -554,7 +513,7 @@
               </item>
              </widget>
             </item>
-            <item row="3" column="0">
+            <item row="2" column="0">
              <widget class="QLabel" name="label">
               <property name="minimumSize">
                <size>
@@ -602,21 +561,21 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
+            <item row="3" column="0">
              <widget class="QLabel" name="label_3">
               <property name="text">
                <string>Scale Data</string>
               </property>
              </widget>
             </item>
-            <item row="4" column="1">
+            <item row="3" column="1">
              <widget class="QLineEdit" name="scaledata_edit">
               <property name="toolTip">
                <string>Constant to multiply the data by before writing out</string>
               </property>
              </widget>
             </item>
-            <item row="5" column="0">
+            <item row="4" column="0">
              <widget class="QLabel" name="label_bkgdsmooth">
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Parameters to smooth background (can run) by FFT smooth algorithm.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -626,7 +585,7 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="1">
+            <item row="4" column="1">
              <widget class="QLineEdit" name="bkgdsmoothpar_edit">
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Parameters to smooth background (can run) by FFT smooth algorithm.&lt;/p&gt;&lt;p&gt;Enter 2 integers.  The suggested values are &amp;quot;20, 2&amp;quot;. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -1263,7 +1222,6 @@
  <tabstops>
   <tabstop>outputfileprefix_edit</tabstop>
   <tabstop>lowres_edit</tabstop>
-  <tabstop>unwrap_edit</tabstop>
   <tabstop>maxchunksize_edit</tabstop>
   <tabstop>scaledata_edit</tabstop>
   <tabstop>bkgdsmoothpar_edit</tabstop>

--- a/scripts/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
+++ b/scripts/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
@@ -50,7 +50,6 @@ class AdvancedSetupScript(BaseScriptElement):
     #
     pushdatapositive = "None"
     offsetdata = 0.0
-    unwrapref = ""
     lowresref = ""
     cropwavelengthmin = ""
     cropwavelengthmax = ""
@@ -99,7 +98,6 @@ class AdvancedSetupScript(BaseScriptElement):
     def createParametersList(self):
         """Create a list of parameter names for SNSPowderReductionPlus()"""
         self.parnamelist = [
-            "UnwrapRef",
             "LowResRef",
             "CropWavelengthMin",
             "CropWavelengthMax",
@@ -157,7 +155,6 @@ class AdvancedSetupScript(BaseScriptElement):
         """Create a dictionary for parameter and parameter values for SNSPowderReductionPlus()"""
         pardict = {}
 
-        pardict["UnwrapRef"] = self.unwrapref
         pardict["LowResRef"] = self.lowresref
         pardict["CropWavelengthMin"] = self.cropwavelengthmin
         pardict["CropWavelengthMax"] = self.cropwavelengthmax
@@ -219,8 +216,6 @@ class AdvancedSetupScript(BaseScriptElement):
         element_list = dom.getElementsByTagName("AdvancedSetup")
         if len(element_list) > 0:
             instrument_dom = element_list[0]
-
-            self.unwrapref = getFloatElement(instrument_dom, "unwrapref", AdvancedSetupScript.unwrapref)
 
             self.lowresref = getFloatElement(instrument_dom, "lowresref", AdvancedSetupScript.lowresref)
 
@@ -319,7 +314,6 @@ class AdvancedSetupScript(BaseScriptElement):
         class_attrs_selected = [
             "pushdatapositive",
             "offsetdata",
-            "unwrapref",
             "lowresref",
             "cropwavelengthmin",
             "cropwavelengthmax",


### PR DESCRIPTION
### Description of work

- Deprecate the algorithm `UnwrapSNS`. The algorithm is no longer needed since this is corrected in the DAQ.
- Remove call to `UnwrapSNS` from `AlignAndFocusPowder`.
- Deprecate property `UnwrapRef` from `AlignAndFocusPowder`, `AlignAndFocusPowderFromFile` and `SNSPowderReduction`.
- Remove property `UnwrapRef` from the Powder Diffraction Reduction Interface.
- Update `AlignAndFocusPowder` docs.

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

*There is no associated issue.*
ORNL internal EWM link: [Story 9983: Deprecate UnwrapSNS](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=9983)

From the EWM story:

> There is no replacement

> Additionally, this algorithm needs to be removed from things in mantid that call it:
> AlignAndFocusPowder: The "UnwrapRef" property will generate errors in the "validateInputs()" method and the "if (LRef > 0.) {" clause in the "exec()" will be removed. Update the docstring on the property that it is no longer allowed
> AlignAndFocusPowderFromFiles: Add the same error in "validateInputs()". Since the property is directly copied, no other changes are needed.
> SNSPowderReduction: Add the same error in "validateInputs()" as the others. Remove "self._LRef" from the code by not passing it to AlignAndFocusPowder or AlignAndFocusPowderFromFiles


<!-- alternative
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

- Test that the dot diagram in the `AlignAndFocusPowder` documentation renders okay. Need to first enable the docs and diagrams using the `cmake` options `-DENABLE_DOCS=on` and `-DDOCS_DOTDIAGRAMS=on`
- Check the Interface "Powder Diffraction Reduction" and verify that the deprecated property "Unwrap Ref" is removed and the reduction behaves as expected

![image](https://github.com/user-attachments/assets/27adeff9-3f38-4d45-bec1-da58454d1542)

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
