### PR TITLE
Only check for merge conflicts on pull requests

### DIFF
--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -1,10 +1,5 @@
 name: 'Check for merge conflicts'
 on:
-  push:
-    branches:
-      - 'main'
-      - 'release-next'
-      - 'ornl-next'
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
Since the [label-merge-conflicts-action](https://github.com/prince-chrismc/label-merge-conflicts-action) can only annotate PRs, there is no point in running it on our protected branches. This removes running the action on `main`, `release-next`, and `ornl-next` which cannot be labeled.

*There is no associated issue.*

### To test:

To see it in action, it will have to be merged into one of those branches and not show that the job was run or skipped.


*This does not require release notes* because it only affects builds on those 3 canonical branches.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
