### PR TITLE
Improve numerical stability of PhaseQuadMuon

### DIFF
--- a/Framework/Muon/CMakeLists.txt
+++ b/Framework/Muon/CMakeLists.txt
@@ -122,7 +122,7 @@ set_property(TARGET Muon PROPERTY FOLDER "MantidFramework")
 
 target_link_libraries(
   Muon
-  PUBLIC Mantid::API Mantid::Kernel Mantid::Geometry
+  PUBLIC Mantid::API Mantid::Kernel Mantid::Geometry Mantid::CurveFitting
   PRIVATE Mantid::DataObjects Mantid::Indexing
 )
 # Add the unit tests directory

--- a/Framework/Muon/src/PhaseQuadMuon.cpp
+++ b/Framework/Muon/src/PhaseQuadMuon.cpp
@@ -272,13 +272,12 @@ API::MatrixWorkspace_sptr PhaseQuadMuon::squash(const API::MatrixWorkspace_sptr 
 
   std::vector<double> aj(nspec), bj(nspec);
   for (size_t h = 0; h < nspec; h++) {
-    if (emptySpectrum[h]) {
-      aj[h] = 0;
-      bj[h] = 0;
-    } else {
+  aj[h] = bj[h] = 0;
+    if (!emptySpectrum[h]) {
       const auto factors = muLamMatrix * n0Vectors[h];
       aj[h] = factors[0];
       bj[h] = factors[1];
+
     }
   }
 

--- a/Framework/Muon/src/PhaseQuadMuon.cpp
+++ b/Framework/Muon/src/PhaseQuadMuon.cpp
@@ -272,12 +272,11 @@ API::MatrixWorkspace_sptr PhaseQuadMuon::squash(const API::MatrixWorkspace_sptr 
 
   std::vector<double> aj(nspec), bj(nspec);
   for (size_t h = 0; h < nspec; h++) {
-  aj[h] = bj[h] = 0;
+    aj[h] = bj[h] = 0;
     if (!emptySpectrum[h]) {
       const auto factors = muLamMatrix * n0Vectors[h];
       aj[h] = factors[0];
       bj[h] = factors[1];
-
     }
   }
 

--- a/Framework/Muon/test/PhaseQuadMuonTest.h
+++ b/Framework/Muon/test/PhaseQuadMuonTest.h
@@ -26,6 +26,7 @@ namespace {
 
 const int dead1 = 4;
 const int dead2 = 12;
+constexpr double DELTA{0.0001};
 
 void populatePhaseTableWithDeadDetectors(const ITableWorkspace_sptr &phaseTable, const MatrixWorkspace_sptr &ws) {
   phaseTable->addColumn("int", "DetectprID");
@@ -187,21 +188,21 @@ public:
     const auto specImY = outputWs->getSpectrum(1).y();
     const auto specImE = outputWs->getSpectrum(1).e();
     // Check real Y values
-    TS_ASSERT_DELTA(specReY[0], -0.6149, 0.0001);
-    TS_ASSERT_DELTA(specReY[20], 0.2987, 0.0001);
-    TS_ASSERT_DELTA(specReY[50], 1.2487, 0.0001);
+    TS_ASSERT_DELTA(specReY[0], -0.6149, DELTA);
+    TS_ASSERT_DELTA(specReY[20], 0.2987, DELTA);
+    TS_ASSERT_DELTA(specReY[50], 1.2487, DELTA);
     // Check real E values
-    TS_ASSERT_DELTA(specReE[0], 0.2927, 0.0001);
-    TS_ASSERT_DELTA(specReE[20], 0.31489, 0.0001);
-    TS_ASSERT_DELTA(specReE[50], 0.3512, 0.0001);
+    TS_ASSERT_DELTA(specReE[0], 0.2927, DELTA);
+    TS_ASSERT_DELTA(specReE[20], 0.31489, DELTA);
+    TS_ASSERT_DELTA(specReE[50], 0.3512, DELTA);
     // Check imaginary Y values
-    TS_ASSERT_DELTA(specImY[0], 1.0823, 0.0001);
-    TS_ASSERT_DELTA(specImY[20], 1.3149, 0.0001);
-    TS_ASSERT_DELTA(specImY[50], 0.4965, 0.0001);
+    TS_ASSERT_DELTA(specImY[0], 1.0823, DELTA);
+    TS_ASSERT_DELTA(specImY[20], 1.3149, DELTA);
+    TS_ASSERT_DELTA(specImY[50], 0.4965, DELTA);
     // Check imaginary E values
-    TS_ASSERT_DELTA(specImE[0], 0.2801, 0.0001);
-    TS_ASSERT_DELTA(specImE[20], 0.3013, 0.0001);
-    TS_ASSERT_DELTA(specImE[50], 0.3360, 0.0001);
+    TS_ASSERT_DELTA(specImE[0], 0.2801, DELTA);
+    TS_ASSERT_DELTA(specImE[20], 0.3013, DELTA);
+    TS_ASSERT_DELTA(specImE[50], 0.3360, DELTA);
   }
   void testExecPhaseTable() {
     auto phaseQuad = setupAlg(m_loadedData, true);
@@ -223,21 +224,21 @@ public:
     const auto specImY = outputWs->getSpectrum(1).y();
     const auto specImE = outputWs->getSpectrum(1).e();
     // Check real Y values
-    TS_ASSERT_DELTA(specReY[0], 2.3212, 0.0001);
-    TS_ASSERT_DELTA(specReY[20], 0.0510, 0.0001);
-    TS_ASSERT_DELTA(specReY[50], -0.0578, 0.0001);
+    TS_ASSERT_DELTA(specReY[0], 2.3212, DELTA);
+    TS_ASSERT_DELTA(specReY[20], 0.0510, DELTA);
+    TS_ASSERT_DELTA(specReY[50], -0.0578, DELTA);
     // Check real E values
-    TS_ASSERT_DELTA(specReE[0], 0.0027, 0.0001);
-    TS_ASSERT_DELTA(specReE[20], 0.0043, 0.0001);
-    TS_ASSERT_DELTA(specReE[50], 0.0050, 0.0001);
+    TS_ASSERT_DELTA(specReE[0], 0.0027, DELTA);
+    TS_ASSERT_DELTA(specReE[20], 0.0043, DELTA);
+    TS_ASSERT_DELTA(specReE[50], 0.0050, DELTA);
     // Check imaginary Y values
-    TS_ASSERT_DELTA(specImY[0], 0.0328, 0.0001);
-    TS_ASSERT_DELTA(specImY[20], -0.0003, 0.0001);
-    TS_ASSERT_DELTA(specImY[50], -0.0033, 0.0001);
+    TS_ASSERT_DELTA(specImY[0], 0.0328, DELTA);
+    TS_ASSERT_DELTA(specImY[20], -0.0003, DELTA);
+    TS_ASSERT_DELTA(specImY[50], -0.0033, DELTA);
     // Check imaginary E values
-    TS_ASSERT_DELTA(specImE[0], 0.0003, 0.0001);
-    TS_ASSERT_DELTA(specImE[20], 0.0004, 0.0001);
-    TS_ASSERT_DELTA(specImE[50], 0.0005, 0.0001);
+    TS_ASSERT_DELTA(specImE[0], 0.0003, DELTA);
+    TS_ASSERT_DELTA(specImE[20], 0.0004, DELTA);
+    TS_ASSERT_DELTA(specImE[50], 0.0005, DELTA);
   }
   void testNoPhase() {
     std::vector<std::string> names = {"ID", "Asym", "dummy"};
@@ -279,21 +280,21 @@ public:
     const auto specImY = outputWs->getSpectrum(1).y();
     const auto specImE = outputWs->getSpectrum(1).e();
     // Check real Y values
-    TS_ASSERT_DELTA(specReY[0], 2.3212, 0.0001);
-    TS_ASSERT_DELTA(specReY[20], 0.0510, 0.0001);
-    TS_ASSERT_DELTA(specReY[50], -0.0578, 0.0001);
+    TS_ASSERT_DELTA(specReY[0], 2.3212, DELTA);
+    TS_ASSERT_DELTA(specReY[20], 0.0510, DELTA);
+    TS_ASSERT_DELTA(specReY[50], -0.0578, DELTA);
     // Check real E values
-    TS_ASSERT_DELTA(specReE[0], 0.0027, 0.0001);
-    TS_ASSERT_DELTA(specReE[20], 0.0043, 0.0001);
-    TS_ASSERT_DELTA(specReE[50], 0.0050, 0.0001);
+    TS_ASSERT_DELTA(specReE[0], 0.0027, DELTA);
+    TS_ASSERT_DELTA(specReE[20], 0.0043, DELTA);
+    TS_ASSERT_DELTA(specReE[50], 0.0050, DELTA);
     // Check imaginary Y values
-    TS_ASSERT_DELTA(specImY[0], 0.0328, 0.0001);
-    TS_ASSERT_DELTA(specImY[20], -0.0003, 0.0001);
-    TS_ASSERT_DELTA(specImY[50], -0.0033, 0.0001);
+    TS_ASSERT_DELTA(specImY[0], 0.0328, DELTA);
+    TS_ASSERT_DELTA(specImY[20], -0.0003, DELTA);
+    TS_ASSERT_DELTA(specImY[50], -0.0033, DELTA);
     // Check imaginary E values
-    TS_ASSERT_DELTA(specImE[0], 0.0003, 0.0001);
-    TS_ASSERT_DELTA(specImE[20], 0.0004, 0.0001);
-    TS_ASSERT_DELTA(specImE[50], 0.0005, 0.0001);
+    TS_ASSERT_DELTA(specImE[0], 0.0003, DELTA);
+    TS_ASSERT_DELTA(specImE[20], 0.0004, DELTA);
+    TS_ASSERT_DELTA(specImE[50], 0.0005, DELTA);
   }
   // add test for different order
 

--- a/Framework/Muon/test/PhaseQuadMuonTest.h
+++ b/Framework/Muon/test/PhaseQuadMuonTest.h
@@ -223,19 +223,19 @@ public:
     const auto specImY = outputWs->getSpectrum(1).y();
     const auto specImE = outputWs->getSpectrum(1).e();
     // Check real Y values
-    TS_ASSERT_DELTA(specReY[0], 2.1969, 0.0001);
+    TS_ASSERT_DELTA(specReY[0], 2.3212, 0.0001);
     TS_ASSERT_DELTA(specReY[20], 0.0510, 0.0001);
-    TS_ASSERT_DELTA(specReY[50], -0.0525, 0.0001);
+    TS_ASSERT_DELTA(specReY[50], -0.0578, 0.0001);
     // Check real E values
-    TS_ASSERT_DELTA(specReE[0], 0.0024, 0.0001);
-    TS_ASSERT_DELTA(specReE[20], 0.0041, 0.0001);
-    TS_ASSERT_DELTA(specReE[50], 0.0047, 0.0001);
+    TS_ASSERT_DELTA(specReE[0], 0.0027, 0.0001);
+    TS_ASSERT_DELTA(specReE[20], 0.0043, 0.0001);
+    TS_ASSERT_DELTA(specReE[50], 0.0050, 0.0001);
     // Check imaginary Y values
-    TS_ASSERT_DELTA(specImY[0], -0.1035, 0.0001);
-    TS_ASSERT_DELTA(specImY[20], -0.0006, 0.0001);
-    TS_ASSERT_DELTA(specImY[50], 0.0047, 0.0001);
+    TS_ASSERT_DELTA(specImY[0], 0.0328, 0.0001);
+    TS_ASSERT_DELTA(specImY[20], -0.0003, 0.0001);
+    TS_ASSERT_DELTA(specImY[50], -0.0033, 0.0001);
     // Check imaginary E values
-    TS_ASSERT_DELTA(specImE[0], 0.0002, 0.0001);
+    TS_ASSERT_DELTA(specImE[0], 0.0003, 0.0001);
     TS_ASSERT_DELTA(specImE[20], 0.0004, 0.0001);
     TS_ASSERT_DELTA(specImE[50], 0.0005, 0.0001);
   }
@@ -279,19 +279,19 @@ public:
     const auto specImY = outputWs->getSpectrum(1).y();
     const auto specImE = outputWs->getSpectrum(1).e();
     // Check real Y values
-    TS_ASSERT_DELTA(specReY[0], 2.1969, 0.0001);
+    TS_ASSERT_DELTA(specReY[0], 2.3212, 0.0001);
     TS_ASSERT_DELTA(specReY[20], 0.0510, 0.0001);
-    TS_ASSERT_DELTA(specReY[50], -0.0525, 0.0001);
+    TS_ASSERT_DELTA(specReY[50], -0.0578, 0.0001);
     // Check real E values
-    TS_ASSERT_DELTA(specReE[0], 0.0024, 0.0001);
-    TS_ASSERT_DELTA(specReE[20], 0.0041, 0.0001);
-    TS_ASSERT_DELTA(specReE[50], 0.0047, 0.0001);
+    TS_ASSERT_DELTA(specReE[0], 0.0027, 0.0001);
+    TS_ASSERT_DELTA(specReE[20], 0.0043, 0.0001);
+    TS_ASSERT_DELTA(specReE[50], 0.0050, 0.0001);
     // Check imaginary Y values
-    TS_ASSERT_DELTA(specImY[0], -0.1035, 0.0001);
-    TS_ASSERT_DELTA(specImY[20], -0.0006, 0.0001);
-    TS_ASSERT_DELTA(specImY[50], 0.0047, 0.0001);
+    TS_ASSERT_DELTA(specImY[0], 0.0328, 0.0001);
+    TS_ASSERT_DELTA(specImY[20], -0.0003, 0.0001);
+    TS_ASSERT_DELTA(specImY[50], -0.0033, 0.0001);
     // Check imaginary E values
-    TS_ASSERT_DELTA(specImE[0], 0.0002, 0.0001);
+    TS_ASSERT_DELTA(specImE[0], 0.0003, 0.0001);
     TS_ASSERT_DELTA(specImE[20], 0.0004, 0.0001);
     TS_ASSERT_DELTA(specImE[50], 0.0005, 0.0001);
   }

--- a/docs/source/algorithms/PhaseQuad-v1.rst
+++ b/docs/source/algorithms/PhaseQuad-v1.rst
@@ -53,7 +53,7 @@ Usage
        tab.addRow([1, 0.2, phi])
    for i in range(0,32):
        phi = 2*pi*i/32.
-       tab.addRow([1, 0.2, phi])
+       tab.addRow([1, 0.21, phi])
    ows = PhaseQuad(InputWorkspace='MUSR00022725', PhaseTable='tab')
    print("Output workspace has {} histograms".format(ows.getNumberHistograms()))
 

--- a/docs/source/release/v6.13.0/Muon/Algorithms/Bugfixes/39178.rst
+++ b/docs/source/release/v6.13.0/Muon/Algorithms/Bugfixes/39178.rst
@@ -1,0 +1,1 @@
+- Improved the numerical stability of :ref:`PhaseQuad <algm-PhaseQuad-v1>`. This algorithm was inverting a 2x2 matrix manually, which resulted in numerically unstable results. Performance should also be improved.


### PR DESCRIPTION
This algorithm was inverting a 2x2 matrix manually, which resulted in numerically unstable results. On different CPU architectures, the results are wildly different, and even doing the calculation in a slightly different order changes the results. By using `EigenMatrix`, we get a more stable inverse.

#### Purpose of work

`PhaseQuadMuon` needs to give consistent results on different CPU architectures. This is important now that we are making an ARM build of Mantid, see #38990.

*There is no associated issue.*

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
