### PR TITLE
rename argument `is_polarized_dataset` as `enable_instrument_settings`

### DIFF
--- a/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
+++ b/Framework/PythonInterface/mantid/utils/reflectometry/orso_helper.py
@@ -62,12 +62,12 @@ class MantidORSODataset:
         reduction_timestamp: datetime,
         creator_name: str,
         creator_affiliation: str,
-        is_polarized_dataset: bool,
+        enable_instrument_settings: bool,
     ) -> None:
         self._data_columns = data_columns
         self._header = None
 
-        self._create_mandatory_header(ws, dataset_name, reduction_timestamp, creator_name, creator_affiliation, is_polarized_dataset)
+        self._create_mandatory_header(ws, dataset_name, reduction_timestamp, creator_name, creator_affiliation, enable_instrument_settings)
 
     @property
     def dataset(self) -> OrsoDataset:
@@ -108,7 +108,7 @@ class MantidORSODataset:
         reduction_timestamp: datetime,
         creator_name: str,
         creator_affiliation: str,
-        is_polarized_dataset: Optional[bool] = None,
+        enable_instrument_settings: Optional[bool] = None,
     ) -> None:
         owner = Person(name=None, affiliation=None)
 
@@ -123,7 +123,7 @@ class MantidORSODataset:
         sample = Sample(name=ws.getTitle())
 
         # This will initially only consider polarization
-        instrument_settings = InstrumentSettings(None, None) if is_polarized_dataset else None
+        instrument_settings = InstrumentSettings(None, None) if enable_instrument_settings else None
         measurement = Measurement(instrument_settings=instrument_settings, data_files=[])
 
         data_source = DataSource(owner=owner, experiment=experiment, sample=sample, measurement=measurement)

--- a/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveISISReflectometryORSO.py
@@ -413,7 +413,7 @@ class SaveISISReflectometryORSO(PythonAlgorithm):
             reduction_timestamp=self._get_reduction_timestamp(refl_dataset.reduction_history),
             creator_name=self.name(),
             creator_affiliation=MantidORSODataset.SOFTWARE_NAME,
-            is_polarized_dataset=refl_dataset.is_polarized,
+            enable_instrument_settings=refl_dataset.is_polarized,  # instrument settings only for polarization data
         )
 
     def _add_optional_header_info(self, dataset: MantidORSODataset, refl_dataset: ReflectometryDataset) -> None:

--- a/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/reflectometry/orso_helper_test.py
@@ -227,7 +227,13 @@ class MantidORSODatasetTest(unittest.TestCase):
         creator_name = "Creator Name"
         creator_affiliation = "Creator Affiliation"
         dataset = MantidORSODataset(
-            dataset_name, self._data_columns, self._ws, reduction_timestamp, creator_name, creator_affiliation, is_polarized_dataset=False
+            dataset_name,
+            self._data_columns,
+            self._ws,
+            reduction_timestamp,
+            creator_name,
+            creator_affiliation,
+            enable_instrument_settings=False,
         )
 
         orso_dataset = dataset.dataset
@@ -363,7 +369,7 @@ class MantidORSODatasetTest(unittest.TestCase):
         self._check_files_are_created(dataset, filenames, 0, len(filenames), False)
 
     def _create_test_dataset(self, polarized=False):
-        return MantidORSODataset("Test dataset", self._data_columns, self._ws, datetime.now(), "", "", is_polarized_dataset=polarized)
+        return MantidORSODataset("Test dataset", self._data_columns, self._ws, datetime.now(), "", "", enable_instrument_settings=polarized)
 
     def _check_mantid_default_header(self, orso_dataset, dataset_name, ws, reduction_timestamp, creator_name, creator_affiliation):
         """Check that the default header contains only the information that can be shared


### PR DESCRIPTION
### Description of work
The new name describes what the code does more accurately

- There is no associated issue.
- This does not require release notes because is a minor change hidden from the public API

PR against `main`: https://github.com/mantidproject/mantid/pull/39192

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
