### PR TITLE
Add git-blame-ignore-revs to hide bot commits - ornl-next

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,15 @@
+# The refspecs listed in this file are ignored by `git blame` when git is configured correctly.
+# The refspecs must be listed in commit order from oldest to newest.
+#
+# MOST OF THE COMMITS LISTED ARE BY BOTS
+#
+# github does this automatically https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view
+#
+# To configure it locally, run
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+# Or add it as an option
+# git blame --ignore-revs-file .git-blame-ignore-revs
+
+dccacdbddbc28f43a4ab9d1b63caf2fda71b1688
+9485437150f800515afbf15ab6ef05108714a0eb
+a90b115e443e27eb187aba3cd794eee591079401

--- a/dev-docs/source/GitWorkflow.rst
+++ b/dev-docs/source/GitWorkflow.rst
@@ -68,6 +68,27 @@ pushed to GitHub, please follow the convention of
 what the branch is for (issue number) and quickly know what is being
 done there (short description).
 
+Git Blame
+---------
+
+The refspecs listed in this file are ignored by ``git blame`` when git is configured correctly.
+This is mostly used to hide commits that are created by bots (e.g. formatting)
+The refspecs must be listed in commit order from oldest to newest.
+Github does this automatically in the `blame view of a file <https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view>`_
+
+To configure it locally (examples assume you are in the root of your local clone), add it as an option to git blame
+
+.. code-block:: sh
+
+   git blame --ignore-revs-file .git-blame-ignore-revs
+
+or configure your local git instance
+
+.. code-block:: sh
+
+   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+
 .. _GitWorkflowPullRequests:
 
 Pull Requests
@@ -143,8 +164,7 @@ The reasons a pull request may be flagged up currently are:
 - The developer has yet to act on comments left in a review
 
 
-(code for the bot is currently `here
-<https://github.com/DanNixon/mantid_pr_bot>`__)
+(code for the bot is currently `here <https://github.com/DanNixon/mantid_pr_bot>`__)
 
 Code Freeze
 -----------

--- a/docs/source/release/v6.13.0/Framework/New_features/39133.rst
+++ b/docs/source/release/v6.13.0/Framework/New_features/39133.rst
@@ -1,0 +1,1 @@
+- Added file ``.git-blame-ignore-revs`` to ignore particular revisions (e.g. by bots) in ``git blame`` listings. See :ref:`GitWorkflow` page for more details.


### PR DESCRIPTION
This is a version of #39133 into `ornl-next`