### PR TITLE
fix same unit on lhs and rhs but output not unitless

### DIFF
--- a/Framework/Algorithms/src/Divide.cpp
+++ b/Framework/Algorithms/src/Divide.cpp
@@ -90,7 +90,7 @@ void Divide::setOutputUnits(const API::MatrixWorkspace_const_sptr lhs, const API
 
   // If the Y units match, then the output will be a distribution and will be
   // dimensionless
-  else if (lhs->YUnit() == rhs->YUnit() && m_rhsBlocksize > 1) {
+  else if (lhs->YUnit() == rhs->YUnit() && m_rhsBlocksize != 1) {
     out->setYUnit("");
     out->setDistribution(true);
   }

--- a/Framework/Algorithms/test/MultiplyDivideTest.in.h
+++ b/Framework/Algorithms/test/MultiplyDivideTest.in.h
@@ -1101,6 +1101,7 @@ public:
     auto rhs = create_RaggedWorkspace();
     lhs->setYUnit("counts");
     rhs->setYUnit("counts");
+    DO_DIVIDE = true;
     auto result = performTest(lhs, rhs, false, DO_DIVIDE ? 1.0 : 4.0, DO_DIVIDE ? 1.4142135625 : 5.6568542436);
     TS_ASSERT(result->isRaggedWorkspace());
     TS_ASSERT_EQUALS(result->isDistribution(), DO_DIVIDE ? true : false);

--- a/Framework/Algorithms/test/MultiplyDivideTest.in.h
+++ b/Framework/Algorithms/test/MultiplyDivideTest.in.h
@@ -1095,6 +1095,18 @@ public:
     TS_ASSERT(result->YUnit().empty());
   }
 
+  void test_RaggedWorkspace_sameunit()
+  {
+    auto lhs = create_RaggedWorkspace();
+    auto rhs = create_RaggedWorkspace();
+    lhs->setYUnit("counts");
+    rhs->setYUnit("counts");
+    auto result = performTest(lhs, rhs, false, DO_DIVIDE ? 1.0 : 4.0, DO_DIVIDE ? 1.4142135625 : 5.6568542436);
+    TS_ASSERT(result->isRaggedWorkspace());
+    TS_ASSERT_EQUALS(result->isDistribution(), DO_DIVIDE ? true : false);
+    TS_ASSERT(result->YUnit().empty());
+  }
+
   void test_RaggedWorkspace_and_single_value()
   {
     auto lhs = create_RaggedWorkspace();

--- a/docs/source/release/v6.13.0/Framework/Algorithms/Bugfixes/39125.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/Bugfixes/39125.rst
@@ -1,0 +1,1 @@
+- Fixes a bug in  :ref:`algm-Divide` which do not clear unit when the YUnit of lhs == rhs due to rhsBlockszie being 0.

--- a/docs/source/release/v6.13.0/Framework/Algorithms/Bugfixes/39125.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/Bugfixes/39125.rst
@@ -1,1 +1,1 @@
-- Fixes a bug in  :ref:`algm-Divide` which do not clear unit when the YUnit of lhs == rhs due to rhsBlockszie being 0.
+- Fixes a bug in  :ref:`algm-Divide` where units were not properly cleared when dividing two :ref:`ragged_workspace <Ragged_Workspace>` with identical Y-axis Units. This issue could cause errors in downstream data reduction workflows where the resulting workspace should be unitless. The fix ensures proper unit handling for :ref:`ragged_workspace <Ragged_Workspace>` division operations.


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->
This address when two ragged workspaces have the same unit but the unit is not cleared when divided by each other.

When the workspace is ragged, the m_rhsblocksize is 0 which should be handled to clear YUnit.

In the uni test, DO_DIVIDE is set to true as only dividing same units creates unitless output. So no need to test in multiply.
Fixes EWM [10307](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=10307) <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

#need to manage weird file names...
pgs = ["all","bank","column"]
dataDir = "/SNS/SNAP/shared/temp/kyle/"

for i,pg in enumerate(pgs):
    
    numeratorPath = f"{dataDir}___reduced_dsp_{pg}_064431_2025-03-28T105256.nxs"
    denominatorPath = f"{dataDir}reduced_normalization_{i}_2025-03-28T105256.nxs"
    
    LoadNexus(Filename=numeratorPath,
        OutputWorkspace="numerator")
        
    LoadNexus(Filename=denominatorPath,
        OutputWorkspace="denominator")
        
    Divide(LHSWorkspace="numerator",
        RHSWorkspace="denominator",
        OutputWorkspace=f"quotient_{pg}")
        
        
        
for i,pg in enumerate(pgs):
    ws = mtd[f"quotient_{pg}"]
    print(f" pixel group: {pg} has {ws.getNumberHistograms()} spectra")
    # print(f" ragged: {ws.isRagged()}") #this returns an error
    print(f" after divide, output ws quotient_{pg} has YUnits = {ws.YUnit()}")

```

This should show quotient_{pg} has no YUnits and mannually obsering the diffraction data you should see all three ws show consistent results. 
![image](https://github.com/user-attachments/assets/bb711470-66a3-4dfc-b1e8-7e4d130b1474)

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
