### PR TITLE
Avoid casting negative times to unsigned int

### DIFF
--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1458,9 +1458,9 @@ void TimeSeriesProperty<TYPE>::create(const Types::Core::DateAndTime &start_time
     m_propSortedFlag = TimeSeriesSortStatus::TSUNSORTED;
   // set the values
   constexpr double SEC_TO_NANO{1000000000.0};
-  const uint64_t start_time_ns = static_cast<uint64_t>(start_time.totalNanoseconds());
+  const auto start_time_ns = static_cast<double>(start_time.totalNanoseconds());
   for (std::size_t i = 0; i < num; i++) {
-    m_values.emplace_back(start_time_ns + static_cast<uint64_t>(time_sec[i] * SEC_TO_NANO), new_values[i]);
+    m_values.emplace_back(static_cast<uint64_t>(start_time_ns + time_sec[i] * SEC_TO_NANO), new_values[i]);
   }
 
   // reset the size

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1458,17 +1458,9 @@ void TimeSeriesProperty<TYPE>::create(const Types::Core::DateAndTime &start_time
     m_propSortedFlag = TimeSeriesSortStatus::TSUNSORTED;
   // set the values
   constexpr double SEC_TO_NANO{1000000000.0};
-  // This used to cast negative times to uint64_t, which is undefined behaviour. Fixing
-  // that for all times results in times changing (only a few nanoseconds but this has
-  // a noticeable effect on the tests). Hence to minimise disruption this only
-  // does the new calculation for negative times, and leaves all positive times with
-  // the old calculation.
-  const auto start_time_ns_d = static_cast<double>(start_time.totalNanoseconds());
-  const auto start_time_ns_u = static_cast<uint64_t>(start_time.totalNanoseconds());
+  const int64_t start_time_ns = start_time.totalNanoseconds();
   for (std::size_t i = 0; i < num; i++) {
-    const uint64_t time = time_sec[i] < 0 ? static_cast<uint64_t>(start_time_ns_d + time_sec[i] * SEC_TO_NANO)
-                                          : start_time_ns_u + static_cast<uint64_t>(time_sec[i] * SEC_TO_NANO);
-    m_values.emplace_back(time, new_values[i]);
+    m_values.emplace_back(start_time_ns + static_cast<int64_t>(time_sec[i] * SEC_TO_NANO), new_values[i]);
   }
 
   // reset the size

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1458,9 +1458,17 @@ void TimeSeriesProperty<TYPE>::create(const Types::Core::DateAndTime &start_time
     m_propSortedFlag = TimeSeriesSortStatus::TSUNSORTED;
   // set the values
   constexpr double SEC_TO_NANO{1000000000.0};
-  const auto start_time_ns = static_cast<double>(start_time.totalNanoseconds());
+  // This used to cast negative times to uint64_t, which is undefined behaviour. Fixing
+  // that for all times results in times changing (only a few nanoseconds but this has
+  // a noticeable effect on the tests). Hence to minimise disruption this only
+  // does the new calculation for negative times, and leaves all positive times with
+  // the old calculation.
+  const auto start_time_ns_d = static_cast<double>(start_time.totalNanoseconds());
+  const auto start_time_ns_u = static_cast<uint64_t>(start_time.totalNanoseconds());
   for (std::size_t i = 0; i < num; i++) {
-    m_values.emplace_back(static_cast<uint64_t>(start_time_ns + time_sec[i] * SEC_TO_NANO), new_values[i]);
+    const uint64_t time = time_sec[i] < 0 ? static_cast<uint64_t>(start_time_ns_d + time_sec[i] * SEC_TO_NANO)
+                                          : start_time_ns_u + static_cast<uint64_t>(time_sec[i] * SEC_TO_NANO);
+    m_values.emplace_back(time, new_values[i]);
   }
 
   // reset the size

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -2171,6 +2171,21 @@ public:
     TS_ASSERT_EQUALS(range.stop(), stop);
   }
 
+  void test_negativeTimes() {
+    using namespace Mantid::Types::Core;
+    TimeSeriesProperty<double> series("doubleProperty");
+    const DateAndTime startTime(100000, 0);
+    const std::vector<double> times{-5000, -1, 0, 1, 5};
+    const std::vector<double> values{1, 1, 1, 1, 1};
+    series.create(startTime, times, values);
+    TS_ASSERT_EQUALS(times.size(), series.size());
+    TS_ASSERT_EQUALS(values.size(), series.valuesAsVector().size());
+    const std::vector<DateAndTime> timesAsVector = series.timesAsVector();
+    for (size_t i = 0; i < times.size(); i++) {
+      TS_ASSERT_EQUALS(startTime + times[i], timesAsVector[i]);
+    }
+  }
+
 private:
   /// Generate a test log
   std::unique_ptr<TimeSeriesProperty<double>> getTestLog() {

--- a/docs/source/release/v6.13.0/Framework/Bugfixes/39126.rst
+++ b/docs/source/release/v6.13.0/Framework/Bugfixes/39126.rst
@@ -1,0 +1,1 @@
+- Fixed undefined behaviour when loading time series data with negative times. This could result in very small changes (nanoseconds) to recorded times due to floating-point arithmetic.


### PR DESCRIPTION
The entries in `time_sec` can be negative, and casting a negative double to a `uint64_t` results in undefined behaviour. The new version will only cast a negative number to a `uint64_t` if the time is before 1970, so most likely not a problem.

This problem was discovered when ARM machines ran this code and have different behaviour when casting the negative number to an unsigned int.

Initially I changed the code to always do the new way of calculating the time, but this results in times changing by a few nanoseconds. To minimise things changing I've isolated the new method to times that would be affected by this problem.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
