### PR TITLE
Avoid casting negative times to unsigned in -- `ornl-next`

### DIFF
--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1458,9 +1458,9 @@ void TimeSeriesProperty<TYPE>::create(const Types::Core::DateAndTime &start_time
     m_propSortedFlag = TimeSeriesSortStatus::TSUNSORTED;
   // set the values
   constexpr double SEC_TO_NANO{1000000000.0};
-  const uint64_t start_time_ns = static_cast<uint64_t>(start_time.totalNanoseconds());
+  const int64_t start_time_ns = start_time.totalNanoseconds();
   for (std::size_t i = 0; i < num; i++) {
-    m_values.emplace_back(start_time_ns + static_cast<uint64_t>(time_sec[i] * SEC_TO_NANO), new_values[i]);
+    m_values.emplace_back(start_time_ns + static_cast<int64_t>(time_sec[i] * SEC_TO_NANO), new_values[i]);
   }
 
   // reset the size

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -2171,6 +2171,21 @@ public:
     TS_ASSERT_EQUALS(range.stop(), stop);
   }
 
+  void test_negativeTimes() {
+    using namespace Mantid::Types::Core;
+    TimeSeriesProperty<double> series("doubleProperty");
+    const DateAndTime startTime(100000, 0);
+    const std::vector<double> times{-5000, -1, 0, 1, 5};
+    const std::vector<double> values{1, 1, 1, 1, 1};
+    series.create(startTime, times, values);
+    TS_ASSERT_EQUALS(times.size(), series.size());
+    TS_ASSERT_EQUALS(values.size(), series.valuesAsVector().size());
+    const std::vector<DateAndTime> timesAsVector = series.timesAsVector();
+    for (size_t i = 0; i < times.size(); i++) {
+      TS_ASSERT_EQUALS(startTime + times[i], timesAsVector[i]);
+    }
+  }
+
 private:
   /// Generate a test log
   std::unique_ptr<TimeSeriesProperty<double>> getTestLog() {

--- a/docs/source/release/v6.13.0/Framework/Bugfixes/39126.rst
+++ b/docs/source/release/v6.13.0/Framework/Bugfixes/39126.rst
@@ -1,0 +1,1 @@
+- Fixed undefined behaviour when loading time series data with negative times. This could result in very small changes (nanoseconds) to recorded times due to floating-point arithmetic.


### PR DESCRIPTION
Sister tor PR #39126 