### PR TITLE
Pin CMake < 4 to avoid Windows packaging failure

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -26,8 +26,9 @@ libboost_devel:
 libboost_python_devel:
   - 1.84 # Aim to follow conda-forge
 
+# CMake 4 currently finds the wrong Python executable in the conda packaging nightly pipeline stage.
 cmake:
-  - '>=3.21.0'
+  - '>=3.21.0,<4'
 
 # 1.10.0 Produces a warning in Framework/Geometry/src/Crystal/HKLFilter.cpp
 doxygen:


### PR DESCRIPTION
### Description of work
CMake FindPython should be finding [this python](https://github.com/mantidproject/mantid/blob/fa168ec14995d14e42b2ee144a4c868c022bb652/conda/recipes/mantid/meta.yaml#L24)
But instead it's finding the one installed in this [conda environment](https://github.com/mantidproject/mantid/blob/fa168ec14995d14e42b2ee144a4c868c022bb652/buildconfig/Jenkins/Conda/package-conda#L86)
Then it fails, quite rightly, because there is no numpy installed in the python environment.

Checkling the CMakeCache.txt confirms the diagnosis:
`_Python_EXECUTABLE:INTERNAL=C:/jenkins_workdir/workspace/main_nightly_deployment/mambaforge/envs/package-conda/python.exe`

For some reason, since CMake has gone up to v4, the behaviour has changed. We can pin it back for now while we work to find a solution that allows us to move forwards.


### To test:
Verify that this Windows packaging build succeeds:
https://builds.mantidproject.org/job/build_packages_from_branch/1070/
And that cmake < 4 is installed in all the relevant PR checks.

*This does not require release notes* because **it's a cmake pin**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
