### PR TITLE
Expose fitting parameters from Component class to python

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Component.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Component.h
@@ -8,6 +8,7 @@
 
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
+#include "MantidKernel/Interpolation.h"
 #include "MantidKernel/Quat.h"
 #include "MantidKernel/V2D.h"
 #include "MantidKernel/V3D.h"
@@ -279,6 +280,9 @@ public:
       return false;
     }
   }
+
+  /// Get fitting parameter
+  double getFittingParameter(const std::string &pname, double xvalue) const;
 
   void printSelf(std::ostream &) const override;
 

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Component.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Component.h
@@ -8,7 +8,6 @@
 
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/Instrument/ParameterMap.h"
-#include "MantidKernel/Interpolation.h"
 #include "MantidKernel/Quat.h"
 #include "MantidKernel/V2D.h"
 #include "MantidKernel/V3D.h"

--- a/Framework/Geometry/src/Instrument/Component.cpp
+++ b/Framework/Geometry/src/Instrument/Component.cpp
@@ -9,6 +9,7 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/ComponentVisitor.h"
+#include "MantidGeometry/Instrument/FitParameter.h"
 #include "MantidGeometry/Instrument/ParComponentFactory.h"
 #include "MantidGeometry/Objects/BoundingBox.h"
 #include "MantidKernel/EigenConversionHelpers.h"
@@ -676,8 +677,34 @@ void Component::setDescription(const std::string &descr) {
 }
 
 size_t Component::registerContents(class ComponentVisitor &componentVisitor) const {
-
   return componentVisitor.registerGenericComponent(*this);
+}
+
+/**
+ * Get fitting parameter from a look up table or a formula
+ * @param pname :: The name of the parameter
+ * @param xvalue :: xvalue to interpolate lookup table of parameter map
+ * components
+ * @returns A list of values
+ */
+double Component::getFittingParameter(const std::string &pname, double xvalue) const {
+  if (m_map) {
+    Parameter_sptr parameter = m_map->getRecursive(this, pname, "fitting");
+    if (!parameter) {
+      throw std::runtime_error(
+          std::format("Fitting parameter={} could not be extracted from component={}", pname, this->getName()));
+    }
+
+    try {
+      const auto &fitParam = parameter->value<FitParameter>();
+      return fitParam.getValue(xvalue);
+    } catch (...) {
+      throw std::runtime_error(
+          std::format("Unable to get lookup table for parameter={} from component={}", pname, this->getName()));
+    }
+  } else {
+    throw std::runtime_error(std::format("Parameter map is not available in component={}", this->getName()));
+  }
 }
 
 } // namespace Mantid::Geometry

--- a/Framework/Geometry/src/Instrument/Component.cpp
+++ b/Framework/Geometry/src/Instrument/Component.cpp
@@ -691,19 +691,19 @@ double Component::getFittingParameter(const std::string &pname, double xvalue) c
   if (m_map) {
     Parameter_sptr parameter = m_map->getRecursive(this, pname, "fitting");
     if (!parameter) {
-      throw std::runtime_error(
-          std::format("Fitting parameter={} could not be extracted from component={}", pname, this->getName()));
+      throw std::runtime_error("Fitting parameter=" + pname +
+                               " could not be extracted from component=" + this->getName());
     }
 
     try {
       const auto &fitParam = parameter->value<FitParameter>();
       return fitParam.getValue(xvalue);
     } catch (...) {
-      throw std::runtime_error(
-          std::format("Unable to get lookup table for parameter={} from component={}", pname, this->getName()));
+      throw std::runtime_error("Unable to get lookup table for parameter=" + pname +
+                               " from component=" + this->getName());
     }
   } else {
-    throw std::runtime_error(std::format("Parameter map is not available in component={}", this->getName()));
+    throw std::runtime_error("Parameter map is not available in component=" + this->getName());
   }
 }
 

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -35,8 +35,6 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getRelativePos, Component::getR
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamShortDescription, Component::getParamShortDescription, 1, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamDescription, Component::getParamDescription, 1, 2)
 
-// }
-
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unused-local-typedef")
 } // namespace

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -93,6 +93,5 @@ void export_Component() {
       // Component_getPositionParameter())
       //.def("getParameter", &Component::getRotationParameter,
       // Component_getRotationParameter())
-
       ;
 }

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -35,6 +35,8 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getRelativePos, Component::getR
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamShortDescription, Component::getParamShortDescription, 1, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamDescription, Component::getParamDescription, 1, 2)
 
+// }
+
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unused-local-typedef")
 } // namespace
