### PR TITLE
Replace `--platform` argument in `mamba create`

### DIFF
--- a/installers/conda/osx/create_bundle.sh
+++ b/installers/conda/osx/create_bundle.sh
@@ -210,7 +210,7 @@ if [[ "$suffix" == "Unstable" ]] || [[ "$suffix" == "Nightly" ]]; then
 fi
 
 echo "Creating Conda environment in '$bundle_conda_prefix'"
-"$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --copy --platform osx-64 \
+CONDA_SUBDIR=osx-64 "$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --copy \
   --channel "$conda_channel" --channel conda-forge --channel $mantid_channel --yes \
   mantidworkbench \
   jq  # used for processing the version string


### PR DESCRIPTION
### Description of work
The [recent update](https://github.com/mantidproject/mantid/pull/39177) to fix packaging requires an additional tweak to build the macOS standalone bundle. Here we remove the `--platform osx-64` argument and replace it by setting `CONDA_SUBDIR=osx-64`. This is already being done in our [mamba-utils](https://github.com/mantidproject/mantid/blob/51657d21d0837db795cd6a508ee06bddd9470d06/buildconfig/Jenkins/Conda/mamba-utils#L44), so we know that it is a viable replacement.

#### Purpose of work
It appears that the `--platform` argument for the `mamba create` command no longer exists (see the bottom of [this build log](https://builds.mantidproject.org/job/build_packages_from_branch/1076/execution/node/364/log/)). This is quite unexpected, since it appears to [still exist](https://docs.conda.io/projects/conda/en/stable/commands/create.html#conda.cli.conda_argparse-generate_parser-channel-customization) as an argument for `conda create`.

*There is no associated issue.*


### To test:
I am inclined to say that we merge it and see if the nightly succeeds. Otherwise, we already know that the nightly will fail so there is nothing to lose.

*This does not require release notes* because **it's a build script update**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
