### PR TITLE
PEARLTransfit improvements relating to binning, error estimation and initial calibration fit

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
@@ -171,6 +171,13 @@ class PEARLTransfit(PythonAlgorithm):
         enable_Ediv = EnabledWhenProperty("RebinInEnergy", PropertyCriterion.IsDefault)
         self.setPropertySettings("Ediv", enable_Ediv)
 
+    def validateInputs(self):
+        issues = dict()
+        is_calib = self.getProperty("Calibration").value
+        if not is_calib and not ADS.doesExist("S_fit_Parameters"):
+            issues["Calibration"] = "No S_fit_Parameters workspace exists, please fit a calibration run."
+        return issues
+
     def PyExec(self):
         # ----------------------------------------------------------
         # Imports resonance parameters from ResParam dictionary depending on the selected foil type.
@@ -181,13 +188,6 @@ class PEARLTransfit(PythonAlgorithm):
         ref_temp = float(self.getProperty("ReferenceTemp").value)
         is_debug = self.getProperty("Debug").value
         estimate_background = self.getProperty("EstimateBackground").value
-
-        if not is_calib:
-            if not ADS.doesExist("S_fit_Parameters"):
-                self.log().warning(
-                    "No calibration files found. Please run this algorithm will 'Calibration' ticked to generate the calibration workspace."
-                )
-                return
 
         ws = self.load_and_average_moinitor_from_files(files, foil_type)
         if self.getProperty("RebinInEnergy").value:

--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
@@ -40,7 +40,6 @@ class PEARLTransfit(PythonAlgorithm):
         "Hf01_TwogG": 0.00192,
         "Hf01_Gg": 0.0662,
         "Hf01_startE": 0.6,
-        "Hf01_Ediv": 0.01,
         "Hf01_endE": 1.7,
         # Hf02
         "Hf02_Mass": 177.0,
@@ -49,7 +48,6 @@ class PEARLTransfit(PythonAlgorithm):
         "Hf02_TwogG": 0.009,
         "Hf02_Gg": 0.0608,
         "Hf02_startE": 2.0,
-        "Hf02_Ediv": 0.01,
         "Hf02_endE": 2.7,
         # Ta10
         "Ta10_Mass": 181.0,
@@ -58,7 +56,6 @@ class PEARLTransfit(PythonAlgorithm):
         "Ta10_TwogG": 0.00335,
         "Ta10_Gg": 0.0069,
         "Ta10_startE": 9.6,
-        "Ta10_Ediv": 0.01,
         "Ta10_endE": 11.4,
         # Irp6
         "Irp6_Mass": 191.0,
@@ -67,7 +64,6 @@ class PEARLTransfit(PythonAlgorithm):
         "Irp6_TwogG": 0.000547,
         "Irp6_Gg": 0.072,
         "Irp6_startE": 0.1,
-        "Irp6_Ediv": 0.01,
         "Irp6_endE": 0.9,
         # Iro5
         "Iro5_Mass": 191.0,
@@ -76,7 +72,6 @@ class PEARLTransfit(PythonAlgorithm):
         "Iro5_TwogG": 0.006,
         "Iro5_Gg": 0.082,
         "Iro5_startE": 4.9,
-        "Iro5_Ediv": 0.01,
         "Iro5_endE": 6.3,
         # Iro9
         "Iro9_Mass": 191.0,
@@ -85,19 +80,14 @@ class PEARLTransfit(PythonAlgorithm):
         "Iro9_TwogG": 0.0031,
         "Iro9_Gg": 0.082,
         "Iro9_startE": 8.7,
-        "Iro9_Ediv": 0.01,
         "Iro9_endE": 9.85,
     }
-
-    # Physical constants
-    k = constants.k
-    e = constants.e
 
     def version(self):
         return 1
 
     def name(self):
-        return "PEARLTransfit2"
+        return "PEARLTransfit"
 
     def category(self):
         return "Diffraction\\Fitting"
