### PR TITLE
Add a CombineTableWorkspaces algorithm

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SRC_FILES
     src/ClearMaskFlag.cpp
     src/CloneWorkspace.cpp
     src/CombineDiffCal.cpp
+    src/CombineTableWorkspaces.cpp
     src/Comment.cpp
     src/CommutativeBinaryOperation.cpp
     src/CompareWorkspaces.cpp
@@ -396,6 +397,7 @@ set(INC_FILES
     inc/MantidAlgorithms/ClearMaskFlag.h
     inc/MantidAlgorithms/CloneWorkspace.h
     inc/MantidAlgorithms/CombineDiffCal.h
+    inc/MantidAlgorithms/CombineTableWorkspaces.h
     inc/MantidAlgorithms/Comment.h
     inc/MantidAlgorithms/CommutativeBinaryOperation.h
     inc/MantidAlgorithms/CompareWorkspaces.h
@@ -753,6 +755,7 @@ set(TEST_FILES
     ClearMaskFlagTest.h
     CloneWorkspaceTest.h
     CombineDiffCalTest.h
+    CombineTableWorkspacesTest.h
     CommentTest.h
     CommutativeBinaryOperationTest.h
     CompareWorkspacesTest.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/CombineTableWorkspaces.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CombineTableWorkspaces.h
@@ -23,7 +23,7 @@ public:
   const std::string category() const override;
   const std::string summary() const override;
   std::map<std::string, std::string> validateInputs() override;
-  static const std::map<std::string, int> allowedTypes();
+  static const std::map<std::string, int> &allowedTypes();
 
 private:
   void init() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/CombineTableWorkspaces.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CombineTableWorkspaces.h
@@ -23,6 +23,7 @@ public:
   const std::string category() const override;
   const std::string summary() const override;
   std::map<std::string, std::string> validateInputs() override;
+  static const std::map<std::string, int> allowedTypes();
 
 private:
   void init() override;

--- a/Framework/Algorithms/inc/MantidAlgorithms/CombineTableWorkspaces.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CombineTableWorkspaces.h
@@ -1,0 +1,33 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAlgorithms/DllConfig.h"
+#include "MantidDataObjects/TableWorkspace.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+/** CombineTableWorkspaces : Take a pair of table workspaces and combine them into a single table
+ * by appending the rows of the second onto the first
+ */
+class MANTID_ALGORITHMS_DLL CombineTableWorkspaces final : public API::Algorithm {
+public:
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
+  std::map<std::string, std::string> validateInputs() override;
+
+private:
+  void init() override;
+  void exec() override;
+};
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/src/CombineTableWorkspaces.cpp
+++ b/Framework/Algorithms/src/CombineTableWorkspaces.cpp
@@ -63,7 +63,7 @@ std::map<std::string, std::string> CombineTableWorkspaces::validateInputs() {
   const DataObjects::TableWorkspace_sptr LHSWorkspace = getProperty("LHSWorkspace");
   const DataObjects::TableWorkspace_sptr RHSWorkspace = getProperty("RHSWorkspace");
 
-  const auto expectedCols = LHSWorkspace->columnCount();
+  const std::size_t expectedCols = LHSWorkspace->columnCount();
 
   // check correct number of columns
   if (RHSWorkspace->columnCount() != expectedCols) {
@@ -82,7 +82,7 @@ std::map<std::string, std::string> CombineTableWorkspaces::validateInputs() {
   bool matchingColumnTypes = true;
   bool allColumnTypesAllowed = true;
 
-  for (int i = 0; i < static_cast<int>(expectedCols); i++) {
+  for (std::size_t i = 0; i < expectedCols; i++) {
     if (lColNames[i] != rColNames[i]) {
       matchingColumnNames = false;
       break;
@@ -133,16 +133,16 @@ void CombineTableWorkspaces::exec() {
   const auto nCols = RHSWorkspace->columnCount();
 
   std::vector<std::string> colTypes = {};
-  for (auto i = 0; i < nCols; i++) {
+  for (std::size_t i = 0; i < nCols; i++) {
     colTypes.emplace_back(RHSWorkspace->getColumn(i)->type());
   }
 
   Progress progress(this, 0.0, 1.0, nRows);
 
-  for (auto r = 0; r < nRows; r++) {
+  for (std::size_t r = 0; r < nRows; r++) {
     TableRow newRow = outputWS->appendRow();
     TableRow currentRow = RHSWorkspace->getRow(r);
-    for (auto c = 0; c < nCols; c++) {
+    for (std::size_t c = 0; c < nCols; c++) {
       const auto dType = colTypes[c];
       const int dTypeVal = allowedColumnTypes.at(dType);
       switch (dTypeVal) {

--- a/Framework/Algorithms/src/CombineTableWorkspaces.cpp
+++ b/Framework/Algorithms/src/CombineTableWorkspaces.cpp
@@ -1,0 +1,150 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidAlgorithms/CombineTableWorkspaces.h"
+#include "MantidAPI/TableRow.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include <any>
+
+namespace Mantid::Algorithms {
+using Mantid::API::Progress;
+using Mantid::API::TableRow;
+using Mantid::API::WorkspaceProperty;
+using Mantid::Kernel::Direction;
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(CombineTableWorkspaces)
+
+//----------------------------------------------------------------------------------------------
+
+/// Algorithms name for identification. @see Algorithm::name
+const std::string CombineTableWorkspaces::name() const { return "CombineTableWorkspaces"; }
+
+/// Algorithm's version for identification. @see Algorithm::version
+int CombineTableWorkspaces::version() const { return 1; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string CombineTableWorkspaces::category() const { return "Utility\\Workspaces"; }
+
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string CombineTableWorkspaces::summary() const {
+  return "Combine a pair of table workspaces into a single table workspace";
+}
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void CombineTableWorkspaces::init() {
+  declareProperty(
+      std::make_unique<WorkspaceProperty<DataObjects::TableWorkspace>>("LHSWorkspace", "", Direction::Input),
+      "The first set of peaks.");
+  declareProperty(
+      std::make_unique<WorkspaceProperty<DataObjects::TableWorkspace>>("RHSWorkspace", "", Direction::Input),
+      "The second set of peaks.");
+  declareProperty(
+      std::make_unique<WorkspaceProperty<DataObjects::TableWorkspace>>("OutputWorkspace", "", Direction::Output),
+      "The combined peaks list.");
+}
+
+std::map<std::string, std::string> CombineTableWorkspaces::validateInputs() {
+  std::map<std::string, std::string> results;
+
+  const DataObjects::TableWorkspace_sptr LHSWorkspace = getProperty("LHSWorkspace");
+  const DataObjects::TableWorkspace_sptr RHSWorkspace = getProperty("RHSWorkspace");
+  DataObjects::TableWorkspace_sptr outputWS = getProperty("OutputWorkspace");
+
+  auto expectedCols = LHSWorkspace->columnCount();
+
+  // check correct number of columns
+  if (RHSWorkspace->columnCount() != expectedCols) {
+    results.emplace("LHSWorkspace", "Both Table Workspaces must have the same number of columns");
+    results.emplace("RHSWorkspace", "Both Table Workspaces must have the same number of columns");
+    return results;
+  }
+
+  // get column titles
+  auto lColNames = LHSWorkspace->getColumnNames();
+  auto rColNames = RHSWorkspace->getColumnNames();
+
+  bool matchingColumnNames = true;
+  bool matchingColumnTypes = true;
+
+  for (auto i = 0; i < expectedCols; i++) {
+    if (lColNames[i] != rColNames[i]) {
+      matchingColumnNames = false;
+      break;
+    }
+    if (LHSWorkspace->getColumn(i)->type() != RHSWorkspace->getColumn(i)->type()) {
+      matchingColumnTypes = false;
+      break;
+    }
+  }
+
+  if (!matchingColumnNames) {
+    results.emplace("LHSWorkspace", "Both Table Workspaces must have the same column titles");
+    results.emplace("RHSWorkspace", "Both Table Workspaces must have the same column titles");
+    return results;
+  }
+
+  if (!matchingColumnTypes) {
+    results.emplace("LHSWorkspace", "Both Table Workspaces must have the same data types for corresponding columns");
+    results.emplace("RHSWorkspace", "Both Table Workspaces must have the same data types for corresponding columns");
+    return results;
+  }
+
+  return results;
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void CombineTableWorkspaces::exec() {
+  const DataObjects::TableWorkspace_sptr LHSWorkspace = getProperty("LHSWorkspace");
+  const DataObjects::TableWorkspace_sptr RHSWorkspace = getProperty("RHSWorkspace");
+
+  const std::string doubleType = "double";
+  const std::string intType = "int";
+  const std::string stringType = "str";
+  const std::string boolType = "bool";
+
+  // Copy the first workspace to our output workspace
+  DataObjects::TableWorkspace_sptr outputWS = LHSWorkspace->clone();
+  // Get hold of the peaks in the second workspace
+  auto nRows = RHSWorkspace->rowCount();
+  auto nCols = RHSWorkspace->columnCount();
+
+  std::vector<std::string> colTypes = {};
+  for (auto i = 0; i < RHSWorkspace->columnCount(); i++) {
+    colTypes.emplace_back(RHSWorkspace->getColumn(i)->type());
+  }
+
+  Progress progress(this, 0.0, 1.0, nRows);
+
+  for (std::size_t r = 0; r < nRows; r++) {
+    TableRow newRow = outputWS->appendRow();
+    TableRow currentRow = RHSWorkspace->getRow(r);
+    for (std::size_t c = 0; c < nCols; c++) {
+      auto dType = colTypes[c];
+      if (colTypes[c] == doubleType) {
+        newRow << currentRow.Double(c);
+      } else if (colTypes[c] == intType) {
+        newRow << currentRow.Int(c);
+      } else if (colTypes[c] == stringType) {
+        std::string val = currentRow.cell<std::string>(c);
+        newRow << val;
+      } else if (colTypes[c] == boolType) {
+        bool val = currentRow.cell<Mantid::API::Boolean>(c);
+        newRow << val;
+      }
+    }
+    progress.report();
+  }
+
+  setProperty("OutputWorkspace", outputWS);
+}
+
+} // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/CombineTableWorkspaces.cpp
+++ b/Framework/Algorithms/src/CombineTableWorkspaces.cpp
@@ -60,7 +60,7 @@ std::map<std::string, std::string> CombineTableWorkspaces::validateInputs() {
   const DataObjects::TableWorkspace_sptr LHSWorkspace = getProperty("LHSWorkspace");
   const DataObjects::TableWorkspace_sptr RHSWorkspace = getProperty("RHSWorkspace");
 
-  const auto expectedCols = static_cast<int>(LHSWorkspace->columnCount());
+  const auto expectedCols = LHSWorkspace->columnCount();
 
   // check correct number of columns
   if (RHSWorkspace->columnCount() != expectedCols) {

--- a/Framework/Algorithms/src/CombineTableWorkspaces.cpp
+++ b/Framework/Algorithms/src/CombineTableWorkspaces.cpp
@@ -79,7 +79,7 @@ std::map<std::string, std::string> CombineTableWorkspaces::validateInputs() {
   bool matchingColumnTypes = true;
   bool allColumnTypesAllowed = true;
 
-  for (auto i = 0; i < expectedCols; i++) {
+  for (int i = 0; i < static_cast<int>(expectedCols); i++) {
     if (lColNames[i] != rColNames[i]) {
       matchingColumnNames = false;
       break;
@@ -129,20 +129,20 @@ void CombineTableWorkspaces::exec() {
   // Copy the first workspace to our output workspace
   DataObjects::TableWorkspace_sptr outputWS = LHSWorkspace->clone();
   // Get hold of the peaks in the second workspace
-  const auto nRows = RHSWorkspace->rowCount();
-  const auto nCols = RHSWorkspace->columnCount();
+  const int nRows = static_cast<int>(RHSWorkspace->rowCount());
+  const int nCols = static_cast<int>(RHSWorkspace->columnCount());
 
   std::vector<std::string> colTypes = {};
-  for (auto i = 0; i < static_cast<int>(RHSWorkspace->columnCount()); i++) {
+  for (auto i = 0; i < nCols; i++) {
     colTypes.emplace_back(RHSWorkspace->getColumn(i)->type());
   }
 
   Progress progress(this, 0.0, 1.0, nRows);
 
-  for (std::size_t r = 0; r < nRows; r++) {
+  for (int r = 0; r < nRows; r++) {
     TableRow newRow = outputWS->appendRow();
     TableRow currentRow = RHSWorkspace->getRow(r);
-    for (std::size_t c = 0; c < nCols; c++) {
+    for (int c = 0; c < nCols; c++) {
       auto dType = colTypes[c];
       if (allowedColumnTypes.at(dType) == 0) {
         newRow << currentRow.Double(c);
@@ -152,7 +152,7 @@ void CombineTableWorkspaces::exec() {
         std::string val = currentRow.cell<std::string>(c);
         newRow << val;
       } else if (allowedColumnTypes.at(dType) == 3) {
-        bool val = currentRow.cell<Mantid::API::Boolean>(c);
+        Mantid::API::Boolean val = currentRow.cell<Mantid::API::Boolean>(c);
         newRow << val;
       } else if (allowedColumnTypes.at(dType) == 4) {
         std::size_t val = currentRow.cell<std::size_t>(c);

--- a/Framework/Algorithms/src/CombineTableWorkspaces.cpp
+++ b/Framework/Algorithms/src/CombineTableWorkspaces.cpp
@@ -60,7 +60,7 @@ std::map<std::string, std::string> CombineTableWorkspaces::validateInputs() {
   const DataObjects::TableWorkspace_sptr LHSWorkspace = getProperty("LHSWorkspace");
   const DataObjects::TableWorkspace_sptr RHSWorkspace = getProperty("RHSWorkspace");
 
-  auto expectedCols = LHSWorkspace->columnCount();
+  const auto expectedCols = static_cast<int>(LHSWorkspace->columnCount());
 
   // check correct number of columns
   if (RHSWorkspace->columnCount() != expectedCols) {
@@ -70,8 +70,8 @@ std::map<std::string, std::string> CombineTableWorkspaces::validateInputs() {
   }
 
   // get column titles
-  auto lColNames = LHSWorkspace->getColumnNames();
-  auto rColNames = RHSWorkspace->getColumnNames();
+  const auto lColNames = LHSWorkspace->getColumnNames();
+  const auto rColNames = RHSWorkspace->getColumnNames();
 
   const std::map<std::string, int> allowedColumnTypes = allowedTypes();
 
@@ -129,11 +129,11 @@ void CombineTableWorkspaces::exec() {
   // Copy the first workspace to our output workspace
   DataObjects::TableWorkspace_sptr outputWS = LHSWorkspace->clone();
   // Get hold of the peaks in the second workspace
-  auto nRows = RHSWorkspace->rowCount();
-  auto nCols = RHSWorkspace->columnCount();
+  const auto nRows = RHSWorkspace->rowCount();
+  const auto nCols = RHSWorkspace->columnCount();
 
   std::vector<std::string> colTypes = {};
-  for (auto i = 0; i < RHSWorkspace->columnCount(); i++) {
+  for (auto i = 0; i < static_cast<int>(RHSWorkspace->columnCount()); i++) {
     colTypes.emplace_back(RHSWorkspace->getColumn(i)->type());
   }
 

--- a/Framework/Algorithms/src/CombineTableWorkspaces.cpp
+++ b/Framework/Algorithms/src/CombineTableWorkspaces.cpp
@@ -59,7 +59,6 @@ std::map<std::string, std::string> CombineTableWorkspaces::validateInputs() {
 
   const DataObjects::TableWorkspace_sptr LHSWorkspace = getProperty("LHSWorkspace");
   const DataObjects::TableWorkspace_sptr RHSWorkspace = getProperty("RHSWorkspace");
-  DataObjects::TableWorkspace_sptr outputWS = getProperty("OutputWorkspace");
 
   auto expectedCols = LHSWorkspace->columnCount();
 

--- a/Framework/Algorithms/src/CombineTableWorkspaces.cpp
+++ b/Framework/Algorithms/src/CombineTableWorkspaces.cpp
@@ -129,8 +129,8 @@ void CombineTableWorkspaces::exec() {
   // Copy the first workspace to our output workspace
   DataObjects::TableWorkspace_sptr outputWS = LHSWorkspace->clone();
   // Get hold of the peaks in the second workspace
-  const int nRows = static_cast<int>(RHSWorkspace->rowCount());
-  const int nCols = static_cast<int>(RHSWorkspace->columnCount());
+  const auto nRows = RHSWorkspace->rowCount();
+  const auto nCols = RHSWorkspace->columnCount();
 
   std::vector<std::string> colTypes = {};
   for (auto i = 0; i < nCols; i++) {
@@ -139,10 +139,10 @@ void CombineTableWorkspaces::exec() {
 
   Progress progress(this, 0.0, 1.0, nRows);
 
-  for (int r = 0; r < nRows; r++) {
+  for (auto r = 0; r < nRows; r++) {
     TableRow newRow = outputWS->appendRow();
     TableRow currentRow = RHSWorkspace->getRow(r);
-    for (int c = 0; c < nCols; c++) {
+    for (auto c = 0; c < nCols; c++) {
       const auto dType = colTypes[c];
       const int dTypeVal = allowedColumnTypes.at(dType);
       switch (dTypeVal) {

--- a/Framework/Algorithms/test/CombineTableWorkspacesTest.h
+++ b/Framework/Algorithms/test/CombineTableWorkspacesTest.h
@@ -251,4 +251,60 @@ public:
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);
   }
+
+  void test_different_tables_with_different_types_but_same_columns_combine() {
+    std::vector<std::string> dTypes = {"int", "str"};
+    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
+    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
+    TableWorkspace_sptr table2 = createTableWorkspace(dTypes, 3, colTitles, 1, "1");
+
+    // Name of the output workspace.
+    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
+
+    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
+    TS_ASSERT(alg->execute())
+
+    // Retrieve the workspace from data service.
+    TableWorkspace_sptr ws = getOutput(outWSName);
+
+    // check properties of output table
+    TS_ASSERT_EQUALS(ws->rowCount(), 5)
+    TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
+    // check the rows added contain the expected values
+    TS_ASSERT_EQUALS(ws->cell<int>(2, 0), 1)
+    TS_ASSERT_EQUALS(ws->cell<std::string>(3, 1), "1")
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+
+  // failures
+
+  void test_different_column_names_throw_error() {
+    std::vector<std::string> dTypes = {"int", "int"};
+    std::vector<std::string> colTitles1 = {"ThingA", "ThingB"};
+    std::vector<std::string> colTitles2 = {"ThingC", "ThingD"};
+    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles1);
+    TableWorkspace_sptr table2 = createTableWorkspace(dTypes, 2, colTitles2);
+
+    // Name of the output workspace.
+    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
+
+    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &)
+  }
+
+  void test_different_types_throw_error() {
+    std::vector<std::string> dTypes1 = {"int", "int"};
+    std::vector<std::string> dTypes2 = {"double", "double"};
+    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
+    TableWorkspace_sptr table1 = createTableWorkspace(dTypes1, 2, colTitles);
+    TableWorkspace_sptr table2 = createTableWorkspace(dTypes2, 2, colTitles);
+
+    // Name of the output workspace.
+    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
+
+    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &)
+  }
 };

--- a/Framework/Algorithms/test/CombineTableWorkspacesTest.h
+++ b/Framework/Algorithms/test/CombineTableWorkspacesTest.h
@@ -1,0 +1,254 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2025 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/TableRow.h"
+#include "MantidAlgorithms/CombineTableWorkspaces.h"
+#include "MantidAlgorithms/CreateSampleWorkspace.h"
+#include "MantidDataObjects/MaskWorkspace.h"
+#include "MantidDataObjects/TableWorkspace.h"
+
+#include "MantidAlgorithms/CreateSampleWorkspace.h"
+
+using namespace Mantid;
+using namespace Mantid::DataObjects;
+using namespace Mantid::API;
+using namespace Mantid::DataHandling;
+using Mantid::Algorithms::CombineTableWorkspaces;
+using Mantid::Algorithms::CreateSampleWorkspace;
+using Mantid::API::TableRow;
+using Mantid::DataObjects::TableWorkspace;
+using Mantid::DataObjects::TableWorkspace_sptr;
+
+/** Create a table workspace
+ * @param types A vector of strings of the data types of the columns (either int or string for the purpose of tesing)
+ * @param rowCount The number of detectors required
+ * @param types A vector of strings of the names of the columns
+ * @return A pointer to the table workspace
+ */
+TableWorkspace_sptr createTableWorkspace(const std::vector<std::string> &dataTypes, const int rowCount,
+                                         const std::vector<std::string> &names, const int defaultInt = 0,
+                                         const std::string &defaultString = "0", const bool defaultBool = true,
+                                         const double defaultDouble = 0.0) {
+  auto table = std::make_shared<TableWorkspace>();
+  for (std::vector<std::string>::size_type i = 0; i < dataTypes.size(); i++) {
+    if (i >= names.size()) {
+      table->addColumn(dataTypes[i], "N/A");
+    } else {
+      table->addColumn(dataTypes[i], names[i]);
+    }
+  }
+  for (int row = 0; row < rowCount; ++row) {
+    TableRow newRow = table->appendRow();
+    for (int col = 0; col < dataTypes.size(); col++) {
+      std::string dType = dataTypes[col];
+      if (dType == "int") {
+        newRow << defaultInt;
+      } else if (dType == "str") {
+        newRow << defaultString;
+      } else if (dType == "bool") {
+        newRow << defaultBool;
+      } else if (dType == "double") {
+        newRow << defaultDouble;
+      }
+    }
+  }
+  return table;
+}
+
+Mantid::API::IAlgorithm_sptr setupAlg(DataObjects::TableWorkspace_sptr LHSWorkspace,
+                                      DataObjects::TableWorkspace_sptr RHSWorkspace, std::string outputWS) {
+  // set up algorithm
+  auto alg = std::make_shared<CombineTableWorkspaces>();
+  TS_ASSERT_THROWS_NOTHING(alg->initialize());
+  TS_ASSERT(alg->isInitialized());
+  TS_ASSERT_THROWS_NOTHING(alg->setProperty("LHSWorkspace", LHSWorkspace));
+  TS_ASSERT_THROWS_NOTHING(alg->setProperty("RHSWorkspace", RHSWorkspace));
+  TS_ASSERT_THROWS_NOTHING(alg->setPropertyValue("OutputWorkspace", outputWS))
+  return alg;
+}
+
+TableWorkspace_sptr getOutput(std::string outputWS) {
+  TableWorkspace_sptr ws;
+  TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<TableWorkspace>(outputWS));
+  TS_ASSERT(ws);
+  return ws;
+}
+
+class CombineTableWorkspacesTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static CombineTableWorkspacesTest *createSuite() { return new CombineTableWorkspacesTest(); }
+  static void destroySuite(CombineTableWorkspacesTest *suite) { delete suite; }
+
+  void test_init() {
+    CombineTableWorkspaces alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
+
+  void test_identical_int_type_combine() {
+    std::vector<std::string> dTypes = {"int", "int"};
+    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
+    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
+    TableWorkspace_sptr table2 = table1->clone();
+
+    // Name of the output workspace.
+    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
+
+    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
+    TS_ASSERT(alg->execute())
+
+    // Retrieve the workspace from data service.
+    TableWorkspace_sptr ws = getOutput(outWSName);
+
+    // check properties of output table
+    TS_ASSERT_EQUALS(ws->rowCount(), 4)
+    TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
+    // check the rows added contain the expected values
+    TS_ASSERT_EQUALS(ws->cell<int>(2, 0), 0)
+    TS_ASSERT_EQUALS(ws->cell<int>(3, 1), 0)
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+
+  void test_identical_double_type_combine() {
+    std::vector<std::string> dTypes = {"double", "double"};
+    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
+    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
+    TableWorkspace_sptr table2 = table1->clone();
+
+    // Name of the output workspace.
+    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
+
+    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
+    TS_ASSERT(alg->execute())
+
+    // Retrieve the workspace from data service.
+    TableWorkspace_sptr ws = getOutput(outWSName);
+
+    // check properties of output table
+    TS_ASSERT_EQUALS(ws->rowCount(), 4)
+    TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
+    // check the rows added contain the expected values
+    TS_ASSERT_EQUALS(ws->cell<double>(2, 0), 0.0)
+    TS_ASSERT_EQUALS(ws->cell<double>(3, 1), 0.0)
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+
+  void test_identical_string_type_combine() {
+    std::vector<std::string> dTypes = {"str", "str"};
+    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
+    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
+    TableWorkspace_sptr table2 = table1->clone();
+
+    // Name of the output workspace.
+    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
+
+    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
+    TS_ASSERT(alg->execute())
+
+    // Retrieve the workspace from data service.
+    TableWorkspace_sptr ws = getOutput(outWSName);
+
+    // check properties of output table
+    TS_ASSERT_EQUALS(ws->rowCount(), 4)
+    TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
+    // check the rows added contain the expected values
+    TS_ASSERT_EQUALS(ws->cell<std::string>(2, 0), "0")
+    TS_ASSERT_EQUALS(ws->cell<std::string>(3, 1), "0")
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+
+  void test_identical_bool_type_combine() {
+    std::vector<std::string> dTypes = {"bool", "bool"};
+    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
+    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
+    TableWorkspace_sptr table2 = table1->clone();
+
+    // Name of the output workspace.
+    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
+
+    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
+    TS_ASSERT(alg->execute())
+
+    // Retrieve the workspace from data service.
+    TableWorkspace_sptr ws = getOutput(outWSName);
+
+    // check properties of output table
+    TS_ASSERT_EQUALS(ws->rowCount(), 4)
+    TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
+    // check the rows added contain the expected values
+    TS_ASSERT_EQUALS(ws->cell<Mantid::API::Boolean>(2, 0), static_cast<Mantid::API::Boolean>(true))
+    TS_ASSERT_EQUALS(ws->cell<Mantid::API::Boolean>(3, 1), static_cast<Mantid::API::Boolean>(true))
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+
+  void test_different_single_type_combine() {
+    std::vector<std::string> dTypes = {"int", "int"};
+    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
+    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
+    TableWorkspace_sptr table2 = createTableWorkspace(dTypes, 3, colTitles, 1);
+
+    // Name of the output workspace.
+    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
+
+    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
+    TS_ASSERT(alg->execute())
+
+    // Retrieve the workspace from data service.
+    TableWorkspace_sptr ws = getOutput(outWSName);
+
+    // check properties of output table
+    TS_ASSERT_EQUALS(ws->rowCount(), 5)
+    TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
+    // check the rows added contain the expected values
+    TS_ASSERT_EQUALS(ws->cell<int>(2, 0), 1)
+    TS_ASSERT_EQUALS(ws->cell<int>(3, 1), 1)
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+
+  void test_identical_tables_with_different_types_combine() {
+    std::vector<std::string> dTypes = {"int", "str"};
+    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
+    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
+    TableWorkspace_sptr table2 = table1->clone();
+
+    // Name of the output workspace.
+    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
+
+    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
+    TS_ASSERT(alg->execute())
+
+    // Retrieve the workspace from data service.
+    TableWorkspace_sptr ws = getOutput(outWSName);
+
+    // check properties of output table
+    TS_ASSERT_EQUALS(ws->rowCount(), 4)
+    TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
+    // check the rows added contain the expected values
+    TS_ASSERT_EQUALS(ws->cell<int>(2, 0), 0)
+    TS_ASSERT_EQUALS(ws->cell<std::string>(3, 1), "0")
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+};

--- a/Framework/Algorithms/test/CombineTableWorkspacesTest.h
+++ b/Framework/Algorithms/test/CombineTableWorkspacesTest.h
@@ -315,6 +315,33 @@ public:
     AnalysisDataService::Instance().remove(outWSName);
   }
 
+  void test_big_tables_combine() {
+    std::string dType = "int";
+    std::vector<std::string> names = {"ThingA", "ThingB", "ThingC", "ThingD", "ThingE", "ThingF", "ThingG", "ThingH"};
+    TableWorkspace_sptr table1 = createSingleTypeTableWorkspace<int>(dType, 50, names, 0);
+    TableWorkspace_sptr table2 = createSingleTypeTableWorkspace<int>(dType, 50, names, 1);
+
+    // Name of the output workspace.
+    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
+
+    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
+    TS_ASSERT(alg->execute())
+
+    // Retrieve the workspace from data service.
+    TableWorkspace_sptr ws = getOutput(outWSName);
+
+    // check properties of output table
+    TS_ASSERT_EQUALS(ws->rowCount(), 100)
+    TS_ASSERT_EQUALS(ws->columnCount(), 8)
+    TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
+    // check the rows added contain the expected values
+    TS_ASSERT_EQUALS(ws->cell<int>(49, 0), 0)
+    TS_ASSERT_EQUALS(ws->cell<int>(50, 1), 1)
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+
   void test_different_tables_with_different_types_but_same_columns_combine() {
     std::pair<std::string, std::string> dTypes = {"int", "double"};
     std::pair<std::string, std::string> colTitles = {"ThingA", "ThingB"};

--- a/Framework/Algorithms/test/CombineTableWorkspacesTest.h
+++ b/Framework/Algorithms/test/CombineTableWorkspacesTest.h
@@ -19,7 +19,6 @@
 using namespace Mantid;
 using namespace Mantid::DataObjects;
 using namespace Mantid::API;
-using namespace Mantid::DataHandling;
 using Mantid::Algorithms::CombineTableWorkspaces;
 using Mantid::API::TableRow;
 using Mantid::DataObjects::TableWorkspace;
@@ -41,7 +40,7 @@ TableWorkspace_sptr createSingleTypeTableWorkspace(std::string &dataType, const 
   }
   for (int row = 0; row < rowCount; ++row) {
     TableRow newRow = table->appendRow();
-    for (int col = 0; col < names.size(); col++) {
+    for (int col = 0; col < static_cast<int>(names.size()); col++) {
       newRow << defaultVal;
     }
   }

--- a/Framework/Algorithms/test/CombineTableWorkspacesTest.h
+++ b/Framework/Algorithms/test/CombineTableWorkspacesTest.h
@@ -32,15 +32,15 @@ using Mantid::Kernel::V3D;
  * @return A pointer to the table workspace
  */
 template <typename T>
-TableWorkspace_sptr createSingleTypeTableWorkspace(std::string &dataType, const int rowCount,
+TableWorkspace_sptr createSingleTypeTableWorkspace(std::string &dataType, const size_t rowCount,
                                                    const std::vector<std::string> &names, const T &defaultVal) {
   auto table = std::make_shared<TableWorkspace>();
   for (auto &name : names) {
     table->addColumn(dataType, name);
   }
-  for (int row = 0; row < rowCount; ++row) {
+  for (size_t row = 0; row < rowCount; ++row) {
     TableRow newRow = table->appendRow();
-    for (int col = 0; col < static_cast<int>(names.size()); col++) {
+    for (size_t col = 0; col < names.size(); col++) {
       newRow << defaultVal;
     }
   }
@@ -81,7 +81,7 @@ TableWorkspace_sptr getOutput(std::string outputWS) {
 }
 
 template <typename T>
-void test_identical_single_type_combine(std::string &dataType, const int rowCount,
+void test_identical_single_type_combine(std::string &dataType, const size_t rowCount,
                                         const std::vector<std::string> &names, const T &defaultVal) {
   TableWorkspace_sptr table1 = createSingleTypeTableWorkspace<T>(dataType, rowCount, names, defaultVal);
   TableWorkspace_sptr table2 = table1->clone();

--- a/Framework/Algorithms/test/CombineTableWorkspacesTest.h
+++ b/Framework/Algorithms/test/CombineTableWorkspacesTest.h
@@ -26,9 +26,9 @@ using Mantid::DataObjects::TableWorkspace_sptr;
 using Mantid::Kernel::V3D;
 
 /** Create a table workspace
- * @param types A vector of strings of the data types of the columns (either int or string for the purpose of tesing)
+ * @param dataType A vector of strings of the data types of the columns (either int or string for the purpose of tesing)
  * @param rowCount The number of detectors required
- * @param types A vector of strings of the names of the columns
+ * @param names A vector of strings of the names of the columns
  * @return A pointer to the table workspace
  */
 template <typename T>
@@ -382,7 +382,10 @@ public:
     std::string outWSName("CombineTableWorkspacesTest_OutputWS");
 
     Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
-    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &)
+    TS_ASSERT_THROWS_EQUALS(alg->execute(), const std::runtime_error &e, std::string(e.what()),
+                            "Some invalid Properties found: \n"
+                            " LHSWorkspace: Both Table Workspaces must have the same number of columns\n"
+                            " RHSWorkspace: Both Table Workspaces must have the same number of columns");
   }
 
   void test_different_column_names_throw_error() {
@@ -396,7 +399,10 @@ public:
     std::string outWSName("CombineTableWorkspacesTest_OutputWS");
 
     Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
-    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &)
+    TS_ASSERT_THROWS_EQUALS(alg->execute(), const std::runtime_error &e, std::string(e.what()),
+                            "Some invalid Properties found: \n"
+                            " LHSWorkspace: Both Table Workspaces must have the same column titles\n"
+                            " RHSWorkspace: Both Table Workspaces must have the same column titles");
   }
 
   void test_different_types_throw_error() {
@@ -410,6 +416,10 @@ public:
     std::string outWSName("CombineTableWorkspacesTest_OutputWS");
 
     Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
-    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &)
+    TS_ASSERT_THROWS_EQUALS(
+        alg->execute(), const std::runtime_error &e, std::string(e.what()),
+        "Some invalid Properties found: \n"
+        " LHSWorkspace: Both Table Workspaces must have the same data types for corresponding columns\n"
+        " RHSWorkspace: Both Table Workspaces must have the same data types for corresponding columns");
   }
 };

--- a/Framework/Algorithms/test/CombineTableWorkspacesTest.h
+++ b/Framework/Algorithms/test/CombineTableWorkspacesTest.h
@@ -9,24 +9,22 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/ColumnFactory.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidAlgorithms/CombineTableWorkspaces.h"
-#include "MantidAlgorithms/CreateSampleWorkspace.h"
-#include "MantidDataObjects/MaskWorkspace.h"
+#include "MantidDataObjects/TableColumn.h"
 #include "MantidDataObjects/TableWorkspace.h"
-
-#include "MantidAlgorithms/CreateSampleWorkspace.h"
 
 using namespace Mantid;
 using namespace Mantid::DataObjects;
 using namespace Mantid::API;
 using namespace Mantid::DataHandling;
 using Mantid::Algorithms::CombineTableWorkspaces;
-using Mantid::Algorithms::CreateSampleWorkspace;
 using Mantid::API::TableRow;
 using Mantid::DataObjects::TableWorkspace;
 using Mantid::DataObjects::TableWorkspace_sptr;
+using Mantid::Kernel::V3D;
 
 /** Create a table workspace
  * @param types A vector of strings of the data types of the columns (either int or string for the purpose of tesing)
@@ -34,36 +32,36 @@ using Mantid::DataObjects::TableWorkspace_sptr;
  * @param types A vector of strings of the names of the columns
  * @return A pointer to the table workspace
  */
-TableWorkspace_sptr createTableWorkspace(const std::vector<std::string> &dataTypes, const int rowCount,
-                                         const std::vector<std::string> &names, const int defaultInt = 0,
-                                         const std::string &defaultString = "0", const bool defaultBool = true,
-                                         const double defaultDouble = 0.0) {
+template <typename T>
+TableWorkspace_sptr createSingleTypeTableWorkspace(std::string &dataType, const int rowCount,
+                                                   const std::vector<std::string> &names, const T &defaultVal) {
   auto table = std::make_shared<TableWorkspace>();
-  for (std::vector<std::string>::size_type i = 0; i < dataTypes.size(); i++) {
-    if (i >= names.size()) {
-      table->addColumn(dataTypes[i], "N/A");
-    } else {
-      table->addColumn(dataTypes[i], names[i]);
-    }
+  for (auto &name : names) {
+    table->addColumn(dataType, name);
   }
   for (int row = 0; row < rowCount; ++row) {
     TableRow newRow = table->appendRow();
-    for (int col = 0; col < dataTypes.size(); col++) {
-      std::string dType = dataTypes[col];
-      if (dType == "int") {
-        newRow << defaultInt;
-      } else if (dType == "str") {
-        newRow << defaultString;
-      } else if (dType == "bool") {
-        newRow << defaultBool;
-      } else if (dType == "double") {
-        newRow << defaultDouble;
-      }
+    for (int col = 0; col < names.size(); col++) {
+      newRow << defaultVal;
     }
   }
   return table;
 }
 
+template <typename T1, typename T2>
+TableWorkspace_sptr createMultiTypeTableWorkspace(std::pair<std::string, std::string> &dataTypes, const int rowCount,
+                                                  const std::pair<std::string, std::string> &names,
+                                                  const T1 &defaultVal1, const T2 &defaultVal2) {
+  auto table = std::make_shared<TableWorkspace>();
+  table->addColumn(dataTypes.first, names.first);
+  table->addColumn(dataTypes.second, names.second);
+  for (int row = 0; row < rowCount; ++row) {
+    TableRow newRow = table->appendRow();
+    newRow << defaultVal1;
+    newRow << defaultVal2;
+  }
+  return table;
+}
 Mantid::API::IAlgorithm_sptr setupAlg(DataObjects::TableWorkspace_sptr LHSWorkspace,
                                       DataObjects::TableWorkspace_sptr RHSWorkspace, std::string outputWS) {
   // set up algorithm
@@ -83,6 +81,61 @@ TableWorkspace_sptr getOutput(std::string outputWS) {
   return ws;
 }
 
+template <typename T>
+void test_identical_single_type_combine(std::string &dataType, const int rowCount,
+                                        const std::vector<std::string> &names, const T &defaultVal) {
+  TableWorkspace_sptr table1 = createSingleTypeTableWorkspace<T>(dataType, rowCount, names, defaultVal);
+  TableWorkspace_sptr table2 = table1->clone();
+
+  // Name of the output workspace.
+  std::string outWSName("CombineTableWorkspacesTest_OutputWS");
+
+  Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
+  TS_ASSERT(alg->execute())
+
+  // Retrieve the workspace from data service.
+  TableWorkspace_sptr ws = getOutput(outWSName);
+
+  // check properties of output table
+  TS_ASSERT_EQUALS(ws->rowCount(), 2 * rowCount)
+  TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
+  // check the rows added contain the expected values
+  TS_ASSERT_EQUALS(ws->cell<T>(2, 0), defaultVal)
+  TS_ASSERT_EQUALS(ws->cell<T>(3, 1), defaultVal)
+
+  // Remove workspace from the data service.
+  AnalysisDataService::Instance().remove(outWSName);
+}
+
+template <typename T1, typename T2>
+void setup_identical_mixed_type_combine(std::pair<std::string, std::string> &dataTypes, const int rowCount,
+                                        const std::pair<std::string, std::string> &names, T1 &defaultVal1,
+                                        T2 &defaultVal2) {
+
+  TableWorkspace_sptr table1 =
+      createMultiTypeTableWorkspace<T1, T2>(dataTypes, rowCount, names, defaultVal1, defaultVal2);
+  TableWorkspace_sptr table2 = table1->clone();
+
+  // Name of the output workspace.
+  std::string outWSName("CombineTableWorkspacesTest_OutputWS");
+
+  Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
+  TS_ASSERT(alg->execute())
+
+  // Retrieve the workspace from data service.
+  TableWorkspace_sptr ws = getOutput(outWSName);
+
+  // check properties of output table
+  TS_ASSERT_EQUALS(ws->rowCount(), 2 * rowCount)
+  TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
+  // check the rows added contain the expected values
+  TS_ASSERT_EQUALS(ws->cell<T1>(2, 0), defaultVal1)
+  TS_ASSERT_EQUALS(ws->cell<T2>(3, 1), defaultVal2)
+
+  // Remove workspace from the data service.
+  AnalysisDataService::Instance().remove(outWSName);
+}
+
 class CombineTableWorkspacesTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
@@ -97,114 +150,150 @@ public:
   }
 
   void test_identical_int_type_combine() {
-    std::vector<std::string> dTypes = {"int", "int"};
-    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
-    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
-    TableWorkspace_sptr table2 = table1->clone();
-
-    // Name of the output workspace.
-    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
-
-    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
-    TS_ASSERT(alg->execute())
-
-    // Retrieve the workspace from data service.
-    TableWorkspace_sptr ws = getOutput(outWSName);
-
-    // check properties of output table
-    TS_ASSERT_EQUALS(ws->rowCount(), 4)
-    TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
-    // check the rows added contain the expected values
-    TS_ASSERT_EQUALS(ws->cell<int>(2, 0), 0)
-    TS_ASSERT_EQUALS(ws->cell<int>(3, 1), 0)
-
-    // Remove workspace from the data service.
-    AnalysisDataService::Instance().remove(outWSName);
-  }
-
-  void test_identical_double_type_combine() {
-    std::vector<std::string> dTypes = {"double", "double"};
-    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
-    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
-    TableWorkspace_sptr table2 = table1->clone();
-
-    // Name of the output workspace.
-    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
-
-    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
-    TS_ASSERT(alg->execute())
-
-    // Retrieve the workspace from data service.
-    TableWorkspace_sptr ws = getOutput(outWSName);
-
-    // check properties of output table
-    TS_ASSERT_EQUALS(ws->rowCount(), 4)
-    TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
-    // check the rows added contain the expected values
-    TS_ASSERT_EQUALS(ws->cell<double>(2, 0), 0.0)
-    TS_ASSERT_EQUALS(ws->cell<double>(3, 1), 0.0)
-
-    // Remove workspace from the data service.
-    AnalysisDataService::Instance().remove(outWSName);
-  }
-
-  void test_identical_string_type_combine() {
-    std::vector<std::string> dTypes = {"str", "str"};
-    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
-    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
-    TableWorkspace_sptr table2 = table1->clone();
-
-    // Name of the output workspace.
-    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
-
-    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
-    TS_ASSERT(alg->execute())
-
-    // Retrieve the workspace from data service.
-    TableWorkspace_sptr ws = getOutput(outWSName);
-
-    // check properties of output table
-    TS_ASSERT_EQUALS(ws->rowCount(), 4)
-    TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
-    // check the rows added contain the expected values
-    TS_ASSERT_EQUALS(ws->cell<std::string>(2, 0), "0")
-    TS_ASSERT_EQUALS(ws->cell<std::string>(3, 1), "0")
-
-    // Remove workspace from the data service.
-    AnalysisDataService::Instance().remove(outWSName);
+    std::string dType = "int";
+    std::vector<std::string> names = {"ThingA", "ThingB"};
+    test_identical_single_type_combine<int>(dType, 2, names, 0);
   }
 
   void test_identical_bool_type_combine() {
-    std::vector<std::string> dTypes = {"bool", "bool"};
-    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
-    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
-    TableWorkspace_sptr table2 = table1->clone();
-
-    // Name of the output workspace.
-    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
-
-    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
-    TS_ASSERT(alg->execute())
-
-    // Retrieve the workspace from data service.
-    TableWorkspace_sptr ws = getOutput(outWSName);
-
-    // check properties of output table
-    TS_ASSERT_EQUALS(ws->rowCount(), 4)
-    TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
-    // check the rows added contain the expected values
-    TS_ASSERT_EQUALS(ws->cell<Mantid::API::Boolean>(2, 0), static_cast<Mantid::API::Boolean>(true))
-    TS_ASSERT_EQUALS(ws->cell<Mantid::API::Boolean>(3, 1), static_cast<Mantid::API::Boolean>(true))
-
-    // Remove workspace from the data service.
-    AnalysisDataService::Instance().remove(outWSName);
+    std::string dType = "bool";
+    std::vector<std::string> names = {"ThingA", "ThingB"};
+    test_identical_single_type_combine<Mantid::API::Boolean>(dType, 2, names, true);
   }
 
+  void test_identical_double_type_combine() {
+    std::string dType = "double";
+    std::vector<std::string> names = {"ThingA", "ThingB"};
+    test_identical_single_type_combine<double>(dType, 2, names, 0.0);
+  }
+
+  void test_identical_string_type_combine() {
+    std::string dType = "str";
+    std::vector<std::string> names = {"ThingA", "ThingB"};
+    test_identical_single_type_combine<std::string>(dType, 2, names, "0");
+  }
+
+  void test_identical_float_type_combine() {
+    std::string dType = "float";
+    std::vector<std::string> names = {"ThingA", "ThingB"};
+    test_identical_single_type_combine<float>(dType, 2, names, 0.0);
+  }
+
+  void test_identical_size_type_combine() {
+    std::string dType = "size_t";
+    std::vector<std::string> names = {"ThingA", "ThingB"};
+    test_identical_single_type_combine<std::size_t>(dType, 2, names, 0);
+  }
+
+  void test_identical_v3d_type_combine() {
+    std::string dType = "V3D";
+    std::vector<std::string> names = {"ThingA", "ThingB"};
+    test_identical_single_type_combine<V3D>(dType, 2, names, V3D(0.0, 0.0, 0.0));
+  }
+
+  void test_identical_mixed_type_combine() {
+    const std::map<std::string, int> allowedColumnTypes = CombineTableWorkspaces::allowedTypes();
+    const std::pair<std::string, std::string> names = {"ThingA", "ThingB"};
+
+    double defaultDouble = 0.0;
+    int defaultInt = 0;
+    std::string defaultString = "0";
+    Mantid::API::Boolean defaultBool = true;
+    std::size_t defaultSize = 0;
+    float defaultFloat = 0.0;
+    V3D defaultV3D = V3D(0.0, 0.0, 0.0);
+
+    std::string doubleString = "double";
+    std::string intString = "int";
+    std::string stringString = "str";
+    std::string boolString = "bool";
+    std::string sizeString = "size_t";
+    std::string floatString = "float";
+    std::string V3DString = "V3D";
+
+    // doubles
+    std::pair<std::string, std::string> dTypes = {doubleString, intString};
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultDouble, defaultInt);
+
+    dTypes.second = stringString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultDouble, defaultString);
+
+    dTypes.second = boolString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultDouble, defaultBool);
+
+    dTypes.second = sizeString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultDouble, defaultSize);
+
+    dTypes.second = floatString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultDouble, defaultFloat);
+
+    dTypes.second = V3DString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultDouble, defaultV3D);
+
+    // ints
+
+    dTypes.first = intString;
+    dTypes.second = stringString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultInt, defaultString);
+
+    dTypes.second = boolString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultInt, defaultBool);
+
+    dTypes.second = sizeString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultInt, defaultSize);
+
+    dTypes.second = floatString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultInt, defaultFloat);
+
+    dTypes.second = V3DString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultInt, defaultV3D);
+
+    // strings
+    dTypes.first = stringString;
+    dTypes.second = boolString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultString, defaultBool);
+
+    dTypes.second = sizeString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultString, defaultSize);
+
+    dTypes.second = floatString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultString, defaultFloat);
+
+    dTypes.second = V3DString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultString, defaultV3D);
+
+    // bools
+    dTypes.first = boolString;
+    dTypes.second = sizeString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultBool, defaultSize);
+
+    dTypes.second = floatString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultBool, defaultFloat);
+
+    dTypes.second = V3DString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultBool, defaultV3D);
+
+    // size_ts
+    dTypes.first = sizeString;
+    dTypes.second = floatString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultSize, defaultFloat);
+
+    dTypes.second = V3DString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultSize, defaultV3D);
+
+    // floats
+    dTypes.first = floatString;
+    dTypes.second = V3DString;
+    setup_identical_mixed_type_combine(dTypes, 2, names, defaultFloat, defaultV3D);
+  }
+
+  // rest of the tests will just be done on on example type combination as functionality should be type independent
+
   void test_different_single_type_combine() {
-    std::vector<std::string> dTypes = {"int", "int"};
-    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
-    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
-    TableWorkspace_sptr table2 = createTableWorkspace(dTypes, 3, colTitles, 1);
+    std::string dType = "int";
+    std::vector<std::string> names = {"ThingA", "ThingB"};
+    TableWorkspace_sptr table1 = createSingleTypeTableWorkspace<int>(dType, 2, names, 0);
+    TableWorkspace_sptr table2 = createSingleTypeTableWorkspace<int>(dType, 3, names, 1);
 
     // Name of the output workspace.
     std::string outWSName("CombineTableWorkspacesTest_OutputWS");
@@ -219,44 +308,18 @@ public:
     TS_ASSERT_EQUALS(ws->rowCount(), 5)
     TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
     // check the rows added contain the expected values
-    TS_ASSERT_EQUALS(ws->cell<int>(2, 0), 1)
-    TS_ASSERT_EQUALS(ws->cell<int>(3, 1), 1)
-
-    // Remove workspace from the data service.
-    AnalysisDataService::Instance().remove(outWSName);
-  }
-
-  void test_identical_tables_with_different_types_combine() {
-    std::vector<std::string> dTypes = {"int", "str"};
-    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
-    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
-    TableWorkspace_sptr table2 = table1->clone();
-
-    // Name of the output workspace.
-    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
-
-    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
-    TS_ASSERT(alg->execute())
-
-    // Retrieve the workspace from data service.
-    TableWorkspace_sptr ws = getOutput(outWSName);
-
-    // check properties of output table
-    TS_ASSERT_EQUALS(ws->rowCount(), 4)
-    TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
-    // check the rows added contain the expected values
-    TS_ASSERT_EQUALS(ws->cell<int>(2, 0), 0)
-    TS_ASSERT_EQUALS(ws->cell<std::string>(3, 1), "0")
+    TS_ASSERT_EQUALS(ws->cell<int>(1, 0), 0)
+    TS_ASSERT_EQUALS(ws->cell<int>(2, 1), 1)
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);
   }
 
   void test_different_tables_with_different_types_but_same_columns_combine() {
-    std::vector<std::string> dTypes = {"int", "str"};
-    std::vector<std::string> colTitles = {"ThingA", "ThingB"};
-    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles);
-    TableWorkspace_sptr table2 = createTableWorkspace(dTypes, 3, colTitles, 1, "1");
+    std::pair<std::string, std::string> dTypes = {"int", "double"};
+    std::pair<std::string, std::string> colTitles = {"ThingA", "ThingB"};
+    TableWorkspace_sptr table1 = createMultiTypeTableWorkspace<int, double>(dTypes, 2, colTitles, 0, 0.0);
+    TableWorkspace_sptr table2 = createMultiTypeTableWorkspace<int, double>(dTypes, 3, colTitles, 1, 1.0);
 
     // Name of the output workspace.
     std::string outWSName("CombineTableWorkspacesTest_OutputWS");
@@ -271,8 +334,10 @@ public:
     TS_ASSERT_EQUALS(ws->rowCount(), 5)
     TS_ASSERT_EQUALS(table1->getColumnNames(), table2->getColumnNames())
     // check the rows added contain the expected values
+    TS_ASSERT_EQUALS(ws->cell<int>(1, 0), 0)
     TS_ASSERT_EQUALS(ws->cell<int>(2, 0), 1)
-    TS_ASSERT_EQUALS(ws->cell<std::string>(3, 1), "1")
+    TS_ASSERT_EQUALS(ws->cell<double>(1, 1), 0.0)
+    TS_ASSERT_EQUALS(ws->cell<double>(2, 1), 1.0)
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);
@@ -280,12 +345,26 @@ public:
 
   // failures
 
+  void test_different_number_of_columns_throw_error() {
+    std::string dType = "int";
+    std::vector<std::string> colTitles1 = {"ThingA", "ThingB"};
+    std::vector<std::string> colTitles2 = {"ThingA", "ThingB", "ThisOtherThing"};
+    TableWorkspace_sptr table1 = createSingleTypeTableWorkspace<int>(dType, 2, colTitles1, 0);
+    TableWorkspace_sptr table2 = createSingleTypeTableWorkspace<int>(dType, 2, colTitles2, 0);
+
+    // Name of the output workspace.
+    std::string outWSName("CombineTableWorkspacesTest_OutputWS");
+
+    Mantid::API::IAlgorithm_sptr alg = setupAlg(table1, table2, outWSName);
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &)
+  }
+
   void test_different_column_names_throw_error() {
-    std::vector<std::string> dTypes = {"int", "int"};
+    std::string dType = "int";
     std::vector<std::string> colTitles1 = {"ThingA", "ThingB"};
     std::vector<std::string> colTitles2 = {"ThingC", "ThingD"};
-    TableWorkspace_sptr table1 = createTableWorkspace(dTypes, 2, colTitles1);
-    TableWorkspace_sptr table2 = createTableWorkspace(dTypes, 2, colTitles2);
+    TableWorkspace_sptr table1 = createSingleTypeTableWorkspace<int>(dType, 2, colTitles1, 0);
+    TableWorkspace_sptr table2 = createSingleTypeTableWorkspace<int>(dType, 2, colTitles2, 0);
 
     // Name of the output workspace.
     std::string outWSName("CombineTableWorkspacesTest_OutputWS");
@@ -295,11 +374,11 @@ public:
   }
 
   void test_different_types_throw_error() {
-    std::vector<std::string> dTypes1 = {"int", "int"};
-    std::vector<std::string> dTypes2 = {"double", "double"};
+    std::string dType1 = "int";
+    std::string dType2 = "double";
     std::vector<std::string> colTitles = {"ThingA", "ThingB"};
-    TableWorkspace_sptr table1 = createTableWorkspace(dTypes1, 2, colTitles);
-    TableWorkspace_sptr table2 = createTableWorkspace(dTypes2, 2, colTitles);
+    TableWorkspace_sptr table1 = createSingleTypeTableWorkspace<int>(dType1, 2, colTitles, 0);
+    TableWorkspace_sptr table2 = createSingleTypeTableWorkspace<double>(dType2, 2, colTitles, 0.0);
 
     // Name of the output workspace.
     std::string outWSName("CombineTableWorkspacesTest_OutputWS");

--- a/docs/source/algorithms/CombineTableWorkspaces-v1.rst
+++ b/docs/source/algorithms/CombineTableWorkspaces-v1.rst
@@ -19,6 +19,52 @@ identical data types.
 The currently supported data types are ``double``, ``int``, ``bool``, ``float``, ``string``,
 ``size_t``, and ``V3D``.
 
+Example Usage
+-------------
+
+Here we have a python function to generate us some example table workspaces:
+
+.. code:: python
+
+    def create_example_table(table_name, data_types, column_names, n_rows, data):
+        """
+        table_name: name for output workspace
+        data_types: collection of strings of data types, one for each column
+        column_names: collection of strings of column names, one for each column
+        n_rows: number of rows in table
+        data: collection of collection of values for each row, if only one is specified it will be
+              reused for all rows
+        """
+        table = CreateEmptyTableWorkspace(OutputWorkspace = table_name)
+        for i, dt in enumerate(data_types):
+            table.addColumn(dt, column_names[i])
+        for r in range(n_rows):
+            if len(data) == 1:
+                table.addRow(data[0])
+            else:
+                table.addRow(data[r])
+
+    # here is an example table with two columns, labelled 1 and 2, with 2 rows each, both taking integer values
+    create_example_table("test_table1", ["int", "int"], ["1", "2"], 2, ([0,1],[2,3]))
+
+We can use this helper function to demonstrate the algorithm usage:
+
+.. code:: python
+
+    create_example_table("test_table1", ["int", "int"], ["1", "2"], 2, ([0,1],[2,3]))
+    create_example_table("test_table2", ["int", "int"], ["1", "2"], 2, ([4,5],[6,7]))
+
+    CombineTableWorkspaces("test_table1", "test_table2", OutputWorkspace = "comb1")
+
+This also works for tables with mixed data types
+
+.. code:: python
+
+    create_example_table("test_table3", ["str", "bool", "int"], ["1", "2", "3"],
+                     50, (["a", True, 1],))
+
+    CombineTableWorkspaces("test_table3", "test_table3", OutputWorkspace = "comb2")
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/algorithms/CombineTableWorkspaces-v1.rst
+++ b/docs/source/algorithms/CombineTableWorkspaces-v1.rst
@@ -1,0 +1,24 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+This algorithm can be used to combine a pair of :ref:`Table Workspaces <TableWorkspace>`
+into a single table. The current algorithm is very lightweight and is intended for situations
+where multiple tables are produced by the same processing pipeline, but ultimately the output
+of all the generated data in a single table would suffice. As such, the algorithm requires that
+the Column names match exactly, are in the exact same order and that corresponding columns have
+identical data types.
+
+The currently supported data types are ``double``, ``int``, ``bool``, ``float``, ``string``,
+``size_t``, and ``V3D``.
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/CombineTableWorkspaces-v1.rst
+++ b/docs/source/algorithms/CombineTableWorkspaces-v1.rst
@@ -9,7 +9,7 @@
 Description
 -----------
 
-This algorithm can be used to combine a pair of :ref:`Table Workspaces <TableWorkspace>`
+This algorithm can be used to combine a pair of :ref:`Table Workspaces <Table Workspaces>`
 into a single table. The current algorithm is very lightweight and is intended for situations
 where multiple tables are produced by the same processing pipeline, but ultimately the output
 of all the generated data in a single table would suffice. As such, the algorithm requires that

--- a/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39181.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39181.rst
@@ -1,0 +1,1 @@
+- New algorithm :ref:`CombineTableWorkspaces` allows combination of a pair of :ref:`Table Workspaces <TableWorkspace>`, provided they have matching column names and data types.

--- a/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39181.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/New_features/39181.rst
@@ -1,1 +1,1 @@
-- New algorithm :ref:`CombineTableWorkspaces` allows combination of a pair of :ref:`Table Workspaces <TableWorkspace>`, provided they have matching column names and data types.
+- New algorithm :ref:`algm-CombineTableWorkspaces` allows combination of a pair of :ref:`Table Workspaces`, provided they have matching column names and data types.


### PR DESCRIPTION
### Description of work

#### Summary of work
Algorithm takes two table workspaces and, if they have the same column titles and data types, combines them into a single table

This has been done so multiple tables with the same data can be rolled into one with history intact. Specifically, I need an algorithm for this for developing the diffraction Texture Analysis pipeline, where each experimental run will generate rows which have: a detector intensity reading and the position of the detector relative to the sample. As the sample is rotated run to run, different relative positions are generated but the final output table should contain all the data from all the runs. 

This algorithm is designed in such a way that it is slightly more general purpose (flexibility of column titles and data types) so it can be used in other similar situations, but isn't intended to be a catch-all solution (limited data type support, requires exact column ordering and name matching).

Perhaps could be extended to handle a broader range of inputs in a future version?

#### Further detail of work
Currently supports data types of `double`, `int`, `float`, `string`, `bool`, `size_t` and `V3D`.

### To test:

Unit tests should cover standard usage. Try putting together tables in workbench and should either get a combined table or an appropriate error

example script:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

def create_example_table(table_name, data_types, column_names, n_rows, data):
    """
    table_name: name for output workspace
    data_types: collection of strings of data types, one for each column
    column_names: iterator of strings of column names, one for each column
    n_rows: number of rows in table
    data: collection of collection of values for each row, if only one is specified it will be
          reused for all rows
    """
    table = CreateEmptyTableWorkspace(OutputWorkspace = table_name)
    for i, dt in enumerate(data_types):
        table.addColumn(dt, column_names[i])
    for r in range(n_rows):
        if len(data) == 1:
            table.addRow(data[0])
        else:
            table.addRow(data[r])

# create some tables

create_example_table("test_table1", ["int", "int"], ["1", "2"], 2, ([0,1],[2,3]))
create_example_table("test_table2", ["int", "int"], ["1", "2"], 2, ([4,5],[6,7]))
create_example_table("test_table3", ["double", "int"], ["1", "2"], 2, ([0.0,1],[2.0,3]))
create_example_table("test_table4", ["double", "int"], ["1", "2"], 2, ([0.1,1],[2.1,3]))
create_example_table("test_table5", ["int", "int"], ["2", "1"], 2, ([4,5],[6,7]))
create_example_table("test_table6", ["int"], ["1"], 2, ([4],[6]))
create_example_table("test_table_big", ["str", "bool", "int"], ["1", "2", "3"], 
                     50, (["a", True, 1],))

# Test some combinations

CombineTableWorkspaces("test_table1", "test_table2", OutputWorkspace = "comb1")
CombineTableWorkspaces("test_table3", "test_table4", OutputWorkspace = "comb2")
CombineTableWorkspaces("test_table_big", "test_table_big", OutputWorkspace = "comb_big")

try:
    #shouldn't work because columns aren't in same order
    CombineTableWorkspaces("test_table1", "test_table5", OutputWorkspace = "comb1")
except:
    print("Test Tables 1 and 5 won't combine")
    
try:
    #shouldn't work because there are different numbers of columns
    CombineTableWorkspaces("test_table1", "test_table6", OutputWorkspace = "comb1")
except:
    print("Test Tables 1 and 6 won't combine")
```

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
