### PR TITLE
Relax test tolerance in BayesQuasiTest

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasiTest.py
@@ -251,17 +251,17 @@ class BayesQuasiTest(unittest.TestCase):
         @param prob Probability workspace from BayesQuasi
         @param group Group workspace of fitted spectra from BayesQuasi
         """
-
+        significant_digits = 3
         # Test values of result
-        self.assertAlmostEqual(result.dataY(0)[0], 81.12644, delta=1e-4)
-        self.assertAlmostEqual(result.dataY(1)[0], 0.0319747, delta=1e-4)
-        self.assertAlmostEqual(result.dataY(2)[0], 0.77168, delta=1e-4)
+        np.testing.assert_approx_equal(result.dataY(0)[0], 81.12644, significant=significant_digits)
+        np.testing.assert_approx_equal(result.dataY(1)[0], 0.0319747, significant=significant_digits)
+        np.testing.assert_approx_equal(result.dataY(2)[0], 0.77168, significant=significant_digits)
 
         # Test values of group
         sub_ws = group.getItem(0)
-        self.assertAlmostEqual(sub_ws.dataY(0)[0], 0.02540, delta=1e-4)
-        self.assertAlmostEqual(sub_ws.dataY(1)[0], 0.01632, delta=1e-4)
-        self.assertAlmostEqual(sub_ws.dataY(2)[0], -0.00908, delta=1e-4)
+        np.testing.assert_approx_equal(sub_ws.dataY(0)[0], 0.02540, significant=significant_digits)
+        np.testing.assert_approx_equal(sub_ws.dataY(1)[0], 0.01632, significant=significant_digits)
+        np.testing.assert_approx_equal(sub_ws.dataY(2)[0], -0.00908, significant=2)
 
     # --------------------------------Helper functions--------------------------------------
 


### PR DESCRIPTION
### Description of work
This test fails with a new alma9 based docker image:
https://builds.mantidproject.org/job/Core_Team_test_pipeline/200/testReport/projectroot.Framework.PythonInterface.test.python.plugins.algorithms/WorkflowAlgorithms/python_WorkflowAlgorithms_BayesQuasiTest_BayesQuasiTest/

Here the tolerances are relaxed sensibly so that it's comparing only the first three significant figures in most cases.

*There is no associated issue.*

### To test:
Verify that the unit tests (especially `BayesQuasiTest`) all pass:
https://builds.mantidproject.org/job/Core_Team_test_pipeline/205/


*This does not require release notes* because **it's just a tolerance change in a test.**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
