### PR TITLE
Fix PredictPeaks Min/Max angle when using CalculateGoniometerForCW

### DIFF
--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -319,7 +319,7 @@ void PredictPeaks::exec() {
       // use default universal goniometer
       goniometerConvension = "YZY";
     }
-    for (auto &possibleHKL : possibleHKLs) {
+    for (const auto &possibleHKL : possibleHKLs) {
       Geometry::Goniometer goniometer(gonioVec.front());
       V3D q_sample = ub * possibleHKL * (2.0 * M_PI * m_qConventionFactor);
       goniometer.calcFromQSampleAndWavelength(q_sample, wavelength, flipX, innerGoniometer);

--- a/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Framework/Crystal/src/PredictPeaks.cpp
@@ -179,6 +179,7 @@ void PredictPeaks::exec() {
   MultipleExperimentInfos_sptr mdWS = std::dynamic_pointer_cast<MultipleExperimentInfos>(rawInputWorkspace);
 
   std::vector<DblMatrix> gonioVec;
+  std::string goniometerConvension;
   if (matrixWS) {
     // Retrieve the goniometer rotation matrix
     try {
@@ -191,6 +192,8 @@ void PredictPeaks::exec() {
                     << e.what() << '\n';
       g_log.warning() << "Using identity goniometer rotation matrix instead.\n";
     }
+
+    goniometerConvension = matrixWS->run().getGoniometer().getConventionFromMotorAxes();
   } else if (peaksWS) {
     // Sort peaks by run number so that peaks with equal goniometer matrices are
     // adjacent
@@ -210,6 +213,7 @@ void PredictPeaks::exec() {
       }
     }
 
+    goniometerConvension = peaksWS->run().getGoniometer().getConventionFromMotorAxes();
   } else if (mdWS) {
     if (mdWS->getNumExperimentInfo() <= 0)
       throw std::invalid_argument("Specified a MDEventWorkspace as InputWorkspace but it does not have "
@@ -233,6 +237,8 @@ void PredictPeaks::exec() {
         g_log.warning() << "Using identity goniometer rotation matrix instead.\n";
       }
     }
+
+    goniometerConvension = inputExperimentInfo->run().getGoniometer().getConventionFromMotorAxes();
   }
 
   // If there's no goniometer matrix at this point, push back an identity
@@ -309,11 +315,15 @@ void PredictPeaks::exec() {
     double angleMax = getProperty("MaxAngle");
     bool innerGoniometer = getProperty("InnerGoniometer");
     bool flipX = getProperty("FlipX");
+    if (goniometerConvension.empty()) {
+      // use default universal goniometer
+      goniometerConvension = "YZY";
+    }
     for (auto &possibleHKL : possibleHKLs) {
       Geometry::Goniometer goniometer(gonioVec.front());
       V3D q_sample = ub * possibleHKL * (2.0 * M_PI * m_qConventionFactor);
       goniometer.calcFromQSampleAndWavelength(q_sample, wavelength, flipX, innerGoniometer);
-      std::vector<double> angles = goniometer.getEulerAngles("YZY");
+      std::vector<double> angles = goniometer.getEulerAngles(goniometerConvension);
       double angle = innerGoniometer ? angles[2] : angles[0];
       DblMatrix orientedUB = goniometer.getR() * ub;
 
@@ -331,8 +341,9 @@ void PredictPeaks::exec() {
         continue;
 
       if (Kernel::withinAbsoluteDifference(wavelength, lambda, 0.01)) {
-        g_log.information() << "Found goniometer rotation to be in YZY convention [" << angles[0] << ", " << angles[1]
-                            << ". " << angles[2] << "] degrees for Q sample = " << q_sample << "\n";
+        g_log.information() << "Found goniometer rotation to be in " << goniometerConvension << " convention ["
+                            << angles[0] << ", " << angles[1] << ". " << angles[2]
+                            << "] degrees for Q sample = " << q_sample << "\n";
         calculateQAndAddToOutput(possibleHKL, orientedUB, goniometer.getR());
         ++allowedPeakCount;
       }

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Goniometer.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Goniometer.h
@@ -90,6 +90,9 @@ public:
   // Return Euler angles acording to a convention
   std::vector<double> getEulerAngles(const std::string &convention = "YZX");
 
+  // determine the convention from the motor axes
+  std::string getConventionFromMotorAxes() const;
+
   void saveNexus(::NeXus::File *file, const std::string &group) const;
   void loadNexus(::NeXus::File *file, const std::string &group);
   /// the method reports if the goniometer was defined with some parameters

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -283,6 +283,38 @@ std::vector<double> Goniometer::getEulerAngles(const std::string &convention) {
   return Quat(getR()).getEulerAngles(convention);
 }
 
+/** return the goniometer convention used determine from the motor axes
+ *
+ * @returns string with the convention
+ */
+std::string Goniometer::getConventionFromMotorAxes() const {
+  if (motors.size() != 3) {
+    g_log.warning() << "Goniometerdoes not have 3 axes. Cannot determine "
+                       "convention.\n";
+    return "";
+  }
+
+  std::string convention;
+  for (const auto &motor : motors) {
+    switch (std::abs(motor.rotationaxis.masterDir())) {
+    case 1:
+      convention += "X";
+      break;
+    case 2:
+      convention += "Y";
+      break;
+    case 3:
+      convention += "Z";
+      break;
+    default:
+      g_log.warning() << "Goniometer has an axis with a non-standard "
+                         "rotation axis.\n";
+      return "";
+    }
+  }
+  return convention;
+}
+
 /// Private function to recalculate the rotation matrix of the goniometer
 void Goniometer::recalculateR() {
   if (initFromR) {

--- a/Framework/Geometry/test/GoniometerTest.h
+++ b/Framework/Geometry/test/GoniometerTest.h
@@ -89,6 +89,7 @@ public:
     TS_ASSERT_EQUALS(G.getAxis(2).name, "phi");
     TS_ASSERT_EQUALS(G.getAxis(1).name, "chi");
     TS_ASSERT_EQUALS(G.getAxis(0).name, "omega");
+    TS_ASSERT_EQUALS(G.getConventionFromMotorAxes(), "YZY");
   }
 
   void test_copy() {
@@ -229,6 +230,18 @@ public:
     TS_ASSERT_DELTA(R[2][0], -0.5, 0.01);
     TS_ASSERT_DELTA(R[2][1], 0.0, 0.001);
     TS_ASSERT_DELTA(R[2][2], 0.866, 0.001);
+  }
+
+  void test_getConventionFromMotorAxes() {
+    Goniometer G;
+    TS_ASSERT_EQUALS(G.getConventionFromMotorAxes(), "");
+    TS_ASSERT_THROWS_NOTHING(G.pushAxis("Axis0", 0., 0., 1., 0));
+    TS_ASSERT_EQUALS(G.getConventionFromMotorAxes(), "");
+    TS_ASSERT_THROWS_NOTHING(G.pushAxis("Axis1", 0., 1., 0., 0));
+    TS_ASSERT_THROWS_NOTHING(G.pushAxis("Axis2", 1., 0., 0., 0));
+    TS_ASSERT_EQUALS(G.getConventionFromMotorAxes(), "ZYX");
+    TS_ASSERT_THROWS_NOTHING(G.pushAxis("Axis3", 1., 0., 0., 0));
+    TS_ASSERT_EQUALS(G.getConventionFromMotorAxes(), "");
   }
 
   /** Save and load to NXS file */

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -71,5 +71,6 @@ void export_Goniometer() {
       .def("getNumberAxes", &Goniometer::getNumberAxes, arg("self"))
       .def("getAxis", &getAxis, (arg("self"), arg("axisnumber")))
       .def("calcFromQSampleAndWavelength", &calcFromQSampleAndWavelength,
-           (arg("self"), arg("positions"), arg("wavelength"), arg("flip_x") = false, arg("inner") = false));
+           (arg("self"), arg("positions"), arg("wavelength"), arg("flip_x") = false, arg("inner") = false))
+      .def("getConventionFromMotorAxes", &Goniometer::getConventionFromMotorAxes, arg("self"));
 }

--- a/Framework/PythonInterface/test/python/mantid/geometry/GoniometerTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/GoniometerTest.py
@@ -47,10 +47,14 @@ class GoniometerTest(unittest.TestCase):
         ws = alg.getProperty("OutputWorkspace").value
         run = ws.run()
         g = run.getGoniometer()
+        self.assertEqual(g.getConventionFromMotorAxes(), "")
         # change the matrix:
         r = np.array([(1.0, 0.0, 0.0), (0.0, 0.0, 1.0), (0.0, -1.0, 0.0)])
         g.setR(r)
         self.assertTrue((g.getR() == r).all())
+
+        alg = run_algorithm("SetGoniometer", Workspace=ws, Axis0="0,0,1,0,1", Axis1="0,0,0,1,1", Axis2="0,0,1,0,1", child=True)
+        self.assertEqual(run.getGoniometer().getConventionFromMotorAxes(), "YZY")
 
 
 if __name__ == "__main__":

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -257,7 +257,6 @@ constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/OptimizeCrystal
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PeakIntegration.cpp:105
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PeakIntensityVsRadius.cpp:184
 constParameterReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PeakStatisticsTools.cpp:209
-constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictPeaks.cpp:312
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels.cpp:109
 constVariableReference:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels.cpp:124
 shadowVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels.cpp:189

--- a/docs/source/release/v6.13.0/Diffraction/Single_Crystal/Bugfixes/39163.rst
+++ b/docs/source/release/v6.13.0/Diffraction/Single_Crystal/Bugfixes/39163.rst
@@ -1,0 +1,1 @@
+- Fixed issue with :ref:`PredictPeaks <algm-PredictPeaks>` and the ``CalculateGoniometerForCW`` option where the angle range was filtered incorrectly when not using the default goniometer convention.


### PR DESCRIPTION
### Description of work

This fixes an issue where the wrong goniometer convention was being with when filtering the angle ranges when doing `CalculateGoniometerForCW` in `PredictPeaks`.

This comes about when using `LoadWANDSCD` and the `sgl` and `sgu` angles are set [here](https://github.com/mantidproject/mantid/blob/main/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py#L347-L350). Since the way the angles are filtered [here](https://github.com/mantidproject/mantid/blob/0596bd362b0c8f3e9c2ee9a6911dc56a2603f121/Framework/Crystal/src/PredictPeaks.cpp#L316-L331), if you use the wrong convention the angle range doesn't match the expected `omega`(`s1` in the logs).

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [EWM8674](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8674)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

You can test with script provided in story, the peaks should now be consistent with the data.

This is the results from before

![ClipboardImage_20250324055825](https://github.com/user-attachments/assets/2b8e6cc3-276d-415f-b715-8f86504821f4)

and now after this change

![Screenshot_2025-04-03_01-31-09](https://github.com/user-attachments/assets/8f9e0f9b-7a46-4350-af27-f07f409444d9)



Or use this and you should be able to see the correct convention is found and the correct angle filtering happens.

```python
from mantid.simpleapi import *
from mantid.geometry import Goniometer

g = Goniometer()

ws= LoadEmptyInstrument(InstrumentName="WAND")
SetUB(ws, 12, 12, 12)
SetGoniometer(ws, Axis0="0,0,1,0,1", Axis1="5,0,0,1,1", Axis2="5,0,1,0,1") # YZY
peaks = PredictPeaks(ws, CalculateGoniometerForCW=True, Wavelength=1, OutputType="LeanElasticPeak", MinAngle=40, MaxAngle=50, MinDSpacing=5, MaxDSpacing=10)
convention = peaks.run().getGoniometer().getConventionFromMotorAxes()
print("Convention", convention)
for p in range(peaks.getNumberPeaks()):
    peak = peaks.getPeak(p)
    g.setR(peak.getGoniometerMatrix())
    print(p, peak.getHKL(), peak.getQSampleFrame(),peak.getQLabFrame(), g.getEulerAngles(convention))
    
SetGoniometer(ws, Axis0="0,0,1,0,1", Axis1="5,1,0,0,1", Axis2="5,0,0,1,1") # YXZ
peaks2 = PredictPeaks(ws, CalculateGoniometerForCW=True, Wavelength=1, OutputType="LeanElasticPeak", MinAngle=40, MaxAngle=50, MinDSpacing=5, MaxDSpacing=10)
convention = peaks2.run().getGoniometer().getConventionFromMotorAxes()
print("Convention", convention)
for p in range(peaks2.getNumberPeaks()):
    peak = peaks2.getPeak(p)
    g.setR(peak.getGoniometerMatrix())
    print(p, peak.getHKL(), peak.getQSampleFrame(),peak.getQLabFrame(), g.getEulerAngles(convention))
```


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
