### PR TITLE
Python Help Window Feature Addition - Use ConfigService for Docs Path

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowbridge.py
@@ -1,12 +1,8 @@
-# Mantid Repository : https://github.com/mantidproject/mantid
-#
 # Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-import os
 import sys
-import argparse
 
 from qtpy.QtWidgets import QApplication
 from mantidqt.widgets.helpwindow.helpwindowpresenter import HelpWindowPresenter
@@ -14,43 +10,53 @@ from mantidqt.widgets.helpwindow.helpwindowpresenter import HelpWindowPresenter
 _presenter = None
 
 
-def show_help_page(relativeUrl, localDocs=None, onlineBaseUrl="https://docs.mantidproject.org/"):
+def show_help_page(relativeUrl, onlineBaseUrl="https://docs.mantidproject.org/"):
     """
     Show the help window at the given relative URL path.
+    Local docs path is now determined internally via ConfigService.
     """
     global _presenter
     if _presenter is None:
-        # Create a Presenter once. Re-use it on subsequent calls.
-        _presenter = HelpWindowPresenter(localDocs=localDocs, onlineBaseUrl=onlineBaseUrl)
+        _presenter = HelpWindowPresenter(onlineBaseUrl=onlineBaseUrl)
 
-    # Ask the Presenter to load the requested page
     _presenter.show_help_page(relativeUrl)
 
 
 def main(cmdargs=sys.argv):
     """
     Run this script standalone to test the Python-based Help Window.
+    Local docs path is determined from Mantid's ConfigService.
     """
+    import argparse
+
     parser = argparse.ArgumentParser(description="Standalone test of the Python-based Mantid Help Window.")
     parser.add_argument(
         "relativeUrl", nargs="?", default="", help="Relative doc path (e.g. 'algorithms/Load-v1.html'), defaults to 'index.html' if empty."
     )
-    parser.add_argument("--local-docs", default=None, help="Path to local Mantid HTML docs. Overrides environment if set.")
+
     parser.add_argument(
         "--online-base-url",
         default="https://docs.mantidproject.org/",
-        help="Base URL for online docs if local docs are not set or invalid.",
+        help="Base URL for online docs if local docs path from config is invalid or not found.",
     )
     args = parser.parse_args(cmdargs or sys.argv[1:])
 