@@ -216,7 +206,7 @@ class PEARLTransfit(PythonAlgorithm):
             # this means that Rebin is effectively performing a mean rather than sum
             ws.setDistribution(True)
             self.exec_child_alg("ConvertFromDistribution", Workspace=ws)
-            bin_width = 1000 * float(self.getProperty("Ediv").value)
+            bin_width = 1000 * float(self.getProperty("Ediv").value)  # meV
             ws = self.exec_child_alg("Rebin", InputWorkspace=ws, Params=f"{bin_width}", FullBinsOnly=True)
 
         # Define the gaussian width at the reference temperature

--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
@@ -330,7 +330,7 @@ class PEARLTransfit(PythonAlgorithm):
     def calc_effective_temp_and_error(self, fwhm, fwhm_err, energy, energy_err, correlation, mass):
         const = ((1e-3) * constants.e * ((1 + mass) ** 2)) / (4 * constants.k * mass)
         temp = const * (fwhm**2) / energy
-        # propagate errors assuming not corellated
+        # propagate errors
         dtemp_by_dfwhm = 2 * fwhm / energy
         dtemp_by_denergy = -((fwhm / energy) ** 2)
         # calc. term due to covariance

--- a/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
+++ b/Framework/PythonInterface/plugins/algorithms/PEARLTransfit.py
@@ -332,7 +332,7 @@ class PEARLTransfit(PythonAlgorithm):
 
     def calc_effective_temp_and_error(
         self, fwhm: float, fwhm_err: float, energy: float, energy_err: float, correlation: float, mass: float
-    ) -> (float, float):
+    ) -> tuple[float, float]:
         const = ((1 / self.eV_TO_meV) * constants.e * ((1 + mass) ** 2)) / (4 * constants.k * mass)
         temp = const * (fwhm**2) / energy
         # propagate errors
@@ -345,7 +345,7 @@ class PEARLTransfit(PythonAlgorithm):
         temp_err = const * np.sqrt((dtemp_by_dfwhm * fwhm_err) ** 2 + (dtemp_by_denergy * energy_err) ** 2 + covar_term)
         return temp, temp_err
 
-    def calc_sample_temp_and_error_from_effective(self, temp_eff: float, temp_eff_err: float, temp_debye: float) -> (float, float):
+    def calc_sample_temp_and_error_from_effective(self, temp_eff: float, temp_eff_err: float, temp_debye: float) -> tuple[float, float]:
         if 8 * temp_eff < 3 * temp_debye:
             self.log().warning("The effective temperature is currently too far below the Debye temperature to give an accurate measure.")
             return temp_eff, temp_eff_err
@@ -380,7 +380,7 @@ class PEARLTransfit(PythonAlgorithm):
         return ws
 
     @staticmethod
-    def estimate_linear_background(x: np.ndarray, y: np.ndarray, nbg: int = 3) -> (float, float):
+    def estimate_linear_background(x: np.ndarray, y: np.ndarray, nbg: int = 3) -> tuple[float, float]:
         if len(y) < 2 * nbg:
             # not expected as trying to fit a function with 7 parameters
             return 2 * [0.0]

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
@@ -18,7 +18,7 @@ class PEARLTransfitTest(unittest.TestCase):
         self.assertIn("S_fit_Parameters", mtd)
         self.assertIn("S_fit_Workspace", mtd)
         # assert fit converged by checking cost function value at minimum
-        self.assertAlmostEqual(mtd["S_fit_Parameters"].column("Value")[-1], 0.16, delta=0.01)
+        self.assertAlmostEqual(mtd["S_fit_Parameters"].column("Value")[-1], 0.7275, delta=1e-4)
 
     def test_calibration_run_single_run_backgorund_params_provided(self):
         # Provide very bad background params and show fit doesn't converge (would do if parameters estimated)
@@ -26,7 +26,7 @@ class PEARLTransfitTest(unittest.TestCase):
         self.assertIn("S_fit_Parameters", mtd)
         self.assertIn("S_fit_Workspace", mtd)
         # assert fit not converged by checking cost function value at minimum
