### PR TITLE
Add Gauge Volume to Monte Carlo Absorption

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
@@ -52,9 +52,11 @@ public:
   }
 
 protected:
-  virtual std::shared_ptr<IMCAbsorptionStrategy>
-  createStrategy(IMCInteractionVolume &interactionVol, const IBeamProfile &beamProfile, Kernel::DeltaEMode::Type EMode,
-                 const size_t nevents, const size_t maxScatterPtAttempts, const bool regenerateTracksForEachLambda);
+  virtual std::shared_ptr<IMCAbsorptionStrategy> createStrategy(std::shared_ptr<IMCInteractionVolume> interactionVol,
+                                                                const IBeamProfile &beamProfile,
+                                                                Kernel::DeltaEMode::Type EMode, const size_t nevents,
+                                                                const size_t maxScatterPtAttempts,
+                                                                const bool regenerateTracksForEachLambda);
   virtual std::shared_ptr<IMCInteractionVolume>
   createInteractionVolume(const API::Sample &sample, const size_t maxScatterPtAttempts,
                           const MCInteractionVolume::ScatteringPointVicinity pointsIn,

--- a/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
@@ -57,10 +57,6 @@ protected:
                                                                 Kernel::DeltaEMode::Type EMode, const size_t nevents,
                                                                 const size_t maxScatterPtAttempts,
                                                                 const bool regenerateTracksForEachLambda);
-  virtual std::shared_ptr<IMCInteractionVolume>
-  createInteractionVolume(const API::Sample &sample, const size_t maxScatterPtAttempts,
-                          const MCInteractionVolume::ScatteringPointVicinity pointsIn,
-                          Geometry::IObject_sptr gaugeVolume = nullptr);
   virtual std::shared_ptr<SparseWorkspace> createSparseWorkspace(const API::MatrixWorkspace &modelWS,
                                                                  const size_t wavelengthPoints, const size_t rows,
                                                                  const size_t columns);

--- a/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
@@ -57,7 +57,8 @@ protected:
                  const size_t nevents, const size_t maxScatterPtAttempts, const bool regenerateTracksForEachLambda);
   virtual std::shared_ptr<IMCInteractionVolume>
   createInteractionVolume(const API::Sample &sample, const size_t maxScatterPtAttempts,
-                          const MCInteractionVolume::ScatteringPointVicinity pointsIn);
+                          const MCInteractionVolume::ScatteringPointVicinity pointsIn,
+                          const Geometry::IObject_sptr gaugeVolume = nullptr);
   virtual std::shared_ptr<SparseWorkspace> createSparseWorkspace(const API::MatrixWorkspace &modelWS,
                                                                  const size_t wavelengthPoints, const size_t rows,
                                                                  const size_t columns);

--- a/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
@@ -52,7 +52,7 @@ public:
   }
 
 protected:
-  virtual [[nodiscard]] std::shared_ptr<IMCAbsorptionStrategy>
+  [[nodiscard]] virtual std::shared_ptr<IMCAbsorptionStrategy>
   createStrategy(std::shared_ptr<IMCInteractionVolume> interactionVol, const IBeamProfile &beamProfile,
                  Kernel::DeltaEMode::Type EMode, const size_t nevents, const size_t maxScatterPtAttempts,
                  const bool regenerateTracksForEachLambda);

--- a/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
@@ -58,7 +58,7 @@ protected:
   virtual std::shared_ptr<IMCInteractionVolume>
   createInteractionVolume(const API::Sample &sample, const size_t maxScatterPtAttempts,
                           const MCInteractionVolume::ScatteringPointVicinity pointsIn,
-                          const Geometry::IObject_sptr gaugeVolume = nullptr);
+                          Geometry::IObject_sptr gaugeVolume = nullptr);
   virtual std::shared_ptr<SparseWorkspace> createSparseWorkspace(const API::MatrixWorkspace &modelWS,
                                                                  const size_t wavelengthPoints, const size_t rows,
                                                                  const size_t columns);

--- a/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
@@ -77,7 +77,7 @@ private:
                                          const bool simulateTracksForEachWavelength, const int seed,
                                          const InterpolationOption &interpolateOpt, const bool useSparseInstrument,
                                          const size_t maxScatterPtAttempts,
-                                         const MCInteractionVolume::ScatteringPointVicinity pointsIn);
+                                         MCInteractionVolume::ScatteringPointVicinity pointsIn);
   API::MatrixWorkspace_uptr createOutputWorkspace(const API::MatrixWorkspace &inputWS) const;
   void interpolateFromSparse(API::MatrixWorkspace &targetWS, const SparseWorkspace &sparseWS,
                              const Mantid::Algorithms::InterpolationOption &interpOpt);

--- a/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
@@ -52,11 +52,10 @@ public:
   }
 
 protected:
-  virtual std::shared_ptr<IMCAbsorptionStrategy> createStrategy(std::shared_ptr<IMCInteractionVolume> interactionVol,
-                                                                const IBeamProfile &beamProfile,
-                                                                Kernel::DeltaEMode::Type EMode, const size_t nevents,
-                                                                const size_t maxScatterPtAttempts,
-                                                                const bool regenerateTracksForEachLambda);
+  virtual [[nodiscard]] std::shared_ptr<IMCAbsorptionStrategy>
+  createStrategy(std::shared_ptr<IMCInteractionVolume> interactionVol, const IBeamProfile &beamProfile,
+                 Kernel::DeltaEMode::Type EMode, const size_t nevents, const size_t maxScatterPtAttempts,
+                 const bool regenerateTracksForEachLambda);
   virtual std::shared_ptr<SparseWorkspace> createSparseWorkspace(const API::MatrixWorkspace &modelWS,
                                                                  const size_t wavelengthPoints, const size_t rows,
                                                                  const size_t columns);

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/IMCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/IMCInteractionVolume.h
@@ -35,16 +35,18 @@ using TrackPair = std::tuple<bool, std::shared_ptr<Geometry::Track>, std::shared
 */
 class MANTID_ALGORITHMS_DLL IMCInteractionVolume {
 public:
+  enum class ScatteringPointVicinity { SAMPLEANDENVIRONMENT, SAMPLEONLY, ENVIRONMENTONLY };
   virtual ~IMCInteractionVolume() = default;
   virtual TrackPair calculateBeforeAfterTrack(Kernel::PseudoRandomNumberGenerator &rng, const Kernel::V3D &startPos,
                                               const Kernel::V3D &endPos, MCInteractionStatistics &stats) const = 0;
+  virtual ComponentScatterPoint generatePoint(Kernel::PseudoRandomNumberGenerator &rng) const = 0;
   virtual const Geometry::BoundingBox getFullBoundingBox() const = 0;
   virtual void setActiveRegion(const Geometry::BoundingBox &region) = 0;
   virtual Geometry::IObject_sptr getGaugeVolume() const = 0;
   virtual void setGaugeVolume(Geometry::IObject_sptr gaugeVolume) = 0;
 
 protected:
-  void init();
+  virtual void init() = 0;
 };
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/IMCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/IMCInteractionVolume.h
@@ -35,7 +35,6 @@ using TrackPair = std::tuple<bool, std::shared_ptr<Geometry::Track>, std::shared
 */
 class MANTID_ALGORITHMS_DLL IMCInteractionVolume {
 public:
-  virtual void init() = 0;
   virtual ~IMCInteractionVolume() = default;
   virtual TrackPair calculateBeforeAfterTrack(Kernel::PseudoRandomNumberGenerator &rng, const Kernel::V3D &startPos,
                                               const Kernel::V3D &endPos, MCInteractionStatistics &stats) const = 0;
@@ -43,6 +42,9 @@ public:
   virtual void setActiveRegion(const Geometry::BoundingBox &region) = 0;
   virtual Geometry::IObject_sptr getGaugeVolume() const = 0;
   virtual void setGaugeVolume(Geometry::IObject_sptr gaugeVolume) = 0;
+
+protected:
+  void init();
 };
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/IMCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/IMCInteractionVolume.h
@@ -35,6 +35,7 @@ using TrackPair = std::tuple<bool, std::shared_ptr<Geometry::Track>, std::shared
 */
 class MANTID_ALGORITHMS_DLL IMCInteractionVolume {
 public:
+  virtual void init() = 0;
   virtual ~IMCInteractionVolume() = default;
   virtual TrackPair calculateBeforeAfterTrack(Kernel::PseudoRandomNumberGenerator &rng, const Kernel::V3D &startPos,
                                               const Kernel::V3D &endPos, MCInteractionStatistics &stats) const = 0;
@@ -43,6 +44,5 @@ public:
   virtual Geometry::IObject_sptr getGaugeVolume() const = 0;
   virtual void setGaugeVolume(Geometry::IObject_sptr gaugeVolume) = 0;
 };
