### PR TITLE
Deprecate LoadPreNexus and LoadPreNexusMonitors - ornl-next

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPreNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPreNexus.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAPI/IEventWorkspace_fwd.h"
 #include "MantidAPI/IFileLoader.h"
 #include "MantidDataHandling/DllConfig.h"
@@ -20,8 +21,12 @@ namespace DataHandling {
 
   @date 2012-01-30
 */
-class MANTID_DATAHANDLING_DLL LoadPreNexus : public API::IFileLoader<Kernel::FileDescriptor> {
+class MANTID_DATAHANDLING_DLL LoadPreNexus : public API::IFileLoader<Kernel::FileDescriptor>,
+                                             public API::DeprecatedAlgorithm {
 public:
+  /// Default constructor
+  LoadPreNexus();
+
   const std::string name() const override;
   /// Summary of algorithms purpose
   const std::string summary() const override { return "Load a collection of PreNexus files."; }

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPreNexusMonitors.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPreNexusMonitors.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidDataHandling/DllConfig.h"
 
@@ -19,7 +20,7 @@ namespace DataHandling {
     @author Stuart Campbell, SNS ORNL
     @date 20/08/2010
 */
-class MANTID_DATAHANDLING_DLL LoadPreNexusMonitors : public Mantid::API::Algorithm {
+class MANTID_DATAHANDLING_DLL LoadPreNexusMonitors : public Mantid::API::Algorithm, public API::DeprecatedAlgorithm {
 public:
   /// (Empty) Constructor
   LoadPreNexusMonitors();

--- a/Framework/DataHandling/src/LoadPreNexus.cpp
+++ b/Framework/DataHandling/src/LoadPreNexus.cpp
@@ -65,6 +65,9 @@ int LoadPreNexus::confidence(Kernel::FileDescriptor &descriptor) const {
     return 0;
 }
 
+/// Default constructor
+LoadPreNexus::LoadPreNexus() : m_outputWorkspace() { deprecatedDate("2025-04-10"); }
+
 /// @copydoc Mantid::API::Algorithm::init()
 void LoadPreNexus::init() {
   // runfile to read in

--- a/Framework/DataHandling/src/LoadPreNexusMonitors.cpp
+++ b/Framework/DataHandling/src/LoadPreNexusMonitors.cpp
@@ -51,7 +51,9 @@ static const std::string WORKSPACE_OUT("OutputWorkspace");
 // It is used to print out information, warning and error messages
 
 LoadPreNexusMonitors::LoadPreNexusMonitors()
-    : Mantid::API::Algorithm(), nMonitors(0), instrument_loaded_correctly(false) {}
+    : Mantid::API::Algorithm(), nMonitors(0), instrument_loaded_correctly(false) {
+  deprecatedDate("2025-04-10");
+}
 
 void LoadPreNexusMonitors::init() {
   // Filename for the runinfo file.

--- a/docs/source/release/v6.13.0/Framework/Data_Handling/Deprecated/39176.rst
+++ b/docs/source/release/v6.13.0/Framework/Data_Handling/Deprecated/39176.rst
@@ -1,0 +1,1 @@
+- :ref:`LoadPreNexus <algm-LoadPreNexus>` and :ref:`LoadPreNexusMonitors <algm-LoadPreNexusMonitors>` has been deprecated. There is no replacement.


### PR DESCRIPTION
This is a version of #39176 into `ornl-next`