### PR TITLE
Expose `ExperimentInfo::populateInstrumentParameters`

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -119,5 +119,7 @@ void export_ExperimentInfo() {
            ":class:`~mantid.geometry.ComponentInfo` "
            "object.")
       .def("setSample", setSample, args("self", "sample"))
-      .def("setRun", setRun, args("self", "run"));
+      .def("setRun", setRun, args("self", "run"))
+      .def("populateInstrumentParameters", &ExperimentInfo::populateInstrumentParameters, (arg("self")),
+           "Update parameters in the instrument-parameter map. Logs must be loaded before calling this method");
 }

--- a/docs/source/release/v6.12.0/Framework/Python/New_features/38684.rst
+++ b/docs/source/release/v6.12.0/Framework/Python/New_features/38684.rst
@@ -1,0 +1,1 @@
+- Exposed `ExperimentInfo.populateInstrumentParameters` to the Python api.  This will facilitate the update of parameterized instruments from Python, allowing parameters to be directly transferred as properties without converting to and from `string`.


### PR DESCRIPTION
From `main` [PR#38684](https://github.com/mantidproject/mantid/pull/38684)