-
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/IMCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/IMCInteractionVolume.h
@@ -40,6 +40,8 @@ public:
                                               const Kernel::V3D &endPos, MCInteractionStatistics &stats) const = 0;
   virtual const Geometry::BoundingBox getFullBoundingBox() const = 0;
   virtual void setActiveRegion(const Geometry::BoundingBox &region) = 0;
+  virtual Geometry::IObject_sptr getGaugeVolume() const = 0;
+  virtual void setGaugeVolume(Geometry::IObject_sptr gaugeVolume) = 0;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCAbsorptionStrategy.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCAbsorptionStrategy.h
@@ -55,7 +55,7 @@ private:
   const size_t m_maxScatterAttempts;
   const Kernel::DeltaEMode::Type m_EMode;
   const bool m_regenerateTracksForEachLambda;
-  void setActiveRegion(std::shared_ptr<IMCInteractionVolume> interactionVolume, const IBeamProfile &beamProfile);
+  void setActiveRegion();
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCAbsorptionStrategy.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCAbsorptionStrategy.h
@@ -40,7 +40,7 @@ class MonteCarloAbsorption;
 */
 class MANTID_ALGORITHMS_DLL MCAbsorptionStrategy : public IMCAbsorptionStrategy {
 public:
-  MCAbsorptionStrategy(IMCInteractionVolume &interactionVolume, const IBeamProfile &beamProfile,
+  MCAbsorptionStrategy(std::shared_ptr<IMCInteractionVolume> interactionVolume, const IBeamProfile &beamProfile,
                        Kernel::DeltaEMode::Type EMode, const size_t nevents, const size_t maxScatterPtAttempts,
                        const bool regenerateTracksForEachLambda);
   virtual void calculate(Kernel::PseudoRandomNumberGenerator &rng, const Kernel::V3D &finalPos,
@@ -49,13 +49,13 @@ public:
                          MCInteractionStatistics &stats) override;
 
 private:
+  std::shared_ptr<IMCInteractionVolume> m_scatterVol;
   const IBeamProfile &m_beamProfile;
-  const IMCInteractionVolume &m_scatterVol;
   const size_t m_nevents;
   const size_t m_maxScatterAttempts;
   const Kernel::DeltaEMode::Type m_EMode;
   const bool m_regenerateTracksForEachLambda;
-  IMCInteractionVolume &setActiveRegion(IMCInteractionVolume &interactionVolume, const IBeamProfile &beamProfile);
+  void setActiveRegion(std::shared_ptr<IMCInteractionVolume> interactionVolume, const IBeamProfile &beamProfile);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
@@ -30,7 +30,7 @@ public:
   enum class ScatteringPointVicinity { SAMPLEANDENVIRONMENT, SAMPLEONLY, ENVIRONMENTONLY };
   MCInteractionVolume(const API::Sample &sample, const size_t maxScatterAttempts = 5000,
                       const ScatteringPointVicinity pointsIn = ScatteringPointVicinity::SAMPLEANDENVIRONMENT,
-                      const Geometry::IObject_sptr gaugeVolume = nullptr);
+                      Geometry::IObject_sptr gaugeVolume = nullptr);
 
   const Geometry::BoundingBox getFullBoundingBox() const override;
   virtual TrackPair calculateBeforeAfterTrack(Kernel::PseudoRandomNumberGenerator &rng, const Kernel::V3D &startPos,
@@ -47,7 +47,7 @@ private:
   Geometry::BoundingBox m_activeRegion;
   const size_t m_maxScatterAttempts;
   const ScatteringPointVicinity m_pointsIn;
-  const Geometry::IObject_sptr m_gaugeVolume;
+  Geometry::IObject_sptr m_gaugeVolume;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
@@ -28,20 +28,22 @@ class IBeamProfile;
 class MANTID_ALGORITHMS_DLL MCInteractionVolume : public IMCInteractionVolume {
 public:
   enum class ScatteringPointVicinity { SAMPLEANDENVIRONMENT, SAMPLEONLY, ENVIRONMENTONLY };
-  MCInteractionVolume(const API::Sample &sample, const size_t maxScatterAttempts = 5000,
-                      const ScatteringPointVicinity pointsIn = ScatteringPointVicinity::SAMPLEANDENVIRONMENT,
-                      Geometry::IObject_sptr gaugeVolume = nullptr);
-
+  static std::shared_ptr<IMCInteractionVolume>
+  create(const API::Sample &sample, const size_t maxScatterAttempts = 5000,
+         const ScatteringPointVicinity pointsIn = ScatteringPointVicinity::SAMPLEANDENVIRONMENT,
+         Geometry::IObject_sptr gaugeVolume = nullptr);
   const Geometry::BoundingBox getFullBoundingBox() const override;
   virtual TrackPair calculateBeforeAfterTrack(Kernel::PseudoRandomNumberGenerator &rng, const Kernel::V3D &startPos,
                                               const Kernel::V3D &endPos, MCInteractionStatistics &stats) const override;
-  ComponentScatterPoint generatePoint(Kernel::PseudoRandomNumberGenerator &rng) const;
+  ComponentScatterPoint generatePoint(Kernel::PseudoRandomNumberGenerator &rng) const override;
   void setActiveRegion(const Geometry::BoundingBox &region) override;
   Geometry::IObject_sptr getGaugeVolume() const override;
   void setGaugeVolume(Geometry::IObject_sptr gaugeVolume) override;
 
 private:
-  void init();
+  MCInteractionVolume(const API::Sample &sample, const size_t maxScatterAttempts = 5000,
+                      const ScatteringPointVicinity pointsIn = ScatteringPointVicinity::SAMPLEANDENVIRONMENT,
+                      Geometry::IObject_sptr gaugeVolume = nullptr);
   int getComponentIndex(Kernel::PseudoRandomNumberGenerator &rng) const;
   std::optional<Kernel::V3D> generatePointInObjectByIndex(int componentIndex,
                                                           Kernel::PseudoRandomNumberGenerator &rng) const;
@@ -51,6 +53,9 @@ private:
   const size_t m_maxScatterAttempts;
   const ScatteringPointVicinity m_pointsIn;
   Geometry::IObject_sptr m_gaugeVolume;
+
+protected:
+  void init() override;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
@@ -27,7 +27,6 @@ class IBeamProfile;
 */
 class MANTID_ALGORITHMS_DLL MCInteractionVolume : public IMCInteractionVolume {
 public:
-  void init() override;
   enum class ScatteringPointVicinity { SAMPLEANDENVIRONMENT, SAMPLEONLY, ENVIRONMENTONLY };
   MCInteractionVolume(const API::Sample &sample, const size_t maxScatterAttempts = 5000,
                       const ScatteringPointVicinity pointsIn = ScatteringPointVicinity::SAMPLEANDENVIRONMENT,
@@ -42,6 +41,7 @@ public:
   void setGaugeVolume(Geometry::IObject_sptr gaugeVolume) override;
 
 private:
+  void init();
   int getComponentIndex(Kernel::PseudoRandomNumberGenerator &rng) const;
   std::optional<Kernel::V3D> generatePointInObjectByIndex(int componentIndex,
                                                           Kernel::PseudoRandomNumberGenerator &rng) const;

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
@@ -29,7 +29,8 @@ class MANTID_ALGORITHMS_DLL MCInteractionVolume : public IMCInteractionVolume {
 public:
   enum class ScatteringPointVicinity { SAMPLEANDENVIRONMENT, SAMPLEONLY, ENVIRONMENTONLY };
   MCInteractionVolume(const API::Sample &sample, const size_t maxScatterAttempts = 5000,
-                      const ScatteringPointVicinity pointsIn = ScatteringPointVicinity::SAMPLEANDENVIRONMENT);
+                      const ScatteringPointVicinity pointsIn = ScatteringPointVicinity::SAMPLEANDENVIRONMENT,
+                      const Geometry::IObject_sptr gaugeVolume = nullptr);
 
   const Geometry::BoundingBox getFullBoundingBox() const override;
   virtual TrackPair calculateBeforeAfterTrack(Kernel::PseudoRandomNumberGenerator &rng, const Kernel::V3D &startPos,
@@ -46,6 +47,7 @@ private:
   Geometry::BoundingBox m_activeRegion;
   const size_t m_maxScatterAttempts;
   const ScatteringPointVicinity m_pointsIn;
+  const Geometry::IObject_sptr m_gaugeVolume;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
@@ -41,6 +41,8 @@ public:
   void setGaugeVolume(Geometry::IObject_sptr gaugeVolume) override;
 
 private:
+  // init required to be called separately to constructor, so here we prevent public access to direct creation of
+  // instance
   explicit MCInteractionVolume(const API::Sample &sample, const size_t maxScatterAttempts = 5000,
                                const ScatteringPointVicinity pointsIn = ScatteringPointVicinity::SAMPLEANDENVIRONMENT,
                                Geometry::IObject_sptr gaugeVolume = nullptr);

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
@@ -27,6 +27,7 @@ class IBeamProfile;
 */
 class MANTID_ALGORITHMS_DLL MCInteractionVolume : public IMCInteractionVolume {
 public:
+  void init() override;
   enum class ScatteringPointVicinity { SAMPLEANDENVIRONMENT, SAMPLEONLY, ENVIRONMENTONLY };
   MCInteractionVolume(const API::Sample &sample, const size_t maxScatterAttempts = 5000,
                       const ScatteringPointVicinity pointsIn = ScatteringPointVicinity::SAMPLEANDENVIRONMENT,

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
@@ -37,6 +37,8 @@ public:
                                               const Kernel::V3D &endPos, MCInteractionStatistics &stats) const override;
   ComponentScatterPoint generatePoint(Kernel::PseudoRandomNumberGenerator &rng) const;
   void setActiveRegion(const Geometry::BoundingBox &region) override;
+  Geometry::IObject_sptr getGaugeVolume() const override;
+  void setGaugeVolume(Geometry::IObject_sptr gaugeVolume) override;
 
 private:
   int getComponentIndex(Kernel::PseudoRandomNumberGenerator &rng) const;

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
@@ -28,7 +28,7 @@ class IBeamProfile;
 class MANTID_ALGORITHMS_DLL MCInteractionVolume : public IMCInteractionVolume {
 public:
   enum class ScatteringPointVicinity { SAMPLEANDENVIRONMENT, SAMPLEONLY, ENVIRONMENTONLY };
-  static std::shared_ptr<IMCInteractionVolume>
+  [[nodiscard]] static std::shared_ptr<IMCInteractionVolume>
   create(const API::Sample &sample, const size_t maxScatterAttempts = 5000,
          const ScatteringPointVicinity pointsIn = ScatteringPointVicinity::SAMPLEANDENVIRONMENT,
          Geometry::IObject_sptr gaugeVolume = nullptr);

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/MCInteractionVolume.h
@@ -41,9 +41,9 @@ public:
   void setGaugeVolume(Geometry::IObject_sptr gaugeVolume) override;
 
 private:
-  MCInteractionVolume(const API::Sample &sample, const size_t maxScatterAttempts = 5000,
-                      const ScatteringPointVicinity pointsIn = ScatteringPointVicinity::SAMPLEANDENVIRONMENT,
-                      Geometry::IObject_sptr gaugeVolume = nullptr);
+  explicit MCInteractionVolume(const API::Sample &sample, const size_t maxScatterAttempts = 5000,
+                               const ScatteringPointVicinity pointsIn = ScatteringPointVicinity::SAMPLEANDENVIRONMENT,
+                               Geometry::IObject_sptr gaugeVolume = nullptr);
   int getComponentIndex(Kernel::PseudoRandomNumberGenerator &rng) const;
   std::optional<Kernel::V3D> generatePointInObjectByIndex(int componentIndex,
                                                           Kernel::PseudoRandomNumberGenerator &rng) const;

--- a/Framework/Algorithms/src/AddAbsorptionWeightedPathLengths.cpp
+++ b/Framework/Algorithms/src/AddAbsorptionWeightedPathLengths.cpp
@@ -119,7 +119,7 @@ void AddAbsorptionWeightedPathLengths::exec() {
   auto beamProfile = BeamProfileFactory::createBeamProfile(*instrument, inputWS->sample());
   // Configure strategy
   std::shared_ptr<IMCInteractionVolume> interactionVol =
-      std::make_shared<MCInteractionVolume>(inputWS->sample(), maxScatterPtAttempts);
+      MCInteractionVolume::create(inputWS->sample(), maxScatterPtAttempts);
   MCAbsorptionStrategy strategy(interactionVol, *beamProfile, DeltaEMode::Elastic, nevents, maxScatterPtAttempts, true);
 
   bool useSinglePath = getProperty("UseSinglePath");

--- a/Framework/Algorithms/src/AddAbsorptionWeightedPathLengths.cpp
+++ b/Framework/Algorithms/src/AddAbsorptionWeightedPathLengths.cpp
@@ -118,7 +118,8 @@ void AddAbsorptionWeightedPathLengths::exec() {
 
   auto beamProfile = BeamProfileFactory::createBeamProfile(*instrument, inputWS->sample());
   // Configure strategy
-  MCInteractionVolume interactionVol(inputWS->sample(), maxScatterPtAttempts);
+  std::shared_ptr<IMCInteractionVolume> interactionVol =
+      std::make_shared<MCInteractionVolume>(inputWS->sample(), maxScatterPtAttempts);
   MCAbsorptionStrategy strategy(interactionVol, *beamProfile, DeltaEMode::Elastic, nevents, maxScatterPtAttempts, true);
 
   bool useSinglePath = getProperty("UseSinglePath");

--- a/Framework/Algorithms/src/MonteCarloAbsorption.cpp
+++ b/Framework/Algorithms/src/MonteCarloAbsorption.cpp
@@ -195,22 +195,6 @@ std::map<std::string, std::string> MonteCarloAbsorption::validateInputs() {
 }
 
 /**
- * Factory method to return an instance of the required interaction volume
- * class
- * @param sample A reference to the object defining details of the sample
- * @param maxScatterPtAttempts The maximum number of tries to generate a random
- * point within the object
- * @param pointsIn Where to generate the scattering point in
- * @return a pointer to an MCAbsorptionStrategy object
- */
-std::shared_ptr<IMCInteractionVolume>
-MonteCarloAbsorption::createInteractionVolume(const API::Sample &sample, const size_t maxScatterPtAttempts,
-                                              const MCInteractionVolume::ScatteringPointVicinity pointsIn,
-                                              const Geometry::IObject_sptr gaugeVolume) {
-  return std::make_shared<MCInteractionVolume>(sample, maxScatterPtAttempts, pointsIn, gaugeVolume);
-}
-
-/**
  * Factory method to return an instance of the required absorption strategy
  * class
  * @param interactionVol The interaction volume object to inject into the
@@ -338,7 +322,7 @@ MatrixWorkspace_uptr MonteCarloAbsorption::doSimulation(const MatrixWorkspace &i
   }
 
   std::shared_ptr<IMCInteractionVolume> interactionVolume =
-      createInteractionVolume(inputWS.sample(), maxScatterPtAttempts, pointsIn, gaugeVolume);
+      MCInteractionVolume::create(inputWS.sample(), maxScatterPtAttempts, pointsIn, gaugeVolume);
 
   Geometry::IObject_sptr gv = interactionVolume->getGaugeVolume();
 

--- a/Framework/Algorithms/src/MonteCarloAbsorption.cpp
+++ b/Framework/Algorithms/src/MonteCarloAbsorption.cpp
@@ -330,9 +330,11 @@ MatrixWorkspace_uptr MonteCarloAbsorption::doSimulation(const MatrixWorkspace &i
   if (hasGaugeVol) {
     std::string xmlString = inputWS.run().getProperty("GaugeVolume")->value();
     gaugeVolume = ShapeFactory().createShape(xmlString);
+    if (pointsIn != MCInteractionVolume::ScatteringPointVicinity::SAMPLEONLY) {
+      g_log.warning("Gauge Volume found. Scattering Points limited to Sample Only.");
+    }
     pointsIn = MCInteractionVolume::ScatteringPointVicinity::SAMPLEONLY; // if gauge volume present, only generate
                                                                          // points from the sample
-    g_log.information("Gauge Volume found. Scattering Points limited to Sample Only.");
   }
 
   std::shared_ptr<IMCInteractionVolume> interactionVolume =

--- a/Framework/Algorithms/src/MonteCarloAbsorption.cpp
+++ b/Framework/Algorithms/src/MonteCarloAbsorption.cpp
@@ -319,8 +319,9 @@ MatrixWorkspace_uptr MonteCarloAbsorption::doSimulation(const MatrixWorkspace &i
 
   // Configure strategy
   Geometry::IObject_sptr gaugeVolume = nullptr;
-  if (inputWS.run().hasProperty("GaugeVolume")) {
+  try {
     Geometry::IObject_sptr gaugeVolume = ShapeFactory().createShape(inputWS.run().getProperty("GaugeVolume")->value());
+  } catch (...) {
   }
   auto interactionVolume = createInteractionVolume(inputWS.sample(), maxScatterPtAttempts, pointsIn, gaugeVolume);
   auto strategy = createStrategy(*interactionVolume, *beamProfile, efixed.emode(), nevents, maxScatterPtAttempts,

--- a/Framework/Algorithms/src/MonteCarloAbsorption.cpp
+++ b/Framework/Algorithms/src/MonteCarloAbsorption.cpp
@@ -278,7 +278,7 @@ MatrixWorkspace_uptr MonteCarloAbsorption::doSimulation(const MatrixWorkspace &i
                                                         const InterpolationOption &interpolateOpt,
                                                         const bool useSparseInstrument,
                                                         const size_t maxScatterPtAttempts,
-                                                        const MCInteractionVolume::ScatteringPointVicinity pointsIn) {
+                                                        MCInteractionVolume::ScatteringPointVicinity pointsIn) {
   auto outputWS = createOutputWorkspace(inputWS);
   const auto inputNbins = static_cast<int>(inputWS.blocksize());
 
@@ -330,6 +330,9 @@ MatrixWorkspace_uptr MonteCarloAbsorption::doSimulation(const MatrixWorkspace &i
   if (hasGaugeVol) {
     std::string xmlString = inputWS.run().getProperty("GaugeVolume")->value();
     gaugeVolume = ShapeFactory().createShape(xmlString);
+    pointsIn = MCInteractionVolume::ScatteringPointVicinity::SAMPLEONLY; // if gauge volume present, only generate
+                                                                         // points from the sample
+    g_log.information("Gauge Volume found. Scattering Points limited to Sample Only.");
   }
 
   std::shared_ptr<IMCInteractionVolume> interactionVolume =

--- a/Framework/Algorithms/src/SampleCorrections/MCAbsorptionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCAbsorptionStrategy.cpp
@@ -45,7 +45,6 @@ MCAbsorptionStrategy::MCAbsorptionStrategy(std::shared_ptr<IMCInteractionVolume>
  * outside the interaction volume class
  * @param interactionVolume The interaction volume object
  * @param beamProfile The beam profile
- * @return The interaction volume object with active region set
  */
 void MCAbsorptionStrategy::setActiveRegion(std::shared_ptr<IMCInteractionVolume> interactionVolume,
                                            const IBeamProfile &beamProfile) {

--- a/Framework/Algorithms/src/SampleCorrections/MCAbsorptionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCAbsorptionStrategy.cpp
@@ -32,7 +32,7 @@ MCAbsorptionStrategy::MCAbsorptionStrategy(std::shared_ptr<IMCInteractionVolume>
                                            const IBeamProfile &beamProfile, DeltaEMode::Type EMode,
                                            const size_t nevents, const size_t maxScatterPtAttempts,
                                            const bool regenerateTracksForEachLambda)
-    : m_beamProfile(beamProfile), m_scatterVol(std::move(interactionVolume)), m_nevents(nevents),
+    : m_scatterVol(std::move(interactionVolume)), m_beamProfile(beamProfile), m_nevents(nevents),
       m_maxScatterAttempts(maxScatterPtAttempts), m_EMode(EMode),
       m_regenerateTracksForEachLambda(regenerateTracksForEachLambda) {
 

--- a/Framework/Algorithms/src/SampleCorrections/MCAbsorptionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCAbsorptionStrategy.cpp
@@ -36,19 +36,16 @@ MCAbsorptionStrategy::MCAbsorptionStrategy(std::shared_ptr<IMCInteractionVolume>
       m_maxScatterAttempts(maxScatterPtAttempts), m_EMode(EMode),
       m_regenerateTracksForEachLambda(regenerateTracksForEachLambda) {
 
-  setActiveRegion(m_scatterVol, beamProfile);
+  setActiveRegion();
 }
 
 /**
  * Set the active region on the interaction volume as smaller of the sample
  * bounding box and the beam cross section. Trying to keep the beam details
  * outside the interaction volume class
- * @param interactionVolume The interaction volume object
- * @param beamProfile The beam profile
  */
-void MCAbsorptionStrategy::setActiveRegion(std::shared_ptr<IMCInteractionVolume> interactionVolume,
-                                           const IBeamProfile &beamProfile) {
-  interactionVolume->setActiveRegion(beamProfile.defineActiveRegion(interactionVolume->getFullBoundingBox()));
+void MCAbsorptionStrategy::setActiveRegion() {
+  m_scatterVol->setActiveRegion(m_beamProfile.defineActiveRegion(m_scatterVol->getFullBoundingBox()));
 }
 
 /**

--- a/Framework/Algorithms/src/SampleCorrections/MCAbsorptionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCAbsorptionStrategy.cpp
@@ -120,7 +120,9 @@ void MCAbsorptionStrategy::calculate(Kernel::PseudoRandomNumberGenerator &rng, c
                                    std::to_string(m_maxScatterAttempts) +
                                    " attempts. Try increasing the maximum "
                                    "threshold or if this does not help then "
-                                   "please check the defined shape.");
+                                   "please check the defined shape and, "
+                                   "if defined, the gauge volume (both its shape "
+                                   "and its intersection with the defined sample shape).");
         }
       } while (true);
     }

--- a/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
@@ -161,17 +161,17 @@ MCInteractionVolume::generatePointInObjectByIndex(int componentIndex, Kernel::Ps
   std::optional<Kernel::V3D> tmpPoint{std::nullopt};
   if (componentIndex == -1) {
     if (m_gaugeVolume != nullptr) {
-      tmpPoint = m_gaugeVolume->generatePointInObject(rng, m_activeRegion, 2);
+      tmpPoint = m_gaugeVolume->generatePointInObject(rng, m_activeRegion, 1);
       if (tmpPoint) {
         if (m_sample->isValid(tmpPoint.value())) {
           pointGenerated = tmpPoint;
         }
       }
     } else {
-      pointGenerated = m_sample->generatePointInObject(rng, m_activeRegion, 2);
+      pointGenerated = m_sample->generatePointInObject(rng, m_activeRegion, 1);
     }
   } else {
-    pointGenerated = m_env->getComponent(componentIndex).generatePointInObject(rng, m_activeRegion, 2);
+    pointGenerated = m_env->getComponent(componentIndex).generatePointInObject(rng, m_activeRegion, 1);
   }
   return pointGenerated;
 }

--- a/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
@@ -79,8 +79,7 @@ const Geometry::BoundingBox MCInteractionVolume::getFullBoundingBox() const {
   auto sampleBox = m_sample->getBoundingBox();
   if (m_gaugeVolume != nullptr) {
     sampleBox = m_gaugeVolume->getBoundingBox();
-  }
-  if (m_pointsIn != ScatteringPointVicinity::SAMPLEONLY && m_env) {
+  } else if (m_pointsIn != ScatteringPointVicinity::SAMPLEONLY && m_env) {
     const auto &envBox = m_env->boundingBox();
     sampleBox.grow(envBox);
   }

--- a/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
@@ -124,9 +124,15 @@ int MCInteractionVolume::getComponentIndex(Kernel::PseudoRandomNumberGenerator &
 std::optional<Kernel::V3D>
 MCInteractionVolume::generatePointInObjectByIndex(int componentIndex, Kernel::PseudoRandomNumberGenerator &rng) const {
   std::optional<Kernel::V3D> pointGenerated{std::nullopt};
+  std::optional<Kernel::V3D> tmpPoint{std::nullopt};
   if (componentIndex == -1) {
     if (m_gaugeVolume != nullptr) {
-      pointGenerated = m_gaugeVolume->generatePointInObject(rng, m_activeRegion, 2);
+      tmpPoint = m_gaugeVolume->generatePointInObject(rng, m_activeRegion, 2);
+      if (tmpPoint) {
+        if (m_sample->isValid(tmpPoint.value())) {
+          pointGenerated = tmpPoint;
+        }
+      }
     } else {
       pointGenerated = m_sample->generatePointInObject(rng, m_activeRegion, 2);
     }

--- a/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
@@ -52,6 +52,27 @@ void MCInteractionVolume::init() {
 }
 
 /**
+ * Factory Method for constructing the volume encompassing the sample + any environment kit. The
+ * active region defines a bounding region for the sampling of the scattering
+ * position.
+ * @param sample A reference to a sample object that defines a valid shape
+ * & material
+ * @param maxScatterAttempts The maximum number of tries to generate a random
+ * point within the object. [Default=5000]
+ * @param pointsIn Where to generate the scattering point in
+ * @param gaugeVolume Pointer to any gauge volume object defined for the interaction
+ * @return returns a shared pointer to interaction volume object
+ */
+std::shared_ptr<IMCInteractionVolume>
+MCInteractionVolume::create(const API::Sample &sample, const size_t maxScatterAttempts,
+                            const MCInteractionVolume::ScatteringPointVicinity pointsIn, IObject_sptr gaugeVolume) {
+  auto interactionVol =
+      std::shared_ptr<MCInteractionVolume>(new MCInteractionVolume(sample, maxScatterAttempts, pointsIn, gaugeVolume));
+  interactionVol->init();
+  return interactionVol;
+}
+
+/**
  * Construct the volume encompassing the sample + any environment kit. The
  * active region defines a bounding region for the sampling of the scattering
  * position.
@@ -60,14 +81,13 @@ void MCInteractionVolume::init() {
  * @param maxScatterAttempts The maximum number of tries to generate a random
  * point within the object. [Default=5000]
  * @param pointsIn Where to generate the scattering point in
+ * @param gaugeVolume Pointer to any gauge volume object defined for the interaction
  */
 MCInteractionVolume::MCInteractionVolume(const API::Sample &sample, const size_t maxScatterAttempts,
                                          const MCInteractionVolume::ScatteringPointVicinity pointsIn,
                                          IObject_sptr gaugeVolume)
     : m_sample(sample.getShape().clone()), m_env(sample.hasEnvironment() ? &sample.getEnvironment() : nullptr),
-      m_maxScatterAttempts(maxScatterAttempts), m_pointsIn(pointsIn), m_gaugeVolume(gaugeVolume) {
-  init();
-}
+      m_maxScatterAttempts(maxScatterAttempts), m_pointsIn(pointsIn), m_gaugeVolume(gaugeVolume) {}
 
 /**
  * Returns the defined gauge volume if one is present, otherwise returns nullptr

--- a/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
@@ -34,7 +34,7 @@ MCInteractionVolume::MCInteractionVolume(const API::Sample &sample, const size_t
                                          IObject_sptr gaugeVolume)
     : m_sample(sample.getShape().clone()), m_env(nullptr), m_maxScatterAttempts(maxScatterAttempts),
       m_pointsIn(pointsIn), m_gaugeVolume(gaugeVolume) {
-  m_activeRegion = getFullBoundingBox();
+  m_activeRegion = this->MCInteractionVolume::getFullBoundingBox();
   try {
     m_env = &sample.getEnvironment();
     assert(m_env);

--- a/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
@@ -31,7 +31,7 @@ namespace Algorithms {
  */
 MCInteractionVolume::MCInteractionVolume(const API::Sample &sample, const size_t maxScatterAttempts,
                                          const MCInteractionVolume::ScatteringPointVicinity pointsIn,
-                                         const IObject_sptr gaugeVolume)
+                                         IObject_sptr gaugeVolume)
     : m_sample(sample.getShape().clone()), m_env(nullptr), m_activeRegion(getFullBoundingBox()),
       m_maxScatterAttempts(maxScatterAttempts), m_pointsIn(pointsIn), m_gaugeVolume(gaugeVolume) {
   try {

--- a/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
@@ -33,8 +33,7 @@ MCInteractionVolume::MCInteractionVolume(const API::Sample &sample, const size_t
                                          const MCInteractionVolume::ScatteringPointVicinity pointsIn,
                                          IObject_sptr gaugeVolume)
     : m_sample(sample.getShape().clone()), m_env(nullptr), m_maxScatterAttempts(maxScatterAttempts),
-      m_pointsIn(pointsIn), m_gaugeVolume(nullptr) {
-  m_gaugeVolume = gaugeVolume;
+      m_pointsIn(pointsIn), m_gaugeVolume(gaugeVolume) {
   m_activeRegion = getFullBoundingBox();
   try {
     m_env = &sample.getEnvironment();
@@ -60,6 +59,16 @@ MCInteractionVolume::MCInteractionVolume(const API::Sample &sample, const size_t
                                 "environment parts must have a valid shape.");
   }
 }
+/**
+ * Returns the defined gauge volume if one is present, otherwise returns nullptr
+ * @return Shared pointer to gauge volume object
+ */
+Geometry::IObject_sptr MCInteractionVolume::getGaugeVolume() const { return m_gaugeVolume; }
+
+/**
+ * Sets the gauge volume on the InteractionVolume
+ */
+void MCInteractionVolume::setGaugeVolume(Geometry::IObject_sptr gaugeVolume) { m_gaugeVolume = gaugeVolume; }
 
 /**
  * Returns the defined gauge volume if one is present, otherwise returns axis-aligned bounding box
@@ -69,7 +78,7 @@ MCInteractionVolume::MCInteractionVolume(const API::Sample &sample, const size_t
 const Geometry::BoundingBox MCInteractionVolume::getFullBoundingBox() const {
   auto sampleBox = m_sample->getBoundingBox();
   if (m_gaugeVolume != nullptr) {
-    auto sampleBox = m_gaugeVolume->getBoundingBox();
+    sampleBox = m_gaugeVolume->getBoundingBox();
   }
   if (m_pointsIn != ScatteringPointVicinity::SAMPLEONLY && m_env) {
     const auto &envBox = m_env->boundingBox();
@@ -117,12 +126,12 @@ MCInteractionVolume::generatePointInObjectByIndex(int componentIndex, Kernel::Ps
   std::optional<Kernel::V3D> pointGenerated{std::nullopt};
   if (componentIndex == -1) {
     if (m_gaugeVolume != nullptr) {
-      pointGenerated = m_gaugeVolume->generatePointInObject(rng, m_activeRegion, 1);
+      pointGenerated = m_gaugeVolume->generatePointInObject(rng, m_activeRegion, 2);
     } else {
-      pointGenerated = m_sample->generatePointInObject(rng, m_activeRegion, 1);
+      pointGenerated = m_sample->generatePointInObject(rng, m_activeRegion, 2);
     }
   } else {
-    pointGenerated = m_env->getComponent(componentIndex).generatePointInObject(rng, m_activeRegion, 1);
+    pointGenerated = m_env->getComponent(componentIndex).generatePointInObject(rng, m_activeRegion, 2);
   }
   return pointGenerated;
 }

--- a/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCInteractionVolume.cpp
@@ -68,6 +68,8 @@ MCInteractionVolume::create(const API::Sample &sample, const size_t maxScatterAt
                             const MCInteractionVolume::ScatteringPointVicinity pointsIn, IObject_sptr gaugeVolume) {
   auto interactionVol =
       std::shared_ptr<MCInteractionVolume>(new MCInteractionVolume(sample, maxScatterAttempts, pointsIn, gaugeVolume));
+  // init calls member functions that require instantiation of virtual functions so deferring this until after
+  // construction through a factory is preferable.
   interactionVol->init();
   return interactionVol;
 }

--- a/Framework/Algorithms/test/MCAbsorptionStrategyTest.h
+++ b/Framework/Algorithms/test/MCAbsorptionStrategyTest.h
@@ -232,6 +232,7 @@ private:
     MOCK_METHOD1(setActiveRegion, void(const Mantid::Geometry::BoundingBox &));
     MOCK_METHOD1(setGaugeVolume, void(Mantid::Geometry::IObject_sptr gaugeVolume));
     MOCK_CONST_METHOD0(getGaugeVolume, Mantid::Geometry::IObject_sptr());
+    MOCK_METHOD0(init, void());
     GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
   class MockTrack final : public Mantid::Geometry::Track {

--- a/Framework/Algorithms/test/MCAbsorptionStrategyTest.h
+++ b/Framework/Algorithms/test/MCAbsorptionStrategyTest.h
@@ -46,8 +46,8 @@ public:
     MockBeamProfile testBeamProfile;
     EXPECT_CALL(testBeamProfile, defineActiveRegion(_)).WillOnce(Return(testSampleSphere.getShape().getBoundingBox()));
     const size_t nevents(10), maxTries(100);
-    MCInteractionVolume interactionVolume(testSampleSphere);
-    MCAbsorptionStrategy mcabsorb(interactionVolume, testBeamProfile, Mantid::Kernel::DeltaEMode::Type::Direct, nevents,
+    std::shared_ptr<IMCInteractionVolume> interactionVol = std::make_shared<MCInteractionVolume>(testSampleSphere);
+    MCAbsorptionStrategy mcabsorb(interactionVol, testBeamProfile, Mantid::Kernel::DeltaEMode::Type::Direct, nevents,
                                   maxTries, false);
     // 3 random numbers per event expected
     MockRNG rng;
@@ -86,8 +86,8 @@ public:
     MockBeamProfile testBeamProfile;
     EXPECT_CALL(testBeamProfile, defineActiveRegion(_)).WillOnce(Return(testSampleSphere.getShape().getBoundingBox()));
     const size_t nevents(3), maxTries(100);
-    MCInteractionVolume interactionVolume(testSampleSphere);
-    MCAbsorptionStrategy mcabsorb(interactionVolume, testBeamProfile, Mantid::Kernel::DeltaEMode::Type::Direct, nevents,
+    std::shared_ptr<IMCInteractionVolume> interactionVol = std::make_shared<MCInteractionVolume>(testSampleSphere);
+    MCAbsorptionStrategy mcabsorb(interactionVol, testBeamProfile, Mantid::Kernel::DeltaEMode::Type::Direct, nevents,
                                   maxTries, false);
     // 3 random numbers per event expected to generate x,y,z of each scatter pt
     MockRNG rng;
@@ -138,7 +138,7 @@ public:
     using namespace MonteCarloTesting;
     using namespace ::testing;
     MockBeamProfile testBeamProfile;
-    MockMCInteractionVolume testInteractionVolume;
+    std::shared_ptr<MockMCInteractionVolume> testInteractionVolume = std::make_shared<MockMCInteractionVolume>();
     MCAbsorptionStrategy testStrategy(testInteractionVolume, testBeamProfile, Mantid::Kernel::DeltaEMode::Elastic, 5, 2,
                                       true);
     MockRNG rng;
@@ -147,7 +147,7 @@ public:
     MCInteractionStatistics trackStatistics(-1, Mantid::API::Sample{});
     Mantid::Geometry::BoundingBox emptyBoundingBox;
     EXPECT_CALL(testBeamProfile, generatePoint(_, _)).Times(Exactly(static_cast<int>(6)));
-    EXPECT_CALL(testInteractionVolume, getFullBoundingBox()).Times(1).WillOnce(Return(emptyBoundingBox));
+    EXPECT_CALL(*testInteractionVolume, getFullBoundingBox()).Times(1).WillOnce(Return(emptyBoundingBox));
 
     auto beforeScatter = std::make_shared<MockTrack>();
     auto afterScatter = std::make_shared<MockTrack>();
@@ -157,7 +157,7 @@ public:
     auto ReturnNullTracksAndFalse = [beforeScatter, afterScatter](auto &, auto &, auto &, auto &) {
       return std::tuple{false, nullptr, nullptr};
     };
-    EXPECT_CALL(testInteractionVolume, calculateBeforeAfterTrack(_, _, _, _))
+    EXPECT_CALL(*testInteractionVolume, calculateBeforeAfterTrack(_, _, _, _))
         .Times(Exactly(6))
         .WillOnce(Invoke(ReturnTracksAndTrue))
         .WillOnce(Invoke(ReturnNullTracksAndFalse))
@@ -192,8 +192,8 @@ public:
     auto testThinAnnulus = MonteCarloTesting::createTestSample(MonteCarloTesting::TestSampleType::ThinAnnulus);
     RectangularBeamProfile testBeamProfile(ReferenceFrame(Y, Z, Right, "source"), V3D(), 1, 1);
     const size_t nevents(10), maxTries(1);
-    MCInteractionVolume interactionVolume(testThinAnnulus);
-    MCAbsorptionStrategy mcabs(interactionVolume, testBeamProfile, Mantid::Kernel::DeltaEMode::Type::Direct, nevents,
+    std::shared_ptr<IMCInteractionVolume> interactionVol = std::make_shared<MCInteractionVolume>(testThinAnnulus);
+    MCAbsorptionStrategy mcabs(interactionVol, testBeamProfile, Mantid::Kernel::DeltaEMode::Type::Direct, nevents,
                                maxTries, false);
     MockRNG rng;
     EXPECT_CALL(rng, nextValue()).WillRepeatedly(Return(0.5));
@@ -230,6 +230,8 @@ private:
                                                      MCInteractionStatistics &stats));
     MOCK_CONST_METHOD0(getFullBoundingBox, const Mantid::Geometry::BoundingBox());
     MOCK_METHOD1(setActiveRegion, void(const Mantid::Geometry::BoundingBox &));
+    MOCK_METHOD1(setGaugeVolume, void(Mantid::Geometry::IObject_sptr gaugeVolume));
+    MOCK_CONST_METHOD0(getGaugeVolume, Mantid::Geometry::IObject_sptr());
     GNU_DIAG_ON_SUGGEST_OVERRIDE
   };
   class MockTrack final : public Mantid::Geometry::Track {

--- a/Framework/Algorithms/test/MCInteractionVolumeTest.h
+++ b/Framework/Algorithms/test/MCInteractionVolumeTest.h
@@ -216,7 +216,7 @@ public:
     MockRNG rng;
     // Sequence will try to select one of the non-container pieces
     EXPECT_CALL(rng, nextInt(_, _)).Times(Exactly(1)).WillOnce(Return(1));
-    EXPECT_CALL(rng, nextValue()).Times(6).WillRepeatedly(Return(0.5));
+    EXPECT_CALL(rng, nextValue()).Times(3).WillRepeatedly(Return(0.5));
 
     using Mantid::API::Sample;
     Sample sample;

--- a/Framework/Algorithms/test/MonteCarloAbsorptionTest.h
+++ b/Framework/Algorithms/test/MonteCarloAbsorptionTest.h
@@ -725,7 +725,7 @@ private:
 
   protected:
     std::shared_ptr<Mantid::Algorithms::IMCAbsorptionStrategy>
-    createStrategy(Mantid::Algorithms::IMCInteractionVolume &interactionVol,
+    createStrategy(std::shared_ptr<Mantid::Algorithms::IMCInteractionVolume> interactionVol,
                    const Mantid::Algorithms::IBeamProfile &beamProfile, Mantid::Kernel::DeltaEMode::Type EMode,
                    const size_t nevents, const size_t maxScatterPtAttempts,
                    const bool regenerateTracksForEachLambda) override {

--- a/docs/source/algorithms/MonteCarloAbsorption-v1.rst
+++ b/docs/source/algorithms/MonteCarloAbsorption-v1.rst
@@ -153,6 +153,13 @@ After the simulation has been run and the spatial interpolation done, the interp
 
 .. note:: If the input workspace contains varying bin widths then the output is always interpolated.
 
+Interaction Region
+##################
+
+Within the algorithm, the ``SimulateScatteringPointIn`` parameter can be used to control whether scattering points are simulate from within the sample, within the environment, or both. Additionally, the volume from which scattered points are generated can be controlled by altering the beam profile (:ref:`SetSample <algm-SetSample>`) or by defining a gauge volume (:ref:`algm-DefineGaugeVolume`).
+
+.. note:: If a gauge volume is set, any definition of ``SimulateScatteringPointIn`` will be overridden to ``SampleOnly``.
+
 Usage
 -----
 

--- a/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39157.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39157.rst
@@ -1,0 +1,1 @@
+In :ref:`algm-MonteCarloAbsorption`, when a gauge volume has been defined with :ref:`algm-DefineGaugeVolume`, the algorithm now uses this gauge volume to generate the scattering points for calculating attenuation within the sample.

--- a/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39157.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39157.rst
@@ -1,1 +1,1 @@
-In :ref:`algm-MonteCarloAbsorption`, when a gauge volume has been defined with :ref:`algm-DefineGaugeVolume`, the algorithm now uses this gauge volume to generate the scattering points for calculating attenuation within the sample.
+- In :ref:`algm-MonteCarloAbsorption`, when a gauge volume has been defined with :ref:`algm-DefineGaugeVolume`, the algorithm now uses this gauge volume to generate the scattering points for calculating attenuation within the sample.


### PR DESCRIPTION
### Description of work

#### Summary of work
If a gauge volume is present on a workspace and `MonteCarloAbsorption` is run, only scattering from within the gauge volume will be calculated.

Fixes #39157

#### Further detail of work
Algorithm now checks for a gauge volume and, if one is present, limits the interaction volume to this gauge volume.

### To test:

The following script contains an analytical treatment for the attenuation coefficient of a rotated cylinder illuminated with a small cylindrical gauge volume (https://doi.org/10.1107/S0567739471000652). The script then compares a range of bragg angles (theta), with a range of cylinder rotations (chi) and compares the attenuation coefficients. It seems to be working as expected, with  largest deviations at high theta, high chi, which corresponds to back scattering through a large inclination of the cylinder. The limitation in these situations is likely the number of simulated points in the monte carlo, as the thickness of material is significant, many points are required to accurately estimate the integral.

Script:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

import numpy as np
from scipy.integrate import quad

def get_q(R, theta, chi):
    sin_theta = np.sin(theta)
    sin_chi = np.sin(chi)
    # q is incoming ellipical radius - Equation (4)
    return R / np.sqrt(1 - (sin_theta**2) * (sin_chi**2))
    

def absorption_correction(theta, chi, mu, R, N_gauss=20):
    # analytical correction for vertical cylinder with small gauge vol along beam
    # https://doi.org/10.1107/S0567739471000652
    
    # q is incoming ellipical radius - Equation (4)
    q = get_q(R, theta, chi)
    
    
    # t, as func of pos z along beam path - Equation (7)
    def t(z):
        sin_theta = np.sin(theta)
        sin_chi = np.sin(chi)
        
        # find sigma^2 - Equation (5)
        A = (1 - sin_theta**2 * sin_chi**2)**2
        B = -2 * R**2 * (1 - sin_theta**2 * sin_chi**2) - 2 * (np.cos(theta)**2 - sin_theta**2 * np.cos(chi)**2) * np.sin(2*theta)**2 * sin_chi**2 * (q - z)**2
        C = R**4 + np.sin(2*theta)**4 * sin_chi**4 * (q - z)**4 + 2 * R**2 * np.sin(2*theta)**2 * sin_chi**2 * (q - z)**2 * np.cos(2*theta)
        
        root_desc = np.nan_to_num(np.sqrt(B**2 - 4*A*C)) # should be positive, if numerical accuracy fails, nan should be zero
        
        sigma_sq_roots = [(-B + root_desc) / (2*A), (-B - root_desc) / (2*A)]
        
        sigma_sq = np.max(sigma_sq_roots) if z <= q else np.min(sigma_sq_roots)
        
        
        # Solve for t(z) Equation (7)
        a = 1
        b = -2 * (q - z) * np.cos(2*theta)
        c = (q - z)**2 - sigma_sq
        t_roots = np.nan_to_num([(-b + np.sqrt(b**2 - 4*a*c)) / (2*a) , (-b - np.sqrt(b**2 - 4*a*c)) / (2*a) ])
        tz = np.max(t_roots)
        return tz # one root should be larger than 0
        
    def integral(z):
        # integral part of Equation (9)
        return np.exp(-mu * 100*(z + t(z))) #mu is in cm-1
        

    integral_eval, _ = quad(integral, 0, 2*q)
    
    #print(integral_eval)
    
    # volume integral
    volume_factor = 2*q

    return integral_eval / volume_factor

def make_cylinder(R, h, ax = (0,1,0)):
    x,y,z = -ax[0]*h/2, -ax[1]*h/2, -ax[2]*h/2
    
    return f"""
<cylinder id="A">
  <centre-of-bottom-base x="{x}" y="{y}" z="{z}" />
  <axis x="{ax[0]}" y="{ax[1]}" z="{ax[2]}" />
  <radius val="{R}" />
  <height val="{h}" />
</cylinder>
"""



def compare_mc_and_analytical(theta, chi, mu = 1, sampleR = 0.01, h = 0.1, gvR_ratio = 0.1, mc_points_per_cm = 50000):
    
    # setup ws 
    ws = CreateSampleWorkspace(OutputWorkspace='ws', Function='Powder Diffraction', 
        XMin=2000, XMax=20000, BinWidth=200, NumBanks=1, BankPixelWidth=1,
        WorkspaceType="Histogram")
        
    # set the instrument to have a detector at 2theta
    EditInstrumentGeometry(Workspace='ws', PrimaryFlightPath = 100, L2=100, Polar=2*theta)
    
    # convert to lambda
    ConvertUnits(InputWorkspace='ws', OutputWorkspace='ws', Target='Wavelength')
    
    # make a second ws to view the sample on
    ws_gv = CloneWorkspace(ws)

    # chi is defined as the rotation about an axis theta degrees from ki (0,0,1)
    rotation_ax = np.array((np.sin(np.deg2rad(theta)), 0 , np.cos(np.deg2rad(theta))))
    
    # construct the sample
    sample = make_cylinder(R = sampleR, h = h, ax = (0,1,0))
    
    
    # construct the gauge volume
    sample_q = get_q(sampleR, np.deg2rad(theta), np.deg2rad(chi))
    gv = make_cylinder(R = sampleR*gvR_ratio, h = 2*sample_q, ax = (0,0,1))
    
    # rotate the sample
    SetGoniometer(ws, Axis0 = f"{chi}, {rotation_ax[0]},0,{rotation_ax[2]},1")

    # set samples, materials and add the gauge volume
    SetSample('ws', Geometry={'Shape': 'CSG', 'Value': sample})
    SetSample('ws_gv', Geometry={'Shape': 'CSG', 'Value': gv})
    SetSampleMaterial('ws', SampleNumberDensity=1.0,
         ScatteringXSection = 1.0, AttenuationXSection=0.0, AtomicNumber = 23) 
    DefineGaugeVolume(ws, gv)

    # compute
    analytical_val = absorption_correction(np.deg2rad(theta), np.deg2rad(chi), mu, sampleR, N_gauss = 40)

    mc_val = MonteCarloAbsorption(ws, OutputWorkspace = "mc_abs",
                                    EventsPerPoint=int(sample_q*100*mc_points_per_cm),
                                    SimulateScatteringPointIn = "SampleOnly").extractY()[0,0]
    
    return 1/analytical_val, 1/mc_val

n_theta = 7
n_chi = 7

sampleR = 0.005
sampleH = 0.1
max_chi = 90 - np.rad2deg(np.arctan(2*sampleR/sampleH)) # any larger a rotation than this, the cross section is no longer elliptical

print(max_chi)

analytical_astars = np.zeros((n_theta,n_chi))
montecarlo_astars = np.zeros_like(analytical_astars)

thetas = np.round(np.linspace(0, 90, n_theta), 2)
chis = np.round(np.linspace(0, max_chi - 15, n_chi), 1)

for it, t in enumerate(thetas):
    for ic, c in enumerate(chis):
        print(t,c)
        aas, mcas = compare_mc_and_analytical(t, c, mc_points_per_cm = 1000)
        analytical_astars[ic, it] = aas 
        montecarlo_astars[ic, it] = mcas
percentage_errors = np.abs((montecarlo_astars/analytical_astars)-1)*100

print(thetas)

set_ax_lab = lambda ax, labels, x : ax.set_xticks(np.arange(len(labels)), labels) if x else ax.set_yticks(np.arange(len(labels)), labels)

fig, axs = plt.subplots(1,3)
aa = axs[0].imshow(analytical_astars)
ma = axs[1].imshow(montecarlo_astars)
da = axs[2].imshow(percentage_errors)
[set_ax_lab(ax, thetas*2, True) for ax in axs]
[set_ax_lab(ax, chis, False) for ax in axs]
fig.supxlabel(r"$2\theta$")
fig.supylabel(r"$\chi$")
axs[0].set_title("Analytical A*")
plt.colorbar(aa, ax = axs[0])
axs[1].set_title("MonteCarlo A*")
plt.colorbar(ma, ax = axs[1])
axs[2].set_title("Percentage Difference in A*")
plt.colorbar(da, ax = axs[2])

fig.show()
```

Result:

![image](https://github.com/user-attachments/assets/03f239fc-111f-4dbc-8335-473b01d7ee6c)



### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