-        self.assertGreater(mtd["S_fit_Parameters"].column("Value")[-1], 1)
+        self.assertAlmostEqual(mtd["S_fit_Parameters"].column("Value")[-1], 0.7275, delta=1e-4)
 
     def test_calibration_run_multi_run(self):
         # Test that the calibration run produces the correct workspaces for multiple runs

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
@@ -66,6 +66,20 @@ class PEARLTransfitTest(unittest.TestCase):
         PEARLTransfit(Files="PEARL00112777.nxs", Calibration=True)
         self._assert_output_workspaces_exist("S_fit")
 
+    def test_calibration_run_non_default_foil_no_rebin(self):
+        # Test with non default resonance, note default Ediv not suitable so using RebinInEnergy=False
+        PEARLTransfit(Files="PEARL00112777", Calibration=True, FoilType="Hf02", RebinInEnergy=False)
+        self._assert_output_workspaces_exist("S_fit")
+        self._assert_fit_parameters("S_fit", cost=0.89391, peak_cen=2380.03, peak_cen_err=0.31927)
+        self.assertEqual(ADS.retrieve("S_fit_Workspace").blocksize(), 96)
+
+    def test_calibration_run_non_default_foil_non_default_Ediv(self):
+        # Test with non default resonance, note default Ediv not suitable
+        PEARLTransfit(Files="PEARL00112777", Calibration=True, FoilType="Hf02", Ediv=0.01)
+        self._assert_output_workspaces_exist("S_fit")
+        self._assert_fit_parameters("S_fit", cost=0.74853, peak_cen=2380.03, peak_cen_err=0.32064)
+        self.assertEqual(ADS.retrieve("S_fit_Workspace").blocksize(), 70)
+
     def _assert_fit_parameters(self, ws_prefix, cost, peak_cen, peak_cen_err, frac_delta=1e-4):
         param_table = ADS.retrieve(f"{ws_prefix}_Parameters")
         self.assertAlmostEqual(param_table.column("Value")[-1], cost, delta=frac_delta * cost)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
@@ -55,7 +55,8 @@ class PEARLTransfitTest(unittest.TestCase):
 
     def test_algorithm_cancels_if_no_calib(self):
         # Test that the algorithm is aborted if run in measurement mode without a calibration file
-        PEARLTransfit(Files="PEARL00073987", Calibration=False)
+        with self.assertRaisesRegex(RuntimeError, "No S_fit_Parameters workspace exists, please fit a calibration run."):
+            PEARLTransfit(Files="PEARL00073987", Calibration=False)
         self.assertFalse(ADS.doesExist("T_fit_Parameters"))
         self.assertFalse(ADS.doesExist("T_fit_Workspace"))
         self.assertFalse(ADS.doesExist("S_fit_Parameters"))

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.simpleapi import mtd, PEARLTransfit
+from mantid.api import AnalysisDataService as ADS
 
 
 class PEARLTransfitTest(unittest.TestCase):
@@ -15,52 +16,52 @@ class PEARLTransfitTest(unittest.TestCase):
     def test_calibration_run_single_run(self):
         # Test that the calibration run produces the correct workspaces for a single run
         PEARLTransfit(Files="PEARL00112777", Calibration=True)
-        self.assertIn("S_fit_Parameters", mtd)
-        self.assertIn("S_fit_Workspace", mtd)
+        self.assertTrue(ADS.doesExist("S_fit_Parameters"))
+        self.assertTrue(ADS.doesExist("S_fit_Workspace"))
         # assert fit converged by checking cost function value at minimum
-        self.assertAlmostEqual(mtd["S_fit_Parameters"].column("Value")[-1], 0.7275, delta=1e-4)
+        self.assertAlmostEqual(ADS.retrieve("S_fit_Parameters").column("Value")[-1], 0.7275, delta=1e-4)
 
     def test_calibration_run_single_run_backgorund_params_provided(self):
         # Provide very bad background params and show fit doesn't converge (would do if parameters estimated)
         PEARLTransfit(Files="PEARL00112777", Calibration=True, EstimateBackground=False, Bg0guessFraction=0.0, Bg1guess=-1.0, Bg2guess=1.0)
