### PR TITLE
38668 Disable Unsupported Rietveld Refinement Method from Diffraction Interface

### DIFF
--- a/docs/source/release/v6.13.0/Diffraction/Engineering/Bugfixes/38668.rst
+++ b/docs/source/release/v6.13.0/Diffraction/Engineering/Bugfixes/38668.rst
@@ -1,0 +1,1 @@
+- `#38668 <https://github.com/mantidproject/mantid/issues/38668>`_ : Disable ``Rietveld`` from :ref:`GSAS-II UI <ui engineering gsas>` Refinement Method combobox options. Add on-hover tooltip to inform users that Rietveld is not currently supported.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/view.py
@@ -63,6 +63,10 @@ class GSAS2View(QtWidgets.QWidget, Ui_calib):
         self.x_min_line_edit.setValidator(LineEditDoubleValidator(self.x_min_line_edit, 0))
         self.x_max_line_edit.setValidator(LineEditDoubleValidator(self.x_max_line_edit, 1))
 
+        combobox_index = self.refinement_method_combobox.findText("Rietveld")
+        self.refinement_method_combobox.model().item(combobox_index).setEnabled(False)
+        self.refinement_method_combobox.model().item(combobox_index).setToolTip("Rietveld is not currently supported.")
+
         # Plotting
         self.figure = None
         self.min_line = None


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
* Disable Rietveld Refinement Method within `refinement_method_combobox` on the GSAS-II tab in the Engineering and Diffraction Interface
* Add on-hover tooltip to state that Rietveld is not currently supported

Fixes #38668  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

- Open the Engineering Diffraction Interface `Interfaces>>Diffraction>>Engineering Diffraction`.
- Go to the `Calibration` tab, select `Create New Calibration`.
- For the `Calibration Sample #` enter `305738` and click the Calibrate button.
- On the `Focus` tab, enter `Sample Run #` `305761` and `Vanadium #` `307521` and click the `Focus` button.
- Change to the `GSASII` tab. The `Instrument Group` path should be pre-filled to a `.prm` file output by the calibration. and the `Focused Data` path should be pre-filled to the `.gss` file output from the `Focus` tab.
- Enter a name into the `Project Name` e.g. Test.
- For the Phase filepath, browse to `MANTID_INSTALL_DIRECTORY/scripts/Engineering/ENGINX/phase_info/FE_GAMMA.cif`.
- Try to select `Rietveld` from the dropdown selections in `Refinement Method` - Validate that you cannot select `Rietveld` and that it is greyed out as a selection option.
- Hover your curser over `Rietveld` in the `Refinement Method` dropdown selection and validate that the following message is displayed: `"Rietveld is not currently supported."`
- Select `Pawley` from the `Refinement Method` dropdown.
- Now, click `Refine in GSAS II`. After a few seconds, the output fit should be plotted.


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