@@ -77,6 +79,9 @@ void export_Component() {
       // untill rows below do not work
       .def("getParameterType", &Component::getParameterType,
            Component_getParameterType((arg("self"), arg("pname"), arg("recursive") = true)))
+      .def("getFittingParameter", &Component::getFittingParameter, (arg("self"), arg("pname"), arg("xvalue")),
+           "Get fit parameter from the parameter map."
+           " The value of the parameter is determined from a look up table or a formula")
       //// this does not work for some obvious or not obvious reasons
       //.def("getParameter", &Component::getNumberParameter,
       // Component_getNumberParameter())

--- a/Framework/PythonInterface/test/python/mantid/geometry/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/geometry/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TEST_PY_FILES
     ReflectionGeneratorTest.py
     DetectorInfoTest.py
     ComponentInfoTest.py
+    ComponentTest.py
 )
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})

--- a/Framework/PythonInterface/test/python/mantid/geometry/ComponentTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/ComponentTest.py
@@ -1,0 +1,44 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from mantid.geometry import Component
+
+
+class ComponenetTest(unittest.TestCase):
+    _testws = None
+
+    def setUp(self):
+        import testhelpers
+
+        if not self.__class__._testws:
+            alg = testhelpers.run_algorithm("LoadEmptyInstrument", Filename="POLDI_Definition_2015.xml", child=True)
+            self.__class__._testws = alg.getProperty("OutputWorkspace").value
+
+    def test_component_getFittingParameters(self):
+        source_comp = self._testws.getInstrument().getComponentByName("source")
+        self.assertTrue(isinstance(source_comp, Component))
+        self.assertTrue(source_comp.hasParameter("WavelengthDistribution"))
+        self.assertEqual(source_comp.getParameterType("WavelengthDistribution"), "fitting")
+        self.assertTrue(source_comp.getFittingParameter("WavelengthDistribution", 1.5) > 0.0)
+
+    def test_non_existing_fitting_param_name(self):
+        source = self._testws.getInstrument().getComponentByName("source")
+        self.assertFalse(source.hasParameter("nonExistingFitParam"))
+        with self.assertRaises(RuntimeError) as err:
+            source.getFittingParameter("nonExistingFitParam", 2.5)
+        self.assertEqual(err.exception.args[0], "Fitting parameter=nonExistingFitParam could not be extracted from component=source")
+
+    def test_access_existing_param_as_fitting_param(self):
+        detector_comp = self._testws.getInstrument().getComponentByName("detector")
+        self.assertTrue(detector_comp.hasParameter("radius"))
+        with self.assertRaises(RuntimeError) as err:
+            detector_comp.getFittingParameter("radius", 2.5)
+        self.assertEqual(err.exception.args[0], "Fitting parameter=radius could not be extracted from component=detector")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/geometry/ComponentTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/ComponentTest.py
@@ -8,7 +8,7 @@ import unittest
 from mantid.geometry import Component
 
 
-class ComponenetTest(unittest.TestCase):
+class ComponentTest(unittest.TestCase):
     _testws = None
 
     def setUp(self):

--- a/docs/source/release/v6.13.0/Diffraction/Powder/New_features/38968.rst
+++ b/docs/source/release/v6.13.0/Diffraction/Powder/New_features/38968.rst
@@ -1,0 +1,1 @@
+- A new method named ``getFittingParameter`` has been added to Mantid::Geometry::Component class and exposed to python to access fitting parameters from components in instrument definition file


### PR DESCRIPTION
### Description of work
POLDI has the wavelength dependence of the flux as a fitting parameter in the IDF - that needs to be accessed from python. In this work, a new method has been added to [Component class](https://github.com/mantidproject/mantid/blob/main/Framework/Geometry/src/Instrument/Component.cpp) exposing it to python so that any fitting parameter in the parameter map can be accessed from python.


Fixes #38968. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->


### To test:
1. Run the below piece of code for different values of xval 
```
from mantid.simpleapi import *
import numpy as np
ws = LoadEmptyInstrument(InstrumentName='POLDI', OutputWorkspace='ws')
source = ws.getInstrument().getComponentByName("source")
assert(source.hasParameter("WavelengthDistribution")) 
xval = 1.023
for xval in np.linspace(0.9, 6.0, 30):
    interpolated_y_val = source.getFittingParameter("WavelengthDistribution", xval)
    print(f"x={xval}, y={interpolated_y_val}")
```
3. Check whether the interpolated y values agrees with the lookup table given for [POLDI intrument definition](https://github.com/mantidproject/mantid/blob/627ae2f554b282261a080126d2123d56f4d43be6/instrument/POLDI_Definition_2015.xml#L47)

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