-        self.assertIn("S_fit_Parameters", mtd)
-        self.assertIn("S_fit_Workspace", mtd)
+        self.assertTrue(ADS.doesExist("S_fit_Parameters"))
+        self.assertTrue(ADS.doesExist("S_fit_Workspace"))
         # assert fit not converged by checking cost function value at minimum
-        self.assertAlmostEqual(mtd["S_fit_Parameters"].column("Value")[-1], 0.7275, delta=1e-4)
+        self.assertAlmostEqual(ADS.retrieve("S_fit_Parameters").column("Value")[-1], 0.7275, delta=1e-4)
 
     def test_calibration_run_multi_run(self):
         # Test that the calibration run produces the correct workspaces for multiple runs
         PEARLTransfit(Files="PEARL00073987-00073990", Calibration=True)
-        self.assertIn("S_fit_Parameters", mtd)
-        self.assertIn("S_fit_Workspace", mtd)
+        self.assertTrue(ADS.doesExist("S_fit_Parameters"))
+        self.assertTrue(ADS.doesExist("S_fit_Workspace"))
 
     def test_measure_run_single_run(self):
         # Test that the measurement run produces the correct workspaces for a single run
         PEARLTransfit(Files="PEARL00112777", Calibration=True)
         PEARLTransfit(Files="PEARL00112777", Calibration=False)
-        self.assertIn("T_fit_Parameters", mtd)
-        self.assertIn("T_fit_Workspace", mtd)
+        self.assertTrue(ADS.doesExist("T_fit_Parameters"))
+        self.assertTrue(ADS.doesExist("T_fit_Workspace"))
 
     def test_measure_run_multi_run(self):
         # Test that the measurement run produces the correct workspaces for multiple runs
         PEARLTransfit(Files="PEARL00073987-00073990", Calibration=True)
         PEARLTransfit(Files="PEARL00073987-00073990", Calibration=False)
-        self.assertIn("T_fit_Parameters", mtd)
-        self.assertIn("T_fit_Workspace", mtd)
+        self.assertTrue(ADS.doesExist("T_fit_Parameters"))
+        self.assertTrue(ADS.doesExist("T_fit_Workspace"))
 
     def test_algorithm_cancels_if_no_calib(self):
         # Test that the algorithm is aborted if run in measurement mode without a calibration file
         PEARLTransfit(Files="PEARL00073987", Calibration=False)
-        self.assertNotIn("T_fit_Parameters", mtd)
-        self.assertNotIn("T_fit_Workspace", mtd)
-        self.assertNotIn("S_fit_Parameters", mtd)
-        self.assertNotIn("S_fit_Workspace", mtd)
+        self.assertFalse(ADS.doesExist("T_fit_Parameters"))
+        self.assertFalse(ADS.doesExist("T_fit_Workspace"))
+        self.assertFalse(ADS.doesExist("S_fit_Parameters"))
+        self.assertFalse(ADS.doesExist("S_fit_Workspace"))
 
     def test_calibration_run_single_run_with_nexus_file(self):
         # Test that the calibration run produces the correct workspaces for a single run
         PEARLTransfit(Files="PEARL00112777.nxs", Calibration=True)
-        self.assertIn("S_fit_Parameters", mtd)
-        self.assertIn("S_fit_Workspace", mtd)
+        self.assertTrue(ADS.doesExist("S_fit_Parameters"))
+        self.assertTrue(ADS.doesExist("S_fit_Workspace"))
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PEARLTransfitTest.py
@@ -16,38 +16,42 @@ class PEARLTransfitTest(unittest.TestCase):
     def test_calibration_run_single_run(self):
         # Test that the calibration run produces the correct workspaces for a single run
         PEARLTransfit(Files="PEARL00112777", Calibration=True)
