### PR TITLE
Sliceviewer: Add option to display HKL peak positions calculated from q instead of peak index - ornl-next

### DIFF
--- a/docs/source/release/v6.13.0/Workbench/SliceViewer/New_features/39169.rst
+++ b/docs/source/release/v6.13.0/Workbench/SliceViewer/New_features/39169.rst
@@ -1,0 +1,1 @@
+- Added the option when plotting peaks in HKL to use the peak positions calculated from Q\ :sub:`sample` using the UB instead of peak index.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -88,6 +88,8 @@ class PeaksViewerPresenter:
         view.subscribe(self)
         view.set_title(model.peaks_workspace.name())
         view.set_peak_color(model.fg_color)
+        self.view.enable_calculate_hkl(self.model.can_calculate_hkl(view.frame))
+
         self.notify(PeaksViewerPresenter.Event.PeaksListChanged)
 
     @property
@@ -137,6 +139,7 @@ class PeaksViewerPresenter:
         """
         self._clear_peaks()
         self.model.draw_peaks(self._view.sliceinfo, self._view.painter, self._view.frame)
+        self.view.call_canvas_draw()
 
     def _peak_selected(self):
         """
@@ -165,6 +168,14 @@ class PeaksViewerPresenter:
         :param concise: bool to set concise or expanded view
         """
         self.view.table_view.filter_columns(concise, PeaksWorkspaceDataPresenter.HIDDEN_COLUMNS)
+
+    def calc_hkl_checkbox_changes(self, calc_hkl):
+        """
+        Respond to a change in the calc_hkl check box state
+        :param calc_hkl: bool to set calc_hkl or not
+        """
+        self.model.set_calculate_hkl(calc_hkl)
+        self.notify(PeaksViewerPresenter.Event.OverlayPeaks)
 
     # private api
     @staticmethod

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/modeltesthelpers.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/modeltesthelpers.py
@@ -13,15 +13,16 @@ from unittest.mock import MagicMock, create_autospec
 from mantid.kernel import SpecialCoordinateSystem
 from mantid.dataobjects import PeaksWorkspace
 from mantid.kernel import V3D
+from mantid.geometry import OrientedLattice
 
 # local imports
 from mantidqt.widgets.sliceviewer.peaksviewer.model import PeaksViewerModel
 from mantidqt.widgets.sliceviewer.peaksviewer.representation.painter import MplPainter
 
 
-def draw_peaks(centers, fg_color, slice_value, slice_width, frame=SpecialCoordinateSystem.QLab):
-    model = create_peaks_viewer_model(centers, fg_color)
-    slice_info = create_slice_info(centers, slice_value, slice_width)
+def draw_peaks(centers, fg_color, slice_value, slice_width, frame=SpecialCoordinateSystem.QLab, calcHKL=False):
+    model = create_peaks_viewer_model(centers, fg_color, calcHKL=calcHKL)
+    slice_info = create_slice_info(lambda pos: pos, slice_value, slice_width)
     mock_painter = MagicMock(spec=MplPainter)
     mock_axes = MagicMock()
     mock_axes.get_xlim.return_value = (-1, 1)
@@ -32,7 +33,7 @@ def draw_peaks(centers, fg_color, slice_value, slice_width, frame=SpecialCoordin
     return model, mock_painter
 
 
-def create_peaks_viewer_model(centers, fg_color, name=None):
+def create_peaks_viewer_model(centers, fg_color, name=None, calcHKL=False):
     peaks = [create_mock_peak(center) for center in centers]
 
     def get_peak(index):
@@ -52,6 +53,8 @@ def create_peaks_viewer_model(centers, fg_color, name=None):
     model.ws.getPeak.side_effect = get_peak
     model.ws.column.side_effect = column
     model.ws.removePeak.side_effect = remove_peak
+    model._orientedLattice = OrientedLattice(3, 4, 5, 90, 90, 120)
+    model.set_calculate_hkl(calcHKL)
 
     return model
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
@@ -62,6 +62,33 @@ class PeaksViewerModelTest(unittest.TestCase):
         self.assertAlmostEqual(0.356, call_kwargs["alpha"], places=3)
         self.assertEqual(fg_color, call_kwargs["color"])
 
+    def test_draw_peaks_with_calc_hkl(self):
+        peak_center = (0.5, 0.2, 0.25)
+
+        # without calcHKL
+        _, mock_painter = draw_peaks((peak_center,), "r", slice_value=0.5, slice_width=30, frame=SpecialCoordinateSystem.HKL, calcHKL=False)
+
+        self.assertEqual(1, mock_painter.cross.call_count)
+        call_args, _ = mock_painter.cross.call_args
+        self.assertEqual(peak_center[0], call_args[0])
+        self.assertEqual(peak_center[1], call_args[1])
+
+        # with calcHKL, the HKL peak position should change
+        _, mock_painter = draw_peaks((peak_center,), "r", slice_value=0.5, slice_width=30, frame=SpecialCoordinateSystem.HKL, calcHKL=True)
+        self.assertEqual(1, mock_painter.cross.call_count)
+        call_args, _ = mock_painter.cross.call_args
+        self.assertAlmostEqual(0.159002, call_args[0], places=6)
+        self.assertAlmostEqual(0.127324, call_args[1], places=6)
+
+        # with calcHKL but with QSample frame, the peak position should not change
+        _, mock_painter = draw_peaks(
+            (peak_center,), "r", slice_value=0.5, slice_width=30, frame=SpecialCoordinateSystem.QSample, calcHKL=True
+        )
+        self.assertEqual(1, mock_painter.cross.call_count)
+        call_args, _ = mock_painter.cross.call_args
+        self.assertAlmostEqual(peak_center[0], call_args[0], places=6)
+        self.assertAlmostEqual(peak_center[1], call_args[1], places=6)
+
     def test_clear_peaks_removes_all_drawn(self):
         # create 2 peaks: 1 visible, 1 not (far outside Z range)
         visible_peak_center, invisible_center = (0.5, 0.2, 0.25), (0.4, 0.3, 25)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_view.py
@@ -23,6 +23,7 @@ class PeaksViewerViewTest(unittest.TestCase):
     def test_sort_by_value_not_string(self):
         npeaks = 5
         peaks_ws = WorkspaceCreationHelper.createPeaksWorkspace(npeaks)
+        PeaksViewerView.frame = None  # override to avoid call to SliceViewer
         view = PeaksViewerView(None, None)
         model = PeaksViewerModel(peaks_ws, fg_color="r", bg_color="w")
         presenter = PeaksViewerPresenter(model, view)


### PR DESCRIPTION
This is a version of #39169 into `ornl-next`