### PR TITLE
Allow Fitting tab in Engineering Diffraction to use data in D-Spacing

### DIFF
--- a/docs/source/release/v6.13.0/Diffraction/Engineering/New_features/39206.rst
+++ b/docs/source/release/v6.13.0/Diffraction/Engineering/New_features/39206.rst
@@ -1,0 +1,1 @@
+- In fitting tab of :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` data can now be loaded that is in d-spacing as well as Time-of-flight.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -113,9 +113,9 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         self.fit_enabled_notifier.notify_subscribers(self.isFitEnabled() and self.isVisible())
 
     def ws_is_valid(self, ws_name, warn):
-        is_valid = ADS.retrieve(ws_name).getAxis(0).getUnit().caption() == "Time-of-flight"
+        is_valid = ADS.retrieve(ws_name).getAxis(0).getUnit().caption() in ("Time-of-flight", "d-Spacing")
         if not is_valid and warn:
-            logger.warning(f"Workspace {ws_name} will not be available for fitting because it doesn't have units of TOF")
+            logger.warning(f"Workspace {ws_name} will not be available for fitting because it doesn't have units of TOF or d-spacing")
         return is_valid
 
     def _get_allowed_spectra(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
@@ -68,6 +68,7 @@ class FittingPlotModel(object):
                 fnames = [fit_functions.name()]
                 nparams = [fit_functions.nParams()]
             params_dict = ADS.retrieve(fit_prop["properties"]["Output"] + "_Parameters").toDict()
+            ws_is_tof = ADS.retrieve(wsname).getXDimension().getUnits() == "microsecond"
             # loop over rows in output workspace to get value and error for each parameter
             istart = 0
             for ifunc, fname in enumerate(fnames):
@@ -75,9 +76,9 @@ class FittingPlotModel(object):
                     irow = istart + iparam
                     key = "_".join([fname, params_dict["Name"][irow].split(".")[-1]])  # funcname_param
                     self._fit_results[wsname]["results"][key].append([params_dict["Value"][irow], params_dict["Error"][irow]])
-                    if key in fit_prop["peak_centre_params"]:
-                        # param corresponds to a peak centre in TOF which we also need in dspacing
-                        # add another entry into the results dictionary
+                    if key in fit_prop["peak_centre_params"] and ws_is_tof:
+                        # param corresponds to a peak centre check if units are TOF
+                        # if so add another entry into the results dictionary in dSpacing
                         key_d = key + "_dSpacing"
                         try:
                             dcen = self._convert_TOF_to_d(params_dict["Value"][irow], wsname)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
@@ -68,7 +68,7 @@ class FittingPlotModel(object):
                 fnames = [fit_functions.name()]
                 nparams = [fit_functions.nParams()]
             params_dict = ADS.retrieve(fit_prop["properties"]["Output"] + "_Parameters").toDict()
-            ws_is_tof = ADS.retrieve(wsname).getXDimension().getUnits() == "microsecond"
+            ws_is_tof = self._ws_is_tof(wsname)
             # loop over rows in output workspace to get value and error for each parameter
             istart = 0
             for ifunc, fname in enumerate(fnames):
@@ -246,3 +246,6 @@ class FittingPlotModel(object):
             table_dict.pop("SpecIndex", None)
             return {col_name.split("_")[-1]: value for col_name, value in table_dict.items()}
         return None
+
+    def _ws_is_tof(self, wsname):
+        return ADS.retrieve(wsname).getXDimension().getUnits() == "microsecond"

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_model.py
@@ -120,37 +120,69 @@ class FittingPlotModelTest(unittest.TestCase):
         }
         return fitprop
 
+    def _run_update_fit(
+        self, mock_ads, mock_create_fit_tables, mock_get_diffs, mock_ws_is_tof, is_tof, mock_table_return_values, func_str, target_results
+    ):
+        mock_loaded_ws_list = mock.MagicMock()
+        mock_active_ws_list = mock.MagicMock()
+        mock_log_ws_name = mock.MagicMock()
+        mock_ws_is_tof.return_value = is_tof
+
+        fitprop = self._setup_update_fit_test(mock_table_return_values, mock_ads, mock_get_diffs, func_str, ["Gaussian_PeakCentre"])
+        self.model.update_fit([fitprop], mock_loaded_ws_list, mock_active_ws_list, mock_log_ws_name)
+
+        self.assertEqual(self.model._fit_results["name1"]["model"], func_str)
+        self.assertEqual(self.model._fit_results["name1"]["results"], target_results)
+        mock_create_fit_tables.assert_called_once_with(mock_loaded_ws_list, mock_active_ws_list, mock_log_ws_name)
+        if is_tof:
+            self.assertEqual(mock_get_diffs.call_count, 4)  # twice for each peak
+        else:
+            self.assertEqual(mock_get_diffs.call_count, 0)
+
     @patch(plot_model_path + ".FittingPlotModel._ws_is_tof")
     @patch(plot_model_path + ".FittingPlotModel._get_diff_constants")
     @patch(plot_model_path + ".FittingPlotModel.create_fit_tables")
     @patch(plot_model_path + ".ADS")
-    def test_update_fit(self, mock_ads, mock_create_fit_tables, mock_get_diffs, mock_ws_is_tof):
-        mock_loaded_ws_list = mock.MagicMock()
-        mock_active_ws_list = mock.MagicMock()
-        mock_log_ws_name = mock.MagicMock()
-        mock_ws_is_tof.return_value = True
+    def test_update_fit_in_tof(self, mock_ads, mock_create_fit_tables, mock_get_diffs, mock_ws_is_tof):
+        is_tof = True
         mock_table_return_values = {
             "Name": ["f0.Height", "f0.PeakCentre", "f0.Sigma", "f1.Height", "f1.PeakCentre", "f1.Sigma", "Cost function value"],
             "Value": [11.0, 40000.0, 54.0, 10.0, 30000.0, 51.0, 1.0],
             "Error": [1.0, 10.0, 2.0, 1.0, 10.0, 2.0, 0.0],
         }
         func_str = "name=Gaussian,Height=11,PeakCentre=40000,Sigma=54;name=Gaussian,Height=10,PeakCentre=30000,Sigma=51"
-        fitprop = self._setup_update_fit_test(mock_table_return_values, mock_ads, mock_get_diffs, func_str, ["Gaussian_PeakCentre"])
-        self.model.update_fit([fitprop], mock_loaded_ws_list, mock_active_ws_list, mock_log_ws_name)
-
-        self.assertEqual(self.model._fit_results["name1"]["model"], func_str)
-        self.assertEqual(
-            self.model._fit_results["name1"]["results"],
-            {
-                "Gaussian_Height": [[11.0, 1.0], [10.0, 1.0]],
-                "Gaussian_PeakCentre": [[40000.0, 10.0], [30000.0, 10.0]],
-                "Gaussian_PeakCentre_dSpacing": [[4.0, 1.0e-3], [3.0, 1.0e-3]],
-                "Gaussian_Sigma": [[54.0, 2.0], [51.0, 2.0]],
-                "Gaussian_fwhm": [self._get_fwhm_values(func_str, 0), self._get_fwhm_values(func_str, 1)],
-            },
+        target_results = {
+            "Gaussian_Height": [[11.0, 1.0], [10.0, 1.0]],
+            "Gaussian_PeakCentre": [[40000.0, 10.0], [30000.0, 10.0]],
+            "Gaussian_PeakCentre_dSpacing": [[4.0, 1.0e-3], [3.0, 1.0e-3]],
+            "Gaussian_Sigma": [[54.0, 2.0], [51.0, 2.0]],
+            "Gaussian_fwhm": [self._get_fwhm_values(func_str, 0), self._get_fwhm_values(func_str, 1)],
+        }
+        self._run_update_fit(
+            mock_ads, mock_create_fit_tables, mock_get_diffs, mock_ws_is_tof, is_tof, mock_table_return_values, func_str, target_results
         )
-        mock_create_fit_tables.assert_called_once_with(mock_loaded_ws_list, mock_active_ws_list, mock_log_ws_name)
-        self.assertEqual(mock_get_diffs.call_count, 4)  # twice for each peak
+
+    @patch(plot_model_path + ".FittingPlotModel._ws_is_tof")
+    @patch(plot_model_path + ".FittingPlotModel._get_diff_constants")
+    @patch(plot_model_path + ".FittingPlotModel.create_fit_tables")
+    @patch(plot_model_path + ".ADS")
+    def test_update_fit_in_d_spacing(self, mock_ads, mock_create_fit_tables, mock_get_diffs, mock_ws_is_tof):
+        is_tof = False
+        mock_table_return_values = {
+            "Name": ["f0.Height", "f0.PeakCentre", "f0.Sigma", "f1.Height", "f1.PeakCentre", "f1.Sigma", "Cost function value"],
+            "Value": [11.0, 4.0, 54.0, 10.0, 3.0, 51.0, 1.0],
+            "Error": [1.0, 10.0, 2.0, 1.0, 10.0, 2.0, 0.0],
+        }
+        func_str = "name=Gaussian,Height=11,PeakCentre=4,Sigma=54;name=Gaussian,Height=10,PeakCentre=3,Sigma=51"
+        target_results = {
+            "Gaussian_Height": [[11.0, 1.0], [10.0, 1.0]],
+            "Gaussian_PeakCentre": [[4.0, 10.0], [3.0, 10.0]],
+            "Gaussian_Sigma": [[54.0, 2.0], [51.0, 2.0]],
+            "Gaussian_fwhm": [self._get_fwhm_values(func_str, 0), self._get_fwhm_values(func_str, 1)],
+        }
+        self._run_update_fit(
+            mock_ads, mock_create_fit_tables, mock_get_diffs, mock_ws_is_tof, is_tof, mock_table_return_values, func_str, target_results
+        )
 
     @patch(plot_model_path + ".FittingPlotModel._convert_TOFerror_to_derror")
     @patch(plot_model_path + ".FittingPlotModel._convert_TOF_to_d")

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_model.py
@@ -120,13 +120,15 @@ class FittingPlotModelTest(unittest.TestCase):
         }
         return fitprop
 
+    @patch(plot_model_path + ".FittingPlotModel._ws_is_tof")
     @patch(plot_model_path + ".FittingPlotModel._get_diff_constants")
     @patch(plot_model_path + ".FittingPlotModel.create_fit_tables")
     @patch(plot_model_path + ".ADS")
-    def test_update_fit(self, mock_ads, mock_create_fit_tables, mock_get_diffs):
+    def test_update_fit(self, mock_ads, mock_create_fit_tables, mock_get_diffs, mock_ws_is_tof):
         mock_loaded_ws_list = mock.MagicMock()
         mock_active_ws_list = mock.MagicMock()
         mock_log_ws_name = mock.MagicMock()
+        mock_ws_is_tof.return_value = True
         mock_table_return_values = {
             "Name": ["f0.Height", "f0.PeakCentre", "f0.Sigma", "f1.Height", "f1.PeakCentre", "f1.Sigma", "Cost function value"],
             "Value": [11.0, 40000.0, 54.0, 10.0, 30000.0, 51.0, 1.0],
@@ -211,15 +213,17 @@ class FittingPlotModelTest(unittest.TestCase):
 
     @patch(plot_model_path + ".FittingPlotModel._convert_TOFerror_to_derror")
     @patch(plot_model_path + ".FittingPlotModel._convert_TOF_to_d")
+    @patch(plot_model_path + ".FittingPlotModel._ws_is_tof")
     @patch(plot_model_path + ".FittingPlotModel._get_diff_constants")
     @patch(plot_model_path + ".FittingPlotModel.create_fit_tables")
     @patch(plot_model_path + ".ADS")
     def test_update_fit_with_composite_peak_and_user_function(
-        self, mock_ads, mock_create_fit_tables, mock_get_diffs, mock_conv_tof_to_d, mock_conv_tof_e
+        self, mock_ads, mock_create_fit_tables, mock_get_diffs, mock_ws_is_tof, mock_conv_tof_to_d, mock_conv_tof_e
     ):
         mock_loaded_ws_list = mock.MagicMock()
         mock_active_ws_list = mock.MagicMock()
         mock_log_ws_name = mock.MagicMock()
+        mock_ws_is_tof.return_value = True
         mock_table_return_values = {
             "Name": [
                 "f0.Height",
@@ -278,18 +282,20 @@ class FittingPlotModelTest(unittest.TestCase):
 
     @patch(plot_model_path + ".FittingPlotModel._convert_TOFerror_to_derror")
     @patch(plot_model_path + ".FittingPlotModel._convert_TOF_to_d")
+    @patch(plot_model_path + ".FittingPlotModel._ws_is_tof")
     @patch(plot_model_path + ".FittingPlotModel._get_diff_constants")
     @patch(plot_model_path + ".GroupWorkspaces")
     @patch(plot_model_path + ".CreateWorkspace")
     @patch(plot_model_path + ".ADS")
     def test_update_fit_with_func_having_fwhm_params(
-        self, mock_ads, mock_create_ws, mock_group_ws, mock_get_diffs, mock_conv_tof_to_d, mock_conv_tof_e
+        self, mock_ads, mock_create_ws, mock_group_ws, mock_get_diffs, mock_ws_is_tof, mock_conv_tof_to_d, mock_conv_tof_e
     ):
         mock_loaded_ws_list = mock.MagicMock()
         mock_loaded_ws_list.__len__.return_value = 1
         mock_active_ws_list = mock.MagicMock()
         mock_log_ws_name = mock.MagicMock()
         mock_log_ws_name.split.return_value = "log_workspace"
+        mock_ws_is_tof.return_value = True
         mock_table_return_values = {
             "Name": [
                 "f0.Mixing",


### PR DESCRIPTION
### Description of work

#### Summary of work
Previously, if data path was provided that was not in TOF, the interface would not load the data for fitting.

#### Purpose of work
Allowing for texture analysis routine, also much easier for sequential fit when TOF varies for the same d-spacing.

*There is no associated issue.*

### To test:

- Open Engineering Diffraction Interface
- Set RB Number to something (`Example` will do)
- Select New Calibration
- Set Sample as `305738`
- Select Texture20 in Set Calibration Region of Interest
- Calibrate
- Go To Focus Tab
- Set Sample run to `305738`
- Focus 
- Go to Fitting tab
- Set filter to dSpacing
- Browse data and load some of the focussed dSpacing data from earlier (`save_dir\User\Example\Focus`)
- Click `Load`

Data should load. You can now fit this data (for example following Test 8 in https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html)

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

### Reviewer

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

#### Code Review

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Do the release notes conform to the [release notes guide](https://developer.mantidproject.org/Standards/ReleaseNotesGuide.html)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

### Gatekeeper

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.