-    # If user gave no --local-docs, fall back to environment
-    if args.local_docs is None:
-        args.local_docs = os.environ.get("MANTID_LOCAL_DOCS_BASE", None)
+    try:
+        import mantid.kernel
+
+        log = mantid.kernel.Logger("HelpWindowBridge")
+        log.information("Mantid kernel imported successfully.")
+    except ImportError as e:
+        print(f"ERROR: Failed to import Mantid Kernel: {e}", file=sys.stderr)
+        print(
+            "Ensure Mantid is built and PYTHONPATH is set correctly (e.g., export PYTHONPATH=/path/to/mantid/build/bin:$PYTHONPATH)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     app = QApplication(sys.argv)
 
-    # Show the requested help page
-    show_help_page(relativeUrl=args.relativeUrl, localDocs=args.local_docs, onlineBaseUrl=args.online_base_url)
+    show_help_page(relativeUrl=args.relativeUrl, onlineBaseUrl=args.online_base_url)
 
     sys.exit(app.exec_())
 

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
@@ -29,13 +29,18 @@ log = Logger("HelpWindowPresenter")
 
 from mantidqt.widgets.helpwindow.helpwindowmodel import HelpWindowModel  # noqa: E402
 from mantidqt.widgets.helpwindow.helpwindowview import HelpWindowView  # noqa: E402
-from qtpy.QtCore import Qt  # noqa: E402
+
+from qtpy.QtCore import Qt, QUrl  # noqa: E402
 
 
 class HelpWindowPresenter:
     def __init__(self, parentApp=None, onlineBaseUrl="https://docs.mantidproject.org/"):
         log.debug(f"Initializing with onlineBaseUrl='{onlineBaseUrl}'")
-        self.model = HelpWindowModel(online_base=onlineBaseUrl)
+        try:
+            self.model = HelpWindowModel(online_base=onlineBaseUrl)
+        except Exception as e:
+            log.error(f"Failed to initialize HelpWindowModel: {e}")
+            self.model = None
         self.parentApp = parentApp
         self._view = None
         self._windowOpen = False
@@ -51,40 +56,96 @@ class HelpWindowPresenter:
 
     def _ensure_view_created(self):
         """Creates the View instance if it doesn't exist yet."""
-        if self._view is None:
+        if self._view is None and self.model is not None:
             log.debug("Creating HelpWindowView instance.")
-            interceptor = self.model.create_request_interceptor()
-            modeString = self.model.get_mode_string()
-            isLocal = self.model.is_local_docs_mode()
+            try:
+                interceptor = self.model.create_request_interceptor()
+                modeString = self.model.get_mode_string()
+                isLocal = self.model.is_local_docs_mode()
 
-            self._view = HelpWindowView(self, interceptor=interceptor)
-            self._view.set_status_indicator(modeString, isLocal)
-            log.debug("HelpWindowView instance created.")
+                self._view = HelpWindowView(self, interceptor=interceptor)
+                self._view.set_status_indicator(modeString, isLocal)
+                log.debug("HelpWindowView instance created.")
+            except Exception as e:
+                log.error(f"Failed to create HelpWindowView: {e}")
+                self._view = None
+        elif self.model is None:
+            log.error("Cannot create view because model initialization failed.")
 
     def show_help_page(self, relativeUrl):
         """
         Build the doc URL from the Model and tell the View to load it.
+        Handles FileNotFoundError from the model for local files.
         Ensures the View is created and visible.
         """
         self._ensure_view_created()
+        if not self._view:
+            log.error("Cannot show help page, view is not available.")
+            return
+
         log.debug(f"Requesting help page: '{relativeUrl}'")
-        docUrl = self.model.build_help_url(relativeUrl)
-        self._view.set_page_url(docUrl)
-        self.show_help_window()
+        try:
+            docUrl = self.model.build_help_url(relativeUrl)
+            self._view.set_page_url(docUrl)
+            self.show_help_window()
+        except FileNotFoundError as e:
+            log.error(f"File not found for help page '{relativeUrl}': {e}")
+            self._view.show_file_not_found_error(str(e), relativeUrl)
+            self.show_help_window()
+        except Exception as e:
+            log.error(f"Error building URL for '{relativeUrl}': {e}")
+            self._view.show_generic_error(f"Error generating help URL: {e}", relativeUrl)
+            self.show_help_window()
 
     def show_home_page(self):
         """
-        Presenter logic to load the 'Home' page, based on model's determined home URL.
-        The View calls this when the user hits the Home button. Ensures View exists.
+        Presenter logic to load the 'Home' page. Handles FileNotFoundError.
+        Ensures View exists.
         """
         self._ensure_view_created()
+        if not self._view:
+            log.error("Cannot show home page, view is not available.")
+            return
+
         log.debug("Requesting home page.")
-        homeUrl = self.model.get_home_url()
-        self._view.set_page_url(homeUrl)
+        try:
+            homeUrl = self.model.get_home_url()
+            self._view.set_page_url(homeUrl)
+        except FileNotFoundError as e:
+            log.error(f"File not found for home page: {e}")
+            self._view.show_file_not_found_error(str(e), "index.html")
+            self.show_help_window()
+        except Exception as e:
+            log.error(f"Error building home URL: {e}")
+            self._view.show_generic_error(f"Error generating home URL: {e}", "index.html")
+            self.show_help_window()
+
+    def get_home_url_for_view(self) -> QUrl:
+        """Provides the home URL (local or online) to the View for links."""
+        if not self.model:
+            return QUrl()
+        try:
+            return self.model.get_home_url()
+        except FileNotFoundError:
+            log.warning("Home file (index.html) not found for error page link.")
+            try:
+                online_home = QUrl(self.model._raw_online_base + "/index.html")
+                if online_home.isValid():
+                    return online_home
+            except Exception:
+                pass
+            return QUrl()
+        except Exception as e:
+            log.error(f"Error getting home URL for view: {e}")
+            return QUrl()
 
     def show_help_window(self):
         """Ensure the HelpWindowView is created and visible."""
-        self._ensure_view_created()
+        if self._view is None:
+            log.error("Cannot show window, view is not created.")
+            self._ensure_view_created()
+            if self._view is None:
+                return
         if not self._windowOpen:
             log.debug("Displaying help window for the first time.")
             self._windowOpen = True

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowpresenter.py
@@ -1,21 +1,41 @@
-# Mantid Repository : https://github.com/mantidproject/mantid
-#
 # Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-import logging
-from mantidqt.widgets.helpwindow.helpwindowmodel import HelpWindowModel
-from mantidqt.widgets.helpwindow.helpwindowview import HelpWindowView
-from qtpy.QtCore import Qt
+
+try:
+    from mantid.kernel import Logger
+except ImportError:
+    print("Warning: Mantid Logger not found, using basic print for logging.")
+
+    class Logger:
+        def __init__(self, name):
+            self._name = name
+
+        def warning(self, msg):
+            print(f"WARNING [{self._name}]: {msg}")
+
+        def debug(self, msg):
+            print(f"DEBUG [{self._name}]: {msg}")
+
+        def information(self, msg):
+            print(f"INFO [{self._name}]: {msg}")
+
+        def error(self, msg):
+            print(f"ERROR [{self._name}]: {msg}")
+
+
+log = Logger("HelpWindowPresenter")
+
+from mantidqt.widgets.helpwindow.helpwindowmodel import HelpWindowModel  # noqa: E402
+from mantidqt.widgets.helpwindow.helpwindowview import HelpWindowView  # noqa: E402
+from qtpy.QtCore import Qt  # noqa: E402
 
 
 class HelpWindowPresenter:
-    _logger = logging.getLogger(__name__)
-
-    def __init__(self, parentApp=None, localDocs=None, onlineBaseUrl="https://docs.mantidproject.org/"):
-        self._logger.debug(f"Initializing with localDocs='{localDocs}', onlineBaseUrl='{onlineBaseUrl}'")
-        self.model = HelpWindowModel(localDocsBase=localDocs, onlineBase=onlineBaseUrl)
+    def __init__(self, parentApp=None, onlineBaseUrl="https://docs.mantidproject.org/"):
+        log.debug(f"Initializing with onlineBaseUrl='{onlineBaseUrl}'")
+        self.model = HelpWindowModel(online_base=onlineBaseUrl)
         self.parentApp = parentApp
         self._view = None
         self._windowOpen = False
@@ -23,24 +43,23 @@ class HelpWindowPresenter:
         if self.parentApp:
             try:
                 self.parentApp.aboutToQuit.connect(self.cleanup)
-                self._logger.debug("Connected cleanup to parentApp.aboutToQuit signal.")
+                log.debug("Connected cleanup to parentApp.aboutToQuit signal.")
             except AttributeError:
-                self._logger.warning("parentApp provided but does not have aboutToQuit signal.")
+                log.warning("parentApp provided but does not have aboutToQuit signal.")
             except Exception as e:
-                self._logger.error(f"Error connecting aboutToQuit signal: {e}")
+                log.error(f"Error connecting aboutToQuit signal: {e}")
 
     def _ensure_view_created(self):
-        """
-        Creates the View instance if it doesn't exist yet.
-        """
+        """Creates the View instance if it doesn't exist yet."""
         if self._view is None:
-            self._logger.debug("Creating HelpWindowView instance.")
+            log.debug("Creating HelpWindowView instance.")
             interceptor = self.model.create_request_interceptor()
             modeString = self.model.get_mode_string()
             isLocal = self.model.is_local_docs_mode()
+
             self._view = HelpWindowView(self, interceptor=interceptor)
             self._view.set_status_indicator(modeString, isLocal)
-            self._logger.debug("HelpWindowView instance created.")
+            log.debug("HelpWindowView instance created.")
 
     def show_help_page(self, relativeUrl):
         """
@@ -48,56 +67,52 @@ class HelpWindowPresenter:
         Ensures the View is created and visible.
         """
         self._ensure_view_created()
-        self._logger.debug(f"Requesting help page: '{relativeUrl}'")
+        log.debug(f"Requesting help page: '{relativeUrl}'")
         docUrl = self.model.build_help_url(relativeUrl)
         self._view.set_page_url(docUrl)
         self.show_help_window()
 
     def show_home_page(self):
         """
-        Presenter logic to load the 'Home' page, which might be local or online.
-        The View calls this when the user hits the Home button.
+        Presenter logic to load the 'Home' page, based on model's determined home URL.
+        The View calls this when the user hits the Home button. Ensures View exists.
         """
         self._ensure_view_created()
-        self._logger.debug("Requesting home page.")
+        log.debug("Requesting home page.")
         homeUrl = self.model.get_home_url()
         self._view.set_page_url(homeUrl)
 
     def show_help_window(self):
+        """Ensure the HelpWindowView is created and visible."""
         self._ensure_view_created()
         if not self._windowOpen:
-            self._logger.debug("Displaying help window for the first time.")
+            log.debug("Displaying help window for the first time.")
             self._windowOpen = True
             self._view.display()
         else:
-            self._logger.debug("Raising existing help window.")
+            log.debug("Raising existing help window.")
             self._view.show()
             self._view.raise_()
             self._view.activateWindow()
 
     def on_close(self):
-        """
-        Called by the View when the window closes.
-        """
-        self._logger.debug("View signaled interactive close.")
+        """Called by the View when the window closes interactively."""
+        log.debug("View signaled interactive close.")
         self._windowOpen = False
 
     def cleanup(self):
-        """
-        Cleanup resources, close the View if open. Called on app quit.
-        """
-        self._logger.debug("Cleanup requested (likely app quitting).")
-        if self._view:
-            if self._windowOpen:
-                self._logger.info("Closing Help Window view during cleanup.")
-                self._view.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
-                self._view.close()
-                self._windowOpen = False
-            else:
-                self._logger.debug("View exists but wasn't marked open during cleanup, ensuring deletion.")
-                self._view.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
-                self._view.close()
-
+        """Cleanup resources, close the View if open. Called on app quit."""
+        log.debug("Cleanup requested (likely app quitting).")
+        if self._view is not None and self._windowOpen:
+            log.information("Closing Help Window view during cleanup.")
+            self._view.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
+            self._view.close()
+            self._windowOpen = False
+            self._view = None
+        elif self._view is not None:
+            log.debug("View exists but wasn't marked open during cleanup, ensuring deletion.")
+            self._view.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
+            self._view.close()
             self._view = None
         else:
-            self._logger.debug("No view instance to clean up.")
+            log.debug("No view instance to clean up.")

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowview.py
@@ -1,5 +1,3 @@
-# Mantid Repository : https://github.com/mantidproject/mantid
-#
 # Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
@@ -88,19 +86,16 @@ class HelpWindowView(QMainWindow):
         self.reloadButton.clicked.connect(self.browser.reload)
         self.toolbar.addWidget(self.reloadButton)
 
-        # --- Add Status Indicator ---
-        # Spacer to push the status label to the right
         spacer = QWidget()
         spacer.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
         self.toolbar.addWidget(spacer)
 
         # Status Label (Icon + Text)
-        self.statusLabel = QLabel("Status: Initializing...")  # Initial text
+        self.statusLabel = QLabel("Status: Initializing...")
         self.statusLabel.setToolTip("Indicates whether documentation is loaded locally (Offline) or from the web (Online)")
-        # Add some padding/margin for aesthetics
+
         self.statusLabel.setStyleSheet("QLabel { padding-left: 5px; padding-right: 5px; margin-left: 5px; }")
         self.toolbar.addWidget(self.statusLabel)
-        # ---------------------------
 
         # Connect signals for enabling/disabling buttons
         self.browser.urlChanged.connect(self.update_navigation_buttons)

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/helpwindowview.py
@@ -3,6 +3,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import logging
+from html import escape
 from qtpy.QtWidgets import (
     QMainWindow,
     QVBoxLayout,
@@ -99,8 +100,123 @@ class HelpWindowView(QMainWindow):
 
         # Connect signals for enabling/disabling buttons
         self.browser.urlChanged.connect(self.update_navigation_buttons)
-        self.browser.loadFinished.connect(self.update_navigation_buttons)
+        # Connect loadFinished to the new handler
+        self.browser.loadFinished.connect(self.handle_load_finished)
         self.update_navigation_buttons()
+
+    def handle_load_finished(self, ok: bool):
+        """Slot handling the loadFinished signal. Shows generic error on failure."""
+        self._logger.debug(f"Load finished signal received. Success: {ok}")
+        self.update_navigation_buttons()  # Update nav state regardless
+
+        if not ok:
+            # Load failed for reasons OTHER than local file not found
+            failed_url = self.browser.url()
+            failed_url_str = escape(failed_url.toString())
+            # Use self._logger consistently
+            self._logger.error(f"Failed to load page (WebEngine signal): {failed_url_str}")
+
+            # Display a more generic error page now
+            error_html = f"""<!DOCTYPE html>
+            <html><head><title>Error Loading Page</title>
+            <style>
+                body {{ font-family: sans-serif; padding: 2em; color: #333; }}
+                h2 {{ color: #d9534f; }}
+                code {{
+                    background-color: #f0f0f0; padding: 0.2em 0.4em;
+                    border-radius: 3px; font-family: monospace;
+                    word-break: break-all;
+                }}
+            </style>
+            </head>
+            <body>
+                <h2>Page Load Error</h2>
+                <p>Sorry, the help page could not be loaded:</p>
+                <p><code>{failed_url_str}</code></p>
+                <p>This could be due to network issues, online server errors, local file permission problems, or other loading errors.</p>
+            </body></html>
+            """
+
+            # Use baseUrl of the failed request for context
+            self.browser.setHtml(error_html, baseUrl=failed_url)
+
+    def show_file_not_found_error(self, error_message: str, requested_url: str):
+        """Displays a specific error page when the Model/Presenter signals a local file wasn't found."""
+        self._logger.debug(f"Displaying FileNotFoundError page for requested relative URL: {requested_url}")
+        error_message_html = escape(error_message)
+        requested_url_html = escape(requested_url)
+
+        # Try to get home link
+        home_link_html = ""
+        try:
+            home_url_obj = self.presenter.get_home_url_for_view()
+            if home_url_obj and home_url_obj.isValid():
+                # Add target="_self" to ensure it loads in the help window
+                home_link_html = f"<p><a href='{escape(home_url_obj.toString())}' target='_self'>Go to Home Page</a></p>"
+        except AttributeError:
+            self._logger.warning("Presenter does not have get_home_url_for_view method.")
+        except Exception as e:
+            self._logger.error(f"Error getting home URL for error page: {e}")
+
+        error_html = f"""<!DOCTYPE html>
+        <html>
+        <head><title>File Not Found</title>
+        <style>
+            body {{ font-family: sans-serif; padding: 2em; color: #333; }}
+            h2 {{ color: #d9534f; }}
+            code {{
+                background-color: #f0f0f0; padding: 0.2em 0.4em;
+                border-radius: 3px; font-family: monospace;
+                word-break: break-all;
+            }}
+        </style>
+        </head>
+        <body>
+            <h2>Help File Not Found</h2>
+            <p>Sorry, the requested local documentation file could not be found.</p>
+            <p>Requested: <code>{requested_url_html}</code></p>
+            <p>Details: <code>{error_message_html}</code></p>
+            <p>Please check that your local documentation is correctly built
+               and the path is correctly configured in Mantid ('docs.html.root').</p>
+            {home_link_html}
+        </body>
+        </html>
+        """
+
+        # Use an empty QUrl or the home URL as the base for setHtml
+        base_url_for_error = QUrl()
+        try:
+            base_url_for_error = self.presenter.get_home_url_for_view() or QUrl()
+        except Exception:
+            pass
+        self.browser.setHtml(error_html, baseUrl=base_url_for_error)
+
+    def show_generic_error(self, error_message: str, requested_url: str):
+        """Displays a generic error page based on message from presenter (e.g., URL build errors)."""
+        # Use self._logger consistently
+        self._logger.debug(f"Displaying generic error page for: {requested_url}")
+        error_message_html = escape(error_message)
+        requested_url_html = escape(requested_url)
+        error_html = f"""<!DOCTYPE html>
+        <html><head><title>Error</title>
+        <style>
+            body {{ font-family: sans-serif; padding: 2em; color: #333; }}
+            h2 {{ color: #d9534f; }}
+            code {{
+                background-color: #f0f0f0; padding: 0.2em 0.4em;
+                border-radius: 3px; font-family: monospace;
+                word-break: break-all;
+            }}
+        </style>
+        </head>
+        <body>
+            <h2>Help Window Error</h2>
+            <p>An error occurred while trying to display help for:</p>
+            <p><code>{requested_url_html}</code></p>
+            <p>Details: {error_message_html}</p>
+        </body></html>
+        """
+        self.browser.setHtml(error_html)
 
     def set_status_indicator(self, modeText: str, isLocal: bool):
         """
@@ -121,8 +237,9 @@ class HelpWindowView(QMainWindow):
         """
         Enable/disable back/forward buttons based on browser history.
         """
-        canGoBack = self.browser.history().canGoBack()
-        canGoForward = self.browser.history().canGoForward()
+        history = self.browser.history() if hasattr(self.browser, "history") else None
+        canGoBack = history.canGoBack() if history else False
+        canGoForward = history.canGoForward() if history else False
         self.backButton.setEnabled(canGoBack)
         self.forwardButton.setEnabled(canGoForward)
         self.reloadButton.setEnabled(True)

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
@@ -38,13 +38,31 @@ class TestHelpWindowModelConfigService(unittest.TestCase):
 
         self.assertTrue(model.is_local_docs_mode(), "Expected is_local_docs_mode() True")
         self.assertEqual(model.MODE_OFFLINE, model.get_mode_string(), "Expected mode string 'Offline Docs'")
-        test_url = model.build_help_url("algorithms/MyAlgorithm-v1.html")
+
+        dummy_home_path = os.path.join(self.temp_dir, "index.html")
+        with open(dummy_home_path, "w") as f:
+            f.write("<html></html>")
+
+        algo_subdir = os.path.join(self.temp_dir, "algorithms")
+        os.makedirs(algo_subdir, exist_ok=True)
+        algo_file_rel_path = "algorithms/MyAlgorithm-v1.html"
+        dummy_algo_path = os.path.join(self.temp_dir, algo_file_rel_path)
+        with open(dummy_algo_path, "w") as f:
+            f.write("<html></html>")
+
+        test_url = model.build_help_url(algo_file_rel_path)
         self.assertTrue(test_url.isLocalFile(), "Expected a local file:// URL")
 
         local_file_path = test_url.toLocalFile()
         norm_local_file_path = os.path.normpath(local_file_path)
-        norm_expected_prefix = os.path.normpath(os.path.abspath(self.temp_dir))
+        norm_expected_file_path = os.path.normpath(dummy_algo_path)
+        self.assertEqual(
+            norm_local_file_path,
+            norm_expected_file_path,
+            f"URL path '{norm_local_file_path}' should match dummy file path '{norm_expected_file_path}'",
+        )
 
+        norm_expected_prefix = os.path.normpath(os.path.abspath(self.temp_dir))
         self.assertTrue(
             norm_local_file_path.startswith(norm_expected_prefix + os.sep),
             f"URL path '{norm_local_file_path}' should start with temp dir path '{norm_expected_prefix}{os.sep}'",
@@ -52,6 +70,9 @@ class TestHelpWindowModelConfigService(unittest.TestCase):
 
         home_url = model.get_home_url()
         self.assertTrue(home_url.isLocalFile(), "Expected a local file:// for home URL")
+        norm_home_path = os.path.normpath(home_url.toLocalFile())
+        norm_expected_home_path = os.path.normpath(dummy_home_path)
+        self.assertEqual(norm_home_path, norm_expected_home_path, "Home URL should point to dummy index.html")
 
         mock_instance.getString.assert_called_once_with(DOCS_ROOT_KEY, True)
         mock_ConfigService.Instance.assert_called_once()

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
@@ -1,123 +1,140 @@
-# Mantid Repository : https://github.com/mantidproject/mantid
-#
 # Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-#  This file is part of the mantid workbench.
 import os
 import tempfile
 import shutil
 import unittest
+from unittest.mock import patch
 
-from mantidqt.widgets.helpwindow.helpwindowmodel import HelpWindowModel
+from mantidqt.widgets.helpwindow.helpwindowmodel import HelpWindowModel, LocalRequestInterceptor, NoOpRequestInterceptor
+
+# --- Define Constants ---
+CONFIG_SERVICE_LOOKUP_PATH = "mantidqt.widgets.helpwindow.helpwindowmodel.ConfigService"
+VERSION_FUNC_LOOKUP_PATH = "mantidqt.widgets.helpwindow.helpwindowmodel.getMantidVersionString"
+DOCS_ROOT_KEY = "docs.html.root"
+ONLINE_BASE_EXAMPLE = "https://example.org"
+# ------------------------
 
 
-class TestHelpWindowModel(unittest.TestCase):
+class TestHelpWindowModelConfigService(unittest.TestCase):
     def setUp(self):
-        # We can create a temporary directory to simulate "local_docs_base" that actually exists
         self.temp_dir = tempfile.mkdtemp()
+        self.invalid_path = os.path.join(self.temp_dir, "non_existent_subfolder")
+        if os.path.exists(self.invalid_path):
+            os.rmdir(self.invalid_path)
 
     def tearDown(self):
-        # Clean up any temporary directories
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
-    def test_init_with_local_docs_configures_for_local(self):
-        model = HelpWindowModel(localDocsBase=self.temp_dir, onlineBase="https://example.org")
+    @patch(CONFIG_SERVICE_LOOKUP_PATH)
+    def test_init_when_config_returns_valid_path_configures_for_local(self, mock_ConfigService):
+        """Test local mode when ConfigService returns a valid directory path."""
+        mock_instance = mock_ConfigService.Instance.return_value
+        mock_instance.getString.return_value = self.temp_dir
 
-        # The model should see this as local
-        self.assertTrue(model.is_local_docs_mode(), "Expected is_local_docs_mode() to be True for a valid folder")
+        model = HelpWindowModel(online_base=ONLINE_BASE_EXAMPLE)
 
-        # Check that the mode string is correctly set to "Local Docs"
-        self.assertEqual(model.MODE_LOCAL, model.get_mode_string(), "Expected mode string to be 'Local Docs'")
-
-        # build_help_url should produce a file:// URL
+        self.assertTrue(model.is_local_docs_mode(), "Expected is_local_docs_mode() True")
+        self.assertEqual(model.MODE_OFFLINE, model.get_mode_string(), "Expected mode string 'Offline Docs'")
         test_url = model.build_help_url("algorithms/MyAlgorithm-v1.html")
         self.assertTrue(test_url.isLocalFile(), "Expected a local file:// URL")
 
-        # home url also should be local
+        local_file_path = test_url.toLocalFile()
+
+        expected_prefix = os.path.abspath(self.temp_dir) + os.sep
+        self.assertTrue(
+            local_file_path.startswith(expected_prefix), f"URL path '{local_file_path}' should start with temp dir path '{expected_prefix}'"
+        )
+
         home_url = model.get_home_url()
         self.assertTrue(home_url.isLocalFile(), "Expected a local file:// for home URL")
 
-    def test_init_with_no_local_docs_uses_online(self):
-        model = HelpWindowModel(localDocsBase=None, onlineBase="https://example.org")
+        mock_instance.getString.assert_called_once_with(DOCS_ROOT_KEY, True)
+        mock_ConfigService.Instance.assert_called_once()
 
-        # The model should see this as NOT local
-        self.assertFalse(model.is_local_docs_mode(), "Expected is_local_docs_mode() to be False")
+    @patch(CONFIG_SERVICE_LOOKUP_PATH)
+    def test_init_when_config_returns_none_uses_online(self, mock_ConfigService):
+        """Test online mode when ConfigService returns None (or empty string) for the path."""
+        mock_instance = mock_ConfigService.Instance.return_value
+        mock_instance.getString.return_value = None
 
-        # Check that the mode string is correctly set to "Online Docs"
-        self.assertEqual(model.MODE_ONLINE, model.get_mode_string(), "Expected mode string to be 'Online Docs'")
+        model = HelpWindowModel(online_base=ONLINE_BASE_EXAMPLE)
 
-        # Print debugging info
-        print("\nDEBUG INFO:")
-        print(f"Base URL: {model.get_base_url()}")
-
-        # build_help_url should produce an https://example.org/ URL
+        self.assertFalse(model.is_local_docs_mode(), "Expected is_local_docs_mode() False")
+        self.assertEqual(model.MODE_ONLINE, model.get_mode_string(), "Expected mode string 'Online Docs'")
         test_url = model.build_help_url("algorithms/MyAlgorithm-v1.html")
-        print(f"Generated URL: {test_url.toString()}")
-
-        # Use a more flexible assertion that just checks it's using the right domain
-        self.assertTrue("example.org" in test_url.toString(), f"Expected URL to contain 'example.org', got: {test_url.toString()}")
-        self.assertTrue("/algorithms/" in test_url.toString(), f"Expected URL to contain '/algorithms/', got: {test_url.toString()}")
-
-        # home url also should be online
+        self.assertFalse(test_url.isLocalFile(), "Expected a non-local (http/https) URL")
+        self.assertEqual(test_url.scheme(), "https")
+        self.assertTrue(ONLINE_BASE_EXAMPLE in test_url.toString())
+        self.assertTrue("algorithms/MyAlgorithm-v1.html" in test_url.toString())
         home_url = model.get_home_url()
-        self.assertTrue("example.org" in home_url.toString(), "Expected an online docs home URL")
+        self.assertFalse(home_url.isLocalFile(), "Expected an online docs home URL")
+        self.assertTrue(ONLINE_BASE_EXAMPLE in home_url.toString())
 
-    def test_init_with_invalid_local_docs_path_falls_back_to_online(self):
-        # Create a path we know doesn't exist anymore
-        invalid_path = os.path.join(self.temp_dir, "non_existent")
-        # We do NOT create that subfolder
+        mock_instance.getString.assert_called_once_with(DOCS_ROOT_KEY, True)
+        mock_ConfigService.Instance.assert_called_once()
 
-        # Model should fall back to online mode without raising an exception
-        model = HelpWindowModel(localDocsBase=invalid_path, onlineBase="https://example.org")
+    @patch(CONFIG_SERVICE_LOOKUP_PATH)
+    def test_init_when_config_returns_invalid_path_falls_back_to_online(self, mock_ConfigService):
+        """Test fallback to online mode when ConfigService returns an invalid/non-existent directory path."""
+        mock_instance = mock_ConfigService.Instance.return_value
+        mock_instance.getString.return_value = self.invalid_path
 
-        # The model should see this as NOT local
-        self.assertFalse(model.is_local_docs_mode(), "Expected is_local_docs_mode() to be False with invalid local path")
+        model = HelpWindowModel(online_base=ONLINE_BASE_EXAMPLE)
 
-        # Check that the mode string is correctly set to "Online Docs" as fallback
-        self.assertEqual(model.MODE_ONLINE, model.get_mode_string(), "Expected mode string to be 'Online Docs' for invalid local path")
+        self.assertFalse(model.is_local_docs_mode(), "Expected is_local_docs_mode() False")
+        self.assertEqual(model.MODE_ONLINE, model.get_mode_string(), "Expected mode string 'Online Docs' on fallback")
 
-    def test_create_request_interceptor_based_on_mode(self):
-        # Test with local mode
-        local_model = HelpWindowModel(localDocsBase=self.temp_dir, onlineBase="https://example.org")
+        mock_instance.getString.assert_called_once_with(DOCS_ROOT_KEY, True)
+        mock_ConfigService.Instance.assert_called_once()
+
+    @patch(CONFIG_SERVICE_LOOKUP_PATH)
+    def test_create_request_interceptor_based_on_mode(self, mock_ConfigService):
+        """Test that the correct interceptor is created based on the mode determined from ConfigService."""
+        # --- Test Local Mode ---
+        mock_instance_local = mock_ConfigService.Instance.return_value
+        mock_instance_local.getString.return_value = self.temp_dir
+        local_model = HelpWindowModel(online_base=ONLINE_BASE_EXAMPLE)
         local_interceptor = local_model.create_request_interceptor()
+        self.assertIsInstance(local_interceptor, LocalRequestInterceptor, "Expected LocalRequestInterceptor for local mode")
+        mock_instance_local.getString.assert_called_once_with(DOCS_ROOT_KEY, True)
+        mock_ConfigService.Instance.reset_mock()
 
-        # Should be a LocalRequestInterceptor
-        self.assertEqual(
-            "LocalRequestInterceptor", local_interceptor.__class__.__name__, "Expected LocalRequestInterceptor for local docs mode"
-        )
-
-        # Test with online mode
-        online_model = HelpWindowModel(localDocsBase=None, onlineBase="https://example.org")
+        # --- Test Online Mode ---
+        mock_instance_online = mock_ConfigService.Instance.return_value
+        mock_instance_online.getString.return_value = None
+        online_model = HelpWindowModel(online_base=ONLINE_BASE_EXAMPLE)
         online_interceptor = online_model.create_request_interceptor()
+        self.assertIsInstance(online_interceptor, NoOpRequestInterceptor, "Expected NoOpRequestInterceptor for online mode")
+        mock_instance_online.getString.assert_called_once_with(DOCS_ROOT_KEY, True)
+        mock_ConfigService.Instance.assert_called_once()
 
-        # Should be a NoOpRequestInterceptor
-        self.assertEqual(
-            "NoOpRequestInterceptor", online_interceptor.__class__.__name__, "Expected NoOpRequestInterceptor for online docs mode"
-        )
+    @patch(CONFIG_SERVICE_LOOKUP_PATH)
+    @patch(VERSION_FUNC_LOOKUP_PATH, return_value=None)
+    def test_online_url_construction_with_trailing_slashes(self, mock_version_func, mock_ConfigService):
+        """Test online base URL construction handles trailing slashes correctly (forced online)."""
+        mock_instance = mock_ConfigService.Instance.return_value
+        mock_instance.getString.return_value = None
 
-    def test_url_construction_with_trailing_slashes(self):
-        # Test base URL construction with and without trailing slashes
-        model1 = HelpWindowModel(localDocsBase=None, onlineBase="https://example.org")
-        model2 = HelpWindowModel(localDocsBase=None, onlineBase="https://example.org/")
+        model1 = HelpWindowModel(online_base="https://example.org")
+        model2 = HelpWindowModel(online_base="https://example.org/")
 
-        # Print debugging info
-        print("\nURL Construction Debug:")
-        print(f"Model1 base URL: {model1.get_base_url()}")
-        print(f"Model2 base URL: {model2.get_base_url()}")
+        self.assertFalse(model1.is_local_docs_mode(), "Model1 should be in online mode")
+        self.assertFalse(model2.is_local_docs_mode(), "Model2 should be in online mode")
+        self.assertTrue(model1.get_base_url().endswith("/"), "get_base_url() should add trailing slash")
+        self.assertTrue(model2.get_base_url().endswith("/"), "get_base_url() should keep trailing slash")
+        self.assertEqual(model1.get_base_url(), model2.get_base_url(), "Base URLs should be identical")
 
         url1 = model1.build_help_url("test.html")
         url2 = model2.build_help_url("test.html")
 
-        print(f"URL1: {url1.toString()}")
-        print(f"URL2: {url2.toString()}")
-
-        # Test with a more flexible assertion
-        self.assertEqual(url1.host(), url2.host(), "URLs should have the same host")
-        self.assertEqual(
-            url1.path().rstrip("/"), url2.path().rstrip("/"), "URLs should have the same path after normalizing trailing slashes"
-        )
+        self.assertEqual(url1.toString(), url2.toString(), "Generated URLs should be identical")
+        self.assertEqual(url1.toString(), "https://example.org/test.html", "Generated URL should be correct (no version)")
+        self.assertTrue(mock_version_func.called)
+        mock_ConfigService.Instance.assert_called()
+        mock_instance.getString.assert_called()
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
+++ b/qt/python/mantidqt/mantidqt/widgets/helpwindow/test/test_helpwindowmodel.py
@@ -42,10 +42,12 @@ class TestHelpWindowModelConfigService(unittest.TestCase):
         self.assertTrue(test_url.isLocalFile(), "Expected a local file:// URL")
 
         local_file_path = test_url.toLocalFile()
+        norm_local_file_path = os.path.normpath(local_file_path)
+        norm_expected_prefix = os.path.normpath(os.path.abspath(self.temp_dir))
 
-        expected_prefix = os.path.abspath(self.temp_dir) + os.sep
         self.assertTrue(
-            local_file_path.startswith(expected_prefix), f"URL path '{local_file_path}' should start with temp dir path '{expected_prefix}'"
+            norm_local_file_path.startswith(norm_expected_prefix + os.sep),
+            f"URL path '{norm_local_file_path}' should start with temp dir path '{norm_expected_prefix}{os.sep}'",
         )
 
         home_url = model.get_home_url()
@@ -93,7 +95,6 @@ class TestHelpWindowModelConfigService(unittest.TestCase):
     @patch(CONFIG_SERVICE_LOOKUP_PATH)
     def test_create_request_interceptor_based_on_mode(self, mock_ConfigService):
         """Test that the correct interceptor is created based on the mode determined from ConfigService."""
-        # --- Test Local Mode ---
         mock_instance_local = mock_ConfigService.Instance.return_value
         mock_instance_local.getString.return_value = self.temp_dir
         local_model = HelpWindowModel(online_base=ONLINE_BASE_EXAMPLE)
@@ -102,7 +103,6 @@ class TestHelpWindowModelConfigService(unittest.TestCase):
         mock_instance_local.getString.assert_called_once_with(DOCS_ROOT_KEY, True)
         mock_ConfigService.Instance.reset_mock()
 
-        # --- Test Online Mode ---
         mock_instance_online = mock_ConfigService.Instance.return_value
         mock_instance_online.getString.return_value = None
         online_model = HelpWindowModel(online_base=ONLINE_BASE_EXAMPLE)


### PR DESCRIPTION
### Description of work

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
Modified the Python Help Window (`HelpWindowModel`) to retrieve the local HTML documentation path from Mantid's `ConfigService` using the existing `docs.html.root` property. This removes the need to explicitly pass this path as a parameter when creating the help window components.
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->
This change utilizes the existing `docs.html.root` configuration property within Mantid's `ConfigService`, centralizing the definition of the local help documentation path and simplifying the Help Window's interface and instantiation. It makes the Help Window consistent with how other parts of Mantid locate configured resources.

Issues #37248

Here is the EWM link: [EWM 10007](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=10007)  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

#### Further detail of work

* Removed the `localDocs`/`localDocsBase` parameter from `HelpWindowModel.__init__`, `HelpWindowPresenter.__init__`, and the `show_help_page` function in `helpwindowbridge.py`.
* Removed the corresponding `--local-docs` command-line argument and `MANTID_LOCAL_DOCS_BASE` environment variable handling from `helpwindowbridge.py`.
* In `HelpWindowModel.__init__`, `mantid.kernel.ConfigService` is now imported at the top level and used to retrieve the path:
    ```python
    config_service = ConfigService.Instance()
    raw_path = config_service.getString("docs.html.root", True)
    ```
* Error handling (`try...except`) around the `ConfigService` import and calls ensures robustness in environments where `ConfigService` might not be fully initialized or the property is absent/empty.
* If a valid directory path is retrieved from `docs.html.root`, the model configures itself for "Offline Docs" mode using that path. Otherwise, it defaults gracefully to "Online Docs" mode.
* Updated `test_helpwindowmodel.py` significantly to reflect the removal of the `localDocsBase` parameter and to use `unittest.mock.patch` to simulate various return values from `ConfigService.Instance().getString("docs.html.root", True)`. This allows testing of different scenarios (valid path, invalid path, no path found) without requiring a live `ConfigService`.
### To test:
In order to test this, you need to first build mantid workbench with the python help window enabled. Follow these steps in order to achieve this:

1. `cmake . -DCMAKE_BUILD_TYPE=Debug -DENABLE_QTASSISTANT=OFF`
2. `ninja all docs-html`
3. `./bin/lauch_mantidworkbench.sh`

Following this use the command `./bin/launch_mantidworkbench.sh` to launch the workbench.

Within the workbench window navigate to the Algorithm Manager window and select any algo:
![image](https://github.com/user-attachments/assets/e1da0ded-daca-42fb-835c-982bb74982dc)

Double left click to open the algo menu:
![image](https://github.com/user-attachments/assets/5275c2f1-c5e2-43a1-8b6a-6fc97f64de47)

Press the "?" button and to launch the python help window and notice within the debug logs that ConfigService is being employed to retrieve the local docs location:

```bash
HelpWindowModel-[Debug] Retrieved 'docs.html.root' from ConfigService: '/home/dzj/mantid/build/docs/html'
```
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