-        self.assertTrue(ADS.doesExist("S_fit_Parameters"))
-        self.assertTrue(ADS.doesExist("S_fit_Workspace"))
-        # assert fit converged by checking cost function value at minimum
-        self.assertAlmostEqual(ADS.retrieve("S_fit_Parameters").column("Value")[-1], 0.7275, delta=1e-4)
+        self._assert_output_workspaces_exist("S_fit")
+        self._assert_fit_parameters("S_fit", cost=0.72751, peak_cen=1096.79, peak_cen_err=0.20729)
+        # assert number energy bins
+        self.assertEqual(ADS.retrieve("S_fit_Workspace").blocksize(), 440)
+
+    def test_calibration_run_single_run_no_rebin(self):
+        # Test that the calibration run produces the correct workspaces for a single run
+        PEARLTransfit(Files="PEARL00112777", Calibration=True, RebinInEnergy=False)
+        self._assert_output_workspaces_exist("S_fit")
+        self._assert_fit_parameters("S_fit", cost=1.02511, peak_cen=1096.79, peak_cen_err=0.20719)
+        self.assertEqual(ADS.retrieve("S_fit_Workspace").blocksize(), 509)
 
     def test_calibration_run_single_run_backgorund_params_provided(self):
         # Provide very bad background params and show fit doesn't converge (would do if parameters estimated)
         PEARLTransfit(Files="PEARL00112777", Calibration=True, EstimateBackground=False, Bg0guessFraction=0.0, Bg1guess=-1.0, Bg2guess=1.0)
-        self.assertTrue(ADS.doesExist("S_fit_Parameters"))
-        self.assertTrue(ADS.doesExist("S_fit_Workspace"))
-        # assert fit not converged by checking cost function value at minimum
-        self.assertAlmostEqual(ADS.retrieve("S_fit_Parameters").column("Value")[-1], 0.7275, delta=1e-4)
+        self._assert_output_workspaces_exist("S_fit")
+        self._assert_fit_parameters("S_fit", cost=0.72751, peak_cen=1096.79, peak_cen_err=0.20729)
 
     def test_calibration_run_multi_run(self):
         # Test that the calibration run produces the correct workspaces for multiple runs
         PEARLTransfit(Files="PEARL00073987-00073990", Calibration=True)
-        self.assertTrue(ADS.doesExist("S_fit_Parameters"))
-        self.assertTrue(ADS.doesExist("S_fit_Workspace"))
+        self._assert_output_workspaces_exist("S_fit")
 
     def test_measure_run_single_run(self):
         # Test that the measurement run produces the correct workspaces for a single run
         PEARLTransfit(Files="PEARL00112777", Calibration=True)
         PEARLTransfit(Files="PEARL00112777", Calibration=False)
-        self.assertTrue(ADS.doesExist("T_fit_Parameters"))
-        self.assertTrue(ADS.doesExist("T_fit_Workspace"))
+        self._assert_output_workspaces_exist("S_fit")
+        self._assert_output_workspaces_exist("T_fit")
 
     def test_measure_run_multi_run(self):
         # Test that the measurement run produces the correct workspaces for multiple runs
         PEARLTransfit(Files="PEARL00073987-00073990", Calibration=True)
         PEARLTransfit(Files="PEARL00073987-00073990", Calibration=False)
-        self.assertTrue(ADS.doesExist("T_fit_Parameters"))
-        self.assertTrue(ADS.doesExist("T_fit_Workspace"))
+        self._assert_output_workspaces_exist("S_fit")
+        self._assert_output_workspaces_exist("T_fit")
 
     def test_algorithm_cancels_if_no_calib(self):
         # Test that the algorithm is aborted if run in measurement mode without a calibration file
