### PR TITLE
Sliceviewer: Add option to display HKL peak positions calculated from q instead of peak index

### DIFF
--- a/docs/source/release/v6.13.0/Workbench/SliceViewer/New_features/39169.rst
+++ b/docs/source/release/v6.13.0/Workbench/SliceViewer/New_features/39169.rst
@@ -1,0 +1,1 @@
+- Added the option when plotting peaks in HKL to use the peak positions calculated from Q\ :sub:`sample` using the UB instead of peak index.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -88,6 +88,8 @@ class PeaksViewerPresenter:
         view.subscribe(self)
         view.set_title(model.peaks_workspace.name())
         view.set_peak_color(model.fg_color)
+        self.view.enable_calculate_hkl(self.model.can_calculate_hkl(view.frame))
+
         self.notify(PeaksViewerPresenter.Event.PeaksListChanged)
 
     @property
@@ -137,6 +139,7 @@ class PeaksViewerPresenter:
         """
         self._clear_peaks()
         self.model.draw_peaks(self._view.sliceinfo, self._view.painter, self._view.frame)
+        self.view.call_canvas_draw()
 
     def _peak_selected(self):
         """
@@ -165,6 +168,14 @@ class PeaksViewerPresenter:
         :param concise: bool to set concise or expanded view
         """
         self.view.table_view.filter_columns(concise, PeaksWorkspaceDataPresenter.HIDDEN_COLUMNS)
+
+    def calc_hkl_checkbox_changes(self, calc_hkl):
+        """
+        Respond to a change in the calc_hkl check box state
+        :param calc_hkl: bool to set calc_hkl or not
+        """
+        self.model.set_calculate_hkl(calc_hkl)
+        self.notify(PeaksViewerPresenter.Event.OverlayPeaks)
 
     # private api
     @staticmethod

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/modeltesthelpers.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/modeltesthelpers.py
@@ -13,15 +13,16 @@ from unittest.mock import MagicMock, create_autospec
 from mantid.kernel import SpecialCoordinateSystem
 from mantid.dataobjects import PeaksWorkspace
 from mantid.kernel import V3D
+from mantid.geometry import OrientedLattice
 
 # local imports
 from mantidqt.widgets.sliceviewer.peaksviewer.model import PeaksViewerModel
 from mantidqt.widgets.sliceviewer.peaksviewer.representation.painter import MplPainter
 
 
-def draw_peaks(centers, fg_color, slice_value, slice_width, frame=SpecialCoordinateSystem.QLab):
-    model = create_peaks_viewer_model(centers, fg_color)
-    slice_info = create_slice_info(centers, slice_value, slice_width)
+def draw_peaks(centers, fg_color, slice_value, slice_width, frame=SpecialCoordinateSystem.QLab, calcHKL=False):
+    model = create_peaks_viewer_model(centers, fg_color, calcHKL=calcHKL)
+    slice_info = create_slice_info(lambda pos: pos, slice_value, slice_width)
     mock_painter = MagicMock(spec=MplPainter)
     mock_axes = MagicMock()
     mock_axes.get_xlim.return_value = (-1, 1)
@@ -32,7 +33,7 @@ def draw_peaks(centers, fg_color, slice_value, slice_width, frame=SpecialCoordin
     return model, mock_painter
 
 
-def create_peaks_viewer_model(centers, fg_color, name=None):
+def create_peaks_viewer_model(centers, fg_color, name=None, calcHKL=False):
     peaks = [create_mock_peak(center) for center in centers]
 
     def get_peak(index):
@@ -52,6 +53,8 @@ def create_peaks_viewer_model(centers, fg_color, name=None):
     model.ws.getPeak.side_effect = get_peak
     model.ws.column.side_effect = column
     model.ws.removePeak.side_effect = remove_peak
+    model._orientedLattice = OrientedLattice(3, 4, 5, 90, 90, 120)
+    model.set_calculate_hkl(calcHKL)
 
     return model
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
@@ -62,6 +62,33 @@ class PeaksViewerModelTest(unittest.TestCase):
         self.assertAlmostEqual(0.356, call_kwargs["alpha"], places=3)
         self.assertEqual(fg_color, call_kwargs["color"])
 
+    def test_draw_peaks_with_calc_hkl(self):
+        peak_center = (0.5, 0.2, 0.25)
+
+        # without calcHKL
+        _, mock_painter = draw_peaks((peak_center,), "r", slice_value=0.5, slice_width=30, frame=SpecialCoordinateSystem.HKL, calcHKL=False)
+
+        self.assertEqual(1, mock_painter.cross.call_count)
+        call_args, _ = mock_painter.cross.call_args
+        self.assertEqual(peak_center[0], call_args[0])
+        self.assertEqual(peak_center[1], call_args[1])
+
+        # with calcHKL, the HKL peak position should change
+        _, mock_painter = draw_peaks((peak_center,), "r", slice_value=0.5, slice_width=30, frame=SpecialCoordinateSystem.HKL, calcHKL=True)
+        self.assertEqual(1, mock_painter.cross.call_count)
+        call_args, _ = mock_painter.cross.call_args
+        self.assertAlmostEqual(0.159002, call_args[0], places=6)
+        self.assertAlmostEqual(0.127324, call_args[1], places=6)
+
+        # with calcHKL but with QSample frame, the peak position should not change
+        _, mock_painter = draw_peaks(
+            (peak_center,), "r", slice_value=0.5, slice_width=30, frame=SpecialCoordinateSystem.QSample, calcHKL=True
+        )
+        self.assertEqual(1, mock_painter.cross.call_count)
+        call_args, _ = mock_painter.cross.call_args
+        self.assertAlmostEqual(peak_center[0], call_args[0], places=6)
+        self.assertAlmostEqual(peak_center[1], call_args[1], places=6)
+
     def test_clear_peaks_removes_all_drawn(self):
         # create 2 peaks: 1 visible, 1 not (far outside Z range)
         visible_peak_center, invisible_center = (0.5, 0.2, 0.25), (0.4, 0.3, 25)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_view.py
@@ -23,6 +23,7 @@ class PeaksViewerViewTest(unittest.TestCase):
     def test_sort_by_value_not_string(self):
         npeaks = 5
         peaks_ws = WorkspaceCreationHelper.createPeaksWorkspace(npeaks)
+        PeaksViewerView.frame = None  # override to avoid call to SliceViewer
         view = PeaksViewerView(None, None)
         model = PeaksViewerModel(peaks_ws, fg_color="r", bg_color="w")
         presenter = PeaksViewerPresenter(model, view)


### PR DESCRIPTION
### Description of work

There was a request for the ability to show the non-indexed peak positions when viewing in HKL. The problem is un-indexed peaks all end up at (0,0,0) which is not helpful. This adds a checkbox that lets you change to plotting the HKL position calculated from the q_sample using the UB. So that you can show the position of all the peaks when viewing in HKL not just the indexed ones. This only changes the plotted positions and not the HKL values shown in the peaks table.



#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes [10378: [User story] Feature request for slice viewer non-indexed peaks](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/10378)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

### To test:

```python
Load(Filename='SXD23767.peaks',OutputWorkspace='peaks')

ubMatrix = [-0.06452276,  0.2478114,  -0.23742194, 0.29161678, -0.00914316, -0.12523779, 0.06958942, -0.1802702,  -0.14649001]
SetUB('peaks',UB=ubMatrix)

IndexPeaks(PeaksWorkspace='peaks',Tolerance=0.12,RoundHKLs=1)

md = CreateMDWorkspace(Dimensions=3, Extents="-5,5,-5,5,-5,5", Names="[H,0,0],[0,K,0],[0,0,L]", Units="r.l.u.,r.l.u.,r.l.u.", Frames="HKL,HKL,HKL")
for h in range(-4, 5):
    for k in range(-4, 5):
        for l in range(-4, 5):
            FakeMDEventData(md, PeakParams=f'10,{h},{k},{l},0.1')        
```

Toggling the new check box you should see the plotted peaks change.
![hkl_plot](https://github.com/user-attachments/assets/6b8002d6-5127-4dd8-ad55-593921bc7ac3)

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
