### PR TITLE
Deprecating UnwrapMonitorsInTOF 

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/UnwrapMonitorsInTOF.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/UnwrapMonitorsInTOF.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAlgorithms/DllConfig.h"
 
@@ -18,8 +19,9 @@ namespace Algorithms {
  *  This can occur when dealing with different time regimes for detectors
  *  and monitors.
  */
-class MANTID_ALGORITHMS_DLL UnwrapMonitorsInTOF final : public API::Algorithm {
+class MANTID_ALGORITHMS_DLL UnwrapMonitorsInTOF final : public API::Algorithm, public API::DeprecatedAlgorithm {
 public:
+  UnwrapMonitorsInTOF();
   const std::string name() const override;
   int version() const override;
   const std::vector<std::string> seeAlso() const override { return {"UnwrapMonitor", "UnwrapSNS"}; }

--- a/Framework/Algorithms/src/UnwrapMonitorsInTOF.cpp
+++ b/Framework/Algorithms/src/UnwrapMonitorsInTOF.cpp
@@ -249,6 +249,9 @@ DECLARE_ALGORITHM(UnwrapMonitorsInTOF)
 
 //----------------------------------------------------------------------------------------------
 
+/// Default Constructor
+UnwrapMonitorsInTOF::UnwrapMonitorsInTOF() { deprecatedDate("2025-04-01"); }
+
 /// Algorithms name for identification. @see Algorithm::name
 const std::string UnwrapMonitorsInTOF::name() const { return "UnwrapMonitorsInTOF"; }
 

--- a/docs/source/release/v6.13.0/Framework/Algorithms/Deprecated/39132.rst
+++ b/docs/source/release/v6.13.0/Framework/Algorithms/Deprecated/39132.rst
@@ -1,0 +1,1 @@
+- :ref:`UnwrapMonitorsInTOF <algm-UnwrapMonitorsInTOF>` has been deprecated. There is no replacement.


### PR DESCRIPTION
* Deprecating UnwrapMonitorsInTOF in ornl-next branch

### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Sibling PR of [39132](https://github.com/mantidproject/mantid/pull/39132)



<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
