### PR TITLE
Move conda build tools to base environment

### DIFF
--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -82,9 +82,9 @@ done
 
 
 # Mamba
-setup_mamba $WORKSPACE/mambaforge "package-conda" true
-# CMake FindPython doesn't work correctly with conda 25.3.0
-mamba install --yes boa conda-verify versioningit conda=25.1.1
+setup_mamba $WORKSPACE/mambaforge "" true
+mamba activate base
+mamba install --yes boa conda-verify versioningit
 
 # Clean up any legacy conda-recipes git clones
 cd $WORKSPACE

--- a/buildconfig/Jenkins/Conda/package-standalone
+++ b/buildconfig/Jenkins/Conda/package-standalone
@@ -59,9 +59,9 @@ do
 done
 
 # Mamba
-setup_mamba $WORKSPACE/mambaforge "package-standalone"
-# Pin conda to known working version. In 24.9 the post-link.bat script doesn't work.
-mamba install --yes mamba=1.5 conda-build conda=24.7
+setup_mamba $WORKSPACE/mambaforge "" true
+mamba activate base
+mamba install --yes conda-index
 
 # Build packages
 # Setup a local conda channel to find our locally built packages package. It is


### PR DESCRIPTION
### Description of work
For as long as we have been using Conda, we have created named environments to install things like `boa` and `conda-build` (used to build our Conda packages). This is [explicitly unsupported](https://docs.conda.io/projects/conda-build/en/stable/install-conda-build.html#way-of-working). I believe it has been the cause of a few problems that we have dusted under the rug by pinning `conda` and `mamba` inside the `package-conda` and `package-standalone` environments:
- #38098 
- #38140 
- #39119 

Here we move away from using named environments to install such tools.

Fixes #39173 
Fixes #38145 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->


### To test:
If CI passes, it has worked because `mantid-developer` has built successfully.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