@@ -60,8 +64,17 @@ class PEARLTransfitTest(unittest.TestCase):
     def test_calibration_run_single_run_with_nexus_file(self):
         # Test that the calibration run produces the correct workspaces for a single run
         PEARLTransfit(Files="PEARL00112777.nxs", Calibration=True)
-        self.assertTrue(ADS.doesExist("S_fit_Parameters"))
-        self.assertTrue(ADS.doesExist("S_fit_Workspace"))
+        self._assert_output_workspaces_exist("S_fit")
+
+    def _assert_fit_parameters(self, ws_prefix, cost, peak_cen, peak_cen_err, frac_delta=1e-4):
+        param_table = ADS.retrieve(f"{ws_prefix}_Parameters")
+        self.assertAlmostEqual(param_table.column("Value")[-1], cost, delta=frac_delta * cost)
+        self.assertAlmostEqual(param_table.column("Value")[0], peak_cen, delta=frac_delta * peak_cen)
+        self.assertAlmostEqual(param_table.column("Error")[0], peak_cen_err, delta=frac_delta * peak_cen)
+
+    def _assert_output_workspaces_exist(self, ws_prefix):
+        self.assertTrue(ADS.doesExist(f"{ws_prefix}_Parameters"))
+        self.assertTrue(ADS.doesExist(f"{ws_prefix}_Workspace"))
 
 
 if __name__ == "__main__":

--- a/docs/source/release/v6.13.0/Diffraction/Powder/Bugfixes/39101.rst
+++ b/docs/source/release/v6.13.0/Diffraction/Powder/Bugfixes/39101.rst
@@ -1,0 +1,4 @@
+- Several bugs fixed in :ref:`algm-PEARLTransfit`:
+
+  - Fixed bug in binning which produced empty bins that caused fits to Ta10 resonance to fail with default ``Ediv``
+  - Corrected error propagation for effective and sample temperature

--- a/docs/source/release/v6.13.0/Diffraction/Powder/New_features/39101.rst
+++ b/docs/source/release/v6.13.0/Diffraction/Powder/New_features/39101.rst
@@ -1,0 +1,5 @@
+- Several improvements to :ref:`algm-PEARLTransfit`:
+
+  - Perform an intial fit with fixed ``GaussianFWHM`` for calibration runs
+  - Accounted for covariance in error calculation for effective temperature
+  - Added new input parameter ``RebinInEnergy`` - if False then the energy bins will be determined from the TOF bins in the input workspace and not the ``Ediv`` parameter.


### PR DESCRIPTION
### Description of work

It was reported in #38701 that the PEARLTransfit fit to the Ta10 resonance was failing - it turned out this was due to the homemade rebinning code producing may empty bins.

In the course of fixing this I came across a variety of improvements covered in this PR:
- Remove homemade rebinning code and use Rebin, CropWorkspace etc.
- Remove calls to simpleapi algorithm wrappers, call them as child algorithms
- Do initial fit with fixed Gaussian width for calibration runs
- Replace error calculations with correct error propagation using partial derivatives
- Account the covariance between Position and GaussianFWHM when calculating error on effective temperature
- Check that final fit was successful
- Add option RebinInEnergy to rebin/or not (default=True to preserve existing behaviour - but in general it is preferable not to rebin with constant bin width as the bin widths converted from the measured TOF are not constant).

There are many things that I would like to change about this algorithm but require a v2 due to breaking backward compatibility:
- Have `T\S_Fit` workspaces as output properties - this would stop workspaces being overwritten and give workspace history
- Have `S_Fit` workspace as an input property required if `Calibration=False` rather than hard-coding name
    - This would also enable sequential fitting by passing the results form previous temperature
- Have sample temperature and other debug info in an output table rather than printing the info to the log
- Get rid of `Ediv` parameter - it's not ideal to bin with constant bin width and this has unite eV where data is in meV!
- Get rid of `Bg0Guess` etc. - allow user to read in parameters from an input table like the do when Calibration=False

Fixes #38701 

**Report to:** Nick Funnell (PEARL)


### To test:

(1) Follow instructions on original issue

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
