### PR TITLE
Pin conda=25.1.1 to avoid CMake FindPython error in Windows packaging

### DIFF
--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -83,7 +83,8 @@ done
 
 # Mamba
 setup_mamba $WORKSPACE/mambaforge "package-conda" true
-mamba install --yes boa conda-verify versioningit
+# CMake FindPython doesn't work correctly with conda 25.3.0
+mamba install --yes boa conda-verify versioningit conda=25.1.1
 
 # Clean up any legacy conda-recipes git clones
 cd $WORKSPACE


### PR DESCRIPTION
### Description of work
Windows packaging is failing with the following error:

```
CMake Error at C:/jenkins_workdir/workspace/main_nightly_deployment/conda-bld/_build_env/Library/share/cmake-4.0/Modules/FindPackageHandleStandardArgs.cmake:227 (message):
  Could NOT find Python (missing: Python_NumPy_INCLUDE_DIRS NumPy) (found
  suitable version "3.11.11", minimum required is "3.6")
Call Stack (most recent call first):
  C:/jenkins_workdir/workspace/main_nightly_deployment/conda-bld/_build_env/Library/share/cmake-4.0/Modules/FindPackageHandleStandardArgs.cmake:591 (_FPHSA_FAILURE_MESSAGE)
  C:/jenkins_workdir/workspace/main_nightly_deployment/conda-bld/_build_env/Library/share/cmake-4.0/Modules/FindPython/Support.cmake:4081 (find_package_handle_standard_args)
  C:/jenkins_workdir/workspace/main_nightly_deployment/conda-bld/_build_env/Library/share/cmake-4.0/Modules/FindPython.cmake:670 (include)
  buildconfig/CMake/Bootstrap.cmake:46 (find_package)
  CMakeLists.txt:87 (include)
```

CMake FindPython should be finding [this python](https://github.com/mantidproject/mantid/blob/fa168ec14995d14e42b2ee144a4c868c022bb652/conda/recipes/mantid/meta.yaml#L24).
But instead it's finding the one installed in this [conda environment](https://github.com/mantidproject/mantid/blob/fa168ec14995d14e42b2ee144a4c868c022bb652/buildconfig/Jenkins/Conda/package-conda#L86).
Then it fails, quite rightly, because there is no numpy installed in the python environment.

Checkling the CMakeCache.txt confirms the diagnosis:
`_Python_EXECUTABLE:INTERNAL=C:/jenkins_workdir/workspace/main_nightly_deployment/mambaforge/envs/package-conda/python.exe`
This variable should be pointing to the mantid build environment.

Initially I assumed it was CMake going up to v4.0, but that has been ruled out [here](https://builds.mantidproject.org/job/build_packages_from_branch/1072/), which failed with the same error.

*There is no associated issue.*

### To test:
Make sure this Windows package build is successful:
https://builds.mantidproject.org/job/build_packages_from_branch/1072/


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
